### PR TITLE
chore(php agent): Add note to relnotes for 10.7.0.319

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -12,10 +12,9 @@ security: []
 ### Important note
 
 If the following error occurs when installing the newrelic-php5 Debian package:
-
+``` php
     Setting up newrelic-php5 (10.7.0.319) ...
     Unknown PHP version: 8.2
-    
 Please run the newrelic-install installation program which will complete the installation of the PHP agent and set up the correct symlink to the PHP extension directory.
 
 ### New features

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -17,6 +17,7 @@ If the following error occurs when installing the newrelic-php5 Debian package:
 Setting up newrelic-php5 (10.7.0.319) ...
 Unknown PHP version: 8.2
 ```
+
 Please run the newrelic-install installation program which will complete the installation of the PHP agent and set up the correct symlink to the PHP extension directory.
 
 ### New features

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -11,7 +11,7 @@ security: []
 
 ### Important note
 
-If the follow error occurs when installing the newrelic-php5 Debian package:
+If the following error occurs when installing the newrelic-php5 Debian package:
 
     Setting up newrelic-php5 (10.7.0.319) ...
     Unknown PHP version: 8.2

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -18,6 +18,7 @@ Setting up newrelic-php5 (10.7.0.319) ...
 Unknown PHP version: 8.2
 ```
 
+
 Please run the newrelic-install installation program which will complete the installation of the PHP agent and set up the correct symlink to the PHP extension directory.
 
 ### New features

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -17,6 +17,7 @@ If the following error occurs when installing the newrelic-php5 Debian package:
 Setting up newrelic-php5 (10.7.0.319) ...
 Unknown PHP version: 8.2
 ```
+Please run the newrelic-install installation program which will complete the installation of the PHP agent and set up the correct symlink to the PHP extension directory.
 
 ### New features
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -13,8 +13,10 @@ security: []
 
 If the following error occurs when installing the newrelic-php5 Debian package:
 
-    Setting up newrelic-php5 (10.7.0.319) ...
-    Unknown PHP version: 8.2
+```
+Setting up newrelic-php5 (10.7.0.319) ...
+Unknown PHP version: 8.2
+```
 
 ### New features
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -9,6 +9,15 @@ security: []
 ---
 ## New Relic PHP Agent v10.7.0.319
 
+### Important note
+
+If the follow error occurs when installing the newrelic-php5 Debian package:
+
+    Setting up newrelic-php5 (10.7.0.319) ...
+    Unknown PHP version: 8.2
+    
+please run the newrelic-install installation program and this will complete the installation of the PHP agent and setup the correct symlink to the PHP extension directory.
+
 ### New features
 
 * Added Support for PHP 8.2.

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -13,7 +13,6 @@ security: []
 
 If the following error occurs when installing the newrelic-php5 Debian package:
 
-```c
     Setting up newrelic-php5 (10.7.0.319) ...
     Unknown PHP version: 8.2
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -16,7 +16,7 @@ If the following error occurs when installing the newrelic-php5 Debian package:
     Setting up newrelic-php5 (10.7.0.319) ...
     Unknown PHP version: 8.2
     
-please run the newrelic-install installation program and this will complete the installation of the PHP agent and setup the correct symlink to the PHP extension directory.
+Please run the newrelic-install installation program which will complete the installation of the PHP agent and set up the correct symlink to the PHP extension directory.
 
 ### New features
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-7-0-319.mdx
@@ -12,10 +12,10 @@ security: []
 ### Important note
 
 If the following error occurs when installing the newrelic-php5 Debian package:
-``` php
+
+```c
     Setting up newrelic-php5 (10.7.0.319) ...
     Unknown PHP version: 8.2
-Please run the newrelic-install installation program which will complete the installation of the PHP agent and set up the correct symlink to the PHP extension directory.
 
 ### New features
 


### PR DESCRIPTION
This PR adds an important note that provides a workaround for some users when installing the PHP agent on some Debian systems.