### PR TITLE
NR-99637 Fix errors in the documentation

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -502,7 +502,7 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
       ```
       {
         actor {
-          entitySearch(query: "alertable is true") {
+          entitySearch(query: "alertable is TRUE") {
             results {
               entities {
                 name
@@ -518,8 +518,8 @@ Entities in NerdGraph rely on [GraphQL interfaces](/docs/apis/graphql-api/gettin
       ```graphql
       {
         actor {
-          entitySearch(query: "domain='APP' and alertable is false") {
-            results( {
+          entitySearch(query: "domain='APM' and alertable is TRUE") {
+            results {
               entities {
                 name
               }


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

It was reported that one of the request of the https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/ contains an invalid request body.

The request body was

```
{
        actor {
          entitySearch(query: "domain='APP' and alertable is false") {
            results( {
              entities {
                name
              }
            }
          }
        }
      }
```
This is wrong because there is a `(` after the word `results` and this is a syntax error. Also, the domain APP does not exist, so I'm changed this to APM.
I've also changed it to `alertable is TRUE` to make this request return results.