### PR TITLE
(Publish 9AM PST on 2/23/23) Update Java Agent 8.0.0 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-800.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-800.mdx
@@ -15,14 +15,14 @@ downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/
 </ButtonGroup>
 
 <Callout variant="important">
-This release includes a change to the `HttpURLConnection` instrumentation that creates a `TimerTask` to help ensure complete externals reporting. Under some circumstances this may result in a large number of threads being created, which may exhaust the maximum allocated to the JVM, causing it to stop. This issue has been fixed in the 8.0.1 release and it is highly recommended that you update to this version of the Java agent.
+This release includes a change to the `HttpURLConnection` instrumentation that creates a `TimerTask` to help ensure complete externals reporting. Under some circumstances this may result in a large number of threads being created, which may exhaust the maximum allocated to the JVM, causing it to stop. This issue has been fixed in the [8.0.1 release](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-801) and it's highly recommended that you update to this version of the Java agent.
 </Callout>
 
 ## New features and improvements
 
 - Added support for Slick 3.4.0 on Scala 2.13
 - Added support for Embedded Tomcat JMX
-- Updated the Java agent’s `snakeyaml` dependency to 1.33
+- Updated the Java agent's `snakeyaml` dependency to 1.33
 - Added tracer debug logging, which will appear when `-Dnewrelic.config.log_level=finest` 
 and `-Dnewrelic.debug=true` are set
 - Improved logging when using the `recordCustomEvent` API now includes event type, key and value
@@ -59,7 +59,7 @@ The following previously deprecated instrumentation modules were removed:
 - `okhttp-3.4.0`
 - `okhttp-3.5.0`
 
-The previously deprecated `http.responseCode`, `response.status` and `response.statusMessage` transaction/span attributes were removed. These have been replaced by `http.statusCode` and `http.statusText`. If you have any custom dashboards or alerts that query the `http.responseCode`, `response.status`, and `response.statusMessage` attributes then they will need to be updated to instead use `http.statusCode` and `http.statusText`.
+The previously deprecated `http.responseCode`, `response.status`, and `response.statusMessage` transaction/span attributes were removed. These have been replaced by `http.statusCode` and `http.statusText`. If you've any custom dashboards or alerts that query the `http.responseCode`, `response.status`, and `response.statusMessage` attributes then they will need to be updated to instead use `http.statusCode` and `http.statusText`.
 
 ## Update to latest version [#procedures]
 
@@ -81,7 +81,7 @@ We add new settings to `newrelic.yml` as we release new versions of the agent. Y
 
 For example, if you `diff` the default `newrelic.yml` files for Java agent versions 7.10.0 and 7.11.0, the results printed to the console will be like:
 
-```
+```yaml
 ➜ diff newrelic_7.10.0.yml newrelic_7.11.0.yml
 ...
 107a108,119
@@ -106,4 +106,4 @@ For example, if you `diff` the default `newrelic.yml` files for Java agent versi
 ...
 ```
 
-In this example, these lines were added to the default `newrelic.yml` in Java agent version 7.11.0. If you are moving to 7.11.0 or higher, you should add these new lines to your original `newrelic.yml`.
+In this example, these lines were added to the default `newrelic.yml` in Java agent version 7.11.0. If you're moving to 7.11.0 or higher, you should add these new lines to your original `newrelic.yml`.

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-800.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-800.mdx
@@ -15,7 +15,7 @@ downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/
 </ButtonGroup>
 
 <Callout variant="important">
-This release includes a change to the `HttpURLConnection` instrumentation that creates a `TimerTask` to help ensure complete externals reporting. Under some circumstances this may result in a large number of threads being created, which may exhaust the maximum allocated to the JVM, causing it to stop. We are working on a fix to this issue and will publish an updated release promptly.
+This release includes a change to the `HttpURLConnection` instrumentation that creates a `TimerTask` to help ensure complete externals reporting. Under some circumstances this may result in a large number of threads being created, which may exhaust the maximum allocated to the JVM, causing it to stop. This issue has been fixed in the 8.0.1 release and it is highly recommended that you update to this version of the Java agent.
 </Callout>
 
 ## New features and improvements


### PR DESCRIPTION
Modify the *important* section of the Java agent 8.0.0 release notes to suggest updating to v8.0.1, that corrects the issue.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.