### PR TITLE
fix(APM): Added missing video that the doc references

### DIFF
--- a/src/content/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction.mdx
+++ b/src/content/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction.mdx
@@ -271,6 +271,12 @@ You can define Apdex T values for each application. You can also define individu
 
 For a quick overview of why Apdex measurements matter, and how to know what threshold is right for your application, watch this short YouTube video (approx. 3:40 minutes).
 
+<Video
+  id="RoLIBfEpYZg"
+  type="youtube"
+/>
+
+
 <CollapserGroup>
   <Collapser
     className="freq-link"


### PR DESCRIPTION
This doc referred to a video that was missing. I added it back in.