### PR TITLE
Update crash-analysis-group-filter-your-crashes.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes.mdx
@@ -187,10 +187,11 @@ Resolved crashes include a banner identifying who resolved the crash and when. B
   >
     From the **Crash types** table, you can drill down into a specific [crash type](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report). From here you can:
 
-    * Examine the [interaction trail](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/interactions-page) from session start through the crash event.
     * Explore the related thread breakdown.
     * Select **Export crash details** so you can examine source code using Xcode.
-    * Resymbolicate the crash report for easier debugging.
+    * Click the View crash libraries button to see what Android map files or iOS .dSYMs we have on file for your application.
+    * Not seeing what you expect, upload a new Android map file or iOS .dSYM by clicking on the Upload link.
+    * Uploading a new file will automatically deobfuscate or symbolicate your crass occurrence.
     * File a ticket, and resolve the crash.
 
       <img
@@ -200,7 +201,7 @@ Resolved crashes include a banner identifying who resolved the crash and when. B
       />
 
       <figcaption>
-        **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile > (select an app) > Crashes > Crash type > (select a crash) > (scroll down to **Stack trace and interaction trail**):** This is an example of an interaction trail that includes the option to resymbolicate the crash occurrence. To analyze and debug your source code using Xcode, select **Export crash details**.
+        **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile > (select an app) > Crashes > Crash type > (select a crash):** This is an example of a stack trace and event trail that includes the option to upload a new Android map file or additional iOS .dSYM files. To analyze and debug your source code using Xcode, select **Export crash details**.
       </figcaption>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes.mdx
@@ -189,9 +189,8 @@ Resolved crashes include a banner identifying who resolved the crash and when. B
 
     * Explore the related thread breakdown.
     * Select **Export crash details** so you can examine source code using Xcode.
-    * Click the View crash libraries button to see what Android map files or iOS .dSYMs we have on file for your application.
-    * Not seeing what you expect, upload a new Android map file or iOS .dSYM by clicking on the Upload link.
-    * Uploading a new file will automatically deobfuscate or symbolicate your crass occurrence.
+    * Click the **View crash libraries** button to see what Android map files or iOS .dSYM files we have for your application.
+    * If you don't see the files you're expecting, upload a new Android map file or iOS .dSYM fieles by clicking on the **Upload** link. Note that uploading a new file automatically de-obfuscates or symbolicate your crass occurrence.
     * File a ticket, and resolve the crash.
 
       <img


### PR DESCRIPTION

<img width="1827" alt="crash_anaysis_nr1" src="https://user-images.githubusercontent.com/51837529/226712302-85e140b2-8eeb-4fd0-bb49-96c126142020.png">
From mobile ui team for changes in crash analysis

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? Updates to crash analysis UI
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc. I added a screen shot that I think should go where the `mobileStackTraceAndInteractionTrail` image is now.
* If your issue relates to an existing GitHub issue, please link to it.