### PR TITLE
Backfill Python agent release notes v7.16.0.178 to 8.7.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71600178.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71600178.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-07-21'
 version: 7.16.0.178
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add APM logs in context', 'Add top level aggregated data usage supportability metric', 'Change data usage supportability metric name']
+bugs: ['Fix data usage supportability metric compression payload calculation']
+security: []
 ---
 
 ## Notes
@@ -13,23 +16,23 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New features
 
-* **APM logs in context**
+* **Add APM logs in context**
 
     Automatic application log forwarding is now enabled by default. This version of the agent will automatically send enriched application logs to New Relic. To learn more about about this feature, see the [APM logs in context documentation](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/get-started-logs-context/). For additional configuration options, see the [Python logs in context documentation](https://docs.newrelic.com/docs/logs/logs-context/configure-logs-context-python/). To learn about how to toggle log ingestion on or off by account, see our documentation to [disable automatic logging](https://docs.newrelic.com/docs/logs/logs-context/disable-automatic-logging) via the UI or API.
 
-* **Top level aggregated data usage supportability metric**
+* **Add top level aggregated data usage supportability metric**
 
     The agent now reports a top level data usage supportability metric: `Supportability/Python/Collector/Output/Bytes`. This aggregates all uncompressed bytes across all agent methods sent to New Relic.
 
 ## Changes
 
-* **Data usage supportability metric name change**
+* **Change data usage supportability metric name**
 
     Previously, the agent reported data usage supportability metrics in the format `Supportability/Python/Collector/Output/Bytes/<agent_method>`. This has been changed to be in the format `Supportability/Python/Collector/<agent_method>/Output/Bytes` to align with the agent specification.
 
 ## Bug fixes
 
-* **Fixes data usage supportability metric compression payload calculation**
+* **Fix data usage supportability metric compression payload calculation**
 
     Previously, the agent was reporting the compressed bytes for the `Supportability/Python/Collector/Output/Bytes` metric group and uncompressed bytes for the `Supportability/Python/Collector/ZLIB/Bytes` metric group. This was incorrect and has been fixed in this release.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80000179.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80000179.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-08-15'
 version: 8.0.0.179
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add Daphne instrumentation', Add module version reporting']
+bugs: ['Fix a bug in file path detection for Loguru']
+security: []
 ---
 
 ## Notes
@@ -19,17 +22,17 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New features
 
