### PR TITLE
fix(PHP agent): Correct minimum glibc version supported

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -101,7 +101,7 @@ however it is no longer tested or officially supported by the New Relic PHP Agen
         * Any other Linux distribution with:
 
           * Kernel version 4.9 (long term) or higher
-          * glibc 2.35 or higher with [NPTL](https://en.wikipedia.org/wiki/Native_POSIX_Thread_Library) support or musl libc version 1.1.24 or higher
+          * glibc 2.17 or higher with [NPTL](https://en.wikipedia.org/wiki/Native_POSIX_Thread_Library) support or musl libc version 1.1.24 or higher
       </td>
     </tr>
 


### PR DESCRIPTION
The PHP team would like to correct the minimum GLIBC version supported for the PHP agent.  We have determined the value we used was too new as the operating systems we say we support use older versions than 2.35.  The new minimum version is from Centos 7 which is a supported OS and uses the oldest GLIBC of any of the ones we support.