### PR TITLE
Remove "preview" from left nav reference

### DIFF
--- a/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
+++ b/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
@@ -51,7 +51,7 @@ Before you jump into the details here about how to view and analyze the impact o
     <Callout variant="tip">
       If you land on a dashboard or entity summary page and don't see the deployment marker you're expecting, check your time picker selection. It might be outside the window you are looking at.
     </Callout>
-* **Entity sidebar:** On the sidebar for any entity with recorded deployments, you can click on **Deployments** to see a table displaying recorded deployments. This is the deployments list page, and it features a time range selector and table filtering and sorting options. Use these to narrow the field of deployments or find a specific deployment.
+* **Entity sidebar:** To see a table of deployments, click on **Deployments** for any entity that has recorded deployments. This is the deployments list page, and it features a time range selector and table filtering and sorting options. Use these to narrow the field of deployments or find a specific deployment.
 
     <img
       style={{align: "left"}}

--- a/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
+++ b/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
@@ -51,7 +51,7 @@ Before you jump into the details here about how to view and analyze the impact o
     <Callout variant="tip">
       If you land on a dashboard or entity summary page and don't see the deployment marker you're expecting, check your time picker selection. It might be outside the window you are looking at.
     </Callout>
-* **Entity sidebar:** On the sidebar for any entity with recorded deployments, you can click on **Deployments preview** to see a table displaying recorded deployments. This is the deployments list page, and it features a time range selector and table filtering and sorting options. Use these to narrow the field of deployments or find a specific deployment.
+* **Entity sidebar:** On the sidebar for any entity with recorded deployments, you can click on **Deployments** to see a table displaying recorded deployments. This is the deployments list page, and it features a time range selector and table filtering and sorting options. Use these to narrow the field of deployments or find a specific deployment.
 
     <img
       style={{align: "left"}}


### PR DESCRIPTION
This was a hold-over from the preview, so I am removing the word "preview."