### PR TITLE
fix: Reword JSON file docs (Pathpoint)

### DIFF
--- a/src/content/docs/new-relic-solutions/business-observability/configure-pathpoint.mdx
+++ b/src/content/docs/new-relic-solutions/business-observability/configure-pathpoint.mdx
@@ -34,9 +34,7 @@ This level of customization empowers you to create a tailored observability solu
 On this page, you'll learn:
 
 * How to configure Pathpoint with the GUI
-* How to configure Pathpoint with a JSON config file
-* How to upload a new JSON config file
-* How to download a currently active JSON config file
+* How to use JSON interchange format
 
 ## Configuring Pathpoint with the GUI
 
@@ -65,21 +63,49 @@ There are three icons that will let you access each of the three main editors in
   alt="TouchPoint editor"
   src={touchpointEditor}
 />
-## What is a JSON configuration file? [#json-config]
 
-JSON (JavaScript Object Notation) is a data structure, whose basic function is to allow for the exchange of information. Through this structure, you can identify each of the elements and components that will facilitate the implementation of Pathpoint. This includes understanding the function of its attributes, queries, and data output. 
+## Using the JSON interchange format
+
+It is extremely easy and intuitive to construct a Pathpoint implementatino using the stages, steps, and touchpoints editors shown in the previous section.  Sometimes it will be useful or necessary to store the configuration in a file and import that configuration at a later time possibly in another account or Pathpoint instance.  For a production Pathpoint implementation we strongly recommend storing an archive of your configuration as JSON in a version control system such as git.
+
+### Download your current configuration as JSON
+
+Pathpoint provides the flexibility to download the current JSON config file directly to your computer. This feature is particularly useful if you need to make changes to the file.
+
+To download the currently active JSON config file:
+
+<Steps>
+
+<Step>
+
+From your New Relic account, go to **Apps** > **Pathpoint**. Click on the <img src={threeLines} class="inline" style={{height: "30px", width: "30px"}} alt="Three lines" title="Three lines" /> in the upper left corner. 
+
+
+</Step>
+
+<Step>
+
+Click **JSON configuration**.
+
+</Step>
+
+<Step>
+
+Next, click on the down arrow.
 
 <img
-  title="JSON file"
-  alt="JSON file"
-  src={jsonfile}
+  title="download active JSON config file"
+  alt="download active JSON config file"
+  src={downloadFile}
 />
 
-The image above shows how each stage can be tied to a few steps, which in turn can be linked to a single touchpoint, or to a few touchpoints. 
+</Step>
 
-To program new stages, steps and touchpoints, you upload a New JSON configuration file.
+Your active JSON config file is now downloaded.
 
-## Upload a new JSON configuration file [#upload-json-config]
+</Steps>
+
+### Replace your current configuration by uploading a JSON file
 
 To load a new JSON config file:
 
@@ -126,43 +152,7 @@ Finally, the Pathpoint is displayed with the updates of the particular JSON file
 
 </Steps>
 
-## Download the currently active JSON config file [#download-current-config]
 
-Pathpoint provides the flexibility to download the current JSON config file directly to your computer. This feature is particularly useful if you need to make changes to the file.
+## More docs in our GitHub repo [#additional-docs]
 
-To download the currently active JSON config file:
-
-<Steps>
-
-<Step>
-
-From your New Relic account, go to **Apps** > **Pathpoint**. Click on the <img src={threeLines} class="inline" style={{height: "30px", width: "30px"}} alt="Three lines" title="Three lines" /> in the upper left corner. 
-
-
-</Step>
-
-<Step>
-
-Click **JSON configuration**.
-
-</Step>
-
-<Step>
-
-Next, click on the down arrow.
-
-<img
-  title="download active JSON config file"
-  alt="download active JSON config file"
-  src={downloadFile}
-/>
-
-</Step>
-
-Your active JSON config file is now downloaded.
-
-</Steps>
-
-## More details in our GitHub repo [#details]
-
-Want more technical details about Pathpoint? See [our GitHub repo](https://github.com/newrelic/nr1-pathpoint).
+Want more technical information about Pathpoint? See the docs in [our GitHub repo](https://github.com/newrelic/nr1-pathpoint/tree/main/docs).

--- a/src/content/docs/new-relic-solutions/business-observability/configure-pathpoint.mdx
+++ b/src/content/docs/new-relic-solutions/business-observability/configure-pathpoint.mdx
@@ -66,7 +66,7 @@ There are three icons that will let you access each of the three main editors in
 
 ## Using the JSON interchange format
 
-It is extremely easy and intuitive to construct a Pathpoint implementatino using the stages, steps, and touchpoints editors shown in the previous section.  Sometimes it will be useful or necessary to store the configuration in a file and import that configuration at a later time possibly in another account or Pathpoint instance.  For a production Pathpoint implementation we strongly recommend storing an archive of your configuration as JSON in a version control system such as git.
+It is extremely easy and intuitive to construct a Pathpoint implementation using the stages, steps, and touchpoints editors shown in the previous section.  Sometimes it will be useful or necessary to store the configuration in a file and import that configuration at a later time possibly in another account or Pathpoint instance.  For a production Pathpoint implementation we strongly recommend storing an archive of your configuration as JSON in a version control system such as git.
 
 ### Download your current configuration as JSON
 
@@ -78,7 +78,7 @@ To download the currently active JSON config file:
 
 <Step>
 
-From your New Relic account, go to **Apps** > **Pathpoint**. Click on the <img src={threeLines} class="inline" style={{height: "30px", width: "30px"}} alt="Three lines" title="Three lines" /> in the upper left corner. 
+From your New Relic account, go to **Apps > Pathpoint**. Click on the <img src={threeLines} class="inline" style={{height: "30px", width: "30px"}} alt="Three lines" title="Three lines" /> in the upper left corner. 
 
 
 </Step>
@@ -113,7 +113,7 @@ To load a new JSON config file:
 
 <Step>
 
-From your New Relic account, navigate to **Apps** > **Pathpoint**, and click <img src={threeLines} class="inline" style={{height: "30px", width: "30px"}} alt="Three lines" title="Three lines" />.
+From your New Relic account, navigate to **Apps > Pathpoint**, and click <img src={threeLines} class="inline" style={{height: "30px", width: "30px"}} alt="Three lines" title="Three lines" />.
 
 </Step>
 


### PR DESCRIPTION
The previous version of the docs don't really clarify the role of the JSON config file for Pathpoint.  Those docs were written prior to GUI support for creating/editing stages, steps, and touchpoints.  I've simplified some things and made the following clear.

1. The JSON config file is now only an `interchange` file
2. It is used for archiving a configuration in a version control system and for some situations when we want to use a configuration in a different account or copy a config from one instance to another.
3. The GUI is the primary means to create and configure a configuration.

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/8333200/231853754-bb3a5778-9ade-41e1-b21d-8309239f66f3.png">

@Sandeep10parmar 
