### PR TITLE
Fixup docs

### DIFF
--- a/src/content/docs/apm/agents/python-agent/back-end-services/python-agent-celery.mdx
+++ b/src/content/docs/apm/agents/python-agent/back-end-services/python-agent-celery.mdx
@@ -146,3 +146,8 @@ How to troubleshoot this will depend on why you want to use the `MAX_TASKS_PER_C
 <Callout variant="important">
   For version 3.2.2.94 or higher, the Python agent will shut down when the `MAX_TASKS_PER_CHILD` limit is reached. No data will be lost.
 </Callout>
+
+
+<Callout variant="important">
+  Monitoring the main process of Celery is not possible with the agent, it can only monitor the worker processes. See [Activate application warning](/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx)
+</Callout>

--- a/src/content/docs/apm/agents/python-agent/back-end-services/python-agent-celery.mdx
+++ b/src/content/docs/apm/agents/python-agent/back-end-services/python-agent-celery.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/agents/python-agent/backend-services/python-agent-celery
 ---
 
-If you are using Celery as a distributed task queuing system, you can use the Python agent to record Celery processes as [non-web transactions](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions).
+If you're using Celery as a distributed task queuing system, you can use the Python agent to record Celery processes as [non-web transactions](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions).
 
 To get the Python agent working with Celery, first follow the [agent installation instructions](/docs/agents/python-agent/installation-and-configuration/python-agent-installation) to install, configure, and [test](/docs/agents/python-agent/installation-and-configuration/testing-python-agent) the agent. Then use these Celery-specific instructions.
 
@@ -64,13 +64,13 @@ The command you use to run Celery with the agent depends on your Celery version 
     id="run-celery-initd"
     title="Init scripts"
   >
-    If you are using one of Celery's generic init scripts, edit the script and wrap the `celery` command that is called when the script is used. This command usually looks like:
+    If you're using one of Celery's generic init scripts, edit the script and wrap the `celery` command that is called when the script is used. This command usually looks like:
 
     ```
     CELERY_BIN=${CELERY_BIN:-"celery"}
     ```
 
-    To add the agent’s wrapper script, change the `CELERY_BIN` variable to the following, where `some/path/` is your actual path to the file or package:
+    To add the agent's wrapper script, change the `CELERY_BIN` variable to the following, where `some/path/` is your actual path to the file or package:
 
     ```
     CELERY_BIN=${CELERY_BIN:-"NEW_RELIC_CONFIG_FILE=/some/path/newrelic.ini /some/path/bin/newrelic-admin run-program /some/path/bin/celery"}
@@ -149,5 +149,5 @@ How to troubleshoot this will depend on why you want to use the `MAX_TASKS_PER_C
 
 
 <Callout variant="important">
-  Monitoring the main process of Celery is not possible with the agent, it can only monitor the worker processes. See [Activate application warning](/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx)
+  Monitoring the main process of Celery isn't possible with the agent, it can only monitor the worker processes. See [Activate application warning](/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python)
 </Callout>

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -4591,7 +4591,7 @@ Here are assorted other settings available via the agent configuration file.
       </tbody>
     </table>
 
-    By default, the agent starts when it receives the first transaction (either web or [non-web](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions)). The agent then starts in parallel, ensuring that this initial request is not delayed. However, the agent does not record the details of this initial request because the agent cannot collect data until registration is complete. This is the recommended configuration for the majority of web applications in order to not delay the first couple transactions while New Relic starts up.
+    By default, the agent starts when it receives the first transaction (either web or [non-web](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions)). The agent then starts in parallel, ensuring that this initial request isn't delayed. However, the agent doesn't record the details of this initial request because the agent cannot collect data until registration is complete. This is the recommended configuration for the majority of web applications in order to not delay the first couple transactions while New Relic starts up.
 
     To override this, you can set a startup timeout in seconds. The agent will then pause the initial transaction and wait for registration to complete. This might be useful when instrumenting a single program run or task, where the process runs once and immediately terminates.
 

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -4591,9 +4591,9 @@ Here are assorted other settings available via the agent configuration file.
       </tbody>
     </table>
 
-    By default, the agent starts when it receives the first transaction (either web or [non-web](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions)). The agent then starts in parallel, ensuring that this initial request is not delayed. However, the agent does not record the details of this initial request because the agent cannot collect data until registration is complete.
+    By default, the agent starts when it receives the first transaction (either web or [non-web](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions)). The agent then starts in parallel, ensuring that this initial request is not delayed. However, the agent does not record the details of this initial request because the agent cannot collect data until registration is complete. This is the recommended configuration for the majority of web applications in order to not delay the first couple transactions while New Relic starts up.
 
-    To override this, you can set a startup timeout in seconds. The agent will then pause the initial transaction and wait for registration to complete.
+    To override this, you can set a startup timeout in seconds. The agent will then pause the initial transaction and wait for registration to complete. This might be useful when instrumenting a single program run or task, where the process runs once and immediately terminates.
 
     <Callout variant="important">
       Since `startup_timeout` delays your app start, we recommend only setting a startup timeout for background task queuing systems, not web applications.

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/registerapplication-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/registerapplication-python-agent-api.mdx
@@ -80,7 +80,7 @@ If you are recording transactions in child worker process, do not call `register
       </td>
 
       <td>
