### PR TITLE
Update no-data-appears-after-disabling-tls-10.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10.mdx
@@ -42,12 +42,10 @@ Also, you also may have noticed an error message in the New Relic agent logs due
 
 The New Relic .NET agent requires a minimum version of TLS 1.2 or above. For TLS 1.2, it also requires .NET to be configured to use it.
 
-<Callout variant="important">
-  If you set a TLS version as default, it will be used by both the application and the New Relic agent. You cannot use a different TLS version for each.
-</Callout>
+Beginning with .NET agent version 10.6.0, upon startup, the agent logs the configured TLS version at INFO-level.
 
-<Callout variant="tip">
-  Beginning with .NET agent version 10.6.0, upon startup, the agent logs the configured TLS version at INFO-level.
+<Callout variant="important">
+  If you set a TLS version as default, it will be used by both the application and the New Relic agent. You can't use a different TLS version for each.
 </Callout>
 
 To enable a specific TLS version protocol:

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-after-disabling-tls-10.mdx
@@ -40,10 +40,14 @@ Also, you also may have noticed an error message in the New Relic agent logs due
 
 ## Solution
 
-The New Relic .NET agent requires at least one version of TLS to be enabled. For TLS 1.1/1.2 it also requires .NET to be configured to use it.
+The New Relic .NET agent requires a minimum version of TLS 1.2 or above. For TLS 1.2, it also requires .NET to be configured to use it.
 
 <Callout variant="important">
   If you set a TLS version as default, it will be used by both the application and the New Relic agent. You cannot use a different TLS version for each.
+</Callout>
+
+<Callout variant="tip">
+  Beginning with .NET agent version 10.6.0, upon startup, the agent logs the configured TLS version at INFO-level.
 </Callout>
 
 To enable a specific TLS version protocol:


### PR DESCRIPTION
Updated minimum TLS requirements that began Feb. 2023 per this notice: https://forum.newrelic.com/s/hubtopic/aAX8W0000008dM6WAI/tls-1011-has-been-disabled-for-all-inbound-connections-on-feb-2nd-2023

Added a tip to determine the version of TLS in use by the agent.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.