### PR TITLE
NEWRELIC-5414 Updated the iOS agent upgrade docs

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -45,7 +45,7 @@ pod update NewRelicAgent
 To download and manually install the New Relic iOS agent:
 
 ```suggestion
-1. Go to https://download.newrelic.com/ios_agent/ and select the iOS agent you want to update to. A download will be initiated. 
+1. Go to https://download.newrelic.com/ios_agent/ and download the iOS agent you want to update to.
 2. Navigate to where the iOS agent was downloaded and unzip it.
 3. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.
 4. Right-click or control-click NewRelic.xcframework, and select **Show in Finder**.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -18,17 +18,35 @@ redirects:
   - /docs/mobile-monitoring/new-relic-mobile-ios/install-configure/upgrade-new-relic-mobiles-ios-sdk-v4
   - /docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk-v4/
 ---
+ For information about the latest version, refer to the [release notes](/docs/releases/ios).
 
-You must be an account Admin to install, configure, and upgrade the iOS agent. For information about the latest version, refer to the [release notes](/docs/releases/ios).
+## Update with Swift Package Manager [#SPM]
 
-## Replace your iOS framework [#upgrading]
+Upadating the New Relic iOS agent using Swift Package Manager:
 
-First, you'll need to replace the earlier version of your iOS agent framework:
+1. Navigate to the NewRelic agent in the Package Dependencies section of the xCode project navigator.
+2. Right-click on the **NewRelic** agent.
+3. Select **Update Package**.
 
-1. From the Project Navigator (**CMD 1**) in Xcode, search for **NewRelic.xcframework**.
-2. Right-click or control-click **NewRelic.xcframework**, and select **Show in Finder**.
-3. Drag **NewRelic.xcframework** to the trash.
-4. Verify that the Xcode project highlights the reference to **NewRelic.xcframework** in red.
-5. Right-click or control-click **NewRelic.xcframework**, and select **Delete** to remove the obsolete reference from the project.
 
-Then, continue with the installation process in the UI at **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile > (select an app) > Settings > Installation**.
+## Update with Cocoa Pods [#Cocoa-Pods]
+
+Upadating the New Relic iOS agent using Cocoa Pods:
+
+1. Open the **Terminal** app and navigate to the directory with your PodFile.
+2. Run the following command:
+```
+pod update NewRelicAgent
+```
+
+
+## Manually replace your iOS framework [#Manual]
+
+Downloading and manually installing the New Relic iOS agent.
+
+1. First click this [link](https://download.newrelic.com/ios_agent/) to be taken to our iOS agent hosting site.
+2. Click the version of the iOS agent you want to update to. This will begin the download.
+3. Navigate to where the iOS agent was downloaded and unzip it.
+4. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.
+5. Right-click or control-click NewRelic.xcframework, and select Show in Finder.
+6. Drag the newly downloaded iOS agent into the same folder as the old, and select to replace the old.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -44,8 +44,8 @@ pod update NewRelicAgent
 
 To download and manually install the New Relic iOS agent:
 
-1. First click this [link](https://download.newrelic.com/ios_agent/) to be taken to our iOS agent hosting site.
-2. Click the version of the iOS agent you want to update to. This will begin the download.
+```suggestion
+1. Go to https://download.newrelic.com/ios_agent/ and select the iOS agent you want to update to. A download will be initiated. 
 3. Navigate to where the iOS agent was downloaded and unzip it.
 4. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.
 5. Right-click or control-click NewRelic.xcframework, and select Show in Finder.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -28,6 +28,9 @@ To update the New Relic iOS agent using Swift Package Manager:
 2. Right-click on the **NewRelic** agent.
 3. Select **Update Package**.
 
+<Callout variant="important">
+Always check the [release notes](/docs/releases/ios) to make sure you are getting the most up to date agent versions. Depending on how your Swift Package Manager rules are set up you may need to change the `Up to Next Major` or Branch settings to include the new version.
+</Callout>
 
 ## Update with Cocoa Pods [#Cocoa-Pods]
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -24,7 +24,7 @@ redirects:
 
 To update the New Relic iOS agent using Swift Package Manager:
 
-1. Navigate to the NewRelic agent in the Package Dependencies section of the xCode project navigator.
+1. Navigate to the **NewRelic** agent in the Package Dependencies section of your xCode project navigator.
 2. Right-click on the **NewRelic** agent.
 3. Select **Update Package**.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -31,7 +31,7 @@ To update the New Relic iOS agent using Swift Package Manager:
 
 ## Update with Cocoa Pods [#Cocoa-Pods]
 
-Updating the New Relic iOS agent using Cocoa Pods:
+To update the New Relic iOS agent using Cocoa Pods:
 
 1. Open the **Terminal** app and navigate to the directory with your PodFile.
 2. Run the following command:

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -22,7 +22,7 @@ redirects:
 
 ## Update with Swift Package Manager [#SPM]
 
-Upadating the New Relic iOS agent using Swift Package Manager:
+Updating the New Relic iOS agent using Swift Package Manager:
 
 1. Navigate to the NewRelic agent in the Package Dependencies section of the xCode project navigator.
 2. Right-click on the **NewRelic** agent.
@@ -31,7 +31,7 @@ Upadating the New Relic iOS agent using Swift Package Manager:
 
 ## Update with Cocoa Pods [#Cocoa-Pods]
 
