### PR TITLE
chore(PHP agent): Add new daemon log level

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1132,6 +1132,7 @@ For more information about ways to start the daemon and when to use an external 
     * `error`
     * `warning`
     * `info`
+    * `healthcheck`
     * `debug`
 
       The more verbose settings can generate a lot of information very quickly. When necessary, set `debug` for short periods of time to identify problems.


### PR DESCRIPTION
The PHP agent has added a new log level for the daemon called 'healthcheck'.   This updates the configuration page for the PHP agent to include this option.

** DO NOT MERGE - I WILL LET YOU KNOW WHEN WE ARE READY **