### PR TITLE
Update browser support versions with link

### DIFF
--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -37,10 +37,10 @@ For more information, review the [instrumentation for browser monitoring](/docs/
 
 The browser agent officially supports the following browser versions:
 
-* [Chrome](https://www.google.com/chrome/) (previous 10 versions)
-* [Safari](https://www.apple.com/safari/) (previous 10 versions)
-* [Firefox](https://www.mozilla.org/firefox/) (previous 10 versions)
-* [Edge](https://www.microsoft.com/adge) (previous 10 versions)
+* [Chrome](https://www.google.com/chrome/) ([previous 10 versions](https://browsersl.ist/#q=last+10+chrome+versions))
+* [Safari](https://www.apple.com/safari/) ([previous 10 versions](https://browsersl.ist/#q=last+10+safari+versions))
+* [Firefox](https://www.mozilla.org/firefox/) ([previous 10 versions](https://browsersl.ist/#q=last+10+firefox+versions))
+* [Edge](https://www.microsoft.com/edge) ([previous 10 versions](https://browsersl.ist/#q=last+10+edge+versions))
 
 Instrumentation and specific features may be compatible with other browsers or versions. 
 


### PR DESCRIPTION
Update browser support versions with link to same resource the browser agent team uses to determine tests to run, this gives the customer accurate insight on which specific browsers are supported.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
This PR updates the supported browser versions UL items with links to the resource that is used by the browser agent team to determine test support.

* What problems does this PR solve?
Gives clarity to customers on which exact browser versions are being described