### PR TITLE
android-sdk-api Add note to recordCustomEvent parameters - eventAttributes

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/recordcustomevent-android-sdk-api.mdx
@@ -92,6 +92,8 @@ For more on other Android APIs, see [Send custom attributes and events](/docs/mo
 
       <td>
         Optional. A map that includes a list of attributes that further designate subcategories to the `$eventType`. You can create attributes for any event descriptors you think will be useful. To name your custom events, create a `name` attribute or use the `eventName` parameter.
+        
+        Note: Not all object types are supported. See [setAttribute](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute/#parameters) for details on supported types.
 
         <Callout variant="important">
           When setting the key for your custom attributes, be aware that there are [default attributes that cannot be overridden](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/set-attribute#description).


### PR DESCRIPTION
### Problem
Not all object types are supported for `eventAttributes` when recording a custom event.  
This leads to an error in the log for each attribute.  
This is not described in the documentation.

### Solution
Add a note linking to setAttribute to help centralize and convey to readers, that there is a limited supported set of types.

