### PR TITLE
chore(Net agent): Removed the trailing slash on the nav path

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -321,7 +321,7 @@ pages:
               - title: Install for WCF
                 path: /docs/apm/agents/net-agent/other-installation/install-net-agent-windows-communication-foundation-wcf
               - title: .NET agent environment variables
-                path: /docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/
+                path: /docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables
               - title: Install resources (advanced)
                 path: /docs/apm/agents/net-agent/other-installation/net-agent-install-resources
               - title: How to verify the checksum of .NET Agent downloads


### PR DESCRIPTION
Removed the trailing slash on the nav path on the [Understanding required .NET agent environment variables](https://docs.newrelic.com/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/)