### PR TITLE
Add MSMQ support to compatibility doc

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -865,6 +865,16 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
       <tbody>
         <tr>
           <td>
+            MSMQ
+          </td>
+
+          <td>
+            * Message send and receive, queue peek and purge
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             NServiceBus
           </td>
 


### PR DESCRIPTION
Update the .NET Agent compatibility and support document (for .NET Framework only) to document our instrumentation support for MSMQ.  No specific version information is called out because MSMQ client support is built in to .NET Framework.