### PR TITLE
chore: Remove Process sample netio metrics

### DIFF
--- a/src/data-dictionary/events/ProcessSample/netIoTotalReceivedPackets.md
+++ b/src/data-dictionary/events/ProcessSample/netIoTotalReceivedPackets.md
@@ -1,9 +1,0 @@
----
-name: netIoTotalReceivedPackets
-type: attribute
-units: count
-events:
-  - ProcessSample
----
-
-Cumulative number of net packets received by this process.

--- a/src/data-dictionary/events/ProcessSample/netIoTotalSentPackets.md
+++ b/src/data-dictionary/events/ProcessSample/netIoTotalSentPackets.md
@@ -1,9 +1,0 @@
----
-name: netIoTotalSentPackets
-type: attribute
-units: count
-events:
-  - ProcessSample
----
-
-Cumulative number of net packets transmitted by this process.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

## Give us some context
Two attributes show in the processSample dictionary, but they do not show up in product at all and per dev conversation they should have been deleted long ago.
Internal Slack reference https://newrelic.slack.com/archives/CK58517B6/p1588722673340200