### PR TITLE
feat(synth): Support custom job timeouts on Job Manager

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
@@ -161,6 +161,18 @@ Environmental variables allow you to fine-tune the synthetics job manager config
 
         <tr>
           <td>
+            `CHECK_TIMEOUT`
+          </td>
+
+          <td>
+            The maximum amount of seconds that your monitor checks are allowed to run. This value must be an integer between 0 seconds (excluded) and 900 seconds (included) (for example, from 1 second to 15 minutes).
+
+            Default: 180 seconds
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             `LOG_LEVEL`
           </td>
 
@@ -345,6 +357,18 @@ Environmental variables allow you to fine-tune the synthetics job manager config
 
           <td>
             Proxy server password for Horde communication. Format: `"password"`.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `global.checkTimeout`
+          </td>
+
+          <td>
+            The maximum amount of seconds that your monitor checks are allowed to run. This value must be an integer between 0 seconds (excluded) and 900 seconds (included) (for example, from 1 second to 15 minutes).
+
+            Default: 180 seconds
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -65,6 +65,5 @@ A few capabilities available to CPMs aren't supported by synthetics job manager.
 
 * Support for SSL certificate expiration, broken link, and step monitors
 * Verified script execution (VSE)
-* Check timeout overrides
 * User defined environment variables
 * Adjusting JVM configuration options


### PR DESCRIPTION
- Removed the limitation for custom job timeouts from the job manager transition guide
- Added config details for CHECK_TIMEOUT (Docker) and globals.checkTimeout (K8s) to the job manager configuration guide