### PR TITLE
chore: include scrape_timeout config field in prometheus-based on-hos…

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/ibmmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/ibmmq-monitoring-integration.mdx
@@ -288,7 +288,7 @@ The following configuration options are available:
       **scrape_timeout**
     </td>
     <td>
-      How long until a scrape request times-out
+      Time until a scrape request times out
     </td>
     <td>
       5s

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/ibmmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/ibmmq-monitoring-integration.mdx
@@ -285,6 +285,17 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
+      **scrape_timeout**
+    </td>
+    <td>
+      How long until a scrape request times-out
+    </td>
+    <td>
+      5s
+    </td>
+  </tr>
+  <tr>
+    <td>
       **mqsslkeyr**
     </td>
     <td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -383,6 +383,17 @@ The following configuration options are available:
       random-port
     </td>
   </tr>
+  <tr>
+    <td>
+      **scrape_timeout**
+    </td>
+    <td>
+      How long until a scrape request times-out
+    </td>
+    <td>
+      5s
+    </td>
+  </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -388,7 +388,7 @@ The following configuration options are available:
       **scrape_timeout**
     </td>
     <td>
-      How long until a scrape request times-out
+      Time until a scrape request times out
     </td>
     <td>
       5s

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/powerdns-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/powerdns-monitoring-integration.mdx
@@ -151,7 +151,7 @@ The following configuration options are available:
       </td>
 
       <td>
-        How long until a scrape request times-out
+        Time until a scrape request times out
       </td>
 
       <td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/powerdns-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/powerdns-monitoring-integration.mdx
@@ -147,6 +147,21 @@ The following configuration options are available:
 
     <tr>
       <td>
+        **scrape_timeout**
+      </td>
+
+      <td>
+        How long until a scrape request times-out
+      </td>
+
+      <td>
+        5s
+      </td>
+    </tr>
+
+
+    <tr>
+      <td>
         **api_key**
       </td>
 


### PR DESCRIPTION
…t integrations

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

The `scrape_timeout` configuration field was recently supported in on-host integrations based on `prometheus-exporters-packages` but it wasn't documented.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

The support was included here:
- https://github.com/newrelic/newrelic-prometheus-exporters-packages/pull/166
- https://github.com/newrelic/newrelic-prometheus-exporters-packages/pull/165
- https://github.com/newrelic/newrelic-prometheus-exporters-packages/pull/164

* If your issue relates to an existing GitHub issue, please link to it.