### PR TITLE
Add release notes for .net agent 10.7.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-7-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-7-0.mdx
@@ -3,33 +3,33 @@ subject: .NET agent
 releaseDate: '2023-02-14'
 version: 10.7.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
-redirects:
-  - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1070
 ---
 
 <Callout variant="important">
 New Relic recommends that you update the agent regularly and at a minimum every 3 months. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent).
 
-This release will be supported for one year after its release date. For a full list of supported versions and their support periods, please see our [EOL policy doc](/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy).
+This release is supported for one year after its release date. For a full list of supported versions and their support periods, please see our [EOL policy doc](/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy).
 
 As of this release, the oldest supported version is [.NET agent 8.24.244.0](/docs/release-notes/agent-release-notes/net-release-notes/agent-8242440).
 </Callout>
 
 ### New Features
-* Postgres client instrumentation support has been extended to include the following versions: 4.0.x, 4.1.x, 5.0.x, 6.0.x and 7.0.x [#1363](https://github.com/newrelic/newrelic-dotnet-agent/pull/1363)
-* Enables gzip compression by default for Infinite Tracing [#1383](https://github.com/newrelic/newrelic-dotnet-agent/pull/1383)
+* Postgres client instrumentation support has been extended to include the following versions: 4.0.x, 4.1.x, 5.0.x, 6.0.x and 7.0.x. [#1363](https://github.com/newrelic/newrelic-dotnet-agent/pull/1363)
+* Enables gzip compression by default for Infinite Tracing. [#1383](https://github.com/newrelic/newrelic-dotnet-agent/pull/1383)
 
 ### Fixes
-* Fix a race condition when using SetApplicationName [#1361](https://github.com/newrelic/newrelic-dotnet-agent/pull/1361)
-* Resolves [#1374](https://github.com/newrelic/newrelic-dotnet-agent/issues/1374) related to enabling Context Data for some loggers [#1381](https://github.com/newrelic/newrelic-dotnet-agent/pull/1381)
+* Fix a race condition when using SetApplicationName. [#1361](https://github.com/newrelic/newrelic-dotnet-agent/pull/1361)
+* Resolves [#1374](https://github.com/newrelic/newrelic-dotnet-agent/issues/1374) related to enabling Context Data for some loggers. [#1381](https://github.com/newrelic/newrelic-dotnet-agent/pull/1381)
 * Add missing supportability metrics to gRPC response streams and improve Infinite Tracing integration test reliability [#1379](https://github.com/newrelic/newrelic-dotnet-agent/pull/1379)
 
 ### Deprecations
-* Infinite Tracing for .NET Framework applications will be deprecated in May 2023. The Infinite Tracing feature depends on the gRPC framework to send streaming data to New Relic. The gRPC library currently in use, [gRPC Core](https://github.com/grpc/grpc/tree/master/src/csharp), has been in the maintenance-only phase since May 2021, and will be deprecated as of May 2023.  The .NET Agent on .NET Core has been migrated to [gRPC for .NET](https://github.com/grpc/grpc-dotnet) per the guidance from grpc.io. However, this library does not have the full functionality that is required for Infinite Tracing on .NET Framework applications.  Those applications will continue to use [gRPC Core](https://github.com/grpc/grpc/tree/master/src/csharp) until May 2023, at which time we will end support for Infinite Tracing for .NET Framework. We may revisit this decision in the future if the situation changes. [#1367](https://github.com/newrelic/newrelic-dotnet-agent/pull/1367)
+Infinite Tracing for .NET Framework applications will be deprecated in May 2023. The Infinite Tracing feature depends on the gRPC framework to send streaming data to New Relic. The gRPC library currently in use, [gRPC Core](https://github.com/grpc/grpc/tree/master/src/csharp), has been in the maintenance-only phase since May 2021, and will be deprecated as of May 2023. 
+
+The .NET Agent on .NET Core has been migrated to [gRPC for .NET](https://github.com/grpc/grpc-dotnet) per the guidance from grpc.io. However, this library doesn't have the full functionality that is required for Infinite Tracing on .NET Framework applications. Those applications will continue to use [gRPC Core](https://github.com/grpc/grpc/tree/master/src/csharp) until May 2023, at which time we'll end support for Infinite Tracing for .NET Framework. We may revisit this decision in the future if the situation changes. [#1367](https://github.com/newrelic/newrelic-dotnet-agent/pull/1367)
 
 ### Other
-* Resolved several static code analysis warnings relating to unused variables and outdated api usage [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)
-* Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period [#1378](https://github.com/newrelic/newrelic-dotnet-agent/pull/1378)
+* Resolved several static code analysis warnings relating to unused variables and outdated api usage. [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)
+* Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period. [#1378](https://github.com/newrelic/newrelic-dotnet-agent/pull/1378)
 * Proxy configuration for Infinite Tracing should be specified using only the `https_proxy` environment variable. `grpc_proxy` is no longer supported for all application types.
 
 Once published, the release artifacts for this release can be found [here](https://download.newrelic.com/dot_net_agent/latest_release/) or on NuGet.org.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-7-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-7-0.mdx
@@ -1,0 +1,53 @@
+---
+subject: .NET agent
+releaseDate: '2023-02-14'
+version: 10.7.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+redirects:
+  - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1070
+---
+
+<Callout variant="important">
+New Relic recommends that you update the agent regularly and at a minimum every 3 months. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent).
+
+This release will be supported for one year after its release date. For a full list of supported versions and their support periods, please see our [EOL policy doc](/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy).
+
+As of this release, the oldest supported version is [.NET agent 8.24.244.0](/docs/release-notes/agent-release-notes/net-release-notes/agent-8242440).
+</Callout>
+
+### New Features
+* Postgres client instrumentation support has been extended to include the following versions: 4.0.x, 4.1.x, 5.0.x, 6.0.x and 7.0.x [#1363](https://github.com/newrelic/newrelic-dotnet-agent/pull/1363)
+* Enables gzip compression by default for Infinite Tracing [#1383](https://github.com/newrelic/newrelic-dotnet-agent/pull/1383)
+
+### Fixes
+* Fix a race condition when using SetApplicationName [#1361](https://github.com/newrelic/newrelic-dotnet-agent/pull/1361)
+* Resolves [#1374](https://github.com/newrelic/newrelic-dotnet-agent/issues/1374) related to enabling Context Data for some loggers [#1381](https://github.com/newrelic/newrelic-dotnet-agent/pull/1381)
+* Add missing supportability metrics to gRPC response streams and improve Infinite Tracing integration test reliability [#1379](https://github.com/newrelic/newrelic-dotnet-agent/pull/1379)
+
+### Deprecations
+* Infinite Tracing for .NET Framework applications will be deprecated in May 2023. The Infinite Tracing feature depends on the gRPC framework to send streaming data to New Relic. The gRPC library currently in use, [gRPC Core](https://github.com/grpc/grpc/tree/master/src/csharp), has been in the maintenance-only phase since May 2021, and will be deprecated as of May 2023.  The .NET Agent on .NET Core has been migrated to [gRPC for .NET](https://github.com/grpc/grpc-dotnet) per the guidance from grpc.io. However, this library does not have the full functionality that is required for Infinite Tracing on .NET Framework applications.  Those applications will continue to use [gRPC Core](https://github.com/grpc/grpc/tree/master/src/csharp) until May 2023, at which time we will end support for Infinite Tracing for .NET Framework. We may revisit this decision in the future if the situation changes. [#1367](https://github.com/newrelic/newrelic-dotnet-agent/pull/1367)
+
+### Other
+* Resolved several static code analysis warnings relating to unused variables and outdated api usage [#1369](https://github.com/newrelic/newrelic-dotnet-agent/pull/1369)
+* Update gRPC log message when a response stream is automatically cancelled due to no messages in a time period [#1378](https://github.com/newrelic/newrelic-dotnet-agent/pull/1378)
+* Proxy configuration for Infinite Tracing should be specified using only the `https_proxy` environment variable. `grpc_proxy` is no longer supported for all application types.
+
+Once published, the release artifacts for this release can be found [here](https://download.newrelic.com/dot_net_agent/latest_release/) or on NuGet.org.
+
+### Checksums
+| File | SHA - 256  Hash |
+| ---| ---|
+| newrelic-dotnet-agent-10.7.0-1.x86_64.rpm | B40A11004136EECD12F56BE28BDDE832E8D8494FC969A4A18EB058DC46E212EC |
+| newrelic-dotnet-agent_10.7.0_amd64.deb | 2444258E09B0029FD18BEC9C21379E5A3F7DE2F67726C3C0D4944CEB271539FC |
+| newrelic-dotnet-agent_10.7.0_amd64.tar.gz | 4AA2CA405CBCBA7A9045E13E888883027681314061FEF88B12605DBF2B1E0350 |
+| newrelic-dotnet-agent_10.7.0_arm64.deb | 060B9ABD3788833F1EF3F9476EF83A8D4FBB46E5897E992C55830214F6C6F27D |
+| newrelic-dotnet-agent_10.7.0_arm64.tar.gz | AAA980762F908C6AD69D085D4C40D55CBD38D8E1A0197DDE79CB3E9B7E55B593 |
+| NewRelicDotNetAgent_10.7.0_x64.msi | 43238C88046CBB39896E749A9A5ED24190A450E3278D52C144777CF5B4FFDF1E |
+| NewRelicDotNetAgent_10.7.0_x64.zip | 622304DD180C2B630A2DFDC00BB71172CF28BFF2CE4414C7AF5C15B64872E3DD |
+| NewRelicDotNetAgent_10.7.0_x86.msi | 3CBCBE7DE060255FDA98A8B4BB7259DD9D0B4752678BA79936653D47031ADDF1 |
+| NewRelicDotNetAgent_10.7.0_x86.zip | 2FD5DE0EFA6AA8B45568C70ACC0120D6264A1F3C2B5C5B7DCF8F2FB9CD3FCF6F |
+
+### Updating
+
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
Add release notes for the .NET Agent 10.7.0 release.