### PR TITLE
feat(synthetics): updated script per hero request

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring.mdx
@@ -215,14 +215,19 @@ You might choose to create a scripted browser monitor instead of a step monitor 
 		<TabsPageItem id="wait">
 
         ```js
-        $webDriver.get("http://telco.nrdemo.com/").then(function(){
-            return $webDriver.findElement($selenium.By.id("supportDropDown")).click();
-        }).then(function(){
-        //Wait up to 20000 seconds for the FAQ page to appear
-            return $webDriver.waitForAndFindElement($selenium.By.id("supportFAQLink"), 20000).then(function(aboutPage){
-                return aboutPage.click();
-            })
-        });
+async function waitForAndFindElement(locator, timeout){
+  const element = await $webDriver.wait($selenium.until.elementLocated(locator), timeout, 'Timed-out waiting for element to be located using: '+locator);
+  await $webDriver.wait($selenium.until.elementIsVisible(element), timeout, 'Timed-out waiting for element to be visible using ${element}');
+  return await $webDriver.findElement(locator);
+}
+
+await $webDriver.get("http://telco.nrdemo.com/")
+
+await $webDriver.findElement($selenium.By.id("supportDropDown")).click();
+
+//Wait up to 20000 seconds for the FAQ page to appear
+let aboutPage = await waitForAndFindElement($selenium.By.id("supportFAQLink"), 20000)
+await aboutPage.click();
         ```
 
         Scripted browser monitors can wait a specified amount of time before reporting an error. Since some images or dynamic elements take time to generate, you can give parameters to `$webDriver.waitForandFindElement()`. In this snippet, your monitor finds `"supportFAQLink"`, then waits `20000` seconds before reporting an error. 


### PR DESCRIPTION
Per hero request:

> The code snippet for the “Wait for a page element” section shows the waitForAndFindElement method being used with $webDriver, which is deprecated on the new runtime

Updated snippet from @bpeckNR 