### PR TITLE
fix(best practice guides): new overview doc

### DIFF
--- a/src/content/docs/new-relic-solutions/best-practices-guides/cx-improve-page-load.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/cx-improve-page-load.mdx
@@ -1,5 +1,5 @@
 ---
-title: Improve page load performance
+title: Guide to improving page load performance
 tags:
   - Observability maturity
   - Customer experience

--- a/src/content/docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime.mdx
@@ -1,5 +1,5 @@
 ---
-title: Improve web uptime
+title: Guide to improving web uptime
 tags:
   - Observability maturity
   - Customer experience

--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices.mdx
@@ -1,0 +1,26 @@
+---
+title: Overview of best practice guides 
+tags:
+  - New Relic solutions
+  - Best practices guides
+metaDescription: A list of New Relic best practice guides. 
+redirects:
+---
+
+Our best practice guides contain tips for using various New Relic features better and more optimally. These guides are meant to supplement our general docs. 
+
+Here's a list of our best practice guides: 
+
+* [Alerting best practice guide](/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices)
+* [APM best practice guide](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/apm-best-practices-guide)
+* Browser monitoring: 
+  * [Browser monitoring best practice guide](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide)
+  * [Browser and Java best practice guide](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java)
+  * [Improve page load](/docs/new-relic-solutions/best-practices-guides/cx-improve-page-load)
+  * [Improve web uptime](/docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime)
+* [Infrastructure monitoring best practice guide](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/infrastructure-monitoring-best-practices-guide)
+* [Logging best practice guide](/docs/logs/get-started/logging-best-practices)
+* [Mobile monitoring best practice guide](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/mobile-monitoring-best-practices-guide)
+* [Synthetic monitoring best practice guide](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide)
+
+Want to get to the next level of observability optimization? See our [observability maturity guides](/docs/new-relic-solutions/observability-maturity/introduction). 

--- a/src/content/docs/new-relic-solutions/overview.mdx
+++ b/src/content/docs/new-relic-solutions/overview.mdx
@@ -16,7 +16,7 @@ Our guides give you best practices and tips for optimizing how you use New Relic
 Here's an overview of our guides: 
 
 * **Set up New Relic**: see [our Install doc](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic) for options.
-* **Learn about the platform**: want to understand common platform experiences and features? [Get to know the platform.](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-one)
+* **Learn about the platform**: want to understand common platform experiences and features? [Get to know the platform](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-one).
 * **Best practice guides**: [Learn best practices for some core New Relic capabilities](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices).
 * **Observability maturity**: [Our observability maturity series](/docs/new-relic-solutions/observability-maturity/introduction) helps you optimize your observability practice and methods. 
 * **Terraform guides**: [Guides to using Terraform](/docs/more-integrations/terraform/terraform-intro) to scale your deployment of New Relic.  

--- a/src/content/docs/new-relic-solutions/overview.mdx
+++ b/src/content/docs/new-relic-solutions/overview.mdx
@@ -3,7 +3,7 @@ title: Solutions, guides, and best practices
 type: landingPage
 tags:
   - New Relic solutions
-metaDescription: New Relic best practice guides and solutions landing page.
+metaDescription: An overview of New Relic guides for helping you optimize your monitoring and observability practices.  
 redirects:
   - /docs/solutions-best-practices-landing-page
   - /docs/using-new-relic/welcome-new-relic/measure-devops-success/guide-measuring-devops-success
@@ -11,15 +11,14 @@ redirects:
   - /docs/new-relic-solutions/table-of-contents
 ---
 
-You need to know exactly how your software performs so you can identify issues, resolve them quickly, and track improvements. And you want to learn from each iteration so your software, customer experience, and business outcomes become even better.
+Our guides give you best practices and tips for optimizing how you use New Relic. If you don't yet have New Relic and have questions, [contact New Relic sales](https://newrelic.com/contact-sales). 
 
-Our guides provide a foundation you can build on and customize based on your goals. During each step of your journey, we can help you with recommended key performance indicators (KPIs), dashboards, how-to docs, and more. If you're not yet a New Relic customer and you have questions, [contact New Relic sales](https://newrelic.com/contact-sales). 
-
-Using our proven methodology, recommendations, and expert guidance, your organization can move faster, stay on course, and transform successfully! Get started with our guides: 
+Here's an overview of our guides: 
 
 * **Set up New Relic**: see [our Install doc](/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic) for options.
-* **Learn about the platform**: want to understand common platform experiences and features? See [our platform UI docs](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-one). 
-* **Best practices guides**: [Learn best practices for some key New Relic features](/docs/new-relic-solutions/best-practices-guides).
-* **Observability maturity**: [Our observability maturity series](/docs/new-relic-solutions/observability-maturity/introduction) identifies common observability goals and teaches you how to meet them. 
+* **Learn about the platform**: want to understand common platform experiences and features? [Get to know the platform.](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-one)
+* **Best practice guides**: [Learn best practices for some core New Relic capabilities](/docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices).
+* **Observability maturity**: [Our observability maturity series](/docs/new-relic-solutions/observability-maturity/introduction) helps you optimize your observability practice and methods. 
+* **Terraform guides**: [Guides to using Terraform](/docs/more-integrations/terraform/terraform-intro) to scale your deployment of New Relic.  
 * **Cloud migration solutions**: Moving to the cloud? Learn how to [create application anomalies](/docs/new-relic-solutions/new-relic-solutions/create-application-baselines) and [optimize your architecture and spend](/docs/new-relic-solutions/new-relic-solutions/optimize-cloud-architecture-spend-continuously-improve-your-modern-cloud-environment).
 * **Solve common issues**: [Find help, run diagnostics, and troubleshoot common problems](/docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal).

