### PR TITLE
[chore] Update kubernetes-components.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
@@ -11,7 +11,7 @@ The New Relic Kubernetes integration gives you full observability into the healt
 
 ## Architecture [#architecture]
 
-The `newrelic-infrastructure` DaemonSet is the main component of the integration. It's divided into three different components: `nrk8s-ksm`, `nrk8s-kubelet`, and `nrk8s-controlplane`. The first is a deployment and the next two are DaemonSets.
+The `newrelic-infrastructure` chart is the main component of the integration. It's divided into three different components: `nrk8s-ksm`, `nrk8s-kubelet`, and `nrk8s-controlplane`. The first is a deployment and the next two are DaemonSets.
 
 Each of the components has two containers:
 


### PR DESCRIPTION
Fix reference to `newrelic-infrastructure` chart. As the next sentence makes clear, the actual daemonsets are nrk8s-kubelet and nrk8s-controlplane.