### PR TITLE
March 9th: feat(whats-new): clm for java php node go post

### DIFF
--- a/src/content/whats-new/2023/03/whats-new-03-09-clm-javaphpnodego.md
+++ b/src/content/whats-new/2023/03/whats-new-03-09-clm-javaphpnodego.md
@@ -1,20 +1,20 @@
 ---
-title: 'Access crucial telemetry data from within your IDE with CodeStream code-level metrics' 
-summary: 'Now available for all APM agents including Java, Go, PHP & Node.js' 
+title: 'CodeStream code-level metrics now available for all APM agents including Java, Go, PHP & Node.js' 
+summary: 'Access crucial telemetry data from within your IDE with CodeStream code-level metrics' 
 releaseDate: '2023-03-09' 
 learnMoreLink: 'https://newrelic.com/blog/nerdlog/codestream-code-level-metrics' 
 getStartedLink: 'https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring/#code-level' 
 ---
-Calling all Java, Go, PHP & Node.js engineers! You can now easily view key telemetry data such as error rate and response time from the service level, all the way down to the method-level, empowering you to take a more proactive approach to your development workflows. CodeStream’s latest features empower you to get ahead of issues before they hit production and accelerate your development cycles resulting in reduced costs & time savings.
+Calling all Java, Go, PHP & Node.js engineers! You can now easily view key telemetry data such as error rate and response time from the service level, all the way down to the method level, empowering you to take a more proactive approach to your development workflows. CodeStream’s latest features empower you to get ahead of issues before they hit production and accelerate your development cycles resulting in reduced costs & time savings.
 
 Updating your agents lets you access the following features: 
-* **Code-level metrics**, or informed development allowing you to see telemetry data like response time and error rate all the way down to the method level to help you identify which function in your codebase is causing issues. Code-level metrics will also be shown inside your IDE diffs for both pull requests and feedback requests, ensuring a data-driven code review process for any code that you push into production. 
+* **Code-level metrics**, or informed development, which allows you to see telemetry data like response time and error rate all the way down to the method level and identify which function in your codebase is causing issues. Code-level metrics will also be shown inside your IDE diffs for both pull requests and feedback requests, ensuring a data-driven code review process for any code that you push into production. 
 * **Service-level telemetry**, which surfaces the telemetry data for the services associated with the repo you have open in your IDE. With just a click you can also see the metrics for any service that calls, or is called by, your service.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/qeHRGCdmbSI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 **How to get started**
-* Install New Relic [CodeStream's IDE Extension](https://newrelic.com/codestream#getstarted) and sign up.
+* Install the New Relic [CodeStream IDE Extension](https://newrelic.com/codestream#getstarted) and sign up for CodeStream.
 * Check out the [requirements](https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring/#clm-requirements) for code-level metrics. 
 * Update and configure your [Java](https://docs.newrelic.com/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation/), [Go](https://docs.newrelic.com/docs/apm/agents/go-agent/instrumentation/instrument-go-transactions/), [PHP](https://docs.newrelic.com/docs/apm/agents/php-agent/features/php-custom-instrumentation/), and [Node.js](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation/) agents.
 * Read the [blog post](https://newrelic.com/blog/nerdlog/codestream-code-level-metrics) for more information.

--- a/src/content/whats-new/2023/03/whats-new-03-09-clm-javaphpnodego.md
+++ b/src/content/whats-new/2023/03/whats-new-03-09-clm-javaphpnodego.md
@@ -1,0 +1,21 @@
+---
+title: 'Access crucial telemetry data from within your IDE with CodeStream code-level metrics' 
+summary: 'Now available for all APM agents including Java, Go, PHP & Node.js' 
+releaseDate: '2023-03-09' 
+learnMoreLink: 'https://newrelic.com/blog/nerdlog/codestream-code-level-metrics' 
+getStartedLink: 'https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring/#code-level' 
+---
+Calling all Java, Go, PHP & Node.js engineers! You can now easily view key telemetry data such as error rate and response time from the service level, all the way down to the method-level, empowering you to take a more proactive approach to your development workflows. CodeStream’s latest features empower you to get ahead of issues before they hit production and accelerate your development cycles resulting in reduced costs & time savings.
+
+Updating your agents lets you access the following features: 
+* **Code-level metrics**, or informed development allowing you to see telemetry data like response time and error rate all the way down to the method level to help you identify which function in your codebase is causing issues. Code-level metrics will also be shown inside your IDE diffs for both pull requests and feedback requests, ensuring a data-driven code review process for any code that you push into production. 
+* **Service-level telemetry**, which surfaces the telemetry data for the services associated with the repo you have open in your IDE. With just a click you can also see the metrics for any service that calls, or is called by, your service.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qeHRGCdmbSI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+**How to get started**
+* Install New Relic [CodeStream's IDE Extension](https://newrelic.com/codestream#getstarted) and sign up.
+* Check out the [requirements](https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring/#clm-requirements) for code-level metrics. 
+* Update and configure your [Java](https://docs.newrelic.com/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation/), [Go](https://docs.newrelic.com/docs/apm/agents/go-agent/instrumentation/instrument-go-transactions/), [PHP](https://docs.newrelic.com/docs/apm/agents/php-agent/features/php-custom-instrumentation/), and [Node.js](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation/) agents.
+* Read the [blog post](https://newrelic.com/blog/nerdlog/codestream-code-level-metrics) for more information.
+* Go through the [demo walkthrough](https://youtu.be/qeHRGCdmbSI)


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

What's New Post set to go out on March 9 2023 - announcing code-level metrics for the remaining APM agents. Morning preferred.
I'm a PMM so does not require further review. 
