### PR TITLE
Add error boundary

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,28 @@
+/* eslint-disable react/sort-comp */
+import React from 'react';
+import ErrorMessage from './ErrorMessage';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch() {
+    this.props.callTessen();
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorMessage />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,28 +1,14 @@
-/* eslint-disable react/sort-comp */
 import React from 'react';
-import ErrorMessage from './ErrorMessage';
+import { useTessen } from '@newrelic/gatsby-theme-newrelic';
+import ErrorBoundaryCC from './ErrorBoundaryCC';
 
-class ErrorBoundary extends React.Component {
-  state = { hasError: false };
-
-  static getDerivedStateFromError() {
-    return { hasError: true };
-  }
-
-  componentDidCatch() {
-    this.props.tessen.track({
-      category: 'PageErrored',
-      eventName: this.props.eventName,
-    });
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return <ErrorMessage />;
-    }
-
-    return this.props.children;
-  }
-}
+const ErrorBoundary = ({ eventName, children }) => {
+  const tessen = useTessen();
+  return (
+    <ErrorBoundaryCC tessen={tessen} eventName={eventName}>
+      {children}
+    </ErrorBoundaryCC>
+  );
+};
 
 export default ErrorBoundary;

--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -3,17 +3,17 @@ import React from 'react';
 import ErrorMessage from './ErrorMessage';
 
 class ErrorBoundary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { hasError: false };
