### PR TITLE
(Publish 3/16) Adding support for Amazon Linux 2023

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -77,7 +77,7 @@ The infrastructure agent supports these operating systems up to their manufactur
   <tbody>
     <tr>
       <td>
-        <img style={{ width: '32px', height: '32px', verticalAlign: 'middle'}} class="inline" title="amazon linux" alt="amazon linux.png" src={osAmazonLinux}/>[Amazon Linux 2, Amazon Linux 2022 (Preview)](/docs/infrastructure-install-amazon-linux-centos-debian-rhel-or-ubuntu)
+        <img style={{ width: '32px', height: '32px', verticalAlign: 'middle'}} class="inline" title="amazon linux" alt="amazon linux.png" src={osAmazonLinux}/>[Amazon Linux 2, Amazon Linux 2023](/docs/infrastructure-install-amazon-linux-centos-debian-rhel-or-ubuntu)
       </td>
 
       <td>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -264,16 +264,16 @@ To install infrastructure in Linux, follow these instructions:
        sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/aarch64/newrelic-infra.repo
        ```
        
-       **Amazon Linux 2022 (x86)**
+       **Amazon Linux 2023 (x86)**
 
        ```bash
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2022/x86_64/newrelic-infra.repo
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2023/x86_64/newrelic-infra.repo
        ```
 
-       **Amazon Linux 2022 (arm64)**
+       **Amazon Linux 2023 (arm64)**
 
        ```bash
-       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2022/aarch64/newrelic-infra.repo
+       sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2023/aarch64/newrelic-infra.repo
        ```
      </Collapser>
 


### PR DESCRIPTION
## Give us some context

* AWS released Amazon Linux 2023, infra-agent release [1.39.0](https://github.com/newrelic/infrastructure-agent/releases/tag/1.39.0) adds support for it. 