### PR TITLE
Tabatha/quickstart chooser bugs

### DIFF
--- a/src/components/QuickstartChooser.js
+++ b/src/components/QuickstartChooser.js
@@ -260,12 +260,12 @@ const Arrow = ({ className }) => (
   <svg
     className={cx(className, 'arrow')}
     css={css`
-      bottom: -4%;
-      left: 77%;
+      bottom: -30%;
+      left: 75%;
       position: absolute;
 
       @media (max-width: 1620px) {
-        bottom: -12%;
+        bottom: -30%;
       }
       @media (max-width: 1585px) {
         left: 60%;

--- a/src/components/QuickstartChooser.js
+++ b/src/components/QuickstartChooser.js
@@ -116,9 +116,11 @@ const ChooserContainer = styled.ul`
   list-style: none;
   padding: 0;
   place-items: center;
+  justify-content: center;
 
   @media (max-width: 1508px) {
     gap: 2rem;
+    column-gap: 6vw;
     justify-content: center;
   }
 
@@ -228,6 +230,10 @@ const Container = styled.div`
     & ${ChooserContainer} {
       gap: 1.625rem;
       grid-template-columns: repeat(auto-fit, 112px);
+      @media only screen and (min-width: 950px) and (max-width: 1270px) {
+        column-gap: 8vw;
+        grid-template-columns: repeat(4, 112px);
+      }
     }
   }
 


### PR DESCRIPTION
Just some cleanup in the APM intro doc.  A content update caused the text to overlap the absolute positioned svg arrow in the top QuickstartChooser, and the secondary layout wasn't' centering on large widths.