-Upadating the New Relic iOS agent using Cocoa Pods:
+Updating the New Relic iOS agent using Cocoa Pods:
 
 1. Open the **Terminal** app and navigate to the directory with your PodFile.
 2. Run the following command:

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -46,7 +46,7 @@ To download and manually install the New Relic iOS agent:
 
 ```suggestion
 1. Go to https://download.newrelic.com/ios_agent/ and select the iOS agent you want to update to. A download will be initiated. 
-3. Navigate to where the iOS agent was downloaded and unzip it.
-4. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.
-5. Right-click or control-click NewRelic.xcframework, and select Show in Finder.
-6. Drag the newly downloaded iOS agent into the same folder as the old, and select to replace the old.
+2. Navigate to where the iOS agent was downloaded and unzip it.
+3. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.
+4. Right-click or control-click NewRelic.xcframework, and select **Show in Finder**.
+5. Drag the newly downloaded iOS agent into the same folder as the old agent, and select to replace the old.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -22,7 +22,7 @@ redirects:
 
 ## Update with Swift Package Manager [#SPM]
 
-Updating the New Relic iOS agent using Swift Package Manager:
+To update the New Relic iOS agent using Swift Package Manager:
 
 1. Navigate to the NewRelic agent in the Package Dependencies section of the xCode project navigator.
 2. Right-click on the **NewRelic** agent.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -44,7 +44,6 @@ pod update NewRelicAgent
 
 To download and manually install the New Relic iOS agent:
 
-```suggestion
 1. Go to https://download.newrelic.com/ios_agent/ and download the iOS agent you want to update to.
 2. Navigate to where the iOS agent was downloaded and unzip it.
 3. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -29,7 +29,7 @@ To update the New Relic iOS agent using Swift Package Manager:
 3. Select **Update Package**.
 
 <Callout variant="important">
-Always check the [release notes](/docs/releases/ios) to make sure you are getting the most up to date agent versions. Depending on how your Swift Package Manager rules are set up you may need to change the `Up to Next Major` or Branch settings to include the new version.
+Always check the [release notes](/docs/releases/ios) to make sure you are getting the most up to date agent versions. Depending on how your Swift Package Manager rules are set up you may need to change the `Up to Next Major` or `Branch` settings to include the new version.
 </Callout>
 
 ## Update with Cocoa Pods [#Cocoa-Pods]

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -29,7 +29,7 @@ To update the New Relic iOS agent using Swift Package Manager:
 3. Select **Update Package**.
 
 <Callout variant="important">
-Always check the [release notes](/docs/releases/ios) to make sure you are getting the most up to date agent versions. Depending on how your Swift Package Manager rules are set up you may need to change the `Up to Next Major` or `Branch` settings to include the new version.
+Always check the [release notes](/docs/releases/ios) to make sure you're getting the most up-to-date agent version. Depending on how your Swift Package Manager rules are set up, you may need to change the `Up to Next Major` or `Branch` settings to include the new version.
 </Callout>
 
 ## Update with Cocoa Pods [#Cocoa-Pods]

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -39,7 +39,6 @@ To update the New Relic iOS agent using Cocoa Pods:
 pod update NewRelicAgent
 ```
 
-
 ## Manually replace your iOS framework [#Manual]
 
 To download and manually install the New Relic iOS agent:

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -45,6 +45,6 @@ To download and manually install the New Relic iOS agent:
 
 1. Go to https://download.newrelic.com/ios_agent/ and download the iOS agent you want to update to.
 2. Navigate to where the iOS agent was downloaded and unzip it.
-3. From the Project Navigator (CMD 1) in Xcode, search for NewRelic.xcframework.
+3. Open the Project Navigator in Xcode (CMD+1) and search for NewRelic.xcframework.
 4. Right-click or control-click NewRelic.xcframework, and select **Show in Finder**.
 5. Drag the newly downloaded iOS agent into the same folder as the old agent, and select to replace the old.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -42,7 +42,7 @@ pod update NewRelicAgent
 
 ## Manually replace your iOS framework [#Manual]
 
-Downloading and manually installing the New Relic iOS agent.
+To download and manually install the New Relic iOS agent:
 
 1. First click this [link](https://download.newrelic.com/ios_agent/) to be taken to our iOS agent hosting site.
 2. Click the version of the iOS agent you want to update to. This will begin the download.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/upgrade-new-relic-mobiles-ios-sdk.mdx
@@ -24,7 +24,7 @@ redirects:
 
 To update the New Relic iOS agent using Swift Package Manager:
 
-1. Navigate to the **NewRelic** agent in the Package Dependencies section of your xCode project navigator.
+1. Navigate to the **NewRelic** agent in the Package Dependencies section of your Xcode project navigator.
 2. Right-click on the **NewRelic** agent.
 3. Select **Update Package**.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/set-max-event-pool-size.mdx
@@ -29,7 +29,7 @@ Compatible with all agent versions.
 ## Description
 
 By default, the iOS agent collects a maximum of 1000 events per [harvest cycle](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#harvest-cycle).
-This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic Android agent will begin [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
+This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic iOS agent will begin [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
 This method lets you override the maximum size of that event pool. You must set this value after `Agent.start()` is called.
 
 * The default value for the event harvest cycle is 600 seconds.


### PR DESCRIPTION
Updated the iOS agent upgrade docs to include SPM and Cocoa Pods
https://issues.newrelic.com/browse/NEWRELIC-5414

## Give us some context

The docs for updating the iOS agent didn't include instructions for SPM or cocoa pods, also the manual instructions weren't complete. I added the SPM and Cocoa Pods instructions and fixed the manual instructions.