### PR TITLE
Browser agent v1227 release notes, EOL, and new INP and longTask info

### DIFF
--- a/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v1227
+      </td>
+
+      <td>
+        Mar 9, 2023
+      </td>
+
+      <td>
+        Mar 9, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v1226
       </td>
 

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -127,6 +127,18 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
       </td>
     </tr>
 
+   <tr>
+      <td>
+        `interactionToNextPaint`
+      </td>
+
+      <td>
+        [Interaction to Next Paint (INP)](https://web.dev/inp/) is available with [agent v1227 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227). INP is a newer metric for measuring [runtime responsiveness](https://web.dev/user-centric-performance-metrics/#types-of-metrics) and user-perceived performance. It measures the largest latency between user interactions and page response or repaints. This is an experimental but identified-as-significant metric added in [Web Vitals](https://github.com/GoogleChrome/web-vitals) v3.
+
+        INP scores up to 200 ms are considered "Good," between 200-500 ms are considered "Needs Improvement," and above 500 ms are considered "Poor."
+      </td>
+    </tr>
+
     <tr>
       <td>
         `timingName`
@@ -154,6 +166,19 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
 
       <td>
         This is the reported size of the `largestContentfulPaint` element. This value will only be reported with the LCP metric.
+      </td>
+    </tr>
+    
+    
+    <tr>
+      <td>
+        `longTask`
+      </td>
+
+      <td>
+        Long task reporting is available starting with [agent v1227](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227). This event represents per entry observed by the experimental [PerformanceLongTaskTiming API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming), which reports tasks that block the main UI thread for >50 ms.
+
+        It's generally recommended to [break up and optimize](https://web.dev/optimize-long-tasks/) these tasks to prevent delays in processing user input or interactions. Long tasks may affect or closely relate to the `interactionToNextPaint` metric. Note that the API currently provides no in-depth context on the cause of these tasks and collates all long tasks within a browsing frame together, even if they consist of multiple different functions.
       </td>
     </tr>
 

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -225,7 +225,7 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
 Requirements:
 
 * Meets [install requirements](/docs/browser/new-relic-browser/getting-started/compatibility-requirements-new-relic-browser).
-* Reporting of this event requires [browser agent version 1153 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes) and a [Pro or Pro+SPA agent](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types).
+* Reporting of this event requires [browser agent version 1153 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes).
 
 Follow our [Browser agent release notes](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes) to find out when new metrics are released.
 
@@ -302,11 +302,37 @@ These metrics are supported by the following browser versions. For unsupported b
 
     <tr>
       <td>
+        `interactionToNextPaint`
+      </td>
+
+      <td>
+        * Chrome 96 or higher
+        * Edge 96 or higher
+
+        Per web-vitals API, support is determined by [PerformanceEventTiming.interactionId](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming/interactionId#browser_compatibility).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `longTask`
+      </td>
+
+      <td>
+        * Chrome 58 or higher
+        * Edge 79 or higher
+
+        Support is determined by [PerformanceLongTaskTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming#browser_compatibility).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         `pageHide`
       </td>
 
       <td>
-        This metric is currently supported by most modern browser versions, except for Safari below 14.1 (desktop) or 14.5 (iOS). 
+        This event is currently supported by most modern browser versions, except for Safari below 14.1 (desktop) or 14.5 (iOS).
         [Compatibility matrix via MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event#browser_compatibility).
       </td>
     </tr>
@@ -317,7 +343,7 @@ These metrics are supported by the following browser versions. For unsupported b
       </td>
 
       <td>
-        This metric is currently supported by all browsers on desktop and mobile. [Compatibility matrix via MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event#Browser_compatibility).
+        This event is currently supported by all browsers on desktop and mobile. [Compatibility matrix via MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event#Browser_compatibility).
       </td>
     </tr>
 
@@ -327,7 +353,7 @@ These metrics are supported by the following browser versions. For unsupported b
       </td>
 
       <td>
-        This metric is currently supported by all browsers on desktop and mobile. [Compatibility matrix via MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event#Browser_compatibility).
+        This event is currently supported by all browsers on desktop and mobile. [Compatibility matrix via MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event#Browser_compatibility).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -177,6 +177,8 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
 
       <td>
         Long task reporting is available starting with [agent v1227](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227). This event represents per entry observed by the experimental [PerformanceLongTaskTiming API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming), which reports tasks that block the main UI thread for >50 ms.
+        
+        NOTE: Though this event is available as an experimental feature, data for it is not automatically collected. It must be enabled in the browser agent's configuration using a flag on the `init` object, e.g. `init: { page_view_timing: { long_task: true } }`.
 
         It's generally recommended to [break up and optimize](https://web.dev/optimize-long-tasks/) these tasks to prevent delays in processing user input or interactions. Long tasks may affect or closely relate to the `interactionToNextPaint` metric. Note that the API currently provides no in-depth context on the cause of these tasks and collates all long tasks within a browsing frame together, even if they consist of multiple different functions.
       </td>

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227.mdx
@@ -7,7 +7,7 @@ version: '1227'
 ## New Features
 
 ### Add INP and long tasks reporting
-The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via the [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the PerformanceLongTaskTiming API are also forwarded to New Relic. This latter functionality is `off` by default, until a curated UI experience is created to utilize this data.
+The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via the [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the `PerformanceLongTaskTiming` API are also forwarded to New Relic. This latter functionality is `off` by default, until a curated UI experience is created to utilize this data.
 
 ## Bug Fixes
 
@@ -20,7 +20,7 @@ Added resiliency code around SPA interaction node save functionality to ensure a
 ## Internal
 
 ### Add internal metrics to evaluate feasibility page resource harvests
-Internal metrics were added to track the feasibility and impact of collecting page resource information using the PerformanceObserver resource timings, such as scripts, images, network calls, and more. 
+Internal metrics were added to track the feasibility and impact of collecting page resource information using the `PerformanceObserver` resource timings, such as scripts, images, network calls, and more. 
 
 ### Collect supportability metrics at the end of page life
-Collate all of the internal statistic metrics calls, which--of today--are sent at page start and periodically, into one call made when the end user is leaving the page.
+Collate all of the internal statistic metrics calls, which, as of today, are sent at page start and periodically into one call made when the end user is leaving the page.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227.mdx
@@ -1,0 +1,26 @@
+---
+subject: Browser agent
+releaseDate: '2023-03-09'
+version: '1227'
+---
+
+## New Features
+
+### Add INP and long tasks reporting
+The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via the [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the PerformanceLongTaskTiming API are also forwarded to New Relic. This latter functionality is `off` by default, until a curated UI experience is created to utilize this data.
+
+## Bug Fixes
+
+### Revert unwrapping of globals on agent abort
+Partial revert of graceful handling change made in v1225 that unwrapped modified global APIs and handlers, which caused integration issues with other wrapping libraries and code.
+
+### Add resiliency around SPA interaction saving
+Added resiliency code around SPA interaction node save functionality to ensure a cancelled interaction node without a parent further up the interaction tree does not cause an exception to be raised from the agent.
+
+## Internal
+
+### Add internal metrics to evaluate feasibility page resource harvests
+Internal metrics were added to track the feasibility and impact of collecting page resource information using the PerformanceObserver resource timings, such as scripts, images, network calls, and more. 
+
+### Collect supportability metrics at the end of page life
+Collate all of the internal statistic metrics calls, which--of today--are sent at page start and periodically, into one call made when the end user is leaving the page.

--- a/src/data-dictionary/events/PageViewTiming/interactionToNextPaint.md
+++ b/src/data-dictionary/events/PageViewTiming/interactionToNextPaint.md
@@ -1,0 +1,11 @@
+---
+name: interactionToNextPaint
+type: attribute
+units: milliseconds (ms)
+events:
+  - PageViewTiming
+---
+
+An experimental metric that assesses responsiveness. A low INP means the page was consistently able to respond quickly to all or nearly all user interactions.
+
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/longTask.md
+++ b/src/data-dictionary/events/PageViewTiming/longTask.md
@@ -6,6 +6,6 @@ events:
   - PageViewTiming
 ---
 
-Generated for every [long task](https://developer.mozilla.org/en-US/docs/Glossary/Long_task) entry that the PerformanceLongTaskTiming API observes throughout the life of the page.
+Generated for every [long task](https://developer.mozilla.org/en-US/docs/Glossary/Long_task) entry that the `PerformanceLongTaskTiming` API observes throughout the life of the page.
 
 For more information, see the [`PageViewTiming` documentation](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/longTask.md
+++ b/src/data-dictionary/events/PageViewTiming/longTask.md
@@ -8,4 +8,4 @@ events:
 
 Generated for every [long task](https://developer.mozilla.org/en-US/docs/Glossary/Long_task) entry that the PerformanceLongTaskTiming API observes throughout the life of the page.
 
-For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).
+For more information, see the [`PageViewTiming` documentation](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).

--- a/src/data-dictionary/events/PageViewTiming/longTask.md
+++ b/src/data-dictionary/events/PageViewTiming/longTask.md
@@ -1,0 +1,11 @@
+---
+name: longTask
+type: attribute
+units: milliseconds (ms)
+events:
+  - PageViewTiming
+---
+
+Generated for every [long task](https://developer.mozilla.org/en-US/docs/Glossary/Long_task) entry that the PerformanceLongTaskTiming API observes throughout the life of the page.
+
+For more information, see the [`PageViewTiming` documentation](https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics).


### PR DESCRIPTION
- Adds release notes for browser agent version 1227.
- Adds EOL entry for browser agent version 1227.
- Adds documentation around two new timings emitted by the browser agent: `interactionToNextPaint` and `longTask`. This PR modifies and supersedes https://github.com/newrelic/docs-website/pull/11854.

Related browser agent PRs:
  - https://github.com/newrelic/newrelic-browser-agent/pull/371
  - https://github.com/newrelic/newrelic-browser-agent/pull/429