### PR TITLE
(end of March) Go agent - User Tracking and Error Groups

### DIFF
--- a/src/content/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api.mdx
+++ b/src/content/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api.mdx
@@ -233,11 +233,11 @@ The agent detects errors automatically. If you want to change the way the Go age
   </tbody>
 </table>
 
-## Error fingerprinting: dynamically apply an error group to each noticed error
+## Error fingerprinting: dynamically apply an error group to each noticed error [#error-fingerprinting]
 
- A callback function can be supplied to the agent to dynamically apply a desired [error group](../../../errors-inbox/errors-inbox) to each noticed error. Use the Go Agent config option [`newrelic.ConfigSetErrorGroupCallbackFunction`](/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration#error-collector) to provide the agent with a callback.
+A callback function can be supplied to the agent to dynamically apply a desired [error group](/docs/errors-inbox/errors-inbox) to each noticed error. Use the Go agent config option [`newrelic.ConfigSetErrorGroupCallbackFunction`](/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration#error-collector) to provide the agent with a callback.
 
- This API call takes a callback method (must be of type `newrelic.ErrorGroupCallback`) as its only argument. Here is an example:
+ This API call takes a callback method (must be of type `newrelic.ErrorGroupCallback`) as its only argument. Here's an example:
 
  ```
  myCallbackFunc := CallbackFunc(errorInfo newrelic.ErrorInfo) string {
@@ -256,9 +256,9 @@ The agent detects errors automatically. If you want to change the way the Go age
  )
  ```
 
- In the example shown, a callback proc is created that will accept an object of type `newrelic.ErrorInfo` and return a string representing the error group. Note that when your ErrorGroupCallback function returns a non empty string, it will override the default grouping behavior of a noticed error and apply server-side grouping logic..
+In the example shown, a callback proc is created that will accept an object of type `newrelic.ErrorInfo` and return a string representing the error group. Note that when your `ErrorGroupCallback` function returns a non-empty string, it will override the default grouping behavior of a noticed error and apply server-side grouping logic. 
 
- The callback function is expected to receive exactly one input argument, a `newrelic.ErrorInfo` object. The object contains the following:
+The callback function is expected to receive exactly one input argument, a `newrelic.ErrorInfo` object. The object contains the following: 
 
  <table>
    <thead>
@@ -286,7 +286,7 @@ The agent detects errors automatically. If you want to change the way the Go age
      </tr>
      <tr>
        <td>`Class`</td>
-       <td>The New Relic error class. If an error implements errorClasser, its value will be derived from that, otherwise, it will be derived from the way the error was collected by the agent. For HTTP errors, this will be the error number. Panics will be the public constant value `newrelic.PanicErrorClass`. Otherwise, the error class will be extracted from the root error object by calling reflect.TypeOf(). The most common root error class is `*errors.errorString`.</td>
+       <td>The New Relic error class. If an error implements `errorClasser`, its value will be derived from that. Otherwise, it will be derived from the way the error was collected by the agent. For HTTP errors, this will be the error number. Panics will be the public constant value `newrelic.PanicErrorClass`. Otherwise, the error class will be extracted from the root error object by calling `reflect.TypeOf()`. The most common root error class is `*errors.errorString`.</td>
      </tr>
      <tr>
        <td>`Expected`</td>
@@ -298,23 +298,23 @@ The agent detects errors automatically. If you want to change the way the Go age
      </tr>
      <tr>
        <td>`GetTransactionUserAttributes(attribute string)`</td>
-       <td>A method that takes an attribute name as an imput, then looks up and returns a transaction user attribute as an interface{}, and a bool that is `true` if the key was found in the attribute map.</td>
+       <td>A method that takes an attribute name as an imput, then looks up and returns a transaction user attribute as an `interface{}`, and a bool that is `true` if the key was found in the attribute map.</td>
      </tr>
      <tr>
        <td>`GetErrorAttribute(attribute string)`</td>
-       <td>A method that takes an attribute name as an input, then looks up and returns an error user attribute as an interface{}, and a bool that is `true` if the key was found in the error attributes map.</td>
+       <td>A method that takes an attribute name as an input, then looks up and returns an error user attribute as an `interface{}`, and a bool that is `true` if the key was found in the error attributes map.</td>
      </tr>
      <tr>
        <td>`GetStackTraceFrames()`</td>
-       <td>A method that returns a slice of StackTraceFrame objects containing a maximum of 100 relevant stack trace lines for an error. Note that calling this method may be expensive since the slice needs to be allocated and populated. It is recommended that this method is only called when needed to to optimize performance.</td>
+       <td>A method that returns a slice of `StackTraceFrame` objects containing a maximum of 100 relevant stack trace lines for an error. Note that calling this method may be expensive because the slice needs to be allocated and populated. It's recommended that this method is only called when needed to optimize performance.</td>
      </tr>
      <tr>
        <td>`GetRequestURI()`</td>
-       <td>A method that returns the URI of the http request made during the parent transaction of the current error. If no web request occured, an empty string will be returned.</td>
+       <td>A method that returns the URI of the HTTP request made during the parent transaction of the current error. If no web request occured, an empty string will be returned.</td>
      </tr>
      <tr>
        <td>`GetRequestMethod()`</td>
-       <td>A method that returns the HTTP method of the web request that occured during the parent transaction of this error. If no web request occured, an empty string will be returned.</td>
+       <td>A method that returns the HTTP method of the web request that occurred during the parent transaction of this error. If no web request occured, an empty string will be returned.</td>
      </tr>
      <tr>
        <td>`GetHttpResponseCode()`</td>
@@ -327,13 +327,13 @@ The agent detects errors automatically. If you want to change the way the Go age
    </tbody>
  </table>
 
- ## User tracking: associating a user ID with each transaction and error
+ ## User tracking: associating a user ID with each transaction and error [#user-tracking]
 
- Transactions and errors can be associated with a user ID if one is known to the New Relic Go agent. Use the Go agent API `txn.SetUserID("example user ID")` to provide the agent with a user ID.
+Transactions and errors can be associated with a user ID if one is known to the New Relic Go agent. Use the Go agent API `txn.SetUserID("example user ID")` to provide the agent with a user ID.
 
- This API call requires a single argument of a string representing a unique identifier for an end user. This string can be a UUID, a database id, etc. The API call should be made at least once per transaction to inform the New Relic Go agent of what user ID to associate the transaction with. Then in turn, when the agent notices errors during the lifespan of the transaction, the errors will bear an `enduser.id` agent attribute that holds the user ID value.
+This API call requires a single argument of a string representing a unique identifier for an end user. This string can be a UUID, a database id, or similar. The API call should be made at least once per transaction to inform the New Relic Go agent of what user ID to associate the transaction with. Then in turn, when the agent notices errors during the lifespan of the transaction, the errors will bear an `enduser.id` agent attribute that holds the user ID value.
 
- Because the API is intended to be called every time a new user ID has entered scope, it will ideally be called via middleware that is aware of user session creation. Once the New Relic Go agent has been made aware of the user ID, it will supply the `enduser.id` agent attribute on the current transaction as well as on any errors noticed during the current transaction's lifespan.
+Because the API is intended to be called every time a new user ID has entered scope, it will ideally be called via middleware that is aware of user session creation. Once the New Relic Go agent has been made aware of the user ID, it will supply the `enduser.id` agent attribute on the current transaction as well as on any errors noticed during the current transaction's lifespan.
 
 ## Send custom data from your app [#custom-data]
 

--- a/src/content/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api.mdx
+++ b/src/content/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api.mdx
@@ -233,6 +233,108 @@ The agent detects errors automatically. If you want to change the way the Go age
   </tbody>
 </table>
 
+## Error fingerprinting: dynamically apply an error group to each noticed error
+
+ A callback function can be supplied to the agent to dynamically apply a desired [error group](../../../errors-inbox/errors-inbox) to each noticed error. Use the Go Agent config option [`newrelic.ConfigSetErrorGroupCallbackFunction`](/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration#error-collector) to provide the agent with a callback.
+
+ This API call takes a callback method (must be of type `newrelic.ErrorGroupCallback`) as its only argument. Here is an example:
+
+ ```
+ myCallbackFunc := CallbackFunc(errorInfo newrelic.ErrorInfo) string {
+	if errorInfo.Message == "example error message" {
+    return "example group 1"
+  }
+  if errorInfo.GetHttpResponseCode() == "403" && errorInfo.GetUserID() == "user 2" {
+    return "user 2 payment issue"
+  }
+
+	// use default error grouping behavior
+	return ""
+}
+ app, err := newrelic.NewApplication(
+    newrelic.ConfigSetErrorGroupCallbackFunction(myCallbackFunc)
+ )
+ ```
+
+ In the example shown, a callback proc is created that will accept an object of type `newrelic.ErrorInfo` and return a string representing the error group. Note that when your ErrorGroupCallback function returns a non empty string, it will override the default grouping behavior of a noticed error and apply server-side grouping logic..
+
+ The callback function is expected to receive exactly one input argument, a `newrelic.ErrorInfo` object. The object contains the following:
+
+ <table>
+   <thead>
+     <tr>
+       <th width={200}>
+         **Key**
+       </th>
+       <th>
+         **Value**
+       </th>
+     </tr>
+   </thead>
+   <tbody>
+     <tr>
+       <td>`Error`</td>
+       <td>The noticed Go error object. This will be nil for HTTP errors and Panics.</td>
+     </tr>
+     <tr>
+       <td>`TimeOccured`</td>
+       <td>The time.Time when the error was noticed by the agent.</td>
+     </tr>
+     <tr>
+       <td>`Message`</td>
+       <td>The error message.</td>
+     </tr>
+     <tr>
+       <td>`Class`</td>
+       <td>The New Relic error class. If an error implements errorClasser, its value will be derived from that, otherwise, it will be derived from the way the error was collected by the agent. For HTTP errors, this will be the error number. Panics will be the public constant value `newrelic.PanicErrorClass`. Otherwise, the error class will be extracted from the root error object by calling reflect.TypeOf(). The most common root error class is `*errors.errorString`.</td>
+     </tr>
+     <tr>
+       <td>`Expected`</td>
+       <td>A bool that is `true` when the error was expected.</td>
+     </tr>
+     <tr>
+       <td>`TransactionName`</td>
+       <td>The formatted name of a transaction as it would appear in the New Relic UI.</td>
+     </tr>
+     <tr>
+       <td>`GetTransactionUserAttributes(attribute string)`</td>
+       <td>A method that takes an attribute name as an imput, then looks up and returns a transaction user attribute as an interface{}, and a bool that is `true` if the key was found in the attribute map.</td>
+     </tr>
+     <tr>
+       <td>`GetErrorAttribute(attribute string)`</td>
+       <td>A method that takes an attribute name as an input, then looks up and returns an error user attribute as an interface{}, and a bool that is `true` if the key was found in the error attributes map.</td>
+     </tr>
+     <tr>
+       <td>`GetStackTraceFrames()`</td>
+       <td>A method that returns a slice of StackTraceFrame objects containing a maximum of 100 relevant stack trace lines for an error. Note that calling this method may be expensive since the slice needs to be allocated and populated. It is recommended that this method is only called when needed to to optimize performance.</td>
+     </tr>
+     <tr>
+       <td>`GetRequestURI()`</td>
+       <td>A method that returns the URI of the http request made during the parent transaction of the current error. If no web request occured, an empty string will be returned.</td>
+     </tr>
+     <tr>
+       <td>`GetRequestMethod()`</td>
+       <td>A method that returns the HTTP method of the web request that occured during the parent transaction of this error. If no web request occured, an empty string will be returned.</td>
+     </tr>
+     <tr>
+       <td>`GetHttpResponseCode()`</td>
+       <td>A method that returns the HTTP response code that was returned during the web request that occured during the parent transaction of this error. If no web request occured, an empty string will be returned.</td>
+     </tr>
+     <tr>
+       <td>`GetUserID()`</td>
+       <td>A method that returns the `UserID` that was applied to this error and transaction. If no `UserID` was defined, an empty string will be returned.</td>
+     </tr>
+   </tbody>
+ </table>
+
+ ## User tracking: associating a user ID with each transaction and error
+
+ Transactions and errors can be associated with a user ID if one is known to the New Relic Go agent. Use the Go agent API `txn.SetUserID("example user ID")` to provide the agent with a user ID.
+
+ This API call requires a single argument of a string representing a unique identifier for an end user. This string can be a UUID, a database id, etc. The API call should be made at least once per transaction to inform the New Relic Go agent of what user ID to associate the transaction with. Then in turn, when the agent notices errors during the lifespan of the transaction, the errors will bear an `enduser.id` agent attribute that holds the user ID value.
+
+ Because the API is intended to be called every time a new user ID has entered scope, it will ideally be called via middleware that is aware of user session creation. Once the New Relic Go agent has been made aware of the user ID, it will supply the `enduser.id` agent attribute on the current transaction as well as on any errors noticed during the current transaction's lifespan.
+
 ## Send custom data from your app [#custom-data]
 
 To record [custom data](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data) with the Go agent, you can use any of the following methods:

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -1508,6 +1508,50 @@ The following settings are used to configure the error collector:
   </Collapser>
 
   <Collapser
+    id="error-capture-events"
+    title="ErrorCollector.ErrorGroupCallback"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            ErrorGroupCallback
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            nil
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+          <td>
+            `newrelic.ConfigSetErrorGroupCallbackFunction` config option
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When not nil, the agent will apply the user defined callback function to all noticed errors at harvest time, applying an error group to them.
+  </Collapser>
+
+  <Collapser
     id="error-ignore-status"
     title="ErrorCollector.IgnoreStatusCodes"
   >


### PR DESCRIPTION
Note from @zuluecho9: This should coincide with Go Agent release 3.21.0 release, estimated end of March some time. 

Document the user tracking and error group callback features added to errors inbox in the APM Go agent.
