### PR TITLE
Release 2/13: Php agent release 10.6

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -27,6 +27,18 @@ Any versions not listed in the following table are no longer supported. Please [
   </thead>
 
   <tbody>
+
+    <tr>
+      <td>
+        v10.6.0.318
+      </td>
+      <td>
+        Feb 08, 2023
+      </td>
+      <td>
+        Feb 08, 2024
+      </td>
+    </tr>
     
     <tr>
       <td>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -314,19 +314,5 @@ Any versions not listed in the following table are no longer supported. Please [
       </td>
     </tr>
     
-    <tr>
-      <td>
-        v9.6.1.256
-      </td>
-
-      <td>
-        Jan 22, 2020
-      </td>
-
-      <td>
-        Jan 22, 2023
-      </td>
-    </tr>
-    
   </tbody>
 </table>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -33,10 +33,10 @@ Any versions not listed in the following table are no longer supported. Please [
         v10.6.0.318
       </td>
       <td>
-        Feb 08, 2023
+        Feb 13, 2023
       </td>
       <td>
-        Feb 08, 2024
+        Feb 13, 2024
       </td>
     </tr>
     

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -312,19 +312,5 @@ Any versions not listed in the following table are no longer supported. Please [
       </td>
     </tr>
     
-    <tr>
-      <td>
-        v9.7.0.258
-      </td>
-
-      <td>
-        Feb 11, 2020
-      </td>
-
-      <td>
-        Feb 11, 2023
-      </td>
-    </tr>
-    
   </tbody>
 </table>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-6-0-318.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-6-0-318.mdx
@@ -11,7 +11,7 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/10.6.0.318'
 * Code Level Metrics (CLM) is now enabled by default.
    - CLM allows you to gather more data associated with each span, including line numbers, function names, filepaths, and namespaces.
    - CLM was introduced in release [10.4.0.316](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-4-0-316/).
-   - Use [this ini value](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-code-level-metrics) to configure CLM.
+   - Use [this ini value](https://docs.newrelic.com/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-code-level-metrics) to configure CLM.
 
 ### Important end-of-life information
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-6-0-318.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-6-0-318.mdx
@@ -1,6 +1,6 @@
 ---
 subject: PHP agent
-releaseDate: '2023-02-08'
+releaseDate: '2023-02-13'
 version: 10.6.0.318
 downloadLink: 'https://download.newrelic.com/php_agent/archive/10.6.0.318'
 ---
@@ -10,8 +10,12 @@ downloadLink: 'https://download.newrelic.com/php_agent/archive/10.6.0.318'
 
 * Code Level Metrics (CLM) is now enabled by default.
    - CLM allows you to gather more data associated with each span, including line numbers, function names, filepaths, and namespaces.
-   - CLM was introduced in release [10.4.0.316](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-4-0-316/)
+   - CLM was introduced in release [10.4.0.316](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-4-0-316/).
    - Use [this ini value](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-code-level-metrics) to configure CLM.
+
+### Important end-of-life information
+
+* Support for PHP versions 5.5 and 5.6 will end June 2023.
 
 ### Support statement
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-6-0-318.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-6-0-318.mdx
@@ -1,0 +1,30 @@
+---
+subject: PHP agent
+releaseDate: '2023-02-08'
+version: 10.6.0.318
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.6.0.318'
+---
+## New Relic PHP Agent v10.6.0.318
+
+### New features
+
+* Code Level Metrics (CLM) is now enabled by default.
+   - CLM allows you to gather more data associated with each span, including line numbers, function names, filepaths, and namespaces.
+   - CLM was introduced in release [10.4.0.316](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-4-0-316/)
+   - Use [this ini value](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-code-level-metrics) to configure CLM.
+
+### Support statement
+
+* Support for 32 bit and FreeBSD ended with release v9.19.0.309 and those binaries **are no longer provided**.
+* Support for ZTS builds ended with release v9.19.0.309.
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform (32 bit, FreeBSD, ZTS, etc), it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages which are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>
+


### PR DESCRIPTION
The PHP agent team is working on releasing the agent with code level metrics (CLM) on by default.
Currently this release is planned for Monday, February 13th.
This PR handles the Release Notes for this 10.6.0 release, as well as updates the EOL matrix for PHP Agents.
This PR is in conjunction with #11391