### PR TITLE
Updated broken link

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
@@ -33,7 +33,7 @@ You can create synthetic monitors without installation. To get started:
 
 ## Create a monitor [#adding-monitors]
 
-Ready to monitor your web apps with one (or several!) of our [synthetic monitors](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring/#types-of-synthetic-monitors)? The steps below walk you through the process for all our monitors. 
+Ready to monitor your web apps with one (or several!) of our [synthetic monitors](/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring/#types-of-synthetic-monitors)? The steps below walk you through the process for all our monitors. 
 
 <img
   title="Create your first synthetic monitor"

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors.mdx
@@ -33,7 +33,7 @@ You can create synthetic monitors without installation. To get started:
 
 ## Create a monitor [#adding-monitors]
 
-Ready to monitor your web apps with one (or several!) of our [synthetic monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors)? The steps below walk you through the process for all our monitors. 
+Ready to monitor your web apps with one (or several!) of our [synthetic monitors](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring/#types-of-synthetic-monitors)? The steps below walk you through the process for all our monitors. 
 
 <img
   title="Create your first synthetic monitor"


### PR DESCRIPTION
Description:

This pull request fixes a broken link in the add/edit monitor doc. The original link was pointing to a page that no longer exists, so I updated it to the new URL. The new link directs users to the correct page with the relevant information. The broken link is also referenced in the attribute dictionary under syntheticsType, with hyperlink Types of synthetic monitors

Changes Made:

Updated the broken link to the new URL
Tested the link to ensure it is working as expected

Testing:

Clicked on the updated link to verify it directs to the correct page.
