### PR TITLE
feat: add function to generate EOL date

### DIFF
--- a/src/utils/__tests__/getEOLDate.test.js
+++ b/src/utils/__tests__/getEOLDate.test.js
@@ -1,0 +1,40 @@
+const getEOLDate = require('../getEOLDate');
+
+describe('eolDate function', () => {
+    it('should throw an error if dateString is missing', () => {
+      expect(() => getEOLDate()).toThrow('releaseDate must be a valid date in yyyy-MM-dd format')
+    })
+  
+    it('should throw an error if dateString is malformed', () => {
+      expect(() => getEOLDate('October 1, 2019')).toThrow('releaseDate must be a valid date in yyyy-MM-dd format')
+    })
+  
+    it('should return an eol date three years from the release date when release date is before Oct 1, 2020', () => {
+      expect(getEOLDate('2020-04-03')).toEqual('2023-04-03')
+    })
+  
+    it('should return an eol date three years from the release date when release date is Sept 30, 2020', () => {
+      expect(getEOLDate('2020-09-30')).toEqual('2023-09-30')
+    })
+  
+    it('should return an eol date two years from the release date when release date is Oct 1, 2020', () => {
+      expect(getEOLDate('2020-10-01')).toEqual('2022-10-01')
+    })
+  
+    it('should return an eol date two years from the release date when release date is between Oct 1, 2020 and Jul 31, 2022', () => {
+      expect(getEOLDate('2021-01-05')).toEqual('2023-01-05')
+    })
+  
+    it('should return an eol date two years from the release date when release date is Jul 31, 2022', () => {
+      expect(getEOLDate('2022-07-31')).toEqual('2024-07-31')
+    })
+  
+    it('should return an eol date one year from the release date when release date is Aug 1, 2022', () => {
+      expect(getEOLDate('2022-08-01')).toEqual('2023-08-01')
+    })
+  
+    it('should return an eol date one year from the release date when release date is after Aug 1, 2022', () => {
+      expect(getEOLDate('2023-03-02')).toEqual('2024-03-02')
+    })
+  })
+  

--- a/src/utils/getEOLDate.js
+++ b/src/utils/getEOLDate.js
@@ -1,0 +1,66 @@
+const {
+  add,
+  format,
+  isBefore,
+  isValid,
+  isWithinInterval,
+  parseISO,
+} = require('date-fns');
+
+const DATE_FORMAT = 'yyyy-MM-dd';
+
+/**
+ * Validation method for ensuring that input is a valid date in yyyy-MM-dd format
+ *
+ * @param {string} str the string to validate
+ * @returns {boolean} whether or not the string passed validation
+ */
+function isValidDateString(str) {
+  return str.match(/^\d{4}-\d{2}-\d{2}$/) && isValid(parseISO(str));
+}
+
+/**
+ * Method for generating an EOL date formatted as yyyy-MM-dd
+ * based on the provided release date.
+ *
+ * Logic is slightly complicated because we've had three different EOL
+ * policies since 2020, so this function accounts for all three.
+ *
+ * EOL Policy Announcement
+ * https://docs.newrelic.com/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/#impact
+ *
+ * @param {string} releaseDateString release date of software, from front-matter field releaseDate
+ * @param {string} eolDateString eol date of software, prioritized for backwards compatability
+ * @returns {string} EOL date for provided release date in yyyy-MM-dd format
+ */
+module.exports = function getEOLDate(releaseDateString, eolDateString) {
+  // TODO: are we sure we need this logic? I couldn't find anything in docs-website that looked like it would be used, but Clark said we should add it.
+  if (eolDateString && isValidDateString(eolDateString)) {
+    return format(new Date(eolDateString), DATE_FORMAT);
+  }
+
+  if (!releaseDateString || !isValidDateString(releaseDateString)) {
+    throw new Error(
+      `releaseDate must be a valid date in ${DATE_FORMAT} format`
+    );
+  }
+
+  const releaseDate = new Date(releaseDateString);
+  let generatedEOLDate;
+
+  if (isBefore(releaseDate, new Date('2020-10-01'))) {
+    generatedEOLDate = add(releaseDate, { years: 3 });
+  } else if (
+    isWithinInterval(releaseDate, {
+      start: new Date('2020-10-01'),
+      end: new Date('2022-07-31'),
+    })
+  ) {
+    generatedEOLDate = add(releaseDate, { years: 2 });
+  } else {
+    // TODO: If EOL policy changes, make this another else-if with a start date of 2022-08-01
+    generatedEOLDate = add(releaseDate, { years: 1 });
+  }
+
+  return format(generatedEOLDate, DATE_FORMAT);
+};

--- a/src/utils/getEOLDate.js
+++ b/src/utils/getEOLDate.js
@@ -1,5 +1,6 @@
 const {
   add,
+  addMinutes,
   format,
   isBefore,
   isValid,
@@ -8,6 +9,22 @@ const {
 } = require('date-fns');
 
 const DATE_FORMAT = 'yyyy-MM-dd';
+
+/**
+ * Helper method for formatting a date taking into account timezones
+ *
+ * date-fns uses native Date under the hood, which is timezone aware,
+ * and without accounting for timezone, will cause issues with formatting
+ * in different timezones.
+ *
+ * An alternative approach would be to use `date-fns-tz`'s [format](https://date-fns.org/v2.29.3/docs/Time-Zones#date-fns-tz)
+ *
+ * @param {Date} date date to format
+ * @returns {String} the formatted date
+ */
+function formatTZAware(date) {
+  return format(addMinutes(date, date.getTimezoneOffset()), DATE_FORMAT);
+}
 
 /**
  * Validation method for ensuring that input is a valid date in yyyy-MM-dd format
@@ -34,9 +51,8 @@ function isValidDateString(str) {
  * @returns {string} EOL date for provided release date in yyyy-MM-dd format
  */
 module.exports = function getEOLDate(releaseDateString, eolDateString) {
-  // TODO: are we sure we need this logic? I couldn't find anything in docs-website that looked like it would be used, but Clark said we should add it.
   if (eolDateString && isValidDateString(eolDateString)) {
-    return format(new Date(eolDateString), DATE_FORMAT);
+    return formatTZAware(new Date(eolDateString));
   }
 
   if (!releaseDateString || !isValidDateString(releaseDateString)) {
@@ -62,5 +78,5 @@ module.exports = function getEOLDate(releaseDateString, eolDateString) {
     generatedEOLDate = add(releaseDate, { years: 1 });
   }
 
-  return format(generatedEOLDate, DATE_FORMAT);
+  return formatTZAware(generatedEOLDate);
 };


### PR DESCRIPTION
Created a new function called `getEOLDate()` that will programatically generate an EOL date based on a piece of software's release date and our EOL policy, which is described
[here](https://docs.newrelic.com/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/#impact).

Function accepts two inputs: the first is the release date of the piece of software. The function assumes this input is a string in yyyy-MM-dd format. Second input is an override EOL date. If passed, the function will favor this EOL date over the generated one.

The intent of this function is to allow this repo to programatically generate the various EOL pages it supports, to ease the release process burden on NR developers (updating HTML programatically is hard and humans can forget to do manual steps). 