### PR TITLE
Added link to statsD helm chart

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -144,6 +144,14 @@ Here are examples of Kubernetes manifests for deployment and service objects:
 
     For configuration details, see [Kubernetes configuration](#k8s-config).
   </Collapser>
+  
+  <Collapser
+    id="k8s-helm-chart"
+    title="Kubernetes Helm Chart"
+  >
+    A [StatsD Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/nri-statsd) is also available to install the integration.
+  </Collapser>
+    
 </CollapserGroup>
 
 <InstallFeedback />


### PR DESCRIPTION
## Give us some context

* Customer feedback: statsD documentation missing a link to statsD Helm chart.