### PR TITLE
chore(PHP agent): Remove Kohana from supported frameworks

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -181,7 +181,7 @@ Supported PHP frameworks include:
 
     <tr>
       <td>
-        Kohana 3.2 and 3.3
+        Laminas 3.x
       </td>
 
       <td>
@@ -191,7 +191,7 @@ Supported PHP frameworks include:
 
     <tr>
       <td>
-        Laminas 3.x
+        Laravel Lumen 6.x, 7.x, and 8.x
       </td>
 
       <td>
@@ -205,7 +205,7 @@ Supported PHP frameworks include:
       </td>
     
       <td>
-        Laravel Lumen 6.x, 7.x, and 8.x
+        
       </td>
 
 


### PR DESCRIPTION
Support for the Kohana framework was removed in PHP agent release 9.17 and this fix removes it from the compatibility page.