### PR TITLE
Update tracing-gap-aws-x-ray-integration.md

### DIFF
--- a/src/content/whats-new/2020/08/tracing-gap-aws-x-ray-integration.md
+++ b/src/content/whats-new/2020/08/tracing-gap-aws-x-ray-integration.md
@@ -10,9 +10,7 @@ Whether you’re managing Amazon EC2 instances or writing AWS Lambda functions, 
 
 Conversely, New Relic Distributed Tracing provides automatic tracing for any application where the New Relic agent is installed—including on-prem and monolithic applications. One thing it lacked was visibility into trace and performance data from AWS-managed services where the agent couldn’t be installed.
 
-Now, you can combine New Relic Distributed Tracing and AWS X-Ray into a single, seamless experience. Automatically see an end-to-end view of requests as they travel through their applications, along with filtering, querying, and visualizing trace data to quickly debug issues.
-
-This update brings rich trace data for AWS-managed services so you can get insight into how services—like AWS Lambda, Amazon Simple Queue Service, Amazon API Gateway, or Amazon DynamoDB—are contributing to your total transaction time or possibly causing errors.
+Now, you can ingest AWS X-Ray distributed tracing data into New Relic to easily query, alert, and view application trace data from your managed AWS services on the same screen as the rest of your distributed tracing data for applications where the New Relic agent is installed.
 
 ## Get started
 
@@ -20,4 +18,4 @@ If you’re an existing New Relic user and you’ve already [connected your AWS 
 
 ![Infrastructure_integrations_AWS_x-ray.png](./images/Infrastructure_integrations_AWS_x-ray.png "Infrastructure_integrations_AWS_x-ray.png")
 
-After you enable the X-Ray integration, AWS X-Ray trace data will automatically display in any distributed tracing view throughout New Relic One.
+After you enable the X-Ray integration, AWS X-Ray trace data will automatically display in any distributed tracing view throughout the New Relic platform.


### PR DESCRIPTION
Updating per request from TSS: NR and AWS traces cannot be blended together into a single end-to-end trace
