### PR TITLE
fix(sonic): Make tabs non-headers

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -84,15 +84,15 @@ Otherwise, let's get you started:
   >
 <Tabs stacked>
   <TabsBar>
-      <TabsBarItem id="apm">### Install an APM agent</TabsBarItem>
-      <TabsBarItem id="browser">### Install browser monitoring</TabsBarItem>
-      <TabsBarItem id="infra">### Install infrastructure monitoring</TabsBarItem>
-      <TabsBarItem id="logs">### Install logs</TabsBarItem>
-      <TabsBarItem id="mobile">### Install mobile monitoring</TabsBarItem>
-      <TabsBarItem id="network">### Identify network monitoring</TabsBarItem>
-      <TabsBarItem id="oss">### Use other open source telemetry tools</TabsBarItem>
-      <TabsBarItem id="synth">### Install synthetic monitors</TabsBarItem>
-      <TabsBarItem id="custom">### Report custom data from any source</TabsBarItem>
+      <TabsBarItem id="apm">Install an APM agent</TabsBarItem>
+      <TabsBarItem id="browser">Install browser monitoring</TabsBarItem>
+      <TabsBarItem id="infra">Install infrastructure monitoring</TabsBarItem>
+      <TabsBarItem id="logs">Install logs</TabsBarItem>
+      <TabsBarItem id="mobile">Install mobile monitoring</TabsBarItem>
+      <TabsBarItem id="network">Identify network monitoring</TabsBarItem>
+      <TabsBarItem id="oss">Use other open source telemetry tools</TabsBarItem>
+      <TabsBarItem id="synth">Install synthetic monitors</TabsBarItem>
+      <TabsBarItem id="custom">Report custom data from any source</TabsBarItem>
   </TabsBar>
       <TabsPages>
         <TabsPageItem id="apm">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42678939/223233599-a6decea0-f5c6-4b47-9b97-31698c30b29c.png)

The tabs here were accidentally set as `### H3s`, leading to strange rendering and a poor viewing experience. This removes the header styling from them. 