### PR TITLE
feat: add `variant`s to DocTiles

### DIFF
--- a/src/components/DocTile.js
+++ b/src/components/DocTile.js
@@ -3,122 +3,165 @@ import { Icon, Surface, Tag } from '@newrelic/gatsby-theme-newrelic';
 import cx from 'classnames';
 import SurfaceLink from './SurfaceLink';
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { animated, useTrail } from 'react-spring';
 
 export const DocTile = ({
   children,
-  forceLightMode = false,
   path,
   instrumentation,
   label,
   date,
   number,
   className,
-}) => (
-  <SurfaceLink
-    base={Surface.BASE.SECONDARY}
-    to={path}
-    interactive
-    instrumentation={instrumentation}
-    className={cx({ forceLightMode }, className)}
-    css={css`
-      display: block;
-      min-height: 130px;
-      border-radius: 4px;
-      background: var(--secondary-background-color);
-
-      &.forceLightMode {
-        background: var(--system-background-surface-1-light);
-      }
-      &.forceLightMode * {
-        color: var(--system-text-primary-light);
-      }
-    `}
-  >
-    <div
+  title,
+}) => {
+  const body = title ? (
+    <>
+      <h3
+        css={css`
+          display: flex;
+          gap: 1rem;
+          font-size: 20px;
+          align-items: center;
+          margin-bottom: 0;
+          .doc-tiles-labs & {
+            gap: 0.5ch;
+          }
+        `}
+      >
+        {number && <Number>{number}</Number>}
+        {title}
+      </h3>
+      <p
+        css={css`
+          color: currentColor;
+          font-size: 18px;
+          margin-bottom: 0.8rem;
+        `}
+      >
+        {children}
+      </p>
+    </>
+  ) : (
+    <h4
       css={css`
+        font-weight: 400;
+        font-size: 20px;
         display: flex;
-        flex-direction: column;
-        height: 100%;
-        justify-content: space-between;
-        align-items: space-between;
+        gap: 1rem;
+        margin-bottom: 1rem;
+      `}
+    >
+      {number && <Number>{number}</Number>}
+      {children}
+    </h4>
+  );
+
+  return (
+    <SurfaceLink
+      base={Surface.BASE.SECONDARY}
+      to={path}
+      interactive
+      instrumentation={instrumentation}
+      className={className}
+      css={css`
+        color: var(--primary-text-color);
+        display: block;
+        min-height: 130px;
+        border-radius: 4px;
         padding: 2rem;
+        &:hover {
+          color: var(--primary-text-color);
+        }
 
         @media screen and (max-width: 650px) {
           padding: 1.5rem;
         }
+
+        .doc-tiles-default & {
+          background: var(--secondary-background-color);
+        }
+
+        .doc-tiles-labs & {
+          background: var(--primary-background-color);
+          font-size: 20px;
+          padding: 1rem;
+          & h3 {
+            margin-bottom: 1rem;
+          }
+          & h4 {
+            gap: 0.5rem;
+          }
+        }
+        .dark-mode .doc-tiles-labs & {
+          background: var(--primary-hover-color);
+        }
+
+        .doc-tiles-light & {
+          background: var(--system-background-surface-1-light);
+        }
+        .doc-tiles-light & * {
+          color: var(--system-text-primary-light);
+        }
       `}
     >
-      <h4
-        css={css`
-          font-weight: 400;
-          font-size: 20px;
-          display: flex;
-          gap: 1rem;
-          margin-bottom: 1rem;
-        `}
-      >
-        {number && (
-          <span
-            css={css`
-              flex: none;
-              display: inline-flex;
-              justify-content: center;
-              align-items: center;
-              height: 2rem;
-              width: 2rem;
-              border-radius: 50%;
-              background: var(--brand-button-primary-accent);
-              color: var(--system-text-primary-light);
-            `}
-          >
-            {number}
-          </span>
-        )}
-        {children}
-      </h4>
       <div
         css={css`
           display: flex;
+          flex-direction: column;
+          height: 100%;
           justify-content: space-between;
+          align-items: space-between;
         `}
       >
-        {label && (
-          <Tag
-            css={css`
-              background: ${label.color};
-              color: var(--system-text-primary-light);
-
-              .dark-mode & {
+        {body}
+        <div
+          css={css`
+            display: flex;
+            justify-content: space-between;
+          `}
+        >
+          {label && (
+            <Tag
+              css={css`
                 background: ${label.color};
                 color: var(--system-text-primary-light);
-              }
-            `}
-          >
-            {label.text}
-          </Tag>
-        )}
-        {date && (
-          <Tag
+
+                .dark-mode & {
+                  background: ${label.color};
+                  color: var(--system-text-primary-light);
+                }
+              `}
+            >
+              {label.text}
+            </Tag>
+          )}
+          {date && (
+            <Tag
+              css={css`
+                color: var(--primary-text-color);
+              `}
+            >
+              {date}
+            </Tag>
+          )}
+          <Icon
+            name="fe-arrow-right"
             css={css`
               color: var(--primary-text-color);
+              margin-left: auto;
+              .doc-tiles-labs & {
+                display: none;
+              }
             `}
-          >
-            {date}
-          </Tag>
-        )}
-        <Icon
-          name="fe-arrow-right"
-          css={css`
-            color: var(--primary-text-color);
-            margin-left: auto;
-          `}
-        />
+          />
+        </div>
       </div>
