### PR TITLE
Giving Example of how to use NRQL for nodetool

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
@@ -622,6 +622,12 @@ Cassandra data is attached to the `CassandraSample` and `CassandraColumnFamilySa
 
 For more on how to find and use your data, see [Understand integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
 
+Here is an example of how to easily recreate [nodetool status](https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/tools/nodetool/toolsStatus.html) with NRQL:
+
+```
+SELECT cluster.datacenter, fullHostname, cluster.name, cluster.rack, entityName, hostStatus, (db.loadBytes /10e3) AS 'kb db.loadBytes' FROM CassandraSample 
+```
+
 ## Metric data [#metrics]
 
 The Cassandra integration collects the following metrics.

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
@@ -622,7 +622,7 @@ Cassandra data is attached to the `CassandraSample` and `CassandraColumnFamilySa
 
 For more on how to find and use your data, see [Understand integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
 
-Here is an example of how to easily recreate [nodetool status](https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/tools/nodetool/toolsStatus.html) with NRQL:
+To recreate [nodetool status](https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/tools/nodetool/toolsStatus.html) with NRQL, run the following query:
 
 ```
 SELECT cluster.datacenter, fullHostname, cluster.name, cluster.rack, entityName, hostStatus, (db.loadBytes /10e3) AS 'kb db.loadBytes' FROM CassandraSample 


### PR DESCRIPTION
SELECT cluster.datacenter, fullHostname, cluster.name, cluster.rack, entityName, hostStatus, (db.loadBytes /10e3) AS 'kb db.loadBytes' FROM CassandraSample 


https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/tools/nodetool/toolsStatus.html

https://cassandra.apache.org/doc/latest/cassandra/troubleshooting/use_nodetool.html

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
An example of a common cli output for Cassandra written in NRQL format
* Add any context that will help us review your changes such as testing notes,
https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/tools/nodetool/toolsStatus.html
https://cassandra.apache.org/doc/latest/cassandra/troubleshooting/use_nodetool.html
* If your issue relates to an existing GitHub issue, please link to it.