### PR TITLE
fix: removed required .net runtimes

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
@@ -19,7 +19,7 @@ This guide assumes you have the following:
 
 * A New Relic account. If you don't have one, [create one for free](https://newrelic.com/signup).
 * An AWS account. If you don't have one, [create one for free](https://aws.amazon.com/).
-* A .NET Lambda Function, if you don't have one yet, [create one now](https://docs.aws.amazon.com/lambda/latest/dg/lambda-csharp.html).
+* A .NET Lambda Function. If you don't have one yet, [create one now](https://docs.aws.amazon.com/lambda/latest/dg/lambda-csharp.html).
 
 ## Step 1: Enable X-Ray [#xray]
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
@@ -19,7 +19,7 @@ This guide assumes you have the following:
 
 * A New Relic account. If you don't have one, [create one for free](https://newrelic.com/signup).
 * An AWS account. If you don't have one, [create one for free](https://aws.amazon.com/).
-* A .NET Lambda Function running under either the `dotnetcore2.1` or `dotnetcore3.1` runtimes. If you don't have one yet, [create one now](https://docs.aws.amazon.com/lambda/latest/dg/lambda-csharp.html).
+* A .NET Lambda Function, if you don't have one yet, [create one now](https://docs.aws.amazon.com/lambda/latest/dg/lambda-csharp.html).
 
 ## Step 1: Enable X-Ray [#xray]
 


### PR DESCRIPTION
Removed at the recommendation of  @alanwest, we copied these required runtimes from other outside docs and they are almost certainly our of date because lambda now accepts more versions of .NET. It was decided it's better to allow the linked docs to tell customers what is acceptable.