### PR TITLE
fix: typo

### DIFF
--- a/src/content/docs/errors-inbox/errors-email-notifications.mdx
+++ b/src/content/docs/errors-inbox/errors-email-notifications.mdx
@@ -41,6 +41,6 @@ Click the **Unsubscribe** link at the bottom of the email notification.
 
 ### Resubscribe to email notifications [#resubscribe]
 
-If you've unsubscribed to email notifications and decide you need to resubscribe, find one your old errors inbox email notifications and click the *Unsubscribe preferences** link.
+If you've unsubscribed to email notifications and decide you need to resubscribe, find one your old errors inbox email notifications and click the **Unsubscribe preferences** link.
 
-The email notification titles start with "[Errors Inbox]".
+The email notification titles start with "**[Errors Inbox]**".


### PR DESCRIPTION
markdown was showing as plain text because of missing `*`: `click the *Unsubscribe preferences** link`
