### PR TITLE
fix: the ESD needs an entityGuid to be returned

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -437,7 +437,7 @@ To determine how null values will be handled, adjust the loss of signal and gap 
 You can avoid `NULL` values entirely with a query order of operations shortcut. To do this, use a `filter` sub-clause, then include all filter elements within that sub-clause. The main body of the query will run and return data, at which point the `SELECT` clause will then run and apply the filter elements. The query will return a value of `0` if the filter elements result in no matching data. Here's an example:
 
 ```
-SELECT filter(count(*), WHERE result = 'SUCCESS' AND monitorName = 'My Favorite Monitor') FROM SyntheticCheck
+SELECT filter(count(*), WHERE result = 'SUCCESS') WHERE monitorName = 'My Favorite Monitor' FROM SyntheticCheck
 ```
 
 For more information, check out our [blog post](https://discuss.newrelic.com/t/relic-solution-how-can-i-figure-out-when-to-use-gap-filling-and-loss-of-signal/120401) on troubleshooting for zero versus null values.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create NRQL alert conditions
 tags:
-  - Alerts and applied intelligence 
+  - Alerts and applied intelligence
   - Alerts
   - Alert conditions
 translate:
@@ -407,7 +407,7 @@ By default, the aggregation window duration is 1 minute, but you can change the 
 Let's say this is your alert condition query:
 
 ```
-SELECT count(*) FROM SyntheticCheck WHERE monitorName = 'My Cool Monitor' AND result = 'FAILURE'
+SELECT count(*) FROM SyntheticCheck WHERE monitorName = 'My Cool Monitor' AND result = 'FAILED'
 ```
 
 If there are no failures for the aggregation window:
@@ -434,11 +434,15 @@ If, in the aggregation window being evaluated, there's at least one instance of 
 
 To determine how null values will be handled, adjust the loss of signal and gap filling settings in the [Alert conditions UI](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#signal-loss).
 
-You can avoid `NULL` values entirely with a query order of operations shortcut. To do this, use a `filter` sub-clause, then include all filter elements within that sub-clause. The main body of the query will run and return data, at which point the `SELECT` clause will then run and apply the filter elements. The query will return a value of `0` if the filter elements result in no matching data. Here's an example:
+You can avoid `NULL` values entirely with a query order of operations shortcut. To do this, use a `filter` sub-clause, then include all filter elements within that sub-clause. The main body of the query should include a `WHERE` clause that defines at least one entity so, for any aggregation window where the monitor performs a check, the signal will be tied to that entity. The `SELECT` clause will then run and apply the filter elements to the data returned by the main body of the query, which will return a value of `0` if the filter elements result in no matching data.
+
+Here's an example to alert on `FAILED` results:
 
 ```
-SELECT filter(count(*), WHERE result = 'SUCCESS') WHERE monitorName = 'My Favorite Monitor' FROM SyntheticCheck
+SELECT filter(count(*), WHERE result = 'FAILED') WHERE monitorName = 'My Favorite Monitor' FROM SyntheticCheck
 ```
+
+In this example, a window with a successful result would return a `0`, allowing the condition's threshold to resolve on its own.
 
 For more information, check out our [blog post](https://discuss.newrelic.com/t/relic-solution-how-can-i-figure-out-when-to-use-gap-filling-and-loss-of-signal/120401) on troubleshooting for zero versus null values.
 


### PR DESCRIPTION
In order for the Entity Status Daemon (ESD) to find the associated Synthetic monitor, the ESD needs an entityGuid to be returned as part of the data gathered by the alert condition query. Moving the identifying attribute out of the `filter()` function will accomplish this and allow the monitor's status to turn red or green rather than remain grey in Synthetics.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.