### PR TITLE
feat: .NET Agent environment variables explainer doc

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/apm/agents/net-agent/azure-installation
 ---
 
-This document explains how to install APM's .NET agent on Microsoft's Azure Cloud Services platform. This is not the same as installing the [Infrastructure integrations for Microsoft Azure](/docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations). To make sure you are using the most relevant instructions, first see the [.NET agent install](/docs/agents/net-agent/installation//install/dotnet-agent).
+This document explains how to install APM's .NET agent on Microsoft's Azure Cloud Services platform. This is not the same as installing the [Infrastructure integrations for Microsoft Azure](/docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations). To make sure you are using the most relevant instructions, first see the [.NET agent install](/docs/agents/net-agent/installation/install/dotnet-agent).
 
 <Callout variant="important">
   Before installing the NuGet package into a multi-project Visual Studio solution, make sure you have selected the correct project for your New Relic .NET application (for example, a specific website project).

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -9,6 +9,9 @@ redirects:
   - /docs/agents/net-agent/configuration/net-agent-configuration 
   - /docs/general/dotnet-agent-configuration
   - /docs/dotnet/dotnet-agent-configuration
+  - /docs/agents/net-agent/installation/install/dotnet-agent
+  - /docs/dotnet/dotnet-agent-configuration#high_security_mode
+  - /docs/dotnet/dotnet-agent-configuration#service
   - /docs/agents/net-agent/installation-and-configuration/net-agent-configuration
   - /docs/agents/net-agent/installation-configuration/net-agent-configuration
   - /docs/agents/net-agent/configuration/environment-variables
@@ -178,7 +181,7 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     CORECLR_NEWRELIC_HOME=<var>C:\ProgramData\New Relic\.NET Agent\</var>
     ```
     
-    The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications. For more information, see our [installation documentation](/install/dotnet#enable-net-core).
+    The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications. See [Compatibility and requirements for .NET Framework](/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework) for .NET Framework applications.
 
     For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
     

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -145,9 +145,11 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     NEWRELIC_INSTALL_PATH="INSERT_THE_PATH_TO_THE_AGENT_DIRECTORY"
     ```
 
-    The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`.
+    The Windows .NET agent installer (.msi) will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`.
 
     When using the Windows .NET agent installer, ensure that `NEWRELIC_INSTALL_PATH` is set to `C:\Program Files\New Relic\.NET Agent\`. This is where the agent DLLs are placed on the system.
+
+    For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
     
     When installing the agent via the Nuget package, the agent requires [a different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-framework).
   </Collapser>
@@ -178,6 +180,8 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     
     The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications. For more information, see our [installation documentation](/install/dotnet#enable-net-core).
 
+    For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
+    
     When installing the agent via the Nuget package in Windows, the agent requires a [different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-windows).
 
   </Collapser>

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -87,7 +87,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        ```
 
        <Callout variant="important">
-         To monitor applications on an arm64 system, `CORECLR_PROFILER_PATH` should be set to APP_DEPLOYMENT_DIRECTORY/newrelic/linux-arm64/libNewRelicProfiler.so`
+         To monitor applications on an arm64 system, `CORECLR_PROFILER_PATH` should be set to `APP_DEPLOYMENT_DIRECTORY/newrelic/linux-arm64/libNewRelicProfiler.so`
        </Callout>
 
        The <InlinePopover type="licenseKey" /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -87,7 +87,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        ```
 
        <Callout variant="important">
-         To monitor applications on an arm64 system, CORECLR_PROFILER_PATH should be set to APP_DEPLOYMENT_DIRECTORY/newrelic/linux-arm64/libNewRelicProfiler.so
+         To monitor applications on an arm64 system, `CORECLR_PROFILER_PATH` should be set to APP_DEPLOYMENT_DIRECTORY/newrelic/linux-arm64/libNewRelicProfiler.so`
        </Callout>
 
        The <InlinePopover type="licenseKey" /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -86,9 +86,15 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        NEW_RELIC_APP_NAME=YOUR_APP_NAME
        ```
 
+       <Callout variant="important">
+         To monitor applications on an arm64 system, CORECLR_PROFILER_PATH should be set to APP_DEPLOYMENT_DIRECTORY/newrelic/linux-arm64/libNewRelicProfiler.so
+       </Callout>
+
        The <InlinePopover type="licenseKey" /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
      </Collapser>
    </CollapserGroup>
+
+   For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
 
 If your application is receiving traffic, data should appear within a few minutes. If it doesn't, see [No data appears](/docs/agents/net-agent/troubleshooting/no-data-appears-net).
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -1,0 +1,102 @@
+---
+title: Understanding required .NET agent environment vairables
+tags:
+  - Agents
+  - NET agent
+  - Other installation
+redirects:
+---
+
+This document explains:
+
+* how environment variables are used by the .NET agent
+* what environment variables are used by the agent in different installation scenarios
+* how environment variables work in general
+
+Note: for the rest of this document, the term ".NET Core" will be used to refer to .NET versions (and applications built with and for .NET versions) 5.0 and higher (which Microsoft calls simply ".NET") as well as .NET Core 2.0 through 3.1.
+
+## How environment variables are used by the .NET agent
+
+The New Relic .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-overview) and implements a subset of the .NET profiling API.
+[Certain environment variables](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/setting-up-a-profiling-environment) must be present in the environment of a .NET process to tell the .NET runtime that the process should be profiled, and by what profiler.
+Additional environment variables are used by the .NET agent itself to let it know where and how it is installed.
+
+Note: for the rest of this document, "the profiler" refers to the component of the agent that implements the .NET profiling API.  When things are configured correctly, the CLR attaches the profiler to your .NET application.  The profiler then loads the rest of the agent into the application. 
+
+## What environment variables are required to use the .NET agent
+
+### Enabling profiling and identifying the correct profiler
+
+There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and what profiler to use.  The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
+
+#### .NET Framework
+
+`COR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application.  Set to 1 to enable profiling, set to 0 to disable it.
+`COR_PROFILER` tells the runtime which profiler to use.  The value is a GUID unique to a given profiler.  For New Relic's profiler for .NET Framework, the correct value is `{71DA0A04-7777-4EC6-9643-7D28B46A8A41}`.
+`COR_PROFILER_PATH` tells the runtime where to find the profiler on the system, and depends on the install type and platform.  Note that this may not be required if the agent was installed with the MSI installer, which registers the profiler DLL with the system based on the GUID set in `COR_PROFILER`.  However, it is safe to have it set anyway as long as the value is set to the correct path.
+
+Typical values:
+```
+COR_ENABLE_PROFILING=1
+COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll"
+
+#### .NET Core
+
+`CORECLR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application.  Set to 1 to enable profiling, set to 0 to disable it.
+`CORECLR_PROFILER` tells the runtime which profiler to use.  The value is a GUID unique to a given profiler.  For New Relic's profiler for .NET Core, the correct value is `{36032161-FFC0-4B61-B559-F6C5D41BAE5A}`.
+`CORECLR_PROFILER_PATH` tells the runtime where to find the profiler on the system.
+
+Typical values:
+```
+CORECLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
+```
+
+### Telling the profiler where the rest of the agent is
+
+Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components.  These variables are also used by parts of the rest of the agent.
+
+Note: depending on your installation scenario, only some of these variables are be required.
+
+#### NEWRELIC_HOME
+
+This variable:
+* is only used in the .NET framework version of the agent
+* is used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
+* may be used to find the agent binary assets, if they are installed in the same place as the configuration assets
+
+Note: when the agent is installed with the MSI installer, this variable may not need to be set, since the MSI also sets a registry key (`HKEY_LOCAL_MACHINE\Software\New Relic\.NET Agent\NewRelicHome`) with the correct value.
+
+#### CORECLR_NEWRELIC_HOME
+
+This variable:
+* is only used in the .NET core version of the agent
+* is used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
+* may be used to find the agent binary assets, if they are installed in the same place as the configuration assets
+
+Note: this variable always needs to be set for the .NET core version of the agent.
+
+#### NEWRELIC_INSTALL_PATH
+
+This variable is primarily used:
+* When both the .NET framework and .NET core versions of the agent are installed side-by-side on the system
+* When the binary components of the agent are installed in a different location on the system than the configuration assets
+* When the agent is installed with the MSI installer on Windows (which does both of the above)
+
+This variable set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it is used.  If the core dll is not found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location.  If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
+
+This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder.  The agent always appends either `netframework` or `netcore` to the value of this variable when it is set.  If it is not set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
+
+### Values for typical installation scenarios
+
+Now that we understand the theory, let's look at some typical installation scenarios and the correct values of these variables.
+
+#### MSI Installer (Windows)
+
+The MSI is easy to use because it does almost everything for you automatically, but what it is doing behind the scenes is complicated, which makes troubleshooting difficult.
+
+The MSI installer puts different parts of the 
+
+

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -13,7 +13,7 @@ This document explains:
 * the environment variables used to attach the profiler to your application
 * the environment variables used by the profiler and the agent to find required assets
 
-Note: for the rest of this document, the term ".NET Core" will be used to refer to .NET versions (and applications built with and for .NET versions) 5.0 and higher (which Microsoft calls simply ".NET") as well as .NET Core 2.0 through 3.1.
+Note: for the rest of this document, the term ".NET Core" will be used to refer to .NET versions (and applications built with and for .NET versions) 5.0 and higher (just ".NET") as well as .NET Core 2.0 through 3.1.
 
 ## How environment variables are used by the .NET agent
 
@@ -126,23 +126,82 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 
 #### ZIP Archive (Windows)
 
-The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories.  Assuming you unzip the contents to "C:\MyCustomAgentPath", these are the correct environment variable values:
+The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories.  Using <CUSTOM_AGENT_PATH> as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
 
 For .NET framework applications
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-COR_PROFILER_PATH="C:\MyCustomAgentPath\netframework\NewRelic.Profiler.dll"
-NEWRELIC_HOME="C:\MyCustomAgentPath\netframework"
+COR_PROFILER_PATH="<CUSTOM_AGENT_PATH>\netframework\NewRelic.Profiler.dll"
+NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netframework"
 ```
 
 For .NET core applications
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-CORECLR_PROFILER_PATH="C:\MyCustomAgentPath\netcore\NewRelic.Profiler.dll"
-CORECLR_NEWRELIC_HOME="C:\MyCustomAgentPath\netcore"
+CORECLR_PROFILER_PATH="<CUSTOM_AGENT_PATH>\netcore\NewRelic.Profiler.dll"
+CORECLR_NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netcore"
 ```
+
+#### Linux Packages
+
+The Linux install package (.deb or .rpm, as appropriate for your Linux distribution) installs the .NET core agent.  By default, it installs everything in `/usr/local/newrelic-dotnet-agent`.  
+
+```
+CORCLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+CORECLR_PROFILER_PATH="/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so"
+CORECLR_NEWRELIC_HOME="/usr/local/newrelic-dotnet-agent"
+```
+
+There is also a `.tar.gz` archive of the agent for manual installation on Linux.  In that case, replace `/usr/local/newrelic-dotnet-agent` with wherever you unpack the archive on your system in the above variables.
+
+#### NewRelic.Agent NuGet Package
+
+When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application.  The correct version of the agent is added for .NET framework or .NET core depending on the type of your application.  The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler.  Using <YOUR_APPLICATION_PATH> as a placeholder for whever your application is deployed on the system, these are the correct environment variable values:
+
+For .NET framework applications (64-bit)
+```
+COR_ENABLE_PROFILING=1
+COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
+NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
+```
+
+For .NET framework applications (32-bit)
+```
+COR_ENABLE_PROFILING=1
+COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\x86\NewRelic.Profiler.dll"
+NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
+```
+
+For .NET core applications (Windows)
+```
+CORCLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
+CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
+```
+
+For .NET core applications (Linux, x64)
+```
+CORCLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/libNewRelicProfiler.so"
+CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
+```
+
+For .NET core applications (Linux, arm64)
+```
+CORCLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/linux-arm64/libNewRelicProfiler.so"
+CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
+```
+
+
 
 
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Understanding required .NET agent environment vairables
+title: Understanding required .NET agent environment variables
 tags:
   - Agents
   - NET agent
@@ -10,8 +10,8 @@ redirects:
 This document explains:
 
 * how environment variables are used by the .NET agent
-* what environment variables are used by the agent in different installation scenarios
-* how environment variables work in general
+* the environment variables used to attach the profiler to your application
+* the environment variables used by the profiler and the agent to find required assets
 
 Note: for the rest of this document, the term ".NET Core" will be used to refer to .NET versions (and applications built with and for .NET versions) 5.0 and higher (which Microsoft calls simply ".NET") as well as .NET Core 2.0 through 3.1.
 
@@ -67,7 +67,7 @@ This variable:
 * is used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
 * may be used to find the agent binary assets, if they are installed in the same place as the configuration assets
 
-Note: when the agent is installed with the MSI installer, this variable may not need to be set, since the MSI also sets a registry key (`HKEY_LOCAL_MACHINE\Software\New Relic\.NET Agent\NewRelicHome`) with the correct value.
+Note: when the agent is installed with the MSI installer, this variable may not need to be set, since the MSI also sets a registry key (`HKEY_LOCAL_MACHINE\Software\New Relic\.NET Agent\NewRelicHome`) with the correct value.  The environment variable takes precedence if set.
 
 #### CORECLR_NEWRELIC_HOME
 
@@ -91,12 +91,56 @@ This variable is also used by the agent to load the instrumentation extension bi
 
 ### Values for typical installation scenarios
 
-Now that we understand the theory, let's look at some typical installation scenarios and the correct values of these variables.
-
 #### MSI Installer (Windows)
 
-The MSI is easy to use because it does almost everything for you automatically, but what it is doing behind the scenes is complicated, which makes troubleshooting difficult.
+The MSI is easy to use because it does almost everything for you automatically, but what it is doing behind the scenes is complicated.
+The MSI installer puts different parts of the agent in different places on the system.  By default, it puts the binary agent assets in `C:\Program Files\New Relic\.NET Agent` and it puts the configuration assets in `C:\ProgramData\New Relic\.NET Agent`.  This is to support scenarios where non-privileged users can access/edit files in `ProgramData` but not in `Program Files`.
+The MSI installer installs both framework and core versions of the agent side-by-side.  The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
 
-The MSI installer puts different parts of the 
+Assuming you do not specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
+
+For .NET framework applications
+```
+COR_ENABLE_PROFILING=1
+COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll" # may not be necessary due to profiler being registered with the system
+NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
+NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due to registry key being set
+```
+
+For .NET core applications
+```
+CORCLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
+NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
+CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
+```
+
+#### ZIP Archive (Windows)
+
+The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories.  Assuming you unzip the contents to "C:\MyCustomAgentPath", these are the correct environment variable values:
+
+For .NET framework applications
+```
+COR_ENABLE_PROFILING=1
+COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+COR_PROFILER_PATH="C:\MyCustomAgentPath\netframework\NewRelic.Profiler.dll"
+NEWRELIC_HOME="C:\MyCustomAgentPath\netframework"
+```
+
+For .NET core applications
+```
+CORCLR_ENABLE_PROFILING=1
+CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+CORECLR_PROFILER_PATH="C:\MyCustomAgentPath\netcore\NewRelic.Profiler.dll"
+CORECLR_NEWRELIC_HOME="C:\MyCustomAgentPath\netcore"
+```
+
+
+
+
+
+
 
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -32,22 +32,29 @@ There is a set of three environment variables used to tell the .NET runtime whet
 #### .NET Framework
 
 `COR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application.  Set to 1 to enable profiling, set to 0 to disable it.
