### PR TITLE
fix(style-guide): Use en dashes as described

### DIFF
--- a/src/content/docs/style-guide/ui-writing/punctuation.mdx
+++ b/src/content/docs/style-guide/ui-writing/punctuation.mdx
@@ -46,13 +46,13 @@ The first sentence says that the speaker loves three separate things, whereas th
 
 ## Dashes and hyphens
 
--   For ranges and number spans, use an en dash (`-`) without a space on either side.
+-   For ranges and number spans, use an en dash (`–`) without a space on either side.
 -   For date spans, use spaces around the en dash.
 
 | Do                          | Don't                     |
 | --------------------------- | ------------------------- |
-| 2-30                        | 2 - 30                    |
-| Jul 12, 2019 - Jul 19, 2019 | Jul 12, 2019-Jul 19, 2019 |
+| 2–30                        | 2 - 30                    |
+| Jul 12, 2019 – Jul 19, 2019 | Jul 12, 2019-Jul 19, 2019 |
 
 ## Ellipses
 

--- a/src/content/docs/style-guide/ui-writing/ranges-and-spans.mdx
+++ b/src/content/docs/style-guide/ui-writing/ranges-and-spans.mdx
@@ -12,10 +12,10 @@ Ranges refer to minimum and maximum values, whereas spans refer to the distance 
 
 | Do                                | Don't                             |
 | --------------------------------- | --------------------------------- |
-| 1-20 servers                      | 1 - 20 servers                    |
-| Aug 21, 2019 - Sep 12, 2019       | Aug 21, 2019-Sep12, 2019          |
-| Aug 21, 2019 from 9:45am - 8:45pm | Aug 21, 2019 from 9:45 am-8:45 pm |
-| $0.00 - $29.99                    | $0.00-$29.99                      |
+| 1–20 servers                      | 1 - 20 servers                    |
+| Aug 21, 2019 – Sep 12, 2019       | Aug 21, 2019-Sep12, 2019          |
+| Aug 21, 2019 from 9:45am – 8:45pm | Aug 21, 2019 from 9:45 am-8:45 pm |
+| $0.00 – $29.99                    | $0.00-$29.99                      |
 | 50+ applications                  | \> 50 applications                |
 | 29K+ rpm                          | 29+K rpm                          |
 


### PR DESCRIPTION
## What problem does this PR solve?

Our style guide docs state that we should use en dashes for ranges and spans, but the docs themselves don't actually use en dashes in the examples. This PR fixes that. 🙂 