### PR TITLE
fix: section IDs duplicates corrected

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1626,7 +1626,7 @@ The `applications` element is a child of the `instrumentation` element. The `app
 
 ### Attributes element [#agent-attributes]
 
-An attribute is a key/value pair that determines the properties of an event or transaction. Each attribute is sent to APM transaction traces, APM error traces, Transaction events, TransactionError events, or PageView events. The primary `attributes` element enables or disables attribute collection for the .NET agent, and defines specific attributes to collect or exclude. You can also configure attribute settings based on their destination: [Error collection](#error-attributes), [transaction traces](#tracer-attributes), [browser instrumentation](#browser-attributes), and [transaction events](#paragrp-attributes).
+An attribute is a key/value pair that determines the properties of an event or transaction. Each attribute is sent to APM transaction traces, APM error traces, Transaction events, TransactionError events, or PageView events. The primary `attributes` element enables or disables attribute collection for the .NET agent, and defines specific attributes to collect or exclude. You can also configure attribute settings based on their destination: [Error collection](#error-attributes), [transaction traces](#tracer-attributes), [browser instrumentation](#browser-attributes), and [transaction events](#transaction-attributes).
 
 In this example, the agent excludes all attributes whose key begins with **myApiKey** (**myApiKey.bar**, **myApiKey.value**), but collects the custom attribute **myApiKey.foo**.
 
@@ -2197,7 +2197,7 @@ The `transactionEvents` element supports the following attributes:
 
 <CollapserGroup>
   <Collapser
-    id="paragrp-enabled"
+    id="transaction-enabled"
     title="enabled"
   >
     <table>
@@ -2228,7 +2228,7 @@ The `transactionEvents` element supports the following attributes:
   </Collapser>
 
   <Collapser
-    id="paragrp-maximumSamplesStored"
+    id="transaction-maximumSamplesStored"
     title="maximumSamplesStored"
   >
     <table>
@@ -2265,7 +2265,7 @@ The `transactionEvents` element supports the following attributes:
   </Collapser>
 
   <Collapser
-    id="paragrp-attributes"
+    id="transaction-attributes"
     title="attributes"
   >
     Use this sub-element to customize your agent attribute settings for transaction events. This sub-element uses the same settings as the primary `attributes` element: [`enabled`](#agent-attributes-enabled), [`include`](#agent-attributes-include), and [`exclude`](#agent-attributes-exclude).
@@ -2323,7 +2323,7 @@ The `customEvents` element supports the following attributes:
   </Collapser>
 
   <Collapser
-    id="paragrp-maximumSamplesStored"
+    id="customevents-maximumSamplesStored"
     title="maximumSamplesStored"
   >
     <table>
@@ -3096,7 +3096,7 @@ The `spanEvents` element supports the following attributes:
 
 <CollapserGroup>
   <Collapser
-    id="paragrp-enabled"
+    id="span-enabled"
     title="enabled"
   >
     <table>
@@ -3127,7 +3127,7 @@ The `spanEvents` element supports the following attributes:
   </Collapser>
 
   <Collapser
-    id="paragrp-max-samples-stored"
+    id="span-max-samples-stored"
     title="maximumSamplesStored"
   >
     <table>
@@ -3166,7 +3166,7 @@ The `spanEvents` element supports the following attributes:
   </Collapser>
 
   <Collapser
-    id="paragrp-attributes"
+    id="span-attributes"
     title="attributes"
   >
     Use this sub-element to customize your agent attribute settings for span events. This sub-element uses the same settings as the primary `attributes` element: [`enabled`](#agent-attributes-enabled), [`include`](#agent-attributes-include), and [`exclude`](#agent-attributes-exclude).
@@ -3298,7 +3298,7 @@ The `applicationLogging` element supports the following attributes and sub-eleme
 
 <CollapserGroup>
   <Collapser
-    id="paragrp-enabled"
+    id="applog-enabled"
     title="enabled"
   >
     <table>
@@ -3329,14 +3329,14 @@ The `applicationLogging` element supports the following attributes and sub-eleme
   </Collapser>
 
   <Collapser
-    id="metrics"
+    id="applog-metrics"
     title="metrics"
   >
     Use this sub-element to enable collection of logging metrics (such as `Logging/lines`) for common .NET logging frameworks. The default value of attribute `enabled` is `true`.
   </Collapser>
 
   <Collapser
-    id="forwarding"
+    id="applog-forwarding"
     title="Log forwarding"
   >
     Use this sub-element to enable forwarding of your application's logs to New Relic. The default value of attribute `enabled` is `true`.  The default value of attribute `maxSamplesStored` is `10000`.


### PR DESCRIPTION
duplicated section ID like `paragrp-enabled` made linking impossible in some places

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.