### PR TITLE
fix (agent release notes): update front matter field names 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -373,8 +373,8 @@ module.exports = {
                 subject
                 releaseDate(fromNow: false)
                 version
-                feature
-                bug
+                features
+                bugs
                 security
                 ingest
               }
@@ -390,8 +390,8 @@ module.exports = {
               agent: getAgentName(frontmatter.subject),
               date: frontmatter.releaseDate,
               version: frontmatter.version,
-              feature: frontmatter.feature,
-              bug: frontmatter.bug,
+              features: frontmatter.features,
+              bugs: frontmatter.bugs,
               security: frontmatter.security,
               ingest: frontmatter.ingest,
               description: excerpt,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -326,8 +326,8 @@ exports.createSchemaCustomization = ({ actions }) => {
     translationType: String
     dataSource: String
     isTutorial: Boolean
-    feature: [String]
-    bug: [String]
+    features: [String]
+    bugs: [String]
     security: [String]
     ingest: [String]
   }
@@ -373,13 +373,13 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve: (source) =>
           hasOwnProperty(source, 'isTutorial') ? source.isTutorial : null,
       },
-      feature: {
+      features: {
         resolve: (source) =>
-          hasOwnProperty(source, 'feature') ? source.feature : null,
+          hasOwnProperty(source, 'features') ? source.features : null,
       },
-      bug: {
+      bugs: {
         resolve: (source) =>
-          hasOwnProperty(source, 'bug') ? source.bug : null,
+          hasOwnProperty(source, 'bugs') ? source.bugs : null,
       },
       security: {
         resolve: (source) =>

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8150.mdx
@@ -3,7 +3,7 @@ subject: Ruby agent
 releaseDate: '2023-01-09'
 version: 8.15.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.15.0.gem'
-feature: ['Add Support for Ruby 3.2.0', 'Add instrumentation for concurrent-ruby', 'Infinite Tracing: Use batching and compression by default', 'Add Support for Padrino 0.15.2 and Sinatra 3']
+features: ['Add Support for Ruby 3.2.0', 'Add instrumentation for concurrent-ruby', 'Infinite Tracing: Use batching and compression by default', 'Add Support for Padrino 0.15.2 and Sinatra 3']
 ---
 
 <Callout variant="important">


### PR DESCRIPTION
This is a followup to [the original PR](https://github.com/newrelic/docs-website/pull/11306) that added four new fields to the front matter of agent release notes. This PR updates two field names to be pluralized for consistency.

`feature` -> `features`
`bug` -> `bugs`

@clarkmcadoo @LizBaker @roadlittledawn 