### PR TITLE
~Apr 13: Java agent: user tracking [DO NOT MERGE UNTIL 8.1 AGENT RELEASE]

### DIFF
--- a/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
@@ -128,7 +128,7 @@ To instrument [`Transactions`](/docs/apm/applications-menu/monitoring/transactio
     </tr>
     <tr>
       <td>
-        To associate a user ID with the current transaction and any errors noticed during the transaction's lifespan by setting an `enduser.id` agent attribute.
+        Adds user tracking to the current transaction by setting the `enduser.id` agent attribute.
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
@@ -126,6 +126,15 @@ To instrument [`Transactions`](/docs/apm/applications-menu/monitoring/transactio
         [`NewRelic.ignoreApdex()`](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html)
       </td>
     </tr>
+    <tr>
+      <td>
+        To associate a user ID with the current transaction and any errors noticed during the transaction's lifespan by setting an `enduser.id` agent attribute.
+      </td>
+
+      <td>
+        [`NewRelic.setUserId()`](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html)
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/apm/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/java-agent-api-custom-instrumentation-annotation-example-app.mdx
@@ -76,6 +76,8 @@ Below is an example of an imaginary store app's servlet using the Java agent API
 
         <a href="#record-user-id">String userId = req.getParameter("userId");</a>
             if (userId != null) {
+                // Tracks the user ID to the current transaction by setting the enduser.id agent attribute 
+                NewRelic.setUserId(userId);
                 // set the user name to associate with the RUM JavaScript footer 
                 // for the current web transaction
                 NewRelic.setUserName(userId);

--- a/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -222,7 +222,7 @@ With APM's Java agent, you can automatically collect user information in by edit
     id="view-user-attributes"
     title="View user attributes in dashboards"
   >
-    Within a few minutes of enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user), you can query the `user` attribute or `endsuser.id` if you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the agent or higher. For example, you could use either of the following [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
+    Within a few minutes of enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user), you can query the `user` attribute or `enduser.id` if you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the agent or higher. For example, you could use either of the following [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
 
     ```
     SELECT uniqueCount(user) FROM Transaction SINCE 1 day ago

--- a/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -209,7 +209,7 @@ With APM's Java agent, you can automatically collect user information in by edit
     NewRelic.setUserId(String userId);
     ```
 
-    Here is an example code snippet setting the user Id:
+    Here's an example code snippet setting the user ID:
 
     ```java
     @Trace(dispatcher = true)
@@ -237,7 +237,7 @@ With APM's Java agent, you can automatically collect user information in by edit
     id="view-user-attributes"
     title="View user attributes in dashboards"
   >
-    If you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the Java agent or higher, through either enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user) or using the [public api](/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api/#transactions) and waiting a few minutes, you can query the `enduser.id` attribute. For example, you could use the following [NRQL query](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
+    If you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the Java agent, or higher, you can query the `enduser.id` attribute through either enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user) or using the [public API](/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api/#transactions) and waiting a few minutes. For example, you could use the following [NRQL query](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
 
     ```
     SELECT uniqueCount(enduser.id) FROM Transaction SINCE 1 day ago
@@ -249,7 +249,7 @@ With APM's Java agent, you can automatically collect user information in by edit
     SELECT uniqueCount(user) FROM Transaction SINCE 1 day ago
     ```
 
-    In both cases, if errors are reported, you can use the user attribute(s) to see [how many users are impacted in a given error group.](/docs/errors-inbox/error-users-impacted/)
+    In both cases, if errors are reported, you can use the user attribute(s) to see [how many users are impacted in a given error group](/docs/errors-inbox/error-users-impacted).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -222,10 +222,14 @@ With APM's Java agent, you can automatically collect user information in by edit
     id="view-user-attributes"
     title="View user attributes in dashboards"
   >
-    Within a few minutes of enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user), you can query the new `user` attribute. For example, you could use this [NRQL query](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
+    Within a few minutes of enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user), you can query the `user` attribute or `endsuser.id` if you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the agent or higher. For example, you could use either of the following [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
 
     ```
     SELECT uniqueCount(user) FROM Transaction SINCE 1 day ago
+    ```
+    or
+    ```
+    SELECT uniqueCount(enduser.id) FROM Transaction SINCE 1 day ago
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -248,6 +248,8 @@ With APM's Java agent, you can automatically collect user information in by edit
     ```
     SELECT uniqueCount(user) FROM Transaction SINCE 1 day ago
     ```
+
+    In both cases, if errors are reported, you can use the user attribute(s) to see [how many users are impacted in a given error group.](/docs/errors-inbox/error-users-impacted/)
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/java-agent/attributes/java-agent-attributes.mdx
@@ -203,7 +203,22 @@ With APM's Java agent, you can automatically collect user information in by edit
     id="collect-user-instructions"
     title="Enable collection of user attributes"
   >
-    To collect user attributes with Java agent 3.10.0 or higher:
+    To collect the `enduser.id` user attribute via the [public api](/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api/#transactions) with Java agent 8.1.0 or higher, call:
+    
+    ```java
+    NewRelic.setUserId(String userId);
+    ```
+
+    Here is an example code snippet setting the user Id:
+
+    ```java
+    @Trace(dispatcher = true)
+    public void run() {
+      NewRelic.setUserId("example-user-id");
+    }
+    ```
+
+    To collect user attributes via our servlet instrumentation with Java agent 3.10.0 or higher:
 
     1. Open `newrelic.yml`, usually located in the same directory as `newrelic.jar`.
     2. In the [`class_transformer`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Custom_Instrumentation) stanza, edit [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user) to set `enabled` to `true`:
@@ -222,14 +237,16 @@ With APM's Java agent, you can automatically collect user information in by edit
     id="view-user-attributes"
     title="View user attributes in dashboards"
   >
-    Within a few minutes of enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user), you can query the `user` attribute or `enduser.id` if you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the agent or higher. For example, you could use either of the following [NRQL queries](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
+    If you are using the [8.1.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the Java agent or higher, through either enabling [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user) or using the [public api](/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api/#transactions) and waiting a few minutes, you can query the `enduser.id` attribute. For example, you could use the following [NRQL query](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) to obtain a unique count of all users:
+
+    ```
+    SELECT uniqueCount(enduser.id) FROM Transaction SINCE 1 day ago
+    ```
+
+    Or if you are using the [3.10.0](/docs/release-notes/agent-release-notes/java-release-notes/) release of the Java agent or higher, and enabled [`com.newrelic.instrumentation.servlet-user`](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#servlet-user), you can query the `user` attribute within a few minutes:
 
     ```
     SELECT uniqueCount(user) FROM Transaction SINCE 1 day ago
-    ```
-    or
-    ```
-    SELECT uniqueCount(enduser.id) FROM Transaction SINCE 1 day ago
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2497,7 +2497,7 @@ These options set in the `class_transformer` stanza and can be [overridden](#Sys
       </tbody>
     </table>
 
-    Enable this option to capture the `userPrincipal` name. This name is included as a transaction trace attribute, and [can be queried](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data).
+    Enable this option to capture the `userPrincipal` name. This name is included as a transaction trace attribute (with attribute names `user` and `enduser.id`), and [can be queried](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2497,7 +2497,7 @@ These options set in the `class_transformer` stanza and can be [overridden](#Sys
       </tbody>
     </table>
 
-    Enable this option to capture the `userPrincipal` name. This name is included as a transaction trace attribute (with attribute names `user` and `enduser.id`), and [can be queried](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data).
+    Enable this option to capture the `userPrincipal` name. This name is included as a transaction trace attribute (with attribute names `user` and `enduser.id`), and [can be queried](/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data). This also allows you to see in [errors inbox how many users are impacted by an error group](/docs/errors-inbox/error-users-impacted/).
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
To go out with https://github.com/newrelic/docs-website/pull/12265. Estimated release date April 13. Confirm with agent team to publish. 

Adds documentation for user tracking for the Java Agent.