### PR TITLE
infra_agent: fix manual installation arch

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/tarball-manual-install-infrastructure-agent-linux.mdx
@@ -63,7 +63,7 @@ To install the agent:
 1. Download the [packaged agent file](https://download.newrelic.com/infrastructure_agent/binaries/linux/) or use the following command that automatically fetches a specific version of the agent, its checksum and verifies it after download. Replace `ARCH=amd64` with desired architecture (amd64, 386, arm64, arm) and `V=1.27.4` with [latest or specific version](https://github.com/newrelic/infrastructure-agent/releases/latest).
 
    ```shell
-   V=1.27.4 ARCH=amd64; echo "https://download.newrelic.com/infrastructure_agent/binaries/linux/${ARCH}/newrelic-infra_linux_${V}_amd64.tar.gz" | { read    url; wget "${url}"{,.sum}; shasum -a 256 --check ${url##*/}.sum; }
+   V=1.27.4 ARCH=amd64; echo "https://download.newrelic.com/infrastructure_agent/binaries/linux/${ARCH}/newrelic-infra_linux_${V}_${ARCH}.tar.gz" | { read    url; wget "${url}"{,.sum}; shasum -a 256 --check ${url##*/}.sum; }
    ```
 
    From version `1.27.4` on, we provide the `tar.gz` package GPG signature. You can check the signature procedure and instructions for


### PR DESCRIPTION
Currently, the architecture in the manual installation one-liner is set to `amd64` . This PR replaces it with the `ARCH` variable.