### PR TITLE
Update requirements-infrastructure-agent.mdx

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -172,7 +172,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Windows Server 2012, 2016, 2019, and 2022, and their service packs.
+        Windows Server 2012 (version 1.37.1 and lower), 2012 R2, 2016, 2019, and 2022, and their service packs.
 
         Windows 10 and their service packs.
       </td>


### PR DESCRIPTION
Server 2012 version 6.2 does not support the SKIPSL attribute that is part of TAKEOWN which is being used in Infrastructure Agent 1.37.2 and forward. Support recommends staying on an older version of the agent so updating the doc for awareness.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.