+
 `COR_PROFILER` tells the runtime which profiler to use.  The value is a GUID unique to a given profiler.  For New Relic's profiler for .NET Framework, the correct value is `{71DA0A04-7777-4EC6-9643-7D28B46A8A41}`.
+
 `COR_PROFILER_PATH` tells the runtime where to find the profiler on the system, and depends on the install type and platform.  Note that this may not be required if the agent was installed with the MSI installer, which registers the profiler DLL with the system based on the GUID set in `COR_PROFILER`.  However, it is safe to have it set anyway as long as the value is set to the correct path.
 
 Typical values:
+
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll"
+```
 
 #### .NET Core
 
 `CORECLR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application.  Set to 1 to enable profiling, set to 0 to disable it.
+
 `CORECLR_PROFILER` tells the runtime which profiler to use.  The value is a GUID unique to a given profiler.  For New Relic's profiler for .NET Core, the correct value is `{36032161-FFC0-4B61-B559-F6C5D41BAE5A}`.
+
 `CORECLR_PROFILER_PATH` tells the runtime where to find the profiler on the system.
 
 Typical values:
+
 ```
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -74,7 +74,7 @@ However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` i
 
 Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components.  These variables are also used by parts of the rest of the agent.
 
-Note: depending on your installation scenario, only some of these variables are be required.
+Note: depending on your installation scenario, only some of these variables are required.
 
 #### NEWRELIC_HOME
 
