### PR TITLE
Edit out an incorrect release note

### DIFF
--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1225.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1225.mdx
@@ -9,11 +9,6 @@ version: '1225'
 ### Gracefully abort agent if not fully instantiated
 When importing of agent code fails, as when content gets blocked, the agent will clean up memory, the global scope, and any wrapped or modified APIs as much as feasible.
 
-## Internal
-
-### Clean up miscellaneous deprecated code
-Some older IE-related code has been removed, as well as a query parameter in our `pageView` RUM call that's no longer being used.
-
 ## Bug Fixes
 
 ### Resolve Google indexing of agent relative paths


### PR DESCRIPTION
## Give us some context

Removes a section from the browser agent v1225 release notes. The redacted text does not accurately reflect the release.