### PR TITLE
Fix broken anchor link

### DIFF
--- a/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
+++ b/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
@@ -231,7 +231,7 @@ More details about GitHub's search syntax can be [found here](https://docs.githu
 
 ### GitLab custom queries [#gitlab]
 
-All searches are done using `attribute=value` format with an `&` between each parameter. For parameters with a space in them, leave them as-is and do not put quotes in the parameter (for example, `labels=foo,help wanted`). You can use `@me` to specify your user id and user name otherwise they can be found on GitLab. All filters, by default, have parameter `scope=all` (see [Minimum Qualifiers](#minimum)). To overwrite this, use `scope=X`. See the examples given below.
+All searches are done using `attribute=value` format with an `&` between each parameter. For parameters with a space in them, leave them as-is and do not put quotes in the parameter (for example, `labels=foo,help wanted`). You can use `@me` to specify your user id and user name otherwise they can be found on GitLab. All filters, by default, have parameter `scope=all` (see [Minimum Qualifiers](#minimum-qualifiers)). To overwrite this, use `scope=X`. See the examples given below.
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
Link to #minimum changed to #minimum-qualifiers

<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>