### PR TITLE
fix: Correct URL for listing location failure conditions

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -1204,9 +1204,8 @@ These API functions include links to the API Explorer, where you can create, upd
     **[API Explorer](https://rpm.newrelic.com/api/explore/alerts_location_failure_conditions/list) > Alerts Location Failure Conditions > GET > List**
 
     ```
-    curl -X GET 'https://api.newrelic.com/v2/alerts_location_failure_conditions.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
-         -d 'policy_id=$POLICY_ID'
+    curl -X GET 'https://api.newrelic.com/v2/alerts_location_failure_conditions/policies/$POLICY_ID.json' \
+         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This doc had previously displayed the wrong endpoint for listing location failure conditions. I've added the correct one (instead of passing `policy_id` as a parameter, you include it in the URL).