### PR TITLE
chore: update API links

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics.mdx
@@ -34,8 +34,8 @@ For custom metric names, use `<class>/<method>` or `<category>/<name>`. For exam
 
 The public API for recording metric data consists of two methods on `newrelic`:
 
-* [`recordMetric`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#record_metric): Use to create a new custom metric.
-* [`incrementMetric`](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#increment_metric): Use to update the value of a custom metric.
+* [`recordMetric`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#record_metric): Use to create a new custom metric.
+* [`incrementMetric`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#increment_metric): Use to update the value of a custom metric.
 
 ## Example custom metric [#example]
 
@@ -45,7 +45,7 @@ Here is an example that shows how you can use metrics to track currency flowing 
 app.post('/cart/checkout', function(req, res) {
   var total = computeCartTotal(req.user);
   newrelic.recordMetric('Cart/ChargeAmount', total);
-  ...
+  // ...
 });
 ```
 


### PR DESCRIPTION
links with this format lose the in-page link when you open them in a new tab:
```
docs/agents/nodejs-agent/supported-features/nodejs-agent-api/#record_metric
```
That results in the `#record_metric` being lost when it redirects to our newer URL patterns (only when opened in new tabs). This link does not do that
```
/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#record_metric
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.