### PR TITLE
fix(manage-accounts-nerdgraph): document regionCode argument

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
@@ -35,7 +35,7 @@ This tutorial will show you how to:
 
 Some tips about some of the fields used in these requests: 
 * The `managedAccount` and `managedAccounts` fields are simply terms for the accounts in an organization. They're synonymous with "accounts."
-* The `regionCode` field refers to [the data center used by an account](/docs/accounts/accounts-billing/account-setup/choose-your-data-center): `US` or `EU`. Note that an organization can only use a single data center: there can't be accounts that use different data centers in a single organization. 
+* The `regionCode` field refers to [the data center used by an account](/docs/accounts/accounts-billing/account-setup/choose-your-data-center). Valid values are `us01` and `eu01` which map to the US and EU regions respectively.
 
 Note that the [NerdGraph explorer](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#explorer) has built-in docs that defines fields.
 
@@ -66,6 +66,20 @@ Here's an example of how to create an account. Before creating an account, make 
 ```graphql
 mutation {
   accountManagementCreateAccount(managedAccount: {name: "NEW_ACCOUNT_NAME"}) {
+    managedAccount {
+      id
+      name
+      regionCode
+    }
+  }
+}
+```
+
+If you have a complex account structure you may use the optional `regionCode` parameter to target a specific data center.
+
+```graphql
+mutation {
+  accountManagementCreateAccount(managedAccount: {name: "NEW_ACCOUNT_NAME"}, regionCode: "eu01") {
     managedAccount {
       id
       name

--- a/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph.mdx
@@ -79,7 +79,7 @@ If you have a complex account structure you may use the optional `regionCode` pa
 
 ```graphql
 mutation {
-  accountManagementCreateAccount(managedAccount: {name: "NEW_ACCOUNT_NAME"}, regionCode: "eu01") {
+  accountManagementCreateAccount(managedAccount: {name: "NEW_ACCOUNT_NAME", regionCode: "eu01"}) {
     managedAccount {
       id
       name


### PR DESCRIPTION
From support, the allowed values for `regionCode` in the `accountManagementCreateAccount` mutation are missing.

- add mutation example with `regionCode`
- note the valid values are `us01` and `eu01`
- remove note about only one region being allowed (that's not always true)