### PR TITLE
fix: link to host file should be HTTPS

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors.mdx
@@ -310,7 +310,7 @@ You can also manually log monitor results to the [script log](/docs/synthetics/n
 
 ## Unblock analytics services [#unblock-service]
 
-Synthetics blocks [popular analytics services'](http://nr-synthetics-assets.s3.amazonaws.com/blacklists/blacklist.hosts) scripts from running by default. You can allow scripts to run for a specified service(s). This allows the service's scripts to run and collect data like it would for a real user.
+Synthetics blocks [popular analytics services'](https://nr-synthetics-assets.s3.amazonaws.com/blacklists/blacklist.hosts) scripts from running by default. You can allow scripts to run for a specified service(s). This allows the service's scripts to run and collect data like it would for a real user.
 
 ```
 //Allow Google Analytics scripts to run


### PR DESCRIPTION
Issues with clicking on the the link to download the host file.  Browser appears to download and delete immediately, or take a long time to verify download.  Using HTTPS instead of HTTP, the file downloads immediately, as expected.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->