### PR TITLE
fix(synthetics): add multiple clarifications

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -99,7 +99,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            A modern, multi-core CPU
+            A modern, multi-core AMD64 / x86_64 CPU
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
@@ -83,7 +83,7 @@ To host synthetics job managers, your system must meet the minimum requirements 
           </td>
 
           <td>
-            A modern, multi-core CPU
+            A modern, multi-core AMD64 / x86_64 CPU
           </td>
         </tr>
 

--- a/src/data-dictionary/events/SyntheticCheck/timestamp.md
+++ b/src/data-dictionary/events/SyntheticCheck/timestamp.md
@@ -5,6 +5,7 @@ units: milliseconds (ms)
 events:
   - SyntheticCheck
   - SyntheticsPrivateLocationStatus
+  - SyntheticRequest
 ---
 
 The start time of the job in milliseconds since the Unix epoch. (See https://currentmillis.com for an example.)

--- a/src/data-dictionary/events/SyntheticRequest/sslCertificateExpirationDaysRemaining.md
+++ b/src/data-dictionary/events/SyntheticRequest/sslCertificateExpirationDaysRemaining.md
@@ -1,0 +1,9 @@
+---
+name: sslCertificateExpirationDaysRemaining
+type: attribute
+units: ID
+events:
+  - SyntheticRequest
+---
+
+How many days remain before the ssl certificate expires. This value is only created for ping monitors with the Verify SSL option enabled.

--- a/src/data-dictionary/events/SyntheticRequest/sslCertificateExpirationMs.md
+++ b/src/data-dictionary/events/SyntheticRequest/sslCertificateExpirationMs.md
@@ -1,9 +1,9 @@
 ---
 name: sslCertificateExpirationMs
 type: attribute
-units: ID
+units: milliseconds (ms)
 events:
   - SyntheticRequest
 ---
 
-The identifier that holds how many milliseconds before the ssl Certificate expires.
+The epoch timestamp that the certificate expires in milliseconds. This value is only created for ping monitors with the Verify SSL option enabled.

--- a/src/data-dictionary/events/SyntheticRequest/sslCertificationExpirationDaysRemaining.md
+++ b/src/data-dictionary/events/SyntheticRequest/sslCertificationExpirationDaysRemaining.md
@@ -1,9 +1,0 @@
----
-name: sslCertificationExpirationDaysRemaining
-type: attribute
-units: ID
-events:
-  - SyntheticRequest
----
-
-The identifier that holds how many days left before the ssl Certification expires for a unique minion.

--- a/src/data-dictionary/events/SyntheticRequest/timeStamp.md
+++ b/src/data-dictionary/events/SyntheticRequest/timeStamp.md
@@ -1,9 +1,0 @@
----
-name: timeStamp
-type: attribute
-units: milliseconds (ms)
-events:
-  - SyntheticRequest
----
-
-The time in which the minion starts processing jobs.


### PR DESCRIPTION
- Added clarifications that AMD64 / x86_64 processors are required for CPM and Job Manager installs
- Removed a duplicate and incorrectly named timestamp attribute from SyntheticRequest, adding SyntheticRequest to the event types of the timestamp attribute used for SyntheticCheck
- Clarified when sslCertificateExpiration attributes are created
- Fixed typos in the name of sslCertificateExpirationDaysRemaining
- Clarified the description of sslCertficiateExpiration related attributes