### PR TITLE
Add Python Agent Metadata

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5120140.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5120140.mdx
@@ -5,6 +5,9 @@ version: 5.12.0.140
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 redirects:
   - /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5120139
+features: ['Adds a new product called Infinite Tracing']
+bugs: ['Fix record transaction failure in async applications']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
@@ -4,7 +4,7 @@ releaseDate: '2020-05-04'
 version: 5.12.1.141
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []
-bugs: ['AIOHTTP http client urls displayed as unknown.url when using YARL URLs', 'Data may not be recorded when tornado's RequestHandler.finish', 'asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions', 'py3: A runtime instrumentation error may have occurred when transactions were finalized', 'Application crash when starting a transaction when one is already active', 'Creating a message transaction with distributed tracing enabled may have resulted in a crash']
+bugs: ['AIOHTTP http client urls displayed as unknown.url when using YARL URLs', 'Data may not be recorded when tornado's RequestHandler.finish', 'asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions', 'py3 - A runtime instrumentation error may have occurred when transactions were finalized', 'Application crash when starting a transaction when one is already active', 'Creating a message transaction with distributed tracing enabled may have resulted in a crash']
 security: []
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
@@ -4,7 +4,7 @@ releaseDate: '2020-05-04'
 version: 5.12.1.141
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []
-bugs: ['AIOHTTP http client urls displayed as unknown.url when using YARL URLs', 'Data may not be recorded when tornado's RequestHandler.finish', 'asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions', 'py3 - A runtime instrumentation error may have occurred when transactions were finalized', 'Application crash when starting a transaction when one is already active', 'Creating a message transaction with distributed tracing enabled may have resulted in a crash']
+bugs: ['AIOHTTP http client urls displayed as unknown.url when using YARL URLs', "Data may not be recorded when tornado's RequestHandler.finish", 'asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions', 'py3 - A runtime instrumentation error may have occurred when transactions were finalized', 'Application crash when starting a transaction when one is already active', 'Creating a message transaction with distributed tracing enabled may have resulted in a crash']
 security: []
 ---
 
@@ -12,25 +12,30 @@ security: []
 
 This release of the Python agent includes bug fixes.
 
-The agent can be installed using easy_install/pip/distribute via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or can be downloaded directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
+The agent can be installed using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or can be downloaded directly from the New Relic [download site](http://download.newrelic.com/python_agent/release).
 
 ## Bug fixes
 
-* **AIOHTTP http client urls displayed as unknown.url when using YARL URLs**
+* **AIOHTTP http client urls displayed as `unknown.url` when using YARL URLs**
 
   When passing a YARL url object to the aiohttp client, the agent did not properly parse this URL, resulting in unknown.url being displayed in the UI. The URL is now parsed correctly in both the YARL url case and the string url case.
-* **Data may not be recorded when tornado's RequestHandler.finish**
 
-  Using RequestHandler.finish in tornado caused the transaction to exit before all traces (inserted by automatic instrumentation) were complete, resulting in missing data. All traces now exit when RequestHandler.finish is called.
-* **asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions**
+* **Data may not be recorded when tornado's `RequestHandler.finish`**
 
-  Calling asyncio.create_task / asyncio.ensure_future was unable to spawn a new transaction if these methods were called from within an existing transaction. New transactions can now be created when ensure_future/create_task is called from within an existing transaction and no traces have been started on the spawned task.
+  Using `RequestHandler.finish` in tornado caused the transaction to exit before all traces (inserted by automatic instrumentation) were complete, resulting in missing data. All traces now exit when `RequestHandler.finish` is called.
+
+* **`asyncio.ensure_future` / `asyncio.create_task` is unable to spawn new transactions**
+
+  Calling `asyncio.create_task` / `asyncio.ensure_future` was unable to spawn a new transaction if these methods were called from within an existing transaction. New transactions can now be created when `ensure_future`/`create_task` is called from within an existing transaction and no traces have been started on the spawned task.
+
 * **py3: A runtime instrumentation error may have occurred when transactions were finalized**
 
   When transactions became garbage (if the reference to the transaction was lost as part of a circular reference for example), a runtime instrumentation error may have been logged. The error conditions have been relaxed to allow for certain states within the agent when a transaction becomes garbage.
+
 * **Application crash when starting a transaction when one is already active**
 
   Starting a transaction via the context manager APIs when a transaction is already active no longer causes an application crash. An error is logged when this case is detected.
+
 * **Creating a message transaction with distributed tracing enabled may have resulted in a crash**
 
-  The agent crashed with an AttributeError when using message transactions with distributed tracing enabled when headers were not provided. This error has been fixed.
+  The agent crashed with an `AttributeError` when using message transactions with distributed tracing enabled when headers were not provided. This error has been fixed.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
@@ -4,7 +4,7 @@ releaseDate: '2020-05-04'
 version: 5.12.1.141
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []
-bugs: ['AIOHTTP http client urls displayed as unknown.url when using YARL URLs', "Data may not be recorded when tornado's RequestHandler.finish", 'asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions', 'py3 - A runtime instrumentation error may have occurred when transactions were finalized', 'Application crash when starting a transaction when one is already active', 'Creating a message transaction with distributed tracing enabled may have resulted in a crash']
+bugs: ['Fix AIOHTTP http client urls displayed as unknown.url when using YARL URLs', 'Fix data not being recorded when using tornado's RequestHandler.finish', 'Fix asyncio.ensure_future / asyncio.create_task being unable to spawn new transactions', 'Fix a runtime instrumentation error occurring when transactions were finalized on Python 3', 'Fix application crash when starting a transaction when one is already active', 'Fix a crash when creating a message transaction with distributed tracing enabled']
 security: []
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
@@ -4,7 +4,7 @@ releaseDate: '2020-05-04'
 version: 5.12.1.141
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []
-bugs: ['Fix AIOHTTP http client urls displayed as unknown.url when using YARL URLs', 'Fix data not being recorded when using tornado's RequestHandler.finish', 'Fix asyncio.ensure_future / asyncio.create_task being unable to spawn new transactions', 'Fix a runtime instrumentation error occurring when transactions were finalized on Python 3', 'Fix application crash when starting a transaction when one is already active', 'Fix a crash when creating a message transaction with distributed tracing enabled']
+bugs: ['Fix AIOHTTP http client urls displayed as unknown.url when using YARL URLs', "Fix data not being recorded when using tornado's RequestHandler.finish", 'Fix asyncio.ensure_future / asyncio.create_task being unable to spawn new transactions', 'Fix a runtime instrumentation error occurring when transactions were finalized on Python 3', 'Fix application crash when starting a transaction when one is already active', 'Fix a crash when creating a message transaction with distributed tracing enabled']
 security: []
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5121141.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-05-04'
 version: 5.12.1.141
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['AIOHTTP http client urls displayed as unknown.url when using YARL URLs', 'Data may not be recorded when tornado's RequestHandler.finish', 'asyncio.ensure_future / asyncio.create_task is unable to spawn new transactions', 'py3: A runtime instrumentation error may have occurred when transactions were finalized', 'Application crash when starting a transaction when one is already active', 'Creating a message transaction with distributed tracing enabled may have resulted in a crash']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5140142.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5140142.mdx
@@ -3,8 +3,8 @@ subject: Python agent
 releaseDate: '2020-06-02'
 version: 5.14.0.142
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Add new span attribute transaction.name', 'Transaction attributes are added to the root span', 'Custom attributes are added to the root span', 'Error attributes added to each span/segment']
-bugs: ['asyncio: application crash when a transaction that started on a completed parent task exits', 'Error attributes are no longer added if the error collector is disabled']
+features: ['Add new span attribute transaction.name', 'Transaction attributes are now added to the root span', 'Custom attributes are now added to the root span', 'Error attributes are now added to each span/segment']
+bugs: ['Fix asyncio application crash when a transaction that started on a completed parent task exits', 'Error attributes are no longer added if the error collector is disabled']
 security: []
 ---
 
@@ -25,9 +25,11 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 * **Transaction attributes are added to the root span**
 
   Transaction attributes, including response attributes, are now added to the root span.
+
 * **Custom attributes are added to the root span**
 
   The public API methods `newrelic.agent.add_custom_param` and `newrelic.agent.add_custom_params` now add the specified custom attribute to the root span in addition to the transaction. If the maximum number of custom attributes is reached, span-level custom attributes take precedence over transaction-level custom attributes.
+
 * **Error attributes added to each span/segment**
 
   Error attributes `error.class` and `error.message` to all spans that exit without handling an exception.
@@ -37,6 +39,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 * **asyncio: application crash when a transaction that started on a completed parent task exits**
 
   When a transaction that started on a completed parent task exited, an exception was raised. This error has been fixed.
+
 * **Error attributes are no longer added if the error collector is disabled**
 
   If the error collector is disabled via error_collector.enabled, error attributes `error.class` and `error.message` are not added to the currently executing span.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5140142.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5140142.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-06-02'
 version: 5.14.0.142
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add new span attribute transaction.name', 'Transaction attributes are added to the root span', 'Custom attributes are added to the root span', 'Error attributes added to each span/segment']
+bugs: ['asyncio: application crash when a transaction that started on a completed parent task exits', 'Error attributes are no longer added if the error collector is disabled']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144.mdx
@@ -5,6 +5,9 @@ version: 5.14.1.144
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 redirects:
   - /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141143
+features: []
+bugs: ['When using newrelic-admin run-program on Python 2.7 applications failed to start']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141144.mdx
@@ -6,7 +6,7 @@ downloadLink: 'https://pypi.python.org/pypi/newrelic'
 redirects:
   - /docs/release-notes/agent-release-notes/python-release-notes/python-agent-5141143
 features: []
-bugs: ['When using newrelic-admin run-program on Python 2.7 applications failed to start']
+bugs: ['Fix applications failing to start when using newrelic-admin run-program on Python 2.7 applications']
 security: []
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5160145.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5160145.mdx
@@ -4,7 +4,7 @@ releaseDate: '2020-08-10'
 version: 5.16.0.145
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['The NewRelicContextFormatter now records extras', 'The agent now internally uses urllib3']
-bugs: ['Fix grpc application crash when credentials are supplied', 'Fix Tornado framework crashes when finish is called from a different task']
+bugs: ['Fix gRPC application crash when credentials are supplied', 'Fix Tornado framework crashes when finish is called from a different task']
 security: []
 ---
 
@@ -25,9 +25,10 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 ## Bug fixes
 
-* **Fix grpc application crash when credentials are supplied**
+* **Fix gRPC application crash when credentials are supplied**
 
-  When using the credentials argument, the agent's built in grpc instrumentation caused an application crash. This crash has been fixed.
+  When using the credentials argument, the agent's built in gRPC instrumentation caused an application crash. This crash has been fixed.
+
 * **Fix Tornado framework crashes when finish is called from a different task**
 
   When finish is called from a different task, applications using the Tornado framework may crash. This crash has been fixed.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5160145.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5160145.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-08-10'
 version: 5.16.0.145
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['The NewRelicContextFormatter now records extras', 'The agent now internally uses urllib3']
+bugs: ['Fix grpc application crash when credentials are supplied', 'Fix Tornado framework crashes when finish is called from a different task']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5161146.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5161146.mdx
@@ -4,7 +4,7 @@ releaseDate: '2020-08-17'
 version: 5.16.1.146
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []
-bugs: ['Data was erroneously discarded when an HTTP protocol error occurred', 'Error when installing with an incompatible setuptools_scm version']
+bugs: ['Fix data erroneously discarded when an HTTP protocol error occurred', 'Fix error when installing with an incompatible setuptools_scm version']
 security: []
 ---
 
@@ -19,6 +19,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 * **Data was erroneously discarded when an HTTP protocol error occurred**
 
   When an unexpected HTTP error occurred (such as a timeout), data was erroneously discarded. Data is now downsampled and retransmitted when an HTTP protocol error occurs.
+
 * **Error when installing with an incompatible setuptools_scm version**
 
   The version requirements were not correctly set for the setuptools_scm build time requirement, which may have resulted in an error at installation. The version requirements for setuptools_scm are now set appropriately.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5161146.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5161146.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-08-17'
 version: 5.16.1.146
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Data was erroneously discarded when an HTTP protocol error occurred', 'Error when installing with an incompatible setuptools_scm version']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5162147.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5162147.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-08-24'
 version: 5.16.2.147
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Fix invalid payloads generated when using serverless mode']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5180148.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5180148.mdx
@@ -3,9 +3,9 @@ subject: Python agent
 releaseDate: '2020-08-31'
 version: 5.18.0.148
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Adds support for ASGI applications via built in APIs']
+features: ['Add support for ASGI applications via built-in APIs']
 bugs: []
-security: ['Upgrades wrapt to 1.12.1']
+security: ['Upgrade wrapt to 1.12.1']
 ---
 
 ## Notes
@@ -19,6 +19,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 * **Adds support for ASGI applications via built in APIs**
 
   ASGI applications can now be timed via middleware-like API calls. Browser monitoring JS is automatically injected into HTML pages by the ASGI browser monitoring middleware for instrumented applications. See the asgi_application docs for details on API usage.
+
 * **Upgrades wrapt to 1.12.1**
 
   This version of the agent ships with wrapt 1.12.1.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5180148.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5180148.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-08-31'
 version: 5.18.0.148
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Adds support for ASGI applications via built in APIs']
+bugs: []
+security: ['Upgrades wrapt to 1.12.1']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5200149.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5200149.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2020-09-21'
 version: 5.20.0.149
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Adds uvicorn instrumentation', 'Adds asyncpg instrumentation', 'Adds db.operation attribute']
+bugs: []
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5200149.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-5200149.mdx
@@ -3,7 +3,7 @@ subject: Python agent
 releaseDate: '2020-09-21'
 version: 5.20.0.149
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Adds uvicorn instrumentation', 'Adds asyncpg instrumentation', 'Adds db.operation attribute']
+features: ['Add uvicorn instrumentation', 'Add asyncpg instrumentation', 'Add db.operation attribute']
 bugs: []
 security: []
 ---
@@ -19,6 +19,7 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 * **Adds uvicorn instrumentation**
 
   ASGI applications are now automatically wrapped when using the uvicorn ASGI server.
+
 * **Adds asyncpg instrumentation**
 
   Support has been added for recording database transactions when using asyncpg database client module for PostgresSQL.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
@@ -3,8 +3,8 @@ subject: Python agent
 releaseDate: '2021-05-25'
 version: 6.4.0.157
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Added new notice_error API', 'Added new expected errors feature', 'Improved NewRelicContextFormatter', 'error_collector.ignore_status_codes is now configurable in server-side configuration']
-bugs: ['Infinite tracing crash fix', 'RuntimeInstrumentationError crash removed', 'SQLite instrumentation consumes generator objects passed to executemany']
+features: ['Add new notice_error API', 'Add new expected errors feature', 'Improve NewRelicContextFormatter', 'error_collector.ignore_status_codes is now configurable in server-side configuration']
+bugs: ['Fix Infinite Tracing crash', 'Fix RuntimeInstrumentationError crash', 'Fix SQLite instrumentation consuming generator objects passed to executemany']
 security: []
 ---
 
@@ -51,7 +51,6 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
   Custom attributes now attempt JSON serialization by default and fallback to strings, meaning dictionaries and other serializable types are now supported.
 
   Thank you to [@chrislawlor](https://github.com/chrislawlor) and [@qvik-olli](https://github.com/qvik-olli) for your contributions!
-
 
 * **`error_collector.ignore_status_codes` is now configurable in server-side configuration**
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60400157.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-05-25'
 version: 6.4.0.157
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Added new notice_error API', 'Added new expected errors feature', 'Improved NewRelicContextFormatter', 'error_collector.ignore_status_codes is now configurable in server-side configuration']
+bugs: ['Infinite tracing crash fix', 'RuntimeInstrumentationError crash removed', 'SQLite instrumentation consumes generator objects passed to executemany']
+security: []
 ---
 
 ## Notes


### PR DESCRIPTION
## Give us some context

* Adds metadata for python agent release versions v5.12.0.140 - v5.20.0.149, and v6.4.0.157.
* Requires review from docs engineering team.