@@ -101,7 +101,7 @@ This variable is primarily used:
 * When the binary components of the agent are installed in a different location on the system than the configuration assets
 * When the agent is installed with the MSI installer on Windows (which does both of the above)
 
-This variable set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it is used.  If the core dll is not found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location.  If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
+This variable is set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it is used.  If the core dll is not found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location.  If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
 
 This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder.  The agent always appends either `netframework` or `netcore` to the value of this variable when it is set.  If it is not set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -82,7 +82,7 @@ Now that the .NET runtime knows how to find the profiler and attach it to your a
 
 Note: Depending on your installation scenario, only some of these variables are required.
 
-#### NEWRELIC_HOME
+#### `NEWRELIC_HOME`
 
 This variable:
 * is only used in the .NET framework version of the agent
@@ -91,7 +91,7 @@ This variable:
 
 Note: When the agent is installed with the MSI installer, this variable may not need to be set, since the MSI also sets a registry key (`HKEY_LOCAL_MACHINE\Software\New Relic\.NET Agent\NewRelicHome`) with the correct value. The environment variable takes precedence if set.
 
-#### CORECLR_NEWRELIC_HOME
+#### `CORECLR_NEWRELIC_HOME`
 
 This variable is:
 * Only used in the .NET core version of the agent
@@ -100,7 +100,7 @@ This variable is:
 
 Note: This variable always needs to be set for the .NET core version of the agent.
 
