### PR TITLE
Correct wording about user type access

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -29,7 +29,7 @@ When it comes to what New Relic features your users can access, there are two ma
 * A user's **[user type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type)**: For organizations on [our usage-based pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing), your users' user type is a billing factor. The user type is what sets the maximum allowed capabilities a user can access. It overrides all role-related access. It's meant to be a fairly long-term setting based on someone's expected New Relic duties.
 * A user's assigned **roles**: after a user's user type is decided, **roles** can be used to more precisely control a user's access. Roles are sets of **capabilities**, which are the granular New Relic abilities (for example, the ability to modify New Relic APM settings). Roles are assigned by applying them to a [user group](#groups). 
 
-Let's say a basic user is assigned a group with a role with wide New Relic access, like [**All product admin**](#standard-roles). That user's user type (basic user) takes precedence, and would prevent them from using some of the features that a core user or full platform user would have access to. 
+Let's say a basic user is assigned a group with a role with wide New Relic access, like [**All product admin**](#standard-roles). That user's user type (basic user) would prevent them from using some of the features that a core user or full platform user would have access to. A User must have access to a feature from both their user type and their access control configuration.
 
 This doc is focused on role-related permissions. For details about user types, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type).
 


### PR DESCRIPTION
There is not precedence between user type and access control configuration, it is an intersection calculation. A user must have access both from their user type and their access control configuration.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.