### PR TITLE
Modify Prometheus Agent data ingest default option

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -118,8 +118,8 @@ The Prometheus Agent of New Relic allows you to easily scrape Prometheus metrics
 
 You can install Prometheus Agent in two modes:
 
-* [Alongside the Kubernetes integration](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#kubernetes-install): Prometheus Agent is installed automatically together with the [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
-* [Standalone](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#prometheus-install): If you don't need to monitor your Kubernetes cluster but the workloads running on it, you can easily deploy the Prometheus agent just by running a single Helm command. Due the lack of the Kubernetes integration, Prometheus metrics won't be decorated with Kubernetes tags like cluster, pod, or container name.
+* [Alongside the Kubernetes integration](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#kubernetes-install): Prometheus agent is installed automatically together with the [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
+* [Standalone](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#prometheus-install):If you don't need to monitor your Kubernetes cluster and only want to monitor workloads running on it, you can easily deploy the Prometheus agent just by running a single Helm command. Keep in mind that if you're only using the Prometheus agent, the Prometheus metrics won't be decorated with Kubernetes tags like cluster, pod, or container name.
 
 With this integration you can:
 

--- a/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -121,8 +121,6 @@ You can install Prometheus Agent in two modes:
 * [Alongside the Kubernetes integration](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#kubernetes-install): Prometheus Agent is installed automatically together with the [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
 * [Standalone](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#prometheus-install): If you don't need to monitor your Kubernetes cluster but the workloads running on it, you can easily deploy the Prometheus agent just by running a single Helm command. Due the lack of the Kubernetes integration, Prometheus metrics won't be decorated with Kubernetes tags like cluster, pod, or container name.
 
-By default Prometheus Agent will only scrape metrics from a set of [Prometheus integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro), but it can easily be configured to monitor the entire cluster or specific endpoints.
-
 With this integration you can:
 
 * Automatically get insights from the most popular workloads. Take advantage of predefined set of dashboards and alerts.

--- a/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -119,7 +119,7 @@ The Prometheus Agent of New Relic allows you to easily scrape Prometheus metrics
 You can install Prometheus Agent in two modes:
 
 * [Alongside the Kubernetes integration](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#kubernetes-install): Prometheus agent is installed automatically together with the [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
-* [Standalone](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#prometheus-install):If you don't need to monitor your Kubernetes cluster and only want to monitor workloads running on it, you can easily deploy the Prometheus agent just by running a single Helm command. Keep in mind that if you're only using the Prometheus agent, the Prometheus metrics won't be decorated with Kubernetes tags like cluster, pod, or container name.
+* [Standalone](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#prometheus-install): If you don't need to monitor your Kubernetes cluster and only want to monitor workloads running on it, you can easily deploy the Prometheus agent just by running a single Helm command. Keep in mind that if you're only using the Prometheus agent, the Prometheus metrics won't be decorated with Kubernetes tags like cluster, pod, or container name.
 
 With this integration you can:
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent.mdx
@@ -64,7 +64,7 @@ The targets annotated with `prometheus.io/scrape: "true"` will be scraped or not
 
 ### Scrape metrics only from Prometheus integrations [#scrape-prometheus-integrations]
 
-The Prometheus agent is configured, by default, to scrape metrics from the most popular integrations in Kubernetes. Have a look at the [list of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro) containing a set of dashboards and alerts to start monitoring out of the box.
+The Prometheus agent can be configured to scrape metrics from the most popular integrations in Kubernetes. Have a look at the [list of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro) containing a set of dashboards and alerts to start monitoring out of the box.
 
 That list is defined in the [values.yaml](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/charts/newrelic-prometheus-agent/values.yaml) of New Relic's Prometheus agent helm chart. You can modify this list, but some dashboards might not work out of the box with custom labels or values.
 


### PR DESCRIPTION
Prometheus Agent doesn't scrape by default anymore Prometheus integrations in the guided install

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.