--- a/src/nav/alerts-applied-intelligence.yml
+++ b/src/nav/alerts-applied-intelligence.yml
@@ -3,6 +3,8 @@ path: /docs/alerts-applied-intelligence
 pages:
   - title: Introduction to alerts and applied intelligence
     path: /docs/alerts-applied-intelligence/overview
+  - title: Alerting best practice guide
+    path: /docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices
   - title: Transition guide
     path: /docs/alerts-applied-intelligence/transition-guide
   - title: Detect problems in your system

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -3,6 +3,8 @@ path: /docs/apm
 pages:
   - title: Introduction to APM
     path: /docs/apm/new-relic-apm/getting-started/introduction-apm
+  - title: APM best practice guide
+    path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/apm-best-practices-guide
   - title: APM data security
     path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
   - title: Install and configure APM agents
@@ -210,7 +212,7 @@ pages:
                 path: /docs/apm/agents/java-agent/instrumentation/monitor-deployments-java-agent
               - title: Instrument webpages via API
                 path: /docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api
-              - title: Browser best practices
+              - title: Browser monitoring best practices
                 path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java
               - title: Instrument Kafka message queues
                 path: /docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -35,11 +35,11 @@ pages:
         path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
   - title: Guides
     pages: 
-      - title: Browser best practice guide
+      - title: Browser monitoring best practices
         path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide
-      - title: "Guide: Improve page load"
+      - title: Improving page load
         path: /docs/new-relic-solutions/best-practices-guides/cx-improve-page-load
-      - title: "Guide: Improve web uptime"
+      - title: Improving web uptime
         path: /docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime
   - title: View browser data
     pages:

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -37,9 +37,9 @@ pages:
     pages: 
       - title: Browser best practice guide
         path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide
-        title: Improve page load
+      - title: "Guide: Improve page load"
         path: /docs/new-relic-solutions/best-practices-guides/cx-improve-page-load
-        title: Improve web uptime
+      - title: "Guide: Improve web uptime"
         path: /docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime
   - title: View browser data
     pages:

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -3,8 +3,6 @@ path: /docs/browser
 pages:
   - title: Intro to browser monitoring
     path: /docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring
-  - title: Best practices
-    path: /docs/browser/browser-monitoring/guides/browser-monitoring-best-practices-guide
   - title: Installation
     pages:
       - title: Install the browser agent
@@ -35,6 +33,14 @@ pages:
         path: /docs/browser/new-relic-browser/configuration/rename-browser-apps
       - title: Delete browser apps
         path: /docs/browser/new-relic-browser/installation/delete-apps-new-relic-browser
+  - title: Guides
+    pages: 
+      - title: Browser best practice guide
+        path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide
+        title: Improve page load
+        path: /docs/new-relic-solutions/best-practices-guides/cx-improve-page-load
+        title: Improve web uptime
+        path: /docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime
   - title: View browser data
     pages:
       - title: Overview of browser UI features

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -91,6 +91,8 @@ pages:
         path: /docs/new-relic-solutions/overview
       - title: New Relic glossary
         path: /docs/new-relic-solutions/get-started/glossary
+      - title: Best practice guides
+        path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices
       - title: Observability maturity guides
         pages:
           - title: Introduction
@@ -139,8 +141,6 @@ pages:
                 path: /docs/new-relic-solutions/observability-maturity/innovation-growth/improving-development-quality-guide
               - title: Release quality
                 path: /docs/new-relic-solutions/observability-maturity/innovation-growth/development-release-quality-guide
-      - title: Best practice guides
-        path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices
       - title: Cloud optimization guides
         pages:
           - title: Create app baselines

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -141,28 +141,8 @@ pages:
                 path: /docs/new-relic-solutions/observability-maturity/innovation-growth/development-release-quality-guide
       - title: Best practice guides
         pages:
-          - title: Alerts best practices
-            path: /docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices
-          - title: APM best practices
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/apm-best-practices-guide
-          - title: Browser and Java agent
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java
-          - title: Browser monitoring best practices
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-guide
-          - title: Improve page load
-            path: /docs/new-relic-solutions/best-practices-guides/cx-improve-page-load       
-          - title: Improve web uptime
-            path: /docs/new-relic-solutions/best-practices-guides/cx-improve-web-uptime
-          - title: Improve page load
-            path: /docs/new-relic-solutions/best-practices-guides/cx-improve-page-load
-          - title: Infrastructure monitoring best practices
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/infrastructure-monitoring-best-practices-guide
-          - title: Logging best practices
-            path: /docs/logs/get-started/logging-best-practices
-          - title: Mobile monitoring best practices
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/mobile-monitoring-best-practices-guide
-          - title: Synthetic monitoring best practices
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide
+          - title: List of best practice guides
+            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices
       - title: Cloud optimization guides
         pages:
           - title: Create app baselines

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -140,9 +140,7 @@ pages:
               - title: Release quality
                 path: /docs/new-relic-solutions/observability-maturity/innovation-growth/development-release-quality-guide
       - title: Best practice guides
-        pages:
-          - title: List of best practice guides
-            path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices
+        path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/overview-best-practices
       - title: Cloud optimization guides
         pages:
           - title: Create app baselines


### PR DESCRIPTION
NR-84528
Work done: 
Remove best practice guides from 'Guides' nav
Create 'Overview of best practice guides' that links out to the docs