### PR TITLE
include jpgs in webp conversion script

### DIFF
--- a/scripts/convertPNGs.mjs
+++ b/scripts/convertPNGs.mjs
@@ -51,11 +51,12 @@ const pngsToConvert = cli.flags.global ? allPNGs : stagedPNGs;
 const mdToConvert = cli.flags.global ? allMDsAndJSs : stagedMDs;
 
 const updateMarkdownReferences = async (mdArray) => {
+  console.log(`⏳  Checking references in ${mdArray.length} markdown & JS files`)
   for (const file of mdArray) {
     const imgImportRegEx = /(?:(\(.+)\.png|(import.*from .+)\.png)/g;
     const contents = await readFile(file, { encoding: 'utf8' });
     if (!imgImportRegEx.test(contents)) {
-      break;
+      continue;
     }
     const newContents = contents.replaceAll(imgImportRegEx, '$1$2.webp');
     await writeFile(file, newContents).then(() =>

--- a/scripts/convertPNGs.mjs
+++ b/scripts/convertPNGs.mjs
@@ -61,7 +61,9 @@ const updateMarkdownReferences = async (mdArray) => {
     'g'
   );
 
-  console.log(`⏳  Checking references in ${mdArray.length} markdown & JS files`)
+  console.log(
+    `⏳  Checking references in ${mdArray.length} markdown & JS files`
+  );
   for (const file of mdArray) {
     const contents = await readFile(file, { encoding: 'utf8' });
     if (!imgImportRegEx.test(contents)) {
@@ -70,12 +72,16 @@ const updateMarkdownReferences = async (mdArray) => {
     const newContents = contents.replaceAll(imgImportRegEx, '$1$2.webp');
     await writeFile(file, newContents).then(() =>
       console.log(`✨  Updated image reference(s) in \x1b[33m${file}\x1b[0m`)
-    );
+    ).catch(err => {
+      console.log(`😵  Failed trying to update reference(s) in \x1b[33m${file}\x1b[0m:`)
+      console.log(err)
+      process.exitCode = 1
+    });
   }
 };
 
 const convertImages = async (imageArray) => {
-  console.log(`⏳  Converting ${imageArray.length} images`)
+  console.log(`⏳  Converting ${imageArray.length} images`);
   for (const imagePath of imageArray) {
     const webpPath = swapExtension(imagePath);
     await webp
@@ -83,7 +89,12 @@ const convertImages = async (imageArray) => {
       .then(() => rm(imagePath))
       .then(() =>
         console.log(`✨  Converted \x1b[33m${imagePath}\x1b[0m to ✨WebP✨`)
-      );
+      )
+      .catch((err) => {
+        console.log(`😵  Failed trying to convert \x1b[33m${imagePath}\x1b[0m:`);
+        console.log(err)
+        process.exitCode = 1
+      });
   }
 };
 

--- a/scripts/convertPNGs.mjs
+++ b/scripts/convertPNGs.mjs
@@ -70,13 +70,17 @@ const updateMarkdownReferences = async (mdArray) => {
       continue;
     }
     const newContents = contents.replaceAll(imgImportRegEx, '$1$2.webp');
-    await writeFile(file, newContents).then(() =>
-      console.log(`✨  Updated image reference(s) in \x1b[33m${file}\x1b[0m`)
-    ).catch(err => {
-      console.log(`😵  Failed trying to update reference(s) in \x1b[33m${file}\x1b[0m:`)
-      console.log(err)
-      process.exitCode = 1
-    });
+    await writeFile(file, newContents)
+      .then(() =>
+        console.log(`✨  Updated image reference(s) in \x1b[33m${file}\x1b[0m`)
+      )
+      .catch((err) => {
+        console.log(
+          `😵  Failed trying to update reference(s) in \x1b[33m${file}\x1b[0m:`
+        );
+        console.log(err);
+        process.exitCode = 1;
+      });
   }
 };
 
@@ -91,9 +95,11 @@ const convertImages = async (imageArray) => {
         console.log(`✨  Converted \x1b[33m${imagePath}\x1b[0m to ✨WebP✨`)
       )
       .catch((err) => {
-        console.log(`😵  Failed trying to convert \x1b[33m${imagePath}\x1b[0m:`);
-        console.log(err)
-        process.exitCode = 1
+        console.log(
+          `😵  Failed trying to convert \x1b[33m${imagePath}\x1b[0m:`
+        );
+        console.log(err);
+        process.exitCode = 1;
       });
   }
 };

--- a/scripts/convertPNGs.mjs
+++ b/scripts/convertPNGs.mjs
@@ -41,7 +41,7 @@ const stagedPNGs = stagedFiles.filter((file) =>
   file.toLocaleLowerCase().endsWith('.png')
 );
 const stagedMDs = stagedFiles.filter((file) =>
-  /.mdx?$/.test(file.toLocaleLowerCase())
+  /\.mdx?$/.test(file.toLocaleLowerCase())
 );
 
 const allPNGs = await glob('**/*.png');


### PR DESCRIPTION
also:

- adds some error handling
- only checks for MD/JS in `src/` (previously running this with the `--global` flag would go through node_modules 😩)
- fixes a bug with the markdown references not being updated when running with the `--global` flag