### PR TITLE
Add warning about winevtlog log type compatibility

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -280,7 +280,7 @@ What you use for the log source depends on the location your logs are sourced fr
   >
     <Callout variant="important">
       Available since infrastructure agent v.1.24.3
-      Only compatible with Windows Server 2019 and later.  Use [winlog](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#winlog) instead for prior versions.
+      Only compatible with Windows Server 2019 and later. Use [winlog](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#winlog) instead for prior versions.
     </Callout>
 
     Collect event from Windows log channels using new Windows Event Log API using the [winevtlog Fluent Bit plugin](https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog).

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -280,6 +280,7 @@ What you use for the log source depends on the location your logs are sourced fr
   >
     <Callout variant="important">
       Available since infrastructure agent v.1.24.3
+      Only compatible with Windows Server 2019 and later.  Use [winlog](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#winlog) instead for prior versions.
     </Callout>
 
     Collect event from Windows log channels using new Windows Event Log API using the [winevtlog Fluent Bit plugin](https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog).


### PR DESCRIPTION
Windows event logs obtained with the winevtlog log source on Windows Server prior to 2019 will have empty/NULL values for the `message` attribute.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Inform users of incompatibility of winevtlog

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
![image](https://user-images.githubusercontent.com/129794260/230758211-6b181fa8-c7d5-493b-b109-d3a2e0137db0.png)



* If your issue relates to an existing GitHub issue, please link to it.