-    </div>
-  </SurfaceLink>
-);
+    </SurfaceLink>
+  );
+};
 
 DocTile.propTypes = {
   label: PropTypes.array,
@@ -127,7 +170,6 @@ DocTile.propTypes = {
   path: PropTypes.string,
   number: PropTypes.number,
   className: PropTypes.string,
-  forceLightMode: PropTypes.bool,
 };
 
 const SPRING = { tension: 186, friction: 16 };
@@ -137,6 +179,7 @@ export const DocTiles = ({
   animated: isAnimated,
   children,
   numbered = false,
+  variant = 'default',
 }) => {
   const trails = useTrail(children.length, {
     config: SPRING,
@@ -170,12 +213,17 @@ export const DocTiles = ({
         grid-template-columns: repeat(auto-fit, minmax(255px, 1fr));
         grid-auto-rows: 1fr;
         grid-gap: 1rem;
+        margin: 1rem 0;
+
+        &.doc-tiles-labs {
+          grid-template-columns: 1fr;
+        }
+
         a {
           margin: 0;
         }
-        margin: 1rem 0;
       `}
-      className={className}
+      className={cx(className, `doc-tiles-${variant}`)}
     >
       {tiles}
     </div>
@@ -186,4 +234,28 @@ DocTiles.propTypes = {
   animated: PropTypes.bool,
   children: PropTypes.node,
   numbered: PropTypes.bool,
+  variant: PropTypes.oneOf(['default', 'labs', 'light']),
 };
+
+const Number = styled.span`
+  flex: none;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  height: 2rem;
+  width: 2rem;
+  border-radius: 50%;
+  background: var(--brand-button-primary-accent);
+  color: var(--system-text-primary-light);
+
+  .doc-tiles-labs & {
+    background: transparent;
+    color: currentColor;
+    height: auto;
+    width: auto;
+
+    &::after {
+      content: '.';
+    }
+  }
+`;

--- a/src/components/HomepageSlabs.js
+++ b/src/components/HomepageSlabs.js
@@ -148,9 +148,8 @@ const HomepageSlabs = () => {
           {activePanel === 1 && <Blurb>{t('home.personas.blurbs.1')}</Blurb>}
         </animated.div>
         {activePanel === 1 && (
-          <DocTiles animated>
+          <DocTiles animated variant="light">
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -162,7 +161,6 @@ const HomepageSlabs = () => {
               {t('home.personas.tiles.1.0.label')}
             </DocTile>
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -174,7 +172,6 @@ const HomepageSlabs = () => {
               {t('home.personas.tiles.1.1.label')}
             </DocTile>
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -210,9 +207,8 @@ const HomepageSlabs = () => {
           {activePanel === 2 && <Blurb>{t('home.personas.blurbs.2')}</Blurb>}
         </animated.div>
         {activePanel === 2 && (
-          <DocTiles animated>
+          <DocTiles animated variant="light">
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -224,7 +220,6 @@ const HomepageSlabs = () => {
               {t('home.personas.tiles.2.0.label')}
             </DocTile>
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -236,7 +231,6 @@ const HomepageSlabs = () => {
               {t('home.personas.tiles.2.1.label')}
             </DocTile>
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -272,9 +266,8 @@ const HomepageSlabs = () => {
           {activePanel === 3 && <Blurb>{t('home.personas.blurbs.3')}</Blurb>}
         </animated.div>
         {activePanel === 3 && (
-          <DocTiles animated>
+          <DocTiles animated variant="light">
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -286,7 +279,6 @@ const HomepageSlabs = () => {
               {t('home.personas.tiles.3.0.label')}
             </DocTile>
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',
@@ -298,7 +290,6 @@ const HomepageSlabs = () => {
               {t('home.personas.tiles.3.1.label')}
             </DocTile>
             <DocTile
-              forceLightMode
               instrumentation={{
                 category: 'PersonaHomepage',
                 eventName: 'docTileClick',


### PR DESCRIPTION
adds a `variant` prop with `default`, `labs`, and `light` as the variants, and a `title` prop. removes the `forceLightMode` prop on DocTile in favor of the `variant` prop on DocTiles. i made sure that `numbered`, `title`, and `label` play nice together across all the `variant`s

## screenshot

![Screenshot 2023-03-22 at 16-40-52 Bring your own data New Relic Documentation](https://user-images.githubusercontent.com/14365008/227032971-00fabb79-1172-4c66-bb36-120e71331d48.png)
