### PR TITLE
fix: backfilling release notes we missed from previous releases

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-2.mdx
@@ -1,0 +1,15 @@
+---
+subject: Node.js agent
+releaseDate: '2022-05-31'
+version: 8.13.2
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Upgraded `protobufjs` to resolve  CVE-2022-25878
+
+
+### Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-2.mdx
@@ -7,7 +7,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* Upgraded `protobufjs` to resolve  CVE-2022-25878
+* Upgraded `protobufjs` to resolve [CVE-2022-25878](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2022-25878)
 
 
 ### Support statement:

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-4-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-4-0.mdx
@@ -7,32 +7,31 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* Removed legacy agent async context propagation. The default behavior is now what was behind the `feature_flag.new_promise_tracking`. You can read more about the difference [here](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-0#new-features). 
+* Removed legacy agent async context propagation. The default behavior is now what was behind the `feature_flag.new_promise_tracking`. You can read more about the difference [here](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-0/#new-features). 
 
 * Fixed an issue with the ES Module loader that properly registers instrumentation when the file path included url encoded characters.
 
 * Added an API for enqueuing application logs for forwarding 
 
-```js
-newrelic.recordLogEvent({ message: 'hello world', level: 'info' })`
-```
+    ```js
+    newrelic.recordLogEvent({ message: 'hello world', level: 'info' })`
+    ```
 
+    **Note**: If you're including a serialized error make sure it's on the `error` key of the log event: 
 
-**Note**: If you are including a serialized error make sure it is on the `error` key of the log event: 
-
-```js
-const error = new Error('testing errors'); 
-newrelic.recordLogEvent({ message: 'error example', level: 'error', error })
-```
+    ```js
+    const error = new Error('testing errors'); 
+    newrelic.recordLogEvent({ message: 'error example', level: 'error', error })
+    ```
 
 * Fixed `cassandra-driver` instrumentation to properly set instance details on query segments/spans.
 
 * Added a new context manager that leverages AsyncLocalStorage for async context propagation.
-    * This will be available via a feature flag  `config.feature_flag.async_local_context`
+    * This will be available via a feature flag `config.feature_flag.async_local_context`
     * Alternatively you can set the environment variable of `NEW_RELIC_FEATURE_FLAG_ASYNC_LOCAL_CONTEXT=1`
     * By enabling this feature flag it should make the agent use less memory and CPU.
 
 
 ### Support statement:
 
-* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/).

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-4-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-4-0.mdx
@@ -1,0 +1,38 @@
+---
+subject: Node.js agent
+releaseDate: '2022-10-24'
+version: 9.4.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Removed legacy agent async context propagation. The default behavior is now what was behind the `feature_flag.new_promise_tracking`. You can read more about the difference [here](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-0#new-features). 
+
+* Fixed an issue with the ES Module loader that properly registers instrumentation when the file path included url encoded characters.
+
+* Added an API for enqueuing application logs for forwarding 
+
+```js
+newrelic.recordLogEvent({ message: 'hello world', level: 'info' })`
+```
+
+
+**Note**: If you are including a serialized error make sure it is on the `error` key of the log event: 
+
+```js
+const error = new Error('testing errors'); 
+newrelic.recordLogEvent({ message: 'error example', level: 'error', error })
+```
+
+* Fixed `cassandra-driver` instrumentation to properly set instance details on query segments/spans.
+
+* Added a new context manager that leverages AsyncLocalStorage for async context propagation.
+    * This will be available via a feature flag  `config.feature_flag.async_local_context`
+    * Alternatively you can set the environment variable of `NEW_RELIC_FEATURE_FLAG_ASYNC_LOCAL_CONTEXT=1`
+    * By enabling this feature flag it should make the agent use less memory and CPU.
+
+
+### Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The team automating upgrade processes noticed we forgot to add release notes for some past releases.  This backfills it
