### PR TITLE
docs: add agent version metadata for Node.js supported releases NR-93129

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-10-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-10-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-06-22'
 version: 6.10.0
+features: ["Add additional Transaction Information to Span Events.","Custom transaction attributes added via `API.addCustomAttribute` or `API.addCustomAttributes` will now be propagated to the currently active span, if available."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-11-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-11-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-07-07'
 version: 6.11.0
+features: ["Add Distributed Tracing option to config file used for first time customers."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-12-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-12-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-08-10'
 version: 6.12.0
+features: ["Upgrade `async` to `v3.2.0`."]
+bugs: ["Fix obfuscation of SQL queries with large data inserts.","On failed instrumentation, prevent multiple requires from re-wrapping shims."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-12-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-12-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-08-20'
 version: 6.12.1
+features: []
+bugs: []
+security: ["Resolve an issue where transaction traces will still capture the request URI when the Node.js agent is configured to exclude the 'request.uri' attribute."]
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-13-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-13-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-08-25'
 version: 6.13.0
+features: ["Add the ability for the agent to write to a named pipe, instead of stdout, when in serverless mode."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-13-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-6-13-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-09-24'
 version: 6.13.1
+features: []
+bugs: ["Fix the named-pipe check for lambda invocations to avoid race-condition."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-680.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-680.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-05-21'
 version: 6.8.0
+features: ["Add whitespace trimming of license key configuration values."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-690.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-690.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2020-06-08'
 version: 6.9.0
+features: ["Add AWS API Gateway V2 Support to lambda instrumentation.","Add 'transaction.name' intrinsic to active span at time transaction name is finalized.","Add 'error.expected' attribute to span active at the time expected error was noticed.","Drop errors earlier during collection when error collection is disabled.","Remov allocation of logging-only objects used by transaction naming when those log levels are disabled."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-04-06'
 version: 7.3.0
+features: ["Add new feature-flag 'new_promise_tracking' which enables cleaning up of segment references on native promise resolve instead of destroy."]
+bugs: ["Fix a memory leak introduced when Infinite Tracing is enabled."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-3-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-04-14'
 version: 7.3.1
+features: ["**Deprecation Warning:** The certificate bundle automatically included by New Relic when using the 'certificates' configuration (commonly with proxies) will be disabled by default in the next major version."]
+bugs: ["Fix issue with 'new_promise_tracking' feature flag functionality where segments for ended transactions would get propagated in certain cases."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-4-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-4-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-05-11'
 version: 7.4.0
+features: ["Handle a proxy misconfiguration of the collector and log an actionable warning message.","Log all New Relic metadata env vars at startup.","Add `flaky_code` and `success_delay_ms` handling of flaky grpc connections to infinite tracing."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-06-01'
 version: 7.5.0
+features: ["Add default support for config files with a 'cjs' extension (`newrelic.cjs`) in addition to `newrelic.js`.","Add the ability to specify a custom config file name with the `NEW_RELIC_CONFIG_FILENAME` environment variable."]
+bugs: ["Fix an issue when using the 'new_promise_tracking' feature flag where segment mapping may not get cleaned up."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-06-21'
 version: 7.5.1
+features: []
+bugs: ["Fix loading config from the main module's directory.."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-5-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-07-07'
 version: 7.5.2
+features: []
+bugs: ["Fix bug where promise-based cursor methods would not properly measure the duration of execution."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-0-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-07-26'
 version: 8.0.0
+features: ["**BREAKING** Drop Node v10.x support.", "**BREAKING**: The agent no-longer includes the New Relic certificate bundle automatically when using the 'certificates' configuration (commonly with proxies).","**BREAKING**: Remove `serverless_mode` as a feature flag."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-1-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-1-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-08-05'
 version: 8.1.0
+features: ["Added necessary instrumentation to support v4 of `mongodb`."]
+bugs: ["Fix issue where Promise based `pg.Client.query` timings were always in sub-millisecond range.","Fix bug where `API.shutdown` would not harvest or keep process active effectively after an agent restart."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-10-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-10-0.mdx
@@ -13,11 +13,11 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 * Added instrumentation for `mysql2/promise`.
    * This previously only existed in our standalone `@newrelic/mysql`, but now gives feature partiy between the two.
 
-* Removed unused native CPU metric sampler.  This logic was no longer getting touched when running Node.js versions higher than 6.1.0.
+* Removed unused native CPU metric sampler. This logic was no longer getting touched when running Node.js versions higher than 6.1.0.
 
 * Fixed promise interceptor from re-throwing errors.
 
-* Added transaction naming documentation ported from a discussion forum post: https://discuss.newrelic.com/t/relic-solution-the-philosophy-of-naming-your-node-agent-transactions/.
+* Added transaction naming documentation ported from a [discussion forum post](https://forum.newrelic.com/s/hubtopic/aAX8W0000008ZfxWAE/relic-solution-the-philosophy-of-naming-your-node-agent-transactions).
 
 * Added `promises.tap.js` to mysql2 versioned tests.
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-10-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-10-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-04-18'
 version: 8.10.0
+features: ["Add instrumentation for `mysql2/promise`.","Remove unused native CPU metric sampler."]
+bugs: ["Fix promise interceptor from re-throwing errors."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-11'
 version: 8.11.0
+features: ["Add application logging for Winston in the Node.js agent.","Support automatic instrumentation of Redis v4."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-0.mdx
@@ -26,7 +26,6 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
     * Added sent, seen, and dropped metrics that collected on every harvest cycle around log lines.
 
-
     * Added supportability metrics for some popular logging frameworks.
     
     * Added supportability metrics to record if the logging features are enabled.

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-13'
 version: 8.11.1
+features: []
+bugs: ["Fix winston instrumentation that caused agent to crash when creating a winston logger from an existing instantiated logger."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-11-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-23'
 version: 8.11.2
+features: []
+bugs: ["Fix winston instrumentation to no longer coerce every log line to be json."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-12-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-12-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-24'
 version: 8.12.0
+features: ["Add pino instrumentation to support log forwarding, decoration, and metrics.","Add an optional way to avoid wrapping browser agent script with <script> tag when using `api.getBrowserTimingHeader`."]
+bugs: []
+security: ["Upgrade `@grpc/proto-loader` to fix CVE-2022-25878 with `protobufjs`."]
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-26'
 version: 8.13.0
+features: []
+bugs: ["Move log forwarding logic so customer transports are not polluted with NR data.","Prevent transmitting logs when application level logging has been disabled."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-27'
 version: 8.13.1
+features: []
+bugs: ["Fix passing undefined as formatter options to `winston.format.combine`"]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-13-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-05-31'
 version: 8.13.2
+features: []
+bugs: []
+security: ["Upgrade `protobufjs` to resolve  CVE-2022-25878"]
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-14-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-14-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-06-06'
 version: 8.14.0
+features: []
+bugs: ["Fix issue with `api.getBrowserTimingHeader` optional script unwrapping issue with util.format.","Fix winston instrumentation to not exit early when `winston.createLogger` is created without options.","Update pino instrumentation to not override user log configurations."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-14-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-14-0.mdx
@@ -11,7 +11,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 ## Notes
 
 * Fixed issue with `api.getBrowserTimingHeader` optional script unwrapping issue with util.format.
-  Thanks for your contribution @github-dd-nicolas 🎉
+  Thanks for your contribution [@github-dd-nicolas](https://github.com/github-dd-nicolas)
 
 * Fixed winston instrumentation to not exit early when `winston.createLogger` is created without options.
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-14-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-14-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-06-09'
 version: 8.14.1
+features: ["Add defensive code in redis v4 instrumentation to check for `opts.socket` first before evaluating `opts.socket.path`."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-15-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-15-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-07-07'
 version: 8.15.0
+features: ["Add instrumentation for grpc-js unary, streaming, and bidirectional client calls.","Add ability to disable server-side configuration via local configuration setting."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-16-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-16-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-07-21'
 version: 8.16.0
+features: ["Automatic application log forwarding is now enabled by default.","Add a support statement to our release notes."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-17-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-17-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-07-27'
 version: 8.17.0
+features: ["Add instrumentation for `grpc-js` server unary, client-streaming, server-streaming and bidirectional streaming handlers."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-17-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-17-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-08-02'
 version: 8.17.1
+features: ["Bound the external client segment to the onReceiveStatus listener to propagate transaction context to the grpc client callbacks."]
+bugs: ["Fix issue where instrumented code invoked within a @grpc/grpc-js client callback would not get tracked by the agent.","Fix issue with truncate in `lib/util/application-logging.js`."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-2-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-08-25'
 version: 8.2.0
+features: ["Add a new feature flag `unresolved_promise_cleanup`.","Support using `connect` to route middleware calls."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-3-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-09-09'
 version: 8.3.0
+features: ["Enable Distributed Tracing (DT) by default.","Add support for properly setting the `host` and `port` for mongodb requests that are to cluster.","Add several environment variables for the corresponding configuration items."]
+bugs: ["Fix an issue where `.fastify` and `.default` properties would be missing from the `fastify` export when instrumented."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-4-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-4-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-09-28'
 version: 8.4.0
+features: ["Deprecate Cross Application Tracing (CAT).","Add support for Cassandra driver v4.0.0 and above."]
+bugs: ["Fix an issue with `clearTimeout` that could result in dropping parent segments or spans.","Fix an issue where DT headers would not be processed by `transaction-shim.handleCATHeaders()` when CAT was explicitly disabled."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-5-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-5-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-10-12'
 version: 8.5.0
+features: ["Add full support for Fastify v2 and v3. Fastify instrumentation is now GA.","Add experimental instrumentation for the undici http client behind a feature flag."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-5-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-5-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-11-03'
 version: 8.5.1
+features: []
+bugs: ["Fix a bug where failure to retrieve CPU/Memory details for certain Linux distros could result in a crash."]
+security: ["Fix a high severity npm audit failure."]
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-5-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-5-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-11-09'
 version: 8.5.2
+features: []
+bugs: ["Fix an issue where unhandled promise rejections were not getting logged as errors in a lambda execution."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-6-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-6-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2021-11-17'
 version: 8.6.0
+features: ["Introduce a context management API to be used in place of manually calling tracer.segment get/set."]
+bugs: ["Fix an issue where `recordConsume` was not binding consumer if it was a promise."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-7-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-7-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-01-04'
 version: 8.7.0
+features: ["Update `onResolved` instrumentation hook to only be called the first time we see a specific module filepath resolved.","Remove `tracer.segment` in place of direct usage of context manager."]
+bugs: ["Fix an issue where `instrumentLoadedModule` would return `true` even if the instrumentation handler indicated it did not apply instrumentation.","Fix an issue where expected status code ranges would not be parsed until ignored status codes were also defined."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-7-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-7-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-01-18'
 version: 8.7.1
+features: []
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-8-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-8-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-02-23'
 version: 8.8.0
+features: ["Update AWS metadata capture to utilize IMDSv2.","Update minimum Node version warning to output the current Node version from process."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-9-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-9-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-03-15'
 version: 8.9.0
+features: ["Add support for `initializeUnorderedBulkOp`, and `initializeOrderedBulkOp` in mongodb v3 instrumentation.","Update logger to delay and queue logging until configuration is parsed.","Add `NEW_RELIC_ALLOW_ALL_HEADERS` as a boolean environment variable with same behavior as existing `allow_all_headers`.","Updated the AWS IMDBS v2 endpoint to use `latest`."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-9-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-8-9-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-03-22'
 version: 8.9.1
+features: []
+bugs: ["Fix `shim.wrapReturn` to call `Reflect.construct` in construct Proxy trap.  Also include `newTarget` to work with inherited classes."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent 
 releaseDate: '2022-08-03'
 version: 9.0.0
+features: ["Drop Node 12.x support.","Remove certificate bundle from agent.","The agent now excludes port when making external HTTPS requests to port 443.","Remove ability to disable async hooks based promise context tracking via the `await_support` feature flag.","Remove instrumentation for the obsolete.","Update the minimum version of `pg` to be 8.2.x.","Update the minimum supported version of hapi to be >= v20.0.0.", "Add official parity support for Node 18."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-1.mdx
@@ -13,7 +13,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 * Fixed properly setting logging metrics when using custom levels with winston.
 
 * Handled setting the logging metric name to `UNKNOWN` when using custom log levels in pino and/or winston.
-    Thanks for your contribution @billouboq 🎉
+    Thanks for your contribution @billouboq.
 
 * Removed unnecessary unit test and fixture for OSS license generation.
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent 
 releaseDate: '2022-08-18'
 version: 9.0.1
+features: ["Handle setting the logging metric name to `UNKNOWN` when using custom log levels in pino and/or winston.","Remove 3rd party `async` library from agent code."]
+bugs: ["Fix properly setting logging metrics when using custom levels with winston."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-08-23'
 version: 9.0.2
+features: ["Expose `compressed_content_encoding` configuration and defaulted it to "gzip".","Add a special case to serialize BigInts.","Add `minami` back as a dev dependency for use with `jsdoc-conf.js`."]
+bugs: [Fix public jsdoc generation.]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-2.mdx
@@ -2,7 +2,7 @@
 subject: Node.js agent
 releaseDate: '2022-08-23'
 version: 9.0.2
-features: ["Expose `compressed_content_encoding` configuration and defaulted it to "gzip".","Add a special case to serialize BigInts.","Add `minami` back as a dev dependency for use with `jsdoc-conf.js`."]
+features: ["Expose `compressed_content_encoding` configuration and defaulted it to 'gzip'.","Add a special case to serialize BigInts.","Add `minami` back as a dev dependency for use with `jsdoc-conf.js`."]
 bugs: [Fix public jsdoc generation.]
 security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-3.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-0-3.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-09-06'
 version: 9.0.3
+features: ["Update gRPC client instrumentation to respect `grpc.record_errors` when deciding to log errors on gRPC client requests."]
+bugs: ["Fix transaction name finalization to properly copy the appropriate transaction name to root segment."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-1-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-1-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-09-22'
 version: 9.1.0
+features: ["Add experimental loader to support instrumentation of CommonJS packages in ECMAScript Module(ESM) applications.","Enhance supportability metrics for ESM support.", "Add new metrics to track usage of ESM loader.","Update instrumentation map for tracking metrics.","Enabled re-throwing ESM import errors of `newrelic.js`."]
+bugs: ["Fix an issue with mongodb instrumentation where IPv6 address([::1]) was not getting mapped to localhost when setting the host attribute on the segment."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-10-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-10-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-02-09'
 version: 9.10.0
+features: ["Expose a method on API to obfuscate sql:`newrelic.obfuscateSql`.","Add support for Multi Value Parameter from API Gateway and ALB events for Lambdas."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-10-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-10-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-02-13'
 version: 9.10.1
+features: []
+bugs: ["Fix error with Lambda/ALB serverless instrumentation when no response headers were included."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-10-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-10-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-02-21'
 version: 9.10.2
+features: []
+bugs: ["Replace `request.aborted` with `response.close` in HTTP instrumentation.","Fix ignoring reporting errors of certain status codes and parse codes as integers."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-11-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-11-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-03-08'
 version: 9.11.0
+features: ["Add instrumentation for Prisma(`@prisma/client`) with minimum supported version 4.0.0."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-11-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-11-0.mdx
@@ -19,7 +19,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
    * Captures SQL Traces.
    * Provides connection between application and database server via service maps. 
 
-Huge shoutout to @osmanmrtacar for the original contribution 🙏🏻
+Huge shoutout to @osmanmrtacar for the original contribution
 
  * Updated `@grpc/protoloader` from 0.7.4 to 0.7.5.
  * Updated `@grpc/grpc-js` from 1.8.7 to 1.8.8. 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-12-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-03-15'
 version: 9.12.1
+features: ["Add ability to mark errors as expected using `newrelic.noticeError.","Ability to disable distributed tracing for aws-sdk >= 3.290.0."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-13-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-13-0.mdx
@@ -2,6 +2,10 @@
 subject: Node.js agent
 releaseDate: '2023-03-20'
 version: 9.13.0
+features: ["Update http instrumentation to no longer remove the `x-new-relic-disable-dt` header when using AWS SDK v3.","Add API method `setUserID` to provide ability to 
+group transaction events, traces, and errors within a transaction.`]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-13-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-13-0.mdx
@@ -2,8 +2,7 @@
 subject: Node.js agent
 releaseDate: '2023-03-20'
 version: 9.13.0
-features: ["Update http instrumentation to no longer remove the `x-new-relic-disable-dt` header when using AWS SDK v3.","Add API method `setUserID` to provide ability to 
-group transaction events, traces, and errors within a transaction.`]
+features: ["Update http instrumentation to no longer remove the `x-new-relic-disable-dt` header when using AWS SDK v3.","Add API method `setUserID` to provide ability to group transaction events, traces, and errors within a transaction.`"]
 bugs: []
 security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-14-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-14-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-03-23'
 version: 9.14.0
+features: ["Add new API `setErrorGroupCallback` to allown error grouping by setting `error.group.name` attribute."]                                                                                                                
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-14-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-14-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-03-23'
 version: 9.14.1
+features: []
+bugs: ["Fix to properly detect attempts to load agent more than once."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-2-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-10-06'
 version: 9.2.0
+features: ["Remove `application_logging.forwarding.enabled` stanza from sample config as the feature is now enabled by default.","Add ability to instrument ES Modules with the New Relic ESM Loader.","Add support for custom ESM instrumentation.","Add supportability metric."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-3-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-10-17'
 version: 9.3.0
+features: ["Add instrumentation to bunyan to support application logging.","Add c8 to track code coverage.","Add documentation about custom instrumentation in ES module applications."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-3-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-3-0.mdx
@@ -12,7 +12,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 * Added instrumentation to bunyan to support application logging use cases: forwarding, local decorating, and metrics.
    
-   Big thanks to @brianphillips for his contribution 🚀
+   Big thanks to @brianphillips for his contribution
 
 * Added c8 to track code coverage.
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-4-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-4-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-10-24'
 version: 9.4.0
+features: ["Remove legacy agent async context propagation.","Add an API for enqueuing application logs for forwarding.","Add a new context manager that leverages AsyncLocalStorage for async context propagation."]
+bugs: ["Fix an issue with the ES Module loader that properly registers instrumentation.", "Fix `cassandra-driver` instrumentation to properly set instance details on query segments/spans."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-5-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-5-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-10-26'
 version: 9.5.0
+features: ["Increase the default limit of custom events from 1,000 events per minute to 3,000 events per minute.","Add a document for our current feature flags."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-6-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-6-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-11-09'
 version: 9.6.0
+features: ["Drop support for `vision` and instead only instrument `@hapi/vision`.","Update configuration system to automatically create an environment variable mapping for a new config value.","Remove `transaction_tracer.hide_internals` configuration."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-11-14'
 version: 9.7.0
+features: ["Add new configuration option, `grpc.ignore_status_codes`."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-12-06'
 version: 9.7.1
+features: ["Reintroduce throttling during startup to prevent EMFILE issues.","Add a new test stanza to run Restify >=10 on Node 18.","Add `newrelic.noticeError()` example to our API docs.","Remove async from benchmark tests, fix failing benchmark suites, and remove deprecated suites."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-1.mdx
@@ -16,7 +16,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
   * Added a new test stanza to run restify >=10 on Node 18.
   * Update our versioned tests to support Restify 9.0.0.
 
-* Laid foundation for supporting Code Level Metrics via [Codestream](https://docs.newrelic.com/docs/codestream/how-use-codestream/performance-monitoring/). Note that this integration is not fully finished and should not be used.
+* Laid foundation for supporting Code Level Metrics via [Codestream](/docs/codestream/how-use-codestream/performance-monitoring/). Note that this integration is not fully finished and should not be used.
 
 * Improved the readability and maintainability of agent by reducing the [Cognitive Complexity](https://www.sonarsource.com/resources/cognitive-complexity/) of various aspects of the agent.
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-2.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-12-07'
 version: 9.7.2
+features: []
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-3.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-3.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-12-12'
 version: 9.7.3
+features: ["Add support for Code Level Metrics on API methods."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-4.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-4.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2022-12-15'
 version: 9.7.4
+features: []
+bugs: ["Fix system info gathering to prevent unhandled promise rejection when an error occurs reading `/proc` information."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-5.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-7-5.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-01-03'
 version: 9.7.5
+features: ["Add a check to the code level metrics utility to ensure filePath was set before adding the `code.*` attributes."]
+bugs: ["Fix connection issue where listing of dependencies and packages from symlinked nested directories created an infinite loop."]
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-8-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-8-0.mdx
@@ -10,7 +10,7 @@ downloadLink: 'https://www.npmjs.com/package/newrelic'
 
 ## Notes
 
-* Updated `getBrowserTimingHeader` to allow the browser agent to be generated even when not in a transaction by adding `allowTransactionlessInjection` to function options. `allowTransactionlessInjection` is a boolean option, and when set to `true`, will allow injection of the browser agent when not in a transaction. This is intended to be used in frameworks that build Static Site Generation(SSG). Note that if you are using this option, you may need to wait until the Node agent has established a connection before calling `getBrowserTimingHeader`. To wait until the agent is connected, you can add the following check to your code: 
+* Updated `getBrowserTimingHeader` to allow the browser agent to be generated even when not in a transaction by adding `allowTransactionlessInjection` to function options. `allowTransactionlessInjection` is a boolean option, and when set to `true`, will allow injection of the browser agent when not in a transaction. This is intended to be used in frameworks that build Static Site Generation(SSG). Note that if you're using this option, you may need to wait until the Node agent has established a connection before calling `getBrowserTimingHeader`. To wait until the agent is connected, you can add the following check to your code: 
 ```js
 if (!newrelic.agent.collector.isConnected()) {
   await new Promise((resolve) => {

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-8-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-8-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-01-17'
 version: 9.8.0
+features: ["Update `getBrowserTimingHeader` by adding `allowTransactionlessinject` to function options."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-8-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-8-1.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-01-25'
 version: 9.8.1
+features: ["Instrument `winston.loggers.add.","Change GCP metadata parsing to use `json-bigint`."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-9-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-9-0.mdx
@@ -2,6 +2,9 @@
 subject: Node.js agent
 releaseDate: '2023-02-06'
 version: 9.9.0
+features: ["Add support for url obfuscation using regex.","Add a new tracking type of instrumentation for logging metrics."]
+bugs: []
+security: []
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 ---
 


### PR DESCRIPTION
adds frontmatter for supported releases