### PR TITLE
Releasing .NET Agent 10.7.0

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -30,6 +30,19 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v10.7.0
+      </td>
+
+      <td>
+        Feb 14, 2023
+      </td>
+
+      <td>
+        Feb 14, 2024
+      </td>
+    </tr>
+    <tr>
+      <td>
         v10.6.0
       </td>
 
@@ -357,34 +370,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Apr 14, 2023
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v8.39.0
-      </td>
-
-      <td>
-        Feb 10, 2021
-      </td>
-
-      <td>
-        Feb 10, 2023
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v8.38.0
-      </td>
-
-      <td>
-        Jan 26, 2021
-      </td>
-
-      <td>
-        Jan 26, 2023
       </td>
     </tr>
 


### PR DESCRIPTION
Adds 10.7.0 to EOL list, and removes 2 older versions that have reached EOL.