### PR TITLE
Fix synthetic alert syntax error

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -440,7 +440,7 @@ You can avoid `NULL` values entirely with a query order of operations shortcut. 
 Here's an example to alert on `FAILED` results:
 
 ```
-SELECT filter(count(*), WHERE result = 'FAILED') WHERE monitorName = 'My Favorite Monitor' FROM SyntheticCheck
+SELECT filter(count(*), WHERE result = 'FAILED') FROM SyntheticCheck WHERE monitorName = 'My Favorite Monitor'
 ```
 
 In this example, a window with a successful result would return a `0`, allowing the condition's threshold to resolve on its own.


### PR DESCRIPTION
Move where clause after select to fix syntax error.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Fixed a NRQL syntax error in the docs.