### PR TITLE
Correct variable expansion for Api-Key

### DIFF
--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -156,7 +156,7 @@ These are the [monitor types](/docs/synthetics/new-relic-synthetics/using-monito
 
 To use the [synthetic monitoring REST API](/docs/apis/synthetics-rest-api), you must have the ability to manage synthetics monitors and use a [user key](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key) (the REST API key won't work).
 
-This API can be used for all synthetic monitors. (Additional API methods for [scripted browser and API test monitors](#scripted-api-monitors-api) are also available to update the script associated with those monitors.) All synthetic monitoring data is available via the API. API examples show cURL commands.
+This API can be used for all synthetic monitors. (Additional API methods for [scripted browser and API test monitors](#scripted-api-monitors-api) are also available to update the script associated with those monitors.) All synthetic monitoring data is available via the API. API examples show curl commands.
 
 For US-based accounts, use the following endpoint:
 
@@ -184,7 +184,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' $API_ENDPOINT/v3/monitors
+         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v3/monitors
     ```
 
     A successful request will return a `200 OK` response. The [data returned](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api#api-attributes) will be a JSON object in the following format:
@@ -219,11 +219,11 @@ https://synthetics.eu.newrelic.com/synthetics/api
     * `offset`: The monitor count offset. Defaults to 0. For example, if you have 40 monitors and you use an offset value of 20, it will return monitors 21-40.
     * `limit`: The number of results per page, maximum 100. Defaults to 50.
 
-    You can include these in your cURL command as follows:
+    You can include these in your curl command as follows:
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' $API_ENDPOINT/v3/monitors \
+         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v3/monitors \
          -G -d 'offset=20&limit=100'
     ```
 
@@ -243,7 +243,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' $API_ENDPOINT/v3/monitors/$MONITOR_ID
+         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v3/monitors/$MONITOR_ID
     ```
 
     A successful request will return a `200 OK` response. The [data returned](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api#api-attributes) will be a JSON object in the following format:
@@ -299,7 +299,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X POST -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' \
+         -X POST -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
          -H 'Content-Type: application/json' $API_ENDPOINT/v3/monitors \
          -d '{ "name" : "monitor1", "frequency" : 15, "uri" : "http://my-uri.com", "locations" : [ "AWS_US_WEST_1" ], "type" : "browser", "status" : "enabled", "slaThreshold" : "1.0"}'
     ```
@@ -323,7 +323,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X PUT -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' \
+         -X PUT -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
          -H 'Content-Type: application/json' $API_ENDPOINT/v3/monitors/$MONITOR_ID \
          -d '{ "name" : "updated monitor name", "type": "monitor type", "frequency" : 15, "uri" : "http://my-uri.com/", "locations" : [ "AWS_US_WEST_1" ], "status" : "enabled", "slaThreshold": "7.0" }'
     ```
@@ -347,7 +347,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X PATCH -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' \
+         -X PATCH -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
          -H 'Content-Type: application/json' $API_ENDPOINT/v3/monitors/$MONITOR_ID \
          -d '{ "name" : "updated monitor name" }'
     ```
@@ -369,7 +369,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' \
+         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
          -X DELETE $API_ENDPOINT/v3/monitors/$MONITOR_ID
     ```
 
@@ -385,14 +385,14 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X GET -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' $API_ENDPOINT/v1/locations
+         -X GET -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v1/locations
     ```
   </Collapser>
 </CollapserGroup>
 
 ## Script API for scripted browser and API test monitors [#scripted-api-monitors-api]
 
-In addition to the general API, there are several API methods for the scripted browsers (`SCRIPT_BROWSER`) and API test browsers (`SCRIPT_API`). These examples show cURL commands.
+In addition to the general API, there are several API methods for the scripted browsers (`SCRIPT_BROWSER`) and API test browsers (`SCRIPT_API`). These examples show curl commands.
 
 <CollapserGroup>
   <Collapser
@@ -403,7 +403,7 @@ In addition to the general API, there are several API methods for the scripted b
 
     ```
     curl -v
-         -H 'Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' 
+         -H "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>"
          $API_ENDPOINT/v3/monitors/$MONITOR_ID/script
     ```
 
@@ -446,7 +446,7 @@ In addition to the general API, there are several API methods for the scripted b
 
 
     curl -v -X PUT \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' \
+         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
          -H 'Content-Type: application/json' \
          $API_ENDPOINT/v3/monitors/$MONITOR_UUID/script \
          -d $scriptPayload
@@ -520,7 +520,7 @@ Here is an example of using New Relic's REST API and the bash script to create a
     id="sample-script"
     title="Scripted browser API example"
   >
-    The following example shows cURL commands to create a scripted browser monitor.
+    The following example shows curl commands to create a scripted browser monitor.
 
     * At the top of the script, replace the variables with your specific values.
     * For the `scriptfile` variable, identify the filename for the script to be created. Here is a sample script that can be saved as `sample_synth_script.js` to use in the example:
@@ -577,7 +577,7 @@ Here is an example of using New Relic's REST API and the bash script to create a
       payload="{  \"name\" : \"$monitorName\", \"frequency\" : $frequency,    \"locations\" : [ $locations ],   \"status\" : \"ENABLED\",  \"type\" : \"$monitorType\", \"slaThreshold\" : $slaThreshold, \"uri\":\"\"}"
       echo "Creating monitor"
 
-      # Make cURL call to API and parse response headers to get monitor UUID
+      # Make curl call to API and parse response headers to get monitor UUID
       shopt -s extglob # Required to trim whitespace; see below
       while IFS=':' read key value; do
         # trim whitespace in "value"

--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -184,7 +184,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v3/monitors
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" $API_ENDPOINT/v3/monitors
     ```
 
     A successful request will return a `200 OK` response. The [data returned](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api#api-attributes) will be a JSON object in the following format:
@@ -223,7 +223,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v3/monitors \
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" $API_ENDPOINT/v3/monitors \
          -G -d 'offset=20&limit=100'
     ```
 
@@ -243,7 +243,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v3/monitors/$MONITOR_ID
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" $API_ENDPOINT/v3/monitors/$MONITOR_ID
     ```
 
     A successful request will return a `200 OK` response. The [data returned](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api#api-attributes) will be a JSON object in the following format:
@@ -299,7 +299,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X POST -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+         -X POST -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" \
          -H 'Content-Type: application/json' $API_ENDPOINT/v3/monitors \
          -d '{ "name" : "monitor1", "frequency" : 15, "uri" : "http://my-uri.com", "locations" : [ "AWS_US_WEST_1" ], "type" : "browser", "status" : "enabled", "slaThreshold" : "1.0"}'
     ```
@@ -322,8 +322,8 @@ https://synthetics.eu.newrelic.com/synthetics/api
     Use a specific monitor ID, and replace the [synthetic monitoring REST API attributes](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api) with your specific values.
 
     ```
-    curl -v \
-         -X PUT -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+   curl -v \
+         -X PUT -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" \
          -H 'Content-Type: application/json' $API_ENDPOINT/v3/monitors/$MONITOR_ID \
          -d '{ "name" : "updated monitor name", "type": "monitor type", "frequency" : 15, "uri" : "http://my-uri.com/", "locations" : [ "AWS_US_WEST_1" ], "status" : "enabled", "slaThreshold": "7.0" }'
     ```
@@ -347,7 +347,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X PATCH -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+         -X PATCH -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" \
          -H 'Content-Type: application/json' $API_ENDPOINT/v3/monitors/$MONITOR_ID \
          -d '{ "name" : "updated monitor name" }'
     ```
@@ -369,7 +369,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" \
          -X DELETE $API_ENDPOINT/v3/monitors/$MONITOR_ID
     ```
 
@@ -385,7 +385,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
 
     ```
     curl -v \
-         -X GET -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" $API_ENDPOINT/v1/locations
+         -X GET -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" $API_ENDPOINT/v1/locations
     ```
   </Collapser>
 </CollapserGroup>
@@ -403,7 +403,7 @@ In addition to the general API, there are several API methods for the scripted b
 
     ```
     curl -v
-         -H "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>"
+         -H "Api-Key: <a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>"
          $API_ENDPOINT/v3/monitors/$MONITOR_ID/script
     ```
 
@@ -446,7 +446,7 @@ In addition to the general API, there are several API methods for the scripted b
 
 
     curl -v -X PUT \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" \
          -H 'Content-Type: application/json' \
          $API_ENDPOINT/v3/monitors/$MONITOR_UUID/script \
          -d $scriptPayload
@@ -492,7 +492,7 @@ In addition to the general API, there are several API methods for the scripted b
 
     ```
     curl -v
-    	-X PUT -H 'Api-Key: '<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>'
+    	-X PUT -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>"
     	-H 'content-type: application/json'
     	$API_ENDPOINT}/v3/monitors/$MONITOR_ID/script
     	-d '{ "scriptText": "dmFyIGFzc2VydCA9IHJlcXVpcmUoJ2Fzc2VydCcpOw0KYXNzZXJ0LmVxdWFsKCcxJywgJzEnKTs=","scriptLocations": [ { "name": "my_vse_enabled_location", "hmac": "MjhiNGE4MjVlMDE1N2M4NDQ4MjNjNDFkZDEyYTRjMmUzZDE3NGJlNjU0MWFmOTJlMzNiODExOGU2ZjhkZTY4ZQ=="} ]}'
@@ -588,7 +588,7 @@ Here is an example of using New Relic's REST API and the bash script to create a
             HTTP*) read PROTO STATUS MSG <<< "$key{$value:+:$value}"
                     ;;
         esac
-      done < <(curl -sS -i  -X POST -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -H 'Content-Type:application/json' https://synthetics.newrelic.com/synthetics/api/v3/monitors -d "$payload")
+      done < <(curl -sS -i  -X POST -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -H 'Content-Type:application/json' https://synthetics.newrelic.com/synthetics/api/v3/monitors -d "$payload")
 
       # Validate monitor creation & add script unless it failed
       if [ $STATUS = 201 ]; then
@@ -597,7 +597,7 @@ Here is an example of using New Relic's REST API and the bash script to create a
           # base64 encode script
           encoded=`echo "$script" | base64`
           scriptPayload="{\"scriptText\":\"$encoded\"}"
-            curl -s -X PUT -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -H 'Content-Type:application/json' "$LOCATION/script" -d $scriptPayload
+            curl -s -X PUT -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -H 'Content-Type:application/json' "$LOCATION/script" -d $scriptPayload
             echo "Script uploaded"
       else
         echo "Monitor creation failed"

--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -403,7 +403,7 @@ In addition to the general API, there are several API methods for the scripted b
 
     ```
     curl -v
-         -H "Api-Key: <a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>"
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>"
          $API_ENDPOINT/v3/monitors/$MONITOR_ID/script
     ```
 


### PR DESCRIPTION
Based on SME feedback in hero channel, we need to change the single quotation marks in the curl headers to double quotation marks to enable variable expansion. This doesn't follow the pattern in our other examples where we don't assume variable expansion and just ask users to insert literal values in the script. Alas, we are leaving this pattern here and just substituting the quotation marks.

Since the URLs embedded in the code snippet use double quotation marks, I just switched the `<a href` to use single quotation marks. This allow us to avoid having nested double quotation marks.