### PR TITLE
Improve MongoDB Atlas requirements

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -66,7 +66,7 @@ For a comprehensive list of specific Linux and Windows versions, check the table
 
 * [Install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic), minimum version 1.24.0.
 * Linux distribution or Windows version [compatible with the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure#operating-systems).
-* MongoDB user with [`clusterMonitor` and `read` permissions](#enable-instance) [More info](#setup-instance).
+* MongoDB user with [`clusterMonitor` and `read` permissions](#enable-instance). See [Setting up your MongoDB](#setup-instance) for more info.
 * To monitor MongoDB Atlas users still need a hosted environment to install the infrastructure agent and integration and remotely connect to the Atlas instance.
 
 ## Install and activate [#install]
@@ -216,7 +216,7 @@ Follow the next steps depending on your environment:
       }
     )
     
-    3. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters mongodb_cluster_name and mongodb_uri. Change other [configuration options](#instance-settings) if required.
+    3. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters `mongodb_cluster_name` and `mongodb_uri`. Change other [configuration options](#instance-settings) if required.
     
     ```
 
@@ -237,7 +237,7 @@ Follow the next steps depending on your environment:
 
     Alternatively, you can use the Atlas UI to create your user and assign the same specific privileges. For more information check the [MongoDB Atlas documentation](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users).
     
-    2. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters mongodb_cluster_name and mongodb_uri. Change other [configuration options](#instance-settings) if required.
+    2. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters `mongodb_cluster_name` and `mongodb_uri`. Change other [configuration options](#instance-settings) if required.
 
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -66,6 +66,7 @@ For a comprehensive list of specific Linux and Windows versions, check the table
 * [Install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic), minimum version 1.24.0.
 * Linux distribution or Windows version [compatible with the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure#operating-systems).
 * MongoDB user with [`clusterMonitor` and `read` permissions](#enable-instance).
+* To monitor MongoDB Atlas users still need a hosted environment to install the infrastructure agent and integration and remotely connect to the Atlas instance.
 
 ## Install and activate [#install]
 
@@ -130,7 +131,7 @@ For example, the following `values.yaml` of the `bitnami/mongodb` chart configur
 ```yaml
 metrics:
   enabled: true
-  extraFlags: "--collect-all --discovering-mode=true" 
+  extraFlags: "--collect-all --discovering-mode=true"
 ```
 
 Notice that, instead of `--collect-all`, you can also pass collectors one by one and disable any of them if needed: `--collector.dbstats --collector.collstats --collector.indexstats --collector.replicasetstatus --collector.topmetrics --collector.diagnosticdata`.
@@ -184,8 +185,6 @@ To retrieve metrics the integration requires a user with `clusterMonitor` and `r
     id="setup-hosted"
     title="Hosted MongoDB or Percona servers"
   >
-    See the MongoDB documentation for details on [creating users](https://docs.mongodb.com/manual/reference/method/db.createUser/index.html).
-
     <Callout variant="tip">
       Complete these steps on the mongos to be monitored. If you want to collect mongod-level metrics,
       such as host or replica set statistics, create the role
@@ -211,6 +210,8 @@ To retrieve metrics the integration requires a user with `clusterMonitor` and `r
     )
     ```
 
+    For more information check the [MongoDB Atlas documentation](https://docs.mongodb.com/manual/reference/method/db.createUser/index.html).
+
   </Collapser>
 </CollapserGroup>
 <CollapserGroup>
@@ -218,15 +219,13 @@ To retrieve metrics the integration requires a user with `clusterMonitor` and `r
     id="setup-atlas"
     title="Atlas"
   >
-    See the MongoDB Atlas documentation for details on [creating users](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users).
-
     1. Using the Atlas CLI run the following command to create a new user, and assign `clusterMonitor` and `readAnyDatabase` roles to the user (Adjust the username and password as required).
 
     ```
     atlas dbuser create -u username -p password --role clusterMonitor,readAnyDatabase
     ```
 
-    Alternatively, you can use the Atlas UI to create your user and assign the same specific privileges.
+    Alternatively, you can use the Atlas UI to create your user and assign the same specific privileges. For more information check the [MongoDB Atlas documentation](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users).
 
   </Collapser>
 </CollapserGroup>
@@ -282,7 +281,7 @@ The following configuration options are available:
     <td>
       Whether or not a direct connect should be made. Direct connections are not valid if multiple hosts are specified or an SRV URI is used, for example for mongoDB Atlas.
 
-      Notice that direct connect should also be set to false if `loadBalanced=true` is specified either in the connection string or in the DNS entry as it happens in case of Serverless Atlas Deployments.    
+      Notice that direct connect should also be set to false if `loadBalanced=true` is specified either in the connection string or in the DNS entry as it happens in case of Serverless Atlas Deployments.
     </td>
     <td>
       true

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -43,9 +43,10 @@ The integration obtains data by scraping the MongoDB API through a Prometheus ex
 
 To install the MongoDB monitoring integration, run through the following steps:
 
-1. [Install and activate the integration](#install).
-2. [Configure the integration](#configuration).
-3. [Find and use data](#find-and-use).
+1. [Check requirements](#req).
+2. [Install and activate the integration](#install).
+3. [Configure the integration](#configuration).
+4. [Find and use data](#find-and-use).
 
 ## Compatibility and requirements [#req]
 
@@ -65,7 +66,7 @@ For a comprehensive list of specific Linux and Windows versions, check the table
 
 * [Install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic), minimum version 1.24.0.
 * Linux distribution or Windows version [compatible with the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure#operating-systems).
-* MongoDB user with [`clusterMonitor` and `read` permissions](#enable-instance).
+* MongoDB user with [`clusterMonitor` and `read` permissions](#enable-instance) [More info](#setup-instance).
 * To monitor MongoDB Atlas users still need a hosted environment to install the infrastructure agent and integration and remotely connect to the Atlas instance.
 
 ## Install and activate [#install]
@@ -114,7 +115,10 @@ To install the integration, follow the instructions for your environment:
     4. Edit the `mongodb3-config.yml` file as described in the [configuration settings](#config).
     5. Restart the [infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
-</CollapserGroup>
+    <Collapser
+    id="linux-install"
+    title="Linux installation"
+  >
 
 ### Containerized environments [#containerized-environments]
 
@@ -160,6 +164,9 @@ new_relic_remote_write:
 
 On the other hand, in a Prometheus server, you can add custom attributes to all metrics with `external_labels`, or per job with `static_configs`, or for more complex scenarios `metric_relabel_config`.
 
+  </Collapser>
+</CollapserGroup>
+
 
 ### Other environments [#other-env]
 
@@ -178,7 +185,7 @@ To configure the integration, edit the config in the integration's YAML configur
 
 ### Setting up your MongoDB [#setup-instance]
 
-To retrieve metrics the integration requires a user with `clusterMonitor` and `readAnyDatabase` roles. Follow the next steps depending on your environment:
+Follow the next steps depending on your environment:
 
 <CollapserGroup>
   <Collapser
@@ -208,6 +215,9 @@ To retrieve metrics the integration requires a user with `clusterMonitor` and `r
                  { role: 'readAnyDatabase', db: 'admin' } ]
       }
     )
+    
+    3. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters mongodb_cluster_name and mongodb_uri. Change other [configuration options](#instance-settings) if required.
+    
     ```
 
     For more information check the [MongoDB Atlas documentation](https://docs.mongodb.com/manual/reference/method/db.createUser/index.html).
@@ -226,6 +236,8 @@ To retrieve metrics the integration requires a user with `clusterMonitor` and `r
     ```
 
     Alternatively, you can use the Atlas UI to create your user and assign the same specific privileges. For more information check the [MongoDB Atlas documentation](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#add-database-users).
+    
+    2. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters mongodb_cluster_name and mongodb_uri. Change other [configuration options](#instance-settings) if required.
 
   </Collapser>
 </CollapserGroup>
@@ -400,7 +412,7 @@ The following configuration options are available:
   </tbody>
 </table>
 
-## mongodb3-config.yml sample files [#examples]
+### Example configurations (mongodb3-config.yml) [#examples]
 
 <CollapserGroup>
   <Collapser
@@ -522,7 +534,7 @@ The following configuration options are available:
 
 - The [New Relic MongoDB Monitor quickstart](https://newrelic.com/instant-observability/mongodb-prometheus) is available through [Instant Observability (I/O)](https://newrelic.com/instant-observability/). It provides a dashboard that lets you easily explore your data, understand context, and resolve problems faster.
 - For more on how to find and use your data, see [Understand integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
-- Metrics are attached to the Metric sample of the entities `MONGODB_INSTANCE`, `MONGODB_DATABASE`, and `MONGODB_COLLECTION`.
+- Metrics are attached to the Metric sample of the [entities](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/) `MONGODB_INSTANCE`, `MONGODB_DATABASE`, and `MONGODB_COLLECTION`.
 - You can [query New Relic's data](/docs/using-new-relic/data/understand-data/query-new-relic-data) for troubleshooting purposes, or to create [custom charts and dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/).
 
 ### Dimensions [#dimensions]
@@ -726,7 +738,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
 
 ### Metric data [#metrics]
 
-These are the 3 entities created: `MONGODB_INSTANCE`, `MONGODB_DATABASE`, and `MONGODB_COLLECTION`.
+These are the 3 [entities](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/) created: `MONGODB_INSTANCE`, `MONGODB_DATABASE`, and `MONGODB_COLLECTION`.
 
 The following dimensional metrics are captured scraping the exporter and linked to the entity **MONGODB_INSTANCE**:
 
@@ -22894,4 +22906,4 @@ The following dimensional metrics are captured scraping the exporter and linked 
 
 This integration is open source software. This means you can [browse its source code](https://github.com/newrelic/newrelic-prometheus-exporters-packages) and send improvements, or create your own fork and build it.
 
-Moreover, this integration leverages an opensource exporter created by the community.
+Moreover, this integration leverages an Prometheus exporter created by the community.


### PR DESCRIPTION
Clarify the Atlas users still need to use a hosted environment to run the agent_integration