### PR TITLE
Update documentation to make note of resource attribute decoration on spans

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -63,3 +63,98 @@ Check out this documentation about how to configure different types of sampling:
        Note that only trace data can be sent to trace observer endpoints. Your application (or collector) will need to separately configure export strategies for OpenTelemetry metrics and logs.
   </Collapser>
 </CollapserGroup>
+
+### Resource attributes and stored bytes [#resources]
+
+OpenTelemetry [resource attributes](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/) are defined to be an immutable representation of the entity producing telemetry and stored as Attributes. It's important to understand how these attributes are applied to tracing data within New Relic and how they can impact stored bytes. We can observe the impact of the resource attributes by using an example OTLP payload and inspecting the resulting NRQL query output.
+
+Example OTLP Trace Payload
+
+```
+{
+   "resourceSpans":[
+      {
+         "resource":{
+            "attributes":[
+               {
+                  "key":"service.name",
+                  "value":{
+                     "stringValue":"newrelic-otlp-service"
+                  }
+               },
+               {
+                  "key":"process.command_line",
+                  "value":{
+                     "stringValue":"/opt/java/openjdk/bin/java -javaagent:agent/opentelemetry-agent.jar"
+                  }
+               }
+            ]
+         },
+         "scopeSpans":[
+            {
+               "scope":{
+                  "name":"newrelic-instrumentation-library",
+                  "version":"1.0.0"
+               },
+               "spans":[
+                  {
+                     "attributes":[
+                        {
+                           "key":"message_id",
+                           "value":{
+                              "stringValue":"000000-aaaaaa-111111-bbbbbb"
+                           }
+                        }
+                     ],
+                     "startTimeUnixNano":"1677182057000000000",
+                     "endTimeUnixNano":"1677182059000000000",
+                     "kind":"SPAN_KIND_INTERNAL",
+                     "name":"example-span",
+                     "spanId":"c469d81892057f5f",
+                     "traceId":"aa04993b9acefbedea802f8d96e4bc58"
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}
+```
+
+
+NRQL query representation
+
+```
+{
+  "duration.ms" : 2000.0,
+  "entity.guid" : "OBFUSCATED",
+  "entity.name" : "newrelic-otlp-service",
+  "entity.type" : "SERVICE",
+  "entityGuid" : "OBFUSCATED",
+  "guid" : "c469d81892057f5f",
+  "id" : "c469d81892057f5f",
+  "instrumentation.provider" : "opentelemetry",
+  "message_id" : "000000-aaaaaa-111111-bbbbbb",
+  "name" : "example-span",
+  "newRelic.ingestPoint" : "api.traces",
+  "newrelic.source" : "api.traces.otlp",
+  "nr.isPrimaryEntityData" : true,
+  "otel.library.name" : "newrelic-instrumentation-library",
+  "otel.library.version" : "1.0.0",
+  "process.command_line" : "/opt/java/openjdk/bin/java -javaagent:agent/opentelemetry-agent.jar",
+  "service.name" : "newrelic-otlp-service",
+  "span.kind" : "internal",
+  "timestamp" : 1677182057000,
+  "trace.id" : "aa04993b9acefbedea802f8d96e4bc58",
+  "traceId" : "aa04993b9acefbedea802f8d96e4bc58"
+}
+```
+
+<Callout variant="tip">
+  The above example is a simplified comparison meant to illustrate the underlying concepts. The real-world versions will look a little different because they have more complexity.
+</Callout>
+
+
+The most important thing to notice with resource attributes is the potential difference in the size of the payload being sent in compared to what is stored in NRDB. All resource attribute values will be applied to every single span in the OTLP payload. In the example above, we are only sending in a single span but if the payload contained 100 spans, each one of them would have `process.command_line` and `service.name` applied to them.
+
+For some Java based applications, the default `process.command_line` attribute can be thousands of characters long which may result in a significant and unexpected increase in billable bytes. If these resource attributes do not provide value they can be disabled by following the [OpenTelemetry and attribute lengths: Best Practices](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes/)

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -66,7 +66,7 @@ Check out this documentation about how to configure different types of sampling:
 
 ### Resource attributes and stored bytes [#resources]
 
-OpenTelemetry [resource attributes](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/) are defined to be an immutable representation of the entity producing telemetry and stored as Attributes. It's important to understand how these attributes are applied to tracing data within New Relic and how they can impact stored bytes. We can observe the impact of the resource attributes by using an example OTLP payload and inspecting the resulting NRQL query output.
+OpenTelemetry [resource attributes](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/) are defined to be an immutable representation of the entity producing telemetry and stored as `Attributes`. It's important to understand how these attributes are applied to tracing data within New Relic and how they can impact stored bytes. We can observe the impact of the resource attributes by using an example OTLP payload and inspecting the resulting NRQL query output.
 
 Example OTLP Trace Payload
 
@@ -151,10 +151,10 @@ NRQL query representation
 ```
 
 <Callout variant="tip">
-  The above example is a simplified comparison meant to illustrate the underlying concepts. The real-world versions will look a little different because they have more complexity.
+  This example is a simplified comparison meant to illustrate the underlying concepts. Real-world versions will look a little different because they have more complexity.
 </Callout>
 
 
-The most important thing to notice with resource attributes is the potential difference in the size of the payload being sent in compared to what is stored in NRDB. All resource attribute values will be applied to every single span in the OTLP payload. In the example above, we are only sending in a single span but if the payload contained 100 spans, each one of them would have `process.command_line` and `service.name` applied to them.
+The most important thing to notice with resource attributes is the potential difference in the size of the payload being sent compared to what is stored in NRDB. All resource attribute values will be applied to every span in the OTLP payload. The example above only shows a single span being sent but if the payload contained 100 spans, each one of them would have `process.command_line` and `service.name` applied to them.
 
 For some Java based applications, the default `process.command_line` attribute can be thousands of characters long which may result in a significant and unexpected increase in billable bytes. If these resource attributes do not provide value they can be disabled by following the [OpenTelemetry and attribute lengths: Best Practices](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes/)


### PR DESCRIPTION
* What problems does this PR solve?

This PR updates our OpenTelemetry best practices for tracing to clarify how resource attributes are handled. This was done as a result of at least one customer being surprised when they compared the size of tracing data in NRDB compared to the payload being sent in.