### PR TITLE
MobileBreadcrumb is now a New Relic event

### DIFF
--- a/src/content/docs/data-apis/understand-data/event-data/events-reported-mobile-monitoring.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/events-reported-mobile-monitoring.mdx
@@ -50,7 +50,7 @@ redirects:
       </td>
 
       <td>
-        There are no attributes listed for this event because it's a custom event; attributes will include the [session attributes](#session-list) and any [custom attributes added](/docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile).
+        There are no attributes listed for this event; attributes will include the [session attributes](#session-list) and any [custom attributes added](/docs/mobile-monitoring/new-relic-mobile/maintenance/add-custom-data-new-relic-mobile).
       </td>
     </tr>
 


### PR DESCRIPTION

* What problems does this PR solve? - Update docs, we have moved mobilebreadcrumb from custom events to New Relic events. 