### PR TITLE
fix(Alerts): Removing a duplicated screenshot

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
+++ b/src/content/docs/alerts-applied-intelligence/notifications/notification-integrations.mdx
@@ -507,39 +507,39 @@ Read more about each of our specific notification integrations.
 
       This integration requires permission to perform the following actions:
 
-      * [List services](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE5Ng-list-services)
+          * [List services](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE5Ng-list-services)
 
-      * [Create an integration](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIwMw-create-a-new-integration)
+          * [Create an integration](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIwMw-create-a-new-integration)
 
-      * [Create a webhook subscription](https://developer.pagerduty.com/api-reference/b3A6MjkyNDc4NA-create-a-webhook-subscription)
+          * [Create a webhook subscription](https://developer.pagerduty.com/api-reference/b3A6MjkyNDc4NA-create-a-webhook-subscription)
 
-      * [Create a note](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE1MA-create-a-note-on-an-incident)
+          * [Create a note](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE1MA-create-a-note-on-an-incident)
 
-      * [List teams](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIyMw-list-teams)
+          * [List teams](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIyMw-list-teams)
 
-      * [List users](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMw-list-users)
+          * [List users](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODIzMw-list-users)
 
       This integration requires a REST API Key. There are two types of REST API keys in PagerDuty:
 
-      * [General access key](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-general-access-rest-api-key): It includes all the above permission and can be obtained by PagerDuty Admins and Account Owners. [See PagerDuty instructions](https://support.pagerduty.com/docs/api-access-keys#generate-a-general-access-rest-api-key).
+          * [General access key](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-general-access-rest-api-key): It includes all the above permission and can be obtained by PagerDuty Admins and Account Owners. [See PagerDuty instructions](https://support.pagerduty.com/docs/api-access-keys#generate-a-general-access-rest-api-key).
 
-      * [Personal user tokens](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-personal-rest-api-key): If your account has advanced permissions, you can create unique personal REST API keys. Requests made using personal REST API keys are restricted to the user's permissions. If you choose to provide a user token API key, make sure it has the required permissions described above. [See PagerDuty instructions](https://support.pagerduty.com/docs/api-access-keys#generate-a-user-token-rest-api-key).
+          * [Personal user tokens](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-personal-rest-api-key): If your account has advanced permissions, you can create unique personal REST API keys. Requests made using personal REST API keys are restricted to the user's permissions. If you choose to provide a user token API key, make sure it has the required permissions described above. [See PagerDuty instructions](https://support.pagerduty.com/docs/api-access-keys#generate-a-user-token-rest-api-key).
 
     ### Set up a destination [#set-up-pagerduty]
 
       To create a PagerDuty destination, go to the integration method tab and enter the following information:
 
-      * **Name**: Custom name to identify the destination.
+          * **Name**: Custom name to identify the destination.
 
-      * **API Key**: For this integration, you will be asked to provide a REST API Key.
+          * **API Key**: For this integration, you will be asked to provide a REST API Key.
 
-      There are two types of REST API keys in PagerDuty, [general access](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-general-access-rest-api-key) and [user tokens](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-personal-rest-api-key).
+      There're two types of REST API keys in PagerDuty, [general access](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-general-access-rest-api-key) and [user tokens](https://support.pagerduty.com/docs/generating-api-keys#section-generating-a-personal-rest-api-key).
 
       Before saving the destination, we recommend testing the connection by clicking the **Test connection** button.
 
       <img
-        title="PagerDuty account-level destination configuration."
-        alt="A screenshot of a PagerDuty account-level destination configuration."
+        title="PagerDuty account-level destination configuration"
+        alt="A screenshot of a PagerDuty account-level destination configuration"
         src={accountsPagerDutyAccountDestinationNewUi}
       />
 
@@ -550,34 +550,28 @@ Read more about each of our specific notification integrations.
       When turned on, a PagerDuty subscription is created at a later stage for the selected PagerDuty service (see [customize a message template](#message-pagerduty)). The webhook contains access details to New Relic (URL and New Relic API key).
 
       By default, any change of state to the PagerDuty incident created by New Relic will sync back to New Relic.
-      <Callout variant="important">Please note that if you are a PagerDuty Event Intelligence or Digital Operations customer using Intelligent Alert Grouping on a given service, there could be a potential mismatch in PagerDuty Incidents sent back to New Relic.</Callout>
+      <Callout variant="important">Please note that if you're a PagerDuty Event Intelligence or Digital Operations customer using Intelligent Alert Grouping on a given service, there could be a potential mismatch in PagerDuty Incidents sent back to New Relic.</Callout>
 
       ### Sync with New Relic workflows [#two-way-sync-workflows]
 
-      * The closure of a New Relic issue is triggered when the PagerDuty incident is resolved.
+          * The closure of a New Relic issue is triggered when the PagerDuty incident is resolved.
 
-      * The acknowledgment of a New Relic issue is triggered when the PagerDuty incident is acknowledged.
+          * The acknowledgment of a New Relic issue is triggered when the PagerDuty incident is acknowledged.
 
       ### Configure the message template [#message-pagerduty]
 
       To configure the message template:
 
-      1. Choose a destination. You can create a new destination at this stage.
+          1. Choose a destination. You can create a new destination at this stage.
 
-      2. Select a PagerDuty service.
+          2. Select a PagerDuty service.
 
-      3. Select a user. New Relic will post notes in behalf of selected user.
-    
-      4. Send details to the Custom Details section in Pagerduty. You can use the default payload or customize it using free text or dynamic variables from the issue payload. Pick variables from the [variables menu](/docs/alerts-applied-   intelligence/notifications/message-templates/#variables-menu) and apply [handlebars syntax](/docs/alerts-applied-intelligence/notifications/message-templates/#handlebars-syntax) to enrich your payload. The **preview** section on the right hand-side shows an expected payload after the template is rendered. If the payload doesn't form a valid JSON, an error will be shown and it won't be possible to save the template.
+          3. Select a user. New Relic will post notes in behalf of selected user.
+        
+          4. Send details to the Custom Details section in Pagerduty. You can use the default payload or customize it using free text or dynamic variables from the issue payload. Pick variables from the [variables menu](/docs/alerts-applied-intelligence/notifications/message-templates/#variables-menu) and apply [handlebars syntax](/docs/alerts-applied-intelligence/notifications/message-templates/#handlebars-syntax) to enrich your payload. The **preview** section on the right hand-side shows an expected payload after the template is rendered. If the payload doesn't form a valid JSON, an error will be shown and it won't be possible to save the template.
 
 
        Note that custom details in PagerDuty Alerts is automatically populated.
-
-       <img
-         title="PagerDuty account-level template configuration."
-         alt="A screenshot of a PagerDuty account-level template configuration."
-         src={accountsPagerDutyAccountDestinationNewUi}
-       />
 
        ### Send a test notification [#test-notification-pagerduty]
 
@@ -602,7 +596,7 @@ Read more about each of our specific notification integrations.
        To create a PagerDuty destination, go to the integration method tab and enter the following information:
 
         * **Name**: Custom name to identify the destination.
-        * **Integration Key**: Paste the integration key you have copied from the New Relic integration.
+        * **Integration Key**: Paste the integration key you've copied from the New Relic integration.
 
       <img
         title="PagerDuty service-level destination configuration."
@@ -643,7 +637,7 @@ Read more about each of our specific notification integrations.
     * **User id:** This will be automatically filled in based on the current logged in user.
     
     <Callout variant="important">
-    Currently you are restricted to creating mobile push destinations for the current logged in user with [modify capabilities](/docs/alerts-applied-intelligence/notifications/destinations#requirements). You may only create a single push destination for your user. If you try to create more then one, an error will pop up. Before saving the destination, we recommend you test the connection via the **Test connection** button.
+    Currently you're restricted to creating mobile push destinations for the current logged in user with [modify capabilities](/docs/alerts-applied-intelligence/notifications/destinations#requirements). You may only create a single push destination for your user. If you try to create more then one, an error will pop up. Before saving the destination, we recommend you test the connection via the **Test connection** button.
     </Callout>
     
     ### Configure when to receive push notifications [#mobile]


### PR DESCRIPTION
Removed a duplicated screenshot from the [PagerDuty section](https://docs.newrelic.com/docs/alerts-applied-intelligence/notifications/notification-integrations/#pagerduty/).