### PR TITLE
Deduping few lines

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-max-event-pool-size.mdx
@@ -27,8 +27,8 @@ Agent version 5.0.0 or higher.
 ## Description
 
 By default, mobile monitoring collects a maximum of 1,000 events per event harvest cycle, which is 600 seconds long by default.
-This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic Android agent will begin sampling events, discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
-This method lets you override the maximum size of that event pool. When the pool size limit is reached, the New Relic Android agent will begin [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
+This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic Android agent will begin  [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
+This method lets you override the maximum size of that event pool. 
 
 * The default value for the event harvest cycle is 600 seconds.
 


### PR DESCRIPTION
"When the pool size limit is reached, the New Relic Android agent will begin sampling events, discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle." 

This line is repeated. Removed one entry.
