### PR TITLE
Tabatha/gh actions deprecations

### DIFF
--- a/.github/workflows/add-slugs-to-translate-queue.yml
+++ b/.github/workflows/add-slugs-to-translate-queue.yml
@@ -23,14 +23,14 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -26,10 +26,10 @@ jobs:
       TRANSLATION_TYPE: human
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Get current date
         id: date
@@ -37,7 +37,7 @@ jobs:
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
@@ -97,10 +97,10 @@ jobs:
       TRANSLATION_TYPE: machine
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Get current date
         id: date
@@ -108,7 +108,7 @@ jobs:
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/check-translations-and-deserialize.yml
+++ b/.github/workflows/check-translations-and-deserialize.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         id: yarn-cache
@@ -59,7 +59,7 @@ jobs:
           git config --local user.name "${{ env.BOT_NAME }}"
           git add ./src/i18n/content
           git commit -m 'chore: add translations'
-          echo "::set-output name=commit::true"
+          echo "commit=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         id: create-pr
@@ -104,7 +104,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date:=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
         id: yarn-cache
@@ -130,7 +130,7 @@ jobs:
           git config --local user.name "${{ env.BOT_NAME }}"
           git add ./src/i18n/content
           git commit -m 'chore: add translations'
-          echo "::set-output name=commit::true"
+          echo "commit=true" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         id: create-pr

--- a/.github/workflows/manual-add-files-to-translation-queue.yml
+++ b/.github/workflows/manual-add-files-to-translation-queue.yml
@@ -29,14 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
 
       - name: Get last release tag
         id: get-last-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: '0'
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
 
       - name: Get last release tag
         id: get-last-tag

--- a/.github/workflows/send-content-to-machine-translate.yml
+++ b/.github/workflows/send-content-to-machine-translate.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/send-content-to-translate.yml
+++ b/.github/workflows/send-content-to-translate.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -42,24 +42,6 @@ jobs:
           git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
           echo "commit=true" >> $GITHUB_OUTPUT
 
-      - name: Temporarily disable branch protection
-        id: disable-branch-protection
-        uses: actions/github-script@v1
-        with:
-          github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
-          previews: luke-cage-preview
-          script: |
-            const result = await github.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: null,
-              restrictions: null,
-              enforce_admins: null,
-              required_pull_request_reviews: null
-            })
-            console.log("Result:", result)
-
         # Push directly to the `develop` branch so we get the changes included in the release PR
       - name: Push Commit
         if: steps.commit-changes.outputs.commit == 'true'
@@ -67,37 +49,3 @@ jobs:
         with:
           github_token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
           branch: develop
-
-      - name: Re-enable branch protection
-        id: enable-branch-protection
-        if: always()
-        uses: actions/github-script@v1
-        with:
-          github-token: ${{ secrets.DEVEX_OPENSOURCE_BOT_TOKEN }}
-          previews: luke-cage-preview
-          script: |
-            const result = await github.repos.updateBranchProtection({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              branch: 'develop',
-              required_status_checks: {
-                strict: false,
-                contexts: [
-                  'Gatsby Build Service - docs-website-develop',
-                  'run linter',
-                  'run tests',
-                  'license/cla',
-                  'unpaired translations removed'
-                ]
-              },
-              restrictions: {
-                users: [],
-                teams: ['docs-engineering']
-              },
-              enforce_admins: null,
-              required_pull_request_reviews: {
-                dismiss_stale_reviews: true,
-                required_approving_review_count: 1
-              }
-            })
-            console.log("Result:", result)

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: develop
           persist-credentials: false

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   update-whats-new-ids:
-    name: generates in-product anncouncements (optional)
+    name: generates in-product announcements (optional)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 

--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -40,7 +40,7 @@ jobs:
           git config --local user.name "${{ env.BOT_NAME }}"
           git add ./src/data/whats-new-ids.json
           git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
-          echo "::set-output name=commit::true"
+          echo "commit=true" >> $GITHUB_OUTPUT
 
       - name: Temporarily disable branch protection
         id: disable-branch-protection

--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run vale
         uses: errata-ai/vale-action@v1

