### PR TITLE
gatsby-focus-wrapper renders twice

### DIFF
--- a/src/pages/introduction-apm.js
+++ b/src/pages/introduction-apm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import {
   FeaturedContent,
@@ -29,6 +29,17 @@ import trackDeps from 'images/new-apm-images/track-deps.png';
 
 const IntroductionApm = () => {
   const { t } = useTranslation();
+
+  useEffect(() => {
+    const gatsbyFocusWrapper = document.querySelectorAll(
+      '#gatsby-focus-wrapper'
+    );
+
+    if (gatsbyFocusWrapper.length > 1) {
+      gatsbyFocusWrapper[1].remove();
+    }
+  }, []);
+
   return (
     <>
       <FeaturedContent


### PR DESCRIPTION
We were having an issue where, upon redirecting from the original mdx url, another gatsby-focus-wrapper would get injected into the DOM and instead of being a wrapper, would render text. this code removes the 2nd wrapper via #gatsby-focus-wrapper

to QA:
visit, `/docs/apm/new-relic-apm/getting-started/introduction-apm/` and look at the bottom of the screen after the redirect

![Screen Shot 2023-03-03 at 8 09 52 AM](https://user-images.githubusercontent.com/26727669/222755656-f3ea5f24-b1ef-4a63-a856-37c424185cc7.png)

a thread i saw for how this isn't configurable - https://github.com/gatsbyjs/gatsby/issues/7310
