### PR TITLE
Update opentelemetry-collector-basic.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
@@ -48,7 +48,7 @@ The collector setup is part of the larger process of setting up OpenTelemetry wi
   ```
 
 2. Run the OpenTelemetry collector after you make the following changes:
-   * Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup#review-settings).
+   * Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
    * Replace `YOUR_KEY_HERE` with your <LicenseKey/>.
 
   ```dockerfile


### PR DESCRIPTION
Updates the link to take the reader directly to the endpoint options. Previous link was broken due to changes we made (new documentation for getting started).