### PR TITLE
docs(logging): remove NR_LOGGING_ENDPOINT env

### DIFF
--- a/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
+++ b/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
@@ -132,6 +132,22 @@ To get your logs streaming to New Relic, attach a trigger to the Lambda:
 
 <InstallFeedback />
 
+## Optional: Configure different logging endpoints [#config-endpoints]
+
+You can set a custom logging endpoint if needed, this will allow you for example to use our FedRAMP compliant endpoints.
+
+For that, you should deploy the application and explained above and then:
+
+1. Go to the recently deployed lambda function view in AWS.
+2. Scroll down and click on the `Configuration` tab.
+3. On the left menu inside the `Configuration` tab, click on `Environment Variables`.
+4. Here you can see a list of the already existing environment variables, just click `Edit` on the top right of the `Environment Variables` table.
+5. Update the `NR_LOGGING_ENDPOINT` with the appropiate endpoint:
+  - *US*: `https://log-api.newrelic.com/log/v1`
+  - *EU*: `https://log-api.eu.newrelic.com/log/v1`
+  - *FedRAMP*: `https://gov-log-api.newrelic.com/log/v1`
+6. Save
+
 ## Optional: Configure retries [#config-retries]
 
 You can configure the number of retries you want to perform in case the function fails to send the data in case of communication issues. Recommended number is 3 retries, but you can change the retry behavior by changing the below parameters:

--- a/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
+++ b/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
@@ -141,12 +141,12 @@ For that, you should deploy the application and explained above and then:
 1. Go to the recently deployed lambda function view in AWS.
 2. Scroll down and click on the `Configuration` tab.
 3. On the left menu inside the `Configuration` tab, click on `Environment Variables`.
-4. Here you can see a list of the already existing environment variables, just click `Edit` on the top right of the `Environment Variables` table.
+4. Here you can see a list of the already existing environment variables, just click **Edit** on the top right of the `Environment Variables` table.
 5. Update the `NR_LOGGING_ENDPOINT` with the appropiate endpoint:
-  - *US*: `https://log-api.newrelic.com/log/v1`
-  - *EU*: `https://log-api.eu.newrelic.com/log/v1`
-  - *FedRAMP*: `https://gov-log-api.newrelic.com/log/v1`
-6. Save
+    - For *US*: `https://log-api.newrelic.com/log/v1`
+    - For *EU*: `https://log-api.eu.newrelic.com/log/v1`
+    - For *FedRAMP*: `https://gov-log-api.newrelic.com/log/v1`
+6. Click **Save**.
 
 ## Optional: Configure retries [#config-retries]
 

--- a/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
+++ b/src/content/docs/logs/forward-logs/aws-lambda-sending-cloudwatch-logs.mdx
@@ -80,19 +80,6 @@ Complete the following:
 
     <tr>
       <td>
-        `NR_LOGGING_ENDPOINT`
-      </td>
-
-      <td>
-        New Relic ingestion endpoint for logs. **Required**. Two endpoints are available:
-
-        * US: `https://log-api.newrelic.com/log/v1`
-        * EU: `https://log-api.eu.newrelic.com/log/v1`
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         `NR_TAGS`
       </td>
 

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -43,6 +43,12 @@ https://log-api.newrelic.com/log/v1
 https://log-api.eu.newrelic.com/log/v1
 ```
 
+FedRAMP endpoint:
+
+```
+https://gov-log-api.newrelic.com/log/v1
+```
+
 ## HTTP setup [#setup]
 
 To send log data to your New Relic account via the Log API:
@@ -55,6 +61,7 @@ To send log data to your New Relic account via the Log API:
 
 * US: `https://log-api.newrelic.com/log/v1`
 * EU: `https://log-api.eu.newrelic.com/log/v1`
+* FedRAMP: `https://gov-log-api.newrelic.com/log/v1`
 
 6. Generate some traffic and wait a few minutes, then [check your account](#what-next) for data.
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
It remove and environment variable from the docs that is not being used and is not required.

* Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.
The lambda code already provides a way of inferring the endpoint by the provided license key.