### PR TITLE
fix: Add K8sCronjobSample, K8sJobSample to Find and Use your K8s data page

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
@@ -1,5 +1,5 @@
 ---
-title: Find and use your Kubernetes data 
+title: Find and use your Kubernetes data
 tags:
   - Integrations
   - Kubernetes integration
@@ -288,6 +288,34 @@ Kubernetes data is attached to the following [events](/docs/using-new-relic/data
 
       <td>
         v2.3.0
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `K8sCronjobSample`
+      </td>
+
+      <td>
+        CronJob data
+      </td>
+
+      <td>
+        v3.10.0
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `K8sJobSample`
+      </td>
+
+      <td>
+        Job data
+      </td>
+
+      <td>
+        v3.10.0
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
We recently added `K8sCronJobSample` and `K8sJobSample`. This PR adds them to a docs page for discoverability. 