### PR TITLE
chore: remove isTutorial logic and frontmatter

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -364,7 +364,6 @@ exports.createSchemaCustomization = ({ actions }) => {
     isFeatured: Boolean
     translationType: String
     dataSource: String
-    isTutorial: Boolean
     hideNavs: Boolean
     downloadLink: String
     signupBanner: SignupBanner
@@ -414,10 +413,6 @@ exports.createResolvers = ({ createResolvers }) => {
       dataSource: {
         resolve: (source) =>
           hasOwnProperty(source, 'dataSource') ? source.dataSource : null,
-      },
-      isTutorial: {
-        resolve: (source) =>
-          hasOwnProperty(source, 'isTutorial') ? source.isTutorial : null,
       },
       hideNavs: {
         resolve: (source) =>

--- a/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
+++ b/plugins/gatsby-plugin-generate-doc-json/gatsby-node.js
@@ -38,9 +38,6 @@ exports.onPostBuild = async ({ graphql, store }) => {
           mdxAST
           slug
           body
-          frontmatter {
-            isTutorial
-          }
         }
       }
       allImageSharp {
@@ -68,11 +65,7 @@ exports.onPostBuild = async ({ graphql, store }) => {
     {}
   );
 
-  const filteredMdx = allMdx.nodes.filter((mdx) => {
-    return mdx.frontmatter.isTutorial !== true;
-  });
-
-  filteredMdx.forEach((node) => {
+  allMdx.forEach((node) => {
     const { body: mdxBody, slug, mdxAST } = node;
 
     const filepath = path.join(program.directory, 'public', `${slug}.json`);

--- a/src/content/docs/more-integrations/terraform/terraform-intro.mdx
+++ b/src/content/docs/more-integrations/terraform/terraform-intro.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Getting started with New Relic and Terraform'
 metaDescription: 'Learn how to provision New Relic resources using [Terraform](https://www.terraform.io/).'
-isTutorial: true
 ---
 
 [Terraform](https://www.terraform.io/) is a popular infrastructure-as-code software tool built by HashiCorp. You use it to provision all kinds of infrastructure and services, including New Relic dashboards and alerts.

--- a/src/content/docs/more-integrations/terraform/terraform-modules.mdx
+++ b/src/content/docs/more-integrations/terraform/terraform-modules.mdx
@@ -2,7 +2,6 @@
 title: 'Using Terraform Modules and Remote Storage'
 template: 'GuideTemplate'
 metaDescription: 'Learn how to use [Terraform](https://www.terraform.io/) modules in your configurations and store them remotely.'
-isTutorial: true
 ---
 
 [Terraform](https://www.terraform.io/) is a popular infrastructure-as-code software tool built by HashiCorp. You use it to provision all kinds of infrastructure and services, including New Relic dashboards and alerts.

--- a/src/content/docs/more-integrations/terraform/terragrunt.mdx
+++ b/src/content/docs/more-integrations/terraform/terragrunt.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Using Terragrunt to Manage Multiple Environments'
 metaDescription: 'Learn how to use [Terragrunt](https://www.terraform.io/) to manage configurations in multiple environments'
-isTutorial: true
 ---
 
 [Terraform](https://www.terraform.io/) is a popular infrastructure-as-code software tool built by HashiCorp. You use it to provision all kinds of infrastructure and services, including New Relic dashboards and alerts.

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -25,7 +25,6 @@ redirects:
   - /docs/new-relic-solutions/get-started/quick-launch-guide
 signupBanner:
   text: Monitor and improve your entire stack. 100GB free. Forever.
-isTutorial: true
 ---
 
 import apmGrafana from 'images/apm_logo_grafana-.png'

--- a/src/content/docs/style-guide/structure/steps.mdx
+++ b/src/content/docs/style-guide/structure/steps.mdx
@@ -1,6 +1,5 @@
 ---
 title: Steps
-isTutorial: true
 tags:
   - Basic style guide
   - Style guide quick reference
@@ -14,7 +13,6 @@ There are three things to note when using the step component:
 
 * All step procedures begin with `<Steps>` and are closed with `</Steps>`
 * Each individual step begins with `<Step>` and is closed with `</Step>`
-* All docs that use step components need `isTutorial: true` in their frontmatter
 
 ## Example
 
@@ -24,7 +22,6 @@ This is the syntax for a doc with the step component. Below that you can see the
 
 ---
 title: Coffee grinding
-isTutorial: true
 ---
 How to grind coffee:
 

--- a/src/i18n/content/jp/docs/more-integrations/terraform/terraform-intro.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/terraform/terraform-intro.mdx
@@ -1,7 +1,6 @@
 ---
 title: New Relic と Terraform を使い始める
 metaDescription: 'Learn how to provision New Relic resources using [Terraform](https://www.terraform.io/).'
-isTutorial: true
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/terraform/terraform-modules.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/terraform/terraform-modules.mdx
@@ -2,7 +2,6 @@
 title: Terraform モジュールとリモート ストレージの使用
 template: GuideTemplate
 metaDescription: 'Learn how to use [Terraform](https://www.terraform.io/) modules in your configurations and store them remotely.'
-isTutorial: true
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/terraform/terragrunt.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/terraform/terragrunt.mdx
@@ -1,7 +1,6 @@
 ---
 title: Terragrunt を使用して複数の環境を管理する
 metaDescription: 'Learn how to use [Terragrunt](https://www.terraform.io/) to manage configurations in multiple environments'
-isTutorial: true
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/terraform/terraform-intro.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/terraform/terraform-intro.mdx
@@ -1,7 +1,6 @@
 ---
 title: New Relic 및 Terraform 시작하기
 metaDescription: 'Learn how to provision New Relic resources using [Terraform](https://www.terraform.io/).'
-isTutorial: true
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/terraform/terraform-modules.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/terraform/terraform-modules.mdx
@@ -2,7 +2,6 @@
 title: Terraform 모듈 및 원격 저장소 사용
 template: GuideTemplate
 metaDescription: 'Learn how to use [Terraform](https://www.terraform.io/) modules in your configurations and store them remotely.'
-isTutorial: true
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/terraform/terragrunt.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/terraform/terragrunt.mdx
@@ -1,7 +1,6 @@
 ---
 title: Terragrunt를 사용하여 여러 환경 관리
 metaDescription: 'Learn how to use [Terragrunt](https://www.terraform.io/) to manage configurations in multiple environments'
-isTutorial: true
 translationType: machine
 ---
 

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -71,19 +71,14 @@ const BasicDoc = ({ data, location, pageContext }) => {
     title,
     metaDescription,
     tags,
+    type,
     translationType,
     dataSource,
-    isTutorial,
     signupBanner,
   } = frontmatter;
 
-  let { type } = frontmatter;
-
   if (typeof window !== 'undefined' && typeof newrelic === 'object') {
     window.newrelic.setCustomAttribute('pageType', 'Template/DocPage');
-  }
-  if (isTutorial) {
-    type = 'tutorial';
   }
 
   const { loggedIn } = useLoggedIn();
@@ -228,7 +223,6 @@ export const pageQuery = graphql`
         metaDescription
         type
         tags
-        isTutorial
         translationType
         dataSource
         signupBanner {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,7 +3,6 @@ export const TYPES = {
     default: 'page',
     apiDoc: 'api_doc',
     troubleshooting: 'troubleshooting_doc',
-    tutorial: 'tutorial_doc',
   },
   LANDING_PAGE: 'term_page_landing_page',
   RELEASE_NOTE: 'release_notes',


### PR DESCRIPTION
Now that we are using embed pages in nr1-help-xp, we don't have to care about new components going through our DLS. 

This PR
* removes all isTutorial type logic
* removes all uses of the isTutorial frontmatter in MDX
* Updates the style-guide