### PR TITLE
Remove open preview callout nri-winservice

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
@@ -10,10 +10,6 @@ import infrastructureWindowsServicesMetric from 'images/infrastructure_screensho
 
 import infrastructureWindowsServices from 'images/infrastructure_diagram_windows-services.png'
 
-<Callout title="PUBLIC PREVIEW">
-  This feature is currently in public preview and only applies to the versions starting on [0.3.0](https://github.com/newrelic/nri-winservices/releases/tag/v0.3.0-beta) released in September 2021. Check [our Support Forum post](https://discuss.newrelic.com/t/introducing-new-open-beta-version-of-the-windows-services-integration/160162) for more details.
-</Callout>
-
 New Relic's Windows services integration collects data about the services running on your Microsoft Windows hosts and sends it to our platform. You can check the state and start mode of each service, find out which hosts are running a service, set up alerts for services, and more.
 
 Our integration is bundled with the [Windows infrastructure agent](/docs/infrastructure/install-infrastructure-agent/windows-installation/install-infrastructure-monitoring-agent-windows). If you're monitoring Windows hosts on New Relic, you only need to enable the integration to get Windows services data into our platform.


### PR DESCRIPTION
Removing the Open Preview callout as the integration [has been promoted to GA](https://github.com/newrelic/infrastructure-agent/releases/tag/1.39.1).

