### PR TITLE
Add front matter to python agent release notes 6.4.1.158 to 7.14.0.177.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60401158.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60401158.mdx
@@ -3,8 +3,9 @@ subject: Python agent
 releaseDate: '2021-06-04'
 version: 6.4.1.158
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Add support for Flask v2']
-bugs: ['Non-PID specific memory metric being reported']
+features: ['Add support for Flask v2', 'Improve logging for 410 status codes']
+bugs: ['Non-PID specific memory metric being reported', 'Reintroduce non-PID specific memory metrics']
+security: []
 ---
 
 ## Notes
@@ -21,12 +22,12 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 ## Improvements
 
-* **Improved logging for 410 status codes**
+* **Improve logging for 410 status codes**
 
   The agent now logs the content of a data collector response which specifies the reason for a disconnect for 410 status codes.
 
 ## Bug Fixes
 
-* **Non-PID specific memory metric being reported**
+* **Reintroduce non-PID specific memory metrics**
 
   In agent version v6.2.0.156, memory metrics were modified to add the PID to each metric name. This release reintroduces non-PID specific memory metrics.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60402159.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60402159.mdx
@@ -3,7 +3,9 @@ subject: Python agent
 releaseDate: '2021-06-22'
 version: 6.4.2.159
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-bugs: ['Fix inspect.formatargspec deprecation warning', 'HTTPX Crash']
+features: ['Update Sanic instrumentation', 'Update Pyramid transaction naming']
+bugs: ['Fix inspect.formatargspec deprecation warning', 'Fix HTTPX crash']
+security: []
 ---
 
 ## Notes
@@ -14,11 +16,11 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Improvements
 
-* **Sanic instrumentation updates**
+* **Update Sanic instrumentation**
 
   The agent has updated support for all Sanic versions, with testing done on all versions >=18.12.0. Additionally, blueprint middleware is now supported.
 
-* **Pyramid transaction naming**
+* **Update Pyramid transaction naming**
 
   Previously, transaction names from exception views overrode route names. We've reversed this priority to be more in line with other instrumentation.
 
@@ -28,6 +30,6 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
   A deprecation warning concerning `inspect.formatargspec` has been fixed.
 
-* **HTTPX Crash**
+* **Fix HTTPX crash**
 
   Initializing the agent after creating an HTTPX client could cause a crash in HTTPX. This has been corrected.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60403160.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60403160.mdx
@@ -3,7 +3,9 @@ subject: Python agent
 releaseDate: '2021-06-23'
 version: 6.4.3.160
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
 bugs: ['Fix Starlette/ FastAPI transaction naming and classification']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60404161.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60404161.mdx
@@ -3,7 +3,9 @@ subject: Python agent
 releaseDate: '2021-07-06'
 version: 6.4.4.161
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-bugs: ['Fixed a crash in memory sampling on BSD kernels']
+features: ['Add wildcard matching to instrumentation via config file']
+bugs: ['Fix a crash in memory sampling on BSD kernels']
+security: []
 ---
 
 ## Notes
@@ -14,12 +16,12 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Improvements
 
-* **Added wildcard matching to instrumentation via config file**
+* **Add wildcard matching to instrumentation via config file**
 
   The agent now supports wildcards for classes and functions when instrumenting via config file. **Note: this does not include module paths.**
 
 ## Bug Fixes
 
-* **Fixed a crash in memory sampling on BSD kernels**
+* **Fix a crash in memory sampling on BSD kernels**
 
   A crash in the memory metric sampler was possible when using kernels besides MacOS and Linux. This has been corrected.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6060162.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6060162.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-07-29'
 version: 6.6.0.162
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for Graphene', 'Add support for Graphene schemas in Starlette/FastAPI with use of an AsyncioExecutor']
+bugs: []
+security: []
 ---
 
 ## Notes
@@ -13,11 +16,11 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 ## New Features
 
-* **Added support for Graphene**
+* **Add support for Graphene**
 
   Graphene applications will now be automatically instrumented.
 
 
