### PR TITLE
feat(node agent): add Prisma as another supported datastore

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -211,7 +211,7 @@ The Node.js agent monitors the performance of Node.js application calls to these
     </tr>
     <tr>
       <td>MySQL</td>
-      <td>via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages</td>
+      <td>Via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages</td>
     </tr>
     <tr>
       <td>[Redis](https://www.npmjs.com/package/redis)</td>
@@ -219,7 +219,7 @@ The Node.js agent monitors the performance of Node.js application calls to these
     </tr>
     <tr>
       <td>[Postgres](https://www.npmjs.com/package/pg)</td>
-      <td>including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages</td>
+      <td>Including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages</td>
     </tr>
     <tr>
       <td>[Prisma](https://www.prisma.io/)</td>

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -189,13 +189,44 @@ For unsupported frameworks or libraries, you'll need to instrument the agent you
 
 The Node.js agent monitors the performance of Node.js application calls to these datastores:
 
-* [Cassandra](https://www.npmjs.com/package/cassandra-driver)
-* [Memcached](https://www.npmjs.com/package/memcached)
-* [MongoDB](https://www.npmjs.com/package/mongodb)
-* MySQL (via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages)
-* [Redis](https://www.npmjs.com/package/redis)
-* [Postgres](https://www.npmjs.com/package/pg) (including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages)
-* [Amazon DynamoDB](https://github.com/aws/aws-sdk-js) - both versions 2 and 3 of AWS SDK.
+<table>
+  <thead>
+    <tr>
+      <th>Datastore</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>[Cassandra](https://www.npmjs.com/package/cassandra-driver)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>[Memcached](https://www.npmjs.com/package/memcached)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>[MongoDB](https://www.npmjs.com/package/mongodb)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>MySQL</td>
+      <td>via [mysql](https://www.npmjs.com/package/mysql) and [mysql2](https://www.npmjs.com/package/mysql2) packages</td>
+    </tr>
+    <tr>
+      <td>[Redis](https://www.npmjs.com/package/redis)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>[Postgres](https://www.npmjs.com/package/pg)</td>
+      <td>including the [native](https://www.npmjs.com/package/pg-native) and [pure JavaScript](https://www.npmjs.com/package/pg-js) packages</td>
+    </tr>
+    <tr>
+      <td>[Prisma](https://www.prisma.io/)</td>
+      <td>The Prisma instrumentation treats Prisma itself as the datastore, not the underlying SQL or NoSQL datastore that Prisma is configured to use. This means metrics and traces will show Prisma ORM queries such as `find` or `updateMany` and not SQL statements such as `SELECT` or `UPDATE`. As an exception, raw Prisma queries will record the actual raw SQL or NoSQL query.</td>
+    </tr>
+  </tbody>
+</table>
 </Collapser>
 
 <Collapser


### PR DESCRIPTION
The Prisma instrumentation for the Node agent is a little idiosyncratic, so I turned the list into a table where I can add a Notes column to explain the idiosyncracy.

Closes NEWRELIC-6383.