### PR TITLE
(4/13) Update Kafka doc for Java Agent 8.1 release notes consistency

### DIFF
--- a/src/content/docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
@@ -104,7 +104,7 @@ Unlike JMS transactions, Kafka Streams transactions are not processed per record
 
 If you do wish to create transactions, you need to enable a `kafka-streams-spans` module.
 
-For example if you want to specify a specific instrumentation module:
+For example, if you want to specify a specific instrumentation module:
 
 ```
 class_transformer:
@@ -112,7 +112,7 @@ class_transformer:
     enabled: true
 ```
 
-Otherwise if you just want any `kafka-streams-spans` instrumentation module:
+Otherwise, if you want to use any `kafka-streams-spans` instrumentation module:
 
 ```
 class_transformer:

--- a/src/content/docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
@@ -102,9 +102,9 @@ If you're using Kafka Streams, by default we do not enable transactions. This is
 
 Unlike JMS transactions, Kafka Streams transactions are not processed per record. Instead, a transaction begins when a Kafka consumer polls records and then the resulting data gets processed.
 
-If you do wish to create transactions, you need to enable a `kafka-streams-spans-<instrumentation module version number>` module.
+If you do wish to create transactions, you need to enable a `kafka-streams-spans` module.
 
-For example:
+For example if you want to specify a specific instrumentation module:
 
 ```
 class_transformer:
@@ -112,7 +112,13 @@ class_transformer:
     enabled: true
 ```
 
-To see what instrumentation module you need to enable for your Kafka Streams version, refer to the [compatibility docs](/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent) to see what instrumentation module you need to enable for your Kafka Streams version.
+Otherwise if you just want any `kafka-streams-spans` instrumentation module:
+
+```
+class_transformer:
+  com.newrelic.instrumentation.kafka-streams-spans:
+    enabled: true
+```
 
 ## Enable Kafka distributed traces [#collect-kafka-distributed-traces]
 


### PR DESCRIPTION
This is an edit for the Java Agent Kafka docs so it is more consistent with the new release notes for the 8.1 release of the Java Agent.