### PR TITLE
Remove unsupported Python agent versions from EOL table.

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy.mdx
@@ -165,7 +165,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jul 21, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.14.0.177
@@ -179,7 +179,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 27, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.12.0.176
@@ -193,7 +193,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 9, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.10.0.175
@@ -207,7 +207,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Apr 6, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.8.0.174
@@ -221,7 +221,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Mar 31, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.6.0.173
@@ -235,7 +235,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Feb 25, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.4.0.172
@@ -249,7 +249,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jan 20, 2024
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.2.4.171
@@ -263,7 +263,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Nov 11, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.2.3.170
@@ -277,7 +277,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Nov 4, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.2.2.169
@@ -291,7 +291,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Oct 15, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.2.1.168
@@ -305,7 +305,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Oct 12, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.2.0.167
@@ -319,7 +319,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Oct 12, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v7.0.0.166
@@ -333,7 +333,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Sep 22, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.10.0.165
@@ -347,7 +347,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Sep 16, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.8.0.164
@@ -361,7 +361,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Aug 24, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.8.0.163
@@ -375,7 +375,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Aug 4, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.6.0.162
@@ -389,7 +389,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jul 29, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.4.4.161
@@ -403,7 +403,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jul 6, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.4.3.160
@@ -417,7 +417,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 23, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.4.2.159
@@ -431,7 +431,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 22, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.4.1.158
@@ -445,7 +445,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 4, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v6.4.0.157
@@ -459,105 +459,7 @@ Any versions not listed in the following table are no longer supported. Please [
         May 25, 2023
       </td>
     </tr>
-    
-    <tr>
-      <td>
-        v6.2.0.156
-      </td>
 
-      <td>
-        Feb 25, 2021
-      </td>
-
-      <td>
-        Feb 25, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v6.0.1.155
-      </td>
-
-      <td>
-        Jan 21, 2021
-      </td>
-
-      <td>
-        Jan 21, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v6.0.0.154
-      </td>
-
-      <td>
-        Jan 21, 2021
-      </td>
-
-      <td>
-        Jan 21, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.24.0.153
-      </td>
-
-      <td>
-        Dec 22, 2020
-      </td>
-
-      <td>
-        Dec 22, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.22.1.152
-      </td>
-
-      <td>
-        Oct 28, 2020
-      </td>
-
-      <td>
-        Oct 28, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.22.0.151
-      </td>
-
-      <td>
-        Oct 22, 2020
-      </td>
-
-      <td>
-        Oct 22, 2022
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.20.1.150
-      </td>
-
-      <td>
-        Oct 6, 2020
-      </td>
-
-      <td>
-        Oct 6, 2022
-      </td>
-    </tr>
-    
     <tr>
       <td>
         v5.20.0.149
@@ -571,7 +473,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Sep 21, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.18.0.148
@@ -585,7 +487,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Aug 31, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.16.2.147
@@ -599,7 +501,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Aug 24, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.16.1.146
@@ -613,7 +515,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Aug 17, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.16.0.145
@@ -627,7 +529,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Aug 10, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.14.1.144
@@ -641,7 +543,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 18, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.14.0.142
@@ -655,7 +557,7 @@ Any versions not listed in the following table are no longer supported. Please [
         Jun 2, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.12.1.141
@@ -669,7 +571,7 @@ Any versions not listed in the following table are no longer supported. Please [
         May 4, 2023
       </td>
     </tr>
-    
+
     <tr>
       <td>
         v5.12.0.140
@@ -681,34 +583,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Apr 13, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.10.0.138
-      </td>
-
-      <td>
-        Mar 9, 2020
-      </td>
-
-      <td>
-        Mar 9, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v5.8.0.136
-      </td>
-
-      <td>
-        Feb 24, 2020
-      </td>
-
-      <td>
-        Feb 24, 2023
       </td>
     </tr>
 


### PR DESCRIPTION
The Python agent EOL table included several outdated agent versions. This PR removes those unsupported agent versions.
