### PR TITLE
Browser agent release v1224

### DIFF
--- a/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
@@ -29,6 +29,34 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v1224
+      </td>
+
+      <td>
+        Feb 8, 2023
+      </td>
+
+      <td>
+        Feb 8, 2024
+      </td>
+    </tr>
+  
+    <tr>
+      <td>
+        v1223
+      </td>
+
+      <td>
+        Jan 27, 2023
+      </td>
+
+      <td>
+        Jan 27, 2024
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
         v1222
       </td>
 

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1224.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1224.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Browser agent
-releaseDate: '2023-02-09'
+releaseDate: '2023-02-08'
 version: '1224'
 ---
 

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1224.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1224.mdx
@@ -1,0 +1,38 @@
+---
+subject: Browser agent
+releaseDate: '2023-02-09'
+version: '1224'
+---
+
+## New Features
+
+### Support SPA, XHR, and session trace features on Chrome for iOS
+Previously, the agent did not collect SPA browser interactions, XHR events, or session trace data in Chrome for iOS (which uses the webkit engine with modifications). The agent will now collect the same data in Chrome for iOS as in other supported browsers.
+
+### Expose build version to newrelic global
+The build version will now be exposed to the `newrelic` global object. It can be accessed under `newrelic.intializedAgents[<agentID>].runtime.version`.
+
+## Internal
+
+### Add automation for docs-site updates on new releases
+A new release of the browser agent will automatically raise a PR to the docs-site team with relevant changelog items.
+
+## Bug Fixes
+
+### Fix multiple custom interaction end times
+Fixed an issue where multiple custom interactions harvested at the same time would result in only one interaction being persisted in NR1.
+
+### Prevent AJAX time slice metrics based on deny list
+Prevent time slice metric collection for AJAX calls when such a call matches an entry in the AJAX deny list.
+
+### Bind navigator scope to sendBeacon
+Some browser versions will throw errors if sendBeacon does not have the navigator scope bound to it. A fail-safe action of binding the navigator scope to sendBeacon was added to try to support those browsers.
+
+### Preserve unhandledPromiseRejection reasons as human-readable strings in error payloads
+The agent will attempt to preserve unhandledPromiseRejection reasons as human-readable messages on the Error payload that gets harvested. The previous strategy did not always work, because Promise.reject can pass any value, not just strings.
+
+### Fix missing interactions for dynamic routes in Next/React
+Fixed an issue where when using the SPA loader with Next/React, route changes that lazy loaded components would not be captured. While the issue specifically called out Next/React, this should apply to Nuxt/Vue and Angular.
+
+### Fix interactions missing API calls in Angular
+Fixed an issue where when using the SPA loader with Angular, route changes that contained API calls, via Angular resolver, would not capture the xhr/fetch on the interaction. This works with eager and lazy routes in an Angular SPA.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1224.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1224.mdx
@@ -7,32 +7,32 @@ version: '1224'
 ## New Features
 
 ### Support SPA, XHR, and session trace features on Chrome for iOS
-Previously, the agent did not collect SPA browser interactions, XHR events, or session trace data in Chrome for iOS (which uses the webkit engine with modifications). The agent will now collect the same data in Chrome for iOS as in other supported browsers.
+Previously, the agent didn't collect SPA browser interactions, XHR events, or session trace data in Chrome for iOS, which uses the webkit engine with modifications. The agent now collects the same data in Chrome for iOS as in other supported browsers.
 
 ### Expose build version to newrelic global
-The build version will now be exposed to the `newrelic` global object. It can be accessed under `newrelic.intializedAgents[<agentID>].runtime.version`.
+The build version is exposed to the `newrelic` global object. You can be access it with `newrelic.intializedAgents[<agentID>].runtime.version`.
 
 ## Internal
 
-### Add automation for docs-site updates on new releases
-A new release of the browser agent will automatically raise a PR to the docs-site team with relevant changelog items.
+### Add automation for documentation site updates on new releases
+A new release of the browser agent will automatically raise a PR to the documentation site with the relevant changelog items.
 
 ## Bug Fixes
 
 ### Fix multiple custom interaction end times
-Fixed an issue where multiple custom interactions harvested at the same time would result in only one interaction being persisted in NR1.
+Fixed an issue where multiple custom interactions harvested at the same time would result in only one interaction being persisted in New Relic.
 
 ### Prevent AJAX time slice metrics based on deny list
 Prevent time slice metric collection for AJAX calls when such a call matches an entry in the AJAX deny list.
 
 ### Bind navigator scope to sendBeacon
-Some browser versions will throw errors if sendBeacon does not have the navigator scope bound to it. A fail-safe action of binding the navigator scope to sendBeacon was added to try to support those browsers.
+Some browser versions will throw errors if sendBeacon doesn't have the navigator scope bound to it. A fail-safe action of binding the navigator scope to sendBeacon was added to try to support those browsers.
 
 ### Preserve unhandledPromiseRejection reasons as human-readable strings in error payloads
-The agent will attempt to preserve unhandledPromiseRejection reasons as human-readable messages on the Error payload that gets harvested. The previous strategy did not always work, because Promise.reject can pass any value, not just strings.
+The agent will attempt to preserve `unhandledPromiseRejection` reasons as human-readable messages on the Error payload that gets harvested. The previous strategy didn't always work, because `Promise.reject` can pass any value, not just strings.
 
 ### Fix missing interactions for dynamic routes in Next/React
-Fixed an issue where when using the SPA loader with Next/React, route changes that lazy loaded components would not be captured. While the issue specifically called out Next/React, this should apply to Nuxt/Vue and Angular.
+Fixed an issue where when using the SPA loader with Next/React, route changes that lazy loaded components wouldn't be captured. While the issue specifically called out Next/React, this should apply to Nuxt/Vue and Angular.
 
 ### Fix interactions missing API calls in Angular
-Fixed an issue where when using the SPA loader with Angular, route changes that contained API calls, via Angular resolver, would not capture the xhr/fetch on the interaction. This works with eager and lazy routes in an Angular SPA.
+Fixed an issue where when using the SPA loader with Angular, route changes that contained API calls, via Angular resolver, wouldn't capture the xhr/fetch on the interaction. This works with eager and lazy routes in an Angular SPA.


### PR DESCRIPTION
These release notes coincide with our roll-out of v1224 of the browser agent. The release date on our repo is February 8 (today) and the roll-out is targeted to begin Friday, February 9.