### PR TITLE
docs(Alerts): Update information about thresholds

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -181,17 +181,17 @@ The following rules apply both to the New Relic user interface and to the REST A
       </td>
 
       <td>
-        0 Warnings, 1 Critical
+        1 Warning or 1 Critical
       </td>
 
       <td>
-        1 Warning, 1 Critical
+        1 Warning and 1 Critical
       </td>
     </tr>
 
     <tr>
       <td id="violation">
-        **Alert violations:**
+        **Alert incidents:**
       </td>
 
       <td/>
@@ -201,9 +201,9 @@ The following rules apply both to the New Relic user interface and to the REST A
 
     <tr>
       <td>
-        [Custom violation descriptions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions)
+        [Custom incident descriptions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions)
       </td>
-
+        n/a
       <td/>
 
       <td>
@@ -213,7 +213,7 @@ The following rules apply both to the New Relic user interface and to the REST A
 
     <tr>
       <td>
-        [Duration for condition violation](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-thresholds-trigger-alert)
+        [Duration for condition incident](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-thresholds-trigger-alert)
       </td>
 
       <td>
@@ -227,34 +227,34 @@ The following rules apply both to the New Relic user interface and to the REST A
 
     <tr>
       <td>
-        Violations per Incident
+        Incidents per Issue
       </td>
 
       <td>
-        1 violation
+        1 incident
       </td>
 
       <td>
-        10,000 violations
+        10,000 incidents
 
-        Violations beyond this limit will not be persisted.
+        Incidents beyond this limit will not be persisted.
       </td>
     </tr>
 
     <tr>
       <td>
-        Violation Search API - Page Size
+        Incident Search API - Page Size
       </td>
 
       <td>
-        1 page (less than or equal to 25 violations)
+        1 page (less than or equal to 25 incidents)
       </td>
 
       <td>
-        1000 pages (25K violations)
+        1000 pages (25K incidents)
 
         <Callout variant="tip">
-          Only use the `only-open` parameter to retrieve all open violations. If you have more than 25K open violations and need to retrieve them via the REST API, please contact New Relic Support.
+          Only use the `only-open` parameter to retrieve all open incidents. If you have more than 25K open incidents and need to retrieve them via the REST API, please contact New Relic Support.
         </Callout>
       </td>
     </tr>

--- a/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
@@ -134,7 +134,7 @@ There are two incident thresholds: critical (red) and warning (yellow). Define t
 
 ## Decide what happens when there's no signal
 