-* **Daphne Instrumentation**
+* **Add Daphne instrumentation**
 
     Instrumentation has been added for [Daphne](https://github.com/django/daphne), a Django project ASGI web server and the recommended server for [Django Channels](https://channels.readthedocs.io/en/stable/deploying.html).
 
-* **Module Version Reporting**
+* **Add module version reporting**
 
     Installed python packages now have their versions reported and are visible in the Environment tab for your application in New Relic One.
 
 ## Bug fixes
 
-* **Fixes a bug in file path detection for Loguru**
+* **Fix a bug in file path detection for Loguru**
 
     Wrappers from the agent interfered with Loguru file path detection for templating messages. This has been corrected on all versions. Thank you to [@rafaelclp](https://github.com/rafaelclp) for your contribution!
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80100180.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80100180.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-09-12'
 version: 8.1.0.180
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add Hypercorn instrumentation']
+bugs: ['Fix instrumentation for Sanic v21.9', 'Fix incorrect PID reported by memory sampler', 'Fix issue with database traces causing crashes']
+security: []
 ---
 
 ## Notes
@@ -13,21 +16,21 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New features
 
-* **Hypercorn Instrumentation**
+* **Add Hypercorn instrumentation**
 
     Instrumentation has been added for [Hypercorn](https://github.com/pgjones/hypercorn/), an ASGI web server.
 
 ## Bug fixes
 
-* **Fixes instrumentation for Sanic v21.9+**
+* **Fix instrumentation for Sanic v21.9+**
 
     Instrumentation for newer versions of Sanic (>=21.9) have either not reported data or crashed due to an incompatibility with Sanic's internal metaprogramming.
 
-* **Fixes incorrect PID reported by memory sampler**
+* **Fix incorrect PID reported by memory sampler**
 
     The PID reported by the memory sampler when sampling processes was incorrectly attributed to the process the agent was initialized from.
 
-* **Fixes issue with database traces rarely causing crashes**
+* **Fix issue with database traces causing crashes**
 
     In rare instances a database trace could result in a setting not being found, causing a crash.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80200181.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80200181.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-09-27'
 version: 8.2.0.181
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add kafka-python instrumentation', 'Add confluent-kafka instrumentation']
+bugs: []
+security: []
 ---
 
 ## Notes
@@ -13,11 +16,11 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New features
 
-* **Kafka Python Instrumentation**
+* **Add kafka-python instrumentation**
 
     Instrumentation has been added for [Kafka Python](https://github.com/dpkp/kafka-python).
 
-* **Confluent Kafka Instrumentation**
+* **Add confluent-kafka instrumentation**
 
     Instrumentation has been added for [Confluent Kafka](https://github.com/confluentinc/confluent-kafka-python).
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80201.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-10-10'
 version: 8.2.1
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Update Sanic middleware support', 'Update wrapt to v1.14.1', 'Add support for Protobuf v4']
+bugs: ['Fix a RuntimeError in the trace cache when using the coroutine profiler', 'Fix an issue with case sensitivity in record-deploy', 'Fix an issue with newer installers failing to install the agent', 'Fix instrumentation for aioredis interfering with transactions', 'Fix a crash when completing various kinds of traces inside a stopped transaction', 'Fix a bug where instrumentation caused certain arguments to confluent-kafka producers to stop working']
+security: []
 ---
 
 ## Notes
@@ -17,7 +20,7 @@ The version number of the agent did not previously follow [Semantic Versioning](
 
 ## Instrumentation updates
 
-* **Updated Sanic middleware support**
+* **Update Sanic middleware support**
 
     Sanic recently changed their APIs surrounding middleware, and instrumentation has been updated to support it.
 
@@ -27,39 +30,39 @@ The version number of the agent did not previously follow [Semantic Versioning](
 
     The internal copy of the wrapt library used by the agent has been updated to v1.14.1 for Python 3.11 compatibility.
 
-* **Protobuf v4 now supported**
+* **Add support for Protobuf v4**
 
     The agent is now fully compatible with Protobuf v4 when using Infinite Tracing. Backwards compatibility with Protobuf v3 has been preserved.
 
 ## Bug fixes
 
-* **Fixed a RuntimeError in the trace cache when using the coroutine profiler.**
+* **Fix a RuntimeError in the trace cache when using the coroutine profiler**
 
     A RuntimeError occurred if traces were started or stopped while the coroutine profiler was sampling the active traces. This should no longer be possible.
 
     Thank you [@lovmat](https://github.com/lovmat) for your contribution!
 
-* **Fixed an issue with case sensitivity in record-deploy** 
+* **Fix an issue with case sensitivity in record-deploy**
 
     Previously application names were incorrectly being treated as case-sensitive when running `newrelic-admin record-deploy`.
 
     Thank you [@michalborkowski96](https://github.com/michalborkowski96) for your contribution!
 
-* **Fixed an issue with newer installers failing to install the agent.**
+* **Fix an issue with newer installers failing to install the agent**
 
     Due to the inclusion of both `scripts` and `entry_points` configuration options, the agent would fail to install with newer installers. This has been corrected and newer PEP compliant installers should have no trouble installing the agent.
 
     Thank you [@admp-fh](https://github.com/admp-fh) for your contribution!
 
-* **Fixed instrumentation for AioRedis interfering with transactions.**
+* **Fix instrumentation for aioredis interfering with transactions**
 
     The agent does not currently support transactions for Redis clients, and previous instrumentation broke transaction functionality in AioRedis. This has been fixed to provide no instrumentation within transactions at this time.
 
-* **Fixed a crash when completing various kinds of traces inside a stopped transaction.**
+* **Fix a crash when completing various kinds of traces inside a stopped transaction**
 
     Previously certain types of traces could throw exceptions and fail to complete when inside stopped transactions. This has been corrected and should no longer be possible.
 
-* **Fixed a bug where instrumentation caused certain arguments to Confluent-Kafka Producers to stop working.**
+* **Fix a bug where instrumentation caused certain arguments to confluent-kafka producers to stop working**
 
     Previously callback and on_delivery arguments were passed through improperly leading to them not working as expected.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80300.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-10-24'
 version: 8.3.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for Python 3.11', 'Add usage metrics for Kafka clients, Daphne, and Hypercorn']
+bugs: ['Fix Flask view support for Code Level Metrics', 'Fix aioredis version crash']
+security: []
 ---
 
 ## Notes
@@ -18,18 +21,18 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## New features
 
-* **Adds support for Python 3.11**
+* **Add support for Python 3.11**
     The agent now supports applications running in Python 3.11.
 
-* **Adds usage metrics for Kafka clients, Daphne, and Hypercorn**
+* **Add usage metrics for Kafka clients, Daphne, and Hypercorn**
   The agent now emits a messagebroker metric for Kafka clients and a dispatcher metric for Daphne and Hypercorn. This metric is similar to the framework metric already being emitted for all web frameworks supported by the agent.
 
 
 ## Bug fixes
-* **Fixed Flask view support for Code Level Metrics**
+* **Fix Flask view support for Code Level Metrics**
     The agent was previously reporting the class name for the code.function attribute in the case of Flask method dispatching. This has been corrected to report the instrumented function name.
 
-* **Fixed aioredis version crash**
+* **Fix aioredis version crash**
     A fix has been implemented to address a crash in aioredis in cases where the agent was initialized before importing aioredis on aioredis>=2.0.1.
 
 ## Support statement

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80400.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80400.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-10-26'
 version: 8.4.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Increase custom event limit']
+bugs: ['Fix NewRelicContextFormatter attribute error']
+security: []
 ---
 
 <Callout variant="important">
@@ -19,12 +22,12 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Changes
 
-* **Custom event limit increase**
+* **Increase custom event limit**
 
   This agent version increases the default limit of custom events from 1,200 events per minute to 3,600 events per minute. In the scenario that custom events were being limited, this change will allow more custom events to be sent to New Relic. There is also a new configurable maximum limit of 100,000 events per minute. To change the limits, see the [docs for event_harvest](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#harvest-limits-custom-event-data). To learn more about the change and how to determine if custom events are being dropped, see our [Explorers Hub post](https://discuss.newrelic.com/t/send-more-custom-events-with-the-latest-apm-agents/190497).
 
 ## Bug fixes
 
-* **NewRelicContextFormatter attribute error**
+* **Fix NewRelicContextFormatter attribute error**
 
   A bug was introduced in v8.3.0 that caused an AttributeError when using the NewRelicContextFormatter. This has been corrected in this release version.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80500.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80500.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2022-12-07'
 version: 8.5.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for redis v4.3.5 and v4.4.0 methods', 'Add record_log_event API']
+bugs: ['Fix RuntimeError: dictionary changed size during iteration', 'Fix confluent-kafka producer arguments', 'Patch sentry SDK to correct ASGI v2/v3 detection', 'Fix missing information issue with Celery workers when using MAX_TASKS_PER_CHILD', 'Fix support for dynamically generated types in Code Level Metrics', 'Fix external node properties initialization']
+security: []
 ---
 
 ## Notes
@@ -17,24 +20,24 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
   New methods added in redis v4.3.5 and v4.4.0 will now be automatically instrumented.
 
-* **record_log_event API**
+* **Add record_log_event API**
 
   This records a [log event](/docs/logs/logs-context/configure-logs-context-python) that can be viewed and queried in the New Relic UI. See [record_log_event](/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api) for details.
 
 ## Bug fixes
-* **RuntimeError: dictionary changed size during iteration**
+* **Fix RuntimeError: dictionary changed size during iteration**
 
   Properly guard `trace_cache` from `RuntimeErrors` raised due to concurrent iteration and size changes of the `TraceCache`.
 
-* **Fix Confluent Kafka Producer Arguments**
+* **Fix confluent-kafka producer arguments**
 
   Fixes a bug where topic provided as a keyword argument can crash Confluent Kafka producers.
 
-* **Patch for sentry SDK to correct ASGI v2/v3 detection**
+* **Patch sentry SDK to correct ASGI v2/v3 detection**
 
   Patches sentry-sdk to fix a bug that causes incorrect ASGI application version detection with our wrapt function wrappers. To fix this, we now instrument the `_looks_like_asgi3()` function to bind out the wrapped app in sentry in order to unwrap it to be able to detect the proper ASGI version.
 
-* **Missing information from Celery workers when using MAX_TASKS_PER_CHILD issue**
+* **Fix missing information issue with Celery workers when using MAX_TASKS_PER_CHILD**
 
   A bug was introduced in v7.8.0.174 when Celery was run with the `--loglevel=INFO` flag to not report any data after the original worker processes shut down. This has been fixed.
 
@@ -42,7 +45,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
   A bug in code level metrics attribute extraction prevented attributes from being applied to types created using the [3 argument type constructor](https://docs.python.org/3/library/functions.html?highlight=type#type). This has been fixed.
 
-* **Initialize external node properties**
+* **Fix external node properties initialization**
 
   A bug caused by uninitialized external node properties when making web requests has been fixed. Thank you [@kmorey](https://github.com/kmorey) for your contribution!
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2023-02-09'
 version: 8.6.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for eleasicsearch 8', 'Add support for redis v4.4.1 and v4.4.2', 'Add support for redis.asyncio', 'Add apdexPerfZone to web transaction event attribute intrinsics']
+bugs: []
+security: []
 ---
 
 ## Notes
@@ -24,7 +27,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
   new location.
   Thank you [@pauk-slon](https://github.com/pauk-slon) for your contribution!
 
-* **Add apdexPerfZone to Web transaction event attribute intrinsics**
+* **Add apdexPerfZone to web transaction event attribute intrinsics**
   Expose nr.apdexPerfZone as apdexPerfZone in Web transaction event attribute intrinsics.
 
 ## Support statement

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80700.mdx
@@ -3,6 +3,9 @@ subject: Python agent
 releaseDate: '2023-02-16'
 version: 8.7.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support batching and compression of infinite tracing']
+bugs: []
+security: []
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80701.mdx
@@ -4,8 +4,8 @@ releaseDate: '2023-03-20'
 version: 8.7.1
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['Add support for a new config option to capture GraphQL introspection query transactions']
-bugs: ['Fixed introspection query recognition for GraphQL']
-security: [] 
+bugs: ['Fix introspection query recognition for GraphQL']
+security: []
 ---
 
 ## Notes
@@ -18,12 +18,12 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 * **Add support for a new config option to capture GraphQL introspection query transactions.**
 
-  Added new config setting instrumentation.graphql.capture_introspection_queries and corresponding environment variable NEW_RELIC_INSTRUMENTATION_GRAPHQL_CAPTURE_INTROSPECTION_QUERIES to control capturing of GraphQL introspection transactions. Defaults to false which retains previous behavior of ignoring transactions with introspection queries. 
+  Added new config setting instrumentation.graphql.capture_introspection_queries and corresponding environment variable NEW_RELIC_INSTRUMENTATION_GRAPHQL_CAPTURE_INTROSPECTION_QUERIES to control capturing of GraphQL introspection transactions. Defaults to false which retains previous behavior of ignoring transactions with introspection queries.
 
 ## Bug fixes
-* **Fixed introspection query recognition for GraphQL.**
+* **Fix introspection query recognition for GraphQL.**
 
-  Fixed introspection query recognition for GraphQL to allow introspection fields to be queried alongside real fields in traces.
+  Fix introspection query recognition for GraphQL to allow introspection fields to be queried alongside real fields in traces.
 
 ## Support statement
 


### PR DESCRIPTION
This PR backfills the final portion of Python agent release notes with front matter metadata.