### PR TITLE
Add metadata to .NET release notes (Part Deux)

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-0-0.mdx
@@ -5,6 +5,9 @@ version: 10.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10000
+features: ['Add Log Forwarding support for Microsoft.Extensions.Logging in .NET framework applications', 'Report all non-sensitive configuration options during agent connect']
+bugs: ['Resolve situation where the slowest transaction trace was not always reported', 'Add SMSvcHost.exe to internal agent ignore list', 'Update Application Logging attribute log.level to be level']
+security: []
 ---
 
 **Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-1-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-1-0.mdx
@@ -5,6 +5,9 @@ version: 10.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1010
+features: ['Add support for label creation via application configuration files', 'Log agent environment variables at debug level during startup', 'Capture and forward exception details for log events', 'Add new API to set the segment or span name']
+bugs: ['Fix intermittent logs in async scenarios', 'Properly calculate event pool limits when configured via environment variable']
+security: ['Respect the configured log level for Microsoft.Extensions.Logging instrumentation']
 ---
 
 **Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-2-0.mdx
@@ -5,6 +5,9 @@ version: 10.2.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1020
+features: ['Add environment variable to configure SendDataOnExit', 'Send Code Level Metrics for CodeStream integration by default']
+bugs: ['Fix occasional crash during exit when using SendDataOnExit', 'Properly inject new versions of the Browser Agent script', 'Add missing instrumentation for Microsoft.Data.SqlClient', 'Fix missing log messages when local decoration was used with NLog', 'Improve serialization of complex custom attributes', 'Include additional profiler environment variables in debug startup logs', 'Resolve race condition during agent reconnect where disabled data types could breifly be sent']
+security: []
 ---
 
 ### New Features
