### PR TITLE
Move Azure troubleshooting doc to installation

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories.mdx
@@ -1,0 +1,78 @@
+---
+title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
+type: troubleshooting
+tags:
+  - Agents
+  - NET agent
+  - Troubleshooting
+metaDescription: Troubleshooting steps if data does not appear in your app after you installed the New Relic .NET agent.
+redirects:
+  - /docs/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
+  - /docs/apm/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
+---
+
+import apmSkipactioninAzurePipeline from 'images/apm_screenshot-crop_skipaction-in-azure-pipeline.png'
+
+## Problem
+
+For Azure web apps using the `NewRelic.Azure.WebSites.Extension`, and deployed with Azure Pipelines, the `newrelic` directories are deleted, so no instrumentation occurs. Further attempts to deploy using the Azure Pipeline indicate that the `NewRelic.Azure.WebSites.Extension` is already installed, so the extension cannot be re-installed using the Azure Pipeline.
+
+## Solution
+
+To control `newrelic` folder retention, use the following options for WebDeploy:
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        **Basic solutions**
+      </th>
+
+      <th>
+        **Comments**
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Enable `skipAction=Delete` WebDeploy arguments.
+      </td>
+
+      <td>
+        Explicitly exclude specific folders from deletion, such as the `newrelic` folders, with the following:
+
+        Azure Pipelines UI:
+
+        Add these arguments to the **Azure App Service deploy -> Additional Deployment Options -> Additional Arguments**
+
+        ```
+        -skip:skipAction=Delete,objectName=dirPath,absolutePath='newrelic$' -skip:skipAction=Delete,objectName=dirPath,absolutePath='newrelic_core$'
+        ```
+
+        OR
+
+        `Pipeline.yml` file:
+
+        add the following `input` to the WebDeploy task:
+
+        ```yml
+        AdditionalArguments: '-skip:skipAction=Delete,objectName=dirPath,absolutePath=''newrelic$'' -skip:skipAction=Delete,objectName=dirPath,absolutePath=''newrelic_core$'''
+        ```
+
+        **Note** the escaped single quotes.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<img
+  title="Screenshot showing skipAction"
+  alt="Screenshot showing skipAction"
+  src={apmSkipactioninAzurePipeline}
+/>
+
+## Cause
+
+If the `Remove additional files at destination` option is selected for the `AzureRmWebAppDeployment` task in the Azure Pipeline, the `newrelic` and `newrelic_core` directories are deleted from `wwwroot`, but the extension is not considered uninstalled by Azure. As a result, the next time the pipeline runs and attempts to install the extension, the pipeline displays the message `Extension 'NewRelic.Azure.WebSites.Extension' already installed.` The extension cannot run without its folders, and Azure will not re-install it because it considers it still installed.

--- a/src/content/docs/apm/agents/net-agent/azure-installation/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
+title: 'Azure Web Apps Troubleshooting: Issue with Azure Pipelines'
 type: troubleshooting
 tags:
   - Agents

--- a/src/content/docs/apm/agents/net-agent/azure-installation/azure-web-apps-using-always-no-data-appears.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/azure-web-apps-using-always-no-data-appears.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Azure Web Apps troubleshooting: Using Always On and no data appears'
+title: 'Azure Web Apps troubleshooting: Issue with Always On'
 tags:
   - Agents
   - NET agent

--- a/src/content/docs/apm/agents/net-agent/azure-installation/no-data-reporting-microsoft-application-insights.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/no-data-reporting-microsoft-application-insights.mdx
@@ -1,5 +1,5 @@
 ---
-title: No data reporting with Microsoft Application Insights
+title: 'Azure Web Apps troubleshooting: App Insights conflict'
 tags:
   - Agents
   - NET agent

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -303,15 +303,15 @@ pages:
                 path: /docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps
               - title: 'Azure Cloud Services troubleshooting: No data appears'
                 path: /docs/apm/agents/net-agent/azure-installation/azure-cloud-services-no-data-appears
-              - title: 'Azure Web Apps troubleshooting: No data appears'
+              - title: 'Azure Web Apps troubleshooting: Issue with Always On'
                 path: /docs/apm/agents/net-agent/azure-installation/azure-web-apps-using-always-no-data-appears
               - title: 'Azure Web Apps troubleshooting: Unable to open log file'
                 path: /docs/apm/agents/net-agent/azure-installation/azure-web-apps-unable-open-log-file
               - title: 'Azure Web Apps troubleshooting: Profiler .dll locks during deployment'
                 path: /docs/apm/agents/net-agent/azure-installation/azure-web-apps-profiler-dll-locks-during-deployment
-              - title: 'Microsoft App Insights troubleshooting: No data appears'
+              - title: 'Azure Web Apps troubleshooting: App Insights conflict'
                 path: /docs/apm/agents/net-agent/azure-installation/no-data-reporting-microsoft-application-insights
-              - title: 'Azure Web Apps troubleshooting: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories'
+              - title: 'Azure Web Apps Troubleshooting: Issue with Azure Pipelines'
                 path: /docs/apm/agents/net-agent/azure-installation/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
           - title: Other installation
             path: /docs/apm/agents/net-agent/other-installation

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -311,6 +311,8 @@ pages:
                 path: /docs/apm/agents/net-agent/azure-installation/azure-web-apps-profiler-dll-locks-during-deployment
               - title: 'Microsoft App Insights troubleshooting: No data appears'
                 path: /docs/apm/agents/net-agent/azure-installation/no-data-reporting-microsoft-application-insights
+              - title: 'Azure Web Apps troubleshooting: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories'
+                path: /docs/apm/agents/net-agent/azure-installation/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
           - title: Other installation
             path: /docs/apm/agents/net-agent/other-installation
             pages:
@@ -461,8 +463,6 @@ pages:
                 path: /docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
               - title: No stack traces
                 path: /docs/apm/agents/net-agent/troubleshooting/no-stack-traces-dotnet
-              - title: Azure Pipelines wipes out NewRelic.Azure.WebSites.Extension directories
-                path: /docs/apm/agents/net-agent/troubleshooting/azure-pipelines-wipes-out-newrelicazurewebsitesextension-directories
               - title: 'WCF apps: agent changes Content-Type header'
                 path: /docs/apm/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
       - title: Node.js monitoring


### PR DESCRIPTION
We had a request in help-documentation to move this troubleshooting doc out of the main troubleshooting section and into the Azure installation section.