### PR TITLE
fix: enabling in web/app config does work

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -69,8 +69,13 @@ Here are details about the configuration methods shown in the diagram, and their
 
       <td>
         Configuration settings set in these files take highest precedence.
+        
+        However, if the agent is disabled in the local or global newrelic.config, the NewRelic.AgentEnabled settings in these files will be ignored.
 
-        If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will enable the agent.
+        If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in an `appsettings.json` these files **will enable the agent**.
+        
+        However, if the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in a `web.config` or `app.config` **will be ignored**.
+
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -70,7 +70,7 @@ Here are details about the configuration methods shown in the diagram, and their
       <td>
         Configuration settings set in these files take highest precedence.
 
-        However, if the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will be ignored.
+        If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will enable the agent.
       </td>
     </tr>
 
@@ -3407,7 +3407,7 @@ For ASP.NET and .NET Framework console apps you can also configure the following
     ```
 
     <Callout variant="important">
-      If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will be ignored.
+      If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will enable the agent.
     </Callout>
   </Collapser>
 
@@ -3471,7 +3471,7 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
     ```
 
     <Callout variant="important">
-      If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` setting in this file will be ignored.
+      If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will enable the agent.
     </Callout>
   </Collapser>
 


### PR DESCRIPTION
Neil tested out this line and found it was inaccurate:

> If the agent is disabled in the local or global newrelic.config, the NewRelic.AgentEnabled settings in these files will be ignored.

--

> The docs appear to be incorrect. After setting the global newrelic.config to `agentEnabled="false"` and adding `"NewRelic.AgentEnabled": "false"` settings to the appsettings.json I get this:

```log
2023-04-12 17:26:19,056 NewRelic  DEBUG: [pid: 2272, tid: 1] Reading value from appsettings.json and appsettings.*.json: 'NewRelic.AgentEnabled=false'
2023-04-12 17:26:19,252 NewRelic  ERROR: [pid: 2272, tid: 1] There was an error initializing the agent: System.Exception: The New Relic agent is disabled.  Update   to re-enable it.
   at NewRelic.Agent.Core.AgentManager.AssertAgentEnabled(configuration config)
   at NewRelic.Agent.Core.AgentManager..ctor()
   at NewRelic.Agent.Core.AgentManager.AgentSingleton.CreateInstance()
```

Then when I change it to `"NewRelic.AgentEnabled": "true"` I get:
```log
2023-04-12 17:28:58,441 NewRelic  DEBUG: [pid: 11500, tid: 1] Reading value from appsettings.json and appsettings.*.json: 'NewRelic.AgentEnabled=true'
2023-04-12 17:28:59,566 NewRelic   INFO: [pid: 11500, tid: 1] The New Relic .NET Agent v10.8.0.2 started (pid 11500) on app domain 'RedisAPI'
```

This might have been accurate at one point but it's not any longer
