### PR TITLE
infra integrations dry-run docs

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/troubleshooting/run-integrations-manually.mdx
+++ b/src/content/docs/infrastructure/host-integrations/troubleshooting/run-integrations-manually.mdx
@@ -1,20 +1,63 @@
 ---
-title: Run integrations manually
+title: Run integrations manually (dry-run)
 type: troubleshooting
 tags:
   - Integrations
   - On-host integrations
   - Troubleshooting
-metaDescription: Run integrations manually.
+metaDescription: Run integrations manually (dry-run).
 redirects:
   - /docs/integrations/host-integrations/troubleshooting/run-integrations-manually
 ---
 
 ## Problem
 
-You want to know if an integration is gathering metrics or not. To diagnose it, run the integration manually.
+You want to know if an integration is configured as expected and gathering metrics. To diagnose it, use the dry-run flag with the Infrastructure Agent or run the integration manually.
 
 ## Solution
+
+### Integrations Dry-run
+Since version 1.27.0, the Infrastructure Agent can run integrations in Dry-Run mode for troubleshooting. In this mode, 
+the Agent will run integrations from provided configuration and it will print the integrations output in the standard 
+output.
+
+This mode supports a single configuration file or a folder with multiple configuration files.
+
+Dry-run flag:
+```
+/usr/bin/newrelic-infra -dry_run -integration_config_path PATH_TO_FILE_OR_DIR
+```
+
+Example: Testing a single integration file:
+```
+/usr/bin/newrelic-infra -dry_run -integration_config_path /any/absolute/path/mysql-config.yml 
+```
+
+Example: Testing all files inside a folder:
+```
+/usr/bin/newrelic-infra -dry_run -integration_config_path /any/absolute/path 
+```
+
+For each integration execution, the command will print the name of the integration and its output.
+
+```
+----------
+Integration Name: nri-mysql
+Integration Output: {"name":"com.newrelic.mysql","protocol_version":"3","integration_version":"1.8.0","data":[{"entity":{"name":"localhost:3309","type":"node","id_attributes":[]},"metrics":[{"cluster.nodeType":"master","db.handlerRollbackPerSecond":0,"db.innodb.bufferPoolPagesData":1139,"db.innodb.bufferPoolPagesFree":7049,"db.innodb.bufferPoolPagesTotal":8192,"db.innodb.dataReadBytesPerSecond":0,"db.innodb.dataWrittenBytesPerSecond":0,"db.innodb.logWaitsPerSecond":0,"db.innodb.rowLockCurrentWaits"...
+```
+When running multiple files, the different integration outputs will be separated with `----------`
+
+```
+----------
+Integration Name: nri-mysql
+Integration Output: {"name":"com.newrelic.mysql","protocol_version":"3","integration_version":"1.8.0","data":...
+
+----------
+Integration Name: nri-ibmmq
+Integration Output: {"protocol_version":"4","integration":{"name":"nri-ibmmq","version":"0.0.2"},"data":....
+```
+
+### Manual execution 
 
 Use the following commands to run your integrations manually:
 


### PR DESCRIPTION
## Give us some context

* Customer feedback: the dry-run mode for infra integrations is only documented in Github and not in public docs. 