### PR TITLE
Add tip/warning to the Java page similar to what the Node agent has

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -4028,6 +4028,10 @@ Depending on the growth rate, it is possible for the log file size to exceed the
     * `fine`
     * `finer`
     * `finest`
+    
+    <Callout variant="caution">
+      Do not use `debug` or `trace` logging unless New Relic Support asks you to use them. These levels of logging can generate excessive overhead. For most situations, use `info`.
+    </Callout>
 
       This setting is dynamic, so running agents will notice changes to `newrelic.yml` without a JVM restart.
   </Collapser>


### PR DESCRIPTION
Jira Link: https://issues.newrelic.com/browse/NR-99643

Copy warning from Node agent about logging levels to Java agent