### PR TITLE
Node Agent release notes v9.12.1

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy.mdx
@@ -39,13 +39,13 @@ Any versions not listed in the following table are no longer supported. Please [
     </tr>
     <tr>
       <td>
-        v9.12.0
+        v9.12.0 (deprecated)
       </td>
       <td>
         2023-03-14
       </td>
       <td>
-        2024-03-14
+        2023-03-14
       </td>
     </tr>
     <tr>

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy.mdx
@@ -28,6 +28,17 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v9.12.1
+      </td>
+      <td>
+        2023-03-15
+      </td>
+      <td>
+        2024-03-15
+      </td>
+    </tr>
+    <tr>
+      <td>
         v9.12.0
       </td>
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-0.mdx
@@ -7,11 +7,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* Added ability to mark errors as expected when using `newrelic.noticeError`, by adding an optional boolean: 
-  * `newrelic.noticeError(error, {customAttributes}, true|false)` when there are custom error attributes.
-  * `newrelic.noticeError(error, true|false)` if there are no custom error attributes.
-  * `expected` errors do not affect error metrics or Apdex. 
-* updated @grpc/grpc-js from 1.8.8 to 1.8.9
+* This version of the agent was not available. The release pipeline did not run successfully.
 
 ### Support statement:
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-0.mdx
@@ -7,7 +7,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* This version of the agent was not available. The release pipeline did not run successfully.
+* This version of the agent was not available, and has been deprecated. The NPM release pipeline did not run successfully. New Relic recommends installing Node Agent v9.12.1 instead.
 
 ### Support statement:
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-0.mdx
@@ -7,7 +7,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* This version of the agent was not available, and has been deprecated. The NPM release pipeline did not run successfully. New Relic recommends installing Node Agent v9.12.1 instead.
+* This version of the agent was not available, and has been deprecated. The NPM release pipeline did not run successfully. New Relic recommends installing Node agent v9.12.1 instead.
 
 ### Support statement:
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-1.mdx
@@ -1,0 +1,23 @@
+---
+subject: Node.js agent
+releaseDate: '2023-03-15'
+version: 9.12.1
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+---
+
+## Notes
+
+* Added ability to mark errors as expected when using `newrelic.noticeError`, by adding an optional boolean:
+  * `newrelic.noticeError(error, {customAttributes}, true|false)` when there are custom error attributes.
+  * `newrelic.noticeError(error, true|false)` if there are no custom error attributes.
+  * `expected` errors do not affect error metrics or Apdex.
+
+* Added ability to disable distributed tracing for aws-sdk >= 3.290.0.
+
+* Updated README header image to latest OSS office required images
+
+* updated @grpc/grpc-js from 1.8.8 to 1.8.9
+
+### Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-1.mdx
@@ -12,11 +12,11 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
   * `newrelic.noticeError(error, true|false)` if there are no custom error attributes.
   * `expected` errors do not affect error metrics or Apdex.
 
-* Added ability to disable distributed tracing for aws-sdk >= 3.290.0.
+* Added ability to disable distributed tracing for aws-sdk 3.290.0 and higher.
 
 * Updated README header image to latest OSS office required images
 
-* updated @grpc/grpc-js from 1.8.8 to 1.8.9
+* Updated @grpc/grpc-js from 1.8.8 to 1.8.9
 
 ### Support statement:
 


### PR DESCRIPTION
v9.12.1 of the Node Agent was published successfully today, March 15, 2023. 

We attempted a release of v9.12.0 yesterday, though that was not successfully published due to a problem in the NPM publishing process. Whatever that problem was, it continued to affect 9.12.0, so we've consolidated its release notes into the new patch release. 