### PR TITLE
fix(errors inbox): adding user tracking

### DIFF
--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -70,7 +70,7 @@ You can use an agent method to identify an end user. See implementation details 
 
 * [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
 * [.Net](/docs/apm/agents/net-agent/net-agent-api/itransaction/#setuserid)
-* [Node.js](docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setUserID)
+* [Node.js](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setUserID)
 * [Python](/docs/apm/agents/python-agent/python-agent-api/setuserid-python-agent-api/)
 * [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#user-tracking)
 

--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -64,4 +64,15 @@ Once you have decided on a NRQL query, it can be used to create a [NRQL alert co
 
 To improve the signal to noise ratio of your triggered alerts see [alert creation tips](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#condition-tips), [how alert thresholds are evaluated](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#advanced-signal), and [alert condition examples](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#examples).
 
+## Set users impacted with setUser method [#set-users]
+
+You can use an agent method to identify an end user. See implementation details for each agent below: 
+
+* [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
+* [Node.js](docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setUserID)
+* [Python](/docs/apm/agents/python-agent/python-agent-api/setuserid-python-agent-api/)
+
+
+
+
 

--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -71,6 +71,7 @@ You can use an agent method to identify an end user. See implementation details 
 * [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
 * [Node.js](docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setUserID)
 * [Python](/docs/apm/agents/python-agent/python-agent-api/setuserid-python-agent-api/)
+* [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#user-tracking)
 
 
 

--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -69,6 +69,7 @@ To improve the signal to noise ratio of your triggered alerts see [alert creatio
 You can use an agent method to identify an end user. See implementation details for each agent below: 
 
 * [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#user-tracking)
+* [.Net](/docs/apm/agents/net-agent/net-agent-api/itransaction/#setuserid)
 * [Node.js](docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setUserID)
 * [Python](/docs/apm/agents/python-agent/python-agent-api/setuserid-python-agent-api/)
 * [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#user-tracking)


### PR DESCRIPTION
Correct me if I am wrong @elucus but we only have four agents who have documented user tracking with errors inbox:

Go
Node
Python
Ruby

**Missing:**
.Net
Java (pending on 4.13)
PHP

This PR contains all the documented user tracking information and is ready for review. 