### PR TITLE
Add 6x agent to eol policy

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -487,20 +487,24 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
-        v8.24.244.0
+        v6.27.0
       </td>
 
       <td>
-        Feb 19, 2020
+        Jan 21, 2021
       </td>
 
       <td>
-        Feb 19, 2023
+        Jan 9, 2029*
       </td>
+    </tr>
+
     </tr>
 
   </tbody>
 </table>
+
+* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only the latest 6.x agent version is supported.
 
 ## Microsoft .NET runtimes [#microsoft-runtimes]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -504,7 +504,7 @@ Any versions not listed in the following table are no longer supported. Please [
   </tbody>
 </table>
 
-* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only the latest 6.x agent version is supported.
+* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only the latest 6.x agent version is supported.  The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
 
 ## Microsoft .NET runtimes [#microsoft-runtimes]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -499,8 +499,6 @@ Any versions not listed in the following table are no longer supported. Please [
       </td>
     </tr>
 
-    </tr>
-
   </tbody>
 </table>
 


### PR DESCRIPTION
Our support team was recently confused about whether we still support .NET agent version 6.27.0, since it was not listed in this EOL policy document.  This PR adds it to the bottom of the list (replacing an old 8.x version that is past its EOL date) along with a footnote explaining the somewhat unusual EOL date. 

Our team's current understanding is that we continue to support the latest 6.x agent for customers who are still using .NET Framework 3.5, which Microsoft says it will support until January 2029.

Note: This probably isn't the right way to do a footnote, could somebody from the docs team suggest a better way?