-Loss of signal occurs when New Relic stops receiving data for a while; technically, we detect loss of signal after a significant amount of time has elapsed since data was last received in a time series. Loss of signal can be used to trigger or resolve an issue, which you can use to set up alerts.
+Loss of signal occurs when New Relic stops receiving data for a while; technically, we detect loss of signal after a significant amount of time has elapsed since data was last received in a time series. Loss of signal can be used to trigger or resolve an incident, which you can use to set up alerts.
 
 You can configure loss of signal settings by condition in the UI or [configure loss of signal via the NerdGraph API](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling/#loss-of-signal).
 

--- a/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
@@ -39,8 +39,8 @@ Read on to learn the best practices for:
 
 * Policies
 * Notification channels
-* Incident preferences
-* Thresholds and violations
+* Issue preferences
+* Thresholds and incidents
 * Muting rules
 
 ## Recommended alerts [#recommend-alerts]
@@ -53,7 +53,7 @@ A policy is a container for similar [conditions](/docs/alerts-applied-intelligen
 
 If you’re new to alerts, learn how to [create, edit, or find policies](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy/).
 
-Organize your policy's scope to a single [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/) when possible. Assign your policy to the essential team or teams that need to be notified when an [incident](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents/) occurs. This way, you keep policies centralized and focused.
+Organize your policy's scope to a single [entity](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/) when possible. Assign your policy to the essential team or teams that need to be notified when an [issue](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/specify-when-alerts-create-incidents/) occurs. This way, you keep policies centralized and focused.
 
 If a team is monitoring several groups of the same entity type, combine those entity clusters (like servers) together into one policy. This way, your team can be notified from one policy rather than navigating several policies at once.
 
@@ -65,7 +65,7 @@ For example:
 * **Operations personnel** may need notifications for poor back-end performance, such as server memory and load averages.
 * **The product owner** may need notifications for positive front-end performance, such as improved end user Apdex scores or sales being monitored in [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
 
-## Set your condition thresholds and violations [#threshold-practices]
+## Set your condition thresholds and incidents [#threshold-practices]
 
 Set meaningful [threshold](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-thresholds-trigger-alert) levels to optimize alerts for your business. Here are some suggested guidelines:
 
@@ -130,15 +130,11 @@ Set meaningful [threshold](/docs/alerts/new-relic-alerts-beta/configuring-alert-
 
 In most of our products (except Infrastructure), the color-coded [health status indicator](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#health-status) in the user interface changes as the alerting threshold escalates or returns to normal. This allows you to monitor a situation through our UI before a critical threshold passes, without needing to receive specific notifications about it.
 
-There are two violation thresholds: critical (red) and warning (yellow). Define these thresholds with different criteria, keeping in mind the suggestions above.
-
-<Callout variant="important">
-  Warning violations do not open incidents. A critical violation can open incidents, but you must define that decision through your [incident preferences](/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices/#incident-practices).
-</Callout>
+There are two incident thresholds: critical (red) and warning (yellow). Define these thresholds with different criteria, keeping in mind the suggestions above.
 
 ## Decide what happens when there's no signal
 
-Loss of signal occurs when New Relic stops receiving data for a while; technically, we detect loss of signal after a significant amount of time has elapsed since data was last received in a time series. Loss of signal can be used to trigger or resolve a violation, which you can use to set up alerts.
+Loss of signal occurs when New Relic stops receiving data for a while; technically, we detect loss of signal after a significant amount of time has elapsed since data was last received in a time series. Loss of signal can be used to trigger or resolve an issue, which you can use to set up alerts.
 
 You can configure loss of signal settings by condition in the UI or [configure loss of signal via the NerdGraph API](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling/#loss-of-signal).
 
@@ -147,43 +143,43 @@ You can configure loss of signal settings by condition in the UI or [configure l
 Assuming you're sending an event to New Relic as part of your batch job, you can set up an alert condition to notify you if your batch jobs fail to run.
 
 1. Set up a simple count query on the event (`SELECT count(*) FROM MyBatchEvent`)
-2. Set Loss of Signal to open a new violation after 24 hours and 30 minutes (you can adjust this, but it's a good idea to allow for a late-running batch job)
+2. Set Loss of Signal to open a new incident after 24 hours and 30 minutes (you can adjust this, but it's a good idea to allow for a late-running batch job)
 3. Make sure to use the Event Timer streaming aggregation method. Since you will only ever get 1 data point every 24 hours, you can set the Timer to its lowest setting, 5 seconds.
 
 ## Use non-null values when there's no signal
 
 By default, gaps in data signals are filled with null values. In cases where you need to be able to create conditions based on those data gaps, you can fill gaps with a custom value or the last known value. You can configure this setting by condition in the UI or [configure gap filling values via NerdGraph](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling/#customize)
 
-## Define your incident preferences [#incident-practices]
+## Define your issue preferences [#incident-practices]
 
-Decide when you get incident notifications so you can respond to incidents when they happen.
+Decide when you get issue notifications so you can respond to issues when they happen.
 
-If you’re new to alerts, learn more about your [incident preferences options](https://discuss.newrelic.com/t/relic-solution-alert-incident-preferences-are-the-key-to-consistent-alert-notifications/40867).
+If you’re new to alerts, learn more about your [issue preferences options](https://discuss.newrelic.com/t/relic-solution-alert-incident-preferences-are-the-key-to-consistent-alert-notifications/40867).
 
-The default incident preference setting combines all conditions within a policy into one incident. Change your default incident preference setting to increase or decrease the number of incidents and incident notifications you receive.
+The default issue preference setting combines all conditions within a policy into one issue. Change your default issue preference setting to increase or decrease the number of issues and issue notifications you receive.
 
-Each team within your organization will have different needs. Ask your team two important questions when deciding your incident preferences:
+Each team within your organization will have different needs. Ask your team two important questions when deciding your issue preferences:
 
 * Do we want to be notified every time something goes wrong?
 * Do we want to group all similar notifications together and be notified once?
 
-When a policy and its conditions have a broader scope (like managing the performance of several entities), increase the amount of incidents you receive. You will need more notifications because two incidents will not necessarily relate to each other.
+When a policy and its conditions have a broader scope (like managing the performance of several entities), increase the amount of issues you receive. You will need more notifications because two issues will not necessarily relate to each other.
 
-When a policy and its conditions have a focused scope (like managing the performance of one entity), opt for the default incident preference. You will need less notifications when two incidents are related to each other or when the team is already notified and fixing an existing problem.
+When a policy and its conditions have a focused scope (like managing the performance of one entity), opt for the default issue preference. You will need less notifications when two issues are related to each other or when the team is already notified and fixing an existing problem.
 
-Decide how you get incident notifications by using our [notification channel best practices](/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices/#channel-practices).
+Decide how you get issue notifications by using our [notification channel best practices](/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices/#channel-practices).
 
 ## Select your notification channels [#channel-practices]
 
-Tailor notifications to the most useful channel and policy so you can avoid alert fatigue and help the right personnel receive and respond to incidents they care about in a systematic way.
+Tailor notifications to the most useful channel and policy so you can avoid alert fatigue and help the right personnel receive and respond to issues they care about in a systematic way.
 
 If you’re new to alerts, learn how to [set up notification channels](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts/).
 
-Notify teams and individuals who needs to stay updated on or resolve a problem when an incident arises.
+Notify teams and individuals who needs to stay updated on or resolve a problem when an issue arises.
 
 To stay updated, select a notification channel that is less intrusive, like email.
 
-For vital notifications and incident responses, select a notification channel that is more intrusive, like PagerDuty or Slack.
+For vital notifications and issue responses, select a notification channel that is more intrusive, like PagerDuty or Slack.
 
 Do not rely on email for quick notifications in case of delays.
 
@@ -191,7 +187,7 @@ Do not rely on email for quick notifications in case of delays.
 
 Mute alerts during routine events, such as maintenance or planned downtime.
 
-You can also silence a policy, a specific entity, and a condition when needed. Incidents can still be opened, but you won't be notified.
+You can also silence a policy, a specific entity, and a condition when needed. Issues can still be opened, but you won't be notified.
 
 If you're new to alerts, learn how to [create and manage muting rules](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications/).
 


### PR DESCRIPTION
- Also update to incident/issue nomenclature

## Give us some context

* Recent changes to the alerts product now allows for conditions to have _only_ a warning threshold (critical is no longer required, but at least one threshold is)
* Also updates from old "violation/incident" nomenclature to updated "incident/issue" nomenclature
