### PR TITLE
docs: add macos Ventura 13 support for infrastructure agent

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -184,7 +184,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        10.15 (Catalina), 11 (Big Sur), 12 (Monterey).
+        10.15 (Catalina), 11 (Big Sur), 12 (Monterey) and 13 (Ventura).
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Infrastructure agent for macOS 13 (Ventura): https://issues.newrelic.com/browse/NEWRELIC-6820
