### PR TITLE
[NR-82890] Namespace retention contradiction

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -701,7 +701,7 @@ Options for increasing retention:
 
 Important points about increasing retention: 
 
-* Retention is increased across the board, for all data types listed in the [**Data retention** UI](#find-ui). It cannot be increased only for specific data types. 
+* When you enable a higher retention period, retention is increased across the board for all data types listed in the [**Data retention** UI](#find-ui). It cannot be increased only for specific data types. 
 * Once you enable a higher retention period, reducing retention for specific data sources has no impact on your billing. To learn about ways to reduce your data ingest and billing, see [Manage data ingest](/docs/data-apis/manage-data/manage-data-coming-new-relic). 
 * When you adjust retention, it can take up to 24 hours to take effect. 
 


### PR DESCRIPTION
This PR edits a bullet point that caused some confusion around whether editing retention can be done per-namespace: yes, it can be edited per-namespace as long as you're editing within your contractual limits, but no it cannot when you're adding additional data retention beyond your existing contract ("increasing retention" was found to be a bit vague).