### PR TITLE
Remove unnecessary redirect.

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/shut-down.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/shut-down.mdx
@@ -7,8 +7,6 @@ tags:
   - New Relic Mobile Android
   - Android SDK API
 metaDescription: 'New Relic API for Android mobile app monitoring: shut down agent.'
-redirects:
-  - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api/shut-down
 ---
 
 ## Syntax


### PR DESCRIPTION
The Shutdown file had a redirect that was identical to the current file location. This seemed to be preventing the left navigation from working correctly.