-#### NEWRELIC_INSTALL_PATH
+#### `NEWRELIC_INSTALL_PATH`
 
 This variable is primarily used:
 * When both the .NET framework and .NET core versions of the agent are installed side-by-side on the system

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -27,7 +27,6 @@ Additional environment variables are used by the .NET agent itself to let it kno
 To use the .NET agent, we require environment variables for:
 * [Enabling profiling and identifying the correct profiler](#enable)
 * [Telling the profiler where the rest of the agent is](#agent)
-See the sections below for details on these required variables.
 
 ### Variables to enable profiling and identify the correct profiler [#enable]
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -7,23 +7,23 @@ tags:
 redirects:
 ---
 
-Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets. If you're interested in diving deeper into how environment variables are used and which ones 
+Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets. If you're interested in diving deeper into how environment variables are used and which ones.
 
-## Terms overview
+## Terms overview [#terms-overview]
 
 Before reading the sections below, here are some tips for understanding terms used on this page:
 
 * ".NET Core" refers to .NET versions (and applications built with and for .NET versions) 5.0 and higher (just ".NET") as well as .NET Core 2.0 through 3.1.
 * "Profiler" refers to the component of the agent that implements the .NET profiling API. When things are configured correctly, the CLR attaches the profiler to your .NET application. The profiler then loads the rest of the agent into the application. 
 
-## How environment variables are used by the .NET agent
+## How environment variables are used by the .NET agent [#env-variables]
 
 Our .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-overview) and implements a subset of the .NET profiling API.
 [Certain environment variables](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/setting-up-a-profiling-environment) must be present in the environment of a .NET process to tell the .NET runtime that the process should be profiled, and by what profiler.
-Additional environment variables are used by the .NET agent itself to let it know where and how it is installed.
+Additional environment variables are used by the .NET agent itself to let it know where and how it's installed.
 
 
-## Required environment variables
+## Required environment variables [#required-env-variables]
 
 To use the .NET agent, we require environment variables for enabling profiling, identifying the correct profiler, and telling the profiler where the rest of the agent is. See the sections below for details on these required variables.
 
@@ -37,7 +37,7 @@ There is a set of three environment variables used to tell the .NET runtime whet
 
 `COR_PROFILER` tells the runtime which profiler to use. The value is a GUID unique to a given profiler. For New Relic's profiler for .NET Framework, the correct value is `{71DA0A04-7777-4EC6-9643-7D28B46A8A41}`.
 
-`COR_PROFILER_PATH` tells the runtime where to find the profiler on the system, and depends on the install type and platform. Note that this may not be required if the agent was installed with the MSI installer, which registers the profiler DLL with the system based on the GUID set in `COR_PROFILER`. However, it is safe to have it set anyway as long as the value is set to the correct path.
+`COR_PROFILER_PATH` tells the runtime where to find the profiler on the system, and depends on the install type and platform. Note that this may not be required if the agent was installed with the MSI installer, which registers the profiler DLL with the system based on the GUID set in `COR_PROFILER`. However, it's safe to have it set anyway as long as the value is set to the correct path.
 
 Typical values:
 
@@ -71,7 +71,7 @@ Note: There is a subtle difference in the behavior of the .NET framework agent v
 * The application is explicitly configured to be instrumented in the system-wide `newrelic.config` file
 * AgentEnabled="true" is set in an app-local `newrelic.config` file
 
-However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we do not recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to 1 in the environment of the processes you want instrumented.
+However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to 1 in the environment of the processes you want instrumented.
 
 ### Telling the profiler where the rest of the agent is
 
@@ -104,19 +104,19 @@ This variable is primarily used:
 * When the binary components of the agent are installed in a different location on the system than the configuration assets
 * When the agent is installed with the MSI installer on Windows (which does both of the above)
 
-This variable is set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it is used. If the core dll is not found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location. If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
+This variable is set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it's used. If the core dll isn't found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location. If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
 
-This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder. The agent always appends either `netframework` or `netcore` to the value of this variable when it is set. If it is not set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
+This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder. The agent always appends either `netframework` or `netcore` to the value of this variable when it's set. If it isn't set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
 
 ### Values for typical installation scenarios
 
 #### MSI installer (Windows)
 
-The MSI is easy to use because it does almost everything for you automatically, but what it is doing behind the scenes is complicated.
+The MSI is easy to use because it does almost everything for you automatically, but what it's doing behind the scenes is complicated.
 The MSI installer puts different parts of the agent in different places on the system. By default, it puts the binary agent assets in `C:\Program Files\New Relic\.NET Agent` and it puts the configuration assets in `C:\ProgramData\New Relic\.NET Agent`. This is to support scenarios where non-privileged users can access/edit files in `ProgramData` but not in `Program Files`.
 The MSI installer installs both framework and core versions of the agent side-by-side. The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
 
-Assuming you do not specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
+Assuming you don't specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
 
 ##### For .NET framework applications
 ```
@@ -171,7 +171,7 @@ There is also a `.tar.gz` archive of the agent for manual installation on Linux.
 
 #### NewRelic.Agent NuGet Package
 
-When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using <YOUR_APPLICATION_PATH> as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
+When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using `<YOUR_APPLICATION_PATH>` as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
 
 ##### For .NET framework applications (64-bit)
 ```

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -138,22 +138,22 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 
 #### ZIP Archive (Windows)
 
-The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Using {'<'}CUSTOM_AGENT_PATH{'>'}  as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
+The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Replace CUSTOM_AGENT_PATH with the path wherever you unzip the archive on your system.
 
 ##### For .NET framework applications:
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-COR_PROFILER_PATH="<CUSTOM_AGENT_PATH>\netframework\NewRelic.Profiler.dll"
-NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netframework"
+COR_PROFILER_PATH="CUSTOM_AGENT_PATH\netframework\NewRelic.Profiler.dll"
+NEWRELIC_HOME="CUSTOM_AGENT_PATH\netframework"
 ```
 
 ##### For .NET core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-CORECLR_PROFILER_PATH="<CUSTOM_AGENT_PATH>\netcore\NewRelic.Profiler.dll"
-CORECLR_NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netcore"
+CORECLR_PROFILER_PATH="CUSTOM_AGENT_PATH\netcore\NewRelic.Profiler.dll"
+CORECLR_NEWRELIC_HOME="CUSTOM_AGENT_PATH\netcore"
 ```
 
 #### Linux Packages

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -25,13 +25,16 @@ Additional environment variables are used by the .NET agent itself to let it kno
 
 ## Required environment variables [#required-env-variables]
 
-To use the .NET agent, we require environment variables for enabling profiling, identifying the correct profiler, and telling the profiler where the rest of the agent is. See the sections below for details on these required variables.
+To use the .NET agent, we require environment variables for:
+* [Enabling profiling and identifying the correct profiler](#enable)
+* [Telling the profiler where the rest of the agent is](#agent)
+See the sections below for details on these required variables.
 
-### Enabling profiling and identifying the correct profiler
+### Enabling profiling and identifying the correct profiler [#enable]
 
 There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and which profiler to use. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
 
-#### For .NET framework applications
+#### For .NET framework applications:
 
 `COR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application. Set to 1 to enable profiling, set to 0 to disable it.
 
@@ -47,7 +50,7 @@ COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll"
 ```
 
-#### For .NET Core applications
+#### For .NET Core applications:
 
 `CORECLR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application. Set to 1 to enable profiling, set to 0 to disable it.
 
@@ -73,7 +76,7 @@ Note: There is a subtle difference in the behavior of the .NET framework agent v
 
 However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to 1 in the environment of the processes you want instrumented.
 
-### Telling the profiler where the rest of the agent is
+### Telling the profiler where the rest of the agent is [#agent]
 
 Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components. These variables are also used by parts of the rest of the agent.
 
@@ -118,7 +121,7 @@ The MSI installer installs both framework and core versions of the agent side-by
 
 Assuming you don't specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
 
-##### For .NET framework applications
+##### For .NET framework applications:
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -127,7 +130,7 @@ NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
 NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due to registry key being set
 ```
 
-##### For .NET core applications
+##### For .NET core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -173,7 +176,7 @@ There is also a `.tar.gz` archive of the agent for manual installation on Linux.
 
 When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using `<YOUR_APPLICATION_PATH>` as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
 
-##### For .NET framework applications (64-bit)
+##### For .NET framework applications (64-bit):
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -181,7 +184,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-##### For .NET framework applications (32-bit)
+##### For .NET framework applications (32-bit):
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -189,7 +192,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\x86\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-##### For .NET core applications (Windows)
+##### For .NET core applications (Windows):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -197,7 +200,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-##### For .NET core applications (Linux, x64)
+##### For .NET core applications (Linux, x64):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -205,7 +208,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
 
-##### For .NET core applications (Linux, arm64)
+##### For .NET core applications (Linux, arm64):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -7,7 +7,7 @@ tags:
 redirects:
 ---
 
-Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets. If you're interested in diving deeper into how environment variables are used, see the sections below.
+Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets. If you're interested in diving deeper into how environment variables are used and which ones 
 
 ## Terms overview
 
@@ -23,13 +23,15 @@ Our .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet
 Additional environment variables are used by the .NET agent itself to let it know where and how it is installed.
 
 
-## What environment variables are required to use the .NET agent
+## Required environment variables
+
+To use the .NET agent, we require environment variables for enabling profiling, identifying the correct profiler, and telling the profiler where the rest of the agent is. See the sections below for details on these required variables.
 
 ### Enabling profiling and identifying the correct profiler
 
-There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and what profiler to use. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
+There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and which profiler to use. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
 
-#### .NET Framework
+#### For .NET framework applications
 
 `COR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application. Set to 1 to enable profiling, set to 0 to disable it.
 
@@ -45,7 +47,7 @@ COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll"
 ```
 
-#### .NET Core
+#### For .NET Core applications
 
 `CORECLR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application. Set to 1 to enable profiling, set to 0 to disable it.
 
@@ -62,6 +64,7 @@ CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Pr
 ```
 
 Note: There is a subtle difference in the behavior of the .NET framework agent vs. the .NET core agent regarding having profiling enabled. For the .NET framework agent, even when profiling is enabled in the environment of a .NET framework process, it will only be instrumented by the agent if one of the following conditions are met:
+
 * The application is hosted in IIS and
   * application pools are configured to be instrumented by default, or
   * the application pool hosting the application is configured to be instrumented explicitly
@@ -107,15 +110,15 @@ This variable is also used by the agent to load the instrumentation extension bi
 
 ### Values for typical installation scenarios
 
-#### MSI Installer (Windows)
+#### MSI installer (Windows)
 
 The MSI is easy to use because it does almost everything for you automatically, but what it is doing behind the scenes is complicated.
 The MSI installer puts different parts of the agent in different places on the system. By default, it puts the binary agent assets in `C:\Program Files\New Relic\.NET Agent` and it puts the configuration assets in `C:\ProgramData\New Relic\.NET Agent`. This is to support scenarios where non-privileged users can access/edit files in `ProgramData` but not in `Program Files`.
-The MSI installer installs both framework and core versions of the agent side-by-side.  The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
+The MSI installer installs both framework and core versions of the agent side-by-side. The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
 
 Assuming you do not specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
 
-For .NET framework applications:
+##### For .NET framework applications
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -124,7 +127,7 @@ NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
 NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due to registry key being set
 ```
 
-For .NET core applications:
+##### For .NET core applications
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -137,7 +140,7 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 
 The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Using <CUSTOM_AGENT_PATH> as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
 
-For .NET framework applications:
+##### For .NET framework applications:
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -145,7 +148,7 @@ COR_PROFILER_PATH="<CUSTOM_AGENT_PATH>\netframework\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netframework"
 ```
 
-For .NET core applications:
+##### For .NET core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -168,9 +171,9 @@ There is also a `.tar.gz` archive of the agent for manual installation on Linux.
 
 #### NewRelic.Agent NuGet Package
 
-When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using <YOUR_APPLICATION_PATH> as a placeholder for whever your application is deployed on the system, these are the correct environment variable values:
+When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using <YOUR_APPLICATION_PATH> as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
 
-For .NET framework applications (64-bit):
+##### For .NET framework applications (64-bit)
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -178,7 +181,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-For .NET framework applications (32-bit):
+##### For .NET framework applications (32-bit)
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -186,7 +189,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\x86\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-For .NET core applications (Windows):
+##### For .NET core applications (Windows)
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -194,7 +197,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-For .NET core applications (Linux, x64):
+##### For .NET core applications (Linux, x64)
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -202,7 +205,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
 
-For .NET core applications (Linux, arm64):
+##### For .NET core applications (Linux, arm64)
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -7,10 +7,11 @@ tags:
 redirects:
 ---
 
-Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets.
+Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets. If you're interested in diving deeper into how environment variables are used, see the sections below.
 
 ## Terms overview
-Before reading the sections below, here are some tips for understanding the terminology used on this page:
+
+Before reading the sections below, here are some tips for understanding terms used on this page:
 
 * ".NET Core" refers to .NET versions (and applications built with and for .NET versions) 5.0 and higher (just ".NET") as well as .NET Core 2.0 through 3.1.
 * "Profiler" refers to the component of the agent that implements the .NET profiling API. When things are configured correctly, the CLR attaches the profiler to your .NET application. The profiler then loads the rest of the agent into the application. 
@@ -26,15 +27,15 @@ Additional environment variables are used by the .NET agent itself to let it kno
 
 ### Enabling profiling and identifying the correct profiler
 
-There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and what profiler to use.  The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
+There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and what profiler to use. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
 
 #### .NET Framework
 
-`COR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application.  Set to 1 to enable profiling, set to 0 to disable it.
+`COR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application. Set to 1 to enable profiling, set to 0 to disable it.
 
-`COR_PROFILER` tells the runtime which profiler to use.  The value is a GUID unique to a given profiler.  For New Relic's profiler for .NET Framework, the correct value is `{71DA0A04-7777-4EC6-9643-7D28B46A8A41}`.
+`COR_PROFILER` tells the runtime which profiler to use. The value is a GUID unique to a given profiler. For New Relic's profiler for .NET Framework, the correct value is `{71DA0A04-7777-4EC6-9643-7D28B46A8A41}`.
 
-`COR_PROFILER_PATH` tells the runtime where to find the profiler on the system, and depends on the install type and platform.  Note that this may not be required if the agent was installed with the MSI installer, which registers the profiler DLL with the system based on the GUID set in `COR_PROFILER`.  However, it is safe to have it set anyway as long as the value is set to the correct path.
+`COR_PROFILER_PATH` tells the runtime where to find the profiler on the system, and depends on the install type and platform. Note that this may not be required if the agent was installed with the MSI installer, which registers the profiler DLL with the system based on the GUID set in `COR_PROFILER`. However, it is safe to have it set anyway as long as the value is set to the correct path.
 
 Typical values:
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -74,7 +74,7 @@ Note: There is a subtle difference in the behavior of the .NET framework agent v
 * The application is explicitly configured to be instrumented in the system-wide `newrelic.config` file
 * AgentEnabled="true" is set in an app-local `newrelic.config` file
 
-However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to 1 in the environment of the processes you want instrumented.
+However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to `1` system wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to `1` in the environment of the processes you want instrumented.
 
 ### Telling the profiler where the rest of the agent is [#agent]
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -22,7 +22,6 @@ Our .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet
 [Certain environment variables](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/setting-up-a-profiling-environment) must be present in the environment of a .NET process to tell the .NET runtime that the process should be profiled, and by what profiler.
 Additional environment variables are used by the .NET agent itself to let it know where and how it's installed.
 
-
 ## Required environment variables [#required-env-variables]
 
 To use the .NET agent, we require environment variables for:
@@ -32,7 +31,7 @@ See the sections below for details on these required variables.
 
 ### Variables to enable profiling and identify the correct profiler [#enable]
 
-There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and which profiler to use. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
+There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and which profiler to use: `COR_ENABLE_PROFILING`, `COR_PROFILER`, and `COR_PROFILER_PATH`. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET Core.
 
 #### For .NET framework applications:
 
@@ -66,7 +65,7 @@ CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
 CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
 ```
 
-Note: There is a subtle difference in the behavior of the .NET framework agent vs. the .NET core agent regarding having profiling enabled. For the .NET framework agent, even when profiling is enabled in the environment of a .NET framework process, it will only be instrumented by the agent if one of the following conditions are met:
+Note: There is a subtle difference in the behavior of the .NET framework agent vs. the .NET Core agent regarding having profiling enabled. For the .NET framework agent, even when profiling is enabled in the environment of a .NET framework process, it will only be instrumented by the agent if one of the following conditions are met:
 
 * The application is hosted in IIS and
   * application pools are configured to be instrumented by default, or
@@ -74,7 +73,7 @@ Note: There is a subtle difference in the behavior of the .NET framework agent v
 * The application is explicitly configured to be instrumented in the system-wide `newrelic.config` file
 * AgentEnabled="true" is set in an app-local `newrelic.config` file
 
-However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to `1` system wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to `1` in the environment of the processes you want instrumented.
+However, for the .NET Core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to `1` system wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to `1` in the environment of the processes you want instrumented.
 
 ### Variables to tell the profiler where the rest of the .NET agent is [#agent]
 
@@ -94,20 +93,20 @@ Note: When the agent is installed with the MSI installer, this variable may not 
 #### `CORECLR_NEWRELIC_HOME`
 
 This variable is:
-* Only used in the .NET core version of the agent
+* Only used in the .NET Core version of the agent
 * Used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
 * May be used to find the agent binary assets, if they are installed in the same place as the configuration assets
 
-Note: This variable always needs to be set for the .NET core version of the agent.
+Note: This variable always needs to be set for the .NET Core version of the agent.
 
 #### `NEWRELIC_INSTALL_PATH`
 
 This variable is primarily used:
-* When both the .NET framework and .NET core versions of the agent are installed side-by-side on the system
+* When both the .NET framework and .NET Core versions of the agent are installed side-by-side on the system
 * When the binary components of the agent are installed in a different location on the system than the configuration assets
 * When the agent is installed with the MSI installer on Windows (which does both of the above)
 
-This variable is set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it's used. If the core dll isn't found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location. If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
+This variable is set to a directory/folder and is used by the profiler to find the agent `Core.dll`. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it's used. If the `Core.dll` isn't found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the `Core.dll` in that location. If the `Core.dll` is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET Core).
 
 This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder. The agent always appends either `netframework` or `netcore` to the value of this variable when it's set. If it isn't set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
 
@@ -117,7 +116,7 @@ This variable is also used by the agent to load the instrumentation extension bi
 
 The MSI is easy to use because it does almost everything for you automatically, but what it's doing behind the scenes is complicated.
 The MSI installer puts different parts of the agent in different places on the system. By default, it puts the binary agent assets in `C:\Program Files\New Relic\.NET Agent` and it puts the configuration assets in `C:\ProgramData\New Relic\.NET Agent`. This is to support scenarios where non-privileged users can access/edit files in `ProgramData` but not in `Program Files`.
-The MSI installer installs both framework and core versions of the agent side-by-side. The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
+The MSI installer installs both framework and Core versions of the agent side-by-side. The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
 
 Assuming you don't specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
 
@@ -130,7 +129,7 @@ NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
 NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due to registry key being set
 ```
 
-##### For .NET core applications:
+##### For .NET Core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -141,7 +140,7 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 
 #### ZIP Archive (Windows)
 
-The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Replace CUSTOM_AGENT_PATH with the path wherever you unzip the archive on your system.
+The ZIP archive of the agent for Windows contains both the framework and Core versions of the agent in side-by-side directories. Replace CUSTOM_AGENT_PATH with the path wherever you unzip the archive on your system.
 
 ##### For .NET framework applications:
 ```
@@ -151,7 +150,7 @@ COR_PROFILER_PATH="CUSTOM_AGENT_PATH\netframework\NewRelic.Profiler.dll"
 NEWRELIC_HOME="CUSTOM_AGENT_PATH\netframework"
 ```
 
-##### For .NET core applications:
+##### For .NET Core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -161,7 +160,7 @@ CORECLR_NEWRELIC_HOME="CUSTOM_AGENT_PATH\netcore"
 
 #### Linux Packages
 
-The Linux install package (.deb or .rpm, as appropriate for your Linux distribution) installs the .NET core agent. By default, it installs everything in `/usr/local/newrelic-dotnet-agent`.  
+The Linux install package (.deb or .rpm, as appropriate for your Linux distribution) installs the .NET Core agent. By default, it installs everything in `/usr/local/newrelic-dotnet-agent`.  
 
 ```
 CORCLR_ENABLE_PROFILING=1
@@ -174,7 +173,7 @@ There is also a `.tar.gz` archive of the agent for manual installation on Linux.
 
 #### NewRelic.Agent NuGet Package
 
-When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using `<YOUR_APPLICATION_PATH>` as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
+When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET Core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using `<YOUR_APPLICATION_PATH>` as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
 
 ##### For .NET framework applications (64-bit):
 ```
@@ -192,7 +191,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\x86\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-##### For .NET core applications (Windows):
+##### For .NET Core applications (Windows):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -200,7 +199,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-##### For .NET core applications (Linux, x64):
+##### For .NET Core applications (Linux, x64):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -208,7 +207,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
 
-##### For .NET core applications (Linux, arm64):
+##### For .NET Core applications (Linux, arm64):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -138,7 +138,7 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 
 #### ZIP Archive (Windows)
 
-The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Using <CUSTOM_AGENT_PATH> as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
+The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Using {'<'}CUSTOM_AGENT_PATH{'>'}  as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
 
 ##### For .NET framework applications:
 ```

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -22,8 +22,6 @@ Our .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet
 [Certain environment variables](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/setting-up-a-profiling-environment) must be present in the environment of a .NET process to tell the .NET runtime that the process should be profiled, and by what profiler.
 Additional environment variables are used by the .NET agent itself to let it know where and how it's installed.
 
-## Required environment variables [#required-env-variables]
-
 To use the .NET agent, we require environment variables for:
 * [Enabling profiling and identifying the correct profiler](#enable)
 * [Telling the profiler where the rest of the agent is](#agent)

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -11,7 +11,7 @@ Our .NET agent is a .NET CLR profiler and relies on your app's environment varia
 
 ## Terms overview [#terms-overview]
 
-Before reading the sections below, here are some tips for understanding terms used on this page:
+Here are some tips for understanding terms used on this page:
 
 * ".NET Core" refers to .NET versions (and applications built with and for .NET versions) 5.0 and higher (just ".NET") as well as .NET Core 2.0 through 3.1.
 * "Profiler" refers to the component of the agent that implements the .NET profiling API. When things are configured correctly, the CLR attaches the profiler to your .NET application. The profiler then loads the rest of the agent into the application. 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -7,21 +7,20 @@ tags:
 redirects:
 ---
 
-This document explains:
+Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets.
 
-* how environment variables are used by the .NET agent
-* the environment variables used to attach the profiler to your application
-* the environment variables used by the profiler and the agent to find required assets
+## Terms overview
+Before reading the sections below, here are some tips for understanding the terminology used on this page:
 
-Note: for the rest of this document, the term ".NET Core" will be used to refer to .NET versions (and applications built with and for .NET versions) 5.0 and higher (just ".NET") as well as .NET Core 2.0 through 3.1.
+* ".NET Core" refers to .NET versions (and applications built with and for .NET versions) 5.0 and higher (just ".NET") as well as .NET Core 2.0 through 3.1.
+* "Profiler" refers to the component of the agent that implements the .NET profiling API. When things are configured correctly, the CLR attaches the profiler to your .NET application. The profiler then loads the rest of the agent into the application. 
 
 ## How environment variables are used by the .NET agent
 
-The New Relic .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-overview) and implements a subset of the .NET profiling API.
+Our .NET agent is a [.NET CLR profiler](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/profiling-overview) and implements a subset of the .NET profiling API.
 [Certain environment variables](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/setting-up-a-profiling-environment) must be present in the environment of a .NET process to tell the .NET runtime that the process should be profiled, and by what profiler.
 Additional environment variables are used by the .NET agent itself to let it know where and how it is installed.
 
-Note: for the rest of this document, "the profiler" refers to the component of the agent that implements the .NET profiling API.  When things are configured correctly, the CLR attaches the profiler to your .NET application.  The profiler then loads the rest of the agent into the application. 
 
 ## What environment variables are required to use the .NET agent
 
@@ -47,9 +46,9 @@ COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.P
 
 #### .NET Core
 
-`CORECLR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application.  Set to 1 to enable profiling, set to 0 to disable it.
+`CORECLR_ENABLE_PROFILING` tells the runtime whether or not to enable profiling for an application. Set to 1 to enable profiling, set to 0 to disable it.
 
-`CORECLR_PROFILER` tells the runtime which profiler to use.  The value is a GUID unique to a given profiler.  For New Relic's profiler for .NET Core, the correct value is `{36032161-FFC0-4B61-B559-F6C5D41BAE5A}`.
+`CORECLR_PROFILER` tells the runtime which profiler to use. The value is a GUID unique to a given profiler. For New Relic's profiler for .NET Core, the correct value is `{36032161-FFC0-4B61-B559-F6C5D41BAE5A}`.
 
 `CORECLR_PROFILER_PATH` tells the runtime where to find the profiler on the system.
 
@@ -61,20 +60,20 @@ CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
 CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
 ```
 
-Note: there is a subtle difference in the behavior of the .NET framework agent vs. the .NET core agent regarding having profiling enabled.  For the .NET framework agent, even when profiling is enabled in the environment of a .NET framework process, it will only be instrumented by the agent if one of the following conditions are met:
+Note: There is a subtle difference in the behavior of the .NET framework agent vs. the .NET core agent regarding having profiling enabled. For the .NET framework agent, even when profiling is enabled in the environment of a .NET framework process, it will only be instrumented by the agent if one of the following conditions are met:
 * The application is hosted in IIS and
   * application pools are configured to be instrumented by default, or
   * the application pool hosting the application is configured to be instrumented explicitly
 * The application is explicitly configured to be instrumented in the system-wide `newrelic.config` file
 * AgentEnabled="true" is set in an app-local `newrelic.config` file
 
-However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent.  Therefore, we do not recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected.  Instead, only set this variable to 1 in the environment of the processes you want instrumented.
+However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we do not recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to 1 in the environment of the processes you want instrumented.
 
 ### Telling the profiler where the rest of the agent is
 
-Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components.  These variables are also used by parts of the rest of the agent.
+Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components. These variables are also used by parts of the rest of the agent.
 
-Note: depending on your installation scenario, only some of these variables are required.
+Note: Depending on your installation scenario, only some of these variables are required.
 
 #### NEWRELIC_HOME
 
@@ -83,16 +82,16 @@ This variable:
 * is used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
 * may be used to find the agent binary assets, if they are installed in the same place as the configuration assets
 
-Note: when the agent is installed with the MSI installer, this variable may not need to be set, since the MSI also sets a registry key (`HKEY_LOCAL_MACHINE\Software\New Relic\.NET Agent\NewRelicHome`) with the correct value.  The environment variable takes precedence if set.
+Note: When the agent is installed with the MSI installer, this variable may not need to be set, since the MSI also sets a registry key (`HKEY_LOCAL_MACHINE\Software\New Relic\.NET Agent\NewRelicHome`) with the correct value. The environment variable takes precedence if set.
 
 #### CORECLR_NEWRELIC_HOME
 
-This variable:
-* is only used in the .NET core version of the agent
-* is used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
-* may be used to find the agent binary assets, if they are installed in the same place as the configuration assets
+This variable is:
+* Only used in the .NET core version of the agent
+* Used to find the agent configuration assets (`newrelic.config` and the instrumentation XML files in the `extensions` subfolder)
+* May be used to find the agent binary assets, if they are installed in the same place as the configuration assets
 
-Note: this variable always needs to be set for the .NET core version of the agent.
+Note: This variable always needs to be set for the .NET core version of the agent.
 
 #### NEWRELIC_INSTALL_PATH
 
@@ -101,21 +100,21 @@ This variable is primarily used:
 * When the binary components of the agent are installed in a different location on the system than the configuration assets
 * When the agent is installed with the MSI installer on Windows (which does both of the above)
 
-This variable is set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it is used.  If the core dll is not found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location.  If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
+This variable is set to a directory/folder and is used by the profiler to find the agent core DLL. If the path specified in this variable contains the `NewRelic.Agent.Core.dll` file, it is used. If the core dll is not found, the profiler appends either `netframework` or `netcore` to the path specified, and searches for the core dll in that location. If the core dll is still not found, the profiler falls back to searching in either `NEWRELIC_HOME` (.NET framework) or `CORECLR_NEWRELIC_HOME` (.NET core).
 
-This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder.  The agent always appends either `netframework` or `netcore` to the value of this variable when it is set.  If it is not set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
+This variable is also used by the agent to load the instrumentation extension binaries from the `extensions` subfolder. The agent always appends either `netframework` or `netcore` to the value of this variable when it is set. If it is not set, the agent falls back to searching in `NEWRELIC_HOME\extensions` (.NET Framework) or `CORECLR_NEWRELIC_HOME\extensions` (.NET Core).
 
 ### Values for typical installation scenarios
 
 #### MSI Installer (Windows)
 
 The MSI is easy to use because it does almost everything for you automatically, but what it is doing behind the scenes is complicated.
-The MSI installer puts different parts of the agent in different places on the system.  By default, it puts the binary agent assets in `C:\Program Files\New Relic\.NET Agent` and it puts the configuration assets in `C:\ProgramData\New Relic\.NET Agent`.  This is to support scenarios where non-privileged users can access/edit files in `ProgramData` but not in `Program Files`.
+The MSI installer puts different parts of the agent in different places on the system. By default, it puts the binary agent assets in `C:\Program Files\New Relic\.NET Agent` and it puts the configuration assets in `C:\ProgramData\New Relic\.NET Agent`. This is to support scenarios where non-privileged users can access/edit files in `ProgramData` but not in `Program Files`.
 The MSI installer installs both framework and core versions of the agent side-by-side.  The MSI installer also sets a number of registry keys which make explicitly setting some of the required environment variables unneccessary, as explained above.
 
 Assuming you do not specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
 
-For .NET framework applications
+For .NET framework applications:
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -124,7 +123,7 @@ NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
 NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due to registry key being set
 ```
 
-For .NET core applications
+For .NET core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -135,9 +134,9 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 
 #### ZIP Archive (Windows)
 
-The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories.  Using <CUSTOM_AGENT_PATH> as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
+The ZIP archive of the agent for Windows contains both the framework and core versions of the agent in side-by-side directories. Using <CUSTOM_AGENT_PATH> as a placeholder for wherever you unzip the archive on your system, these are the correct environment variable values:
 
-For .NET framework applications
+For .NET framework applications:
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -145,7 +144,7 @@ COR_PROFILER_PATH="<CUSTOM_AGENT_PATH>\netframework\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netframework"
 ```
 
-For .NET core applications
+For .NET core applications:
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -155,7 +154,7 @@ CORECLR_NEWRELIC_HOME="<CUSTOM_AGENT_PATH>\netcore"
 
 #### Linux Packages
 
-The Linux install package (.deb or .rpm, as appropriate for your Linux distribution) installs the .NET core agent.  By default, it installs everything in `/usr/local/newrelic-dotnet-agent`.  
+The Linux install package (.deb or .rpm, as appropriate for your Linux distribution) installs the .NET core agent. By default, it installs everything in `/usr/local/newrelic-dotnet-agent`.  
 
 ```
 CORCLR_ENABLE_PROFILING=1
@@ -164,13 +163,13 @@ CORECLR_PROFILER_PATH="/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="/usr/local/newrelic-dotnet-agent"
 ```
 
-There is also a `.tar.gz` archive of the agent for manual installation on Linux.  In that case, replace `/usr/local/newrelic-dotnet-agent` with wherever you unpack the archive on your system in the above variables.
+There is also a `.tar.gz` archive of the agent for manual installation on Linux. In that case, replace `/usr/local/newrelic-dotnet-agent` with wherever you unpack the archive on your system in the above variables.
 
 #### NewRelic.Agent NuGet Package
 
-When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application.  The correct version of the agent is added for .NET framework or .NET core depending on the type of your application.  The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler.  Using <YOUR_APPLICATION_PATH> as a placeholder for whever your application is deployed on the system, these are the correct environment variable values:
+When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using <YOUR_APPLICATION_PATH> as a placeholder for whever your application is deployed on the system, these are the correct environment variable values:
 
-For .NET framework applications (64-bit)
+For .NET framework applications (64-bit):
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -178,7 +177,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-For .NET framework applications (32-bit)
+For .NET framework applications (32-bit):
 ```
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -186,7 +185,7 @@ COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\x86\NewRelic.Profiler.dll"
 NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-For .NET core applications (Windows)
+For .NET core applications (Windows):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -194,7 +193,7 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
-For .NET core applications (Linux, x64)
+For .NET core applications (Linux, x64):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
@@ -202,20 +201,10 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
 
-For .NET core applications (Linux, arm64)
+For .NET core applications (Linux, arm64):
 ```
 CORCLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/linux-arm64/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
-
-
-
-
-
-
-
-
-
-

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -7,7 +7,7 @@ tags:
 redirects:
 ---
 
-Our .NET agent uses environment variables to attach the profiler to your application, which allows the .NET agent and profiler to find required assets. If you're interested in diving deeper into how environment variables are used and which ones.
+Our .NET agent is a .NET CLR profiler and relies on your app's environment variables to connect your .NET app with New Relic. To learn more about which environment variables the .NET agent uses, see the sections below. 
 
 ## Terms overview [#terms-overview]
 
@@ -30,7 +30,7 @@ To use the .NET agent, we require environment variables for:
 * [Telling the profiler where the rest of the agent is](#agent)
 See the sections below for details on these required variables.
 
-### Enabling profiling and identifying the correct profiler [#enable]
+### Variables to enable profiling and identify the correct profiler [#enable]
 
 There is a set of three environment variables used to tell the .NET runtime whether or not to enable profiling, and which profiler to use. The names of these variables and the correct value for each depends on whether your application is built for .NET framework or .NET core.
 
@@ -76,7 +76,7 @@ Note: There is a subtle difference in the behavior of the .NET framework agent v
 
 However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent. Therefore, we don't recommend setting this environment variable to `1` system wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected. Instead, only set this variable to `1` in the environment of the processes you want instrumented.
 
-### Telling the profiler where the rest of the agent is [#agent]
+### Variables to tell the profiler where the rest of the .NET agent is [#agent]
 
 Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components. These variables are also used by parts of the rest of the agent.
 

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -61,6 +61,15 @@ CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
 CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
 ```
 
+Note: there is a subtle difference in the behavior of the .NET framework agent vs. the .NET core agent regarding having profiling enabled.  For the .NET framework agent, even when profiling is enabled in the environment of a .NET framework process, it will only be instrumented by the agent if one of the following conditions are met:
+* The application is hosted in IIS and
+  * application pools are configured to be instrumented by default, or
+  * the application pool hosting the application is configured to be instrumented explicitly
+* The application is explicitly configured to be instrumented in the system-wide `newrelic.config` file
+* AgentEnabled="true" is set in an app-local `newrelic.config` file
+
+However, for the .NET core agent, any process where `CORECLR_ENABLE_PROFILING` is set to 1 in its environment will be instrumented by the agent.  Therefore, we do not recommend setting this environment variable to 1 system-wide, as it may result in excess system resource consumption and/or more data being sent to New Relic than expected.  Instead, only set this variable to 1 in the environment of the processes you want instrumented.
+
 ### Telling the profiler where the rest of the agent is
 
 Now that the .NET runtime knows how to find the profiler and attach it to your application, other environment variables are needed to find the rest of the agent assets, which include both binary (DLL) and configuration (XML) components.  These variables are also used by parts of the rest of the agent.

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
@@ -69,6 +69,8 @@ Based on the output, here's what you need to do:
   * `CORECLR_PROFILER_PATH`: Must be set to the fully qualified path to the file `libNewRelicProfiler.so`. This is almost always equal to `CORECLR_NEWRELIC_HOME + /libNewRelicProfiler.so`.
 * If you made any changes to your environment variables, restart your app and go back to [Step 1](#step-one).
 
+For more details on these variables please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
+
 ## Step 4: Check permissions [#step-four]
 
 Check the following permissions tasks:

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-windows.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-windows.mdx
@@ -78,20 +78,16 @@ If the correct variables are set and the application you're trying to monitor ha
     title=".NET Framework: check for environment variables"
   >
 
-The environment variables that appear in the environment tab should be similar to these:
+Assuming you installed the agent using the .msi installer, the environment variables that appear in the environment tab should be similar to these:
 
 ```
 COR_ENABLE_PROFILING = 1
 COR_PROFILER = {71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 NEWRELIC_INSTALL_PATH = C:\Program Files\New Relic\.NET Agent
 ```
-Details on these variables: 
+For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/). 
 
-* `COR_ENABLE_PROFILING` tells the .NET CLR that profiling should be enabled for this process. It must be set to `1` in order for **any** .NET Framework profiler (including our .NET agent) to function.
-* `COR_PROFILER` identifies the New Relic profiler as the profiler to load into the process. If the CLSID shown in Process Explorer does not match the one above, you have multiple profilers installed on your system and a different profiler is currently configured to monitor the process. This is known as a [profiler conflict](/docs/agents/net-agent/troubleshooting/profiler-conflicts).
-* `NEWRELIC_INSTALL_PATH` tells the profiler where to find the New Relic files needed for monitoring. If you installed the agent to the default path, the path should match the entry above.
-
-If the environment variables don't match what you see above you can re-run the .NET agent installer and select `Repair` when prompted to restore them to the default.
+If the environment variables don't match what you see above you can re-run the .NET agent installer (.msi) and select `Repair` when prompted to restore them to the default.
 
 If the environment variables above are not present in the process at all, it usually means one of the following things:
 
@@ -117,7 +113,7 @@ If your application does not use one of those compatible app frameworks, you may
     title=".NET Core: check for environment variables"
   >
 
-The environment variables that appear in the environment tab should be similar to these:
+Assuming you installed the agent using the .msi installer, the environment variables that appear in the environment tab should be similar to these:
 
 ```
 CORECLR_ENABLE_PROFILING=1
@@ -128,12 +124,7 @@ CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\
 
 These variables are set manually as part of the installation process or at run time. If changes need to be made, adjust the variables in Windows or wherever you have set the variables for this application.
 
-Details on these variables: 
-
-* `CORECLR_ENABLE_PROFILING` tells the .NET Core Runtime that profiling should be enabled for this process. It must be set to `1` in order for **any** .NET Core profiler (including the .NET agent) to function.
-* `CORECLR_PROFILER` identifies the New Relic profiler as the profiler to load into the process. If the CLSID shown in Process Explorer does not match the one above, you have multiple profilers installed on your system and a different profiler is currently configured to monitor the process. This is known as a [profiler conflict](/docs/agents/net-agent/troubleshooting/profiler-conflicts).
-* `NEWRELIC_INSTALL_PATH` tells the profiler where to find the New Relic files needed for monitoring. If you installed the agent to the default path, the path should match the entry above.
-* `CORECLR_NEWRELIC_HOME` is the path to the location where the .NET Core agent is installed on your system.
+For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
 
 If you don't see the variables above in Process Explorer when inspecting your application's process, make sure you have the variables set and that they are accessible to the application at run time.
 

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -38,7 +38,10 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
        COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
        NEWRELIC_INSTALL_PATH=path\to\agent\directory
        ```
+
+    Note: the above environment variables and their values are valid for the agent when installed on Windows with the .msi installer. For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
   </Collapser>
+
 
   <Collapser
     id="compare-registry-keys"
@@ -116,6 +119,8 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
     ```
 
     For non-IIS applications and Windows services, either re-run the installer and use the `Repair` feature, or manually edit the system-wide environment variables. For some Windows services, a reboot is required to pick up the new variables.
+
+    Note: the above environment variables and their values are valid for the agent when installed on Windows with the .msi installer. For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
@@ -45,6 +45,8 @@ To resolve SCOM profiler conflicts:
 3. Run these commands **each** time you restart your server, or create a startup script to restore these settings.
 4. Recycle your app pool, or from a command prompt, run **`IISRESET`**.
 
+For more details on the above environment variable settings in the registry, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
+
 <Callout variant="important">
   You must repair your installation each time you restart your server.
 </Callout>

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -320,6 +320,8 @@ pages:
                 path: /docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container
               - title: Install for WCF
                 path: /docs/apm/agents/net-agent/other-installation/install-net-agent-windows-communication-foundation-wcf
+              - title: Understanding required .NET agent environment variables
+                path: /docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/
               - title: Install resources (advanced)
                 path: /docs/apm/agents/net-agent/other-installation/net-agent-install-resources
               - title: How to verify the checksum of .NET Agent downloads

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -320,7 +320,7 @@ pages:
                 path: /docs/apm/agents/net-agent/other-installation/install-net-agent-docker-container
               - title: Install for WCF
                 path: /docs/apm/agents/net-agent/other-installation/install-net-agent-windows-communication-foundation-wcf
-              - title: Understanding required .NET agent environment variables
+              - title: .NET agent environment variables
                 path: /docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/
               - title: Install resources (advanced)
                 path: /docs/apm/agents/net-agent/other-installation/net-agent-install-resources


### PR DESCRIPTION
This PR attempts to address some confusion about how the .NET agent uses required environment variables, and the correct values of those variables, reported by both our customers and our support team.  It has the following changes:

- Introduce a new document that gives an overview of how the required env vars are used by the agent, as well as correct values for common installation scenarios
- Link to this new document from multiple places around the rest of the .NET agent docs that reference required environment variables
- A few minor tweaks

I'm creating this PR in draft state initially to solicit feedback from the rest of the .NET agent team.  I would also appreciate any feedback from the docs team on the general formatting of the new document (I know it's pretty long and could probably use some collapsers).