### PR TITLE
fix(original user pricing): clarify 'monthly prov user'

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing.mdx
@@ -116,7 +116,7 @@ Here are details about our [original user billing version](#pricing-versions):
 The following rules apply only for organizations on the original [user billing version](#pricing-versions):
 
 * **How billable users are determined.** For a calendar month, an organization is billed based on a calculation of the number of billable users for that month.
-* **Prorating in first and last month.** The count of billable users is prorated based on when a New Relic organization starts their subscription, or based on when a user becomes a full platform user (added as a full platform user or converted to one).
+* **Prorating in first and last month.** The count of billable users is prorated based on when a New Relic organization starts their subscription, or based on when a user becomes a monthly provisioned user (added as a monthly provisioned user or converted to one).
 * **Users are billable when provisioned.** A user counts as billable the moment they are set to a billable user type in New Relic. This applies regardless of whether that user has ever logged into or used New Relic.
 * **User count based on email address.** If there are multiple user records in an organization that have the same email address, for billing purposes that would count as a single user.
 * **Caveat for our original user model.** If your organization has users on our [original user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models): If a user is set as a basic user in one account in the organization and as a billable user in another account, the billable user status takes precedence.
@@ -128,6 +128,6 @@ The following rules apply only for organizations on the original [user billing v
   >
 The following user downgrade rules apply for organizations on the [original user billing version](#pricing-versions):
 
-User type is meant to be a fairly long-term setting based on a user's expected New Relic duties and responsibilities. For that reason, a full platform user may only be downgraded a maximum of two times in a 12-month period. If a user's user type has changed more than this allowed number of changes, New Relic can charge that user as a full platform user.
+User type is meant to be a fairly long-term setting based on a user's expected New Relic duties and responsibilities. For that reason, a monthly provisioned user may only be downgraded a maximum of two times in a 12-month period. If a user's user type has changed more than this allowed number of changes, New Relic can charge that user as a monthly provisioned user.
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
some clarifications, for non-Core user billing model, how we refer to 'monthly provisioned user'.