### PR TITLE
fix: incompatible ServiceStack.Redis version

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -669,7 +669,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
               name="fe-check"
             />
           </td>
-
+            * Known incompatible versions: 4.0.44 or higher
           <td/>
         </tr>
 
@@ -687,7 +687,6 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
             * Minimum supported version: 1.0.488
             * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66
-            * Known incompatible versions: 4.0.44 or higher
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
I made this change yesterday and I put this in the wrong row (put the version in StackExchange.Redis instead of ServiceStack.Redis)
