### PR TITLE
docs(logging): Fix sample grok parsing rule

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -10,7 +10,7 @@ metaDescription: How New Relic uses parsing and how to send customized log data.
 redirects:
   - /docs/logs/new-relic-logs/ui-data/customizing-log-data
   - /docs/logs/new-relic-logs/ui-data/customize-logs-using-parsing
-  - /docs/logs/log-management/ui-data/parsing 
+  - /docs/logs/log-management/ui-data/parsing
 ---
 
 import logsParsingUi from 'images/logs_screenshot-full_parsing-ui.png'
@@ -21,7 +21,7 @@ New Relic parses log data automatically according to certain parsing rules. In t
 
 You can also create, query, and manage your log parsing rules by using NerdGraph, our GraphQL API, at [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql). For more information, see our [NerdGraph tutorial for parsing](/docs/apis/nerdgraph/examples/nerdgraph-log-parsing-rules-tutorial/).
 
-Here's a 5-minute video about log parsing: 
+Here's a 5-minute video about log parsing:
 
 <Video
   id="xPWM46yw3bQ"
@@ -156,7 +156,7 @@ Note that variable names must be explicitly set and be lowercase like `%{URI:uri
     To do this, create a Grok pattern that extracts these three fields; for example:
 
     ```
-    "%{IP:host_ip} %{INT:bytes_received} %{INT:bytes_sent}"
+    %{IP:host_ip} %{INT:bytes_received} %{INT:bytes_sent}
     ```
 
     After processing, your log record will include the fields `host_ip`, `bytes_received`, and `bytes_sent`. Now you can use these fields in New Relic to filter, facet, and perform statistical operations on your log data. For more details about how to parse logs with Grok patterns in New Relic, see [our blog post](https://newrelic.com/blog/how-to-relic/how-to-use-grok-log-parsing).


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
It fixes a GROK pattern example that is wrapped in double quotes, if you copy/paste that without removing them, it won't work. So removing them.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
N/A

* If your issue relates to an existing GitHub issue, please link to it.
N/A