### PR TITLE
Changes 'tip' to cover third use-case

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -535,7 +535,7 @@ mutation {
 While you can't change the monitor type after creating it, you can update its settings. Only the guid and the settings that need updated are required as part of the request.
 
 <Callout variant="tip">
-  Include the runtime object that includes runtimeType, runtimeTypeVersion, and scriptLanguage to [upgrade a monitor](#upgrade-monitor-runtime) to use a newer runtime. Do not include this object and these attributes to continue using a legacy runtime.
+  Include the runtime object that includes runtimeType, runtimeTypeVersion, and scriptLanguage to [upgrade a monitor](#upgrade-monitor-runtime) to use a newer runtime. Include this object and set these attributes to empty string to downgrade to a legacy runtime. Do not include this object and these attributes to continue using a legacy runtime. 
 </Callout>
 
 <CollapserGroup>


### PR DESCRIPTION
In the 'Update your synthetic monitors', the current tip implies that not including the runtime will downgrade a monitor. However, you have to instead include runtime and set the attributes to empty strings ("") to downgrade the monitor.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

'Update your synthetic monitors' section does not cover the use-case for downgrading monitors

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Was told this by Engineering, verified in my test account

* If your issue relates to an existing GitHub issue, please link to it.