### PR TITLE
[Chore] Update install-kubernetes-integration-using-helm.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -106,7 +106,7 @@ While it's possible to install those charts separately, we strongly recommend us
 4. Make sure everything is configured properly in the chart by running the following command. Notice that we're specifying `--dry-run` and `--debug`, so nothing will be installed in this step:
 
   ```shell
-    helm upgrade --install newrelic newrelic/nri-bundle \
+    helm upgrade --install newrelic-bundle newrelic/nri-bundle \
 --namespace newrelic --create-namespace \
   -f values-newrelic.yaml \
   --dry-run \
@@ -127,7 +127,7 @@ While it's possible to install those charts separately, we strongly recommend us
 5. Install the Kubernetes integration by running the command without `--debug` and `--dry-run`:
 
   ```shell
-  helm upgrade --install newrelic newrelic/nri-bundle \
+  helm upgrade --install newrelic-bundle newrelic/nri-bundle \
   --namespace newrelic --create-namespace \
   -f values-newrelic.yaml 
   ```
@@ -180,7 +180,7 @@ You should see:
     3. Make sure everything is configured properly in the chart by running the following command. This step uses the `--dry-run` and `--debug` switches and therefore the agent is not installed.
 
        ```shell
-       helm upgrade --install newrelic newrelic/nri-bundle \
+       helm upgrade --install newrelic-bundle newrelic/nri-bundle \
        --version 3.2.11 \
        --dry-run \
        --debug \
@@ -198,7 +198,7 @@ You should see:
     4. Install the New Relic Kubernetes integration by running the same command without `--dry-run` and `--debug`
 
        ```shell
-       helm upgrade --install newrelic newrelic/nri-bundle \
+       helm upgrade --install newrelic-bundle newrelic/nri-bundle \
        --version 3.2.11 \
        --namespace newrelic \
        --set global.licenseKey=_YOUR_NEW_RELIC_LICENSE_KEY_ \


### PR DESCRIPTION
This updates the release name to `newrelic-bundle` as seen in the chart docs and elsewhere: https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle#configure-components

* What problems does this PR solve?

The chart release name must be referenced in other Helm commands used throughout the lifecycle of the deployment, and other docs use `newrelic-bundle` for the release name.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Reference to release name in nri-bundle chart docs: https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle#configure-components

* If your issue relates to an existing GitHub issue, please link to it.

N/A