### PR TITLE
Error fingerprinting/user tracking API methods for Node agent

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -351,6 +351,24 @@ Usually the agent detects errors automatically. However, you can manually mark a
         See [`newrelic.noticeError()`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError).
       </td>
     </tr>
+    <tr>
+      <td>
+        Group errors by name, using a custom filter function you define
+      </td>
+
+      <td>
+        See [`newrelic.setErrorGroupCallback()`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#setErrorGroupCallback).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Associate errors with users
+      </td>
+
+      <td>
+        See [`newrelic.setUserId()`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#setUserId).
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -770,25 +770,6 @@ New Relic's Node.js agent includes additional API calls.
   </Collapser>
 
   <Collapser
-    id="ignore"
-    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
-  >
-    ```js
-    newrelic.setIgnoreTransaction(ignored)
-    ```
-
-    Tell the module whether or not to ignore a given request. This allows you to explicitly filter long-polling, irrelevant routes or requests you know will be time-consuming. This also allows you to gather metrics for requests that otherwise would be ignored.
-
-    * To ignore the transaction, set the parameter to `true` will ignore the transaction.
-    * To prevent a transaction from being ignored with this function, pass the parameter `false`.
-    * Passing `null` or `undefined` will not change whether the transaction is ignored.
-
-    <Callout variant="caution">
-      This method is deprecated and was removed in version 7.0.0. Please use [transactionHandle.ignore()](#transaction-handle-ignore)
-    </Callout>
-  </Collapser>
-
-  <Collapser
     id="noticeError"
     title={<InlineCode>newrelic.noticeError(error, [customAttributes], [expected])</InlineCode>}
   >
@@ -820,6 +801,64 @@ New Relic's Node.js agent includes additional API calls.
       Errors recorded using this method do not obey the [`ignore_status_codes`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#error_ignore) configuration value.
     </Callout>
   </Collapser>
+
+  <Collapser
+    id="setErrorGroupCallback"
+    title={<InlineCode>newrelic.setErrorGroupCallback(callback)</InlineCode>}
+  >
+    ```js
+    newrelic.setErrorGroupCallback(callback)
+    ```
+    This method lets you define a custom callback to generate Error Group names, which will be used by the Errors Inbox to group similar errors together via the `error.group.name` agent attribute.
+
+    Provided functions must return a string, and receive an object as an argument, which contains information related to the Error that occurred, and has the following format:
+
+    ```
+    {
+      customAttributes: object,
+      'request.uri': string,
+      'http.statusCode': string,
+      'http.method': string,
+      error: Error,
+      'error.expected': boolean
+    }
+    ```
+
+    Calling this function multiple times will replace previously defined versions of this callback function.
+
+    To learn more about this function, please refer to our [example app](https://github.com/newrelic/newrelic-node-examples/tree/main/error-fingerprinting).
+  </Collapser>
+
+  <Collapser
+    id="ignore"
+    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
+  >
+    ```js
+    newrelic.setIgnoreTransaction(ignored)
+    ```
+
+    Tell the module whether or not to ignore a given request. This allows you to explicitly filter long-polling, irrelevant routes or requests you know will be time-consuming. This also allows you to gather metrics for requests that otherwise would be ignored.
+
+    * To ignore the transaction, set the parameter to `true` will ignore the transaction.
+    * To prevent a transaction from being ignored with this function, pass the parameter `false`.
+    * Passing `null` or `undefined` will not change whether the transaction is ignored.
+
+    <Callout variant="caution">
+      This method is deprecated and was removed in version 7.0.0. Please use [transactionHandle.ignore()](#transaction-handle-ignore)
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="setUserID"
+    title={<InlineCode>newrelic.setUserID(string)</InlineCode>}
+  >
+    ```js
+    newrelic.setUserID(string)
+    ```
+    This method gives you a way to associate a unique identifier with a transaction event, transaction trace and errors within transaction. A new property, `enduser.id`, will be added to the error and reported to Errors Inbox.
+
+  </Collapser>
+
 
   <Collapser
     id="shutdown"

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -809,9 +809,9 @@ New Relic's Node.js agent includes additional API calls.
     ```js
     newrelic.setErrorGroupCallback(callback)
     ```
-    This method lets you define a custom callback to generate Error Group names, which will be used by the Errors Inbox to group similar errors together via the `error.group.name` agent attribute.
+    This method lets you define a custom callback to generate error group names, which will be used by errors inbox to group similar errors together via the `error.group.name` agent attribute.
 
-    Provided functions must return a string, and receive an object as an argument, which contains information related to the Error that occurred, and has the following format:
+    Provided functions must return a string, and receive an object as an argument. The object contains information related to the error that occurred, and has the following format:
 
     ```
     {
@@ -831,21 +831,22 @@ New Relic's Node.js agent includes additional API calls.
 
   <Collapser
     id="ignore"
-    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
+    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode> (DEPRECATED)}
   >
+    <Callout variant="caution">
+      This method is deprecated and was removed in version 7.0.0. Please use [transactionHandle.ignore()](#transaction-handle-ignore)
+    </Callout>
+    
     ```js
     newrelic.setIgnoreTransaction(ignored)
     ```
 
     Tell the module whether or not to ignore a given request. This allows you to explicitly filter long-polling, irrelevant routes or requests you know will be time-consuming. This also allows you to gather metrics for requests that otherwise would be ignored.
 
-    * To ignore the transaction, set the parameter to `true` will ignore the transaction.
+    * To ignore the transaction, set the parameter to `true`: this will ignore the transaction.
     * To prevent a transaction from being ignored with this function, pass the parameter `false`.
     * Passing `null` or `undefined` will not change whether the transaction is ignored.
 
-    <Callout variant="caution">
-      This method is deprecated and was removed in version 7.0.0. Please use [transactionHandle.ignore()](#transaction-handle-ignore)
-    </Callout>
   </Collapser>
 
   <Collapser
@@ -855,7 +856,7 @@ New Relic's Node.js agent includes additional API calls.
     ```js
     newrelic.setUserID(string)
     ```
-    This method gives you a way to associate a unique identifier with a transaction event, transaction trace and errors within transaction. A new property, `enduser.id`, will be added to the error and reported to Errors Inbox.
+    This method gives you a way to associate a unique identifier with a transaction event, transaction trace and errors within transaction. A new property, `enduser.id`, will be added to the error and reported to errors inbox.
 
   </Collapser>
 

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -831,7 +831,7 @@ New Relic's Node.js agent includes additional API calls.
 
   <Collapser
     id="ignore"
-    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode> (DEPRECATED)}
+    title={<InlineCode>newrelic.setIgnoreTransaction(ignored)</InlineCode>}
   >
     <Callout variant="caution">
       This method is deprecated and was removed in version 7.0.0. Please use [transactionHandle.ignore()](#transaction-handle-ignore)


### PR DESCRIPTION
New API methods support new Errors Inbox functionality: `setErrorGroupCallback` and `setUserId`.