### PR TITLE
Only show tooltip on default view

### DIFF
--- a/src/components/ToggleView/ToggleSelector.js
+++ b/src/components/ToggleView/ToggleSelector.js
@@ -8,8 +8,10 @@ import {
 } from '@newrelic/gatsby-theme-newrelic';
 
 import { useToggleViewContext } from './ToggleViewContext';
+
 import Tooltip from '../Tooltip';
 
+const SAVED_TOGGLE_VIEW_KEY = 'docs-website/homepage-selected-view';
 export const TOGGLE_VIEWS = {
   newUserView: 'new-user-view',
   defaultView: 'default-view',
@@ -21,6 +23,17 @@ const ToggleSelector = ({ className }) => {
   const [currentView, setCurrentView] = useToggleViewContext();
   const tessen = useTessen();
   const { t } = useTranslation();
+
+  /* this check prevents the tooltip from continuing to show
+   * on each render of the defaultview if it's triggered
+   * by the user selecting the toggle buttons which sets the local
+   * storage key
+   */
+
+  const showTooltip =
+    currentView === TOGGLE_VIEWS.defaultView &&
+    window.localStorage.getItem(SAVED_TOGGLE_VIEW_KEY) !==
+      TOGGLE_VIEWS.newUserView;
 
   return (
     <div
@@ -54,23 +67,25 @@ const ToggleSelector = ({ className }) => {
           }
         `}
       >
-        <Tooltip
-          css={css`
-            position: absolute;
-            bottom: 150%;
-            left: -50px;
-            & p:nth-of-type(2) {
-              font-size: 12px;
-            }
-          `}
-        >
-          <Trans i18nKey="home.toggle.tooltip">
-            <p>👋 Hey there! Are you a new user?</p>
-            <p>
-              Check out our <strong>new</strong>quick launch view here!
-            </p>
-          </Trans>
-        </Tooltip>
+        {showTooltip && (
+          <Tooltip
+            css={css`
+              position: absolute;
+              bottom: 150%;
+              left: -50px;
+              & p:nth-of-type(2) {
+                font-size: 12px;
+              }
+            `}
+          >
+            <Trans i18nKey="home.toggle.tooltip">
+              <p>👋 Hey there! Are you a new user?</p>
+              <p>
+                Check out our <strong>new</strong>quick launch view here!
+              </p>
+            </Trans>
+          </Tooltip>
+        )}
         <button
           type="button"
           onClick={() => {

--- a/src/components/ToggleView/ToggleSelector.js
+++ b/src/components/ToggleView/ToggleSelector.js
@@ -11,7 +11,6 @@ import { useToggleViewContext } from './ToggleViewContext';
 
 import Tooltip from '../Tooltip';
 
-const SAVED_TOGGLE_VIEW_KEY = 'docs-website/homepage-selected-view';
 export const TOGGLE_VIEWS = {
   newUserView: 'new-user-view',
   defaultView: 'default-view',
@@ -19,21 +18,10 @@ export const TOGGLE_VIEWS = {
 
 const mobileBreakpoint = '450px';
 
-const ToggleSelector = ({ className }) => {
+const ToggleSelector = ({ className, showTooltip }) => {
   const [currentView, setCurrentView] = useToggleViewContext();
   const tessen = useTessen();
   const { t } = useTranslation();
-
-  /* this check prevents the tooltip from continuing to show
-   * on each render of the defaultview if it's triggered
-   * by the user selecting the toggle buttons which sets the local
-   * storage key
-   */
-
-  const showTooltip =
-    currentView === TOGGLE_VIEWS.defaultView &&
-    window.localStorage.getItem(SAVED_TOGGLE_VIEW_KEY) !==
-      TOGGLE_VIEWS.newUserView;
 
   return (
     <div

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,14 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
-import { useToggleViewContext } from './ToggleView/ToggleViewContext';
-import { TOGGLE_VIEWS } from './ToggleView';
 
 const Tooltip = ({ className, children }) => {
-  const [currentView] = useToggleViewContext();
   const [shouldHide, setShouldHide] = useState(false);
-  // const [shouldHide, setShouldHide] = useState(
-  //   currentView === TOGGLE_VIEWS.newUserView
-  // );
 
   useEffect(() => {
     const timer = setTimeout(() => setShouldHide(true), 5000);

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -1,8 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { css } from '@emotion/react';
+import { useToggleViewContext } from './ToggleView/ToggleViewContext';
+import { TOGGLE_VIEWS } from './ToggleView';
 
 const Tooltip = ({ className, children }) => {
+  const [currentView] = useToggleViewContext();
   const [shouldHide, setShouldHide] = useState(false);
+  // const [shouldHide, setShouldHide] = useState(
+  //   currentView === TOGGLE_VIEWS.newUserView
+  // );
 
   useEffect(() => {
     const timer = setTimeout(() => setShouldHide(true), 5000);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -34,6 +34,7 @@ const HomePage = ({ data }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const hasToggled = useRef(false);
   const [currentView, setCurrentView] = useState(TOGGLE_VIEWS.newUserView);
+  const [showTooltip, setShowTooltip] = useState();
   const updateView = (id) => {
     hasToggled.current = true;
     setCurrentView(id);
@@ -48,11 +49,21 @@ const HomePage = ({ data }) => {
    */
   useEffect(() => {
     const storedToggleView = window.localStorage.getItem(SAVED_TOGGLE_VIEW_KEY);
+    const chooseViewByLoggedIn = loggedIn
+      ? TOGGLE_VIEWS.defaultView
+      : TOGGLE_VIEWS.newUserView;
+
     if (!storedToggleView && loggedIn !== null) {
-      setCurrentView(
-        loggedIn ? TOGGLE_VIEWS.defaultView : TOGGLE_VIEWS.newUserView
-      );
+      setCurrentView(chooseViewByLoggedIn);
     }
+    /* prevents the tooltip from continuing to show on every render
+     * of the defaultview if it's triggered by the toggle buttons
+     * and only on initial page load to defaultview
+     */
+    setShowTooltip(
+      storedToggleView === TOGGLE_VIEWS.defaultView ||
+        chooseViewByLoggedIn === TOGGLE_VIEWS.defaultView
+    );
     if (storedToggleView) {
       setCurrentView(storedToggleView);
     }
@@ -90,6 +101,7 @@ const HomePage = ({ data }) => {
         `}
       >
         <ToggleSelector
+          showTooltip={showTooltip}
           css={css`
             justify-self: end;
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -34,7 +34,7 @@ const HomePage = ({ data }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const hasToggled = useRef(false);
   const [currentView, setCurrentView] = useState(TOGGLE_VIEWS.newUserView);
-  const [showTooltip, setShowTooltip] = useState();
+  const [showTooltip, setShowTooltip] = useState(); // used for tooltip
   const updateView = (id) => {
     hasToggled.current = true;
     setCurrentView(id);
@@ -56,14 +56,17 @@ const HomePage = ({ data }) => {
     if (!storedToggleView && loggedIn !== null) {
       setCurrentView(chooseViewByLoggedIn);
     }
+
     /* prevents the tooltip from continuing to show on every render
      * of the defaultview if it's triggered by the toggle buttons
      * and only on initial page load to defaultview
      */
-    setShowTooltip(
-      storedToggleView === TOGGLE_VIEWS.defaultView ||
-        chooseViewByLoggedIn === TOGGLE_VIEWS.defaultView
-    );
+    if (loggedIn) {
+      setShowTooltip(storedToggleView !== TOGGLE_VIEWS.newUserView);
+    } else if (!loggedIn) {
+      setShowTooltip(storedToggleView === TOGGLE_VIEWS.defaultView);
+    }
+
     if (storedToggleView) {
       setCurrentView(storedToggleView);
     }


### PR DESCRIPTION
In order to only show the tooltip on the `defaultView` on the initial page load only, we are considering these cases:

* User logged in, no selected view in storage -> renders `defaultView` -> show tooltip
* User logged in, `newUserView` saved in storage -> user toggles `defaultView` -> don't show tooltip
* User not logged in, no selected view in storage -> user toggles `defaultView` -> don't show tooltip
* User not logged in, `defaultView` saved in storage -> show tooltip
