### PR TITLE
fix: Adjust TileLogo css

### DIFF
--- a/src/components/TileSelect/TileOption.js
+++ b/src/components/TileSelect/TileOption.js
@@ -39,9 +39,8 @@ const TileOption = ({ displayName, value, logo, onChange, isSelected }) => {
           name={logo}
           css={css`
             margin-bottom: 0;
-            img {
-              width: 2rem;
-            }
+            max-height: 3rem;
+            max-width: 80%;
           `}
         />
       )}


### PR DESCRIPTION
The css that was in there wasn't actually affecting anything. I moved it out of the nested img selector and adjusted it a bit. here's an example where i pulled in some random pngs for demo purposes:

<img width="707" alt="Screen Shot 2023-04-17 at 1 48 22 PM" src="https://user-images.githubusercontent.com/39655074/232607737-23dd0d96-8f28-4df7-a90e-99a965ce7140.png">
