### PR TITLE
Php 55 56 eol

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -22,6 +22,10 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
 
 <Callout variant="important">
+  Support for PHP versions 5.5 and 5.6 will be end of lifed in June 2023.
+</Callout>
+
+<Callout variant="important">
   Compatibility note: When PHP 8.0 or 8.1 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
 
   Support for PHP 8.1 does not include Fibers.

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -26,7 +26,7 @@ New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
 
   Support for PHP 8.1 does not include Fibers.
 
-  Support for PHP versions 5.5 and 5.6 will be end of lifed in June 2023.
+Support for PHP versions 5.5 and 5.6 ends in June 2023.
 </Callout>
 
 * We recommend using a [supported release](http://php.net/supported-versions.php) of PHP.

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -22,13 +22,11 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
 
 <Callout variant="important">
-  Support for PHP versions 5.5 and 5.6 will be end of lifed in June 2023.
-</Callout>
-
-<Callout variant="important">
   Compatibility note: When PHP 8.0 or 8.1 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
 
   Support for PHP 8.1 does not include Fibers.
+
+  Support for PHP versions 5.5 and 5.6 will be end of lifed in June 2023.
 </Callout>
 
 * We recommend using a [supported release](http://php.net/supported-versions.php) of PHP.


### PR DESCRIPTION
PHP agent team is EOL'ing PHP 5.5 and 5.6 in June 2023 and this change adds this information to the compatibility page.