### PR TITLE
chore(ruby agent): Update docs for 9.2.0 release

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -132,7 +132,7 @@ These settings are available for agent configuration. Some settings depend on yo
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`info`</td></tr>
+        <tr><th>Default</th><td>`"info"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_LEVEL`</td></tr>
       </tbody>
     </table>
@@ -216,7 +216,7 @@ These settings are available for agent configuration. Some settings depend on yo
   When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
 
     <Callout variant="caution">
-      When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. <b>Recommendation:</b> To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
+      When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
     </Callout>
 
   </Collapser>
@@ -242,11 +242,12 @@ These settings are available for agent configuration. Some settings depend on yo
       </tbody>
     </table>
 
-  Path to `newrelic.yml`. If undefined, the agent checks the following directories (in order): 
+  Path to `newrelic.yml`. If undefined, the agent checks the following directories (in order):
     * `config/newrelic.yml`
     * `newrelic.yml`
     * `$HOME/.newrelic/newrelic.yml`
     * `$HOME/newrelic.yml`
+
   </Collapser>
 
   <Collapser id="exclude_newrelic_header" title="exclude_newrelic_header">
@@ -313,7 +314,7 @@ These settings are available for agent configuration. Some settings depend on yo
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`log/`</td></tr>
+        <tr><th>Default</th><td>`"log/"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_FILE_PATH`</td></tr>
       </tbody>
     </table>
@@ -325,7 +326,7 @@ These settings are available for agent configuration. Some settings depend on yo
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`json`</td></tr>
+        <tr><th>Default</th><td>`"json"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_MARSHALLER`</td></tr>
       </tbody>
     </table>
@@ -453,6 +454,23 @@ These settings are available for agent configuration. Some settings depend on yo
   Defines the maximum number of seconds the agent should spend attempting to connect to the collector.
   </Collapser>
 
+  <Collapser id="defer_rails_initialization" title="defer_rails_initialization">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DEFER_RAILS_INITIALIZATION`</td></tr>
+      </tbody>
+    </table>
+
+              If `true`, when the agent is in an application using Ruby on Rails, it will start after `config/initializers` run.
+
+            <Callout variant="caution">
+              This option may only be set by environment variable.
+            </Callout>
+
+  </Collapser>
+
 </CollapserGroup>
 
 ## Transaction Tracer
@@ -525,7 +543,7 @@ The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces)
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`obfuscated`</td></tr>
+        <tr><th>Default</th><td>`"obfuscated"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_RECORD_SQL`</td></tr>
       </tbody>
     </table>
@@ -1387,7 +1405,6 @@ Use these settings to toggle instrumentation types during agent startup.
       </tbody>
     </table>
 
-
   If `true`, disables Active Storage instrumentation.
   </Collapser>
 
@@ -1707,16 +1724,17 @@ Use these settings to toggle instrumentation types during agent startup.
     <table>
       <tbody>
         <tr><th>Type</th><td>Symbol</td></tr>
-        <tr><th>Default</th><td>`high`</td></tr>
+        <tr><th>Default</th><td>`:high`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_COMPRESSION_LEVEL`</td></tr>
       </tbody>
     </table>
 
   Configure the compression level for data sent to the trace observer.
-    
-  May be one of: `none`, `low`, `medium`, `high`. 
-    
-  Set the level to `none` to disable compression.
+
+  May be one of: `:none`, `:low`, `:medium`, `:high`.
+
+  Set the level to `:none` to disable compression.
+
   </Collapser>
 
 </CollapserGroup>
@@ -1751,11 +1769,23 @@ Use these settings to toggle instrumentation types during agent startup.
   Controls auto-instrumentation of bunny at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
+  <Collapser id="instrumentation-fiber" title="instrumentation.fiber">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_FIBER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Fiber class at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
   <Collapser id="instrumentation-concurrent_ruby" title="instrumentation.concurrent_ruby">
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_CONCURRENT_RUBY`</td></tr>
       </tbody>
     </table>
@@ -1791,7 +1821,7 @@ Use these settings to toggle instrumentation types during agent startup.
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ELASTICSEARCH`</td></tr>
       </tbody>
     </table>
@@ -1809,18 +1839,6 @@ Use these settings to toggle instrumentation types during agent startup.
     </table>
 
   Controls auto-instrumentation of Excon at start up. May be one of: `enabled`, `disabled`.
-  </Collapser>
-  
-  <Collapser id="instrumentation-fiber" title="instrumentation.fiber">
-    <table>
-      <tbody>
-        <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
-        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_FIBER`</td></tr>
-      </tbody>
-    </table>
-
-  Controls auto-instrumentation of the Fiber class at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
   </Collapser>
 
   <Collapser id="instrumentation-grape" title="instrumentation.grape">
@@ -2067,7 +2085,7 @@ Use these settings to toggle instrumentation types during agent startup.
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD`</td></tr>
       </tbody>
     </table>
@@ -2091,7 +2109,7 @@ Use these settings to toggle instrumentation types during agent startup.
     <table>
       <tbody>
         <tr><th>Type</th><td>String</td></tr>
-        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
         <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TILT`</td></tr>
       </tbody>
     </table>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -30,6 +30,20 @@ Any versions not listed in the following table are no longer supported. Please [
 
     <tr>
       <td>
+        v9.2.0
+      </td>
+
+      <td>
+        April 17, 2023
+      </td>
+
+      <td>
+        April 17, 2024
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         v9.1.0
       </td>
 
@@ -431,20 +445,6 @@ Any versions not listed in the following table are no longer supported. Please [
 
       <td>
         Jun 3, 2023
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v6.10.0
-      </td>
-
-      <td>
-        Apr 8, 2020
-      </td>
-
-      <td>
-        Apr 8, 2023
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

The Ruby agent is releasing version 9.2.0. The release notes are in a separate PR. This PR:
* Updates config options  
* Updates EOL policy page 

This is ready to merge/deploy.