### PR TITLE
Add security article

### DIFF
--- a/src/content/docs/codestream/troubleshooting/security.mdx
+++ b/src/content/docs/codestream/troubleshooting/security.mdx
@@ -1,0 +1,39 @@
+---
+title: CodeStream security
+metaDescription: "Security is core to everything we do."
+---
+
+We know that your source code is one of your most valuable and sensitive assets. For most development teams, it's a literal representation of your most important work product.
+
+## Source Code Access and Storage [#code-storage]
+
+CodeStream’s servers do not require access to your source code, as all interactions with the code are done locally in your IDE leveraging your IDE’s access to the code. For example, when you select a block of code to discuss, CodeStream captures the commit IDs and line number offsets to allow us to maintain the connection between the discussion and the block of code.
+‍
+Note that CodeStream does need to store snippets of code in our database. This happens when you discuss a block of code by creating a Codemark. CodeStream saves that block of code in the database for a variety of reasons, not the least of which is the possibility that the code in question may not have been pushed and storing it would be the only way to share it with your teammates. This also happens when you ask a teammate to review your code by creating a Feedback Request. CodeStream stores diffs required to reconstruct the changeset so that your teammate can do the review without needing to switch branches or pull the latest.
+‍
+CodeStream’s integrations with GitHub, GitLab and Bitbucket allow you to create, manage and review pull requests from your IDE. In order to provide this robust functionality, CodeStream asks for the minimal scopes possible from each service, but the integrations do require both read and write access to your GitHub organizations/GitLab groups/Bitbucket teams. When working with pull requests via these integrations, the CodeStream extension hits the GitHub/GitLab/Bitbucket backend directly. Nothing goes through, or is stored on, the CodeStream backend when it comes to pull requests.
+
+## Access Controls [#access-controls]
+
+* Access to all internal systems is protected by a VPN, and is regularly reviewed and revoked upon termination or when no longer needed.
+* Within the network, access is further restricted by employee responsibility or roles using ssh and IP range based network packet filters.
+* Application and server logs are maintained on Loggly, a log aggregation and querying solution.
+* Company policy prevents customer data from being downloaded to portable devices, such as laptops.
+* Servers are monitored using New Relic.
+
+## Network Security [#network-security]
+
+* CodeStream is hosted on AWS (https://aws.amazon.com/security/), where all storage volumes are encrypted at rest.
+* All external network communication between production services occur over HTTPS / TLS.
+* Systems are protected using network and server packet filters which limit all outside access to only those public services we provide.
+* Our dedicated security team at CodeStream handles all security escalations, and is available 24/7.
+Customer data can be deleted from all primary and backup systems within 7 days of request.
+
+## Site Security [#site-secutiry]
+
+* All data from codestream.com is transmitted over HTTPS.
+* Monitoring services alert our 24/7 support team of potential attacks.
+
+## General Data Protection Regulation (GDPR) [#gdpr]
+
+CodeStream is committed to helping our users understand the rights and obligations under the General Data Protection Regulation (GDPR), which took effect on May 25, 2018. We have introduced tools and processes to ensure our compliance with requirements imposed by the GDPR and to help our customers comply as well. 

--- a/src/content/docs/codestream/troubleshooting/security.mdx
+++ b/src/content/docs/codestream/troubleshooting/security.mdx
@@ -7,7 +7,7 @@ We know that your source code is one of your most valuable and sensitive assets.
 
 ## Source Code Access and Storage [#code-storage]
 
-CodeStream’s servers do not require access to your source code, as all interactions with the code are done locally in your IDE leveraging your IDE’s access to the code. For example, when you select a block of code to discuss, CodeStream captures the commit IDs and line number offsets to allow us to maintain the connection between the discussion and the block of code.
+CodeStream’s servers do not require access to your source code as all interactions with the code are done locally in your IDE, leveraging your IDE’s access to the code. For example, when you select a block of code to discuss, CodeStream captures the commit IDs and line number offsets to allow us to maintain the connection between the discussion and the block of code.
 
 Note that CodeStream does need to store snippets of code in our database. This happens when you discuss a block of code by creating a Codemark. CodeStream saves that block of code in the database for a variety of reasons, not the least of which is the possibility that the code in question may not have been pushed and storing it would be the only way to share it with your teammates. This also happens when you ask a teammate to review your code by creating a Feedback Request. CodeStream stores diffs required to reconstruct the changeset so that your teammate can do the review without needing to switch branches or pull the latest.
 

--- a/src/content/docs/codestream/troubleshooting/security.mdx
+++ b/src/content/docs/codestream/troubleshooting/security.mdx
@@ -8,9 +8,9 @@ We know that your source code is one of your most valuable and sensitive assets.
 ## Source Code Access and Storage [#code-storage]
 
 CodeStream’s servers do not require access to your source code, as all interactions with the code are done locally in your IDE leveraging your IDE’s access to the code. For example, when you select a block of code to discuss, CodeStream captures the commit IDs and line number offsets to allow us to maintain the connection between the discussion and the block of code.
-‍
+
 Note that CodeStream does need to store snippets of code in our database. This happens when you discuss a block of code by creating a Codemark. CodeStream saves that block of code in the database for a variety of reasons, not the least of which is the possibility that the code in question may not have been pushed and storing it would be the only way to share it with your teammates. This also happens when you ask a teammate to review your code by creating a Feedback Request. CodeStream stores diffs required to reconstruct the changeset so that your teammate can do the review without needing to switch branches or pull the latest.
-‍
+
 CodeStream’s integrations with GitHub, GitLab and Bitbucket allow you to create, manage and review pull requests from your IDE. In order to provide this robust functionality, CodeStream asks for the minimal scopes possible from each service, but the integrations do require both read and write access to your GitHub organizations/GitLab groups/Bitbucket teams. When working with pull requests via these integrations, the CodeStream extension hits the GitHub/GitLab/Bitbucket backend directly. Nothing goes through, or is stored on, the CodeStream backend when it comes to pull requests.
 
 ## Access Controls [#access-controls]

--- a/src/nav/codestream.yml
+++ b/src/nav/codestream.yml
@@ -55,3 +55,5 @@ pages:
         path: /docs/codestream/troubleshooting/proxy-support
       - title: Reverse proxy
         path: /docs/codestream/troubleshooting/reverse-proxy
+      - title: CodeStream security
+        path: /docs/codestream/troubleshooting/security


### PR DESCRIPTION
In a month or two when we launch unified identity, the codestream.com website will be going away and we need to find a new home for our /security page. I know that this may not be the perfect spot, but it should do for now. Once CodeStream is fully migrated to the NR platform later in the year the page will go away.

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>