--- a/.github/workflows/validate-datasource.yml
+++ b/.github/workflows/validate-datasource.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/3
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/3
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
@@ -43,16 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
@@ -69,16 +69,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: Cache dependencies
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/scripts/actions/check-job-progress.js
+++ b/scripts/actions/check-job-progress.js
@@ -265,7 +265,7 @@ const main = async () => {
     log(`batchUids: ${batchesToDeserialize.map(prop('batchUid')).join(', ')}`);
 
     console.log(
-      `::set-output name=batchesToDeserialize::${batchesToDeserialize.length}`
+      `batchesToDeserialize=${batchesToDeserialize.length} >> $GITHUB_OUTPUT`
     );
 
     // download the newly translated files and deserialize them (into MDX).
@@ -291,10 +291,10 @@ const main = async () => {
       `Final results --- ${results.totalSuccesses} files completed, ${results.totalFailures} files errored.`
     );
     console.log(
-      `::set-output name=successfulTranslations::${results.totalSuccesses}`
+      `successfulTranslations=${results.totalSuccesses} >> $GITHUB_OUTPUT`
     );
     console.log(
-      `::set-output name=failedTranslations::${results.totalFailures}`
+      `failedTranslations=${results.totalFailures} >> $GITHUB_OUTPUT`
     );
 
     await trackTranslationEvent({

--- a/scripts/actions/translation_workflow/testing/README.md
+++ b/scripts/actions/translation_workflow/testing/README.md
@@ -2,7 +2,7 @@
 
 ## Background
 
-There previously wasn't a way to run through the code components of the translation pipeline w/o pushing the code into the mainline branch, and running the workflows on github. We do have unit tests, but the coverage isn't complete, and may not cover interactions we care about -- connecting to the database, interacting with smartling api. 
+There previously wasn't a way to run through the code components of the translation pipeline w/o pushing the code into the mainline branch, and running the workflows on github. We do have unit tests, but the coverage isn't complete, and may not cover interactions we care about -- connecting to the database, interacting with smartling api.
 
 The hope with this script is that it is a decent first attempt at being able to proactively test the pipeline end-to-end. You can run the script, and for some small controlable input, it will execute the primary steps of the translation process in less than a minute and give you general feedback. This is not necesarilly the best way to test, nor is it the end goal of what can be done, but is hopefully a decent iteration for the moment.
 
@@ -14,29 +14,28 @@ Most of the manual work involved is getting everything you need to be able to ru
 
 You'll need to fill out values for variables in `script.sh`.
 
-1. Provide a github token. A GitHub token can be generated through the GitHub UI. 
+1. Provide a github token. A GitHub token can be generated through the GitHub UI.
 
-  ```sh
-  export GITHUB_TOKEN='' # token with no permissions
-  ```
+```sh
+export GITHUB_TOKEN='' # token with no permissions
+```
 
 2. Provide translation variables. Values for the translation variables can be found through the vendor UI.
 
-  ```sh
-  export TRANSLATION_VENDOR_PROJECT='' # use machine translation project
-  export TRANSLATION_VENDOR_USER='' # MT user
-  export TRANSLATION_VENDOR_SECRET='' # MT user secret
-  ```
-
+```sh
+export TRANSLATION_VENDOR_PROJECT='' # use machine translation project
+export TRANSLATION_VENDOR_USER='' # MT user
+export TRANSLATION_VENDOR_SECRET='' # MT user secret
+```
 
 3. Finally, the DB_CONNECTION_INFO secret needs to be populated in `connection_info.json`. The recommendation for this is to spin up a local postgres instance and connect to that, so that you dont need to test against a resource in the cloud. See the next section for setting up a local postgres instance on Docker. The values for this are currently:
 
 ```json
 {
-    "username": "root",
-    "password": "root",
-    "host": "localhost",
-    "database": "translations"
+  "username": "root",
+  "password": "root",
+  "host": "localhost",
+  "database": "translations"
 }
 ```
 
@@ -47,6 +46,7 @@ This section assumes you are using Docker for the local environment, so be sure 
 Once you have Docker installed, from the `root` of the repository, run `yarn db:start`. This executes a `docker-compose` command using [this compose file](./docker-compose.yml). Three containers will be spun up: one for postgres, one for pgadmin, and one for executing a migration (using Node.js sequelize).
 
 The migration takes the longest to execute. Once you see text similar to:
+
 ```
 migration_1 | wait-for-it.sh: timeout occurred after waiting 15 seconds for db:5432
 migration_1 |
@@ -59,6 +59,7 @@ migration_1 | == 20211201221649-test: migrated (0.124s)
 migration_1 |
 testing_migration_1 exited with code 0
 ```
+
 that will indicate that database is running & set up -- tables exist, and data is populated.
 
 Once the migration is complete, you can run the testing script, or set up pgadmin and connect to the postgres database. This last bit isn't needed, but is useful for debugging and introspecting the database during development.
@@ -66,15 +67,15 @@ Once the migration is complete, you can run the testing script, or set up pgadmi
 ## How to connect to postgres database in pgadmin
 
 1. To connect to the pgadmin UI, open a browser and navigate to `http://localhost:15432`. Login with username:`admin@pgadmin.com` and password:`password`. The url, username, and password are all defined in [the docker-compose file](./docker-compose.yml) for the pgadmin service.
-2. To connect to your postgres container, click on `Create A Server`. On the `Connection` tab, enter the following details: 
-    ```
-    Hostname/address: postgres
-    Port: 5432
-    Maintenance database: postgres
-    Username: root
-    Password: root
-    ```
-    You may also need to go into the `General` and give a name to the server. You can call it `translations` (but it can be called anything).
+2. To connect to your postgres container, click on `Create A Server`. On the `Connection` tab, enter the following details:
+   ```
+   Hostname/address: postgres
+   Port: 5432
+   Maintenance database: postgres
+   Username: root
+   Password: root
+   ```
+   You may also need to go into the `General` and give a name to the server. You can call it `translations` (but it can be called anything).
 
 <img width="200" alt="portfolio_view" src="https://github.com/newrelic/docs-website/blob/feature/machine-translation/scripts/actions/translation_workflow/testing/pgadmin_query.png">
 ## Use node 16
@@ -85,16 +86,17 @@ The script requires node.js version 16. The following commands use `nvm` to inst
   ```
 
 ## Make a change to translate
+
 The last thing you will need to do is make a unique change to the file `src/content/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences.mdx`. The reason being that the PR URL the script uses is for a PR which changes only that file. In order to get the vendor to recognize content for translation, we have to submit unique content everytime. The simplest thing to do here is just delete the existing body of the document, and replace it with something like "bird" or a short phrase, etc.
 
 To move through the entire Machine Translation workflow you will also need to remove the `translate: jp` entry in the frontmatter of the file, otherwise it will think it needs to be Human Translated.
-
 
 # Run the script
 
 Run script from docs-website (repo root)
 
 Once all the setup is complete, assuming there are no issues that crop up, you should be able to run the script like so:
+
 ```sh
 ./scripts/actions/translation_workflow/testing/script.sh
 ```
@@ -102,6 +104,7 @@ Once all the setup is complete, assuming there are no issues that crop up, you s
 This will execute the script, and only one other step remains. Halfway through the script, after the file has been uploaded for translation, you will need to authorize the job with the vendor. To do that, navigate to the job in the vendor UI, and click `authorize` once you do that, the script should continue and run to completion.
 
 A complete execution will produce an output similar to:
+
 ```sh
 \$ node scripts/actions/add-files-to-translation-queue.js https://api.github.com/repos/newrelic/docs-website/pulls/3271/files
 Done in 4.52s.
@@ -139,12 +142,12 @@ Successful response
 Successful response
 [*]Jobs completed: [{"id":3,"job_uid":"f5lauqavyoq9","batch_uid":"glzideuwre8p","status":"COMPLETED","locale":"ja-JP","date_created":"2021-07-29T15:10:22.543Z","date_modified":"2021-07-29T15:11:22.979Z"}][*]1 batches ready to be deserialized
 [*]batchUids: glzideuwre8p
-::set-output name=batchesToDeserialize::1
+"batchesToDeserialize=1" >> $GITHUB_OUTPUT
 [*] Deserializing /accounts/accounts/account-maintenance/change-passwords-user-preferences
 [*]Content deserialized
-::set-output name=batchUids::,
-::set-output name=completedBatches::[object Object]
-::set-output name=deserializedFileUris::src/content/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences.mdx
+"batchUids= " >> $GITHUB_OUTPUT,
+"completedBatches=[object Object]"
+"deserializedFileUris=src/content/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences.mdx" >> $GITHUB_OUTPUT
 Successful response
 Successful response
 [*] Successfully deleted https://docs.newrelic.com/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences context.

--- a/src/content/docs/agile-handbook/appendices/backlog-review.mdx
+++ b/src/content/docs/agile-handbook/appendices/backlog-review.mdx
@@ -52,3 +52,4 @@ When you review an issue, perform the following checks:
 <Callout variant="tip">
   We welcome thoughts or questions on our handbook! The easiest way to get in touch is to [file a GitHub issue](https://github.com/newrelic/docs-website/issues/new/choose).
 </Callout>
+


### PR DESCRIPTION
Update our github workflows and third party actions before deprecations go into effect

Testing here: [PR](https://github.com/newrelic/docs-website/pull/12791)

This branch
  * |_ Feat/test-gh-actions -> added feat branch to pullrequest branches in workflow files
    *  |_ tabatha/test-updated-actions -> added changes to trigger whats-new, datasources, and lint workflows


Without making changes to translations files we can see to following check run successfully in the test PR on the updated v3

- Vale-linter
- Generates-in-product-announcements
- Run-tests
- Run-linter
- Unpaired-translations
- release
