### PR TITLE
fix: set the 10.8 release build number to the correct number

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-8-0-323.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-8-0-323.mdx
@@ -1,13 +1,13 @@
 ---
 subject: PHP agent
 releaseDate: '2023-03-22'
-version: 10.8.0.320
-downloadLink: 'https://download.newrelic.com/php_agent/archive/10.8.0.320'
+version: 10.8.0.323
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.8.0.323'
 features: ['Add healthcheck daemon log level']
 bugs: ['Fix Debian package installation addition step', 'Fix warning when passing null to curl_multi_exec']
 security: []
 ---
-## New Relic PHP Agent v10.8.0.320
+## New Relic PHP Agent v10.8.0.323
 
 ### New features
 


### PR DESCRIPTION
Our previous release notes had the incorrect build number. This changes the number from 320 to 323