### PR TITLE
[fix] Link to Nginx integration

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/installation/container-auto-discovery-host-integrations.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/container-auto-discovery-host-integrations.mdx
@@ -27,7 +27,7 @@ An integration will be executed as many times as it finds discovery elements. If
 
 In your integration configuration, you must create `${discovery.<property>}` placeholders. These will then be automatically replaced by specific container information.
 
-These examples (for Docker-only environments and for Kubernetes) show how to configure an [NGINX integration](/docs/integrations/host-integrations/host-integrations-list/apache-monitoring-integration) to monitor all local containers that have an image name containing `nginx`, and that are labeled as `env=production`. Each service will be available through different IPs and ports, so they must be variables.
+These examples (for Docker-only environments and for Kubernetes) show how to configure an [NGINX integration](/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration) to monitor all local containers that have an image name containing `nginx`, and that are labeled as `env=production`. Each service will be available through different IPs and ports, so they must be variables.
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
The link to Nginx integration was to Apache. The examples are for Nginx.

## Give us some context

* What problems does this PR solve?
Wrong link

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration/