### PR TITLE
Add metadata backfill to Python Agent

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60401158.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60401158.mdx
@@ -3,6 +3,8 @@ subject: Python agent
 releaseDate: '2021-06-04'
 version: 6.4.1.158
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for Flask v2']
+bugs: ['Non-PID specific memory metric being reported']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60402159.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60402159.mdx
@@ -3,6 +3,7 @@ subject: Python agent
 releaseDate: '2021-06-22'
 version: 6.4.2.159
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+bugs: ['Fix inspect.formatargspec deprecation warning', 'HTTPX Crash']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60403160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60403160.mdx
@@ -3,6 +3,7 @@ subject: Python agent
 releaseDate: '2021-06-23'
 version: 6.4.3.160
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+bugs: ['Fix Starlette/ FastAPI transaction naming and classification']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60404161.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60404161.mdx
@@ -3,6 +3,7 @@ subject: Python agent
 releaseDate: '2021-07-06'
 version: 6.4.4.161
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+bugs: ['Fixed a crash in memory sampling on BSD kernels']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60800163.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60800163.mdx
@@ -3,6 +3,8 @@ subject: Python agent
 releaseDate: '2021-08-04'
 version: 6.8.0.163
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Added wheel support for ARM64 (a.k.a. AArch 64, ARMv8)']
+bugs: ['Fix a crash in unsupported GraphQL versions']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-61000165.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-61000165.mdx
@@ -3,6 +3,8 @@ subject: Python agent
 releaseDate: '2021-09-16'
 version: 6.10.0.165
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Added new instrumentation for Strawberry', 'Added new instrumentation for Ariadne']
+bugs: ['TimeTrace.**str** recursion']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166.mdx
@@ -3,6 +3,7 @@ subject: Python agent
 releaseDate: '2021-09-22'
 version: 7.0.0.166
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Reservoir sizes now configurable using settings and environment variables']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70200167.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70200167.mdx
@@ -3,6 +3,8 @@ subject: Python agent
 releaseDate: '2021-10-12'
 version: 7.2.0.167
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Python 3.10 Wheels']
+bugs: ['Errors fail to be ignored by server-side config', 'Deprecation warnings for imp module removed']
 ---
 
 ## Notes


### PR DESCRIPTION
This PR adds metadata to the Python Agent for versions 6.4.1.158-7.2.0.167 of the agent.