### PR TITLE
Ruby agent v9.1.0 1 year EOL policy

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -30,6 +30,20 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v9.1.0
+      </td>
+
+      <td>
+        Mar 29, 2023
+      </td>
+
+      <td>
+        Mar 29, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v9.0.0
       </td>
 


### PR DESCRIPTION
Add Ruby agent v9.1.0 to the EOL policy page, with a 1 year timeframe

Hello reviewers. Due to a complete oversight on the Ruby agent dev team's part, we missed the updating of this page which should have been included with #12357.

Given that #12357, please feel free to merge this one whenever it's convenient. Thank you!