### PR TITLE
Removing out of date Synthetics IP info.

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -37,14 +37,6 @@ Minions are deployed on servers, and the agents are activated using non-personal
 
 IP addresses for released locations are subject to change. If a change is needed, we'll attempt to proactively notify customers prior to any changes via e-mail. You can also check the [Support Forum](https://discuss.newrelic.com/) for updates. The IP ranges listed are reserved for use by New Relic and cannot be used by anyone else.
 
-Monitors using legacy runtimes, which include scripted browser monitors using Chrome 72 or lower, scripted API monitors using Node 10 or lower, step monitors, broken link monitors, and certificate check monitors utilize /32 IP ranges.
-
-Monitors using [new runtimes](/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/), which include all ping and simple browser monitors, scripted browser monitors using Chrome 100, and scripted API monitors using Node 16.10 will use larger IP ranges.
-
-<Callout variant="important">
-  All legacy runtime monitors will be migrated from smaller /32 IP ranges to the larger IP ranges listed for each public location starting on January 31, 2023. The larger IP ranges have been in use since October 2022 for all existing ping, simple browser, and monitors using newer runtimes. No impact is expected from this change.
-</Callout>
-
 <table style={{ width: "300px" }}>
   <thead>
     <tr>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
The migration to the new IP space for legacy monitors has already been done. Removing outdated info from the synthetics ip informational page. 

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.