-* **Added support for Graphene schemas in Starlette/FastAPI with use of an AsyncioExecutor**
+* **Add support for Graphene schemas in Starlette/FastAPI with use of an AsyncioExecutor**
 
   Starlette/ FastAPI applications using GraphQL in conjunction with an [AsyncioExecutor](https://www.starlette.io/graphql/#sync-or-async-executors) will now be automatically instrumented.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60800163.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-60800163.mdx
@@ -3,8 +3,9 @@ subject: Python agent
 releaseDate: '2021-08-04'
 version: 6.8.0.163
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Added wheel support for ARM64 (a.k.a. AArch 64, ARMv8)']
+features: ['Add wheel support for ARM64 (a.k.a. AArch 64, ARMv8)']
 bugs: ['Fix a crash in unsupported GraphQL versions']
+security: []
 ---
 
 ## Notes
@@ -15,7 +16,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New Features
 
-* **Added wheel support for ARM64 (a.k.a. AArch 64, ARMv8)**
+* **Add wheel support for ARM64 (a.k.a. AArch 64, ARMv8)**
 
   The agent now provides prebuilt wheels for ARM64 for Python versions >=3.6. This requires a version of pip>=19.3.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-6081164.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-08-24'
 version: 6.8.1.164
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Update log_file location in default `newrelic.ini']
+bugs: ['Handle `cherryPy.HTTPRedirects', 'Address DeprecationWarning for invalid escape sequence']
+security: []
 ---
 
 ## Notes
@@ -13,16 +16,16 @@ The agent can be installed using easy_install/pip/distribute via the [Python Pac
 
 ## Improved Features
 
-* **Updated log_file location in default `newrelic.ini`**
+* **Update log_file location in default `newrelic.ini`**
 
   The `newrelic.ini` generated using `newrelic-admin generate-config` has been updated to set the default `log_file` location to `stdout` for improved initial visibility. This setting can still be customized to log to `stderr` or a user-specified file as well.
 
 ## Bug Fixes
 
-* **Handling of `cherryPy.HTTPRedirects`**
+* **Handle `cherryPy.HTTPRedirects`**
 
   `cherrypy.HttpRedirects` were incorrectly being reported as errors. This has now been corrected thanks to a contribution from [@bdeeney](https://github.com/bdeeney)!
 
-* **`DeprecationWarning` invalid escape sequence**
+* ** Address `DeprecationWarning` for invalid escape sequence**
 
   A deprecation warning concerning unrecognized escape sequences in Python 3.6 (and higher) has been fixed. Thank you [@urianchang](https://github.com/urianchang) for your contribution!

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-61000165.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-61000165.mdx
@@ -3,7 +3,7 @@ subject: Python agent
 releaseDate: '2021-09-16'
 version: 6.10.0.165
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Added new instrumentation for Strawberry', 'Added new instrumentation for Ariadne']
+features: ['Add new instrumentation for Strawberry', 'Add new instrumentation for Ariadne', 'Add new and changed metrics for Graphene applications', 'Improve tracing in Starlette GraphQL applications']
 bugs: ['TimeTrace.**str** recursion']
 ---
 
@@ -15,23 +15,23 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New Features
 
-* **Added new instrumentation for Strawberry**
+* **Add new instrumentation for Strawberry**
 
   GraphQL applications built using Strawberry will now be automatically instrumented.
 
-* **Added new instrumentation for Ariadne**
+* **Add new instrumentation for Ariadne**
 
   GraphQL applications built using Ariadne will now be automatically instrumented.
 
 ## Improvements
 
-* **New and changed metrics for Graphene applications**
+* **Add new and changed metrics for Graphene applications**
 
   Metrics specifying the framework details for Graphene have been added, and GraphQL metrics now include Graphene as a product field.
 
   (eg. `GraphQL/operation/Graphene/query/<query_name>/<query_path>`)
 
-* **Improved tracing in Starlette GraphQL applications**
+* **Improve tracing in Starlette GraphQL applications**
 
   GraphQL applications using Starlette now support all executor classes. Previously, only async executor classes were supported.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166.mdx
@@ -3,7 +3,9 @@ subject: Python agent
 releaseDate: '2021-09-22'
 version: 7.0.0.166
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Reservoir sizes now configurable using settings and environment variables']
+features: ['Reservoir sizes now configurable using settings and environment variables', 'Distributed tracing is enabled by default']
+bugs: []
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70200167.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70200167.mdx
@@ -3,8 +3,9 @@ subject: Python agent
 releaseDate: '2021-10-12'
 version: 7.2.0.167
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Python 3.10 Wheels']
-bugs: ['Errors fail to be ignored by server-side config', 'Deprecation warnings for imp module removed']
+features: ['Add Python 3.10 wheels', 'Upgrade internal urllib3 to v1.26.7']
+bugs: ['Ensure errors are ignored by server-side config', 'Deprecation warnings for imp module removed']
+security: []
 ---
 
 ## Notes
@@ -15,7 +16,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New Features
 
-* **Python 3.10 Wheels**
+* **Add Python 3.10 wheels**
 
   Wheels for Python 3.10 are now available and supported.
 
@@ -27,7 +28,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Bug Fixes
 
-* **Errors fail to be ignored by server-side config**
+* **Ensure errors are ignored by server-side config**
 
   Previously it was possible on transaction exit to have an error fail to be ignored when the settings were supplied via server-side config. This has been fixed.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70201168.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70201168.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-10-12'
 version: 7.2.1.168
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Fix wheels for Python 3.10']
+security: []
 ---
 
 ## Notes
@@ -13,6 +16,6 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Bug Fixes
 
-* **Wheels not available for Python 3.10**
+* **Fix wheels for Python 3.10**
 
   An incorrect version of `cibuildwheel` failed to create Python 3.10 wheels. This has been fixed and wheels should now be available.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70202169.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70202169.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-10-15'
 version: 7.2.2.169
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Fix urllib3 recursion regression', 'Fix import error caused by non-ASCII character in comments']
+security: []
 ---
 
 ## Notes
@@ -13,10 +16,10 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Bug Fixes
 
-* **Urllib3 Recursion Regression**
+* **Fix urllib3 recursion regression**
 
   Urllib3 recursion regression issue that was seen in Gevent has been fixed
 
-* **Import Error caused by non-ASCII character in comments**
+* **Fix import error caused by non-ASCII character in comments**
 
   An import error caused by non-ASCII characters has been fixed to the correct quotation formatting

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70203170.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70203170.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-11-04'
 version: 7.2.3.170
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Fix FastAPI context propagation error', 'Fix gRPC incompatibilities']
+security: []
 ---
 
 ## Notes
@@ -13,11 +16,11 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Bug Fixes
 
-* **FastAPI Context Propagation Error**
+* **Fix FastAPI context propagation error**
 
   A runtime instrumentation error stemming from context propagation in FastAPI has been fixed.
 
-* **gRPC Incompatiblities**
+* **Fix gRPC incompatibilities**
 
   The version of gRPC has been pinned until compatiblity can be ensured with newer versions.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70204171.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70204171.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2021-11-11'
 version: 7.2.4.171
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Fix gRPC retry logic', 'Fix crash in database trace']
+security: []
 ---
 
 ## Notes
@@ -13,10 +16,10 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Bug Fixes
 
-* **gRPC Retry Logic**
+* **Fix gRPC retry logic**
 
   Previously gRPC subchannels left open by infinite tracing could cause network congestion and strain our trace observers. This issue has been corrected. As such, specific versions of gRPC are no longer required.
 
-* **Crash in Database Trace**
+* **Fix crash in database trace**
 
   A crash in database traces resulting from nullified settings (seen rarely in Django) has been corrected.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70400172.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70400172.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-01-20'
 version: 7.4.0.172
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for Django v4', 'Add support for Redis v4', 'Add support for graphql-core v3.2.0']
+bugs: ['Fix Graphene framework details', 'Fix memory sample exception', 'Fix import hook warnings for Python 3.10']
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70800174.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70800174.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-03-31'
 version: 7.8.0.174
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for GraphQL Server', 'Add a log handler', 'Add more robust `should_ignore_error` calls']
+bugs: []
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71000175.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71000175.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-04-06'
 version: 7.10.0.175
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add integration with CodeStream']
+bugs: []
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71200176.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71200176.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-06-09'
 version: 7.12.0.176
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add APM logs in context', 'Add support for logging metrics', 'Adds support for forwarding application logs to New Relic', 'Add support for enriching application logs written to disk or standard out', 'Rename whitelist setting to allowlist']
+bugs: ['Fix incompatibility with gRPC v4', 'Fix Starlette v0.19.1+ instrumentation', 'Fix unhelpful error messages appearing outside of debug logs']
+security: []
 ---
 
 ## Notes
@@ -14,39 +17,39 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 ## New features
 
 * **Add APM logs in context**
-  
+
   A quick way to view logs no matter where you are in the platform.
-  
+
   To learn more, see the documentation about [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context).
 
-  * **Adds support for logging metrics** 
-    
+  * **Add support for logging metrics**
+
     Logging metrics show the rate of log messages by severity in the logs chart in the APM **Summary** view. This is enabled by default in this release.
 
-  * **Adds support for forwarding application logs to New Relic**
-    
+  * **Add support for forwarding application logs to New Relic**
+
     This automatically sends application logs that have been enriched to power APM logs in context. This is disabled by default in this release. This will be on by default in a future release. For more information, see our documentation about [logs in context for Python](/docs/logs/logs-context/configure-logs-context-python).
 
-  * **Adds support for enriching application logs written to disk or standard out**
-    
+  * **Add support for enriching application logs written to disk or standard out**
+
     This can be used with another log forwarder to power APM logs in context if in-agent log forwarding is not desired. We recommend enabling either log forwarding or local log decorating, but not both features. This is disabled by default in this release.
 
-## Changes 
+## Changes
 
 * **Rename Whitelist Setting to Allowlist**
-  
+
   The setting `strip_exception_messages.whitelist` has been renamed to the more modern name `strip_exception_messages.allowlist`. The original setting will continue to function but issue a deprecation warning.
 
 ## Bug Fixes
 
 * **Fix incompatibility with gRPC v4**
-  
+
   Previously a crash was possible in the agent when gRPC v4 was installed when not using the infinite tracing feature. This has been corrected and the agent can safely be used with gRPC v4.
 
 * **Fix Starlette v0.19.1+ instrumentation**
   * A crash in CustomRoutes in Starlette v0.19.1 has been addressed and fixed.
   * Starlette v0.20.1 reorganized important files which were then uninstrumented. This has been fixed.
 
-* **Fixed unhelpful error messages appearing outside of debug logs**
-  
+* **Fix unhelpful error messages appearing outside of debug logs**
+
   Error messages related to context propagation have been demoted to debug logs to avoid unwanted and unhelpful messages appearing in logs.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71400177.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71400177.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-06-27'
 version: 7.14.0.177
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for aioredis', 'Enhance support for redis and aredis', ]
+bugs: ['Fix `threading.currentThread` deprecation']
+security: []
 ---
 
 ## Notes
@@ -20,13 +23,13 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Improvements
 
-* **Enhanced support for redis and aredis**
+* **Enhance support for redis and aredis**
 
   The agent now instruments a more extensive list of commands for redis and aredis clients. This includes commands under the search, graph, timeseries, json, sentinel, and bf modules.
 
 ## Bug Fixes
 
-* **Fixes `threading.currentThread` deprecation**
+* **Fix `threading.currentThread` deprecation**
 
   `threading.currentThread` was [deprecated in Python 3.10](https://docs.python.org/3.12/whatsnew/3.10.html#deprecated) and has been replaced with `threading.current_thread`. Thank you [hugovk](https://github.com/hugovk) for your contribution to the agent!
 


### PR DESCRIPTION
This PR adds new front matter to a portion of python agent release notes. 
cc: @clarkmcadoo @roadlittledawn 