### PR TITLE
fix: ensures children is an array for DocTiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.18.10",
+    "@newrelic/gatsby-theme-newrelic": "6.19.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/src/components/DocTile.js
+++ b/src/components/DocTile.js
@@ -181,6 +181,9 @@ export const DocTiles = ({
   numbered = false,
   variant = 'default',
 }) => {
+  if (!Array.isArray(children)) {
+    children = [children];
+  }
   const trails = useTrail(children.length, {
     config: SPRING,
     from: { opacity: 0, y: 124 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2609,10 +2609,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.18.10":
-  version "6.18.10"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.18.10.tgz#ea4281305429e46e63b349c21f65cb798821c3c8"
-  integrity sha512-+zGS40793JIMOKpX9WpKv0EnMhPhaZj55jwd/JigZQECNnwm0DE7CXbVcF6sjTVXQhxKZCTl9glWW3X/XP6yGw==
+"@newrelic/gatsby-theme-newrelic@6.19.0":
+  version "6.19.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.19.0.tgz#700b4a9b1ac9a8ca65d0aa6bc1429b6593951850"
+  integrity sha512-fkBHdcbGZaByfDzoqBDPVUyHAdTZMMtv6oSnDSqGh3qUXnO3dQlfZTJvr7b+XTu/E8H0YvejSmwx5liD1bZ5Dg==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
`children` was coming in as an object if there's only 1 node in the parent element instead of an array
