### PR TITLE
chore: lots of minor improvements

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -69,7 +69,7 @@ When running the Ruby agent in a Rails app, the agent first looks for the `NEW_R
 When you edit the config file, be sure to:
 
 * Indent only with two spaces.
-* Indent only where relevant, in stanzas such as **error_collector**.
+* Indent only where relevant, in stanzas such as **`error_collector`**.
 
 If you do not indent correctly, the agent may throw an `Unable to parse configuration file` error on startup.
 
@@ -132,7 +132,7 @@ These settings are available for agent configuration. Some settings depend on yo
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"info"`</td></tr>
+        <tr><th>Default</th><td>`info`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_LEVEL`</td></tr>
       </tbody>
     </table>
@@ -254,7 +254,11 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Path to <b>newrelic.yml</b>. If undefined, the agent checks the following directories (in order): <b>config/newrelic.yml</b>, <b>newrelic.yml</b>, <b>$HOME/.newrelic/newrelic.yml</b> and <b>$HOME/newrelic.yml</b>.
+  Path to `newrelic.yml`. If undefined, the agent checks the following directories (in order): 
+    * `config/newrelic.yml`
+    * `newrelic.yml`
+    * `$HOME/.newrelic/newrelic.yml`
+    * `$HOME/newrelic.yml`
   </Collapser>
 
   <Collapser id="exclude_newrelic_header" title="exclude_newrelic_header">
@@ -321,7 +325,7 @@ These settings are available for agent configuration. Some settings depend on yo
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"log/"`</td></tr>
+        <tr><th>Default</th><td>`log/`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_FILE_PATH`</td></tr>
       </tbody>
     </table>
@@ -333,7 +337,7 @@ These settings are available for agent configuration. Some settings depend on yo
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"json"`</td></tr>
+        <tr><th>Default</th><td>`json`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_MARSHALLER`</td></tr>
       </tbody>
     </table>
@@ -545,7 +549,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"obfuscated"`</td></tr>
+        <tr><th>Default</th><td>`obfuscated`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_RECORD_SQL`</td></tr>
       </tbody>
     </table>
@@ -632,7 +636,7 @@ For information on ignored and expected errors, [see this page on Error Analytic
       </tbody>
     </table>
 
-  If `true`, the agent collects [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights).
+  If `true`, the agent collects [`TransactionError` events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights).
   </Collapser>
 
   <Collapser id="error_collector-enabled" title="error_collector.enabled">
@@ -760,7 +764,7 @@ For information on ignored and expected errors, [see this page on Error Analytic
       </tbody>
     </table>
 
-  Defines the maximum number of [TransactionError events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights) reported per harvest cycle.
+  Defines the maximum number of [`TransactionError` events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights) reported per harvest cycle.
   </Collapser>
 
 </CollapserGroup>
@@ -1233,7 +1237,7 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-  List of allowed endpoints to include in audit log
+  List of allowed endpoints to include in audit log.
   </Collapser>
 
   <Collapser id="audit_log-path" title="audit_log.path">
@@ -1265,7 +1269,7 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-  Specify a list of constants that should prevent the agent from starting automatically. Separate individual constants with a comma `,`. For example, `Rails::Console,UninstrumentedBackgroundJob`.
+  Specify a list of constants that should prevent the agent from starting automatically. Separate individual constants with a comma `,`. For example, `"Rails::Console,UninstrumentedBackgroundJob"`.
   </Collapser>
 
   <Collapser id="autostart-denylisted_executables" title="autostart.denylisted_executables">
@@ -1277,7 +1281,7 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-  Defines a comma-delimited list of executables that the agent should not instrument. For example, `rake,my_ruby_script.rb`.
+  Defines a comma-delimited list of executables that the agent should not instrument. For example, `"rake,my_ruby_script.rb"`.
   </Collapser>
 
   <Collapser id="autostart-denylisted_rake_tasks" title="autostart.denylisted_rake_tasks">
@@ -1289,7 +1293,7 @@ Available logging-related config options include:
       </tbody>
     </table>
 
-  Defines a comma-delimited list of Rake tasks that the agent should not instrument. For example, `assets:precompile,db:migrate`.
+  Defines a comma-delimited list of Rake tasks that the agent should not instrument. For example, `"assets:precompile,db:migrate"`.
   </Collapser>
 
 </CollapserGroup>
@@ -1544,7 +1548,7 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.bunny](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-bunny).
+  <b>DEPRECATED</b> Please see: [`instrumentation.bunny`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-bunny).
 
 If `true`, disables instrumentation for the bunny gem.
   </Collapser>
@@ -1570,7 +1574,7 @@ If `true`, disables instrumentation for the bunny gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.curb](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-curb).
+  <b>DEPRECATED</b> Please see: [`instrumentation.curb`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-curb).
 
 If `true`, disables instrumentation for the curb gem.
   </Collapser>
@@ -1608,7 +1612,7 @@ If `true`, disables instrumentation for the curb gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
+  <b>DEPRECATED</b> Please see: [`instrumentation.memcache`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
 
 If `true`, disables instrumentation for the dalli gem.
   </Collapser>
@@ -1622,7 +1626,7 @@ If `true`, disables instrumentation for the dalli gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
+  <b>DEPRECATED</b> Please see: [`instrumentation.memcache`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
 
 If `true`, disables instrumentation for the dalli gem's additional CAS client support.
   </Collapser>
@@ -1648,9 +1652,9 @@ If `true`, disables instrumentation for the dalli gem's additional CAS client su
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.delayed_job](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-delayed_job).
+  <b>DEPRECATED</b> Please see: [`instrumentation.delayed_job`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-delayed_job).
 
-If `true`, disables [Delayed::Job instrumentation](/docs/agents/ruby-agent/background-jobs/delayedjob).
+If `true`, disables [`Delayed::Job` instrumentation](/docs/agents/ruby-agent/background-jobs/delayedjob).
   </Collapser>
 
   <Collapser id="disable_excon" title="disable_excon">
@@ -1662,7 +1666,7 @@ If `true`, disables [Delayed::Job instrumentation](/docs/agents/ruby-agent/backg
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.excon](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-excon).
+  <b>DEPRECATED</b> Please see: [`instrumentation.excon`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-excon).
 
 If `true`, disables instrumentation for the excon gem.
   </Collapser>
@@ -1676,7 +1680,7 @@ If `true`, disables instrumentation for the excon gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcached](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached).
+  <b>DEPRECATED</b> Please see: [`instrumentation.memcached`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcached).
 
 If `true`, disables instrumentation for the memcached gem.
   </Collapser>
@@ -1690,7 +1694,7 @@ If `true`, disables instrumentation for the memcached gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache-client](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache-client).
+  <b>DEPRECATED</b> Please see: [`instrumentation.memcache-client`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache-client).
 
 If `true`, disables instrumentation for the memcache-client gem.
   </Collapser>
@@ -1704,7 +1708,7 @@ If `true`, disables instrumentation for the memcache-client gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.memcache](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
+  <b>DEPRECATED</b> Please see: [`instrumentation.memcache`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-memcache).
 
 If `true`, disables memcache instrumentation.
   </Collapser>
@@ -1718,7 +1722,7 @@ If `true`, disables memcache instrumentation.
       </tbody>
     </table>
 
-  If `true`, disables the use of GC::Profiler to measure time spent in garbage collection
+  If `true`, disables the use of `GC::Profiler` to measure time spent in garbage collection
   </Collapser>
 
   <Collapser id="disable_grape" title="disable_grape">
@@ -1730,7 +1734,7 @@ If `true`, disables memcache instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.grape](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-grape).
+  <b>DEPRECATED</b> Please see: [`instrumentation.grape`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-grape).
 
 If `true`, the agent won't install Grape instrumentation.
   </Collapser>
@@ -1744,7 +1748,7 @@ If `true`, the agent won't install Grape instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.httpclient](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httpclient).
+  <b>DEPRECATED</b> Please see: [`instrumentation.httpclient`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httpclient).
 
 If `true`, disables instrumentation for the httpclient gem.
   </Collapser>
@@ -1758,7 +1762,7 @@ If `true`, disables instrumentation for the httpclient gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.httprb](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httprb).
+  <b>DEPRECATED</b> Please see: [`instrumentation.httprb`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-httprb).
 
 If `true`, the agent won't install instrumentation for the http.rb gem.
   </Collapser>
@@ -1772,7 +1776,7 @@ If `true`, the agent won't install instrumentation for the http.rb gem.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.mongo](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-mongo).
+  <b>DEPRECATED</b> Please see: [`instrumentation.mongo`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-mongo).
 
 If `true`, the agent won't install [instrumentation for the Mongo gem](/docs/agents/ruby-agent/frameworks/mongo-instrumentation).
   </Collapser>
@@ -1798,7 +1802,7 @@ If `true`, the agent won't install [instrumentation for the Mongo gem](/docs/age
       </tbody>
     </table>
 
-  If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via Rack::Builder or Rails).
+  If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via `Rack::Builder` or Rails).
   </Collapser>
 
   <Collapser id="disable_net_http" title="disable_net_http">
@@ -1810,9 +1814,9 @@ If `true`, the agent won't install [instrumentation for the Mongo gem](/docs/age
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.net_http](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-net_http).
+  <b>DEPRECATED</b> Please see: [`instrumentation.net_http`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-net_http).
 
-If `true`, disables instrumentation for Net::HTTP.
+If `true`, disables instrumentation for `Net::HTTP`.
   </Collapser>
 
   <Collapser id="disable_puma_rack" title="disable_puma_rack">
@@ -1824,9 +1828,9 @@ If `true`, disables instrumentation for Net::HTTP.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack).
+  <b>DEPRECATED</b> Please see: [`instrumentation.puma_rack`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack).
 
-If `true`, prevents the agent from hooking into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup.
+If `true`, prevents the agent from hooking into the `to_app` method in `Puma::Rack::Builder` to find gems to instrument during application startup.
   </Collapser>
 
   <Collapser id="disable_puma_rack_urlmap" title="disable_puma_rack_urlmap">
@@ -1838,9 +1842,9 @@ If `true`, prevents the agent from hooking into the `to_app` method in Puma::Rac
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.puma_rack_urlmap](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack_urlmap).
+  <b>DEPRECATED</b> Please see: [`instrumentation.puma_rack_urlmap`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-puma_rack_urlmap).
 
-If `true`, prevents the agent from hooking into Puma::Rack::URLMap to install middleware tracing.
+If `true`, prevents the agent from hooking into `Puma::Rack::URLMap` to install middleware tracing.
   </Collapser>
 
   <Collapser id="disable_rack" title="disable_rack">
@@ -1852,9 +1856,9 @@ If `true`, prevents the agent from hooking into Puma::Rack::URLMap to install mi
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rack](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack).
+  <b>DEPRECATED</b> Please see: [`instrumentation.rack`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack).
 
-If `true`, prevents the agent from hooking into the `to_app` method in Rack::Builder to find gems to instrument during application startup.
+If `true`, prevents the agent from hooking into the `to_app` method in `Rack::Builder` to find gems to instrument during application startup.
   </Collapser>
 
   <Collapser id="disable_rack_urlmap" title="disable_rack_urlmap">
@@ -1866,9 +1870,9 @@ If `true`, prevents the agent from hooking into the `to_app` method in Rack::Bui
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rack_urlmap](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack_urlmap).
+  <b>DEPRECATED</b> Please see: [`instrumentation.rack_urlmap`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rack_urlmap).
 
-If `true`, prevents the agent from hooking into Rack::URLMap to install middleware tracing.
+If `true`, prevents the agent from hooking into `Rack::URLMap` to install middleware tracing.
   </Collapser>
 
   <Collapser id="disable_rake" title="disable_rake">
@@ -1880,7 +1884,7 @@ If `true`, prevents the agent from hooking into Rack::URLMap to install middlewa
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.rake](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rake).
+  <b>DEPRECATED</b> Please see: [`instrumentation.rake`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-rake).
 
 If `true`, disables Rake instrumentation.
   </Collapser>
@@ -1894,7 +1898,7 @@ If `true`, disables Rake instrumentation.
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.redis](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-redis).
+  <b>DEPRECATED</b> Please see: [`instrumentation.redis`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-redis).
 
 If `true`, the agent won't install [instrumentation for Redis](/docs/agents/ruby-agent/frameworks/redis-instrumentation).
   </Collapser>
@@ -1908,7 +1912,7 @@ If `true`, the agent won't install [instrumentation for Redis](/docs/agents/ruby
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.resque](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-resque).
+  <b>DEPRECATED</b> Please see: [`instrumentation.resque`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-resque).
 
 If `true`, disables [Resque instrumentation](/docs/agents/ruby-agent/background-jobs/resque-instrumentation).
   </Collapser>
@@ -1958,9 +1962,9 @@ If `true`, disables [Resque instrumentation](/docs/agents/ruby-agent/background-
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.sinatra](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-sinatra).
+  <b>DEPRECATED</b> Please see: [`instrumentation.sinatra`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-sinatra).
 
-If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/frameworks/sinatra-support).
+If `true`, disables [Sinatra instrumentation](/docs/agents/ruby-agent/frameworks/sinatra-support).
   </Collapser>
 
   <Collapser id="disable_sinatra_auto_middleware" title="disable_sinatra_auto_middleware">
@@ -1979,7 +1983,7 @@ If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/framework
 
       To continue using cross application tracing, update the following options in your `newrelic.yml` configuration file:
 
-      ```
+      ```yaml
       # newrelic.yml
 
         cross_application_tracer:
@@ -2000,7 +2004,7 @@ If `true` , disables [Sinatra instrumentation](/docs/agents/ruby-agent/framework
       </tbody>
     </table>
 
-  <b>DEPRECATED</b> Please see: [instrumentation.typhoeus](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-typhoeus).
+  <b>DEPRECATED</b> Please see: [`instrumentation.typhoeus`](docs/agents/ruby-agent/configuration/ruby-agent-configuration#instrumentation-typhoeus).
 
 If `true`, the agent won't install instrumentation for the typhoeus gem.
   </Collapser>
@@ -2110,7 +2114,7 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
       </tbody>
     </table>
 
-  Ordinarily the agent reports dyno names with a trailing dot and process ID (for example, <b>worker.3</b>). You can remove this trailing data by specifying the prefixes you want to report without trailing data (for example, <b>worker</b>).
+  Ordinarily the agent reports dyno names with a trailing dot and process ID (for example, `worker.3`). You can remove this trailing data by specifying the prefixes you want to report without trailing data (for example, `worker`).
   </Collapser>
 
 </CollapserGroup>
@@ -2154,22 +2158,23 @@ If `true`, the agent won't install instrumentation for the typhoeus gem.
       </tbody>
     </table>
 
-  If `true` (the default), data sent to the trace observer is batched
-instead of sending each span individually.
+  If `true` (the default), data sent to the trace observer is batched instead of sending each span individually.
   </Collapser>
 
   <Collapser id="infinite_tracing-compression_level" title="infinite_tracing.compression_level">
     <table>
       <tbody>
         <tr><th>Type</th><td>Symbol</td></tr>
-        <tr><th>Default</th><td>`:high`</td></tr>
+        <tr><th>Default</th><td>`high`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_COMPRESSION_LEVEL`</td></tr>
       </tbody>
     </table>
 
