### PR TITLE
Add supported datastore client versions for Elasticsearch

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -550,6 +550,37 @@ Minimum supported version: 1.0.488
 Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66
 		  </td>
         </tr>
+
+        <tr>
+          <td>
+            Elasticsearch
+          </td>
+
+          <td className="fcenter">
+            <Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+          </td>
+
+          <td>
+Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clients.Elasticsearch), [NEST](https://www.nuget.org/packages/NEST), or [Elasticsearch.Net](https://www.nuget.org/packages/Elasticsearch.Net).
+
+**Elastic.Clients.Elasticsearch**
+* Minimum supported version: 8.0.0
+* Verified compatible versions: 8.0.0, 8.1.0
+
+**NEST**
+* Minimum supported version: 7.0.0
+* Verified compatible versions: 7.17.5
+
+
+**Elasticsearch.Net**
+* Minimum supported version: 7.0.0
+* Verified compatible versions: 7.17.5
+          </td>
+        </tr>
+
       </tbody>
     </table>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -690,6 +690,37 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
             * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66
           </td>
         </tr>
+
+        <tr>
+          <td>
+            Elasticsearch
+          </td>
+
+          <td className="fcenter">
+            <Icon
+              style={{color: '#328787'}}
+              name="fe-check"
+            />
+          </td>
+
+          <td>
+Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clients.Elasticsearch), [NEST](https://www.nuget.org/packages/NEST), or [Elasticsearch.Net](https://www.nuget.org/packages/Elasticsearch.Net).
+
+**Elastic.Clients.Elasticsearch**
+* Minimum supported version: 8.0.0
+* Verified compatible versions: 8.0.0, 8.1.0
+
+**NEST**
+* Minimum supported version: 7.0.0
+* Verified compatible versions: 7.17.5
+
+
+**Elasticsearch.Net**
+* Minimum supported version: 7.0.0
+* Verified compatible versions: 7.17.5
+          </td>
+        </tr>
+
       </tbody>
     </table>
 </Collapser>


### PR DESCRIPTION
The .NET agent is releasing instrumentation for Elasticsearch clients in agent version 10.10.0.  This PR updates the agent's compatibility and support documentation with information on the versions supported and tested.