### PR TITLE
fix: update theme to latest version for gatsby-plugin-newrelic updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "6.19.0",
+    "@newrelic/gatsby-theme-newrelic": "6.19.1",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,10 +2616,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@6.19.0":
-  version "6.19.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.19.0.tgz#700b4a9b1ac9a8ca65d0aa6bc1429b6593951850"
-  integrity sha512-fkBHdcbGZaByfDzoqBDPVUyHAdTZMMtv6oSnDSqGh3qUXnO3dQlfZTJvr7b+XTu/E8H0YvejSmwx5liD1bZ5Dg==
+"@newrelic/gatsby-theme-newrelic@6.19.1":
+  version "6.19.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-6.19.1.tgz#272c95527d4b111a395e4851e70dea67c0f0d1b3"
+  integrity sha512-ZvL1LeDT+jsweWUIa4NhTCaBSJslrglfd5PBmXstdJ6eOVZHPAPjht6AsRcG6C28EiyvzVnI12GSaLiEwv/bbw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"
@@ -2629,7 +2629,7 @@
     file-saver "^2.0.5"
     gatsby-plugin-emotion "^6.10.0"
     gatsby-plugin-layout "^2.10.0"
-    gatsby-plugin-newrelic "^2.0.0"
+    gatsby-plugin-newrelic "2.3.0"
     gatsby-plugin-react-helmet "^5.4.0"
     gatsby-plugin-robots-txt "^1.6.8"
     gatsby-plugin-sharp "4.25.0"
@@ -8499,10 +8499,10 @@ gatsby-plugin-meta-redirect@^1.1.1:
   dependencies:
     fs-extra "^7.0.0"
 
-gatsby-plugin-newrelic@^2.0.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-2.2.2.tgz#4d540d7fd827d103c3c222e4af8d3b85a1d53e5a"
-  integrity sha512-axMVeUig6PE/RN2qR4hT7/39NtNz+9by5hc4Php25N65zlLWYtuwqTtGpbeJUNyzh2PeqGEchN97nrT0KhEm4g==
+gatsby-plugin-newrelic@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-newrelic/-/gatsby-plugin-newrelic-2.3.0.tgz#6e0f08fc9b7081bab905551d47af2df55909efb2"
+  integrity sha512-Q7IIc6XKCGAr8AeYYNzFl3FjFxeJNaM6S3vBQwDgeCUF0svs4qj2zsWTCwshSZiZdb3wwI12uJYzmB/gqW3O7w==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
Tessen and the Browser agent seem to be working and on the desired versions.

![Screen Shot 2023-04-13 at 12 19 15 PM](https://user-images.githubusercontent.com/26727669/231836515-86e98e8d-d143-4cb7-b75c-fa5ccec2630c.png)
![Screen Shot 2023-04-13 at 12 19 08 PM](https://user-images.githubusercontent.com/26727669/231836519-3a47f0de-c26b-4801-bafe-8fad7d1624d2.png)
