### PR TITLE
chore: add license key component instances inside collapsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.16.2",
+    "@newrelic/gatsby-theme-newrelic": "6.16.3",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
@@ -101,7 +101,7 @@ Every time you install the New Relic add-on for Heroku, New Relic will automatic
     id="heroku-add-on-license-key"
     title="License key"
   >
-    The license key identifies the account where your application reports. To check the license key your app is using:
+    The <LicenseKey /> identifies the account where your application reports. To check the license key your app is using:
 
     1. From a command line, run:
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -82,7 +82,7 @@ To get started with API keys:
   <tbody>
     <tr>
       <td>
-        license key ,
+        <LicenseKey /> ,
         used for data ingest
       </td>
 
@@ -254,7 +254,7 @@ Besides the main API keys explained above, we have several other, older API keys
     title="Insights insert key (not recommended)"
   >
     <Callout variant="important">
-      This key is still in use but we highly recommend using the license key, which can be used for the same things and more.
+      This key is still in use but we highly recommend using the <LicenseKey />, which can be used for the same things and more.
     </Callout>
 
     One of our older New Relic API keys used for data ingest is the Insights insert key, also known as an insert key. Note that the license key is used for the same functionality and more, which is why we recommend the license key over this key.

--- a/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
@@ -52,7 +52,7 @@ To install the C SDK into your application's code library, follow this procedure
     title="1. Verify requirements."
   >
     1. Make sure your application meets New Relic's [compatibility and requirements for the C SDK](/docs/c-agent-compatibility-requirements).
