### PR TITLE
.NET Agent: correct compatibility doc for ServiceStack.Redis

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -669,7 +669,8 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
               name="fe-check"
             />
           </td>
-
+            * Verified compatible versions: 4.0.40
+            * Known incompatible versions: 4.0.44 or higher
           <td/>
         </tr>
 
@@ -687,7 +688,6 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
             * Minimum supported version: 1.0.488
             * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66
-            * Known incompatible versions: 4.0.44 or higher
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
A PR (https://github.com/newrelic/docs-website/pull/11673) was done yesterday to update the .NET Agent's compatibility and support docs regarding known compatible vs. incompatible versions of our instrumentation for `ServiceStack.Redis`; however, the data was accidentally added to the table row for `StackExchange.Redis` which is a different library.  This PR corrects the error.