### PR TITLE
fix(C SDK ): Updated C SDK for being deprecated

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -24,7 +24,6 @@ Access to the New Relic EU region requires the latest versions of our agents.
 
 Minimum APM agent version required:
 
-* [C SDK 1.0.0](/docs/release-notes/agent-release-notes/c-sdk-release-notes) or higher
 * [Go 2.0.0](/docs/release-notes/agent-release-notes/go-release-notes) or higher
 * [Java 4.0.0](/docs/release-notes/agent-release-notes/java-release-notes) or higher
 * [.NET 8.0.0](/docs/release-notes/agent-release-notes/net-release-notes) or higher

--- a/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
+++ b/src/content/docs/apis/intro-apis/introduction-new-relic-apis.mdx
@@ -192,7 +192,6 @@ See [Manage alerts with NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-api-a
           <td>
             Every APM language agent has an API that lets you customize the agent's default behavior, including reporting custom data. APM agent APIs include:
 
-            * [C SDK API](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api)
             * [Go agent API](/docs/agents/go-agent/get-started/instrument-go-transactions)
             * [Java agent API](/docs/agents/java-agent/api-guides/guide-using-java-agent-api)
             * [.NET agent API](/docs/agents/net-agent/api-guides/guide-using-net-agent-api)

--- a/src/content/docs/apm/agents/c-sdk/get-started/apm-security-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/apm-security-c-sdk.mdx
@@ -15,7 +15,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+  From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 Due of the nature of the C SDK, you have direct control over what data is reported to New Relic. To ensure data privacy and to limit the types of information New Relic receives, no customer data is captured except what you supply in your API calls. In addition, the C SDK reports all data to New Relic over HTTPS.

--- a/src/content/docs/apm/agents/c-sdk/get-started/c-sdk-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/c-sdk-compatibility-requirements.mdx
@@ -18,7 +18,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+  From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 New Relic's C SDK provides a generic library you can customize to communicate with New Relic. Before you install New Relic's C SDK, make sure your system meets these requirements. Also refer to the [C SDK licenses documentation](/docs/c-sdk-licenses).

--- a/src/content/docs/apm/agents/c-sdk/get-started/introduction-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/introduction-c-sdk.mdx
@@ -45,7 +45,7 @@ import apmCSDKArchitecture from 'images/apm_diagram_C-SDK-architecture.png'
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. Please explore the [option to use OpenTelemetry](/docs/apm/agents/c-sdk/get-started/otel_cpp_example) as an alternative to send C++ telemetry data to New Relic. For more details about the EOL, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. Please explore the [option to use OpenTelemetry](/docs/apm/agents/c-sdk/get-started/otel_cpp_example) as an alternative to send C++ telemetry data to New Relic. For more details about the EOL, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 The C SDK is designed to support the often complex, multi-threaded nature of C/C++ applications. You can gain a new level of visibility to help you identify and solve performance issues. You can also collect and analyze data to help you improve the customer experience and make data-driven business decisions.

--- a/src/content/docs/apm/agents/c-sdk/get-started/otel_cpp_example.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/otel_cpp_example.mdx
@@ -8,6 +8,14 @@ tags:
 metaDescription: 'Explore OpenTelemetry to send your C++ instrumentation data to New Relic.'
 ---
 
+<Callout
+  variant="important"
+  title="EOL NOTICE"
+  >
+  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+</Callout>
+
+
 OpenTelemetry C++ is an exciting observability [solution](https://github.com/open-telemetry/opentelemetry-cpp) with stable functionality and a wide base of contributors in an active codebase. New Relic is [compatible](/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic/) with OpenTelemetry and the [benefits](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/) it can provide, such as future proofing code by putting end-point agnostic instrumentation calls versus adhering to vendor-specific formats.
 
 Please see the [New Relic OpenTelemetry setup](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup/) for detailed instructions on how to use OpenTelemetry to work with the language of your choice to send data to New Relic.
@@ -38,7 +46,7 @@ Open a terminal in the C++ container and run the following commands:
 2. `mkdir build`
 3. `cd build`
 4. `rm -rf *`
-5.
+
 ```
 cmake -DCMAKE_BUILD_TYPE=Debug  \
 -DWITH_METRICS_PREVIEW=ON \
@@ -47,10 +55,10 @@ cmake -DCMAKE_BUILD_TYPE=Debug  \
 -DWITH_OTLP=ON \
 ..
 ```
-6. `cd examples`
-7. `make`
-8. `cd otlp`
-9. `./example_otlp_http`
+5. `cd examples`
+6. `make`
+7. `cd otlp`
+8. `./example_otlp_http`
 
 ### 3. View your data [#view-data]
 
@@ -58,7 +66,7 @@ Verify data has arrived by querying your New Relic account data:
 
 1. To see span data: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Query your data** and enter this query:
 
-```
+```sql
 FROM Span SELECT * where telemetry.sdk.name = 'opentelemetry'
 ```
 
@@ -68,7 +76,7 @@ FROM Span SELECT * where telemetry.sdk.name = 'opentelemetry'
 
 ### docker-compose-collector.yaml
 
-```
+```yaml
 version: '3.7'
 services:
   cpp:
@@ -152,7 +160,7 @@ CMD /bin/bash
 
 ### config.dev.yaml
 
-```
+```yaml
 exporters:
   newrelic:
     apikey: 'EDIT_TO_ADD_YOUR_KEY_HERE'

--- a/src/content/docs/apm/agents/c-sdk/get-started/otel_cpp_example.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/otel_cpp_example.mdx
@@ -8,14 +8,6 @@ tags:
 metaDescription: 'Explore OpenTelemetry to send your C++ instrumentation data to New Relic.'
 ---
 
-<Callout
-  variant="important"
-  title="EOL NOTICE"
-  >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
-</Callout>
-
-
 OpenTelemetry C++ is an exciting observability [solution](https://github.com/open-telemetry/opentelemetry-cpp) with stable functionality and a wide base of contributors in an active codebase. New Relic is [compatible](/docs/integrations/open-source-telemetry-integrations/opentelemetry/introduction-opentelemetry-new-relic/) with OpenTelemetry and the [benefits](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/) it can provide, such as future proofing code by putting end-point agnostic instrumentation calls versus adhering to vendor-specific formats.
 
 Please see the [New Relic OpenTelemetry setup](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup/) for detailed instructions on how to use OpenTelemetry to work with the language of your choice to send data to New Relic.

--- a/src/content/docs/apm/agents/c-sdk/install-configure/c-sdk-configuration.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/c-sdk-configuration.mdx
@@ -14,7 +14,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 Your C application requires two configuration values:

--- a/src/content/docs/apm/agents/c-sdk/install-configure/docker-other-container-environments-install-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/docker-other-container-environments-install-c-sdk.mdx
@@ -13,7 +13,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+  From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 You can install the [New Relic C SDK](/docs/agents/c-sdk/get-started/introduction-c-sdk) on a Docker container (or other container) to monitor one or more of your C applications.

--- a/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
@@ -17,7 +17,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 Our C SDK auto-instruments your code so you can start monitoring applications. You can use our launcher, or follow the instructions in this document to complete a basic C SDK installation.

--- a/src/content/docs/apm/agents/c-sdk/install-configure/uninstall-remove-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/uninstall-remove-c-sdk.mdx
@@ -18,7 +18,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+  From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 Follow these procedures as appropriate to temporarily disable the C SDK in your app's code library or to remove it completely.

--- a/src/content/docs/apm/agents/c-sdk/install-configure/update-your-c-sdk-library.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/update-your-c-sdk-library.mdx
@@ -15,10 +15,10 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
-To ensure you have the most up-to-date version of the New Relic C SDK for your application's code library, check the [release notes](/docs/release-notes/agent-release-notes/c-release-notes).
+To ensure you've the most up-to-date version of the New Relic C SDK for your application's code library, check the [release notes](/docs/release-notes/agent-release-notes/c-release-notes).
 
 ## Update your C SDK code library [#update-production]
 

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/distributed-tracing-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/distributed-tracing-c-sdk.mdx
@@ -14,7 +14,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 Distributed tracing allows you to see the entire journey of your requests throughout a [distributed system](/docs/distributed-tracing/concepts/introduction-distributed-tracing). The [C SDK](https://github.com/newrelic/c-sdk) supports [standard distributed tracing](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#head-based) with head-based sampling. It doesn't support the feature called Infinite Tracing or W3C Trace context.

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api.mdx
@@ -15,7 +15,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 New Relic's C SDK monitors your applications and microservices to help you identify and solve performance issues. C applications run from a compiled, native binary file. In order to monitor [transactions](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm), you must manually instrument your code by adding New Relic methods to it.

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-errors-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-errors-c-sdk.mdx
@@ -11,7 +11,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 New Relic defines a [web or non-web transaction](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm) as one logical unit of work in a software application. Once you [instrument a transaction](/docs/instrument-transactions-c-agent), you can also instrument errors in the transaction so you can monitor them in the New Relic UI. In order to use the C SDK to monitor errors, you must manually instrument your source code by adding the New Relic function `newrelic_notice_error()` to it.

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-transactions-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-transactions-c-sdk.mdx
@@ -13,7 +13,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+  From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 Instrument [transactions](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm) using the C SDK so you can monitor any application on Linux that uses a language that can import C libraries. After you manually instrument transactions in your source code by adding New Relic functions, you can view the data on the [**Transactions** page](/docs/apm/applications-menu/monitoring/transactions-page) in the New Relic UI.

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk.mdx
@@ -17,7 +17,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 In order to monitor any application on Linux using a language that can import C libraries, you must:

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk.mdx
@@ -18,7 +18,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 In New Relic, **attributes** are key-value pairs containing information that determines the properties of an [event](/docs/accounts-partnerships/getting-started-new-relic/glossary#event) or [transaction](/docs/accounts-partnerships/getting-started-new-relic/glossary#transaction). These key-value pairs can help you gain greater insight into your application and [query your data](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder).

--- a/src/content/docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk.mdx
@@ -17,7 +17,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 ## Problem

--- a/src/content/docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk.mdx
@@ -16,7 +16,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 ## Problem

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes.mdx
@@ -211,7 +211,6 @@ User attributes, request attributes, and message queue parameters are limited by
 
 Each APM agent [collects custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes). The supported attributes depend on the specific agent:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-attributes)
 * [Java](/docs/agents/java-agent/attributes/enabling-disabling-attributes-java)
 * [.NET](/docs/agents/net-agent/attributes/net-agent-attributes)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics.mdx
@@ -68,7 +68,6 @@ Implementing custom metrics requires API calls. The exact details of the API cal
       </td>
 
       <td>
-        * **C SDK:** [`newrelic_record_custom_metric()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#aee71182588ace508cc816044d2024ff3)
         * **Go:** [`app.RecordCustomMetric`](/docs/agents/go-agent/instrumentation/create-custom-metrics-go)
         * **Java:** [`recordMetric`](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/NewRelic.html#recordMetric(java.lang.String,%20float))
         * **.NET:** [`RecordMetric`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics.mdx
@@ -68,6 +68,7 @@ Implementing custom metrics requires API calls. The exact details of the API cal
       </td>
 
       <td>
+        * **C SDK:** [`newrelic_record_custom_metric()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#aee71182588ace508cc816044d2024ff3)
         * **Go:** [`app.RecordCustomMetric`](/docs/agents/go-agent/instrumentation/create-custom-metrics-go)
         * **Java:** [`recordMetric`](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/NewRelic.html#recordMetric(java.lang.String,%20float))
         * **.NET:** [`RecordMetric`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/custom-instrumentation.mdx
@@ -49,13 +49,6 @@ Each agent implements custom instrumentation differently:
 
 <CollapserGroup>
   <Collapser
-    id="c-sdk"
-    title="C SDK custom instrumentation"
-  >
-    For applications monitored by the C SDK, you must manually instrument transactions, segments, and errors. For more information, see the [C SDK instrumentation procedures](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk).
-  </Collapser>
-
-  <Collapser
     id="go"
     title="Go custom instrumentation"
   >

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -25,7 +25,6 @@ APM agents include API calls to report (or "notice") errors. These are useful wh
 
 To learn how to get an APM agent to report an error, see the agent-specific API documentation:
 
-* **C SDK**: [`newrelic_notice_error()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a02a9a959015a0ca68ce11c750f690475)
 * **Go**: [`NoticeError()`](https://github.com/newrelic/go-agent/blob/master/transaction.go)
 * **Java**: [`NoticeError()`](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html)
 * **.NET**: [`NoticeError()`](/docs/agents/net-agent/net-agent-api/notice-error)
@@ -63,7 +62,6 @@ There are two ways to ignore errors: through the agent configuration or through 
   >
     To ignore an error using the agent configuration, see the configuration documentation for your agent:
 
-    * **C SDK**: Not available. For more information, see the [C SDK errors example on GitHub](https://newrelic.github.io/c-sdk/ex_notice_error_8c-example.html).
     * **Go**: [`ErrorCollector.IgnoreStatusCodes`](/docs/agents/go-agent/instrumentation/go-agent-configuration#error-ignore-status).
     * **Java**: `error_collector.ignore_classes`, `error_collector.ignore_classes.message`, or `error_collector.ignore_status_codes`. For additional information, see [Java agent error configuration](/docs/agents/java-agent/configuration/java-agent-error-configuration).
     * **.NET**: [`ignoreErrors`](/docs/agents/net-agent/configuration/net-agent-configuration#error-ignoreErrors) or [`ignoreStatusCodes`](/docs/agents/net-agent/configuration/net-agent-configuration#error-ignoreStatusCodes).

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/real-time-streaming.mdx
@@ -94,7 +94,6 @@ You can visualize the results of your NRQL query in through real time charts:
 
 Real time streaming is supported by all APM agents. Here are the minimum agent versions:
 
-* **C SDK:** [v1.3.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
 * **Go:** [v2.8.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
 * **Java:** [v5.5.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
 * **.NET:** [v8.23.107.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts.mdx
@@ -58,16 +58,6 @@ To set a display name:
   <tbody>
     <tr>
       <td>
-        C SDK
-      </td>
-
-      <td>
-        Edit the [`newrelic_datastore_segment_params_t::host`](https://newrelic.github.io/c-sdk/structnewrelic__datastore__segment__params__t.html#a6a2595298045f0174b9b9c39ea31b6eb) datastore segment.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         Go
       </td>
 

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/enable-configurable-security-policies.mdx
@@ -30,7 +30,6 @@ For more information about New Relic's security measures, see our [security and 
 
 APM agent versions that support this feature include:
 
-* C SDK: not available
 * [Go](/docs/agents/go-agent/installation/install-new-relic-go): 2.1 or higher
 * [Java](/docs/agents/java-agent/installation/upgrade-java-agent): 4.1 or higher
 * [.NET](/docs/agents/net-agent/installation/update-net-agent): 8.1 or higher

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/high-security-mode.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/high-security-mode.mdx
@@ -41,16 +41,6 @@ Currently there are two versions of high security mode. [Version 1](#version1des
   <tbody>
     <tr>
       <td>
-        C SDK
-      </td>
-
-      <td>
-        n/a
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration#high_security)
       </td>
 
@@ -164,7 +154,6 @@ To enable high security, you must update both the local configuration on your se
       <td>
         Enable high security mode in your agent configuration file. High security mode is disabled by default, and the exact procedure to enable it varies by agent:
 
-        * C SDK: n/a
         * [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration#high_security)
         * [Java](/docs/java/java-agent-configuration#cfg-enable_high_security)
         * [.NET](/docs/dotnet/dotnet-agent-configuration#high_security_mode)

--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration.mdx
@@ -23,7 +23,7 @@ Server-side configuration transitions some core settings from your language agen
 
 ## Requirements [#requirements]
 
-Server-side configuration is not available for our C SDK agent or our PHP agent.
+Server-side configuration is not available for our PHP agent.
 
 ## Centralization and security [#features]
 
@@ -37,7 +37,6 @@ This feature provides the convenience of managing the available configuration se
 
 For more information about the hierarchy of settings, see the illustration for the specific agent:
 
-* [C SDK configuration](/docs/agents/c-sdk/install-configure/c-sdk-configuration): A hierarchy is not applicable, because configuration values come from API calls. Also, server-side configuration is not supported. However, you can change the app name from the [UI](/docs/agents/c-sdk/install-configure/c-sdk-configuration#change-ui) or from the C SDK [configuration settings](/docs/agents/c-sdk/install-configure/c-sdk-configuration#change-app-name).
 * [Go hierarchy](/docs/agents/go-agent/instrumentation/go-agent-configuration#options)
 * [Java hierarchy](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#config-options-precedence)
 * [.NET hierarchy](/docs/agents/net-agent/installation-configuration/net-agent-configuration#config-options-precedence)
@@ -48,7 +47,7 @@ For more information about the hierarchy of settings, see the illustration for t
 
 ## Configure from the UI [#enable-ssc]
 
-The C SDK and PHP agent do not support server-side configuration. To enable server-side configuration settings for monitored apps from the UI:
+The PHP agent doesn't support server-side configuration. To enable server-side configuration settings for monitored apps from the UI:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM**.
 2. Click on your app. Then click **Settings > Application > Server-side agent configuration**.
@@ -63,7 +62,7 @@ For how to enable this with NerdGraph, see the [NerdGraph tutorial](/docs/apis/n
 
 If you use server-side configuration, you must still include your `license_key` and `app_name` in the local config file. These settings are required for the agent to communicate with the New Relic collector.
 
-The C SDK and PHP agent do not support server-side configuration. To view or change the available server-side configuration settings through the UI for apps that use other New Relic agents:
+The PHP agent doesn't support server-side configuration. To view or change the available server-side configuration settings through the UI for apps that use other New Relic agents:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM**.
 2. Click on your app. Then click **Settings > Application > Server-side agent configuration**.

--- a/src/content/docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights.mdx
@@ -90,6 +90,3 @@ This is caused by a configuration mismatch with the agent. See the relevant agen
   </Collapser>
 </CollapserGroup>
 
-<Callout variant="tip">
-  This error does not apply to the C SDK or PHP agents.
-</Callout>

--- a/src/content/docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/troubleshooting/agent-nrintegrationerrors-appear-insights.mdx
@@ -90,3 +90,6 @@ This is caused by a configuration mismatch with the agent. See the relevant agen
   </Collapser>
 </CollapserGroup>
 
+<Callout variant="tip">
+  This error doesn't apply to the PHP agents.
+</Callout>

--- a/src/content/docs/apm/apm-ui-pages/error-analytics/manage-error-data.mdx
+++ b/src/content/docs/apm/apm-ui-pages/error-analytics/manage-error-data.mdx
@@ -100,7 +100,6 @@ Sometimes you want to collect error data, but not have those errors wake you up 
 
 To prevent certain errors from being reported to New Relic, disable them in your agent's configuration file. For most agents, you can ignore certain error codes or disable errors completely. For more information, see your specific agent's configuration documentation:
 
-* [C SDK](https://github.com/newrelic/c-sdk/blob/master/GUIDE.md#error-instrumentation)
 * Go (not applicable; the agent only reports errors when configured to do so)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Error_Collector)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration#error_collector)

--- a/src/content/docs/apm/apm-ui-pages/features/analyze-database-instance-level-performance-issues.mdx
+++ b/src/content/docs/apm/apm-ui-pages/features/analyze-database-instance-level-performance-issues.mdx
@@ -35,7 +35,6 @@ Using APM's [transaction traces](/docs/apm/transactions/transaction-traces/trans
 
 New Relic collects instance details for a variety of databases and database drivers. The ability to view specific instances and the types of database information in APM depends on your database driver and agent version:
 
-* **C SDK:** See [C SDK compatibility](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#datastore-segments) for datastore segments.
 * **Go:** See [Go agent instance-level compatibility](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements#datastores) for datastores.
 * **Java:** See [Java agent instance-level compatibility](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent#instance-level-db) for databases.
 * **.NET:** See [.NET agent instance-level compatibility](/docs/agents/net-agent/getting-started/compatibility-requirements-net-agent#instance-details) for datastores.

--- a/src/content/docs/apm/apm-ui-pages/monitoring/databases-page-view-operations-throughput-response-time.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/databases-page-view-operations-throughput-response-time.mdx
@@ -93,7 +93,6 @@ To delete all traces for your app permanently:
 
 Additional features on the **Databases** page are available with following agent versions. For more information, see [Update the New Relic agent](/docs/agents/manage-apm-agents/installation/update-new-relic-agent).
 
-* C SDK 1.0.0 or higher
 * Go 1.4 or higher
 * Java 3.14.0 or higher
 * .NET 4.1.134 or higher

--- a/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
@@ -35,16 +35,7 @@ Complete the following for each service you want to view in external services:
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        See the documentation about [instrumenting segments](/docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk/#external-segments).
-      </td>
-    </tr>
-
+    
     <tr>
       <td>
         Go
@@ -166,16 +157,7 @@ If you’re not seeing the type of detail you want in the UI, you can increase t
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        The reservoir is not currently configurable
-      </td>
-    </tr>
-
+    
     <tr>
       <td>
         Go

--- a/src/content/docs/apm/apm-ui-pages/monitoring/view-slow-query-details.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/view-slow-query-details.mdx
@@ -55,13 +55,7 @@ In general, you can configure your slow query settings either of these ways:
 Agent configuration gives you more options than server-side configuration does. How you choose to configure slow queries will depend on your own setup and preferences. For more information, see the documentation for the specific agent:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    You can report slow query traces for SQL databases only. For more information, see [Instrument your application with the C SDK](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#slow-query-datastore).
-  </Collapser>
-
+  
   <Collapser
     id="go"
     title="Go"

--- a/src/content/docs/apm/applications-menu/features/configure-request-queue-reporting.mdx
+++ b/src/content/docs/apm/applications-menu/features/configure-request-queue-reporting.mdx
@@ -25,10 +25,6 @@ Most New Relic agents will interpret an `X-Queue-Start` or `X-Request-Start` hea
 
 Nearly any front-end HTTP server or load balancer can be configured to add this header. Additional details depend on your specific agent and server configuration. For more information, see the [request queue configuration examples](/docs/apm/applications-menu/features/request-queue-server-configuration-examples).
 
-## C SDK
-
-The C SDK does not support request queuing.
-
 ## Go agent [#go]
 
 With the Go agent, set either header to record a metric for it.

--- a/src/content/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction.mdx
+++ b/src/content/docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction.mdx
@@ -30,12 +30,7 @@ Setting useful thresholds for your Apdex levels help you:
 Ready to get started? Click a logo to install an APM agent and start measuring user satisfaction. It takes just a few minutes!
 
 <TechTileGrid>
-  <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="https://one.newrelic.com/nr1-core?state=d7fc8850-4c26-1ac0-ab64-21dab92ede90"
-  />
-
+  
   <TechTile
     name="Go agent"
     icon="logo-go"

--- a/src/content/docs/apm/new-relic-apm/getting-started/apm-agent-data-security.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/apm-agent-data-security.mdx
@@ -21,7 +21,6 @@ Our APM agent is a publicly accessible plugin for web applications. The agent do
 
 Most of our agents are open source, so you can see what our code does:
 
-* [C SDK](https://github.com/newrelic/c-sdk)
 * [Go](https://github.com/newrelic/go-agent)
 * [.NET](https://github.com/newrelic/newrelic-dotnet-agent)
 * [Node.js](https://github.com/newrelic/node-newrelic)
@@ -106,7 +105,6 @@ If you want to restrict the information that New Relic receives, you can enable 
   >
     Depending on the agent, the default settings provide security for request parameters, HTTPS usage, and SQL:
 
-    * [C SDK default security settings](/docs/agents/c-sdk/get-started/apm-security-c-sdk#default)
     * [Go default security settings](/docs/agents/go-agent/get-started/apm-agent-security-go#default)
     * [Java default security settings](/docs/agents/java-agent/getting-started/apm-agent-security-java#default)
     * [.NET default security settings](/docs/agents/net-agent/getting-started/apm-agent-security-net#default)
@@ -124,7 +122,6 @@ If you want to restrict the information that New Relic receives, you can enable 
 
     In addition, high security mode applies restrictions to custom events, custom instrumentation, user attributes, exception messages, or message queue parameters, depending on the agent:
 
-    * C SDK: n/a
     * [Go high security mode settings](/docs/agents/go-agent/get-started/apm-agent-security-go#restricted)
     * [Java high security mode settings](/docs/agents/java-agent/getting-started/apm-agent-security-java#restricted)
     * [.NET high security mode settings](/docs/agents/net-agent/getting-started/apm-agent-security-net#restricted)
@@ -140,7 +137,6 @@ If you want to restrict the information that New Relic receives, you can enable 
   >
     If you want custom security settings, you can customize the configuration file, change custom attribute settings, or use the API, depending on your agent:
 
-    * [C SDK custom security settings](/docs/agents/c-sdk/get-started/apm-security-c-sdk#customize)
     * [Go custom security settings](/docs/agents/go-agent/get-started/apm-agent-security-go#custom)
     * [Java custom security settings](/docs/agents/java-agent/getting-started/apm-agent-security-java#custom)
     * [.NET custom security mode settings](/docs/agents/net-agent/getting-started/apm-agent-security-net#custom)
@@ -239,7 +235,6 @@ This information applies to all APM agents no matter what security settings you 
 
 [Our preferred protocol for all domains](/docs/apm/new-relic-apm/getting-started/networks#tls) is TLS 1.2. APM agents enable SSL by default. To verify which release includes SSL by default and to ensure that you have the most up-to-date version, refer to your agent's release notes:
 
-* [C SDK](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
 * [Go](/docs/release-notes/agent-release-notes/go-release-notes)
 * [Java](/docs/release-notes/agent-release-notes/java-release-notes)
 * [.NET](/docs/release-notes/agent-release-notes/net-release-notes)
@@ -249,8 +244,6 @@ This information applies to all APM agents no matter what security settings you 
 * [Ruby](/docs/release-notes/agent-release-notes/ruby-release-notes)
 
 The configuration file also includes an optional flag (`ssl`) to enable or disable SSL using HTTPS. New Relic does not do host authentication with HTTPS, just communication encryption.
-
-**Exception:** You cannot disable SSL for the C SDK. The C SDK daemon can only connect with SSL.
 
 New Relic requires HTTPS for all traffic to APM and the REST API. This includes both inbound and outbound traffic. If your [REST API call uses HTTP](/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls), or if you have disabled SSL in your configuration file, change your script or program to HTTPS.
 
@@ -278,16 +271,6 @@ Optional settings are available so that you can configure the agent to communica
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        `-proxy` at daemon startup
-      </td>
-    </tr>
-
     <tr>
       <td>
         Go

--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -32,12 +32,7 @@ Want to save time with a single unified monitoring solution? Click a logo to get
 
 
 <TechTileGrid>
-  <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="https://one.newrelic.com/nr1-core?state=d7fc8850-4c26-1ac0-ab64-21dab92ede90"
-  />
-
+  
   <TechTile
     name="Go agent"
     icon="logo-go"
@@ -106,12 +101,6 @@ Get started with APM in just a few short steps:
 2. Install the language agent for your app:
 
 <TechTileGrid>
-  <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="https://one.newrelic.com/nr1-core?state=4bb150a3-4e8a-0c89-56ba-32e99f6dadce"
-  />
-
   <TechTile
     name="Go agent"
     icon="logo-go"

--- a/src/content/docs/apm/new-relic-apm/maintenance/disable-apm-agent.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/disable-apm-agent.mdx
@@ -20,13 +20,7 @@ Related procedures:
 Select your agent type for instructions:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    The C SDK cannot be turned on or off directly. However, you can write your code for the SDK so that a quick recompile and deploy can enable or disable your instrumentation. Follow standard procedures to [disable or uninstall the C SDK](/docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk).
-  </Collapser>
-
+  
   <Collapser
     id="go"
     title="Go"

--- a/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
+++ b/src/content/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic.mdx
@@ -43,7 +43,6 @@ Before you can remove an application monitored by New Relic APM, browser monitor
     title="APM applications"
   >
     1. Disable an APM agent using these instructions:
-       * [**C SDK**](/docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk#disable): Do a quick recompile and deploy. For example, surround your instrumentation in `#ifdef`, and set the value of `YOURNAMESPACE_NEWRELIC_ENABLED` with your build system.
        * [**Go**](/docs/agents/go-agent/instrumentation/go-agent-configuration#enabled): Set `Enabled` to `false`.
        * [**Java**](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#cfg-agent_enabled): Set `agent_enabled` to `false`.
        * [**.NET**](/docs/agents/net-agent/installation-configuration/net-agent-configuration#app-cfg-agent-enabled): Set `Newrelic.AgentEnabled` to `false`.

--- a/src/content/docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing.mdx
+++ b/src/content/docs/apm/transactions/cross-application-traces/troubleshoot-cross-application-tracing.mdx
@@ -33,16 +33,6 @@ Make sure you meet these requirements for your agent's version, protocols, inter
   <tbody>
     <tr>
       <td>
-        C SDK
-      </td>
-
-      <td>
-        Use [distributed tracing](/docs/agents/c-sdk/instrumentation/enable-distributed-tracing-your-c-applications).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [Go 1.11 or higher](/docs/release-notes/agent-release-notes/go-release-notes/go-agent-111)
       </td>
 
@@ -119,7 +109,6 @@ Make sure you meet these requirements for your agent's version, protocols, inter
 
 In general, New Relic's cross application tracing feature is enabled by default. Requirements to change your configuration file vary, depending on your New Relic agent:
 
-* C SDK (not supported)
 * Go (not supported)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Cross_Application_Tracer)
 * [.NET](/docs/agents/net-agent/installation-and-configuration/net-agent-configuration#cross_application_tracer)

--- a/src/content/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions.mdx
+++ b/src/content/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions.mdx
@@ -84,13 +84,6 @@ To create new non-web transactions, follow the procedures for your APM language 
 
 <CollapserGroup>
   <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    Follow the procedures for [instrumenting a non-web transaction](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#instrument-c-txn).
-  </Collapser>
-
-  <Collapser
     id="go"
     title="Go"
   >

--- a/src/content/docs/apm/transactions/intro-transactions/transactions-new-relic-apm.mdx
+++ b/src/content/docs/apm/transactions/intro-transactions/transactions-new-relic-apm.mdx
@@ -35,46 +35,6 @@ Cumulative transaction data appears in APM on the [Transactions page](/docs/apm/
 Our agents have these transaction sub-types:
 
 <CollapserGroup>
-  <Collapser
-    id="agent-c-sdk"
-    title="C SDK"
-  >
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "200px" }}>
-            Sub-type
-          </th>
-
-          <th>
-            Description
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            Custom
-          </td>
-
-          <td>
-            The execution of the named custom transaction. Usually recorded via manual instrumentation APIs.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Function
-          </td>
-
-          <td>
-            The invocation of the named function.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
 
   <Collapser
     id="agent-go"

--- a/src/content/docs/apm/transactions/transaction-traces/configure-transaction-traces.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/configure-transaction-traces.mdx
@@ -26,7 +26,6 @@ In APM, [transaction traces](/docs/apm/transactions/transaction-traces/transacti
 
 You can customize your transaction trace settings via New Relic agent configuration files and other "local" configuration methods such as environment variables. For more information about transaction trace configuration options, see the specific New Relic language agent's documentation:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk#instrument-c-txn)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration#transaction-tracer)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#h2-transaction-tracer)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration#transaction_tracer)
@@ -77,7 +76,6 @@ You can create custom transactions for app activity that isn't being automatical
 
 For [data security reasons](/docs/apm/transactions/transaction-traces/security-options-transaction-traces), transaction traces do not collect potentially sensitive HTTP request attributes, sometimes called **parameters**. Traces do collect some basic HTTP request attributes, which New Relic calls **agent attributes**. To edit attribute collection settings, see the specific New Relic agent:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-attributes)
 * [Java](/docs/agents/java-agent/attributes/java-agent-attributes)
 * [.NET](/docs/agents/net-agent/attributes/net-agent-attributes)

--- a/src/content/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent.mdx
+++ b/src/content/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent.mdx
@@ -86,7 +86,6 @@ Our APM agents can instrument webpages with the required JavaScript for page loa
 
 For more information, see the instructions for your APM agent:
 
-* [C SDK](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api/#browser)
 * [Go](/docs/agents/go-agent/features/install-new-relic-browser-go-apps)
 * [Java](/docs/agents/java-agent/instrumentation/page-load-timing-java)
 * [.NET](/docs/agents/net-agent/features/page-load-timing-net)

--- a/src/content/docs/browser/browser-monitoring/troubleshooting/troubleshoot-your-browser-monitoring-installation.mdx
+++ b/src/content/docs/browser/browser-monitoring/troubleshooting/troubleshoot-your-browser-monitoring-installation.mdx
@@ -80,7 +80,6 @@ These troubleshooting steps apply to problems when the browser monitoring agent 
 
     Also verify that a second script element exists in one of two locations, depending on the app server agent language.
 
-    * **C SDK**: n/a
     * **Go**: n/a
     * **Java**: Before the `</body>` tag (which must be added to the page if missing)
     * **.NET**: Immediately before the first script element
@@ -112,7 +111,6 @@ These troubleshooting steps apply to problems when the browser monitoring agent 
   >
     If you are using New Relic's automatic instrumentation feature, ensure your agent is configured properly. Each agent has a configuration file setting and specific instructions to turn auto-instrumentation on or off:
 
-    * **C SDK**: n/a
     * **Go**: n/a
     * [Java](/docs/agents/java-agent/instrumentation/page-load-timing-java#auto_instrumentation)
     * [.NET](/docs/agents/net-agent/features/page-load-timing-net#auto_instrumentation)
@@ -132,7 +130,6 @@ These troubleshooting steps apply to problems when the browser monitoring agent 
   >
     If you are manually calling the New Relic agent API to generate and insert the JavaScript, verify that the calls are actually being made. The APIs and how to use them are specific to your agent:
 
-    * **C SDK**: n/a
     * **Go**: n/a
     * [Java agent](/docs/agents/java-agent/instrumentation/page-load-timing-java#manual_instrumentation)
     * [.NET agent](/docs/agents/net-agent/features/page-load-timing-net#manual_instrumentation)

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
@@ -36,7 +36,6 @@ Make sure you have the necessary minimum versions for your browser monitoring ag
 
 **APM:**
 
-* [C SDK 1.3](/docs/release-notes/agent-release-notes/c-sdk-release-notes) or higher
 * [Java 5.9.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-590) or higher
 * [PHP](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-940249) 9.4.0 or higher
 * [Other APM agent version requirements](/docs/understand-dependencies/distributed-tracing/enable-configure/enable-distributed-tracing#compatibility-requirements)

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -130,7 +130,6 @@ You can deploy the browser agent for apps monitored by APM, or you can deploy th
 
 If you're deploying browser for an app using APM, make sure your agent supports browser monitoring:
 
-* [C SDK](/docs/release-notes/agent-release-notes/c-sdk-release-notes): Version 1.0.0 or higher
 * [Go](/docs/release-notes/agent-release-notes/go-release-notes): Version 2.5.0 or higher
 * [Java](/docs/release-notes/agent-release-notes/java-release-notes): Version 3.4.0 or higher
 * [.NET](/docs/release-notes/agent-release-notes/net-release-notes): Version 2.20.25.0 or higher

--- a/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes.mdx
@@ -53,14 +53,7 @@ When creating your own custom events and attributes, follow data requirements fo
 * [Reserved words](/docs/telemetry-data-platform/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words)
 
 <CollapserGroup>
-  <Collapser
-    className="freq-link"
-    id="c-sdk"
-    title="C SDK"
-  >
-    To add a custom event to apps monitored by the C SDK, start a transaction and use the `newrelic_create_custom_event` and `newrelic_record_custom_event` functions. For more information, see the [Guide to using the C SDK API](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api#custom-events). You can then add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes#c-sdk-att) for your C SDK app.
-  </Collapser>
-
+  
   <Collapser
     className="freq-link"
     id="go"

--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -78,13 +78,7 @@ SELECT count(*) FROM TransactionError
 To enable and use custom attributes for APM, follow the procedure for your APM agent:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk-att"
-    title="C SDK"
-  >
-    To add custom attributes to applications monitored by the C SDK, call one of the [attribute functions](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#abfe6f64a8eec7d60d8588f8969781d34); for example, `newrelic_add_attribute_double()`. The key name for your custom attribute depends on what you specify when you call the function.
-  </Collapser>
-
+  
   <Collapser
     id="go-att"
     title="Go"

--- a/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -138,16 +138,7 @@ There are two ways to add custom attributes to the `PageView` event:
          </thead>
 
          <tbody>
-           <tr>
-             <td>
-               C SDK
-             </td>
-
-             <td>
-               Not supported.
-             </td>
-           </tr>
-
+           
            <tr>
              <td>
                Go

--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses.mdx
@@ -22,7 +22,7 @@ redirects:
 In addition, the C SDK uses source code from third-party libraries, which are licensed under their own terms. This document lists these other third-party libraries and their licenses.
 
 <Callout variant="important">
-  New Relic has contributed the C SDK to the open source community under an [Apache 2.0 license](https://github.com/newrelic/c-sdk/blob/master/LICENSE).
+  New Relic contributed the C SDK to the open source community under an [Apache 2.0 license](https://github.com/newrelic/c-sdk/blob/master/LICENSE).
 </Callout>
 
 <table>

--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses.mdx
@@ -10,11 +10,20 @@ redirects:
   - /docs/licenses/license-information/agent-licenses/c-sdk-licenses
 ---
 
+
+<Callout
+  variant="important"
+  title="EOL NOTICE"
+  >
+  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+</Callout>
+
+
+In addition, the C SDK uses source code from third-party libraries, which are licensed under their own terms. This document lists these other third-party libraries and their licenses.
+
 <Callout variant="important">
   New Relic has contributed the C SDK to the open source community under an [Apache 2.0 license](https://github.com/newrelic/c-sdk/blob/master/LICENSE).
 </Callout>
-
-In addition, the C SDK uses source code from third-party libraries, which are licensed under their own terms. This document lists these other third-party libraries and their licenses.
 
 <table>
   <thead>

--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses.mdx
@@ -15,7 +15,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+  From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 

--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/new-relic-apm-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-apm/new-relic-apm-licenses.mdx
@@ -14,7 +14,6 @@ redirects:
 
 We use many third-party libraries and tools to create APM, including a large number contributed by the open source community. For more information about APM agent licenses, see the specific APM agent licenses categories.
 
-* [C SDK](/docs/licenses/product-or-service-licenses/new-relic-apm/c-sdk-licenses/)
 * [Go](/docs/licenses/product-or-service-licenses/new-relic-apm/go-agent-licenses/)
 * [Java](/docs/licenses/product-or-service-licenses/new-relic-apm/java-agent-licenses/)
 * [.NET](/docs/licenses/product-or-service-licenses/new-relic-apm/net-agent-licenses/)

--- a/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
+++ b/src/content/docs/logs/logs-context/annotate-logs-logs-context-using-apm-agent-apis.mdx
@@ -39,16 +39,7 @@ APM agent APIs:
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        [C SDK (n/a)](/docs/logs/logs-context/c-sdk-configure-logs-context/)
-      </td>
-
-      <td>
-        See our [Log API documentation](/docs/logs/log-api/introduction-log-api/).
-      </td>
-    </tr>
-
+    
     <tr>
       <td>
         Go
@@ -138,7 +129,6 @@ For more information about using the [trace metadata and linking metadata APIs](
 
 Also, review the source code for our own manually installed logs in context extensions to see how we use these APIs:
 
-* C SDK: n/a
 * Go: [Logs In Context Extensions](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2)
 * Java: [Log4j2 extension](https://github.com/newrelic/java-log-extensions/blob/master/log4j2/src/main/java/com/newrelic/logging/log4j2/NewRelicLayout.java)
 * .NET: [Serilog extension](https://github.com/newrelic/newrelic-logenricher-dotnet/tree/main/src/NewRelic.LogEnrichers.Serilog)

--- a/src/content/docs/logs/logs-context/c-sdk-configure-logs-context.mdx
+++ b/src/content/docs/logs/logs-context/c-sdk-configure-logs-context.mdx
@@ -9,6 +9,14 @@ redirects:
   - /docs/logs/enable-log-management-new-relic/configure-logs-context/c-sdk-configure-logs-context
 ---
 
+<Callout
+  variant="important"
+  title="EOL NOTICE"
+  >
+  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+</Callout>
+
+
 Logs in context is not available for apps monitored by the C SDK. Instead, you can build your own logging extension library by using the [Log API](/docs/logs/log-management/log-api/introduction-log-api/). Make sure your app has distributed tracing enabled, so you can quickly understand what happens to requests as they travel through upstream and downstream services.
 
 To enable distributed tracing for apps monitored by the C SDK, [install](/docs/distributed-tracing/enable-configure/quick-start/) or [update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library/) to the latest C SDK version. Distributed tracing requires [C SDK version 1.1.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes/).

--- a/src/content/docs/logs/logs-context/c-sdk-configure-logs-context.mdx
+++ b/src/content/docs/logs/logs-context/c-sdk-configure-logs-context.mdx
@@ -13,7 +13,7 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>
 
 

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -99,8 +99,6 @@ Whether you're considering New Relic or you're already using our capabilities, t
 
     **APM agents:**
 
-    * [C SDK API](/docs/agents/c-sdk/instrumentation/guide-using-c-sdk-api)
-
     * [Go agent API](/docs/agents/go-agent/api-guides/guide-using-go-agent-api)
 
     * [Java agent API](/docs/java/java-agent-api)
@@ -620,7 +618,6 @@ For more information, see [incidents] (/docs/new-relic-solutions/get-started/glo
 
     New Relic automatically instruments many common frameworks. For more about the frameworks New Relic supports, see the agent-specific documentation:
 
-    * [C SDK supported frameworks](/docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements)
     * [Go supported frameworks](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements)
     * [Java supported frameworks](/docs/agents/java-agent/getting-started/new-relic-java#h2-compatibility)
     * [.NET supported frameworks](/docs/agents/net-agent/getting-started/new-relic-net#requirements)

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -66,12 +66,6 @@ New Relic is an observability platform that helps you build better software. You
   />
 
   <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="https://one.newrelic.com/nr1-core?state=4bb150a3-4e8a-0c89-56ba-32e99f6dadce"
-  />
-
-  <TechTile
     name="Grafana"
     to="/docs/more-integrations/grafana-integrations/get-started/grafana-support-prometheus-promql"
     icon={<img variant="TechTile" src={apmGrafana} alt="Grafana"/>}

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/compatibility-requirements-new-relic-agents-products.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/compatibility-requirements-new-relic-agents-products.mdx
@@ -20,7 +20,6 @@ In this doc, we have links to some of our most popular tools. For a complete lis
 
 ## APM compatibility and requirements [#apm-compatibility]
 
-* [C SDK](/docs/agents/c-sdk/get-started/c-sdk-compatibility-requirements)
 * [Go](/docs/agents/go-agent/get-started/go-agent-compatibility-requirements)
 * [Java](/docs/compatibility-requirements-java-agent)
 * [.NET Core](/docs/agents/net-agent/installation/compatibility-requirements-net-core-agent)

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/configure-new-relic-agents.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/configure-new-relic-agents.mdx
@@ -30,7 +30,6 @@ The only required settings for the APM agents are your [license key](/docs/apis/
 
 For additional configuration options, see:
 
-* [C SDK](/docs/agents/c-sdk/install-configure/c-sdk-configuration)
 * [Go](/docs/agents/go-agent/instrumentation/go-agent-configuration)
 * [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file)
 * [.NET](/docs/agents/net-agent/installation-configuration/net-agent-configuration)

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic.mdx
@@ -82,12 +82,6 @@ If you're on our EU data center, [start here](https://one.eu.newrelic.com/market
   />
 
   <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="https://one.newrelic.com/nr1-core?state=4bb150a3-4e8a-0c89-56ba-32e99f6dadce"
-  />
-
-  <TechTile
     name="Grafana"
     to="/docs/more-integrations/grafana-integrations/get-started/grafana-support-prometheus-promql"
     icon={<img variant="TechTile" src={apmGrafana} alt="Grafana"/>}

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/uninstall-agent.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/uninstall-agent.mdx
@@ -31,7 +31,6 @@ If you encounter problems, see [support.newrelic.com](https://support.newrelic.c
 
 After uninstalling APM agents or making a change to your startup script, you must restart your app (or the app server or web server where it is located). You must do this because New Relic agents typically run in the memory of the process running the app. Simply removing those files will **not** stop the applications that are currently running from sending data to New Relic.
 
-* [C SDK](/docs/agents/c-sdk/install-configure/uninstall-remove-c-sdk)
 * [Go](/docs/agents/go-agent/installation-configuration/uninstall-go-agent)
 * [Java](/docs/agents/java-agent/installation/uninstall-java-agent)
 * [.NET](/docs/agents/net-agent/installation-configuration/uninstall-net-agent)

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent.mdx
@@ -74,7 +74,7 @@ See the docs for your agent:
     id="apm"
     title="APM agents"
   >
-* **C SDK**: [Update](/docs/agents/c-sdk/install-configure/update-your-c-sdk-library) \| [Release notes](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
+
 * **Go**: [Update](/docs/agents/go-agent/installation/update-go-agent) \| [Release notes](/docs/release-notes/agent-release-notes/go-release-notes)
 * **Java**: [Update](/docs/agents/java-agent/installation/upgrading-java-agent) \| [Release notes](/docs/release-notes/agent-release-notes/java-release-notes)
 * **.NET**: [Update](/docs/agents/net-agent/installation-configuration/upgrading-net-agent) \| [Release notes](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/new-relic-solutions/new-relic-one/ui-data/service-maps/how-use-service-maps.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/ui-data/service-maps/how-use-service-maps.mdx
@@ -36,7 +36,6 @@ For best results, update existing agents to the latest version. The required min
   >
     The required minimum agent versions for maps using distributed tracing are:
 
-    * [C SDK 1.1.0 or higher](/docs/release-notes/agent-release-notes/c-sdk-release-notes)
     * [Go agent 2.1.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
     * [Java agent 4.3.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
     * [.NET agent 8.6.45.0 or higher](/docs/release-notes/agent-release-notes/net-release-notes)
@@ -52,7 +51,6 @@ For best results, update existing agents to the latest version. The required min
   >
     The minimum version requirements for maps not using distributed tracing are:
 
-    * C SDK: not available
     * [Go 1.11 or higher](/docs/release-notes/agent-release-notes/go-release-notes)
     * [Java 3.9.0 or higher](/docs/release-notes/agent-release-notes/java-release-notes)
     * [.NET 4.2 or higher](/docs/release-notes/agent-release-notes/net-release-notes)

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -370,7 +370,7 @@ distributed_tracing: {
 
 Data volume will also vary based on whether you are using [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing).
 
-Standard distributed tracing for APM agents (above) captures up to 10% of your traces, but if you want us to analyze all your data and find the most relevant traces, you can set up Infinite Tracing. This alternative to standard distributed tracing is available for all APM language agents except C SDK.
+Standard distributed tracing for APM agents (above) captures up to 10% of your traces, but if you want us to analyze all your data and find the most relevant traces, you can set up Infinite Tracing. This alternative to standard distributed tracing is available for all APM language agents.
 
 The main parameters that could drive a small increase in monthly ingest are:
 * Configure trace observer monitoring

--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
@@ -43,7 +43,7 @@ For additional troubleshooting steps for your agent, check out [Not seeing data]
 
 The Diagnostics CLI is available for Linux, macOS, and Windows. It can detect common configuration issues for:
 
-* **APM**: Available for all APM agents except C SDK. For the Go agent, only basic connectivity checks are available.
+* **APM**: Available for all APM agents. For the Go agent, only basic connectivity checks are available.
 * **Browser monitoring**: Browser agent detection
 * **Infrastructure monitoring**: Linux and Windows agents
 * **Mobile agents**: iOS and Android

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/find-agent-root-directory.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/find-agent-root-directory.mdx
@@ -30,13 +30,7 @@ You may need to find the agent root directory for several reasons:
 The agent root directory depends on the agent you're using:
 
 <CollapserGroup>
-  <Collapser
-    id="c-sdk"
-    title="C SDK"
-  >
-    The C SDK may not necessarily be [installed](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code) in a single place, and it does not have an installation tool or script. The "root directory" depends on what the user does. In general, the root directory is the location of the `libnewrelic.so` or `libnewrelic.a` library file as well as the location of the `libnewrelic.h` file.
-  </Collapser>
-
+  
   <Collapser
     id="go-agent"
     title="Go agent"

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/generate-new-relic-agent-logs-troubleshooting.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/generate-new-relic-agent-logs-troubleshooting.mdx
@@ -20,7 +20,6 @@ Related docs:
 
 ## APM agent logging [#apm-install]
 
-* [C SDK logs](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code#logging)
 * [Go agent logs](/docs/agents/go-agent/configuration/go-agent-logging)
 * [Java logs](/docs/agents/java-agent/troubleshooting/generate-debug-logs-troubleshooting-java)
 * [.NET logs](/docs/agents/net-agent/troubleshooting/generate-logs-troubleshooting-net)

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
@@ -37,20 +37,7 @@ For details about the audit logging options for your APM agent's configuration f
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        When [starting the C SDK daemon](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code#daemon), add `-auditlog <file>` to the daemon configuration file. For example:
-
-        ```
-        ./newrelic-daemon -f -logfile stdout -loglevel debug -auditlog audit.log
-        ```
-      </td>
-    </tr>
-
+    
     <tr>
       <td>
         Go

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/metric-grouping-issues.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/metric-grouping-issues.mdx
@@ -90,16 +90,6 @@ If the problem persists, follow the procedures for your agent:
 
     <tr>
       <td>
-        C SDK
-      </td>
-
-      <td>
-        Avoid using URLs to name your transactions. Instead, follow the procedures to [instrument your app with the C SDK](/docs/agents/c-sdk/instrumentation/instrument-your-app-c-sdk).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         Go
       </td>
 

--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/not-seeing-data.mdx
@@ -29,7 +29,6 @@ You should start seeing data within a few minutes after installing a New Relic a
 
 Follow the troubleshooting procedures for your APM agent:
 
-* [C SDK](/docs/agents/c-sdk/troubleshooting/no-data-appears-c)
 * [Go](/docs/agents/go-agent/troubleshooting/no-data-appears-go)
 * [Java](/docs/agents/java-agent/troubleshooting/no-data-appears-java)
 * [.NET](/docs/agents/net-agent/troubleshooting/no-data-appears-net)

--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -9,5 +9,5 @@ redirects:
   variant="important"
   title="EOL NOTICE"
   >
-  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+ From April 2022, we don't support the C SDK capability. For more details, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
 </Callout>

--- a/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/c-sdk-release-notes/index.mdx
@@ -5,3 +5,9 @@ redirects:
   - /docs/agents/c-sdk/get-started/c-sdk-release-notes
   - /docs/release-notes/apm-agent-release-notes/c-sdk-release-notes
 ---
+<Callout
+  variant="important"
+  title="EOL NOTICE"
+  >
+  As of April 2022, we're discontinuing support for several capabilities, including the C SDK. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/q1-bulk-eol-announcement-fy23/181744).
+</Callout>

--- a/src/content/docs/release-notes/index.mdx
+++ b/src/content/docs/release-notes/index.mdx
@@ -21,12 +21,6 @@ To take full advantage of New Relic's latest features, enhancements, and importa
   />
 
   <TechTile
-    name="C SDK"
-    icon="logo-c"
-    to="/docs/release-notes/agent-release-notes/c-sdk-release-notes"
-  />
-
- <TechTile
     name="Capacitor plugin"
     icon="logo-newrelic"
     to="/docs/release-notes/mobile-release-notes/capacitor-release-notes"

--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -66,22 +66,7 @@ To ensure FedRAMP compliance, all [APM agent configurations](/docs/using-new-rel
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        C SDK
-      </td>
-
-      <td>
-        In code:
-
-        ```c
-        strcpy(_newrelic_app_config_t->redirect_collector, "gov-collector.newrelic.com");
-        ```
-
-        Environment variable: none
-      </td>
-    </tr>
-
+    
     <tr>
       <td>
         Go

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-release-notes.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-release-notes.mdx
@@ -47,7 +47,7 @@ To add a new release notes category, update the following areas of the docs site
 
 In `/src/content/docs/release-notes`, add the following:
 
-* A folder for your new release notes category. The RSS feed link, page format, and date order for release notes listed on this page are generated automatically. For example, see the [C SDK category landing page format](/docs/release-notes/agent-release-notes/c-sdk-release-notes/).
+* A folder for your new release notes category. The RSS feed link, page format, and date order for release notes listed on this page are generated automatically. For example, see the [Go category landing page format](/docs/release-notes/agent-release-notes/go-release-notes/).
 * An `index.mdx` file in your new folder containing the `subject`. The `subject` is the name that will appear on the [Release notes landing page](/docs/release-notes/).
 * A [placeholder release note](/docs/style-guide/article-templates/create-release-notes/#new-note) in this folder for the agent team to fill out. If used, the `downloadLink` field in the release note will be formatted automatically in the published release note.
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -9,59 +9,6 @@ pages:
     path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
   - title: Install and configure APM agents
     pages:
-      - title: C monitoring
-        path: /docs/apm/agents/c-sdk
-        pages:
-          - title: Monitor your C application
-            path: /docs/apm/agents/c-sdk/get-started/introduction-c-sdk
-          - title: Releases and compatibility
-            path: /docs/apm/agents/c-sdk/get-started
-            pages:
-              - title: C SDK OpenTelemetry alternative
-                path: /docs/apm/agents/c-sdk/get-started/otel_cpp_example
-              - title: Compatibility and requirements
-                path: /docs/apm/agents/c-sdk/get-started/c-sdk-compatibility-requirements
-              - title: C SDK security
-                path: /docs/apm/agents/c-sdk/get-started/apm-security-c-sdk
-              - title: Latest release
-                path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/current
-              - title: C SDK release notes
-                path: /docs/release-notes/agent-release-notes/c-sdk-release-notes
-          - title: Advanced installation and configuration
-            path: /docs/apm/agents/c-sdk/install-configure
-            pages:
-              - title: Install (compile) the C SDK
-                path: /docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
-              - title: Docker and other containers
-                path: /docs/apm/agents/c-sdk/install-configure/docker-other-container-environments-install-c-sdk
-              - title: C SDK configuration
-                path: /docs/apm/agents/c-sdk/install-configure/c-sdk-configuration
-              - title: Update your C SDK library
-                path: /docs/apm/agents/c-sdk/install-configure/update-your-c-sdk-library
-              - title: Uninstall (remove) the C SDK
-                path: /docs/apm/agents/c-sdk/install-configure/uninstall-remove-c-sdk
-          - title: Instrumentation
-            path: /docs/apm/agents/c-sdk/instrumentation
-            pages:
-              - title: Instrument your app
-                path: /docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk
-              - title: Instrument transactions
-                path: /docs/apm/agents/c-sdk/instrumentation/instrument-transactions-c-sdk
-              - title: Instrument errors
-                path: /docs/apm/agents/c-sdk/instrumentation/instrument-errors-c-sdk
-              - title: Distributed tracing
-                path: /docs/apm/agents/c-sdk/instrumentation/distributed-tracing-c-sdk
-              - title: Guide to using the C SDK API
-                path: /docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api
-              - title: Use default or custom attributes
-                path: /docs/apm/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
-          - title: Troubleshooting
-            path: /docs/apm/agents/c-sdk/troubleshooting
-            pages:
-              - title: No data appears (C SDK)
-                path: /docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
-              - title: Troubleshooting logs (C SDK)
-                path: /docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
       - title: Go monitoring
         path: /docs/apm/agents/go-agent
         pages:
@@ -1229,6 +1176,59 @@ pages:
                 path: /docs/apm/agents/manage-apm-agents/app-naming/name-your-application
               - title: Use multiple names for an app
                 path: /docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app
+          - title: C monitoring (deprecated)
+            path: /docs/apm/agents/c-sdk
+            pages:
+              - title: Monitor your C application
+                path: /docs/apm/agents/c-sdk/get-started/introduction-c-sdk
+              - title: Releases and compatibility
+                path: /docs/apm/agents/c-sdk/get-started
+                pages:
+                  - title: C SDK OpenTelemetry alternative
+                    path: /docs/apm/agents/c-sdk/get-started/otel_cpp_example
+                  - title: Compatibility and requirements
+                    path: /docs/apm/agents/c-sdk/get-started/c-sdk-compatibility-requirements
+                  - title: C SDK security
+                    path: /docs/apm/agents/c-sdk/get-started/apm-security-c-sdk
+                  - title: Latest release
+                    path: /docs/release-notes/agent-release-notes/c-sdk-release-notes/current
+                  - title: C SDK release notes
+                    path: /docs/release-notes/agent-release-notes/c-sdk-release-notes
+              - title: Advanced installation and configuration
+                path: /docs/apm/agents/c-sdk/install-configure
+                pages:
+                    - title: Install (compile) the C SDK
+                      path: /docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code
+                    - title: Docker and other containers
+                      path: /docs/apm/agents/c-sdk/install-configure/docker-other-container-environments-install-c-sdk
+                    - title: C SDK configuration
+                      path: /docs/apm/agents/c-sdk/install-configure/c-sdk-configuration
+                    - title: Update your C SDK library
+                      path: /docs/apm/agents/c-sdk/install-configure/update-your-c-sdk-library
+                    - title: Uninstall (remove) the C SDK
+                      path: /docs/apm/agents/c-sdk/install-configure/uninstall-remove-c-sdk
+              - title: Instrumentation
+                path: /docs/apm/agents/c-sdk/instrumentation
+                pages:
+                  - title: Instrument your app
+                    path: /docs/apm/agents/c-sdk/instrumentation/instrument-your-app-c-sdk
+                  - title: Instrument transactions
+                    path: /docs/apm/agents/c-sdk/instrumentation/instrument-transactions-c-sdk
+                  - title: Instrument errors
+                    path: /docs/apm/agents/c-sdk/instrumentation/instrument-errors-c-sdk
+                  - title: Distributed tracing
+                    path: /docs/apm/agents/c-sdk/instrumentation/distributed-tracing-c-sdk
+                  - title: Guide to using the C SDK API
+                    path: /docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api
+                  - title: Use default or custom attributes
+                    path: /docs/apm/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
+          - title: Troubleshooting
+            path: /docs/apm/agents/c-sdk/troubleshooting
+            pages:
+              - title: No data appears (C SDK)
+                path: /docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
+              - title: Troubleshooting logs (C SDK)
+                path: /docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
           - title: Configuration
             path: /docs/apm/agents/manage-apm-agents/configuration
             pages:

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1222,13 +1222,13 @@ pages:
                     path: /docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api
                   - title: Use default or custom attributes
                     path: /docs/apm/agents/c-sdk/instrumentation/use-default-or-custom-attributes-c-sdk
-          - title: Troubleshooting
-            path: /docs/apm/agents/c-sdk/troubleshooting
-            pages:
-              - title: No data appears (C SDK)
-                path: /docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
-              - title: Troubleshooting logs (C SDK)
-                path: /docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
+              - title: Troubleshooting
+                path: /docs/apm/agents/c-sdk/troubleshooting
+                pages:
+                  - title: No data appears (C SDK)
+                    path: /docs/apm/agents/c-sdk/troubleshooting/no-data-appears-c-sdk
+                  - title: Troubleshooting logs (C SDK)
+                    path: /docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk
           - title: Configuration
             path: /docs/apm/agents/manage-apm-agents/configuration
             pages:


### PR DESCRIPTION
Modifying the docs site because C SDK was deprecated.

This is the ticket: [NR-87960](https://issues.newrelic.com/browse/NR-87960)