### PR TITLE
Remove obsolete links to clones and templates

### DIFF
--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
@@ -58,10 +58,10 @@ Watch the video for a more detailed walkthrough:
 
 ## Create new docs [#creating-docs]
 
-You have a few options to help you create a new doc if you're unfamiliar with the front matter and doc sections:
+If you're unfamiliar with how to structure a new document, here are some tricks for getting started:
 
 * Find a similar doc and use it as a guide to the layout.
-* In the left navigation for the style guide, look under **Doc types and templates** for formatting tips.
+* In the left navigation pane of the style guide, look under **Doc types and templates** for formatting tips.
 
 To create a new doc:
 

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
@@ -58,7 +58,12 @@ Watch the video for a more detailed walkthrough:
 
 ## Create new docs [#creating-docs]
 
-You can use [article templates](/docs/style-guide/article-templates) or [clone an existing doc](#clone-doc) as a template. To create a new doc:
+You have a few options to help you create a new doc if you're unfamiliar with the front matter and doc sections:
+
+* Find a similar doc and use it as a guide to the layout.
+* In the left navigation for the style guide, look under **Doc types and templates** for formatting tips.
+
+To create a new doc:
 
 1. Clone the repo on your computer.
 2. In `/src/content/docs/`, find a good location for your doc.


### PR DESCRIPTION
We had a help-documentation comment telling us that there were two failing links in the guide to creating new docs.