### PR TITLE
Move Dot-Net and Java tutorials into Enable section

### DIFF
--- a/src/nav/serverless-function-monitoring.yml
+++ b/src/nav/serverless-function-monitoring.yml
@@ -29,16 +29,16 @@ pages:
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy
           - title: Update serverless monitoring
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda
+          - title: Trace your Java Lambda functions with New Relic and OpenTelemetry
+            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-java
+          - title: Trace your .NET Lambda functions with New Relic and OpenTelemetry
+            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet
       - title: UI and data
         pages:
           - title: Understand and use the UI
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/ui-data/understand-lambda-monitoring-ui
           - title: Lambda data structure
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/ui-data/understand-lambda-data-structure
-          - title: Trace your Java Lambda functions with New Relic and OpenTelemetry
-            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-java
-          - title: Trace your .NET Lambda functions with New Relic and OpenTelemetry
-            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet
       - title: Troubleshooting
         pages:
           - title: Troubleshoot Lambda monitoring

--- a/src/nav/serverless-function-monitoring.yml
+++ b/src/nav/serverless-function-monitoring.yml
@@ -29,10 +29,12 @@ pages:
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy
           - title: Update serverless monitoring
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda
-          - title: Trace your Java Lambda functions with New Relic and OpenTelemetry
-            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-java
-          - title: Trace your .NET Lambda functions with New Relic and OpenTelemetry
-            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet
+          - title: OpenTelemetry
+            pages:
+              - title: Trace your Java Lambda functions with New Relic and OpenTelemetry
+                path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-java
+              - title: Trace your .NET Lambda functions with New Relic and OpenTelemetry
+                path: /docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet
       - title: UI and data
         pages:
           - title: Understand and use the UI


### PR DESCRIPTION
The Dot-Net and Java tutorials have been in the UI section for a while, but they really should have been listed under the "Enable" section.

There was no need to update any redirects because I didn't move the actual files. Instead, I just moved the entries in the nav file.