### PR TITLE
docs: update .net agent api docs to include new SetUserId method

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
@@ -24,7 +24,7 @@ Provides access to transaction-specific methods in the New Relic API.
 
 Provides access to transaction-specific methods in the New Relic .NET agent API. To obtain a reference to `ITransaction`, use the current transaction method available on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent).
 
-This section contains descriptions and parameters of three ITransaction methods:
+The following methods are available on `ITransaction`:
 
 <table>
   <thead>
@@ -97,6 +97,16 @@ This section contains descriptions and parameters of three ITransaction methods:
 
       <td>
         Provides access to the currently executing [span](/docs/agents/net-agent/net-agent-api/ispan), which provides access to span-specific methods in the New Relic API.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [SetUserId](#setuserid)
+      </td>
+
+      <td>
+        Associates a User Id to the current transaction.
       </td>
     </tr>
   </tbody>
@@ -448,6 +458,55 @@ ITransaction transaction = agent.CurrentTransaction;
 ISpan currentSpan = transaction.CurrentSpan;
 ```
 
-## Examples
+## SetUserId
 
-See [Parameters section](#parameters).
+Associates a User Id with the current transaction.
+
+This method requires .NET agent and .NET agent API [version 10.8.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1080) or higher.
+
+### Syntax
+
+```cs
+ITransaction SetUserId(string userId)
+```
+
+### Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `userId`
+
+        _string_
+      </td>
+
+      <td>
+        The User Id to be associated with this transaction.
+
+        * Null, empty and whitespace values will be ignored.
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+### Example
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ITransaction transaction = agent.CurrentTransaction; 
+transaction.SetUserId("BobSmith123");
+```


### PR DESCRIPTION
Adds documentation for a new `SetUserId` method available in the .NET Agent API.

**Please do not merge until after 4pm Pacific time today (3/28)!**