### PR TITLE
chore: add new relic deploy marker step on releasePRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-          
+
       - name: Setup python
         uses: actions/setup-python@v2
 
@@ -29,23 +29,33 @@ jobs:
         run: |
           echo LAST_RELEASE=$(git describe --tags --abbrev=0) >> $GITHUB_ENV
           echo $LAST_RELEASE
-            
+
       - name: Create release timestamp
         run: |
           echo RELEASE_TIMESTAMP=$(TZ=America/Los_Angeles date '+%m.%d.%Y-%H.%M') >> $GITHUB_ENV
-          
+
       - name: Create new release tag
         id: create-new-tag
         run: |
           echo NEW_TAG=$(echo "release-${{ env.RELEASE_TIMESTAMP }}") >> $GITHUB_ENV
-          
+
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install PyGithub
           pip install invoke
-          
+
       - name: Create Updates and Release
         id: py-get-updates
         run: |
           python ./scripts/actions/release-notes.py
+
+      - name: Set Release Version from Tag
+        run: echo "RELEASE_VERSION=${{ env.NEW_TAG }}" >> $GITHUB_ENV
+
+      - name: Create New Relic deployment marker
+        uses: newrelic/deployment-marker-action@v2-beta
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY_DEPLOY_MARKERS }}
+          guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
+          version: '${{ env.RELEASE_VERSION }}'


### PR DESCRIPTION
## Description

Adds a step on the release github workflow (when PRs close to `main`) to send a deploy marker to New Relic. Uses the release tag created in earlier step as release version name.

I also added the two required env vars to repo secrets:
* `NEW_RELIC_API_KEY_DEPLOY_MARKERS`: created new user key specifically for this
* `NEW_RELIC_DEPLOYMENT_ENTITY_GUID`: added the entity guid for prod app so we can see those markers alongside prod data in NR UI

## Links
- https://docs.newrelic.com/docs/change-tracking/ci-cd/change-tracking-github-actions/