### PR TITLE
migrated NPM lab from developer site

### DIFF
--- a/src/content/docs/network-performance-monitoring/get-started/network-performance-monitoring-guide.mdx
+++ b/src/content/docs/network-performance-monitoring/get-started/network-performance-monitoring-guide.mdx
@@ -34,6 +34,6 @@ This track utilizes an ephemeral virtual machine. As a result, you need to finis
 
 Well done! Now that you've gotten your feet wet using ktranslate and New Relic to monitor your network devices, here are some things you can do on your own as you prepare to monitor your real-life network:
 
-- Read "[Get started with Network Performance Monitoring](https://docs.newrelic.com/docs/network-performance-monitoring/get-started/npm-introduction/)" to learn how to get the most of New Relic's network performance monitoring
+- Read "[Get started with Network Performance Monitoring](/docs/network-performance-monitoring/get-started/npm-introduction/)" to learn how to get the most of New Relic's network performance monitoring
 - Visit the [ktranslate GitHub repository](https://github.com/kentik/ktranslate) to learn how ktranslate works
-- Read "[What is an entity?](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/)" to learn more about New Relic entities and how to synthesize your own. This will help you get more mileage from your **Kentik default** entities.
+- Read "[What is an entity?](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/)" to learn more about New Relic entities and how to synthesize your own. This will help you get more mileage from your **Kentik default** entities.

--- a/src/content/docs/network-performance-monitoring/get-started/network-performance-monitoring-guide.mdx
+++ b/src/content/docs/network-performance-monitoring/get-started/network-performance-monitoring-guide.mdx
@@ -1,0 +1,39 @@
+---
+title: 'Monitor your network devices with New Relic'
+description: 'Monitor your network devices with New Relic'
+---
+
+You’re an operations engineer relying on a network of SNMP-enabled devices. Your team already uses New Relic’s features for monitoring software and infrastructure, but it’s time to monitor your network devices as well.
+
+In this track, you use Kentik’s ktranslate library to automatically discover your network devices, gather data, and send that data to New Relic to correlate network performance with infrastructure, applications, and digital experiences. Then you use New Relic to monitor the health of your network.
+
+## Objectives
+
+- Poll SNMP data from network devices and send it to New Relic
+- Sample network flow data and send it to New Relic
+- Create a New Relic dashboard for monitoring your network devices
+- Create a New Relic workload to logically group your devices and set up anomaly detection
+- Use your new data to understand behaviors within your network
+
+## Requirements
+
+- A free New Relic account
+- A full platform user or a core user with the Nerdpack modify user privilege
+
+<Callout variant="important">
+
+This track utilizes an ephemeral virtual machine. As a result, you need to finish the entire track in one sitting or you'll lose your progress when time expires.
+
+</Callout>
+
+## Lab
+
+<iframe width="1140" height="640" sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-modals" src="https://play.instruqt.com/embed/newrelic/tracks/network-performance-monitoring?token=em_8vjt8dquoemjh76q" style="border: 0;"></iframe>
+
+## Homework
+
+Well done! Now that you've gotten your feet wet using ktranslate and New Relic to monitor your network devices, here are some things you can do on your own as you prepare to monitor your real-life network:
+
+- Read "[Get started with Network Performance Monitoring](https://docs.newrelic.com/docs/network-performance-monitoring/get-started/npm-introduction/)" to learn how to get the most of New Relic's network performance monitoring
+- Visit the [ktranslate GitHub repository](https://github.com/kentik/ktranslate) to learn how ktranslate works
+- Read "[What is an entity?](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic/)" to learn more about New Relic entities and how to synthesize your own. This will help you get more mileage from your **Kentik default** entities.

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -3,6 +3,9 @@ path: /docs/network-performance-monitoring
 pages:
   - title: Get started with network monitoring
     path: /docs/network-performance-monitoring/get-started/npm-introduction
+  - title: Monitor your network devices
+    path: /docs/network-performance-monitoring/get-started/network-performance-monitoring-guide
+    label: Lab
   - title: Set up network data monitoring
     pages:
       - title: Network security prerequisites

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -3,9 +3,6 @@ path: /docs/network-performance-monitoring
 pages:
   - title: Get started with network monitoring
     path: /docs/network-performance-monitoring/get-started/npm-introduction
-  - title: Monitor your network devices
-    path: /docs/network-performance-monitoring/get-started/network-performance-monitoring-guide
-    label: Lab
   - title: Set up network data monitoring
     pages:
       - title: Network security prerequisites
@@ -24,6 +21,9 @@ pages:
         path: /docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring
   - title: Visualize your network data in New Relic
     path: /docs/network-performance-monitoring/monitoring-network-data/visualize-network-data
+  - title: Monitor your network devices
+    path: /docs/network-performance-monitoring/get-started/network-performance-monitoring-guide
+    label: Lab
   - title: Advanced configuration
     pages:
       - title: Advanced config for network monitoring


### PR DESCRIPTION
This is a copy of the [Network Performance Monitoring Lab](https://developer.newrelic.com/collect-data/network-performance-monitoring) from the developer site, as part of the migration. 