### PR TITLE
chore: add json for apm js doc pathname

### DIFF
--- a/src/data/nav-footer-cta.json
+++ b/src/data/nav-footer-cta.json
@@ -10,6 +10,12 @@
         "link": "https://one.newrelic.com/nr1-core?filters=%28domain%20IN%20%28%27APM%27%2C%20%27EXT%27%29%20AND%20type%20IN%20%28%27APPLICATION%27%2C%20%27SERVICE%27%29%29&state=62bc4f1a-cea5-dbdd-6c12-ab2653bdba94",
         "icon": "nr-apm"
     },
+    "apm-JSDoc": {
+        "i18nKey": "apm",
+        "directory": "introduction-apm",
+        "link": "https://one.newrelic.com/nr1-core?filters=%28domain%20IN%20%28%27APM%27%2C%20%27EXT%27%29%20AND%20type%20IN%20%28%27APPLICATION%27%2C%20%27SERVICE%27%29%29&state=62bc4f1a-cea5-dbdd-6c12-ab2653bdba94",
+        "icon": "nr-apm"
+    },
     "browser": {
         "i18nKey": "browser",
         "directory": "/docs/browser",


### PR DESCRIPTION
this adds a json object with regex for the APM intro doc that isn't under the /docs/apm path