### PR TITLE
chore(synth IPs): Added clarification

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -35,7 +35,7 @@ Minions are deployed on servers, and the agents are activated using non-personal
 
 ## Daily JSON listings for IP addresses [#dynamic-ip-addresses]
 
-IP addresses for released locations are subject to change. If a change is needed, we'll attempt to proactively notify customers prior to any changes via e-mail. You can also check the [Support Forum](https://discuss.newrelic.com/) for updates.
+IP addresses for released locations are subject to change. If a change is needed, we'll attempt to proactively notify customers prior to any changes via e-mail. You can also check the [Support Forum](https://discuss.newrelic.com/) for updates. The IP ranges listed are reserved for use by New Relic and cannot be used by anyone else.
 
 Monitors using legacy runtimes, which include scripted browser monitors using Chrome 72 or lower, scripted API monitors using Node 10 or lower, step monitors, broken link monitors, and certificate check monitors utilize /32 IP ranges.
 


### PR DESCRIPTION
Added a note about the IP ranges being reserved for New Relic use only.