### PR TITLE
.NET Agent metadata update

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-62700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-62700.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2021-01-28'
 version: 6.27.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/6.x_release/'
+features: ['Continue to support .NET Framework 4.5 and below']
+bugs: []
+security: []
 ---
 
 ### Notes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8266300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8266300.mdx
@@ -5,6 +5,9 @@ version: 8.26.630.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs/release-notes/agent-release-notes/net-release-notes/net-agent-8262300
+features: ['Add Infinite Tracing feature', 'Add Error Attributes to Span Events']
+bugs: ['Fix InstrumentAllNETFramework option on MSI installs', 'Fix incompatibility with Azure App Service and Kudu on Linux', 'Better handle Ignored Errors', 'Fix possible exception when instrumenting StackExchange.Redis']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8271390.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8271390.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2020-04-30'
 version: 8.27.139.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add support for W3C Trace Context']
+bugs: ['Fix incompatibility between Synthetics and Distributed Tracing', 'Remove unnecessary dependencices on RPM-based Linux distros', 'Correctly report TransportDuration metric']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8280.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8280.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2020-06-04'
 version: 8.28.0.0
+features: []
+bugs: ['Improve performance of Infinite Tracing', 'Fix issue tracking transactions across threads', 'Fix exception with some MVC controller actions', 'Always report Error Events with Error Traces']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-82900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-82900.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2020-06-25'
 version: 8.29.0.0
+features: ['Add Request Parameters and other attributes to Span Events']
+bugs: ['Fix potential crash when updating custom instrumentation at runtime']
+security: []
 ---
 
 ### New Features
@@ -11,7 +14,8 @@ version: 8.29.0.0
   1. Request Parameters request.parameter.\*
   2. Custom Attribute Values applied to the Transaction via API Calls AddCustomParameter and ITransaction.AddCustomAttribute.
   3. request.uri
-  4. response.status 5 host.displayName
+  4. response.status
+  5. host.displayName
 * Security Recommendation Review your [Transaction Attributes](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#transaction_events) configuration. Any attribute include or exclude settings specific to Transaction Events, should be applied to your [Span Attributes](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#span_events) configuration or your [Global Attributes](https://docs.newrelic.com/docs/agents/net-agent/configuration/net-agent-configuration#agent-attributes) configuration.
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83000.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2020-07-16'
 version: 8.30.0.0
+features: ['Convert the .NET Agent to an open source project']
+bugs: ['Correctly report memory usage on Linux', 'Improve Infinite Tracing performance', 'Allow configuration changes at runtime on .NET 5']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83100.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2020-08-17'
 version: 8.31.0.0
+features: ['Add support for Expected Errors', 'Add more configuration options for Ignored Errors']
+bugs: ['Correctly report garbage collection metrics on Windows', 'Prevent overwriting config file on Linux upgrade']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83200.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83200.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2020-09-16'
 version: 8.32.0.0
+features: ['Allow obfuscating proxy password', 'Add instrumentation for MySqlConnector ADO.NET driver', 'Allow nullable reference types in the Agent API', 'Improve support for NetTCP Binding in WCF']
+bugs: ['Fix potential exception with MVC 3', 'Fix timing of some async methods']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83902.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-83902.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2021-04-14'
 version: 8.39.2.0
+features: []
+bugs: ['Always include Error attribute even if no errors', 'Fix setting to disable stack traces']
+security: []
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84010.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84010.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2021-07-08'
 version: 8.40.1.0
+features: []
+bugs: ['Fix missing data when using Infinite Tracing and SendDataOnExit', 'No longer record a transaction for invalid MVC actions', 'Correct transaction name around attribute-based routing', 'Correctly handle OPTIONS requests', 'Report missing external calls in WCF services', 'Ignore Kudu on Linux Azure', 'Fix startup failure due to invalid config file', 'Always report thread ID in Agent log', 'Fix failures in creating SQL Explain Plans']
+security: []
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84100.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2021-07-21'
 version: 8.41.0.0
+features: ['Capture HTTP request method on transactions', 'Capture stack traces in Transaction Traces', 'Report name configuration in Environment data']
+bugs: ['No longer delete user headers from RabbitMQ messages']
+security: []
 ---
 
 ## New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-84110.mdx
@@ -2,6 +2,9 @@
 subject: .NET agent
 releaseDate: '2021-08-25'
 version: 8.41.1.0
+features: []
+bugs: ['Fix gRPC error on disconnect', 'Allow setting stack trace depth to 0 to disable']
+security: []
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9000.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2021-09-16'
 version: 9.0.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Enable Distributed Tracing by default', 'Allow configuration of number of span event samples', 'Allow setting log level and directory by environment variable', 'Deprecate Cross Application Tracing, support for Castle.Monorail, and some Agent APIs']
+bugs: ['Fix missing SQL Explain Plans', 'Fix serialization error with some custom attributes', 'Reduce install size']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9100.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2021-10-26'
 version: 9.1.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/previous_releases'
+features: ['Add support for Linux ARM64/AWS Graviton2']
+bugs: ['Fix potential startup hang when using Microsoft.Configuration.ConfigurationBuilders']
+security: []
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9110.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2021-11-02'
 version: 9.1.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: []
+bugs: ['Reduce gRPC traffic on connection failure', 'Install correct gRPC binaries with MSI installer']
+security: []
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9200.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9200.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2021-11-18'
 version: 9.2.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add support for .NET 6', 'Add instrumentation for Microsoft.Azure.Cosmos', 'Add additional Garbage Collection metrics']
+bugs: ['Fix thread safety issue with HttpClient', 'Accurately report .NET Framework version in Environment data']
+security: []
 ---
 
 ### .NET 6 Compatibility

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9500.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9500.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-02-01'
 version: 9.5.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Use same Profiler for .NET Framework and .NET Core']
+bugs: ['Fix inaccurate NuGet package metadata']
+security: []
 ---
 
 <Callout variant="caution">


### PR DESCRIPTION
Adds `features`, `bugs`, and `security` fields to front matter in release notes for currently supported versions of the .NET Agent.

Note: There will be a second PR with additional updated release notes.