### PR TITLE
Incorrect link to Ansible Automation page

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/ansible-controller-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/ansible-controller-integration.mdx
@@ -184,7 +184,7 @@ FROM Metric SELECT latest(awx_pending_jobs_total) AS 'Pending Jobs', latest(awx_
 
 ## See Ansible Automation Controller metrics in a dashboard [#dash]
 
-With the infrastructure agent installed and instrumented with your app, you can view your raw data in our **Metrics & events**. Our default dashboards transform that raw data into charts and graphs, which provide a bird's eye view of your system's health. To install our default dashboards, go to our Ansible Automation Controller [instant observability page](https://newrelic.com/instant-observability/ansible).
+With the infrastructure agent installed and instrumented with your app, you can view your raw data in our **Metrics & events**. Our default dashboards transform that raw data into charts and graphs, which provide a bird's eye view of your system's health. To install our default dashboards, go to our Ansible Automation Controller [instant observability page](https://newrelic.com/instant-observability/ansible-automation-controller).
 
 ## What's next?
 


### PR DESCRIPTION
Modified the link to the observability page from https://newrelic.com/instant-observability/ansible to https://newrelic.com/instant-observability/ansible-automation-controller

