### PR TITLE
fix: remove lang identifier

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
@@ -20,7 +20,7 @@ New Relic.
 
 To install or upgrade the New Relic instrumentation layer, run:
 
-```bash
+```
 newrelic-lambda layers install --nr-account-id <a href="/docs/accounts/accounts-billing/account-setup/account-id">YOUR_NR_ACCOUNT_ID</a> --function my-function --upgrade
 ```
 


### PR DESCRIPTION
In a commit I made earlier today I created an issue, you can't have an embedded link in a codeblock with an identifier attached. I forgot about that and broke the code block.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/48165493/224166258-6f0db0cf-b6f9-441d-8a2b-6e3df882b8c9.png">

The PR which introduced the issue:  https://github.com/newrelic/docs-website/pull/11980

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.