### PR TITLE
feat(apm:go-agent): 3.21.0 release

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
@@ -27,6 +27,19 @@ Any versions not listed in the following table are no longer supported. Please [
   </thead>
 
     <tbody>
+    <tr>
+      <td>
+        v3.21.0
+      </td>
+
+      <td>
+        Mar 22, 2023
+      </td>
+
+      <td>
+        Mar 22, 2024
+      </td>
+    </tr>
      <tr>
       <td>
         v3.20.4

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
@@ -1,0 +1,30 @@
+---
+subject: Go agent
+releaseDate: '2023-03-22'
+version: 3.21.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.21.0'
+features: ["Error Fingerprinting", "User Tracking", "Redis 9 Instrumentation"]
+bugs: []    
+security: ["Improved grpc test coverage"]
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+## 3.21.0
+
+### Added
+* New Errors inbox features:
+  * User tracking: You can now see the number of users impacted by an error group. Identify the end user with the setUser method.
+  * Error fingerprint: Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
+* Automatically instrument Redis 9 code using the new instrumentation package nrredis-v9.
+
+### Fixed
+* Improved test coverage for gRPC integration, nrgrpc
+
+### Support Statement
+
+We also using the latest version of the Go language. At minimum, you should at least be using no version of Go older than what is supported by the Go team themselves.
+
+See the [Go Agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go Agent and third-party components.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
@@ -15,7 +15,7 @@ We recommend updating to the latest agent version as soon as it's available. If 
 ## 3.21.0
 
 ### Added
-* New Errors inbox features:
+* New errors inbox features:
   * User tracking: You can now see the number of users impacted by an error group. Identify the end user with the setUser method.
   * Error fingerprint: Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
 * Automatically instrument Redis 9 code using the new instrumentation package nrredis-v9.
@@ -23,8 +23,8 @@ We recommend updating to the latest agent version as soon as it's available. If 
 ### Fixed
 * Improved test coverage for gRPC integration, nrgrpc
 
-### Support Statement
+### Support statement
 
-We also using the latest version of the Go language. At minimum, you should at least be using no version of Go older than what is supported by the Go team themselves.
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
 
-See the [Go Agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go Agent and third-party components.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
@@ -3,7 +3,7 @@ subject: Go agent
 releaseDate: '2023-03-22'
 version: 3.21.0
 downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.21.0'
-features: ["Error Fingerprinting", "User Tracking", "Redis 9 Instrumentation"]
+features: ["Error Fingerprinting", "User Tracking", "Disable Parameterized Query Collection nrpgx-5"]
 bugs: []    
 security: ["Improved grpc test coverage"]
 ---
@@ -18,7 +18,6 @@ We recommend updating to the latest agent version as soon as it's available. If 
 * New errors inbox features:
   * User tracking: You can now see the number of users impacted by an error group. Identify the end user with the setUser method.
   * Error fingerprint: Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
-* Automatically instrument Redis 9 code using the new instrumentation package nrredis-v9.
 * Ability to disable reporting parameterized query in nrpgx-5
 
 ### Fixed

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-21-0.mdx
@@ -19,6 +19,7 @@ We recommend updating to the latest agent version as soon as it's available. If 
   * User tracking: You can now see the number of users impacted by an error group. Identify the end user with the setUser method.
   * Error fingerprint: Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
 * Automatically instrument Redis 9 code using the new instrumentation package nrredis-v9.
+* Ability to disable reporting parameterized query in nrpgx-5
 
 ### Fixed
 * Improved test coverage for gRPC integration, nrgrpc


### PR DESCRIPTION
Errors inbox release for GO agent -- > targeting EOD today.