### PR TITLE
Fix typo and broken link for MLOps documentation

### DIFF
--- a/src/content/docs/mlops/bring-your-own/mlops-byo.mdx
+++ b/src/content/docs/mlops/bring-your-own/mlops-byo.mdx
@@ -19,7 +19,7 @@ import modelperformancemonitoringModelPerformanceTab from 'images/model-performa
 
 New Relic's MLOps solution provides a Python library that makes it easy to monitor your machine learning models. New Relic Bring Your Own (BYO) **Machine Learning Model Monitoring** is an offering of the New Relic product suite that allows users to monitor the performance of their own machine learning models, regardless of the platform or framework they are using. This can help users identify issues with their models and take corrective action before those issues impact the accuracy or performance of their applications.
 
-In an increasingly complex digital space, data teams rely heavily on prediction engines to make decisions. New Relic Machine Learning Model Monitoring allows your team to take a step back and look at the whole picture.Our model performance monitoring allows your team to examine your ML models to identify issues efficiently and make decisions by leveraging NR core features like setting alerts on any metrics and get notified once your ML performance has changed
+In an increasingly complex digital space, data teams rely heavily on prediction engines to make decisions. New Relic Machine Learning Model Monitoring allows your team to take a step back and look at the whole picture. Our model performance monitoring allows your team to examine your ML models to identify issues efficiently and make decisions by leveraging NR core features like setting alerts on any metrics and get notified once your ML performance has changed
 
 
 ## Easy to Integrate [#integrate]
@@ -72,7 +72,7 @@ Get insight and statistical data on your features and get alerted on any deviati
 
 ## How to start monitoring your ML model performance [#get-benefits]
 
-First Use the [gettingstarted](https://docs.newrelic.com/docs/mlops/bring-your-own/getting-started/) documentation to start streaming your model data. Then, click on **Model Performance** in the All Capabilities page in the New Relic UI (don’t forget to pin it) and you will see your model performance view based on the data your model is sending. 
+First Use the [getting started](https://docs.newrelic.com/docs/mlops/bring-your-own/getting-started-byo/) documentation to start streaming your model data. Then, click on **Model Performance** in the All Capabilities page in the New Relic UI (don’t forget to pin it) and you will see your model performance view based on the data your model is sending. 
 
 <img
   title="An image of the model performance tab in the New Relic navigation menu"


### PR DESCRIPTION
## Give us some context

* I just read through one page of the MLOps docs and saw a typo and a broken "getting started" link.
