### PR TITLE
fix: theme bump to fix 404 search slash issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.18.0",
+    "@newrelic/gatsby-theme-newrelic": "6.18.1",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,10 +2609,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.18.0":
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.18.0.tgz#bd31268b206b49e4e79234dd4ba9dd6816312661"
-  integrity sha512-thZY/0cVPsXqpsR8nkU+1ZID1XTnH2MaaRdyQt8q2HlGATv44A8b4mEUAJdvYgVsrqhRmGILmsQ7Di6yM6zXUA==
+"@newrelic/gatsby-theme-newrelic@6.18.1":
+  version "6.18.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.18.1.tgz#ac77db95daeab88662e7356f5c64965bcb2bd22d"
+  integrity sha512-3YzZJwulMD2JayR4XuWCrKmgfNxfGfu7+msWSU7fQNJHRElhD3Wk4HqBzrFtG+qLX9lepA+F0plBedK3S1zXFQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
Fixes trailing slash being added to search bar on 404 page

to QA: go to `/apache` and click into the search bar

![Screen Shot 2023-03-09 at 3 13 48 PM](https://user-images.githubusercontent.com/26727669/224161591-62158af4-0a86-45f8-8da1-2320e5347f67.png)
