### PR TITLE
docs: .NET Agent 10.9.0 Release Notes

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -30,6 +30,20 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v10.9.0
+      </td>
+
+      <td>
+        March 28, 2023
+      </td>
+
+      <td>
+        March 28, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v10.8.0
       </td>
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-9-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-9-0.mdx
@@ -1,0 +1,54 @@
+---
+subject: .NET agent
+releaseDate: '2023-03-28'
+version: 10.9.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Rename NewRelic.Providers.Wrapper.Asp35 to NewRelic.Providers.Wrapper.AspNet', 'Agent API supports associating a User Id with the current transaction', 'Agent API supports providing a callback to determine what error group an exception should be grouped under', 'Adds the Supportability/Logging/Forwarding/Dropped metric to track the number of log messages that were dropped due to capacity constraints']
+bugs: ['Reduce redundant collector request data payload logging in the agent log at DEBUG level', 'Fix a regression in NLog local decoration when logging messages with object parameters']
+security: []
+---
+
+<Callout variant="important">
+New Relic recommends that you update the agent regularly and at a minimum every 3 months. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent).
+
+This release is supported for one year after its release date. For a full list of supported versions and their support periods, please see our [EOL policy doc](/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy).
+
+As of this release, the oldest supported version is [.NET agent 8.26.630.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8266300).
+</Callout>
+
+### New Errors inbox features
+* **User tracking**: You can now see the number of users impacted by an error group. Identify the end user with the setUserId method.
+* **Error fingerprint**: Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
+
+### New Features
+* Agent API now supports associating a User Id with the current transaction. See our [ITransaction API documentation](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/itransaction/#setuserid) for more details.  [#1420](https://github.com/newrelic/newrelic-dotnet-agent/pull/1420)
+* Agent API now supports providing a callback to determine what error group an exception should be grouped under. See our [SetErrorGroupCallback API documentation](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/seterrorgroupcallback-net-agent-api/) for more details. [#1434](https://github.com/newrelic/newrelic-dotnet-agent/pull/1434)
+* Adds the `Supportability/Logging/Forwarding/Dropped` metric to track the number of log messages that were dropped due to capacity constraints. [#1470](https://github.com/newrelic/newrelic-dotnet-agent/pull/1470)
+
+### Fixes
+* Reduce redundant collector request data payload logging in the agent log at DEBUG level. [#1449](https://github.com/newrelic/newrelic-dotnet-agent/pull/1449)
+* Fixes [#1459](https://github.com/newrelic/newrelic-dotnet-agent/issues/1459), a regression in NLog local decoration when logging messages with object parameters. [#1480](https://github.com/newrelic/newrelic-dotnet-agent/pull/1480)
+
+### Other
+* Renamed `NewRelic.Providers.Wrapper.Asp35` to `NewRelic.Providers.Wrapper.AspNet` since this wrapper instruments multiple versions of ASP.NET. Updated installers to remove old `Asp35` artifacts. [#1448](https://github.com/newrelic/newrelic-dotnet-agent/pull/1448)
+
+Once published, you can find the release artifacts for this release [here](https://download.newrelic.com/dot_net_agent/latest_release/) or on [NuGet.org](https://www.nuget.org/).
+
+### Checksums
+| File | SHA - 256  Hash |
+| ---| ---|
+| newrelic-dotnet-agent-10.9.0-1.x86_64.rpm | 26AA1CE84A2724E65991E3035FB9F2899DF47447DC96618DC1969C424D18DFEB |
+| newrelic-dotnet-agent_10.9.0_amd64.deb | F03AF60E81DFCAF706551BC8DB8DEB7B6FE7ADDCD961DDA72AA3B7F7D866B319 |
+| newrelic-dotnet-agent_10.9.0_amd64.tar.gz | 04F0A8699A35FF4E22D0FF704227B7E2DBA900064B17490D86270D4ADC01DB23 |
+| newrelic-dotnet-agent_10.9.0_arm64.deb | 2C16448899297496B2659C31B6B72BDF08EE0B3A23218374FC9FE515BB714361 |
+| newrelic-dotnet-agent_10.9.0_arm64.tar.gz | C1795D4A94268DAEB57290DD2012822D9E9A76C7F38C52E84F93729BC89862D4 |
+| NewRelicDotNetAgent_10.9.0_x64.msi | CFC4F5A33888B532808FEE8D256EF552804D59672726E43A34AADA20B31C972A |
+| NewRelicDotNetAgent_10.9.0_x64.zip | 8D4682B2C3540527AB96EA08CB01F9B050917B66A67D651EECBD1A69DFC6FB59 |
+| NewRelicDotNetAgent_10.9.0_x86.msi | A3C8FCC210F984BD89B91AD1237F212F17AA9DC77E7B977AA67D52FA4E4030AE |
+| NewRelicDotNetAgent_10.9.0_x86.zip | 87775474DF6AF523380A9F434C316EC53694FF55784435BD53CFF272D1B4E085 |
+
+  
+### Updating
+
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).


### PR DESCRIPTION
Add the release notes for .NET Agent release 10.9.0 and update the EOL page with the new version.  No versions removed from EOL.