### PR TITLE
chore: remove new relic deploy marker job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,3 @@ jobs:
 
       - name: Set Release Version from Tag
         run: echo "RELEASE_VERSION=${{ env.NEW_TAG }}" >> $GITHUB_ENV
-
-      - name: Create New Relic deployment marker
-        uses: newrelic/deployment-marker-action@v2.1.0
-        with:
-          apiKey: ${{ secrets.NEW_RELIC_API_KEY_DEPLOY_MARKERS }}
-          guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
-          version: '${{ env.RELEASE_VERSION }}'
-          user: '${{ github.actor }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,9 @@ jobs:
         run: echo "RELEASE_VERSION=${{ env.NEW_TAG }}" >> $GITHUB_ENV
 
       - name: Create New Relic deployment marker
-        uses: newrelic/deployment-marker-action@v2-beta
+        uses: newrelic/deployment-marker-action@v2.1.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY_DEPLOY_MARKERS }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
           version: '${{ env.RELEASE_VERSION }}'
+          user: '${{ github.actor }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,12 @@ jobs:
 
       - name: Set Release Version from Tag
         run: echo "RELEASE_VERSION=${{ env.NEW_TAG }}" >> $GITHUB_ENV
+
+      - name: Create New Relic deployment marker
+        uses: newrelic/deployment-marker-action@v2.1.0
+        with:
+          apiKey: ${{ secrets.NEW_RELIC_API_KEY_DEPLOY_MARKERS }}
+          guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
+          region: 'staging'
+          version: '${{ env.RELEASE_VERSION }}'
+          user: '${{ github.actor }}'


### PR DESCRIPTION
## Description

Recent deploy marker job failed on release workflow.

I believe because our entity is behind staging. Seems like we be able to use `staging` as region for CLI to send request to right place.

## More info
 - https://github.com/newrelic/docs-website/actions/runs/4119431190/jobs/7113085120
 - https://github.com/newrelic/deployment-marker-action
 - https://docs.newrelic.com/docs/change-tracking/ci-cd/change-tracking-github-actions/
 - https://github.com/newrelic/docs-website/pull/11411