-        Optional but highly recommended. The number of seconds that the app will try to register before giving up and sending a response. A value of `0` means that the application will not wait for registration before it serves requests. The default is `0`.
+        The number of seconds that the app will try to register before giving up and sending a response; meaning this line will block until New Relic starts up or the timeout is exceeded. A value of `0` means that the application will not wait for registration before it serves requests. The default is `0`. If running a web application, setting this value is not recommended as it will block and delay the application  while New Relic starts up. If instrumenting a single program run or task, where the process runs once and immediately terminates, setting this is recommended as otherwise New Relic will not be started in time to capture the information. 
 
         This value gives the maximum number of seconds the caller should be blocked before control is returned and the caller allowed to proceed. With no value, the call uses the globally configured [`startup_timeout`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#startup-timeout) setting in the agent configuration, which is `0.0` by default.
       </td>

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/registerapplication-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/registerapplication-python-agent-api.mdx
@@ -38,11 +38,11 @@ Do not call `register_application` with a non-zero timeout when the Python globa
 
 Note that many WSGI servers import the module containing the WSGI application via the standard Python module import mechanisms. In those cases, the global import lock will be held and the deadlock problem described above can occur.
 
-For Gunicorn: The deadlock issue just described can also occur when using Gunicorn. The problem is that triggering `register_application` from the WSGI module is not safe, because it preloads the module into the parent process. To use `register_application` with Gunicorn (with or without a timeout) call it from a `post_fork()` callback. This is not a problem with Apache/mod_wsgi, since those tools have been designed not to do this, so it is safe to create background threads when the WSGI application is loaded.
+For Gunicorn: The deadlock issue just described can also occur when using Gunicorn. The problem is that triggering `register_application` from the WSGI module is not safe, because it preloads the module into the parent process. To use `register_application` with Gunicorn (with or without a timeout) call it from a `post_fork()` callback. This is not a problem with Apache/mod_wsgi, since those tools have been designed not to do this, so it's safe to create background threads when the WSGI application is loaded.
 
 ### Call after worker process fork [#worker-processes]
 
-If you are recording transactions in child worker process, do not call `register_application` in the parent process before the child worker processes are forked. If you were to call `register_application` before forking, the background agent thread would be killed when the process is forked. Since the parent thread is reporting data to the collector, the agent will not be able to report data from child worker process.
+If you're recording transactions in child worker process, do not call `register_application` in the parent process before the child worker processes are forked. If you were to call `register_application` before forking, the background agent thread would be killed when the process is forked. Since the parent thread is reporting data to the collector, the agent will not be able to report data from child worker process.
 
 ## Parameters
 
@@ -80,7 +80,7 @@ If you are recording transactions in child worker process, do not call `register
       </td>
 
       <td>
-        The number of seconds that the app will try to register before giving up and sending a response; meaning this line will block until New Relic starts up or the timeout is exceeded. A value of `0` means that the application will not wait for registration before it serves requests. The default is `0`. If running a web application, setting this value is not recommended as it will block and delay the application  while New Relic starts up. If instrumenting a single program run or task, where the process runs once and immediately terminates, setting this is recommended as otherwise New Relic will not be started in time to capture the information. 
+        The number of seconds that the app will try to register before giving up and sending a response; meaning this line will block until New Relic starts up or the timeout is exceeded. A value of `0` means that the application will not wait for registration before it serves requests. The default is `0`. If running a web application, setting this value isn't recommended as it'll block and delay the application  while New Relic starts up. If instrumenting a single program run or task, where the process runs once and immediately terminates, setting this is recommended as otherwise New Relic will not be started in time to capture the information. 
 
         This value gives the maximum number of seconds the caller should be blocked before control is returned and the caller allowed to proceed. With no value, the call uses the globally configured [`startup_timeout`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#startup-timeout) setting in the agent configuration, which is `0.0` by default.
       </td>

--- a/src/content/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx
+++ b/src/content/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx
@@ -12,6 +12,9 @@ redirects:
 ---
 
 ## Problem
+<Callout variant="important">
+  Note this is only an issue if no data is being reported.
+</Callout>
 
 You are using the [latest Python agent](/docs/release-notes/agent-release-notes/python-release-notes), and you see a log entry with a warning message such as:
 
@@ -75,19 +78,20 @@ To solve this problem with your app:
 For other tips when no data appears, see the [Python troubleshooting documentation](/docs/agents/python-agent/troubleshooting/no-data-appears-python).
 
 ## Cause
+There are two primary causes of this issue. The first is creating an application instance multiple times or creating an application instance prior to forking.
 
-This is usually caused by a call to [`newrelic.agent.register_application`](/docs/agents/python-agent/python-agent-api/register_application) or [`newrelic.agent.application`](/docs/agents/python-agent/python-agent-api/application) occurring at import time.
+1. This is usually caused by a call to [`newrelic.agent.register_application`](/docs/agents/python-agent/python-agent-api/register_application) or [`newrelic.agent.application`](/docs/agents/python-agent/python-agent-api/application) occurring at import time.
 
-**Example**:
+    **Example**:
+    
+    ```
+    import newrelic.agent
+    
+    # This will cause the agent to activate whenever custom_event is imported
+    app = newrelic.agent.application()
+    
+    def custom_event():
+        newrelic.agent.record_custom_event('CustomEvent', {}, application=app)
+    ```
 
-```
-import newrelic.agent
-
-# This will cause the agent to activate whenever custom_event is imported
-app = newrelic.agent.application()
-
-def custom_event():
-    newrelic.agent.record_custom_event('CustomEvent', {}, application=app)
-```
-
-Code typically is loaded before a fork occurs in frameworks such as Celery or multiprocessing. As a result, the code is imported into the parent process instead of the child, launching the agent. Since the agent is launched in the parent process, no data is collected in the child process.
+1. This issue can also occur when monitoring services like celery where a main parent process launches worker processes. It occurs when an agent application instance is created on the main thread prior to forking the worker processes. Since the agent is launched in the parent process, no data is collected in the child process.

--- a/src/content/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx
+++ b/src/content/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx
@@ -16,7 +16,7 @@ redirects:
   Note this is only an issue if no data is being reported.
 </Callout>
 
-You are using the [latest Python agent](/docs/release-notes/agent-release-notes/python-release-notes), and you see a log entry with a warning message such as:
+You're using the [latest Python agent](/docs/release-notes/agent-release-notes/python-release-notes), and you see a log entry with a warning message such as:
 
 ```
 Attempt to activate application in a process different to where the agent harvest thread was started.
@@ -78,7 +78,7 @@ To solve this problem with your app:
 For other tips when no data appears, see the [Python troubleshooting documentation](/docs/agents/python-agent/troubleshooting/no-data-appears-python).
 
 ## Cause
-There are two primary causes of this issue. The first is creating an application instance multiple times or creating an application instance prior to forking.
+There're two primary causes of this issue. The first is creating an application instance multiple times or creating an application instance prior to forking.
 
 1. This is usually caused by a call to [`newrelic.agent.register_application`](/docs/agents/python-agent/python-agent-api/register_application) or [`newrelic.agent.application`](/docs/agents/python-agent/python-agent-api/application) occurring at import time.
 
@@ -94,4 +94,4 @@ There are two primary causes of this issue. The first is creating an application
         newrelic.agent.record_custom_event('CustomEvent', {}, application=app)
     ```
 
-1. This issue can also occur when monitoring services like celery where a main parent process launches worker processes. It occurs when an agent application instance is created on the main process prior to forking the worker processes. Since the agent is launched in the parent process, no data is collected in the child process.
+2. This issue can also occur when monitoring services like celery where a main parent process launches worker processes. It occurs when an agent application instance is created on the main process prior to forking the worker processes. Since the agent is launched in the parent process, no data is collected in the child process.

--- a/src/content/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx
+++ b/src/content/docs/apm/agents/python-agent/troubleshooting/activate-application-warning-python.mdx
@@ -94,4 +94,4 @@ There are two primary causes of this issue. The first is creating an application
         newrelic.agent.record_custom_event('CustomEvent', {}, application=app)
     ```
 
-1. This issue can also occur when monitoring services like celery where a main parent process launches worker processes. It occurs when an agent application instance is created on the main thread prior to forking the worker processes. Since the agent is launched in the parent process, no data is collected in the child process.
+1. This issue can also occur when monitoring services like celery where a main parent process launches worker processes. It occurs when an agent application instance is created on the main process prior to forking the worker processes. Since the agent is launched in the parent process, no data is collected in the child process.

--- a/src/install/python/python-agent-non-web-apps.mdx
+++ b/src/install/python/python-agent-non-web-apps.mdx
@@ -146,7 +146,7 @@ Due to the limitation on what Django management commands can be monitored, you n
 instrumentation.scripts.django_admin = syncdb sqlflush
 ```
 
-By default, the startup timeout is automatically specified to be 10.0 seconds when monitoring the Django management commands. If you need to override the startup timeout, you can set the `instrumentation.background_task.startup_timeout` setting within the same `import-hook:django` configuration section.
+By default, the startup timeout is automatically specified to be 10.0 seconds when monitoring the Django management commands. This means New Relic will block the command for up to 10s giving New Relic a chance to start up so it can monitor the command, otherwise it would not be able to start in time and would not be able to instrument the command. If you need to override the startup timeout, you can set the `instrumentation.background_task.startup_timeout` setting within the same `import-hook:django` configuration section.
 
 Once the additional configuration has been specified, you can then run your Django management command wrapped by our `newrelic-admin` wrapper script:
 

--- a/src/install/python/python-agent-non-web-apps.mdx
+++ b/src/install/python/python-agent-non-web-apps.mdx
@@ -146,7 +146,7 @@ Due to the limitation on what Django management commands can be monitored, you n
 instrumentation.scripts.django_admin = syncdb sqlflush
 ```
 
-By default, the startup timeout is automatically specified to be 10.0 seconds when monitoring the Django management commands. This means New Relic will block the command for up to 10s giving New Relic a chance to start up so it can monitor the command, otherwise it would not be able to start in time and would not be able to instrument the command. If you need to override the startup timeout, you can set the `instrumentation.background_task.startup_timeout` setting within the same `import-hook:django` configuration section.
+By default, the startup timeout is automatically specified to be 10.0 seconds when monitoring the Django management commands. This means New Relic will block the command for up to 10 seconds giving New Relic a chance to start up so it can monitor the command, otherwise it would not be able to start in time and would not be able to instrument the command. If you need to override the startup timeout, you can set the `instrumentation.background_task.startup_timeout` setting within the same `import-hook:django` configuration section.
 
 Once the additional configuration has been specified, you can then run your Django management command wrapped by our `newrelic-admin` wrapper script:
 


### PR DESCRIPTION
## Clarify a couple common problem areas in the Python docs
* Add additional info and clarify causes of active application warning.
* Add in note about not being able to monitor the main process of celery.
* Clarify under what circumstance startup_timeout should be used.