### PR TITLE
chore: update tracking gha (action 2.1.0 -> 2.3.0)

### DIFF
--- a/src/content/docs/change-tracking/ci-cd/change-tracking-github-actions.mdx
+++ b/src/content/docs/change-tracking/ci-cd/change-tracking-github-actions.mdx
@@ -219,7 +219,7 @@ jobs:
         run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
       # This step creates a new Change Tracking Marker
       - name: New Relic Application Deployment Marker
-        uses: newrelic/deployment-marker-action@v2.1.0
+        uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
@@ -254,7 +254,7 @@ jobs:
         run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
       # This step creates a new Change Tracking Marker for App123
       - name: App123 Marker
-        uses: newrelic/deployment-marker-action@v2.1.0
+        uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID_App123 }}
@@ -267,7 +267,7 @@ jobs:
           user: "${{ github.actor }}"
       # This step creates a new Change Tracking Marker for App456
       - name: App456 Marker
-        uses: newrelic/deployment-marker-action@v2.1.0
+        uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID_App456 }}
@@ -280,7 +280,7 @@ jobs:
           user: "${{ github.actor }}"
       # This step creates a new Change Tracking Marker for App789
       - name: App789 Marker
-        uses: newrelic/deployment-marker-action@v2.1.0
+        uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID_App789 }}

--- a/src/content/docs/change-tracking/ci-cd/change-tracking-github-actions.mdx
+++ b/src/content/docs/change-tracking/ci-cd/change-tracking-github-actions.mdx
@@ -200,7 +200,11 @@ Make sure the following [Github secrets](https://docs.github.com/en/actions/secu
 * `NEW_RELIC_API_KEY` - Personal API key
 * `NEW_RELIC_DEPLOYMENT_ENTITY_GUID` - New Relic Entity GUID to create the marker on
 
+Check the [New Relic Application Deployment Marker](https://github.com/marketplace/actions/new-relic-application-deployment-marker) page and click the **Use latest version** button to make sure you use the latest version available.
+
+
 >*There are a number of [default GitHub environment variables](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) that are used in these examples as well.*
+
 ### Minimum required fields
 
 ```yaml


### PR DESCRIPTION
https://github.com/newrelic/deployment-marker-action/releases/tag/v2.3.0

## Give us some context

What problems does this PR solve?

* Updates `https://docs.newrelic.com/docs/change-tracking/ci-cd/change-tracking-github-actions/` page to follow updates from [the upstream `newrelic/deployment-marker-action`](https://github.com/newrelic/deployment-marker-action): 
   * https://github.com/newrelic/deployment-marker-action/releases/tag/v2.3.0