### PR TITLE
chore: Add correct class prefix to class method

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -21,7 +21,7 @@ To send error data that you are handling in your own code to New Relic, use the 
 This API call takes the exception and an optional options hash. Use this format:
 
 ```
-notice_error(exception, options = { }) ⇒ Object
+NewRelic::Agent.notice_error(exception, options = { }) ⇒ Object
 ```
 
 This function records the given error and passes it through the normal error filtering process, including [configuration-based ignoring of errors](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#error_collector.ignore_errors) and the global `#ignore_error_filter` method if defined.


### PR DESCRIPTION
The documented strategy for calling the method is wrong.
