### PR TITLE
feat: Add K8s namespace filtering instructions

### DIFF
--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -662,17 +662,17 @@ newrelic-infrastructure:
 
 You can also use Kubernetes match expressions to include or exclude namespaces.  The valid operators are:
 
-- In
-- NotIn
-- Exists
-- DoesNotExist
+* In
+* NotIn
+* Exists
+* DoesNotExist
 
-The general structure the `matchExpressions` section is one or more of the following lines
+The general structure the `matchExpressions` section is one or more of the following lines:
 
 ```yaml
 {key: VALUE, operator: OPERATOR, values: LIST_OF_VALUES}
 ```
-A following is a complete example
+Here's a complete example:
 
 ```yaml
 common:
@@ -683,10 +683,10 @@ common:
 ```
 
 <Callout variant="tip">
-  More than one line can be included in the `matchExpresions` section and the expressions are concatenated.  All must be true for the filter to apply. Labels and match expressions are explained in more detail [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
+  More than one line can be included in the `matchExpresions` section, and the expressions are concatenated.  All must be true for the filter to apply. Labels and match expressions are explained in more detail [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 </Callout>
 
-In this example namespaces with the label `newrelic.com/scrape` set to `false` will be excluded:
+In this example, namespaces with the label `newrelic.com/scrape` set to `false` will be excluded:
 
 ```yaml
 global:

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -627,6 +627,101 @@ It's not surprising that a complex and decentralized system like Kubernetes has 
 
 Depending on your observability objectives you may consider adjusting the scrape interval. The default is 15s. Now the Kubernetes cluster explorer only refreshes every 45s. If your primary use of the K8s data is to support the KCE visualizations you may consider changing your scrape interval to 20s. That change from 15s to 20s can have a substantial impact. For more details about managing this, see our [Helm integration scrape interval docs](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm/#scrape-interval).
 
+### Filtering Namespaces
+
+The Kubernetes Integration v3 and above allows filtering which namespaces are scraped by labelling them. By default all namespaces are scraped.
+
+We use the `namespaceSelector` in the same way Kubernetes does. In order to include only namespaces matching a label, change the `namespaceSelector` by adding the following to your `values-newrelic.yaml`, under the `newrelic-infrastructure` section:
+
+```yaml
+common:
+  config:
+    namespaceSelector:
+      matchLabels:
+        key1 : "value1"
+```
+
+In this example only namespaces with the label `newrelic.com/scrape` set to `true` will be scraped:
+
+```yaml
+global:
+  licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
+  cluster: _K8S_CLUSTER_NAME_
+
+# ... Other settings as shown above
+
+# Configuration for newrelic-infrastructure
+newrelic-infrastructure:
+  # ... Other settings as shown above
+  common:
+    config:
+      namespaceSelector:
+        matchLabels:
+          newrelic.com/scrape: "true"
+```
+
+You can also use Kubernetes expressions to include or exclude namespaces using the following syntax:
+
+```yaml
+common:
+  config:
+    namespaceSelector:
+      matchExpressions:
+      - {key: newrelic.com/scrape, operator: NotIn, values: ["false"]}
+      - {key: key1, operator: In, values: ["value1"]}
+```
+
+<Callout variant="tip">
+  The expressions under `matchExpressions` are concatenated.
+</Callout>
+
+In this example namespaces with the label `newrelic.com/scrape` set to `false` will be excluded:
+
+```yaml
+global:
+  licenseKey: _YOUR_NEW_RELIC_LICENSE_KEY_
+  cluster: _K8S_CLUSTER_NAME_
+
+# ... Other settings as shown above
+
+# Configuration for newrelic-infrastructure
+newrelic-infrastructure:
+  # ... Other settings as shown above
+  common:
+    config:
+      namespaceSelector:
+        matchExpressions:
+        - {key: newrelic.com/scrape, operator: NotIn, values: ["false"]}
+```
+
+See a full list of the settings that can be modified in the [chart's README file](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure).
+
+#### How can I know which namespaces are excluded? [#excluded-namespaces]
+
+All the namespaces within the cluster are listed thanks to the `K8sNamespace` sample. The `nrFiltered` attribute determines whether the data related to the namespace is going to be scraped.
+
+Use this query to know which namespaces are being monitored:
+
+```sql
+FROM K8sNamespaceSample SELECT displayName, nrFiltered WHERE clusterName = <clusterName> SINCE 2 MINUTES AGO
+```
+
+#### What data is being discarded from the excluded namespaces? [#namespaces-discarded-data]
+
+The following samples won't be available for the excluded namespaces:
+
+- `K8sContainerSample`
+- `K8sDaemonsetSample`
+- `K8sDeploymentSample`
+- `K8sEndpointSample`
+- `K8sHpaSample`
+- `K8sPodSample`
+- `K8sReplicasetSample`
+- `K8sServiceSample`
+- `K8sStatefulsetSample`
+- `K8sVolumeSample`
+
+
 ### Kube state metrics
 
 The Kubernetes cluster explorer requires only the following kube state metrics (KSM):

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -660,7 +660,19 @@ newrelic-infrastructure:
           newrelic.com/scrape: "true"
 ```
 
-You can also use Kubernetes expressions to include or exclude namespaces using the following syntax:
+You can also use Kubernetes match expressions to include or exclude namespaces.  The valid operators are:
+
+- In
+- NotIn
+- Exists
+- DoesNotExist
+
+The general structure the `matchExpressions` section is one or more of the following lines
+
+```yaml
+{key: VALUE, operator: OPERATOR, values: LIST_OF_VALUES}
+```
+A following is a complete example
 
 ```yaml
 common:
@@ -668,11 +680,10 @@ common:
     namespaceSelector:
       matchExpressions:
       - {key: newrelic.com/scrape, operator: NotIn, values: ["false"]}
-      - {key: key1, operator: In, values: ["value1"]}
 ```
 
 <Callout variant="tip">
-  The expressions under `matchExpressions` are concatenated.
+  More than one line can be included in the `matchExpresions` section and the expressions are concatenated.  All must be true for the filter to apply. Labels and match expressions are explained in more detail [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/).
 </Callout>
 
 In this example namespaces with the label `newrelic.com/scrape` set to `false` will be excluded:
@@ -703,7 +714,9 @@ All the namespaces within the cluster are listed thanks to the `K8sNamespace` sa
 Use this query to know which namespaces are being monitored:
 
 ```sql
-FROM K8sNamespaceSample SELECT displayName, nrFiltered WHERE clusterName = <clusterName> SINCE 2 MINUTES AGO
+FROM K8sNamespaceSample SELECT displayName, nrFiltered
+WHERE clusterName = INSERT_NAME_OF_CLUSTER SINCE
+2 MINUTES AGO
 ```
 
 #### What data is being discarded from the excluded namespaces? [#namespaces-discarded-data]


### PR DESCRIPTION
The Kubernetes Integration v3 and above allows filtering which namespaces are scraped by labelling them. By default all namespaces are scraped.  This PR adds instructions to the guide on how to use this feature.

