### PR TITLE
docs: clarify metric units for timeslice metrics

### DIFF
--- a/src/content/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql.mdx
@@ -171,7 +171,7 @@ Here are how the original [APM metric timeslice](/docs/using-new-relic/data/unde
 
 Some of the APM metrics made available as dimensional metrics:
 
-<table style={{ width: "700px" }}>
+<table>
   <thead>
     <tr>
       <th>
@@ -185,6 +185,10 @@ Some of the APM metrics made available as dimensional metrics:
       <th>
         Attributes
       </th>
+
+      <th>
+        Metric unit
+      </th>
     </tr>
   </thead>
 
@@ -196,6 +200,10 @@ Some of the APM metrics made available as dimensional metrics:
 
       <td>
         Time spent in user-mode code
+      </td>
+
+      <td>
+        percentage
       </td>
 
       <td>
@@ -215,6 +223,10 @@ Some of the APM metrics made available as dimensional metrics:
       <td>
         `datastoreType`, `table`, `operation`
       </td>
+
+      <td>
+        seconds
+      </td>
     </tr>
 
     <tr>
@@ -228,6 +240,10 @@ Some of the APM metrics made available as dimensional metrics:
 
       <td>
         `transactionType`
+      </td>
+
+      <td>
+        count
       </td>
     </tr>
 
@@ -243,6 +259,10 @@ Some of the APM metrics made available as dimensional metrics:
       <td>
         `external.host`
       </td>
+
+      <td>
+        seconds
+      </td>
     </tr>
 
     <tr>
@@ -255,6 +275,10 @@ Some of the APM metrics made available as dimensional metrics:
       </td>
 
       <td/>
+
+      <td>
+        count
+      </td>
     </tr>
 
     <tr>
@@ -267,6 +291,10 @@ Some of the APM metrics made available as dimensional metrics:
       </td>
 
       <td/>
+
+      <td>
+        megabytes
+      </td>
     </tr>
 
     <tr>
@@ -280,6 +308,10 @@ Some of the APM metrics made available as dimensional metrics:
 
       <td>
         `transactionName`, `transactionType`
+      </td>
+
+      <td>
+        apdex
       </td>
     </tr>
 
@@ -295,6 +327,10 @@ Some of the APM metrics made available as dimensional metrics:
       <td>
         `keyTransactionName`, `transactionName`, `transactionType`
       </td>
+
+      <td>
+        seconds
+      </td>
     </tr>
 
     <tr>
@@ -308,6 +344,10 @@ Some of the APM metrics made available as dimensional metrics:
 
       <td>
         `keyTransactionName`, `transactionName`, `transactionType`
+      </td>
+
+      <td>
+        count
       </td>
     </tr>
 
@@ -323,11 +363,22 @@ Some of the APM metrics made available as dimensional metrics:
       <td>
         `transactionType`
       </td>
+
+      <td>
+        seconds
+      </td>
     </tr>
   </tbody>
 </table>
 
 Learn how to [see all metrics available to you](#get-list).
+To get the metric unit for a given metric name, you can use a query like:
+```sql
+FROM Metric
+  SELECT metricUnit
+  WHERE appName = 'YOUR_APP_NAME'
+  AND metricName = 'METRIC_NAME'
+```
 
 To understand more about the general structure of metric timeslice data, including some common examples, see [Metric timeslice data](/docs/using-new-relic/data/understand-data/new-relic-data-types#timeslice-data).
 


### PR DESCRIPTION
Clarify metric units for timeslice metrics

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  Clarify metric unit for timeslice metrics
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  The units are taken from this query 
  ```
  FROM Metric SELECT metricName, metricUnit WHERE appName = 'YOUR_APP_NAME' and metricName IN ('apm.service.cpu.usertime.utilization','apm.service.datastore.operation.duration','apm.service.error.count','apm.service.external.host.duration','apm.service.instance.count','apm.service.memory.physical','apm.service.transaction.apdex','apm.service.transaction.duration','apm.service.transaction.error.count','apm.service.transaction.external.duration') limit max
  ```
* If your issue relates to an existing GitHub issue, please link to it.