### PR TITLE
fix: added missing line items for supported aws services

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -2,9 +2,9 @@
 title: Compatibility and requirements for the Node.js agent
 tags:
   - Agents
-  - Nodejs agent 
+  - Nodejs agent
   - Getting started
-translate: 
+translate:
   - jp
 metaDescription: 'The New Relic Node.js agent supports these frameworks, architectures, and operating systems.'
 redirects:
@@ -17,8 +17,8 @@ Our Node.js agent is publicly available on the [Node Package Manager (npm) repos
 
 ## Requirements to install the agent
 
-Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent), check that your system meets its minimum requirements. For best performance, use the latest active long term support (LTS) version of Node.js. 
- 
+Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent), check that your system meets its minimum requirements. For best performance, use the latest active long term support (LTS) version of Node.js.
+
 <CollapserGroup>
 <Collapser
     id="operating systems"
@@ -30,7 +30,7 @@ The Node.js agent is compatible with the following operating systems:
 * Linux
 * SmartOS
 * macOS 10.7 and higher
-* Windows Server 2008 and higher 
+* Windows Server 2008 and higher
 The following are proposed time ranges. The actual release date may vary.
 </Collapser>
 <Collapser
@@ -173,13 +173,13 @@ The following are proposed time ranges for EOL on older Node.js versions. The ac
   </tbody>
 </table>
 </Collapser>
-</CollapserGroup> 
+</CollapserGroup>
 
 ## Instrument with Node.js [#instrument]
 
-After installation, the agent automatically instruments with our catalog of supported Node.js libraries and frameworks. This gives you immediate access to granular information specific to your web apps and servers. 
+After installation, the agent automatically instruments with our catalog of supported Node.js libraries and frameworks. This gives you immediate access to granular information specific to your web apps and servers.
 
-For unsupported frameworks or libraries, you'll need to instrument the agent yourself using the [Node.js agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api). 
+For unsupported frameworks or libraries, you'll need to instrument the agent yourself using the [Node.js agent API](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api).
 
 <CollapserGroup>
 <Collapser
@@ -195,6 +195,7 @@ The Node.js agent monitors the performance of Node.js application calls to these
 * MySQL (via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages)
 * [Redis](https://www.npmjs.com/package/redis)
 * [Postgres](https://www.npmjs.com/package/pg) (including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages)
+* [Amazon DynamoDB](https://github.com/aws/aws-sdk-js) - both versions 2 and 3 of AWS SDK.
 </Collapser>
 
 <Collapser
@@ -211,6 +212,9 @@ The Node.js agent monitors the performance of Node.js application calls to these
 The Node.js agent instruments the native `http` module.
 
 In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
+
+All calls to Amazon Web Services(AWS) with the [aws-sdk](https://www.npmjs.com/package/aws-sdk) are tracked.
+
 </Collapser>
 
 <Collapser
@@ -301,7 +305,7 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
       <td>
         [MySQL](http://www.mysql.com/)
       </td>
- 
+
       <td>
         [mysql](https://www.npmjs.com/package/mysql)
       </td>
@@ -332,12 +336,30 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
         1.33.0
       </td>
     </tr>
+
+<tr>
+      <td>
+        [Amazon DynamoDB](https://aws.amazon.com/dynamodb/)
+      </td>
+
+      <td>
+        [aws-sdk](https://www.npmjs.com/package/aws-sdk) - both versions 2 and 3.
+      </td>
+
+      <td>
+        2.380.0
+      </td>
+
+      <td>
+        6.1.0
+      </td>
+    </tr>
   </tbody>
 </table>
 
 To request instance-level information from datastores currently not listed for your New Relic agent, get support at [support.newrelic.com](https://support.newrelic.com).
 </Collapser>
-<Collapser 
+<Collapser
     id="logging"
     title="Logging libraries"
 >
@@ -354,7 +376,10 @@ In order to support [APM logs in context](/docs/apm/new-relic-apm/getting-starte
     title="Messages queue"
 >
 
-[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation: `amqplib`. 
+[Message queue instrumentation](/docs/agents/nodejs-agent/troubleshooting/troubleshoot-message-consumers) is only available with the [New Relic Node.js agent v2 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes). Currently supported message queue instrumentation:
+ * [amqplib](https://www.npmjs.com/package/amqplib).
+ * [Amazon SQS](https://www.npmjs.com/package/aws-sdk) - both versions 2 and 3 of AWS SDK.
+ * [Amazon SNS](https://www.npmjs.com/package/aws-sdk) - both versions 2 and 3 of AWS SDK.
 
 For other message queue libraries, use [custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation#message-client).
 
@@ -363,7 +388,7 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
     id="langtech"
     title="Supported languages and technologies"
 >
-[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box. 
+[TypeScript](https://www.npmjs.com/package/typescript) is a programming language that can compile to JavaScript. After installation, the Node.js agent automatically instruments your TypeScript apps, giving you immediate access to performance data right out of the box.
 
 [ES modules](https://nodejs.org/api/esm.html#introduction) are the official standard for packaging JavaScript code for sharing/reuse. The Node.js agent has **experimental** support for ES module applications running Node.js version 16.12.0 or higher and agent version 9.1.0 or higher. Please see our [ES module documentation](/docs/apm/agents/nodejs-agent/installation-configuration/es-modules) for additional information and instructions.
 </Collapser>


### PR DESCRIPTION

## Give us some context

* What problems does this PR solve?

GTS mentioned we don't explicitly call out we support DynamoDB, SQS, SNS, and general calls to AWS. This PR updates the Node.js compatibility page with these line items