### PR TITLE
Add clarifying note for apdex_t usage in Python Agent

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -1213,6 +1213,10 @@ These settings are available in the agent configuration file.
     We'll record transaction traces when they exceed this threshold. The format is a number of seconds (decimal points allowed).
 
     See our glossary entry for [apdex_t](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#apdex_t)
+
+    <Callout variant="important">
+      This is only set in the config file or the environment variable if `serverless_mode` is set, which is enabled for AWS Lambda.  Otherwise, the local `apdex_t` value is overridden by the value in UI application settings and that is then used to set the `apdex_f` value.
+    </Callout>
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -1215,7 +1215,7 @@ These settings are available in the agent configuration file.
     See our glossary entry for [apdex_t](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#apdex_t)
 
     <Callout variant="important">
-      This is only set in the config file or the environment variable if `serverless_mode` is set, which is enabled for AWS Lambda.  Otherwise, the local `apdex_t` value is overridden by the value in UI application settings and that is then used to set the `apdex_f` value.
+      This is only set in the config file or the environment variable if `serverless_mode` is set, which is enabled for AWS Lambda.  Otherwise, the local `apdex_t` value is overridden by the value in UI application settings which is then used to set the `apdex_f` value.
     </Callout>
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This PR adds [a clarifying note](https://github.com/newrelic/docs-website/issues/10686) about the usage of `apdex_t` for the Python Agent