### PR TITLE
feat(Dictionary): Updating the resetCause definition

### DIFF
--- a/src/data-dictionary/events/NrAiSignal/resetCause.md
+++ b/src/data-dictionary/events/NrAiSignal/resetCause.md
@@ -5,12 +5,12 @@ events:
   - NrAiSignal
 ---
 
-For reset events only. NrAiSignal indicates suppression as a `resetCause` when New Relic has had internal problems and alerts have been suppressed to avoid a wave of false alerts. Available values:
+For reset events only. Available values:
 
   * `New`: It's a new signal coming online.
   * `Expired`: Signal reset due to loss of signal configuration.
-  * `ConditionDisabled`: The user disabled the in the UI.
-  * `delayedEvaluation`: The condition has a delayed evaluation configuration before it starts evaluating.
+  * `ConditionDisabled`: The user disabled the condition in the UI.
+  * `delayedEvaluation`: The condition has a delayed evaluation configured. Therefore, New Relic sends resets through the system to prevent evaluation before the expected time.
   * `Suppression`: Because of an ongoing incident, alerts are suppressed.
   * `Interrupt`: When we detect issues, we internally interrupt our services. Issues are mainly out-of-order data points that can cause false alerts.
   * `ConditionDeleted`: The user has deleted the condition in the UI.


### PR DESCRIPTION
Updated the description of the `resetCause` definition on the [New Relic data dictionary](https://docs.newrelic.com/attribute-dictionary/?event=NrAiSignal&attribute=resetCause) page.

This is the ticket: NR-96653