### PR TITLE
add back signup banner

### DIFF
--- a/src/content/docs/mlops/get-started/intro-mlops.mdx
+++ b/src/content/docs/mlops/get-started/intro-mlops.mdx
@@ -4,6 +4,8 @@ metaDescription: "Use New Relic ML model performance monitoring to monitor and o
 redirects: 
   - /docs/alerts-applied-intelligence/mlops/get-started/intro-mlops
   - /docs/alerts-applied-intelligence/applied-intelligence/mlops-integrations
+signupBanner:
+  text: howdy pardner 🤠👉👉 this is a ✨signup banner✨
 ---
 
 Machine-learning operations is a set of practices designed to increase the quality, simplify the management process, and automate the deployment of machine learning models in large-scale production environments.

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
@@ -91,7 +91,12 @@ const BasicDoc = ({ data, location, pageContext }) => {
     `docBannerDismissed-${title}`
   );
   const [bannerDismissed, setBannerDismissed] = useBannerDismissed(false);
-  const bannerVisible = !loggedIn && !bannerDismissed && signupBanner;
+  const [mounted, setMounted] = useState(false);
+  const bannerVisible =
+    !loggedIn && !bannerDismissed && signupBanner && mounted;
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const onCloseBanner = () => {
     setBannerDismissed(true);


### PR DESCRIPTION
conditionally renders the banner based on logged in status and whether the user has previously dismissed the banner. only does so after mount, this fixes the hydration issue

https://docswebsitedevelop-sunnyfixsignupbanner.gatsbyjs.io/docs/mlops/get-started/intro-mlops/
