### PR TITLE
ON HOLD (scheduled for February 22nd) docs: Browser Agent Release 1226

### DIFF
--- a/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v1226
+      </td>
+
+      <td>
+        Feb 22, 2023
+      </td>
+
+      <td>
+        Feb 22, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v1225
       </td>
 
@@ -40,7 +54,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Feb 10, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v1224
@@ -54,7 +68,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Feb 8, 2024
       </td>
     </tr>
-  
+
     <tr>
       <td>
         v1223
@@ -68,7 +82,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jan 27, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v1222
@@ -231,7 +245,7 @@ Any versions not listed in the following table are no longer supported. Please [
       <td>
         May 20, 2021
       </td>
-      
+
       <td>
         May 20, 2023
       </td>

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1226.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1226.mdx
@@ -1,0 +1,21 @@
+---
+subject: Browser agent
+releaseDate: '2023-02-22'
+version: '1226'
+---
+
+## New Features
+
+### Enable back/forward cache
+Updating the agent default configuration to enable the back/forward cache feature previously released in version 1222 by default.
+
+## Bug Fixes
+
+### Revert xhr deny list timeslice metrics
+Customers were losing visibility into all calls on the page when denying timeslice metrics based on the deny list. This change reverts to the behavior seen in all previous versions of the browser agent.
+
+### Handle unhandledPromiseRejections more gracefully
+The agent will attempt to handle niche objects throw from `unhandledPromiseRejection` events more gracefully. These cases could include objects with frozen or static properties, or custom extensions of the Error class without a `set` method in place.
+
+### Disable metrics for missing entitlement
+Fixing issue where metrics harvesting was not being halted when the agent RUM call indicated the account did not have entitlement to the jserrors endpoint. Before this change, customers missing this entitlement would see network calls to the New Relic jserrors endpoint result in 403 or 409 errors.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1226.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1226.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Browser agent
-releaseDate: '2023-02-22'
+releaseDate: '2023-02-23'
 version: '1226'
 ---
 


### PR DESCRIPTION
Release notes for Browser Agent release 1226

Note: I accidentally merged the original PR too soon, so this a duplicate of https://github.com/newrelic/docs-website/pull/11659.