### PR TITLE
fix(errors inbox): fingerprinting changes

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -102,6 +102,7 @@ To configure a fingerprint, see the agent-specific documentation:
 
 * [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
 * [Node.js](/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api/#errors)
+* [.Net](/docs/apm/agents/net-agent/net-agent-api/seterrorgroupcallback-net-agent-api)
 * [Python](/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api)
 * [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)
 

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -100,8 +100,7 @@ Error events get grouped into an error group when they share the [same fingerpri
 
 To configure a fingerprint, see the agent-specific documentation: 
 
-* [Ruby](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector)
-
+* [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)
 
 
 ## View errors in the UI [#view-errors]

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -92,6 +92,23 @@ To view expected errors, [query your data](/docs/using-new-relic/data/understand
 * To view charts of expected errors, create a query for the [`error.expected`](/docs/insights/insights-data-sources/default-events-attributes/apm-default-event-attributes#transerror-expected) attribute.
 * To create [alert conditions for NRQL queries](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries), use the `error.expected` attribute.
 
+## Error fingerprinting with errors inbox [#error-fingerprinting]
+
+Errors inbox intelligently groups error occurrences to reduce noise and highlight important errors. 
+
+Error events get grouped into an error group when they share the [same fingerprint](/docs/errors-inbox/errors-inbox/#how-groups-work). While our managed rules are able to provide automatic error grouping based on a predefined set of patterns, it is impossible to recognize every possible combination. For this reason, customers can also set their own fingerprint via a callback function if they find that our managed rules are not grouping occurrences accurately. 
+
+To configure a fingerprint, see the agent-specific documentation: 
+
+
+* [Java](/docs/agents/java-agent/configuration/java-agent-error-configuration)
+* [Ruby](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector)
+* [Node.js](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)
+* [.NET](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#error_collector)
+* [Go](/docs/apm/agents/go-agent/configuration/go-agent-configuration/#error-collector)
+* [Python](/docs/agents/python-agent/configuration/python-agent-configuration/#error-collector-settings)
+
+
 ## View errors in the UI [#view-errors]
 
 Among other places, error data appears in these parts of the UI:

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -101,6 +101,8 @@ Error events get grouped into an error group when they share the [same fingerpri
 To configure a fingerprint, see the agent-specific documentation: 
 
 * [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)
+* [Python](/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api)
+* [Node.js](/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api/#errors)
 
 
 ## View errors in the UI [#view-errors]

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -98,7 +98,7 @@ Errors inbox intelligently groups error occurrences to reduce noise and highligh
 
 Error events get grouped into an error group when they share the [same fingerprint](/docs/errors-inbox/errors-inbox/#how-groups-work). While our managed rules are able to provide automatic error grouping based on a predefined set of patterns, it is impossible to recognize every possible combination. For this reason, customers can also set their own fingerprint via a callback function if they find that our managed rules are not grouping occurrences accurately. 
 
-To configure a fingerprint, see the agent-specific documentation: 
+To configure custom fingerprint logic, see the agent-specific documentation: 
 
 * [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
 * [Node.js](/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api/#errors)

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -100,13 +100,8 @@ Error events get grouped into an error group when they share the [same fingerpri
 
 To configure a fingerprint, see the agent-specific documentation: 
 
-
-* [Java](/docs/agents/java-agent/configuration/java-agent-error-configuration)
 * [Ruby](/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error-collector)
-* [Node.js](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration)
-* [.NET](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#error_collector)
-* [Go](/docs/apm/agents/go-agent/configuration/go-agent-configuration/#error-collector)
-* [Python](/docs/agents/python-agent/configuration/python-agent-configuration/#error-collector-settings)
+
 
 
 ## View errors in the UI [#view-errors]

--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected.mdx
@@ -100,10 +100,10 @@ Error events get grouped into an error group when they share the [same fingerpri
 
 To configure a fingerprint, see the agent-specific documentation: 
 
-* [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)
-* [Python](/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api)
+* [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
 * [Node.js](/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api/#errors)
-
+* [Python](/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api)
+* [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)
 
 ## View errors in the UI [#view-errors]
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -101,11 +101,11 @@ The `exception` is the exception to be recorded, or an error message. If needed,
 </table>
 
 
-## Error fingerprinting: dynamically apply an error group to each noticed error
+## Error fingerprinting: dynamically apply an error group to each noticed error [#error-fingerprinting]
 
 Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
 
-A `Proc` based callback can be supplied to the agent to dynamically apply a desired [error group](../../../errors-inbox/errors-inbox) to each noticed error. Use the Ruby agent API [`NewRelic::Agent.set_error_group_callback`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent#set_error_group_callback-instance_method) to provide the agent with a callback.
+A `Proc` based callback can be supplied to the agent to dynamically apply a desired [error group](docs/errors-inbox/errors-inbox/#how-groups-work) to each noticed error. Use the Ruby agent API [`NewRelic::Agent.set_error_group_callback`](https://www.rubydoc.info/github/newrelic/newrelic-ruby-agent/NewRelic/Agent#set_error_group_callback-instance_method) to provide the agent with a callback.
 
 This API call takes a callback method (must be of type `Proc`) as its only argument. The argument is required. The API call only needs to be made once per New Relic Ruby agent launch, so the call can be placed in a Rails initializer or similar. If subsequent calls to the API are made, the callback method will update to the newest one provided. Here's an example of a callback being defined and passed to the `NewRelic::Agent.set_error_group_callback` API method:
 


### PR DESCRIPTION
Ready for review!

Correct me if I am wrong @elucus but we only have four agents who have documented error fingerprinting with errors inbox:

- Go
- Node
- Python
- Ruby

**Missing:**

- .Net
- Java (pending on 4.13)
- PHP