### PR TITLE
Release 03/08 - Php agent 10.7.0 release

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -21,14 +21,14 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 
 
 
-New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
+New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
 
 <Callout variant="important">
-  Compatibility note: When PHP 8.0 or 8.1 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
+  Compatibility note: When PHP 8.0, 8.1 or 8.2 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
 
-  Support for PHP 8.1 does not include Fibers.
+  Support for PHP 8.1 and 8.2 does not include Fibers.
 
-Support for PHP versions 5.5 and 5.6 ends in June 2023.
+  Support for PHP versions 5.5 and 5.6 ends in June 2023.
 </Callout>
 
 * We recommend using a [supported release](http://php.net/supported-versions.php) of PHP.
@@ -119,6 +119,7 @@ however it is no longer tested or officially supported by the New Relic PHP Agen
 
             * PHP 8.0 and with New Relic PHP Agent 9.18.1 or later.
             * PHP 8.1 and with New Relic PHP Agent 9.19.0 or later.
+            * PHP 8.2 and with New Relic PHP Agent 10.7.0 or later.
           </Callout>
 
           For more information on ARM64 support, please see [the ARM64 installation info](/docs/apm/agents/php-agent/installation/php-agent-installation-arm64).
@@ -444,7 +445,7 @@ To request instance-level information from datastores currently not listed for y
 
 ## Codesteam/Code-level metrics
 
-The PHP agent supports code-level metrics for PHP releases 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, and 8.1.
+The PHP agent supports code-level metrics for PHP releases 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
 
 ## Logs In Context [#logging]
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
@@ -30,6 +30,18 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v10.7.0.319
+      </td>
+      <td>
+        Mar 08, 2023
+      </td>
+      <td>
+        Mar 08, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v10.6.0.318
       </td>
       <td>
@@ -197,20 +209,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Apr 21, 2023
-      </td>
-    </tr>
-    
-    <tr>
-      <td>
-        v9.16.0.295
-      </td>
-
-      <td>
-        Jan 25, 2021
-      </td>
-
-      <td>
-        Jan 25, 2023
       </td>
     </tr>
     

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -1,0 +1,34 @@
+---
+subject: PHP agent
+releaseDate: '2023-03-08'
+version: 10.7.0.319
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.7.0.319'
+features: ['Add support for PHP 8.2']
+bugs: []
+security: []
+---
+## New Relic PHP Agent v10.7.0.319
+
+### New features
+
+* Added Support for PHP 8.2.
+
+### Important end-of-life information
+
+* Support for PHP versions 5.5 and 5.6 will end June 2023.
+
+### Support statement
+
+* Support for 32 bit and FreeBSD ended with release v9.19.0.309 and those binaries **are no longer provided**.
+* Support for ZTS builds ended with release v9.19.0.309.
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform (32 bit, FreeBSD, ZTS, etc), it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages which are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>
+


### PR DESCRIPTION
This PR handles the necessary updates to our Release Notes, Compatibility page, and EOL table for the upcoming 10.7.0 PHP Agent release.
This release is currently planned for 03/08.