-    2. Make sure you have a license key.
+    2. Make sure you have a <LicenseKey />.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/java-agent/heroku/java-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/java-agent/heroku/java-agent-heroku.mdx
@@ -82,7 +82,7 @@ After you [provide the path to the jar file](#provide-path), configure your Hero
        ```
        heroku config:set NEW_RELIC_APP_NAME="APP_NAME"
        ```
-    2. Add your license key:
+    2. Add your <LicenseKey />:
 
        ```
        heroku config:set <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ev-NEW_RELIC_LICENSE_KEY">NEW_RELIC_LICENSE_KEY</a>="LICENSE_KEY"

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -50,7 +50,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
          To monitor 32-bit applications, COR_PROFILER_PATH should be set to APP_DEPLOYMENT_DIRECTORY\\newrelic\\x86\\NewRelic.Profiler.dll
        </Callout>
 
-       The license key and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
+       The <LicenseKey /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
      </Collapser>
 
      <Collapser
@@ -70,7 +70,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
          To monitor 32-bit applications, CORECLR_PROFILER_PATH should be set to APP_DEPLOYMENT_DIRECTORY\\newrelic\\x86\\NewRelic.Profiler.dll
        </Callout>
 
-       The license key and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
+       The <LicenseKey /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
      </Collapser>
 
      <Collapser
@@ -86,7 +86,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        NEW_RELIC_APP_NAME=YOUR_APP_NAME
        ```
 
-       The license key and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
+       The <LicenseKey /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
      </Collapser>
    </CollapserGroup>
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
@@ -162,7 +162,7 @@ The scriptable installers are ZIP archives containing a PowerShell script for in
              </td>
 
              <td>
-               **Required**. Your license key.
+               **Required**. Your <LicenseKey />.
              </td>
            </tr>
 
@@ -324,7 +324,7 @@ The scriptable installers are ZIP archives containing a PowerShell script for in
              </td>
 
              <td>
-               **Required**. Your license key.
+               **Required**. Your <LicenseKey />.
              </td>
            </tr>
 

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/install-new-relic-nodejs-agent-gae-flexible-environment.mdx
@@ -46,7 +46,7 @@ For more information about deploying and configuring your Node.js app in the GAE
     id="setup-gae"
     title="1. Set up the GAE project and install dependencies"
   >
-    1. Follow standard procedures to [install New Relic's Node.js agent](/docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent), including your license key. Be sure to save the `newrelic` module to the `package.json` file.
+    1. Follow standard procedures to [install New Relic's Node.js agent](/docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent), including your <LicenseKey />. Be sure to save the `newrelic` module to the `package.json` file.
     2. Follow [Google App Engine procedures for Node.js](https://cloud.google.com/appengine/docs/flexible/nodejs/quickstart) to create a new Cloud Platform project, create an App Engine application, and complete other prerequisites for the [Google Cloud SDK](https://cloud.google.com/sdk/gcloud/).
 
        The Google Cloud SDK provides the `gcloud` command line tool to manage and deploy GAE apps.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -173,7 +173,7 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    This setting is required. Your New Relic license key. For example, `license_key: '40HexadecimalCharacters'`.
+    This setting is required. Your New Relic <LicenseKey />. For example, `license_key: '40HexadecimalCharacters'`.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -97,7 +97,7 @@ To set up the PHP agent and daemon in the same Docker container:
     You must edit three parts of this example Dockerfile:
 
     * `PHP_AGENT_URL`: The download URL for your PHP agent version. To find the most recent version of the agent, go to **[download.newrelic.com/php_agent/release/](https://download.newrelic.com/php_agent/release/)**.
-    * `YOUR_LICENSE_KEY`: Replace this with your license key. Note that `"REPLACE_WITH_REAL_KEY"` is an actual string in the default **newrelic.ini** file for the PHP agent. Don't edit that string. The `sed` command replaces that default string with the actual 40-character key, in quotes.
+    * `YOUR_LICENSE_KEY`: Replace this with your <LicenseKey />. Note that `"REPLACE_WITH_REAL_KEY"` is an actual string in the default **newrelic.ini** file for the PHP agent. Don't edit that string. The `sed` command replaces that default string with the actual 40-character key, in quotes.
     * `YOUR_APPLICATION_NAME`: Replace with the your application name, in quotes.
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/install-new-relic-php-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/install-new-relic-php-agent-gae-flexible-environment.mdx
@@ -27,7 +27,7 @@ For more information about deploying and configuring your PHP app in the GAE fle
     id="setup-gae"
     title="1. Set up the GAE project and install dependencies"
   >
-    1. Follow standard procedures to [install the New Relic PHP agent](/docs/agents/php-agent/installation/php-agent-installation-overview) for your specific app server, and obtain your license key.
+    1. Follow standard procedures to [install the New Relic PHP agent](/docs/agents/php-agent/installation/php-agent-installation-overview) for your specific app server, and obtain your <LicenseKey />.
     2. Follow [Google App Engine procedures for PHP](https://cloud.google.com/appengine/docs/flexible/php/quickstart) to create a new Cloud Platform project, create an App Engine application, and complete other prerequisites for the [Google Cloud SDK](https://cloud.google.com/sdk/docs/).
 
        The Google Cloud SDK provides the `gcloud` command line tool to manage and deploy GAE apps.
@@ -37,7 +37,7 @@ For more information about deploying and configuring your PHP app in the GAE fle
     id="custom"
     title="2. Extend the GAE image for PHP"
   >
-    In this example, the Dockerfile extends the generic PHP image with application files for a single application in Debian. You can add your license key directly to your Dockerfile, or use an environment variable in your `docker run` command.
+    In this example, the Dockerfile extends the generic PHP image with application files for a single application in Debian. You can add your <LicenseKey /> directly to your Dockerfile, or use an environment variable in your `docker run` command.
 
     ```
     FROM gcr.io/google-appengine/php:latest

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/silent-mode-install-script-advanced.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/silent-mode-install-script-advanced.mdx
@@ -335,7 +335,7 @@ This is the list of environment variables you can set prior to invoking [`newrel
           </th>
 
           <td>
-            Set to your New Relic license key on new installs.
+            Set to your New Relic <LicenseKey /> on new installs.
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/use-newrelic-install-script-php.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/use-newrelic-install-script-php.mdx
@@ -98,7 +98,7 @@ Follow this process to install New Relic.
     id="license-key"
     title="2. Provide your New Relic license key."
   >
-    At the prompt, enter your New Relic license key. This key will be inserted into any INI files created during the rest of the installation process.
+    At the prompt, enter your New Relic <LicenseKey />. This key will be inserted into any INI files created during the rest of the installation process.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -487,7 +487,7 @@ These settings are available in the `newrelic.ini` file.
       </tbody>
     </table>
 
-    Sets the New Relic license key to use. In a multi-tenant system this can be set on a per-directory basis.
+    Sets the New Relic <LicenseKey /> to use. In a multi-tenant system this can be set on a per-directory basis.
 
     <Callout variant="tip">
       When you upgrade from an old agent version to 3.0 or higher, the license will be removed from your daemon configuration file (with a comment explaining why) and stored in the file `/etc/newrelic/upgrade_please.key`. Copy the license out of that file and set it in your `newrelic.ini` file. Delete the `upgrade_please.key` file.
@@ -935,7 +935,7 @@ For more information about ways to start the daemon and when to use an external 
       </tbody>
     </table>
 
-    Sets the name and optional port of the collector host which the daemon will contact to verify your license key and send agent data.
+    Sets the name and optional port of the collector host which the daemon will contact to verify your <LicenseKey /> and send agent data.
 
     This is either just the name of the host or the name and port number in the form `"hostname:port"`. Specifying a port number of `0` will use the default port, which is 80.
 

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -492,7 +492,7 @@ These settings are available in the agent configuration file.
       </tbody>
     </table>
 
-    Specifies the license key of your New Relic account. This key associates your app's metrics with your New Relic account.
+    Specifies the <LicenseKey /> of your New Relic account. This key associates your app's metrics with your New Relic account.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/python-agent/hosting-services/install-python-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/apm/agents/python-agent/hosting-services/install-python-agent-gae-flexible-environment.mdx
@@ -47,7 +47,7 @@ For more information about deploying and configuring your Node.js app in the GAE
   >
     When building a custom runtime using Docker, set the [`NEW_RELIC_CONFIG_FILE`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#agent-configuration-file) as an environment variable pointing to the Dockerfile instead of to your Python app's `newrelic.ini`.
 
-    1. Follow standard procedures to [install the Python agent](/docs/agents/python-agent/getting-started/python-agent-quick-start#install), including your license key.
+    1. Follow standard procedures to [install the Python agent](/docs/agents/python-agent/getting-started/python-agent-quick-start#install), including your <LicenseKey />.
     2. Follow Google App Engine procedures Python to create a [Google Cloud Platform project](https://cloud.google.com/appengine/docs/flexible/python/managing-projects-apps-billing#create), create an App Engine application, and complete other prerequisites for the [Google Cloud SDK](http://cloud.google.com/appengine/docs/flexible/python/download).
 
        The Google Cloud SDK also provides the `gcloud` command line tool to manage and deploy GAE apps.

--- a/src/content/docs/apm/agents/python-agent/troubleshooting/testing-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/troubleshooting/testing-python-agent.mdx
@@ -48,7 +48,7 @@ Here are examples of error messages you may find.
   >
     **ERROR - No license key was set in agent configuration.**
 
-    Ensure that the license key has been specified in the agent configuration file or via the `NEW_RELIC_LICENSE_KEY` environment variable. Correct the problem with the license key, or get support at [support.newrelic.com](https://support.newrelic.com).
+    Ensure that the <LicenseKey /> has been specified in the agent configuration file or via the `NEW_RELIC_LICENSE_KEY` environment variable. Correct the problem with the license key, or get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser
@@ -57,7 +57,7 @@ Here are examples of error messages you may find.
   >
     **ERROR - Data collector indicates that an incorrect license key has been supplied by the agent.**
 
-    The value used by the agent is `...`. Correct the problem with the license key, or get support at [support.newrelic.com](https://support.newrelic.com).
+    The value used by the agent is `...`. Correct the problem with the <LicenseKey />, or get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/background-jobs/monitor-ruby-background-processes.mdx
@@ -113,7 +113,7 @@ Configuring your **newrelic.yml** depends on the context of the background appli
     id="non_rails"
     title="Non-Rails background application"
   >
-    If your background app is non-Rails application already running the Ruby agent, copy your **newrelic.yml** file to the directory where you launch the background job or in the **config** subdirectory. Make sure it includes your license key.
+    If your background app is non-Rails application already running the Ruby agent, copy your **newrelic.yml** file to the directory where you launch the background job or in the **config** subdirectory. Make sure it includes your <LicenseKey />.
 
     Background jobs that do not run in a Rails context will examine the `NEW_RELIC_ENV` environment variable to determine which section of the configuration file to read, falling back to the `RUBY_ENV`, `RAILS_ENV`, and `RACK_ENV` environment variables in sequence, and finally defaulting to `development` if none of these environment variables are set.
   </Collapser>

--- a/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment.mdx
@@ -48,7 +48,7 @@ For more information about deploying and configuring your Ruby app in the GAE fl
     id="setup-gae"
     title="1. Set up the GAE project and install dependencies"
   >
-    1. Follow standard procedures to install New Relic's Ruby agent, including your license key.
+    1. Follow standard procedures to install New Relic's Ruby agent, including your <LicenseKey />.
     2. Follow Google App Engine procedures for Ruby to create a new [Google Cloud Platform project](https://cloud.google.com/appengine/docs/flexible/ruby/managing-projects-apps-billing#create), create an App Engine application, and complete other prerequisites for the [Google Cloud SDK](http://cloud.google.com/appengine/docs/flexible/ruby/download).
 
        The Google Cloud SDK provides the `gcloud` command line tool to manage and deploy GAE apps.

--- a/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
+++ b/src/content/docs/distributed-tracing/infinite-tracing/set-trace-observer.mdx
@@ -65,7 +65,7 @@ To create a new trace observer if you're using New Relic APM agents or third-par
 
        To send this sample request:
 
-       1. Get the license key for the account you want to report data to and have it ready.
+       1. Get the <LicenseKey /> for the account you want to report data to and have it ready.
        2. Copy the following `curl` request into a text editor:
 
           ```bash
@@ -132,7 +132,7 @@ To create a new trace observer if you're using New Relic APM agents or third-par
                 </td>
 
                 <td>
-                  Replace this with your ingest license key.
+                  Replace this with your ingest <LicenseKey />.
                 </td>
               </tr>
 
@@ -209,7 +209,7 @@ If you haven't already set up a trace observer, complete the following:
 
        To send this sample request:
 
-       1. Get the license key for the account you want to report data to and have it ready.
+       1. Get the <LicenseKey /> for the account you want to report data to and have it ready.
        2. Copy the following `curl` request into a text editor:
 
           ```bash
@@ -276,7 +276,7 @@ If you haven't already set up a trace observer, complete the following:
                 </td>
 
                 <td>
-                  Replace this with your license key.
+                  Replace this with your <LicenseKey />.
                 </td>
               </tr>
 

--- a/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
+++ b/src/content/docs/distributed-tracing/trace-api/trace-api-general-requirements-limits.mdx
@@ -328,7 +328,7 @@ There are two ways success/errors are signaled:
             </td>
 
             <td>
-              Authentication error. May occur with an invalid license key or if you lack necessary entitlement to use the Trace API.
+              Authentication error. May occur with an invalid <LicenseKey /> or if you lack necessary entitlement to use the Trace API.
             </td>
           </tr>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -76,7 +76,7 @@ Here are examples of Kubernetes manifests for deployment and service objects:
     id="k8s-manifest-examples"
     title="Kubernetes manifest examples"
   >
-    Below are examples of Kubernetes manifests to deploy StatsD in a Kubernetes environment and create a StatsD service named `newrelic-statsd`. You need to insert your [account ID](/docs/accounts/install-new-relic/account-setup/account-id) and your license key.
+    Below are examples of Kubernetes manifests to deploy StatsD in a Kubernetes environment and create a StatsD service named `newrelic-statsd`. You need to insert your [account ID](/docs/accounts/install-new-relic/account-setup/account-id) and your <LicenseKey />.
 
     **deployment.yml**:
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-chef.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-chef.mdx
@@ -60,7 +60,7 @@ The `default` recipe supplies the following Chef attributes:
       </tbody>
     </table>
 
-    Defines your license key.
+    Defines your <LicenseKey />.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -39,7 +39,7 @@ For an example of how all these variables can be used, see our [sample configura
     id="license-key"
     title={<>license_key (<strong>REQUIRED)</strong></>}
   >
-    Specifies the license key for your New Relic account. The agent uses this key to associate your server's metrics with your New Relic account. This setting is created as part of the standard installation process.
+    Specifies the <LicenseKey /> for your New Relic account. The agent uses this key to associate your server's metrics with your New Relic account. This setting is created as part of the standard installation process.
 
     <table>
       <thead>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -65,7 +65,7 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
          brew services start newrelic-infra-agent
        ```
     
-    5. Create the configuration file and add your license key:
+    5. Create the configuration file and add your <LicenseKey />:
 
        Intel x86:
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/remote-write-errors-error-messages.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/remote-write-errors-error-messages.mdx
@@ -22,7 +22,7 @@ If you receive an integration error message from New Relic or error messages in 
     id=""
     title="Configuration errors"
   >
-    Missing or incorrect characters in the remote write URL in the config file (for example the endpoint, license key, or `prometheus_server` name) or incorrect placement of the information in the file will result in the Prometheus server not starting, remote write not working properly, or errors appearing in Prometheus server logs.
+    Missing or incorrect characters in the remote write URL in the config file (for example the endpoint, <LicenseKey />, or `prometheus_server` name) or incorrect placement of the information in the file will result in the Prometheus server not starting, remote write not working properly, or errors appearing in Prometheus server logs.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -173,7 +173,7 @@ You can customize the following parameters if you are writing to more than one a
     id="x-license-key"
     title="X-License Key"
   >
-    Your license key is not an API key. The license key is used for authentication and to identify which account to write data into. If you are configuring Prometheus to write into different New Relic accounts, use a different key on each remote write URL.
+    Your <LicenseKey /> is not an API key. The license key is used for authentication and to identify which account to write data into. If you are configuring Prometheus to write into different New Relic accounts, use a different key on each remote write URL.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/install-fargate-integration.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/install-fargate-integration.mdx
@@ -373,7 +373,7 @@ Complete the following for manual injection:
        id="secret"
        title="Secret"
      >
-       Create the following `Secret` that has a license with the Base64 encoded value of your license key. One secret is needed in each namespace where a pod you want to monitor is running.
+       Create the following `Secret` that has a license with the Base64 encoded value of your <LicenseKey />. One secret is needed in each namespace where a pod you want to monitor is running.
 
        ```
        apiVersion: v1

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-error-messages.mdx
@@ -28,7 +28,7 @@ You are getting error messages for the [New Relic Kubernetes integration](/docs/
      were not accepted: 401 401 Unauthorized Invalid license key."
     ```
 
-    To resolve this problem make sure you specify a valid license key.
+    To resolve this problem make sure you specify a valid <LicenseKey />.
 
   </Collapser>
 

--- a/src/content/docs/logs/forward-logs/google-cloud-platform-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/google-cloud-platform-log-forwarding.mdx
@@ -311,7 +311,7 @@ To send your GCP logs to New Relic using a Dataflow job, you will use our Datafl
     This command only requires these two values:
 
     * The input PubSub subscription used to read log messages
-    * The New Relic license key used to send your logs
+    * The New Relic <LicenseKey /> used to send your logs
 
     <CollapserGroup>
       <Collapser
@@ -361,7 +361,7 @@ To send your GCP logs to New Relic using a Dataflow job, you will use our Datafl
           </td>
 
           <td>
-            New Relic license key.
+            New Relic <LicenseKey />.
           </td>
         </tr>
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -983,7 +983,7 @@ This is a list of the environment variables you should export if you're doing tu
           <td>
             OTEL_EXPORTER_OTLP_HEADERS=api-key=YOUR_LICENSE_KEY
 
-            * Headers: This determines which New Relic account your data will be sent to. Replace `YOUR_LICENSE_KEY` with your license key>.
+            * Headers: This determines which New Relic account your data will be sent to. Replace `YOUR_LICENSE_KEY` with your <LicenseKey />.
           </td>
         </tr>
         <tr>

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -302,7 +302,7 @@ Whether you're considering New Relic or you're already using our capabilities, t
     id="application-name"
     title="application name"
   >
-    The name that New Relic combines with your license key to uniquely identify a particular app. For more information, see [Name your application](/docs/agents/manage-apm-agents/app-naming/name-your-application).
+    The name that New Relic combines with your <LicenseKey /> to uniquely identify a particular app. For more information, see [Name your application](/docs/agents/manage-apm-agents/app-naming/name-your-application).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
@@ -148,7 +148,7 @@ The `newrelic-lambda` CLI adds your New Relic <LicenseKey /> as a secret in [AWS
 <Callout variant="tip">
   **Storing the New Relic license key in the AWS Secrets Manager**
 
-  Your license key identifies and authenticates you to New Relic, allowing us to associate your telemetry with your New Relic account. Each function that sends telemetry needs access to this value, and it needs to be managed securely. The AWS Secrets Manager solves these problems.
+  Your <LicenseKey /> identifies and authenticates you to New Relic, allowing us to associate your telemetry with your New Relic account. Each function that sends telemetry needs access to this value, and it needs to be managed securely. The AWS Secrets Manager solves these problems.
 
   If your organization prevents you from using AWS Secrets Manager or if you need to store more than one secret per region, see below for an alternative method to set your license key.
 </Callout>
@@ -166,7 +166,7 @@ The `newrelic-lambda` CLI adds your New Relic <LicenseKey /> as a secret in [AWS
     the [linking process](/docs/integrations/amazon-integrations/get-started/connect-aws-new-relic-infrastructure-monitoring)
     manually. Be sure to enable Lambda when selecting services to be monitored.
 
-    Don't forget to configure the license key secret manually, as described next.
+    Don't forget to configure the <LicenseKey /> secret manually, as described next.
 
     ### Manually configure the license key secret
 
@@ -175,7 +175,7 @@ The `newrelic-lambda` CLI adds your New Relic <LicenseKey /> as a secret in [AWS
     1. Download this CloudFormation Template: [license-key-secret.yaml](https://github.com/newrelic/newrelic-lambda-cli/blob/master/newrelic_lambda_cli/templates/license-key-secret.yaml)
     2. Using the AWS CLI, or the AWS CloudFormation Console, install the template, supplying the `LicenseKey` parameter.
        It
-       will be labeled "INGEST - LICENSE". Be sure to use the license key for the account you configured with the Infrastructure UI above.
+       will be labeled "INGEST - LICENSE". Be sure to use the <LicenseKey /> for the account you configured with the Infrastructure UI above.
 
        AWS CLI example:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,10 +2609,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.16.2":
-  version "6.16.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.16.2.tgz#ff05ad55b260a2a87cc8cc85ea2039a291879ef5"
-  integrity sha512-HpEXnzwD5GD1iArsJZAf0ITlhYRvFBImchw67L2rbcKen4I61llI9auwjRLNmKPr95YIYAjn5Z2aw2t9ymofYQ==
+"@newrelic/gatsby-theme-newrelic@6.16.3":
+  version "6.16.3"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.16.3.tgz#e373d3253db68b617d5c34075c7e5af57cc533e1"
+  integrity sha512-L8WReUIWdj/b8Fm9mTdtXnKVRwOnWcQwvVMfwO35nErMAINECSg2pVu4J7JWfpA2k67EjSvm26LLFaFxIZenGA==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
This reinstates the instances(32) of the use of the new LicenseKey component that was removed from the initial PR due to a UI bug. 

This was the [commit](https://github.com/newrelic/docs-website/pull/11368/commits/ceb5d532703d1aa84d73477fc278f1937ebb3401) that removed them if a reference is needed to double check.

We are waiting for a theme repo update before merging to confirm it is working as expected. 