### PR TITLE
fix: Revise query example in NRQL conditions doc

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -440,7 +440,7 @@ You can avoid `NULL` values entirely with a query order of operations shortcut. 
 Here's an example to alert on `FAILED` results:
 
 ```
-SELECT filter(count(*), WHERE result = 'FAILED') WHERE monitorName = 'My Favorite Monitor' FROM SyntheticCheck
+SELECT filter(count(*), WHERE result = 'FAILED') FROM SyntheticCheck WHERE monitorName = 'My Favorite Monitor'
 ```
 
 In this example, a window with a successful result would return a `0`, allowing the condition's threshold to resolve on its own.


### PR DESCRIPTION
Fixed incorrect NRQL syntax in a query example (`FROM` should not follow `WHERE`).