### PR TITLE
Update external-services-setup.mdx

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
@@ -29,6 +29,10 @@ Complete the following for each service you want to view in external services:
       </th>
 
       <th>
+        Required Version
+      </th>
+      
+      <th>
         Setup
       </th>
     </tr>
@@ -40,6 +44,10 @@ Complete the following for each service you want to view in external services:
       <td>
         Go
       </td>
+      
+      <td>
+        3.6.0
+      </td>
 
       <td>
         See the documentation about using [`NewRoundTripper()`](/docs/apm/agents/go-agent/instrumentation/instrument-go-segments/).
@@ -50,6 +58,10 @@ Complete the following for each service you want to view in external services:
       <td>
         Java
       </td>
+      
+      <td>
+        5.13.0
+      </td>
 
       <td>
         See the documentation about using the [Java agent API](/docs/apm/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks/) to instrument external calls.
@@ -59,6 +71,10 @@ Complete the following for each service you want to view in external services:
     <tr>
       <td>
         .NET
+      </td>
+      
+      <td>
+        8.29.0
       </td>
 
       <td>
@@ -73,6 +89,10 @@ Complete the following for each service you want to view in external services:
       <td>
         Node.js
       </td>
+      
+      <td>
+        6.9.0
+      </td>
 
       <td>
         See the documentation about using the [Node.js agent API](/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api/#external-services).
@@ -82,6 +102,10 @@ Complete the following for each service you want to view in external services:
     <tr>
       <td>
         PHP
+      </td>
+      
+      <td>
+        9.12.0.268
       </td>
 
       <td>
@@ -93,6 +117,10 @@ Complete the following for each service you want to view in external services:
       <td>
         Python
       </td>
+      
+      <td>
+        5.14.0.142
+      </td>
 
       <td>
         No extra steps are necessary: External calls are instrumented automatically.
@@ -102,6 +130,10 @@ Complete the following for each service you want to view in external services:
     <tr>
       <td>
         Ruby
+      </td>
+      
+      <td>
+        6.12.0.367
       </td>
 
       <td>


### PR DESCRIPTION
Add required agent versions

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

In general, even after we fix an ingest bug, any customers using old agent versions will not have correct transaction names on their spans. This docs updates provides the required agent versions for external services to be registered properly.