### PR TITLE
OpenTelemetry: Fix link to Java tutorial from intro to setup

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-get-started-intro.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-get-started-intro.mdx
@@ -33,7 +33,7 @@ Monitor your Kubernetes clusters with the OpenTelemetry collector. See the instr
 
 Instead of jumping right into the setup for your own app, you can spin up our demo Java app with OpenTelemetry and New Relic.
 
-We have three [Java tutorials](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-tutorials/opentelemetry-tutorial-java) to help you get acquainted with OpenTelemetry:
+We have three [Java tutorials](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java) to help you get acquainted with OpenTelemetry:
 
 * Inspect a pre-instrumented app you can quickly spin up to send data into New Relic.
 * Use the OpenTelemetry Java agent to automatically instrument a demo app.


### PR DESCRIPTION
Here's the Jira for this: NR-88389