### PR TITLE
Browser agent v1228 release notes & EOL

### DIFF
--- a/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
+++ b/src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
@@ -29,6 +29,20 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v1228
+      </td>
+
+      <td>
+        Mar 21, 2023
+      </td>
+
+      <td>
+        Mar 21, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v1227
       </td>
 

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-v1228.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-v1228.mdx
@@ -1,0 +1,10 @@
+---
+subject: Browser agent
+releaseDate: '2023-03-21'
+version: '1228'
+---
+
+## Bug Fixes
+
+### Fix negative offset timings
+Fix an issue that caused session trace offset timings to be miscalculated in the early-page lifecycle, sometimes leading to negative "backend" timings.


### PR DESCRIPTION
- Adds release notes for browser agent version 1227.
- Adds EOL entry for browser agent version 1227.