### PR TITLE
fix: remove section for tls buffer

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs.mdx
@@ -25,6 +25,18 @@ There are several possible causes for this memory increase and potential solutio
 
 <CollapserGroup>
   <Collapser
+    id="cluster"
+    title="Increase caused by cluster worker slab allocations"
+  >
+    Node.js provides the [Cluster module](http://nodejs.org/api/cluster.html). This allows for handling requests in parallel by using all processor cores available on a host. However, each cluster worker allocates its own slab buffer for SSL transactions, and keeps its own copy of Node.js agent data. This multiplies the memory overhead by the number of cluster workers used.
+    The is also true if a host runs multiple Node.js applications at the same time.
+
+    **Solution:**
+
+    Some cloud service providers use environments that state a higher number of processor cores than can actually be used at any given time. Reducing the number of cluster workers or running without Cluster support may decrease memory usage without impacting performance.
+  </Collapser>
+  
+  <Collapser
     id="log"
     title="Increase caused by log messages stored to disk"
   >

--- a/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/troubleshooting/troubleshooting-large-memory-usage-nodejs.mdx
@@ -25,38 +25,6 @@ There are several possible causes for this memory increase and potential solutio
 
 <CollapserGroup>
   <Collapser
-    id="slab"
-    title="Increase caused by TLS memory buffer allocation"
-  >
-    The first time a Node.js application uses any form of encryption, including SSL and HTTPS, a [slab buffer](http://en.wikipedia.org/wiki/Slab_allocation) is created. The default size for this buffer is 10 MB.
-
-    Applications running in environments where SSL termination on inbound requests occurs in a separate router layer do not normally incur this overhead. Cloud services like Heroku and AWS often operate this way. However, the Node.js agent sends outbound data to New Relic services over HTTPS, and this triggers the allocation of a slab buffer.
-
-    **Solution:**
-
-    In some cases, you can reduce the slab buffer below its 10 MB default.
-
-    To set the slab buffer size, use [`tls.SLAB_BUFFER_SIZE`](http://nodejs.org/api/tls.html#tls_tls_slab_buffer_size).
-
-    <Callout variant="caution">
-      When using the New Relic agent, do not set the slab buffer size below 128 KB. The slab buffer allocation should not be reduced for apps that communicate with services or clients using SSL, HTTPS, or any other form of cryptography.
-    </Callout>
-  </Collapser>
-
-  <Collapser
-    id="cluster"
-    title="Increase caused by cluster worker slab allocations"
-  >
-    Node.js provides the [Cluster module](http://nodejs.org/api/cluster.html). This allows for handling requests in parallel by using all processor cores available on a host. However, each cluster worker allocates its own slab buffer for SSL transactions, and keeps its own copy of Node.js agent data. This multiplies the memory overhead by the number of cluster workers used.
-
-    The is also true if a host runs multiple Node.js applications at the same time.
-
-    **Solution:**
-
-    Some cloud service providers use environments that state a higher number of processor cores than can actually be used at any given time. Reducing the number of cluster workers or running without Cluster support may decrease memory usage without impacting performance.
-  </Collapser>
-
-  <Collapser
     id="log"
     title="Increase caused by log messages stored to disk"
   >


### PR DESCRIPTION
`tls.SLAB_BUFFER_SIZE` was removed from node over 5 years ago and this is no longer relevant to the agent according to the node engineering team

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.