### PR TITLE
fix: Update new-relic-api-keys.mdx

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -233,9 +233,9 @@ To create or manage API keys, use the UI at [one.newrelic.com/launcher/api-keys-
   >
     New Relic user keys, sometimes referred to as "personal API keys," are required for using [NerdGraph](/docs/apis/intro-apis/introduction-new-relic-apis/#graphql) and our [REST API](/docs/apis/intro-apis/introduction-new-relic-apis/#rest-api).
 
-    A user key is tied to a specific New Relic user, and cannot be transferred. The user key allows you to make queries for any accounts you've been granted access to, not just the specific account the key was associated with. If a New Relic user is deleted in New Relic, their user keys are also deactivated and won't work.
+    A user key is tied to a specific New Relic user, and cannot be transferred. The user key allows you to run NerdGraph queries and mutations for any accounts you've been granted access to, not just the specific account the key was associated with. If a New Relic user is deleted in New Relic, their user keys are also deactivated and won't work.
 
-    Even though they provide a user access to multiple accounts, user keys are linked to a single specific account. The significance of this is that if an account is deleted, any user keys associated with that account no longer work. 
+    Even though they provide a user access to multiple accounts, user keys are linked to a single specific account. The significance of this is that if an account is deleted, any user keys associated with that account no longer work. Additionally, REST API calls are limited to the context of the user key's associated account.
 
     To prevent a user from viewing or managing user keys, assign them a role without those capabilities: [original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on) \| [newer user model](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities).
   </Collapser>


### PR DESCRIPTION
The section on user keys is ambiguous enough to potentially mislead a customer into thinking that the REST API supports cross-account user key authentication. However, our REST API endpoints only recognize a user key as being associated with its root account.

This edit attempts to clarify that point.