### PR TITLE
Update net-agent-compatibility-requirements-net-core.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -160,7 +160,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0 and 7.0. You can find the target framework in your `.csproj` file:
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0 and 7.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application’s targeted version of .NET Core, please refer to the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
 
     Supported:
 


### PR DESCRIPTION
The section "Target Framework version" correctly states that we support applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0 and 7.0. The purpose of this PR is to make it clear that we support these versions, but some .NET Core versions require specific agent version ranges to be compatible. For example, a target framework of .NET Core 2.0 is only compatible with agent versions 8.19.353.0 up to 9.9.0 and not our latest 10.x versions.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.