### PR TITLE
Added a callout explaining not to use recordHandledException with Swift

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/disable-features.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/disable-features.mdx
@@ -27,7 +27,7 @@ The `disableFeatures` API can be used to disable features you don't want to run.
 For more information on the flags that can be disabled see [iOS agent configuration and feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags). 
 
 <Callout variant="important">
-This function must be called before calling `startWithApplicationToken` for the settings to take effect.
+This function must be called before calling `startWithApplicationToken:` for the settings to take effect.
 </Callout>
 
 ## Parameters

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/disable-features.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/disable-features.mdx
@@ -27,10 +27,7 @@ The `disableFeatures` API can be used to disable features you don't want to run.
 For more information on the flags that can be disabled see [iOS agent configuration and feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags). 
 
 <Callout variant="important">
-This function must be called just before calling:
-
-Objective-C: +[NewRelic startWithApplicationToken:]
-Swift: NewRelic.start(withApplicationToken:)   
+This function must be called before calling `startWithApplicationToken` for the settings to take effect.
 </Callout>
 
 ## Parameters

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/enable-features.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/enable-features.mdx
@@ -27,7 +27,7 @@ Most of the features in the New Relic iOS agent are enabled by default. The `ena
 For more information on which features are enabled by default see [iOS agent configuration and feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags).
 
 <Callout variant="important">
-This function must be called before calling `startWithApplicationToken` for the settings to take effect.
+This function must be called before calling `startWithApplicationToken:` for the settings to take effect.
 </Callout>
 
 ## Parameters

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/enable-features.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/enable-features.mdx
@@ -27,10 +27,7 @@ Most of the features in the New Relic iOS agent are enabled by default. The `ena
 For more information on which features are enabled by default see [iOS agent configuration and feature flags](/docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags).
 
 <Callout variant="important">
-This function must be called just before calling:
-
-Objective-C: +[NewRelic startWithApplicationToken:]
-Swift: NewRelic.start(withApplicationToken:)   
+This function must be called before calling `startWithApplicationToken` for the settings to take effect.
 </Callout>
 
 ## Parameters

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-handled-exception.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/record-handled-exception.mdx
@@ -33,6 +33,10 @@ For context on how to use this API, see the documentation about sending custom a
 
 * [Objective-C](/docs/mobile-monitoring/new-relic-mobile-ios/install-configure/work-ios-sdk-api#objc-custom-att-events)
 
+<Callout variant="important">
+This fuction should not be used with Swift code. Please use [recordError](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/recorderror-ios-sdk-api) to track handled errors in Swift code.
+</Callout>
+
 ## Parameters
 
 <table>


### PR DESCRIPTION


## Give us some context
https://issues.newrelic.com/browse/NR-91529
I added a callout to address confusion around recordHandledException in Swift code. 
I also didn't like the way the callout for disable and enable feature looked so I changed it.