### PR TITLE
fix: add theme config options for sitemap generation and robots

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -244,8 +244,6 @@ module.exports = {
       },
     },
     // 'gatsby-plugin-generate-doc-json',
-    // Comment in below to run a build that checks links
-    // 'gatsby-plugin-check-links',
     {
       resolve: 'gatsby-plugin-generate-json',
       options: {
@@ -442,6 +440,23 @@ module.exports = {
     {
       resolve: '@newrelic/gatsby-theme-newrelic',
       options: {
+        sitemap: process.env.ENVIRONMENT === 'production',
+        robots: {
+          siteUrl,
+          resolveEnv: () => process.env.ENVIRONMENT || 'development',
+          env: {
+            staging: {
+              host: 'https://docs-dev.newrelic.com',
+              policy: [{ userAgent: '*', disallow: ['/'] }],
+            },
+            development: {
+              policy: [{ userAgent: '*', disallow: ['/'] }],
+            },
+            production: {
+              policy: [{ userAgent: '*', allow: '/' }],
+            },
+          },
+        },
         oneTrustID: 'e66f9ef1-3a12-4043-b7c0-1a2ea66f6d41',
         layout: {
           contentPadding: '1.5rem',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.18.4",
+    "@newrelic/gatsby-theme-newrelic": "6.18.5",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,10 +2609,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.18.4":
-  version "6.18.4"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.18.4.tgz#4b9481863137d49d94970c492a65fba62874dd68"
-  integrity sha512-kgh2mI9BBMP0Rwfl9wdCHz/h1NXW6kDG6w8hsfiDdjR7lXZJObTJ936ycJJU1164BFhcaUhNPTEsq9Js1MCVDg==
+"@newrelic/gatsby-theme-newrelic@6.18.5":
+  version "6.18.5"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.18.5.tgz#b5ecf54efe2d6f50a2571ef3fe249c4308530169"
+  integrity sha512-txYfLyrdhdMxP5Rx0RYMw9iIod45kdKt+FlP7SmxfVVUWmRk6A/Oem8TdFmYrlnWpr2WZMU8EJKwlR//yGuLAQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Description

Adds theme options to only generate a sitemap if in production. And to generate a robots.txt file that disallows crawling pages if not in production.

Unfortunately [gatsby cloud access controls](https://support.gatsbyjs.com/hc/en-us/articles/360056430174-Access-Control) only apply to build previews and not the hosted site.

Tested via theme demo site build and no sitemap was generated.

Includes theme bump that excludes `/embed` pages from sitemap for good measure.

This may / may not be full solution to google indexing docs-dev.newrelic.com. we may need to add meta robot noindex tags to all pages if in staging site or add auth or something else ¯\_(ツ)_/¯

## Related
- https://github.com/newrelic/gatsby-theme-newrelic/pull/899
- https://developers.google.com/search/docs/crawling-indexing/robots/intro
- https://developers.google.com/search/docs/crawling-indexing/block-indexing
