### PR TITLE
02/17/23 - Release Python Agent 8.7.0

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
@@ -29,15 +29,28 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v8.7.0
+      </td>
+
+      <td>
+        Feb 16, 2023
+      </td>
+
+      <td>
+        Feb 16, 2024
+      </td>
+    </tr>
+    <tr>
+      <td>
         v8.6.0
       </td>
 
       <td>
-        Jan 26, 2023
+        Feb 9, 2023
       </td>
 
       <td>
-        Jan 26, 2024
+        Feb 9, 2024
       </td>
     </tr>
 
@@ -696,20 +709,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Feb 24, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.6.0.135
-      </td>
-
-      <td>
-        Feb 3, 2020
-      </td>
-
-      <td>
-        Feb 3, 2023
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80700.mdx
@@ -1,0 +1,22 @@
+---
+subject: Python agent
+releaseDate: '2023-02-16'
+version: 8.7.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+---
+
+## Notes
+
+This release of the Python agent adds support for batching and compression.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](http://download.newrelic.com/python_agent/release).
+
+## New features
+
+* **Add support batching and compression of infinite tracing**
+  Adds configuration options infinite_tracing.compression and infinite_tracing.batching
+  and sets both to on by default.
+
+## Support statement
+
+  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.8.0.136](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80700.mdx
@@ -14,9 +14,9 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 ## New features
 
 * **Add support batching and compression of infinite tracing**
-  Adds configuration options infinite_tracing.compression and infinite_tracing.batching
-  and sets both to on by default.
+
+  Adds configuration options `infinite_tracing.compression` and `infinite_tracing.batching` and sets both to on by default.
 
 ## Support statement
 
-  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.8.0.136](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136). More information can be found in the [EOL Policy Page](https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/).
+  New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [5.8.0.136](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-580136). Find more information in the [EOL Policy Page](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy).


### PR DESCRIPTION
Add release notes and documentation for version 8.7.0 of the Python Agent.
* Add release notes for 8.7.0.
* Update EOL table and deprecate old version.
* Fix previous version release date.
* TODO: Add batching and compression configuration options to configuration docs.