### PR TITLE
Remove Maximum Package Version from Python Agent docs

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
@@ -392,10 +392,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
       </th>
 
       <th>
-        Maximum package version
-      </th>
-
-      <th>
         Minimum agent version
       </th>
     </tr>
@@ -413,10 +409,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
 
       <td>
         2.0.14
-      </td>
-
-      <td>
-        latest
       </td>
 
       <td>
@@ -438,10 +430,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
       </td>
 
       <td>
-        latest
-      </td>
-
-      <td>
         2.74.0.54
       </td>
     </tr>
@@ -457,10 +445,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
 
       <td>
         2.6.2
-      </td>
-
-      <td>
-        latest
       </td>
 
       <td>
@@ -482,10 +466,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
       </td>
 
       <td>
-        latest
-      </td>
-
-      <td>
         7.6.0.173
       </td>
     </tr>
@@ -501,10 +481,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
 
       <td>
         1.3.1
-      </td>
-
-      <td>
-        latest
       </td>
 
       <td>
@@ -526,10 +502,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
       </td>
 
       <td>
-        latest
-      </td>
-
-      <td>
         2.76.0.55
       </td>
     </tr>
@@ -545,10 +517,6 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
 
       <td>
         0.45
-      </td>
-
-      <td>
-        7.17.5
       </td>
 
       <td>


### PR DESCRIPTION
This PR remove the Maximum Package Version column from the instrumented database table in the Python Agent docs (since now they are all at "latest")