### PR TITLE
chore(PHP agent): Add callout about pinning version

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -34,6 +34,14 @@ Support for PHP versions 5.5 and 5.6 ends in June 2023.
 * We recommend using a [supported release](http://php.net/supported-versions.php) of PHP.
 * Release [9.19](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-9190309) was the last release to support ZTS builds.
 
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform (examples: 32 bit OSes, FreeBSD, ZTS), it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages which are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>
+
 ## Permissions [#permissions]
 
 * Installation: Root access [is required](/docs/agents/php-agent/troubleshooting/determing-permissions-requirements) for most installations.


### PR DESCRIPTION
This PR adds a callout in the PHP compatibility page gives guidance on how users should prevent upgrades to newer agent versions if they are going to continue using the PHP agent on a platform that is not supported by newer agent versions.

For example - older PHP agent versions supported 32 bit operating systems.  This support was removed recently.  If the user were to allow the system to upgrade to a recent PHP agent version their system would stop reporting to New Relic because the newer package does not have support for their system.

By preventing upgrades of the specified packages the user could continue to use an older version of the agent which supported the now unsupported platform.
