### PR TITLE
docs: Use NEW_RELIC_APP_NAME in example code

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/net-agent-install-resources.mdx
@@ -100,7 +100,7 @@ For installations requiring you to manually set environment variables, you can a
 * **App name**. Setting a [meaningful application name](/docs/agents/manage-apm-agents/app-naming/name-your-application#app-name) is recommended, but you can also set this after install. The environment variable is:
 
   ```ini
-  NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
+  NEW_RELIC_APP_NAME = YOUR_APP_NAME
   ```
 
   You can also [set this via the newrelic.config, the app's config file, or the API](/docs/agents/net-agent/configuration/name-your-net-application).


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve? The website was talking about setting an app name, but the example was related to setting a license key

Context for environment variable: https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/app-naming/name-your-application/