### PR TITLE
fix: Update Ruby APM agent version supported by Vuln Mgmt

### DIFF
--- a/src/content/docs/vulnerability-management/integrations/intro.mdx
+++ b/src/content/docs/vulnerability-management/integrations/intro.mdx
@@ -67,7 +67,7 @@ CVE detection coverage differs between agents:
     </tr>
     <tr>
       <td>Ruby</td>
-      <td>3.20.0 or higher</td>
+      <td>All supported versions</td>
       <td>Gems</td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR fixes the minimum version of the Ruby agent required for New Relic's Runtime SCA to operate