### PR TITLE
Removing support via Github reference in ansible/puppet/chef

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-puppet.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-puppet.mdx
@@ -102,7 +102,3 @@ Here are the parameters for the `newrelic_infra::agent` public class:
     </tr>
   </tbody>
 </table>
-
-## For more help [#more_help]
-
-If you need additional help, [file an issue at **newrelic/infrastructure-agent-puppet** on GitHub](https://github.com/newrelic/infrastructure-agent-puppet/issues).

--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-ansible.mdx
@@ -109,7 +109,3 @@ Here are available variables for configuring the `newrelic.newrelic-infra` role:
     </tr>
   </tbody>
 </table>
-
-## For more help [#more_help]
-
-If you need additional help, [file an issue at **newrelic/infrastructure-agent-ansible** on GitHub](https://github.com/newrelic/infrastructure-agent-ansible/issues).

--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-chef.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-using-chef.mdx
@@ -183,7 +183,3 @@ The New Relic cookbook is available from the [public Chef Supermarket](https://s
    ```
 3. Optional: To control version usage and updating, customize the recipe with [Chef attributes](#attributes).
 4. Include the default New Relic recipe by using `include_recipe ‘newrelic-infra::default'` or by adding the recipe to your run list.
-
-## For more help [#more_help]
-
-If you need additional help, [file an issue at **newrelic/infrastructure-agent-chef** on GitHub](https://github.com/newrelic/infrastructure-agent-chef/issues).


### PR DESCRIPTION
## Give us some context

* These IaC integrations had an old reference to "learn more" from the github repo. We don't have this callout in other integrations and it's confusing for customers. 