### PR TITLE
Change docs to support OpenShift v4.12

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
@@ -58,7 +58,7 @@ Each component of the control plane has a dedicated section, which allows to ind
 
 You can check all configuration options available in the [values.yaml](https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/values.yaml) of the nri-kubernetes chart under the `controlPlane` key.
 
-If you are installing the integration thorught the `nri-bundle` chart you need to [pass the values to the corresponding subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/). For example to disable the `etcd` monitoring in the `controlPlane` component you can do the following:
+If you are installing the integration through the `nri-bundle` chart you need to [pass the values to the corresponding subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/). For example to disable the `etcd` monitoring in the `controlPlane` component you can do the following:
 
 ```yaml
 newrelic-infrastructure:
@@ -551,15 +551,31 @@ Follow these instructions to set up mutual TLS authentication for etcd in [OpenS
 1. Export the etcd client certificates from the cluster to an opaque secret. In a default managed OpenShift cluster, the secret is named `kube-etcd-client-certs` and it is stored in the `openshift-monitoring` namespace.
 
    ```shell
-   kubectl get secret kube-etcd-client-certs -n openshift-monitoring -o yaml > etcd-secret.yaml
+   kubectl get secret etcd-client -n openshift-etcd -o yaml > etcd-secret.yaml
    ```
 
-2. Optionally, change the secret name and namespace to something meaningful.
+  The content of the etcd-secret.yaml would look something like the following.
+
+   ```yaml
+    apiVersion: v1
+    data:
+      tls.crt: <CERT VALUE>
+      tls.key: <KEY VALUE>
+    kind: Secret
+    metadata:
+      creationTimestamp: "2023-03-23T23:19:17Z"
+      name: etcd-client
+      namespace: openshift-etcd
+      resourceVersion: 
+      uid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    type: kubernetes.io/tls   
+   ```
+
+2. Optionally, change the secret name and namespace to something meaningful. The next steps assume secret name and namespace are changed to `mysecret` and `newrelic` respectively.
 
 3. Remove these unnecessary keys in the metadata section:
    * `creationTimestamp`
    * `resourceVersion`
-   * `selfLink`
    * `uid`
 
 4. Install the manifest with its new name and namespace:
@@ -568,7 +584,30 @@ Follow these instructions to set up mutual TLS authentication for etcd in [OpenS
    kubectl apply -n newrelic -f etcd-secret.yaml
    ```
 
