### PR TITLE
fix: Ignore synthetics node subjects

### DIFF
--- a/src/utils/getAgentName.js
+++ b/src/utils/getAgentName.js
@@ -19,6 +19,7 @@ const AGENTS = [
 // keeping the naming streamlined and in matching with previous data
 const RENAMES = { '.net': 'dotnet', node: 'nodejs' };
 
+const IGNORE_SUBECTS = ['Node API runtime', 'Node browser runtime'];
 /**
  * @param {string} subject The release note "subject" in frontmatter
  * @returns {string}
@@ -29,7 +30,9 @@ const getAgentName = (subject) => {
     const subjLowercase = subject.toLowerCase();
     const agentName = AGENTS.find(
       (agent) =>
-        subjLowercase.includes(agent) && !subjLowercase.includes('insights')
+        subjLowercase.includes(agent) &&
+        !subjLowercase.includes('insights') &&
+        !IGNORE_SUBECTS.includes(subject)
     );
 
     return RENAMES[agentName] || agentName;


### PR DESCRIPTION
Right now the release notes under synthetics with 'node' in the subject are getting grabbed as part of the release notes json under the node agent. we should probably rewrite this but in the interest of time this is a quick fix

to test: 
check out the json at /api/agent-release-notes.json and command f for any of these versions:
(they may show up for other agents with overlapping version but none should show up under nodejs)
```
        {
          "date": "2022-09-23",
          "version": "1.1.19"
        },
        {
          "date": "2022-09-15",
          "version": "1.1.17"
        },
        {
          "date": "2022-10-04",
          "version": "1.1.21"
        },
        {
          "date": "2022-11-10",
          "version": "1.1.25"
        },
        {
          "date": "2022-10-04",
          "version": "1.1.20"
        },
        {
          "date": "2023-01-17",
          "version": "1.1.31"
        },
        {
          "date": "2023-01-17",
          "version": "1.1.76"
        },
        {
          "date": "2022-10-14",
          "version": "1.1.23"
        },
        {
          "date": "2022-12-01",
          "version": "1.1.27"
        },
        {
          "date": "2022-12-01",
          "version": "1.1.28"
        },
        {
          "date": "2022-12-08",
          "version": "1.1.29"
        },
        {
          "date": "2023-02-02",
          "version": "1.1.33"
        },
        {
          "date": "2023-02-28",
          "version": "1.1.35"
        },
        {
          "date": "2023-01-10",
          "version": "1.1.30"
        }
```
