### PR TITLE
Fix: Update drop-data-drop-filter-rules.mdx

### DIFF
--- a/src/content/docs/logs/ui-data/drop-data-drop-filter-rules.mdx
+++ b/src/content/docs/logs/ui-data/drop-data-drop-filter-rules.mdx
@@ -107,8 +107,6 @@ There are three different ways you can create a drop filter:
 
 To manage your drop filter rules programmatically, you can use [NerdGraph](/docs/accounts/accounts/data-management/drop-data-using-nerdgraph), our GraphQL Explorer, to create, query, and delete your drop filter rules.
 
-If you create drop filter rules for log events using NerdGraph, set the `source` attribute to `Logging`. The Logs UI only displays drop filters with the `source` attribute.
-
 ## Types of drop filter rules [#types]
 
 The drop filters UI prompts you to select whether to drop logs based on the query or on specific attributes.


### PR DESCRIPTION
`source` is not a public attribute available to customers in NerdGraph on drop rule creation. Its usage should not be recommended in this document.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
    * Removes the recommendation of a NerdGraph input field that is not available to the customers in the described scenario 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
    * The document recommends setting a `source` attribute while creating a new drop rule in NerdGraph but such input field is not available in `nrqlDropRulesCreate`: 
<img width="183" alt="image" src="https://user-images.githubusercontent.com/123484873/221620639-74860a0c-0987-4655-9d05-b9160619b7c0.png">

* If your issue relates to an existing GitHub issue, please link to it.
    * N/A