### PR TITLE
Add a new setting to RabbitMQ

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
@@ -291,6 +291,28 @@ The RabbitMQ integration collects both Metrics(<strong>M</strong>) and Inventory
 
     <tr>
       <td>
+        **TIMEOUT**
+      </td>
+
+      <td>
+        Timeout in seconds to timeout the connection to RabbitMQ endpoint.
+      </td>
+
+      <td>
+        30
+      </td>
+
+      <td style={{ 'text-align': 'center' }}>
+        M/I
+      </td>
+    </tr>
+
+    {
+      ' '
+    }
+
+    <tr>
+      <td>
         **MANAGEMENT_PATH_PREFIX**
       </td>
 


### PR DESCRIPTION
We added a new parameter to RabbitMQ so the timeout can be configurable: https://github.com/newrelic/nri-rabbitmq/pull/99

We would like to have it available in the docs.