-5. Configure the integration to use the newly created secret as described in [the mtls section](#mtls).
+5. Configure the integration to use the newly created secret as described in [the mtls section](#mtls). This can be done by adding the following configuration in the `values.yaml` if you are installing the integration through the `nri-bundle` chart.
+
+ ```yaml
+ newrelic-infrastructure:
+  controlPlane:
+    enabled: true
+    config:
+      etcd:
+        enabled: true
+        autodiscover:
+          - selector: "app=etcd,etcd=true,k8s-app=etcd"
+            namespace: openshift-etcd
+            matchNode: true
+            endpoints:
+              - url: https://<ETCD_ENDPOINT>:<PORT>
+                insecureSkipVerify: true
+                auth:
+                  type: mTLS
+                  mtls:
+                    secretName: mysecret
+                    secretNamespace: newrelic
+ ```
+
+
 
 ## See your data [#check-integration-works]
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/configure-control-plane-monitoring.mdx
@@ -58,7 +58,7 @@ Each component of the control plane has a dedicated section, which allows to ind
 
 You can check all configuration options available in the [values.yaml](https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/values.yaml) of the nri-kubernetes chart under the `controlPlane` key.
 
-If you are installing the integration through the `nri-bundle` chart you need to [pass the values to the corresponding subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/). For example to disable the `etcd` monitoring in the `controlPlane` component you can do the following:
+If you're installing the integration through the `nri-bundle` chart you need to [pass the values to the corresponding subchart](https://helm.sh/docs/chart_template_guide/subcharts_and_globals/). For example to disable the `etcd` monitoring in the `controlPlane` component you can do the following:
 
 ```yaml
 newrelic-infrastructure:
@@ -198,10 +198,10 @@ Please keep in mind that if `staticEndpoint` is set, the `autodiscover` section 
 #### Limitations [#static-endpoints-limitations]
 
 <Callout variant="important">
-  If you are using `staticEndpoint` pointing to an out-of-node (i.e. not `localhost`) endpoint, you must change `controlPlane.kind` from `DaemonSet` to `Deployment`.
+  If you're using `staticEndpoint` pointing to an out-of-node (i.e. not `localhost`) endpoint, you must change `controlPlane.kind` from `DaemonSet` to `Deployment`.
 </Callout>
 
-When using `staticEndpoint`, all `nrk8s-controlplane` pods will attempt to reach and scrape said endpoint. This means that, if `nrk8s-controlplane` is a DaemonSet (the default), all instances of the DaemonSet will scrape this endpoint. While this is fine if you are pointing them to `localhost`, if the endpoint is not local to the node you could potentially produce to duplicate metrics and increased billable usage. If you are using `staticEndpoint` and pointing it to a non-local URL, make sure to change `controlPlane.kind` to Deployment.
+When using `staticEndpoint`, all `nrk8s-controlplane` pods will attempt to reach and scrape said endpoint. This means that, if `nrk8s-controlplane` is a DaemonSet (the default), all instances of the DaemonSet will scrape this endpoint. While this is fine if you're pointing them to `localhost`, if the endpoint is not local to the node you could potentially produce to duplicate metrics and increased billable usage. If you're using `staticEndpoint` and pointing it to a non-local URL, make sure to change `controlPlane.kind` to Deployment.
 
 For the same reason above, it is currently not possible to use autodiscovery for some control plane components, and a static endpoint for others. This is a known limitation we are working to address in future versions of the integration.
 
@@ -584,7 +584,7 @@ Follow these instructions to set up mutual TLS authentication for etcd in [OpenS
    kubectl apply -n newrelic -f etcd-secret.yaml
    ```
 
-5. Configure the integration to use the newly created secret as described in [the mtls section](#mtls). This can be done by adding the following configuration in the `values.yaml` if you are installing the integration through the `nri-bundle` chart.
+5. Configure the integration to use the newly created secret as described in [the mtls section](#mtls). This can be done by adding the following configuration in the `values.yaml` if you're installing the integration through the `nri-bundle` chart.
 
  ```yaml
  newrelic-infrastructure:

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -140,7 +140,7 @@ New Relic's Kubernetes integration is compatible with different flavors. We test
         OpenShift
       </td>
       <td>
-        Tested with OpenShift 4.10 and lower. Note that 3.x versions are no longer supported.
+        Tested with OpenShift 4.12 and lower. Note that 3.x versions are no longer supported.
       </td>
     </tr>
     <tr>

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -131,6 +131,7 @@ Before starting our [guided install](https://one.newrelic.com/nr1-core?state=51f
        oc adm policy add-scc-to-user privileged system:serviceaccount:<namespace>:<release_name>-newrelic-logging
        oc adm policy add-scc-to-user privileged system:serviceaccount:<namespace>:<release_name>-nri-kube-events
        oc adm policy add-scc-to-user privileged system:serviceaccount:<namespace>:<release_name>-nri-metadata-injection-admission
+       oc adm policy add-scc-to-user privileged system:serviceaccount:<namespace>:<release_name>-nrk8s-controlplane
        oc adm policy add-scc-to-user privileged system:serviceaccount:<namespace>:default
        ```
 


### PR DESCRIPTION
- Add OpenShift v4.12 to the support compatibility matrix.
- Update the "Setup mTLS for ECTD with OpenShift" with working steps and improve the existing one with examples..
- Add additional service account setting for control plane.