### PR TITLE
Updates deployment markers support for OTel

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -864,7 +864,7 @@ It may not necessarily be reported by the SDK in use, but users can manually set
 
 New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 👀 Limited support
 
-You can now [record a deployment](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/#start-tracking) and see it in the activity feed of your OpenTelemetry service. You will also see the change markers on the three charts in your Summary view, whereas New Relic APM will also display it in Transactions and database charts as well. 
+You can now [record a deployment](/docs/change-tracking/change-tracking-introduction/#start-tracking) and see it in the activity feed of your OpenTelemetry service. You can also see the change markers on the three charts in your **Summary** view, whereas New Relic APM displays it in Transactions and database charts as well. 
 
 ## Activity stream [#act-stream]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -864,7 +864,7 @@ It may not necessarily be reported by the SDK in use, but users can manually set
 
 New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 👀 Limited support
 
-There is no specification in OpenTelemetry for recording deployments. A potential workaround is to add a `service.version` attribute to spans, which you can then use to filter for different deployment versions in your environment. This workaround may not offer the same benefits you may be looking for. This is because the value of deployment markers is that they show up in the activity stream alongside anomalies and can be viewed in real time. However, it can still provide value by allowing filtering.
+You can now [record a deployment](https://docs.newrelic.com/docs/change-tracking/change-tracking-introduction/#start-tracking) and see it in the activity feed of your OpenTelemetry service. You will also see the change markers on the three charts in your Summary view, whereas New Relic APM will also display it in Transactions and database charts as well. 
 
 ## Activity stream [#act-stream]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -862,7 +862,7 @@ It may not necessarily be reported by the SDK in use, but users can manually set
 
 ## Deployments [#deploym]
 
-New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 👀 Limited support
+New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 🟡 Limited support in New Relic
 
 You can now [record a deployment](/docs/change-tracking/change-tracking-introduction/#start-tracking) and see it in the activity feed of your OpenTelemetry service. You can also see the change markers on the three charts in your **Summary** view, whereas New Relic APM displays it in Transactions and database charts as well. 
 


### PR DESCRIPTION
We added support for deployment markers for OTel recently. This PR updates the deployment markers section to reflect this change.

However, I need stakeholders to weigh in on what to update the status icon to -- it's not full parity with NR APM, because NR APM will also show deployment markers on Transaction and DB charts, whereas it's only available for the three Summary charts for OTel services. 