### PR TITLE
Added AWS Static IP blocks for Outbound ALERT notifications

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -466,14 +466,16 @@ Synthetic private minions report to a specific endpoint based on region. To allo
 Endpoints that use `api.newrelic.com` (such as our [GraphQL API for NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph)) and our New Relic-generated [webhooks for alert policies](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-controlling-where-send-alerts#webhook) use an IP address from designated network blocks for the US or [European Union region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center). [TLS is required](#tls) for all addresses in these blocks.
 
 Network blocks for US region accounts:
-
-* 162.247.240.0/22
-
+* 162.247.240.0/22 (Private Data Center)
+* 18.246.82.0/25 (AWS, US-WEST-2 , Effective 7/1/2023)
+* 3.145.244.128/25 (AWS, US-EAST-2, Effective 7/1/2023)
+`
 Network blocks for EU region accounts:
 
-* 158.177.65.64/29
-* 159.122.103.184/29
-* 161.156.125.32/28
+* 158.177.65.64/29 (Private Data Center)
+* 159.122.103.184/29 (Private Data Center)
+* 161.156.125.32/28 (Private Data Center)
+* 3.77.79.0/25 (AWS, EU-CENTRAL-1, Effective 7/1/2023)
 
 These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations).
 


### PR DESCRIPTION
Added AWS Static IP blocks for Outbound ALERT notifications Services.  Marked which are for the legacy Private Data Centers, and which are for the AWS data centers.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.