### PR TITLE
fix: remove `$` from cmds

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-heroku.mdx
@@ -74,15 +74,15 @@ You can customize the New Relic [`newrelic.js` config file](/docs/agents/nodejs-
 Here is an example of using the Heroku command line to set environment variables instead of using your `newrelic.js` config file.
 
 ```shell
-$ heroku config:set NEW_RELIC_LICENSE_KEY=your license key
-$ heroku config:set NEW_RELIC_APP_NAME=your production app name
-$ heroku config:set NEW_RELIC_NO_CONFIG_FILE='true'
+heroku config:set NEW_RELIC_LICENSE_KEY=your license key
+heroku config:set NEW_RELIC_APP_NAME=your production app name
+heroku config:set NEW_RELIC_NO_CONFIG_FILE='true'
 ```
 
 To confirm your settings from the command line, use:
 
 ```shell
-$ heroku config
+heroku config
 ```
 
 ## Upgrade from an existing New Relic installation [#upgrading]


### PR DESCRIPTION
Our docs site automatically adds a `$` when it's a `shell` or `bash` code block. Those aren't to be typed, they are an indicator of it being a command line:

<img width="534" alt="image" src="https://user-images.githubusercontent.com/48165493/230161401-ef633aaa-63ba-4a86-930c-e7416a10ebee.png">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.