-  Configure the compression level for data sent to the trace observer
-May be one of [none|low|medium|high]
-'high' is the default. Set the level to 'none' to disable compression
+  Configure the compression level for data sent to the trace observer.
+    
+  May be one of: `none`, `low`, `medium`, `high`. 
+    
+  Set the level to `none` to disable compression.
   </Collapser>
 
 </CollapserGroup>
@@ -2189,7 +2194,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of ActiveSupport::Logger at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of `ActiveSupport::Logger` at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-bunny" title="instrumentation.bunny">
@@ -2201,19 +2206,19 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of bunny at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of bunny at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-concurrent_ruby" title="instrumentation.concurrent_ruby">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_CONCURRENT_RUBY`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the concurrent-ruby library at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of the concurrent-ruby library at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-curb" title="instrumentation.curb">
@@ -2225,7 +2230,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Curb at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Curb at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-delayed_job" title="instrumentation.delayed_job">
@@ -2237,19 +2242,19 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Delayed Job at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Delayed Job at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-elasticsearch" title="instrumentation.elasticsearch">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ELASTICSEARCH`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the elasticsearch library at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of the elasticsearch library at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-excon" title="instrumentation.excon">
@@ -2261,7 +2266,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Excon at start up. May be one of [enabled|disabled].
+  Controls auto-instrumentation of Excon at start up. May be one of: `enabled`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grape" title="instrumentation.grape">
@@ -2273,7 +2278,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Grape at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Grape at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grpc_client" title="instrumentation.grpc_client">
@@ -2285,7 +2290,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of gRPC clients at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of gRPC clients at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grpc-host_denylist" title="instrumentation.grpc.host_denylist">
@@ -2297,7 +2302,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Specifies a list of hostname patterns separated by commas that will match gRPC hostnames that traffic is to be ignored by New Relic for. New Relic's gRPC client instrumentation will ignore traffic streamed to a host matching any of these patterns, and New Relic's gRPC server instrumentation will ignore traffic for a server running on a host whose hostname matches any of these patterns. By default, no traffic is ignored when gRPC instrumentation is itself enabled. For example, "private.com$,exception.*"
+  Specifies a list of hostname patterns separated by commas that will match gRPC hostnames that traffic is to be ignored by New Relic for. New Relic's gRPC client instrumentation will ignore traffic streamed to a host matching any of these patterns, and New Relic's gRPC server instrumentation will ignore traffic for a server running on a host whose hostname matches any of these patterns. By default, no traffic is ignored when gRPC instrumentation is itself enabled. For example, `"private.com$,exception.*"`
   </Collapser>
 
   <Collapser id="instrumentation-grpc_server" title="instrumentation.grpc_server">
