### PR TITLE
Ruby agent 8.10.0 example

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8100.mdx
@@ -3,8 +3,8 @@ subject: Ruby agent
 releaseDate: '2022-08-17'
 version: 8.10.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.10.0.gem'
-features: ["New gRPC instrumentation", "Code-level metrics functionality is enabled by default", "Performance updates"]
-bugs: ["Correctly identify the configuration value of transaction_tracer.transaction_threshold: apdex_f", "Check if a Logger object is frozen before attempting to modify"]
+features: ["Add gRPC instrumentation", "Enable code-level metrics functionality by default", "Boost performance by defaulting to frozen string literals", "Boost performace by reworking timing range overlap calculations for multiple transaction segments"] 
+bugs: ["Identify the config value of transaction_tracer.transaction_threshold correctly", "Check if a Logger object is frozen before attempting to modify"]
 security: []
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8100.mdx
@@ -3,6 +3,9 @@ subject: Ruby agent
 releaseDate: '2022-08-17'
 version: 8.10.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.10.0.gem'
+features: ["New gRPC instrumentation", "Code-level metrics functionality is enabled by default", "Performance updates"]
+bugs: ["Fix error when setting the yaml configuration with `transaction_tracer.transaction_threshold: apdex_f`", "Check if a Logger object is frozen before attempting to modify"]
+security: []
 ---
 
   ## v8.10.0

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-8100.mdx
@@ -4,7 +4,7 @@ releaseDate: '2022-08-17'
 version: 8.10.0
 downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-8.10.0.gem'
 features: ["New gRPC instrumentation", "Code-level metrics functionality is enabled by default", "Performance updates"]
-bugs: ["Fix error when setting the yaml configuration with `transaction_tracer.transaction_threshold: apdex_f`", "Check if a Logger object is frozen before attempting to modify"]
+bugs: ["Correctly identify the configuration value of transaction_tracer.transaction_threshold: apdex_f", "Check if a Logger object is frozen before attempting to modify"]
 security: []
 ---
 


### PR DESCRIPTION
Metadata example for Ruby agent 8.10.0

Added `features`, `bugs`, and `security` field metadata. Field content is a modified version of the release notes.
