### PR TITLE
Update aws-metric-stream-setup.mdx

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -228,7 +228,7 @@ To confirm you're receiving data from the Metric Streams, follow these steps:
 It may take few minutes until new resources are detected and synthesized as entities. See [cloud integrationssystem limits](/docs/data-apis/manage-data/view-system-limits) for more information.
 
 <Callout variant="tip">
-  AWS CloudWatch metrics for global services, such AWS Billing, is only availble in the **us-east-1** region. Make sure there's an active CloudWatch metric stream configured in that region.
+  AWS CloudWatch metrics for global services, such AWS Billing, are only availble in the **us-east-1** region. Make sure there's an active CloudWatch metric stream configured in that region.
 </Callout>
 
 ## Queries, metric storage, and mapping [#query-experience]

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup.mdx
@@ -228,7 +228,7 @@ To confirm you're receiving data from the Metric Streams, follow these steps:
 It may take few minutes until new resources are detected and synthesized as entities. See [cloud integrationssystem limits](/docs/data-apis/manage-data/view-system-limits) for more information.
 
 <Callout variant="tip">
-  AWS CloudWatch metrics for global services, such as AWS S3 or AWS Billing, are only availble in the **us-east-1** region. Make sure there's an active CloudWatch metric stream configured in that region.
+  AWS CloudWatch metrics for global services, such AWS Billing, is only availble in the **us-east-1** region. Make sure there's an active CloudWatch metric stream configured in that region.
 </Callout>
 
 ## Queries, metric storage, and mapping [#query-experience]


### PR DESCRIPTION
AWS S3 metrics can be deployed per region, this TIP is no longer accurate

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

Update out-of-date documentation, AWS S3 metrics can be obtained per region, they don't require metric stream configured in us-east-1