### PR TITLE
Added missing EOL date enteries for Go Agent

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
@@ -319,7 +319,77 @@ Any versions not listed in the following table are no longer supported. Please [
         Jan 11, 2023
       </td>
     </tr>
-    
+
+    <tr>
+      <td>
+        v3.9.0
+      </td>
+
+      <td>
+        Sep 3, 2020
+      </td>
+
+      <td>
+        Sep 3, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v3.8.1
+      </td>
+
+      <td>
+        Jul 15, 2020
+      </td>
+
+      <td>
+        Jul 15, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v3.8.0
+      </td>
+
+      <td>
+        Jul 1, 2020
+      </td>
+
+      <td>
+        Jul 1, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v3.7.0
+      </td>
+
+      <td>
+        Jun 18, 2020
+      </td>
+
+      <td>
+        Jun 18, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v3.6.0
+      </td>
+
+      <td>
+        Jun 9, 2020
+      </td>
+
+      <td>
+        Jun 9, 2023
+      </td>
+    </tr>
+
     <tr>
       <td>
         v3.5.0


### PR DESCRIPTION
Versions 3.6.0-3.9.0 were missing from the Go Agent EOL policy. This PR adds them back in