### PR TITLE
chore(PHP agent): Remove kohana framework from config docs

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -371,7 +371,6 @@ These settings are available in the `newrelic.ini` file.
     * `"drupal"` (for Drupal 6 and 7)
     * `"drupal8"`
     * `"joomla"`
-    * `"kohana"`
     * `"laravel"`
     * `"magento"`
     * `"magento2"`


### PR DESCRIPTION
Removing reference to unsupported Kohana framework for PHP agent.