### PR TITLE
fix cluster documentation config for rabbitmq integration

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
@@ -156,7 +156,7 @@ Specific settings related to RabbitMQ are defined using the `env` section of the
 
 **Cluster environments**
 
-In cluster environments, only one node should use `METRICS=false` and `INVENTORY=false`; the rest should use `INVENTORY=true` and `METRICS=false`. For more on these, see [instance settings](#instance-settings).
+In cluster environments, the integration collects metrics from all the cluster with only one instance of the integration connected to one node. This instance should use `METRICS=true` and `true`. For the rest of the nodes only Inventory should be collected using `METRICS=false` and `INVENTORY=true`. For more on these, see [instance settings](#instance-settings).
 
 If you're running a cluster environment in Kubernetes, you need to deploy RabbitMQ as a [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/), and configure the agent to query all the metrics from the RabbitMQ pod. Set the autodiscovery matching condition [in the config file](https://github.com/newrelic/nri-rabbitmq/blob/master/rabbitmq-config.yml.k8s_sample) to this value:
 


### PR DESCRIPTION
It clarifies how to configure the integration in a cluster environment.