### PR TITLE
fix(IntroLink): Fixed scripted browser intro link

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower.mdx
@@ -13,7 +13,7 @@ redirects:
 
 This document is for synthetic monitor versions 0.4.x or lower. See also the documentation for [Synthetic monitor versions 0.5 or 0.6.0](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050) and [monitor version Chrome 100 and newer](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetic-scipted-browser-reference-monitor-versions-chrome100).
 
-Common usage examples are available in the [introduction to scripted browser monitors documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/).
+For some common usage examples, see [Introduction to scripted browser monitors](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors).
 
 ## Overview
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower.mdx
@@ -13,6 +13,8 @@ redirects:
 
 This document is for synthetic monitor versions 0.4.x or lower. See also the documentation for [Synthetic monitor versions 0.5 or 0.6.0](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050) and [monitor version Chrome 100 and newer](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetic-scipted-browser-reference-monitor-versions-chrome100).
 
+Common usage examples are available in the [introduction to scripted browser monitors documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/).
+
 ## Overview
 
 Synthetic [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) provide you access to the [Selenium Webdriver APIs 2.47.0](http://nr-synthetics-sw-jsdoc.s3-website-us-east-1.amazonaws.com/) via the variables `$driver` and `$browser`. In particular:

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
@@ -28,7 +28,7 @@ For more on monitor versions and runtime differences, see [Runtime environments]
   Selenium WebDriver promise manager / control flow allowed some functions to execute in order, without manually managing promises/async functions. This was removed in Selenium WebDriver 4.0 and is no longer available in the runtime. All async functions and promises need to be managed with `await` or with `.then` promise chains. This will ensure script functions execute in the expected order.
 </Callout>
 
-Common usage examples are available in the [introduction to scripted browser monitors documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/).
+For some common usage examples, see [Introduction to scripted browser monitors](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors).
 
 ## Top-level functions: Build your script [#structure]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
@@ -28,6 +28,8 @@ For more on monitor versions and runtime differences, see [Runtime environments]
   Selenium WebDriver promise manager / control flow allowed some functions to execute in order, without manually managing promises/async functions. This was removed in Selenium WebDriver 4.0 and is no longer available in the runtime. All async functions and promises need to be managed with `await` or with `.then` promise chains. This will ensure script functions execute in the expected order.
 </Callout>
 
+Common usage examples are available in the [introduction to scripted browser monitors documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/).
+
 ## Top-level functions: Build your script [#structure]
 
 New Relic calls top-level functions directly from your `$webDriver` instance. These provide a wide range of functionality that covers many basic scriptable actions.

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
@@ -13,7 +13,7 @@ This document describes scripted browser functions available for synthetic monit
 
 For more on monitor versions and runtime differences, see [Runtime environments](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment).
 
-Common usage examples are available in the [introduction to scripted browser monitors documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/). 
+For some common usage examples, see [Introduction to scripted browser monitors](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors).
 
 ## Selenium Webdriver APIs [#selenium]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
@@ -13,6 +13,8 @@ This document describes scripted browser functions available for synthetic monit
 
 For more on monitor versions and runtime differences, see [Runtime environments](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment).
 
+Common usage examples are available in the [introduction to scripted browser monitors documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/). 
+
 ## Selenium Webdriver APIs [#selenium]
 
 By using the variables `$driver` and `$browser`, your [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) get access to [Selenium Webdriver APIs 3.6.0](http://seleniumhq.github.io/selenium/docs/api/javascript/index.html) for monitor version 0.6.x and [Selenium Webdriver APIs 3.5.0](http://seleniumhq.github.io/selenium/docs/api/javascript/index.html) for monitor version 0.5.x.

--- a/src/nav/synthetics.yml
+++ b/src/nav/synthetics.yml
@@ -44,7 +44,7 @@ pages:
   - title: Scripting monitors
     pages:
       - title: Introduction to scripted browsers
-        path: /docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring
+        path: /docs/synthetics/synthetic-monitoring/using-monitors/intro-scripted-browser-monitors
       - title: Write synthetic API tests
         path: /docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests
       - title: Write synthetic API tests (legacy runtime - Node.js 10 and lower)


### PR DESCRIPTION
- The intro to scripted browser link was pointing to a synthetics intro page instead
- Added a reference to this doc and the helpful examples it contains from our browser runtime reference pages