### PR TITLE
infrastructure dimensional metrics: metric name limitation

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
@@ -336,19 +336,23 @@ Here are some examples of NQRL queries with and without dimensional metrics:
 
 ## Known limitations
 
-* Metric queries with `*` do not return Infrastructure sample data. For example: 
+* Metric queries with `*` do not return Infrastructure sample data. For example:
   ```sql
   SELECT * FROM Metric
   ```
-* In order to select attributes starting with `tags.` a metric name has to be provided. For example, this does not work without the `WHERE` clause: 
+* Metric queries with `metricName LIKE` do not return Infrastructure sample data. For example:
+  ```sql
+  SELECT uniques(metricName) FROM Metric where metricName like 'k8%'
+  ```
+* In order to select attributes starting with `tags.` a metric name has to be provided. For example, this does not work without the `WHERE` clause:
   ```sql
   SELECT uniques(tags.environment) FROM Metric WHERE metricName='aws.lambda.function.duration'
-  ``` 
+  ```
 * Results may not be complete if the selection criteria matches too many samples. For example, this maps to all Infrastructure samples, and may return incomplete results:
   ```sql
   SELECT uniqueCount(entity.guid) FROM Metric
   ```
-* Initially there is no support for the newly introduced metric wildcarding feature, for example: 
+* Initially there is no support for the newly introduced metric wildcarding feature, for example:
   ```sql
   SELECT average(host.swap%Bytes) FROM Metric
   ```


### PR DESCRIPTION

* What problems does this PR solve? 
Infra Shimming has a limitation when the customers try to use LIKE to filter infra metric names.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Ticket: https://issues.newrelic.com/browse/NEWRELIC-6218