### PR TITLE
Corrected use of "New Relic"

### DIFF
--- a/src/content/docs/style-guide/ui-writing/button-labels.mdx
+++ b/src/content/docs/style-guide/ui-writing/button-labels.mdx
@@ -20,7 +20,7 @@ A mislabeled or misleading button can cause confusion when users go to take acti
 
 # Exceptions to the rule
 
-We're deliberately blending the concepts of search and filter in our various filter bars in New Relic One, specifically for distributed tracing, maps, logs, and the shared filter component that appears in the chart builder. We don't want to call out one or the other concept, so we're avoiding those specific terms.
+We're deliberately blending the concepts of search and filter in our various filter bars in the New Relic platform, specifically for distributed tracing, maps, logs, and the shared filter component that appears in the chart builder. We don't want to call out one or the other concept, so we're avoiding those specific terms.
 
 In these cases, we're using descriptive language to set up the actions, and then a generic "Apply" button to apply your changes and see your results.
 


### PR DESCRIPTION
Changed "New Relic One" to "the New Relic platform."

<!-- Thanks for contributing to our docs! -->