-  }
+  state = { hasError: false };
 
   static getDerivedStateFromError() {
     return { hasError: true };
   }
 
   componentDidCatch() {
-    this.props.callTessen();
+    this.props.tessen.track({
+      category: 'PageErrored',
+      eventName: this.props.eventName,
+    });
   }
 
   render() {

--- a/src/components/ErrorBoundaryCC.js
+++ b/src/components/ErrorBoundaryCC.js
@@ -1,0 +1,28 @@
+/* eslint-disable react/sort-comp */
+import React from 'react';
+import ErrorMessage from './ErrorMessage';
+
+class ErrorBoundary extends React.Component {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch() {
+    this.props.tessen.track({
+      category: 'PageErrored',
+      eventName: this.props.eventName,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorMessage />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorMessage.js
+++ b/src/components/ErrorMessage.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const ErrorMessage = () => (
+  <ErrorContainer>
+    <h3>Oops! Something went wrong.</h3>
+  </ErrorContainer>
+);
+
+const ErrorContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  background: var(--secondary-background-color);
+  height: 100%;
+  width: calc(100vw - var(--sidebar-width) - 3rem);
+  h3 {
+    color: var(--secondary-text-color);
+  }
+`;
+
+export default ErrorMessage;

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -11,6 +11,7 @@ import {
   useQueryParams,
   Icon,
   useTranslation,
+  useTessen,
   ComplexFeedback,
   Table,
 } from '@newrelic/gatsby-theme-newrelic';
@@ -19,6 +20,7 @@ import { TYPES } from '../utils/constants';
 import DataDictionaryFilter from '../components/DataDictionaryFilter';
 import SEO from '../components/SEO';
 import PageTitle from '../components/PageTitle';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 const AttributeDictionary = ({ data, pageContext, location }) => {
   const { allDataDictionaryEvent } = data;
@@ -39,6 +41,8 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
     () => allDataDictionaryEvent.edges.map((edge) => edge.node),
     [allDataDictionaryEvent]
   );
+
+  const tessen = useTessen();
 
   useEffect(() => {
     let filteredEvents = events;
@@ -73,7 +77,14 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
   const { t } = useTranslation();
 
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({
+          category: 'PageErrored',
+          eventName: 'attributeDictionary',
+        })
+      }
+    >
       <SEO
         location={location}
         type={TYPES.BASIC_PAGE.default}
@@ -157,7 +168,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
           />
         </Layout.PageTools>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -11,7 +11,6 @@ import {
   useQueryParams,
   Icon,
   useTranslation,
-  useTessen,
   ComplexFeedback,
   Table,
 } from '@newrelic/gatsby-theme-newrelic';
@@ -41,8 +40,6 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
     () => allDataDictionaryEvent.edges.map((edge) => edge.node),
     [allDataDictionaryEvent]
   );
-
-  const tessen = useTessen();
 
   useEffect(() => {
     let filteredEvents = events;
@@ -77,7 +74,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
   const { t } = useTranslation();
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="attributeDictionary">
+    <ErrorBoundary eventName="attributeDictionary">
       <SEO
         location={location}
         type={TYPES.BASIC_PAGE.default}

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -77,14 +77,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
   const { t } = useTranslation();
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({
-          category: 'PageErrored',
-          eventName: 'attributeDictionary',
-        })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="attributeDictionary">
       <SEO
         location={location}
         type={TYPES.BASIC_PAGE.default}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,6 +22,7 @@ import {
   TOGGLE_VIEWS,
 } from '../components/ToggleView';
 import HomepageVideo from '../components/HomepageVideo';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 const SAVED_TOGGLE_VIEW_KEY = 'docs-website/homepage-selected-view';
 
@@ -90,187 +91,200 @@ const HomePage = ({ data }) => {
   });
 
   return (
-    <ToggleViewContext.Provider value={[currentView, updateView]}>
-      <div
-        css={css`
-          display: grid;
-          gap: 1rem;
-          justify-content: space-between;
-          grid-template-columns: 1fr max-content;
-          align-items: center;
-          @media (max-width: 920px) {
-            grid-template-columns: 1fr auto;
-          }
-        `}
-      >
-        <ToggleSelector
-          showTooltip={showTooltip}
-          css={css`
-            justify-self: end;
-            @media screen and (max-width: 760px) {
-              display: none;
-            }
-          `}
-        />
-      </div>
-      <ToggleView id={TOGGLE_VIEWS.newUserView}>
-        <HomepageVideo />
-      </ToggleView>
-      <ToggleView id={TOGGLE_VIEWS.defaultView}>
-        <h1
-          css={css`
-            font-size: 3.5rem;
-            font-weight: 500;
-            line-height: 1;
-            @media screen and (max-width: ${mobileBreakpoint}) {
-              font-size: 1.5rem;
-            }
-          `}
-        >
-          {t('home.pageTitle')}
-        </h1>
-        <SearchInput
-          placeholder={t('home.search.placeholder')}
-          size={SearchInput.SIZE.LARGE}
-          value={searchTerm || ''}
-          iconName={SearchInput.ICONS.SEARCH}
-          isIconClickable
-          alignIcon={SearchInput.ICON_ALIGNMENT.RIGHT}
-          onChange={(e) => setSearchTerm(e.target.value)}
-          onSubmit={() => {
-            tessen.track({
-              eventName: 'defaultViewSearch',
-              category: 'SearchInput',
-            });
-            navigate(`?q=${searchTerm || ''}`);
-          }}
-          css={css`
-            @media screen and (max-width: ${mobileBreakpoint}) {
-              margin-bottom: 1rem;
-            }
-          `}
-        />
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({
+          category: 'PageErrored',
+          eventName: 'homepage',
+        })
+      }
+    >
+      <ToggleViewContext.Provider value={[currentView, updateView]}>
         <div
           css={css`
-            margin-top: 1rem;
-            width: 40%;
-            display: flex;
-            width: 100%;
-            flex-wrap: wrap;
-            a {
-              margin-left: 0.75rem;
-            }
-            @media screen and (max-width: ${mobileBreakpoint}) {
-              display: none;
+            display: grid;
+            gap: 1rem;
+            justify-content: space-between;
+            grid-template-columns: 1fr max-content;
+            align-items: center;
+            @media (max-width: 920px) {
+              grid-template-columns: 1fr auto;
             }
           `}
         >
-          <p>{t('home.search.popularSearches.title')}: </p>
-          <Link to="?q=nrql">{t('home.search.popularSearches.options.0')}</Link>
-          <Link to="?q=logs">{t('home.search.popularSearches.options.1')}</Link>
-          <Link to="?q=alert">
-            {t('home.search.popularSearches.options.2')}
-          </Link>
-          <Link to="?q=best practices">
-            {t('home.search.popularSearches.options.3')}
-          </Link>
-          <Link to="?q=kubernetes">
-            {t('home.search.popularSearches.options.4')}
-          </Link>
+          <ToggleSelector
+            showTooltip={showTooltip}
+            css={css`
+              justify-self: end;
+              @media screen and (max-width: 760px) {
+                display: none;
+              }
+            `}
+          />
         </div>
-        <HomepageBanner />
-        <Section
-          layout={layout}
-          css={css`
-            border: none;
-            background: var(--tertiary-background-color);
-          `}
-        >
-          <SectionTitle title={t('home.popularDocs.title')} />
-          <div
+        <ToggleView id={TOGGLE_VIEWS.newUserView}>
+          <HomepageVideo />
+        </ToggleView>
+        <ToggleView id={TOGGLE_VIEWS.defaultView}>
+          <h1
             css={css`
-              display: grid;
-              grid-template-columns: repeat(3, 1fr);
-              grid-gap: 1rem;
-              counter-reset: welcome-tile;
-              flex: 2;
-              align-self: flex-start;
-              @media screen and (max-width: 1500px) {
-                align-self: auto;
-              }
-              @media screen and (max-width: 1050px) {
-                grid-template-columns: 1fr;
-              }
-              @media screen and (max-width: 760px) {
-                grid-template-columns: repeat(3, 1fr);
-              }
-              @media screen and (max-width: 650px) {
-                grid-template-columns: 1fr;
+              font-size: 3.5rem;
+              font-weight: 500;
+              line-height: 1;
+              @media screen and (max-width: ${mobileBreakpoint}) {
+                font-size: 1.5rem;
               }
             `}
           >
-            <DocTile
-              label={{ text: 'Get started', color: '#F4CBE7' }}
-              path="/docs/apm/new-relic-apm/getting-started/introduction-apm"
-            >
-              {t('home.popularDocs.t1.title')}
-            </DocTile>
-            <DocTile
-              label={{ text: 'Get started', color: '#F4CBE7' }}
-              path="/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring/"
-            >
-              {t('home.popularDocs.t2.title')}
-            </DocTile>
-            <DocTile
-              label={{ text: 'Get started', color: '#F4CBE7' }}
-              path="/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/"
-            >
-              {t('home.popularDocs.t3.title')}
-            </DocTile>
+            {t('home.pageTitle')}
+          </h1>
+          <SearchInput
+            placeholder={t('home.search.placeholder')}
+            size={SearchInput.SIZE.LARGE}
+            value={searchTerm || ''}
+            iconName={SearchInput.ICONS.SEARCH}
+            isIconClickable
+            alignIcon={SearchInput.ICON_ALIGNMENT.RIGHT}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            onSubmit={() => {
+              tessen.track({
+                eventName: 'defaultViewSearch',
+                category: 'SearchInput',
+              });
+              navigate(`?q=${searchTerm || ''}`);
+            }}
+            css={css`
+              @media screen and (max-width: ${mobileBreakpoint}) {
+                margin-bottom: 1rem;
+              }
+            `}
+          />
+          <div
+            css={css`
+              margin-top: 1rem;
+              width: 40%;
+              display: flex;
+              width: 100%;
+              flex-wrap: wrap;
+              a {
+                margin-left: 0.75rem;
+              }
+              @media screen and (max-width: ${mobileBreakpoint}) {
+                display: none;
+              }
+            `}
+          >
+            <p>{t('home.search.popularSearches.title')}: </p>
+            <Link to="?q=nrql">
+              {t('home.search.popularSearches.options.0')}
+            </Link>
+            <Link to="?q=logs">
+              {t('home.search.popularSearches.options.1')}
+            </Link>
+            <Link to="?q=alert">
+              {t('home.search.popularSearches.options.2')}
+            </Link>
+            <Link to="?q=best practices">
+              {t('home.search.popularSearches.options.3')}
+            </Link>
+            <Link to="?q=kubernetes">
+              {t('home.search.popularSearches.options.4')}
+            </Link>
           </div>
-        </Section>
-        <Section layout={layout}>
-          <SectionTitle title={t('home.whatsNew.title')} />
-          <div
+          <HomepageBanner />
+          <Section
+            layout={layout}
             css={css`
-              display: grid;
-              grid-template-columns: repeat(3, 1fr);
-              grid-gap: 1rem;
-              counter-reset: welcome-tile;
-              flex: 2;
-              align-self: flex-start;
-              @media screen and (max-width: 1500px) {
-                align-self: auto;
-              }
-              @media screen and (max-width: 1050px) {
-                grid-template-columns: 1fr;
-              }
-
-              @media screen and (max-width: 760px) {
-                grid-template-columns: repeat(3, 1fr);
-              }
-
-              @media screen and (max-width: 650px) {
-                grid-template-columns: 1fr;
-              }
+              border: none;
+              background: var(--tertiary-background-color);
             `}
           >
-            {latestWhatsNewPosts.map((post) => (
+            <SectionTitle title={t('home.popularDocs.title')} />
+            <div
+              css={css`
+                display: grid;
+                grid-template-columns: repeat(3, 1fr);
+                grid-gap: 1rem;
+                counter-reset: welcome-tile;
+                flex: 2;
+                align-self: flex-start;
+                @media screen and (max-width: 1500px) {
+                  align-self: auto;
+                }
+                @media screen and (max-width: 1050px) {
+                  grid-template-columns: 1fr;
+                }
+                @media screen and (max-width: 760px) {
+                  grid-template-columns: repeat(3, 1fr);
+                }
+                @media screen and (max-width: 650px) {
+                  grid-template-columns: 1fr;
+                }
+              `}
+            >
               <DocTile
-                key={post.title}
-                date={post.releaseDate}
-                path={post.path}
+                label={{ text: 'Get started', color: '#F4CBE7' }}
+                path="/docs/apm/new-relic-apm/getting-started/introduction-apm"
               >
-                {post.title}
+                {t('home.popularDocs.t1.title')}
               </DocTile>
-            ))}
-          </div>
-        </Section>
-        <Section layout={layout}>
-          <FindYourQuickStart />
-        </Section>
-      </ToggleView>
-    </ToggleViewContext.Provider>
+              <DocTile
+                label={{ text: 'Get started', color: '#F4CBE7' }}
+                path="/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring/"
+              >
+                {t('home.popularDocs.t2.title')}
+              </DocTile>
+              <DocTile
+                label={{ text: 'Get started', color: '#F4CBE7' }}
+                path="/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/"
+              >
+                {t('home.popularDocs.t3.title')}
+              </DocTile>
+            </div>
+          </Section>
+          <Section layout={layout}>
+            <SectionTitle title={t('home.whatsNew.title')} />
+            <div
+              css={css`
+                display: grid;
+                grid-template-columns: repeat(3, 1fr);
+                grid-gap: 1rem;
+                counter-reset: welcome-tile;
+                flex: 2;
+                align-self: flex-start;
+                @media screen and (max-width: 1500px) {
+                  align-self: auto;
+                }
+                @media screen and (max-width: 1050px) {
+                  grid-template-columns: 1fr;
+                }
+
+                @media screen and (max-width: 760px) {
+                  grid-template-columns: repeat(3, 1fr);
+                }
+
+                @media screen and (max-width: 650px) {
+                  grid-template-columns: 1fr;
+                }
+              `}
+            >
+              {latestWhatsNewPosts.map((post) => (
+                <DocTile
+                  key={post.title}
+                  date={post.releaseDate}
+                  path={post.path}
+                >
+                  {post.title}
+                </DocTile>
+              ))}
+            </div>
+          </Section>
+          <Section layout={layout}>
+            <FindYourQuickStart />
+          </Section>
+        </ToggleView>
+      </ToggleViewContext.Provider>
+    </ErrorBoundary>
   );
 };
 HomePage.propTypes = {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -91,7 +91,7 @@ const HomePage = ({ data }) => {
   });
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="homepage">
+    <ErrorBoundary eventName="homepage">
       <ToggleViewContext.Provider value={[currentView, updateView]}>
         <div
           css={css`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -91,14 +91,7 @@ const HomePage = ({ data }) => {
   });
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({
-          category: 'PageErrored',
-          eventName: 'homepage',
-        })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="homepage">
       <ToggleViewContext.Provider value={[currentView, updateView]}>
         <div
           css={css`

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -205,7 +205,7 @@ const InstallPage = ({ data, location }) => {
   }, []);
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="install">
+    <ErrorBoundary eventName="install">
       <SEO
         location={location}
         title={title}

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -205,11 +205,7 @@ const InstallPage = ({ data, location }) => {
   }, []);
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'install' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="install">
       <SEO
         location={location}
         title={title}

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -17,6 +17,7 @@ import AppInfoConfigOption from '../../components/AppInfoConfigOption';
 import InstallNextSteps from '../../components/InstallNextSteps';
 import SEO from '../../components/SEO';
 import { TYPES } from '../../utils/constants';
+import ErrorBoundary from '../../components/ErrorBoundary';
 
 const slugify = (str) =>
   str
@@ -204,7 +205,11 @@ const InstallPage = ({ data, location }) => {
   }, []);
 
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'install' })
+      }
+    >
       <SEO
         location={location}
         title={title}
@@ -293,7 +298,7 @@ const InstallPage = ({ data, location }) => {
           <TableOfContents headings={headings} />
         </Layout.PageTools>
       </Layout.Main>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/pages/introduction-apm.js
+++ b/src/pages/introduction-apm.js
@@ -99,7 +99,7 @@ const IntroductionApm = () => {
   }, []);
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="apm">
+    <ErrorBoundary eventName="apm">
       <FeaturedContent
         text={[t('apm.intro.text.0'), t('apm.intro.text.1')]}
         title={t('apm.intro.title')}

--- a/src/pages/introduction-apm.js
+++ b/src/pages/introduction-apm.js
@@ -99,11 +99,7 @@ const IntroductionApm = () => {
   }, []);
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'apm' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="apm">
       <FeaturedContent
         text={[t('apm.intro.text.0'), t('apm.intro.text.1')]}
         title={t('apm.intro.title')}

--- a/src/pages/introduction-apm.js
+++ b/src/pages/introduction-apm.js
@@ -17,6 +17,7 @@ import {
   TitleBlock,
 } from '../components/IntroductionApm';
 import QuickstartChooser from '../components/QuickstartChooser';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 import introImage from 'images/new-apm-images/intro.png';
 import entitiesImage from 'images/new-apm-images/entities.png';
@@ -98,7 +99,11 @@ const IntroductionApm = () => {
   }, []);
 
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'apm' })
+      }
+    >
       <FeaturedContent
         text={[t('apm.intro.text.0'), t('apm.intro.text.1')]}
         title={t('apm.intro.title')}
@@ -215,7 +220,7 @@ const IntroductionApm = () => {
         </SideBySide>
       </VisibilitySensor>
       <QuickstartChooser secondary />
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -41,11 +41,7 @@ const WhatsNew = ({ data, location, pageContext }) => {
   const tessen = useTessen();
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'whatsNewOverview' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="whatsNewOverview">
       <SEO
         location={location}
         title="What's new in New Relic"

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -8,7 +8,6 @@ import {
   Icon,
   Link,
   useTranslation,
-  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import Timeline from '../components/Timeline';
 import SEO from '../components/SEO';
@@ -38,10 +37,9 @@ const WhatsNew = ({ data, location, pageContext }) => {
   }
 
   const { t } = useTranslation();
-  const tessen = useTessen();
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="whatsNewOverview">
+    <ErrorBoundary eventName="whatsNewOverview">
       <SEO
         location={location}
         title="What's new in New Relic"

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -8,9 +8,11 @@ import {
   Icon,
   Link,
   useTranslation,
+  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import Timeline from '../components/Timeline';
 import SEO from '../components/SEO';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { TYPES } from '../utils/constants';
 
 const WhatsNew = ({ data, location, pageContext }) => {
@@ -36,9 +38,14 @@ const WhatsNew = ({ data, location, pageContext }) => {
   }
 
   const { t } = useTranslation();
+  const tessen = useTessen();
 
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'whatsNewOverview' })
+      }
+    >
       <SEO
         location={location}
         title="What's new in New Relic"
@@ -122,7 +129,7 @@ const WhatsNew = ({ data, location, pageContext }) => {
           </Timeline>
         </Layout.Content>
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -14,7 +14,6 @@ import {
   TableOfContents,
   LoggedInProvider,
   useLoggedIn,
-  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import Layout from '../components/Layout';
 import MachineTranslationCallout from '../components/MachineTranslationCallout';
@@ -100,10 +99,8 @@ const BasicDoc = ({ data, location, pageContext }) => {
     setBannerDismissed(true);
   };
 
-  const tessen = useTessen();
-
   return (
-    <ErrorBoundary tessen={tessen} eventName="doc">
+    <ErrorBoundary eventName="doc">
       <SEO
         location={location}
         title={title}

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -14,6 +14,7 @@ import {
   TableOfContents,
   LoggedInProvider,
   useLoggedIn,
+  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import Layout from '../components/Layout';
 import MachineTranslationCallout from '../components/MachineTranslationCallout';
@@ -21,6 +22,7 @@ import SEO from '../components/SEO';
 import GithubSlugger from 'github-slugger';
 import { TYPES } from '../utils/constants';
 import { useMainLayoutContext } from '../components/MainLayoutContext';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 const BANNER_HEIGHT = '78px';
 
@@ -98,8 +100,14 @@ const BasicDoc = ({ data, location, pageContext }) => {
     setBannerDismissed(true);
   };
 
+  const tessen = useTessen();
+
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'doc' })
+      }
+    >
       <SEO
         location={location}
         title={title}
@@ -231,7 +239,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
           </CSSTransition>
         )}
       </div>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -103,11 +103,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
   const tessen = useTessen();
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'doc' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="doc">
       <SEO
         location={location}
         title={title}

--- a/src/templates/embedPage.js
+++ b/src/templates/embedPage.js
@@ -37,11 +37,7 @@ const EmbedPage = ({ data }) => {
   }, [darkMode, embedDarkMode]);
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'embed' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="embed">
       <EmbedContext.Provider value={{ isEmbedded: true }}>
         <h1>{title}</h1>
         <Layout.Content>

--- a/src/templates/embedPage.js
+++ b/src/templates/embedPage.js
@@ -1,12 +1,7 @@
 import React, { useEffect } from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
-import {
-  Layout,
-  useQueryParams,
-  Link,
-  useTessen,
-} from '@newrelic/gatsby-theme-newrelic';
+import { Layout, useQueryParams, Link } from '@newrelic/gatsby-theme-newrelic';
 import useDarkMode from 'use-dark-mode';
 import EmbedContext from '../components/EmbedContext';
 import ErrorBoundary from '../components/ErrorBoundary';
@@ -26,8 +21,6 @@ const EmbedPage = ({ data }) => {
   const embedDarkMode = queryParams.get('embedDarkMode');
   const darkMode = useDarkMode(embedDarkMode === 'enabled');
 
-  const tessen = useTessen();
-
   useEffect(() => {
     if (embedDarkMode === 'enabled') {
       darkMode.enable();
@@ -37,7 +30,7 @@ const EmbedPage = ({ data }) => {
   }, [darkMode, embedDarkMode]);
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="embed">
+    <ErrorBoundary eventName="embed">
       <EmbedContext.Provider value={{ isEmbedded: true }}>
         <h1>{title}</h1>
         <Layout.Content>

--- a/src/templates/embedPage.js
+++ b/src/templates/embedPage.js
@@ -1,9 +1,15 @@
 import React, { useEffect } from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
-import { Layout, useQueryParams, Link } from '@newrelic/gatsby-theme-newrelic';
+import {
+  Layout,
+  useQueryParams,
+  Link,
+  useTessen,
+} from '@newrelic/gatsby-theme-newrelic';
 import useDarkMode from 'use-dark-mode';
 import EmbedContext from '../components/EmbedContext';
+import ErrorBoundary from '../components/ErrorBoundary';
 import MDXContainer from '../components/MDXContainer';
 
 const components = {
@@ -20,6 +26,8 @@ const EmbedPage = ({ data }) => {
   const embedDarkMode = queryParams.get('embedDarkMode');
   const darkMode = useDarkMode(embedDarkMode === 'enabled');
 
+  const tessen = useTessen();
+
   useEffect(() => {
     if (embedDarkMode === 'enabled') {
       darkMode.enable();
@@ -29,12 +37,18 @@ const EmbedPage = ({ data }) => {
   }, [darkMode, embedDarkMode]);
 
   return (
-    <EmbedContext.Provider value={{ isEmbedded: true }}>
-      <h1>{title}</h1>
-      <Layout.Content>
-        <MDXContainer components={components} body={body} />
-      </Layout.Content>
-    </EmbedContext.Provider>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'embed' })
+      }
+    >
+      <EmbedContext.Provider value={{ isEmbedded: true }}>
+        <h1>{title}</h1>
+        <Layout.Content>
+          <MDXContainer components={components} body={body} />
+        </Layout.Content>
+      </EmbedContext.Provider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
-import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout, Link, useTessen } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/SEO';
+import ErrorBoundary from '../components/ErrorBoundary';
 import { TYPES } from '../utils/constants';
 
 const getTitle = ({ title, version, subject }) => {
@@ -25,6 +26,8 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
     },
   } = data;
 
+  const tessen = useTessen();
+
   const { disableSwiftype } = pageContext;
 
   const title = getTitle(frontmatter);
@@ -34,7 +37,11 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
   }
 
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'releaseNote' })
+      }
+    >
       <SEO
         location={location}
         title={title}
@@ -105,7 +112,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
       >
         <MDXContainer body={body} />
       </Layout.Content>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -37,11 +37,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
   }
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'releaseNote' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="releaseNote">
       <SEO
         location={location}
         title={title}

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
-import { Icon, Layout, Link, useTessen } from '@newrelic/gatsby-theme-newrelic';
+import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/SEO';
@@ -26,8 +26,6 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
     },
   } = data;
 
-  const tessen = useTessen();
-
   const { disableSwiftype } = pageContext;
 
   const title = getTitle(frontmatter);
@@ -37,7 +35,7 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
   }
 
   return (
-    <ErrorBoundary tessen={tessen} eventName="releaseNote">
+    <ErrorBoundary eventName="releaseNote">
       <SEO
         location={location}
         title={title}

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -42,11 +42,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
   const tessen = useTessen();
 
   return (
-    <ErrorBoundary
-      callTessen={() =>
-        tessen.track({ category: 'PageErrored', eventName: 'whatsNew' })
-      }
-    >
+    <ErrorBoundary tessen={tessen} eventName="whatsNew">
       <SEO
         location={location}
         title={title}

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -8,10 +8,12 @@ import {
   Link,
   MarkdownContainer,
   ContributingGuidelines,
+  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import SEO from '../components/SEO';
 import PageTitle from '../components/PageTitle';
 import { TYPES } from '../utils/constants';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 const WhatsNewTemplate = ({ data, location, pageContext }) => {
   const {
@@ -37,8 +39,14 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
     window.newrelic.setCustomAttribute('pageType', 'Template/WhatsNew');
   }
 
+  const tessen = useTessen();
+
   return (
-    <>
+    <ErrorBoundary
+      callTessen={() =>
+        tessen.track({ category: 'PageErrored', eventName: 'whatsNew' })
+      }
+    >
       <SEO
         location={location}
         title={title}
@@ -150,7 +158,7 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
           issueLabels={['feedback', 'feedback-issue']}
         />
       </Layout.Content>
-    </>
+    </ErrorBoundary>
   );
 };
 

--- a/src/templates/whatsNew.js
+++ b/src/templates/whatsNew.js
@@ -8,7 +8,6 @@ import {
   Link,
   MarkdownContainer,
   ContributingGuidelines,
-  useTessen,
 } from '@newrelic/gatsby-theme-newrelic';
 import SEO from '../components/SEO';
 import PageTitle from '../components/PageTitle';
@@ -39,10 +38,8 @@ const WhatsNewTemplate = ({ data, location, pageContext }) => {
     window.newrelic.setCustomAttribute('pageType', 'Template/WhatsNew');
   }
 
-  const tessen = useTessen();
-
   return (
-    <ErrorBoundary tessen={tessen} eventName="whatsNew">
+    <ErrorBoundary eventName="whatsNew">
       <SEO
         location={location}
         title={title}


### PR DESCRIPTION
This adds an error boundary component that can wrap our templates and js pages should there be a js error. it'll render a message in the UI and sent a browser event that we can use for alerts.

from [react's docs](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) "There is currently no way to write an error boundary as a function component". it's a little inconvenient, but since you can't use hooks in class components i'm passing the tessen call through

example event:
<img width="354" alt="Screen Shot 2023-04-24 at 4 05 47 PM" src="https://user-images.githubusercontent.com/39655074/234135311-6f22a177-41d3-4dee-8e14-6053e1d444df.png">


UI:
<img width="1370" alt="Screen Shot 2023-04-24 at 3 44 46 PM" src="https://user-images.githubusercontent.com/39655074/234135055-8fc8ca3b-b363-4ff6-8b9c-e5b42251f399.png">

<img width="1370" alt="Screen Shot 2023-04-24 at 3 44 55 PM" src="https://user-images.githubusercontent.com/39655074/234135049-b39c7cf4-d47f-40b7-ba3a-3230113c580f.png">
