### PR TITLE
chore: bump theme to 6.16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.16.3",
+    "@newrelic/gatsby-theme-newrelic": "6.16.4",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,10 +2609,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.16.3":
-  version "6.16.3"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.16.3.tgz#e373d3253db68b617d5c34075c7e5af57cc533e1"
-  integrity sha512-L8WReUIWdj/b8Fm9mTdtXnKVRwOnWcQwvVMfwO35nErMAINECSg2pVu4J7JWfpA2k67EjSvm26LLFaFxIZenGA==
+"@newrelic/gatsby-theme-newrelic@6.16.4":
+  version "6.16.4"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.16.4.tgz#10047fa9b1f671047b442945f49b2e955491a5cf"
+  integrity sha512-zyxw+uK3HGbwBAyng69LHBi+B2PQn0JeM+MxX1fPwkeZ1VzqSwR5PdvbPTQ0sSE/FF41/a7dCBFgPhYF7bl7bQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
this fixes the collapser visibility bug