### PR TITLE
Move doc tile component

### DIFF
--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -103,6 +103,14 @@ module.exports = {
     deserialize: deserializeComponent,
     serialize: serializeComponent,
   },
+  DocTile: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
+  DocTiles: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
   DoNotTranslate: {
     deserialize: deserializeComponent,
     serialize: (h, node) =>

--- a/src/components/DocTile.js
+++ b/src/components/DocTile.js
@@ -118,6 +118,10 @@ DocTile.propTypes = {
   label: PropTypes.array,
   date: PropTypes.string,
   instrumentation: PropTypes.object,
+  children: PropTypes.node,
+  path: PropTypes.string,
+  number: PropTypes.number,
+  className: PropTypes.string,
 };
 
 export const DocTiles = ({ children, numbered = false }) => (

--- a/src/components/DocTile.js
+++ b/src/components/DocTile.js
@@ -1,0 +1,164 @@
+import React, { cloneElement } from 'react';
+import { Icon, Surface, Tag } from '@newrelic/gatsby-theme-newrelic';
+import SurfaceLink from './SurfaceLink';
+import { css } from '@emotion/react';
+import PropTypes from 'prop-types';
+
+export const DocTile = ({
+  children,
+  path,
+  instrumentation,
+  label,
+  date,
+  number,
+  className,
+}) => (
+  <SurfaceLink
+    base={Surface.BASE.SECONDARY}
+    to={path}
+    interactive
+    instrumentation={instrumentation}
+    css={css`
+      display: block;
+      min-height: 130px;
+      border-radius: 4px;
+      background: var(--secondary-background-color);
+
+      .dark-mode & {
+        background: var(--secondary-background-color);
+      }
+
+      @media screen and (max-width: 1050px) {
+        &:not(:last-child) {
+          margin-bottom: 2rem;
+        }
+      }
+
+      @media screen and (max-width: 760px) {
+        && {
+          margin-bottom: 0;
+        }
+      }
+
+      @media screen and (max-width: 650px) {
+        font-size: 14px;
+        &:not(:last-child) {
+          margin-bottom: 2rem;
+        }
+      }
+    `}
+    className={className}
+  >
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        justify-content: space-between;
+        align-items: space-between;
+        padding: 2rem;
+
+        @media screen and (max-width: 650px) {
+          padding: 1.5rem;
+        }
+      `}
+    >
+      <h4
+        css={css`
+          font-weight: 400;
+          font-size: 20px;
+          display: flex;
+          gap: 1rem;
+          margin-bottom: 1rem;
+        `}
+      >
+        {number && (
+          <span
+            css={css`
+              flex: none;
+              display: inline-flex;
+              justify-content: center;
+              align-items: center;
+              height: 2rem;
+              width: 2rem;
+              border-radius: 50%;
+              background: var(--brand-button-primary-accent);
+              color: var(--system-text-primary-light);
+            `}
+          >
+            {number}
+          </span>
+        )}
+        {children}
+      </h4>
+      <div
+        css={css`
+          display: flex;
+          justify-content: space-between;
+        `}
+      >
+        {label && (
+          <Tag
+            css={css`
+              background: ${label.color};
+              color: var(--system-text-primary-light);
+
+              .dark-mode & {
+                background: ${label.color};
+                color: var(--system-text-primary-light);
+              }
+            `}
+          >
+            {label.text}
+          </Tag>
+        )}
+        {date && (
+          <Tag
+            css={css`
+              color: var(--primary-text-color);
+            `}
+          >
+            {date}
+          </Tag>
+        )}
+        <Icon
+          name="fe-arrow-right"
+          css={css`
+            color: var(--primary-text-color);
+            margin-left: auto;
+          `}
+        />
+      </div>
+    </div>
+  </SurfaceLink>
+);
+
+DocTile.propTypes = {
+  label: PropTypes.array,
+  date: PropTypes.string,
+  instrumentation: PropTypes.object,
+};
+
+export const DocTiles = ({ children, numbered = false }) => (
+  <div
+    css={css`
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(255px, 1fr));
+      grid-auto-rows: 1fr;
+      grid-gap: 1rem;
+      a {
+        margin: 0;
+      }
+      margin: 1rem 0;
+    `}
+  >
+    {numbered
+      ? children.map((child, idx) => cloneElement(child, { number: ++idx }))
+      : children}
+  </div>
+);
+
+DocTiles.propTypes = {
+  children: PropTypes.node,
+  numbered: PropTypes.bool,
+};

--- a/src/components/DocTile.js
+++ b/src/components/DocTile.js
@@ -27,25 +27,6 @@ export const DocTile = ({
       .dark-mode & {
         background: var(--secondary-background-color);
       }
-
-      @media screen and (max-width: 1050px) {
-        &:not(:last-child) {
-          margin-bottom: 2rem;
-        }
-      }
-
-      @media screen and (max-width: 760px) {
-        && {
-          margin-bottom: 0;
-        }
-      }
-
-      @media screen and (max-width: 650px) {
-        font-size: 14px;
-        &:not(:last-child) {
-          margin-bottom: 2rem;
-        }
-      }
     `}
     className={className}
   >

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -10,7 +10,9 @@ import {
   SideBySide,
   Side,
 } from '@newrelic/gatsby-theme-newrelic';
+import { css } from '@emotion/react';
 
+import { DocTile, DocTiles } from './DocTile';
 import LandingPageHero from './LandingPageHero';
 import LandingPageTile from './LandingPageTile';
 import LandingPageTileGrid from './LandingPageTileGrid';
@@ -62,6 +64,17 @@ const defaultComponents = {
         />
       </Lightbox>
     ),
+  DocTile: (props) => (
+    <DocTile
+      css={css`
+        margin: 1rem 0;
+      `}
+      {...props}
+    >
+      {props.children}
+    </DocTile>
+  ),
+  DocTiles,
   ExternalLink: (props) => (
     <ExternalLink {...props} onClick={(e) => e.stopPropagation()} />
   ),

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,20 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import { navigate } from '@reach/router';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
+import PropTypes from 'prop-types';
 import {
   Link,
   Icon,
   SearchInput,
-  Surface,
-  Tag,
   useInstrumentedHandler,
   useTranslation,
   useLoggedIn,
 } from '@newrelic/gatsby-theme-newrelic';
-import SurfaceLink from '../components/SurfaceLink';
 import HomepageBanner from '../components/HomepageBanner';
+import { DocTile } from '../components/DocTile';
 import FindYourQuickStart from '../components/FindYourQuickstart';
 import MDXContainer from '../components/MDXContainer';
 import {
@@ -207,20 +205,23 @@ const HomePage = ({ data }) => {
             `}
           >
             <DocTile
-              title={t('home.popularDocs.t1.title')}
               label={{ text: 'Get started', color: '#F4CBE7' }}
               path="/docs/apm/new-relic-apm/getting-started/introduction-apm"
-            />
+            >
+              {t('home.popularDocs.t1.title')}
+            </DocTile>
             <DocTile
-              title={t('home.popularDocs.t2.title')}
               label={{ text: 'Security', color: '#FCD672' }}
               path="/docs/vulnerability-management/overview"
-            />
+            >
+              {t('home.popularDocs.t2.title')}
+            </DocTile>
             <DocTile
-              title={t('home.popularDocs.t3.title')}
               label={{ text: 'APM', color: '#AFE2E3' }}
               path="/install/java/"
-            />
+            >
+              {t('home.popularDocs.t3.title')}
+            </DocTile>
           </div>
         </Section>
         <Section layout={layout}>
@@ -253,10 +254,11 @@ const HomePage = ({ data }) => {
             {latestWhatsNewPosts.map((post) => (
               <DocTile
                 key={post.title}
-                title={post.title}
                 date={post.releaseDate}
                 path={post.path}
-              />
+              >
+                {post.title}
+              </DocTile>
             ))}
           </div>
         </Section>
@@ -403,112 +405,6 @@ SectionTitle.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.elementType,
   to: PropTypes.string,
-};
-
-const DocTile = ({ title, path, instrumentation, label, date }) => (
-  <SurfaceLink
-    base={Surface.BASE.SECONDARY}
-    to={path}
-    interactive
-    instrumentation={instrumentation}
-    css={css`
-      min-height: 130px;
-      border-radius: 4px;
-      background: var(--secondary-background-color);
-
-      .dark-mode & {
-        background: var(--secondary-background-color);
-      }
-
-      @media screen and (max-width: 1050px) {
-        &:not(:last-child) {
-          margin-bottom: 2rem;
-        }
-      }
-
-      @media screen and (max-width: 760px) {
-        && {
-          margin-bottom: 0;
-        }
-      }
-
-      @media screen and (max-width: 650px) {
-        font-size: 14px;
-        &:not(:last-child) {
-          margin-bottom: 2rem;
-        }
-      }
-    `}
-  >
-    <div
-      css={css`
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-        justify-content: space-between;
-        align-items: space-between;
-        padding: 2rem;
-
-        @media screen and (max-width: 650px) {
-          padding: 1.5rem;
-        }
-      `}
-    >
-      <h4
-        css={css`
-          margin-bottom: 1rem;
-          font-weight: 400;
-          font-size: 20px;
-        `}
-      >
-        {title}
-      </h4>
-      <div
-        css={css`
-          display: flex;
-          justify-content: space-between;
-        `}
-      >
-        {label && (
-          <Tag
-            css={css`
-              background: ${label.color};
-              color: var(--system-text-primary-light);
-
-              .dark-mode & {
-                background: ${label.color};
-                color: var(--system-text-primary-light);
-              }
-            `}
-          >
-            {label.text}
-          </Tag>
-        )}
-        {date && (
-          <Tag
-            css={css`
-              color: var(--primary-text-color);
-            `}
-          >
-            {date}
-          </Tag>
-        )}
-        <Icon
-          name="fe-arrow-right"
-          css={css`
-            color: var(--primary-text-color);
-          `}
-        />
-      </div>
-    </div>
-  </SurfaceLink>
-);
-
-DocTile.propTypes = {
-  label: PropTypes.array,
-  title: PropTypes.string,
-  date: PropTypes.string,
-  instrumentation: PropTypes.object,
 };
 
 export default HomePage;


### PR DESCRIPTION
This moves the doc tile component out of the index page and adds an optional wrapper for formatting.
passing `numbered` to the wrapper will auto number the tiles, but you can also pass a number to individual tiles (not used in the wrapper) via a `number` prop. there is also a label prop which takes an object with text and a color.

tested serialization and deserialization without issue

### screenshots
<img width="700" alt="Screen Shot 2023-02-13 at 1 54 29 PM" src="https://user-images.githubusercontent.com/39655074/218585739-49d0d8a2-2363-44b3-9c1b-57f23c849965.png">
<img width="700" alt="Screen Shot 2023-02-13 at 1 54 35 PM" src="https://user-images.githubusercontent.com/39655074/218585612-cd4839fe-132c-47d8-9527-2d844e707e2e.png">
<img width="700" alt="Screen Shot 2023-02-13 at 1 58 45 PM" src="https://user-images.githubusercontent.com/39655074/218585669-5a04df60-ba0b-4187-88df-ca25f12ea748.png">
<img width="700" alt="Screen Shot 2023-02-13 at 1 58 51 PM" src="https://user-images.githubusercontent.com/39655074/218585679-8f5ec9be-cf70-44fa-b302-6972e8464dd3.png">

