### PR TITLE
Add missing space in `Use workloads`

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/workloads/use-workloads.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/workloads/use-workloads.mdx
@@ -111,7 +111,7 @@ A workload should contain the entities you and your team want to see. Your choic
   **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > Workloads > Create a workload:** When you [create a workload](#create), you choose the associated accounts and monitored entities.
 </figcaption>
 
-You can use the UIor [the NerdGraph API](/docs/nerdgraph-workloads-tutorials) to create a workload. Follow these steps to create a workload using the UI:
+You can use the UI or [the NerdGraph API](/docs/nerdgraph-workloads-tutorials) to create a workload. Follow these steps to create a workload using the UI:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** and click on the **Explorer**, and then click **+ Create a workload**.
 2. Give the workload a name that will be meaningful for you and your team later.


### PR DESCRIPTION
Fixes a typo.