@@ -16,7 +19,7 @@ redirects:
 * Resolves an issue where the .NET agent incorrectly injects the browser agent script inside HTML pages. [#1247](https://github.com/newrelic/newrelic-dotnet-agent/pull/1247)
 * Resolves an issue where some instrumentation was missing for `Microsoft.Data.SqlClient` in .NET Framework. [#1248](https://github.com/newrelic/newrelic-dotnet-agent/pull/1248)
 * Resolves an issue with local log decoration for NLog where the original log message was not included in the output. [#1249](https://github.com/newrelic/newrelic-dotnet-agent/pull/1249)
-* Resolves an issue where the .NET agent failed to serialize custom attributes containing some non-primtive types. [#1256](https://github.com/newrelic/newrelic-dotnet-agent/pull/1256)
+* Resolves an issue where the .NET agent failed to serialize custom attributes containing some non-primitive types. [#1256](https://github.com/newrelic/newrelic-dotnet-agent/pull/1256)
 * Includes missing profiler environment variables in debug logs during application startup. [#1255](https://github.com/newrelic/newrelic-dotnet-agent/pull/1255)
 * Resolves an issue where the .NET agent still sends up disabled event types during reconnecting period. [#1251](https://github.com/newrelic/newrelic-dotnet-agent/pull/1251)
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-3-0.mdx
@@ -5,6 +5,9 @@ version: 10.3.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1030
+features: ['Increase default limit of Custom Events per second from 10,000 to 30,000']
+bugs: []
+security: []
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-4-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-4-0.mdx
@@ -5,6 +5,9 @@ version: 10.4.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1040
+features: ['Verified support for .NET 7 applications', 'Add option to capture and forward log context data', 'Include Arm64 profiler in Agent NuGet package', 'Improve logging when attribute limits are reached']
+bugs: ['Fix potential crash when using Infinite Tracing']
+security: []
 ---
 
 <Callout variant="important">
@@ -15,7 +18,7 @@ As of this release, the oldest supported version is [.NET agent 8.22.181.0](/doc
 
 ### New Features
 * Support for .NET 7 has been verified with the GA version of the .NET 7 SDK. Please note that if you use [dynamically-created assemblies](https://learn.microsoft.com/en-us/dotnet/framework/reflection-and-codedom/emitting-dynamic-methods-and-assemblies), there is a [bug in .NET 7](https://github.com/dotnet/runtime/issues/76016) that prevents them from being instrumented at this time.
-* Application log fowarding can now be configured to capture and forward context data (also referred to as "custom attributes") to New Relic.  Details (including how to enable and configure this new feature) can be found [here](https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all/).
+* Application log fowarding can now be configured to capture and forward context data to New Relic.  Details (including how to enable and configure this new feature) can be found [here](https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all/).
 * The [NewRelic.Agent NuGet package](https://www.nuget.org/packages/NewRelic.Agent) now includes the Linux Arm64 profiler. This can be found in the `newrelic/linux-arm64` directory. Configure your `CORECLR_PROFILER_PATH` environment variable to use this version of the profiler when deploying to linux ARM64 targets.
 * When finest logs are enabled, the transaction guid will be applied to attribute limit log messages, if present.
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-5-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-5-0.mdx
@@ -5,6 +5,9 @@ version: 10.5.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1050
+features: []
+bugs: ['Improve attribute collection limit and update logic', 'Resolve issue where Agent could cause socket errors in applications using HttpClient']
+security: []
 ---
 
 <Callout variant="important">
@@ -20,8 +23,7 @@ Some of the NuGet packages from this release were incomplete and have been unpub
 </Callout>
 
 ### Fixes
-* Attribute collections in the agent will now more reliably track 
-the number of attributes contained, and allow updates to attributes that already exist in the collection when collection limits have been reached 
+* Attribute collections in the agent will now more reliably track the number of attributes contained, and allow updates to attributes that already exist in the collection when collection limits have been reached 
 (255 global attributes, 65 custom attributes). ([#1335](https://github.com/newrelic/newrelic-dotnet-agent/pull/1335))
 * The agent has been updated to use `System.Net.Http.HTTPClient` to send data to New Relic instead of `System.Net.WebRequest`, in order to fix issue [#897](https://github.com/newrelic/newrelic-dotnet-agent/issues/897), as well as remove use of a deprecated library. ([#1325](https://github.com/newrelic/newrelic-dotnet-agent/pull/1325))
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-5-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-5-1.mdx
@@ -5,6 +5,9 @@ version: 10.5.1
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1051
+features: []
+bugs: ['Add missing content to NuGet packages']
+security: []
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-6-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-6-0.mdx
@@ -5,6 +5,9 @@ version: 10.6.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
 redirects:
   - /docs.newrelic.com/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1060
+features: ['Add ability to target assembly versions in instrumentation', 'Add missing instrumentation for some versions of RestSharp', 'Log current TLS options during startup']
+bugs: ['Improve performance when instrumenting Redis']
+security: []
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-7-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-7-0.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2023-02-14'
 version: 10.7.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add instrumentation for new versions of Postgres', 'Enable gzip compression by default for Infinite Tracing']
+bugs: ['Fix race condition when using SetApplicationName API', 'Fix issue where enabling log context data could cause log forwarding to break', 'Add missing supportability metrics for Infinite Tracing']
+security: ['Upgrade from soon to be deprecated gRPC libary to one with long term future support']
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-8-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-8-0.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2023-03-14'
 version: 10.8.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Report Linux distro and version during agent connect']
+bugs: ['Fix identification of .NET Core applications running in IIS when hosted out of process']
+security: []
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9510.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9510.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-02-03'
 version: 9.5.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: []
+bugs: ['Fix application crash on Alpine Linux']
+security: []
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9600.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-02-24'
 version: 9.6.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add supportability metrics for agent data']
+bugs: []
+security: ['Use IMDSv2 to gather AWS utilization details']
 ---
 
 ### New Features

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9610.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9610.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-03-15'
 version: 9.6.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: []
+bugs: ['Fix application pool allow/deny list issue']
+security: []
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9700.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-04-04'
 version: 9.7.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add in agent log forwarding', 'Add application log metrics', 'Add in agent log decoration', 'Add flexibility to accepted values for boolean environment variables']
+bugs: ['Add environment variable to disable the use of AppDomain for method caching']
+security: []
 ---
 
 **Notice:** For the new application logging features, if you install using the MSI, please update to version 9.7.1 or later.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9710.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9710.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-04-13'
 version: 9.7.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: []
+bugs: ['Add missing application log forwarding components to MSI installer', 'Create intermediate log directories on Linux']
+security: []
 ---
 
 **Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9800.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9800.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-05-05'
 version: 9.8.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Increase maximum length of error messages to 1023 characters', 'Add environment variables for attribute filtering', 'Add environment variables to disable cloud provider detection', 'Add environment variables to configure agent proxy', 'Add configuration option to force new transactions in async scenarios']
+bugs: ['Fix capture of explain plans for parameterized stored procedures', 'Fix duplicate log instrumentation for Serilog']
+security: []
 ---
 
 **Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9810.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9810.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-05-19'
 version: 9.8.1.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: []
+bugs: ['Agent no longer intermittently forwards logs when the log forwarding is disabled at the account level', 'Ignore deprecated instrumentation to avoid duplicate data']
+security: []
 ---
 
 **Notice:** If using Microsoft.Extensions.Logging as your logging framework of choice, please use .NET agent version 10.1.0 or newer.  We encourage you to adopt the newer version due to bug [#1230](https://github.com/newrelic/newrelic-dotnet-agent/issues/1230), which we fixed in [#1237](https://github.com/newrelic/newrelic-dotnet-agent/pull/1237), that was resolved in .NET agent version 10.1.0.

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9900.mdx
@@ -3,6 +3,9 @@ subject: .NET agent
 releaseDate: '2022-06-08'
 version: 9.9.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add log instrumentation for NLog', 'Add support for code level metrics CodeStream integration', 'Installers now clean up deprecated instrumentation']
+bugs: ['Properly report application logging configuration during agent connect']
+security: ['Upgrade Newtonsoft.Json to v13.0.1']
 ---
 
 <Callout variant="important">


### PR DESCRIPTION
Adds `features`, `bugs`, and `security` fields to front matter in release notes for currently supported versions of the .NET Agent.

Relates to #12182