### PR TITLE
fix(DeviceEmulation): Added job manager version requirements

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/device-emulation.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/device-emulation.mdx
@@ -18,7 +18,7 @@ Device emulation allows you to test a browser-based application using a simulate
 ## Requirements [#requirements]
 
 * Chrome 100+ runtimes only
-* Private locations must use [job manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide) and synthetics-node-browser-runtime version 1.1.98 or higher
+* Private locations must use [job manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide) version 225 or higher and synthetics-node-browser-runtime version 1.1.98 or higher
 
 ## Configure device emulation [#devices]
 


### PR DESCRIPTION
Added the version of job manager required to use device emulation on private locations.