### PR TITLE
fix: Update choose-your-aggregation-method.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/choose-your-aggregation-method.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/choose-your-aggregation-method.mdx
@@ -105,7 +105,7 @@ Cadence is our original aggregation method. It aggregates data on specific time 
 
 We recommend that you use one of our other aggregation methods instead, unless your events are susceptible to clock skew and you don't have control on the producer to correct it. For instance, `PageAction` events are instrumented on users browsers, and rely on the user device clock to assign a timestamp. A single event with a skewed timestamp can affect event flow or even timer alerts, as windows may be aggregated too early and result in false positives.
 
-If you're currently using cadence, choose one of the other aggregation methods. Event flow is best for consistent, predictable data points. Event timer is best for inconsistent, sporadic data points.
+Outside of this scenario, you will want to choose one of the other aggregation methods. Event flow is best for consistent, predictable data points. Event timer is best for inconsistent, sporadic data points.
 
 ## Aggregation and loss of signal [#loss-signal]
 


### PR DESCRIPTION
Our docs provide a clear, concise example for the particular scenario in which you'd want to use the cadence aggregation method. However, we immediately follow it up with a contradictory statement:

> If you're currently using cadence, choose one of the other aggregation methods.

This edit softens the statement to note that we only advise against cadence outside of the case mentioned above it. Before going any further, though, I'd like @HenryTech to give this approach a review from his standpoint.