### PR TITLE
rabbitmq queue size limitation (NR-107429)

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
@@ -168,6 +168,10 @@ discovery:
       podName: rabbitmq-0
 ```
 
+<Callout variant="important">
+  The intrgration has a limitation of the number of queues that can be collected. If the number of queues, after queue filters are applied, exceedes 2000 the integration will not report any of them.
+</Callout>
+
 ### RabbitMQ instance settings [#instance-settings]
 
 The RabbitMQ integration collects both Metrics(<strong>M</strong>) and Inventory(<strong>I</strong>) information. Check the **Applies To** column below to find which settings can be used for each specific collection:

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration.mdx
@@ -25,7 +25,7 @@ Before installing the integration, make sure that you meet the following require
 * RabbitMQ [Management Plugin](https://www.rabbitmq.com/management.html) configured.
 * RabbitMQ command line tool, [rabbitmqctl](#rabbitmqctl), in the `PATH` of the root user.
 * If RabbitMQ is **not** running on Kubernetes or Amazon ECS, you must [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a host running RabbitMQ. Otherwise:
-  * If running on Kubernetes, see [these requirements](/docs/monitor-service-running-kubernetes#requirements).
+  * If running on Kubernetes, see [these requirements](/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements/).
   * If running on ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 
 ## Install and activate [#install]
@@ -122,7 +122,7 @@ To install the RabbitMQ integration, follow the instructions for your environmen
 
 Additional notes:
 
-* **Advanced:** Integrations are also available in [tarball format](/docs/integrations/host-integrations/installation/install-host-integrations-built-new-relic#tarball) to allow for install outside of a package manager.
+* **Advanced:** Integrations are also available in [tarball format](/docs/infrastructure/host-integrations/installation/install-infrastructure-host-integrations/#tarball) to allow for install outside of a package manager.
 * **On-host integrations do not automatically update.** For best results, regularly [update the integration package](/docs/integrations/host-integrations/installation/update-infrastructure-host-integration-package) and [the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/update-infrastructure-agent).
 
 <Callout variant="important">
@@ -146,7 +146,7 @@ For an example configuration, see [Example config file](#example-config).
 The configuration file has common settings applicable to all integrations like `interval`, `timeout`, `inventory_source`. To read all about these common settings refer to our [Configuration Format](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-newer-configuration-format/#configuration-basics) document.
 
 <Callout variant="important">
-  If you are still using our Legacy configuration/definition files please refer
+  If you're still using our Legacy configuration/definition files please refer
   to this
   [document](/docs/create-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/)
   for help.
@@ -169,7 +169,7 @@ discovery:
 ```
 
 <Callout variant="important">
-  The intrgration has a limitation of the number of queues that can be collected. If the number of queues, after queue filters are applied, exceedes 2000 the integration will not report any of them.
+  The integration has a limitation on the number of queues that can be collected. If the number of queues exceeds 2000, after the application of queue filters, the integration won't report any of them.
 </Callout>
 
 ### RabbitMQ instance settings [#instance-settings]

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: Compatibility and requirements of the New Relic Kubernetes integration.
 redirects:
   - /docs/integrations/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements
+  - /docs/monitor-service-running-kubernetes
 ---
 
 The [Kubernetes integration](/docs/integrations/kubernetes-integration/get-started/introduction-kubernetes-integration) is compatible with many different platforms including GKE, EKS, AKS, OpenShift, and more. Each has a different compatibility with our integration. You can find more information in this page.


### PR DESCRIPTION
The rabbitmq integration has a non documented limitation regarding the maximum amount of queues that can be collected. this PR documents that