### PR TITLE
chore(apm): fix typo in ruby-agent

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/installation/ruby-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/ruby-agent-heroku.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/agents/ruby-agent/installation-configuration/ruby-agent-heroku
 ---
 
-[Heroku](https://devcenter.heroku.com/articles/newrelic) is a Platform as a Service (PaaS) solution for hosting web applications in various agent languages, including Ruby. With New Relic, you can extend Heroku using [APM](/docs/apm/new-relic-apm) and [browser monitoring](/docs/browser/new-relic-browser) metrics. This page describes special considerations for using Heroku as a hosting service with New Relic's Ruby agent.
+[Heroku](https://devcenter.heroku.com/articles/newrelic) is a Platform as a Service (PaaS) solution for hosting web applications in various agent languages, including Ruby. With New Relic, you can extend Heroku using [APM](/docs/apm/new-relic-apm) and [browser monitoring](/docs/browser/new-relic-browser) metrics. This page describes special considerations for using Heroku as a hosting service with the Ruby agent for New Relic.
 
 ## Install the New Relic agent add-on [#installing]
 
@@ -73,7 +73,7 @@ After deploying your Ruby app on Heroku, install the New Relic agent:
     id="heroku-non-rails"
     title="Non-Rails applications"
   >
-    If you are using New Relic's Ruby agent with a non-Rails application, Heroku users need to install the plugin in your repository manually. For example, in a Sinatra app, add the `newrelic_rpm` gem to your `Gemfile`, and then add the following code to your app:
+    If you're using Ruby agent for New Relic with a non-Rails application, Heroku users need to install the plugin in your repository manually. For example, in a Sinatra app, add the `newrelic_rpm` gem to your `Gemfile`, and then add the following code to your app:
 
     ```ruby
     configure :production do
@@ -101,12 +101,12 @@ heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
 
 ## Configure the Ruby agent on Heroku [#configuring]
 
-You can configure New Relic in your `newrelic.yml` file, or you can use [environment variables](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration) to take precedence over the values in your config file. Use `heroku config:set` to modify the agent's settings for your Herokuru application.
+You can configure New Relic in your `newrelic.yml` file, or you can use [environment variables](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration) to take precedence over the values in your config file. Use `heroku config:set` to modify the agent's settings for your Heroku application.
 
-For example, to set the [`analytics_events.max_samples_stored`](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#analytics_events) setting to 500:
+For example, to set the [`custom_insights_events.max_samples_stored`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#custom_insights_events-max_samples_stored) setting to 500:
 
 ```bash
-heroku config:set NEW_RELIC_ANALYTICS_EVENTS_MAX_SAMPLES_STORED=500
+heroku config:set NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED=500
 ```
 
 ## Hostnames on Heroku [#hostnames]
@@ -119,7 +119,7 @@ Starting in version 3.9.5, the Ruby agent reports the Heroku dyno name as the ho
 
 Some dynos have names that are dynamically generated, and these may take on many unique values over time. Examples include `scheduler` dynos created by the Scheduler add-on, and `run` dynos created by invoking `heroku run` on the command line. In order to keep the number of unique hostnames reasonable, the Ruby agent will automatically aggregate data from `scheduler` and `run` dynos into hostnames called `scheduler.*` and `run.*`.
 
-If you have other dyno types that are dynamically created, use the [`heroku.dyno_name_prefixes_to_shorten`](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#heroku) configuration setting to apply the same aggregation to these other dyno types.
+If you have other dyno types that are dynamically created, use the [`heroku.dyno_name_prefixes_to_shorten`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#heroku) configuration setting to apply the same aggregation to these other dyno types.
 
 ## Logging for Heroku [#logging]
 
@@ -138,7 +138,7 @@ To retrieve logs on Heroku:
    heroku config:set NEW_RELIC_LOG="stdout"
    ```
 3. Open your `newrelic.yml` file in an editor.
-4. Change the [`log_level`](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#log_level) to `debug` and save the file. Be sure you do not modify the indentation.
+4. Change the [`log_level`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#log_level) to `debug` and save the file. Be sure you do not modify the indentation.
 5. Restart your web app.
 6. Generate some traffic to your app and run it for about five minutes.
 7. Run the following Heroku toolbelt command to view logs only from the New Relic agent:
@@ -147,4 +147,4 @@ To retrieve logs on Heroku:
    heroku logs -n 1500 | grep -i relic
    ```
 8. If sending your log file to New Relic Support, attach the log file to your support ticket, along with `newrelic.yml`, your `Gemfile`, and `Gemfile.lock`.
-9. Edit `newrelic.yml` again, and change the [`log_level`](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#log_level) to the previous setting. Save the file.
+9. Edit `newrelic.yml` again, and change the [`log_level`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#log_level) to the previous setting. Save the file.

--- a/src/content/docs/apm/agents/ruby-agent/installation/ruby-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/ruby-agent-heroku.mdx
@@ -101,7 +101,7 @@ heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
 
 ## Configure the Ruby agent on Heroku [#configuring]
 
-You can configure New Relic in your `newrelic.yml` file, or you can use [environment variables](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration) to take precedence over the values in your config file. Use `heroku config:set` to modify the agent's settings for your Heroku appication.
+You can configure New Relic in your `newrelic.yml` file, or you can use [environment variables](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration) to take precedence over the values in your config file. Use `heroku config:set` to modify the agent's settings for your Herokuru application.
 
 For example, to set the [`analytics_events.max_samples_stored`](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#analytics_events) setting to 500:
 

--- a/src/content/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring.mdx
@@ -16,6 +16,7 @@ redirects:
   - /docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring
   - /docs/browser/browser-monitoring
   - /docs/browser
+  - /docs/browser/new-relic-browser
 hideNavs: true
 ---
 


### PR DESCRIPTION
Fix a typo in https://docs.newrelic.com/docs/apm/agents/ruby-agent/installation/ruby-agent-heroku/#configuring