### PR TITLE
chore(Java): capping supported version of oracle r2dbc

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -463,7 +463,7 @@ The agent automatically instruments these frameworks and libraries:
     * R2DBC MariaDB 1.0.2 to 1.1.1
     * R2DBC MySQL 0.8.x to latest
     * R2DBC MSSQL 0.8.0 to latest
-    * R2DBC Oracle 0.x to latest
+    * R2DBC Oracle 0.x to 1.1.0
     * R2DBC Postgres 0.9.0 to 0.9.1
     * Slick 3.0.0 to 3.3.x
     * Solr 4.0 to latest


### PR DESCRIPTION
## Give us some context

A new version of Oracle r2dbc was released and is incompatible with the Java agent.