### PR TITLE
[Chore] Fix typo in anchor link

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/kubernetes-events-integration.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/kubernetes-events-integration.mdx
@@ -77,7 +77,7 @@ Then, to view the pod details:
 1. In the Kubernetes cluster explorer, select a pod.
 2. Select **Show pod events**.
 
-## Optional: Collect metrics of the event collector [#events-mentrics]
+## Optional: Collect metrics of the event collector [#events-metrics]
 
 To collect metric data for the event collector itself, install the New Relic Prometheus agent integration. To get started:
 


### PR DESCRIPTION
Fixed typo 'mentrics' - should be 'metrics'.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Typo in anchor link
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
 Old link: https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/kubernetes-events-integration/#events-mentrics
* If your issue relates to an existing GitHub issue, please link to it.