### PR TITLE
Update advanced-config.mdx

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1360,8 +1360,7 @@ Example:
 
 ```yaml
 devices:
-  - "@neteng-devices.yaml"
-  - "@dc-ops.yaml"
+  "@neteng-devices.yaml"
 ```
 
 The device files should use the same syntax as the standard `devices` section of the main config file, omitting the optional fields that are generated during discovery:


### PR DESCRIPTION
Removing one of the example configs because it leads users toward a bad pattern.  They should not be using multiple files for the devices lists.