### PR TITLE
fix(user mgmt concepts): clarifying type vs roles

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -26,12 +26,18 @@ Here we'll explain how New Relic users get access to specific capabilities and s
 
 When it comes to what New Relic features your users can access, there are two main factors: 
 
-* A user's **[user type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type)**: For organizations on [our usage-based pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing), your users' user type is a billing factor. The user type is what sets the maximum allowed capabilities a user can access. It overrides all role-related access. It's meant to be a fairly long-term setting based on someone's expected New Relic duties.
+* A user's **[user type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type)**: For organizations on [our usage-based pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing), your users' user type is a billing factor. The user type is what sets the maximum allowed capabilities a user can access. It's meant to be a long-term setting based on someone's expected New Relic duties over the next few months or years.
 * A user's assigned **roles**: after a user's user type is decided, **roles** can be used to more precisely control a user's access. Roles are sets of **capabilities**, which are the granular New Relic abilities (for example, the ability to modify New Relic APM settings). Roles are assigned by applying them to a [user group](#groups). 
 
-Let's say a basic user is assigned a group with a role with wide New Relic access, like [**All product admin**](#standard-roles). That user's user type (basic user) would prevent them from using some of the features that a core user or full platform user would have access to. A User must have access to a feature from both their user type and their access control configuration.
+### How user type and role access intersect [#user-type-role]
 
-This doc is focused on role-related permissions. For details about user types, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type).
+A New Relic user is given permission to use a New Relic feature by the combination of their a) user type, and their b) role permissions. For a New Relic user to access something, that must be allowed by both the user type and an assigned role.  
+
+For example, let's say a basic user is assigned a role with a lot of New Relic access, like [**All product admin**](#standard-roles). Their user type (basic user) would prevent them from using many of the features that a core user or full platform user can access. In order to get more access, she'd have to upgrade to a core or full platform user. 
+
+As another example: let's say a full platform user has a single, restrictive role assigned (like [**Read only**]((#standard-roles)). A full platform user can theoretically access all of New Relic, but in this case their role assignment is restricting their access. To get access to more features, someone on their team would have to adjust their role assignment.
+
+The rest of this doc is focused on roles and groups. For information on user type, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type).
 
 ## Groups give users access to roles and accounts [#understand-concepts]
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -31,7 +31,7 @@ When it comes to what New Relic features your users can access, there are two ma
 
 ### How user type and role access intersect [#user-type-role]
 
-A New Relic user is given permission to use a New Relic feature by the combination of their a) user type, and their b) role permissions. For a New Relic user to access something, that must be allowed by both the user type and an assigned role.  
+A New Relic user is given permission to use a New Relic feature by the combination of their a) user type, and their b) role permissions. Put another way: for a New Relic user to access something, neither the user type nor any assigned roles must restrict that. 
 
 For example, let's say a basic user is assigned a role with a lot of New Relic access, like [**All product admin**](#standard-roles). Their user type (basic user) would prevent them from using many of the features that a core user or full platform user can access. In order to get more access, they'd have to upgrade to a core or full platform user. 
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -35,9 +35,9 @@ A New Relic user is given permission to use a New Relic feature by the combinati
 
 For example, let's say a basic user is assigned a role with a lot of New Relic access, like [**All product admin**](#standard-roles). Their user type (basic user) would prevent them from using many of the features that a core user or full platform user can access. In order to get more access, she'd have to upgrade to a core or full platform user. 
 
-As another example: let's say a full platform user has a single, restrictive role assigned (like [**Read only**]((#standard-roles)). A full platform user can theoretically access all of New Relic, but in this case their role assignment is restricting their access. To get access to more features, someone on their team would have to adjust their role assignment.
+As another example: let's say a full platform user has a single, restrictive role assigned (like [**Read only**](#standard-roles)). A full platform user can theoretically access all of New Relic, but in this case their assigned role would restrict their access. To get more access, their assigned roles would need to be changed (for example, by assigning them to a different group, or adjusting the roles assigned to their group).
 
-The rest of this doc is focused on roles and groups. For information on user type, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type).
+The rest of this doc is focused on roles and groups. For more on user type, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type).
 
 ## Groups give users access to roles and accounts [#understand-concepts]
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -33,9 +33,9 @@ When it comes to what New Relic features your users can access, there are two ma
 
 A New Relic user is given permission to use a New Relic feature by the combination of their a) user type, and their b) role permissions. For a New Relic user to access something, that must be allowed by both the user type and an assigned role.  
 
-For example, let's say a basic user is assigned a role with a lot of New Relic access, like [**All product admin**](#standard-roles). Their user type (basic user) would prevent them from using many of the features that a core user or full platform user can access. In order to get more access, she'd have to upgrade to a core or full platform user. 
+For example, let's say a basic user is assigned a role with a lot of New Relic access, like [**All product admin**](#standard-roles). Their user type (basic user) would prevent them from using many of the features that a core user or full platform user can access. In order to get more access, they'd have to upgrade to a core or full platform user. 
 
-As another example: let's say a full platform user has a single, restrictive role assigned (like [**Read only**](#standard-roles)). A full platform user can theoretically access all of New Relic, but in this case their assigned role would restrict their access. To get more access, their assigned roles would need to be changed (for example, by assigning them to a different group, or adjusting the roles assigned to their group).
+As another example: let's say a full platform user has a restrictive role assigned (like [**Read only**](#standard-roles)). A full platform user can theoretically access all of New Relic, but in this case their assigned role would restrict their access. To get more access, their assigned roles would need to be changed (for example, by assigning them to a different group, or adjusting the roles assigned to their group).
 
 The rest of this doc is focused on roles and groups. For more on user type, see [User type](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type).
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -24,7 +24,7 @@ Want to learn about how users are calculated for billing purposes? See [New Reli
 
 ## What's the "user type"? [#user-type-defined]
 
-A user's **user type** is what determines the set of New Relic capabilities a user is entitled to access. A user can only access functionality that is both available to their user type and configured in their access control configuration. ([Learn more about factors that affect user access.](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#user-type-groups-relation))
+A user's **user type** is what determines the maximum set of New Relic capabilities a user is entitled to access. (In addition to user type, there can be other role-related restrictions. [Learn more about how user type relates to roles](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#user-type-groups-relation).)
 
 There are three user types:
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -22,9 +22,9 @@ In this doc you'll learn how we define **user type**, what capabilities each use
 
 Want to learn about how users are calculated for billing purposes? See [New Relic pricing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing). If you haven't already, be sure to [sign up for a New Relic account](https://newrelic.com/signup). It's free, forever.
 
-## What's the "user type"? [#user-type-defined]
+## What is user type? [#user-type-defined]
 
-A user's **user type** is what determines the maximum set of New Relic capabilities a user is entitled to access. (In addition to user type, there can be other role-related restrictions. [Learn more about how user type relates to roles](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#user-type-groups-relation).)
+A user's **user type** is what determines the maximum set of New Relic capabilities a user is entitled to access. (In addition to user type, there can be additional [role-related restrictions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#user-type-groups-relation).)
 
 There are three user types:
 


### PR DESCRIPTION
More work based on changes made in https://github.com/newrelic/docs-website/pull/11652/files and https://github.com/newrelic/docs-website/pull/11648/files

Basically: we previously described user type as taking 'precedence' over roles, but this isn't true; both roles and user type work in concert to determine permissions. You can be restricted by either one, in practice. 