### PR TITLE
Remove Spring Boot support designation

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -386,7 +386,6 @@ The agent automatically instruments these frameworks and libraries:
     * Spring 3.0.0.RELEASE to 5.3.x
     * Spring webclient 5.0.0.RELEASE to 5.3.x
     * Spring Web Services from 1.5.7 to latest
-    * Spring Boot 1.4.x to 2.7.x
     * Spring Webflux 5.0.0.RELEASE to 5.3.24
     * SqsClient 2.1.0 to latest
     * Struts 2


### PR DESCRIPTION
Spring Boot is not a library in and of itself.  It is a collection of Spring modules.  Our instrumentation targets certain libraries/modules and we provide instrumentation for a range of versions for some individual libraries.  It is misleading to say we support Spring Boot X, because we do not provide instrumentation for every library in Spring Boot.   Instead, we should list the libraries for which we provide instrumentation, along with the range of versions.  Removing this Spring Boot line achieves that.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.