### PR TITLE
Update indents of install-kubernetes-integration-using-helm.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -79,29 +79,29 @@ While it's possible to install those charts separately, we strongly recommend us
 
 3. Create a file named `values-newrelic.yaml`, which will be used to define your configuration:
 
-  ```yaml
-    global:
-      licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
-      cluster: _K8S_CLUSTER_NAME_
+```yaml
+global:
+  licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
+  cluster: _K8S_CLUSTER_NAME_
 
-    newrelic-prometheus-agent:
-      # Automatically scrape prometheus metrics for annotated services in the cluster
-      # Collecting prometheus metrics for large clusters might impact data usage significantly
-      enabled: true
-    nri-metadata-injection:
-      # Deploy our webhook to link APM and Kubernetes entities
-      enabled: true
-    nri-kube-events:
-      # Report Kubernetes events
-      enabled: true
-    newrelic-logging:
-      # Report logs for containers running in the cluster
-      enabled: true
-    kube-state-metrics:
-      # Deploy kube-state-metrics in the cluster.
-      # Set this to true unless it is already deployed.
-      enabled: true
-  ```
+newrelic-prometheus-agent:
+  # Automatically scrape prometheus metrics for annotated services in the cluster
+  # Collecting prometheus metrics for large clusters might impact data usage significantly
+  enabled: true
+nri-metadata-injection:
+  # Deploy our webhook to link APM and Kubernetes entities
+  enabled: true
+nri-kube-events:
+  # Report Kubernetes events
+  enabled: true
+newrelic-logging:
+  # Report logs for containers running in the cluster
+  enabled: true
+kube-state-metrics:
+  # Deploy kube-state-metrics in the cluster.
+  # Set this to true unless it is already deployed.
+  enabled: true
+```
 
 4. Make sure everything is configured properly in the chart by running the following command. Notice that we're specifying `--dry-run` and `--debug`, so nothing will be installed in this step:
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm.mdx
@@ -79,29 +79,29 @@ While it's possible to install those charts separately, we strongly recommend us
 
 3. Create a file named `values-newrelic.yaml`, which will be used to define your configuration:
 
-```yaml
-global:
-  licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
-  cluster: _K8S_CLUSTER_NAME_
+  ```yaml
+  global:
+    licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
+    cluster: _K8S_CLUSTER_NAME_
 
-newrelic-prometheus-agent:
-  # Automatically scrape prometheus metrics for annotated services in the cluster
-  # Collecting prometheus metrics for large clusters might impact data usage significantly
-  enabled: true
-nri-metadata-injection:
-  # Deploy our webhook to link APM and Kubernetes entities
-  enabled: true
-nri-kube-events:
-  # Report Kubernetes events
-  enabled: true
-newrelic-logging:
-  # Report logs for containers running in the cluster
-  enabled: true
-kube-state-metrics:
-  # Deploy kube-state-metrics in the cluster.
-  # Set this to true unless it is already deployed.
-  enabled: true
-```
+  newrelic-prometheus-agent:
+    # Automatically scrape prometheus metrics for annotated services in the cluster
+    # Collecting prometheus metrics for large clusters might impact data usage significantly
+    enabled: true
+  nri-metadata-injection:
+    # Deploy our webhook to link APM and Kubernetes entities
+    enabled: true
+  nri-kube-events:
+    # Report Kubernetes events
+    enabled: true
+  newrelic-logging:
+    # Report logs for containers running in the cluster
+    enabled: true
+  kube-state-metrics:
+    # Deploy kube-state-metrics in the cluster.
+    # Set this to true unless it is already deployed.
+    enabled: true
+  ```
 
 4. Make sure everything is configured properly in the chart by running the following command. Notice that we're specifying `--dry-run` and `--debug`, so nothing will be installed in this step:
 


### PR DESCRIPTION
Fix the indent of step3 of "Install the Kubernetes integration using Helm" make the aforementioned indent to be consistent to the one in the "Configure the integration" on the same page

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.