@@ -2309,7 +2314,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of gRPC servers at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of gRPC servers at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-httpclient" title="instrumentation.httpclient">
@@ -2321,7 +2326,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of HTTPClient at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of HTTPClient at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-httprb" title="instrumentation.httprb">
@@ -2333,7 +2338,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of http.rb gem at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of http.rb gem at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-logger" title="instrumentation.logger">
@@ -2345,7 +2350,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Ruby standard library Logger at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Ruby standard library Logger at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-memcache" title="instrumentation.memcache">
@@ -2357,7 +2362,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of dalli gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of dalli gem for Memcache at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-memcached" title="instrumentation.memcached">
@@ -2369,7 +2374,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of memcached gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of memcached gem for Memcache at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-memcache_client" title="instrumentation.memcache_client">
@@ -2381,7 +2386,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of memcache-client gem for Memcache at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of memcache-client gem for Memcache at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-mongo" title="instrumentation.mongo">
@@ -2393,7 +2398,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Mongo at start up. May be one of [enabled|disabled].
+  Controls auto-instrumentation of Mongo at start up. May be one of: `enabled`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-net_http" title="instrumentation.net_http">
@@ -2405,7 +2410,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Net::HTTP at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of `Net::HTTP` at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-puma_rack" title="instrumentation.puma_rack">
@@ -2417,7 +2422,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Puma::Rack. When enabled, the agent hooks into the `to_app` method in Puma::Rack::Builder to find gems to instrument during application startup. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of `Puma::Rack`. When enabled, the agent hooks into the `to_app` method in `Puma::Rack::Builder` to find gems to instrument during application startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-puma_rack_urlmap" title="instrumentation.puma_rack_urlmap">
@@ -2429,7 +2434,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Puma::Rack::URLMap at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of `Puma::Rack::URLMap` at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-rack" title="instrumentation.rack">
@@ -2441,7 +2446,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in Rack::Builder to find gems to instrument during application startup. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in `Rack::Builder` to find gems to instrument during application startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-rack_urlmap" title="instrumentation.rack_urlmap">
@@ -2453,7 +2458,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Rack::URLMap at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of `Rack::URLMap` at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-rake" title="instrumentation.rake">
@@ -2465,7 +2470,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of rake at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of rake at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-redis" title="instrumentation.redis">
@@ -2477,7 +2482,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Redis at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Redis at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-resque" title="instrumentation.resque">
@@ -2489,7 +2494,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of resque at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of resque at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-sinatra" title="instrumentation.sinatra">
@@ -2501,19 +2506,19 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Sinatra at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Sinatra at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-thread" title="instrumentation.thread">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asynchronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of the Thread class at start up to allow the agent to correctly nest spans inside of an asynchronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-thread-tracing" title="instrumentation.thread.tracing">
@@ -2532,12 +2537,12 @@ May be one of [none|low|medium|high]
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TILT`</td></tr>
       </tbody>
     </table>
 
-  Controls auto-instrumentation of the Tilt template rendering library at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of the Tilt template rendering library at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-typhoeus" title="instrumentation.typhoeus">
@@ -2549,7 +2554,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Controls auto-instrumentation of Typhoeus at start up. May be one of [auto|prepend|chain|disabled].
+  Controls auto-instrumentation of Typhoeus at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
 </CollapserGroup>
@@ -2769,7 +2774,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`).
+  Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.
   </Collapser>
 
   <Collapser id="slow_sql-use_longer_sql_id" title="slow_sql.use_longer_sql_id">
@@ -2781,7 +2786,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Generate a longer sql_id for slow SQL traces. sql_id is used for aggregation of similar queries.
+  Generate a longer `sql_id` for slow SQL traces. `sql_id` is used for aggregation of similar queries.
   </Collapser>
 
 </CollapserGroup>
@@ -2825,7 +2830,7 @@ May be one of [none|low|medium|high]
       </tbody>
     </table>
 
-  Defines the maximum number of span events reported from a single harvest. Any Integer between 1 and 10000 is valid.
+  Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.
   </Collapser>
 
 </CollapserGroup>


### PR DESCRIPTION
This was supposed to be a small fix that got out of hand. I made a lot small improvements like
- add missing punctuation
-  wrapping code in backticks
- add syntax highlighting to one codeblock
- tried to make our style consistent. In yaml you don't need to use `""` for most strings unless they contain special chars like `\` or `,`
    - so I removed `"` where they aren't needed (since we went back and forth) and added them where they would be needed (like where lists containing `,`)
