### PR TITLE
chore: add language identifiers for syntax highlighting

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
@@ -63,19 +63,19 @@ The guided install automates the discovery, configuration, and installation of O
 
 To install any individual on-host integration, you would use a command similar to the following, which specifies the type of integration you want to install. This is the syntax for Linux:
 
-```
+```bash
 curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n INSERT_THE_INTEGRATION_NAME
 ```
 
 For example, to install the Apache integration:
 
-```
-curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=<API_KEY> NEW_RELIC_ACCOUNT_ID=<ACCOUNT_ID> /usr/local/bin/newrelic install -n apache-open-source-integration
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID /usr/local/bin/newrelic install -n apache-open-source-integration
 ```
 
 This is the syntax for Windows:
 
-```
+```powershell
 [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; (New-Object System.Net.WebClient).DownloadFile("https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1", "$env:TEMP\install.ps1"); & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\install.ps1; $env:NEW_RELIC_API_KEY='INSERT_YOUR_API_KEY'; $env:NEW_RELIC_ACCOUNT_ID='INSERT_YOUR_ACCOUNT_ID'; $env:NEW_RELIC_REGION='INSERT_YOUR_REGION'; & 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe' install
 ```
 
@@ -109,7 +109,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n apache-open-source-integration
+        `newrelic install -n apache-open-source-integration`
       </td>
     </tr>
 
@@ -119,7 +119,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n cassandra-open-source-integration
+        `newrelic install -n cassandra-open-source-integration`
       </td>
     </tr>
 
@@ -129,7 +129,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n couchbase-open-source-integration
+        `newrelic install -n couchbase-open-source-integration`
       </td>
     </tr>
 
@@ -139,7 +139,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n elasticsearch-open-source-integration
+        `newrelic install -n elasticsearch-open-source-integration`
       </td>
     </tr>
 
@@ -149,7 +149,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n haproxy-open-source-integration
+        `newrelic install -n haproxy-open-source-integration`
       </td>
     </tr>
 
@@ -159,7 +159,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n hashicorp-consul-open-source-integration
+        `newrelic install -n hashicorp-consul-open-source-integration`
       </td>
     </tr>
 
@@ -169,7 +169,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n memcached-open-source-integration
+        `newrelic install -n memcached-open-source-integration`
       </td>
     </tr>
 
@@ -180,7 +180,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n mssql-server-integration-installer
+        `newrelic install -n mssql-server-integration-installer`
       </td>
     </tr>
 
@@ -190,7 +190,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n mongodb-open-source-integration
+        `newrelic install -n mongodb-open-source-integration`
       </td>
     </tr>
 
@@ -200,7 +200,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n mysql-open-source-integration
+        `newrelic install -n mysql-open-source-integration`
       </td>
     </tr>
 
@@ -210,7 +210,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n nagios-open-source-integration
+        `newrelic install -n nagios-open-source-integration`
       </td>
     </tr>
 
@@ -220,7 +220,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n nginx-open-source-integration
+        `newrelic install -n nginx-open-source-integration`
       </td>
     </tr>
 
@@ -230,7 +230,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n postgres-open-source-integration
+        `newrelic install -n postgres-open-source-integration`
       </td>
     </tr>
 
@@ -240,7 +240,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n rabbitmq-open-source-integration
+        `newrelic install -n rabbitmq-open-source-integration`
       </td>
     </tr>
 
@@ -250,7 +250,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n redis-open-source-integration
+        `newrelic install -n redis-open-source-integration`
       </td>
     </tr>
 
@@ -260,7 +260,7 @@ The table below lists the integrations supported by the guided install CLI comma
       </td>
 
       <td>
-        newrelic install -n varnish-cache-open-source-integration
+        `newrelic install -n varnish-cache-open-source-integration`
       </td>
     </tr>
   </tbody>
@@ -282,19 +282,19 @@ As we identify areas where the guided install fails, we'll document them here an
 
     Create a user `newrelic@localhost` with a specific password.
 
-    ```
+    ```bash
     sudo mysql -e "CREATE USER 'newrelic'@'localhost' IDENTIFIED BY 'YOUR_SELECTED_PASSWORD';"
     ```
 
     Give replication privileges to `newrelic@localhost` with a maximum of 5 connections.
 
-    ```
+    ```bash
     sudo mysql -e "GRANT REPLICATION CLIENT ON *.* TO 'newrelic'@'localhost' WITH MAX_USER_CONNECTIONS 5;"
     ```
 
     Give select privileges to `newrelic@localhost` with a maximum of 5 connections.
 
-    ```
+    ```bash
     sudo mysql -e "GRANT SELECT ON *.* TO 'newrelic'@'localhost' WITH MAX_USER_CONNECTIONS 5;"
     ```
 


### PR DESCRIPTION
I also wrapped the rest of the command lines in backticks and made the API key/Account ID stand-ins consistent (removed the `<>` from one code block)

I'm not positive if docs.newrelic recognizes `powershell` code blocks, but we can add it if it's not yet recognized.
