### PR TITLE
fix: Correct return value keys

### DIFF
--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelicgettracemetadata.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelicgettracemetadata.mdx
@@ -32,8 +32,8 @@ Returns an associative array containing the identifiers of the current trace and
 
 An associative array containing the keys:
 
-* `trace.id`: the currently executing trace identifier. An empty value will be returned if the transaction does not support this functionality or distributed tracing is disabled.Returns:
-* `span.id`: the currently executing span identifier. An empty value will be returned if the transaction does not support this functionality or distributed tracing is disabled.
+* `trace_id`: the currently executing trace identifier. An empty value will be returned if the transaction does not support this functionality or distributed tracing is disabled.Returns:
+* `span_id`: the currently executing span identifier. An empty value will be returned if the transaction does not support this functionality or distributed tracing is disabled.
 
 ## Examples
 


### PR DESCRIPTION
This PR corrects the return value's keys listed in the documentation.  These keys actually have underscores - not periods - as seen in the example code immediately below.