### PR TITLE
chore(MonitorDowntime): Added clarifications

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times.mdx
@@ -20,8 +20,14 @@ Schedule **monitor downtimes** to specify times that your synthetic [monitors](/
 * Service interruptions
 
 <Callout variant="important">
-  During synthetic monitor downtimes, your selected monitors stop running until their scheduled end time. To temporarily disable alerts without pausing your monitors, [mute them](/docs/synthetics/new-relic-synthetics/using-monitors/alerting-synthetics#mute) instead.
+  During synthetic monitor downtimes, your selected monitors stop running until their scheduled end time. To temporarily disable alerts without pausing your monitors, [mute them](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications) instead.
 </Callout>
+
+## Monitor downtime tips [#tips]
+
+A monitor downtime has a maximum duration of 24 hours. Monitor downtime windows larger than 24 hours will need to be split across multiple monitor downtime configurations.
+
+If the start and end times of a monitor downtime span midnight, the monitor downtime will last until the next day at the end time specified. For example, a start time of 11:30PM and an end time of 5:00AM would start on the day listed and last until 5:00AM the next day.
 
 ## Create recurring monitor downtimes [#create-window]
 
@@ -35,7 +41,7 @@ Create recurring monitor downtimes for routine monitor maintenance or regularly 
 2. Select **<Icon name="fe-plus-circle"/>
    Create monitor downtime**.
 3. Specify a name for the monitor downtime.
-4. Select a daily, weekly, or monthly frequency. Choose additional scheduling options, such as day of the week, time of day, and how long the window will last.
+4. Select a daily, weekly, or monthly frequency. Choose additional scheduling options, such as day of the week, time of day, and how long the window will last. 
 5. Select the monitors that you would like to be included in the monitor downtime. There is no maximum for the amount of monitors that can be selected.
 6. Select **Create**.
 
@@ -50,12 +56,6 @@ For spontaneous maintenance or service interruptions, create one-time monitor do
 4. Select **once** for the frequency, along with the date and start time for the monitor downtime.
 5. Select the monitors to include in the monitor downtime. There is no maximum for the amount of monitors that can be selected.
 6. Select **Create**.
-
-## View downtime monitors [#view]
-
-Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Synthetic monitoring >(select your monitor) > Summary**. When a monitor downtime occurs, it will be visible on your [**Summary** page](/docs/synthetics/new-relic-synthetics/pages/synthetics-overview-page-view-monitors-performance) within the **Load time chart** as a yellow vertical line. To see which monitor downtime occurred within the chart, hover over the yellow line to view the monitor downtime name.
-
-You can view additional details in the **Results** and **Resources** sections.
 
 ## Delete a monitor downtime [#delete]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/monitor-downtimes-disable-monitoring-during-scheduled-maintenance-times.mdx
@@ -25,7 +25,7 @@ Schedule **monitor downtimes** to specify times that your synthetic [monitors](/
 
 ## Monitor downtime tips [#tips]
 
-A monitor downtime has a maximum duration of 24 hours. Monitor downtime windows larger than 24 hours will need to be split across multiple monitor downtime configurations.
+The maximum duration for a monitor downtime is 24 hours. If you need your downtime to last longer than 24 hours, create multiple monitor downtimes or use a recurring downtime.
 
 If the start and end times of a monitor downtime span midnight, the monitor downtime will last until the next day at the end time specified. For example, a start time of 11:30PM and an end time of 5:00AM would start on the day listed and last until 5:00AM the next day.
 
@@ -41,7 +41,7 @@ Create recurring monitor downtimes for routine monitor maintenance or regularly 
 2. Select **<Icon name="fe-plus-circle"/>
    Create monitor downtime**.
 3. Specify a name for the monitor downtime.
-4. Select a daily, weekly, or monthly frequency. Choose additional scheduling options, such as day of the week, time of day, and how long the window will last. 
+4. Select a daily, weekly, or monthly frequency. Choose additional scheduling options, such as day of the week, time of day, and how long the window lasts. 
 5. Select the monitors that you would like to be included in the monitor downtime. There is no maximum for the amount of monitors that can be selected.
 6. Select **Create**.
 


### PR DESCRIPTION
- Changed link to mute a monitor to point to muting rules instead of setting the monitor state to muted. Setting the monitor state to muted does not mute all alert types
- Removed the section that indicates that monitors in a downtime window would have a yellow indication in the overview UI. This is no longer true
- Added a tips section to address frequent questions