### PR TITLE
chore(ruby): Add row for version 9.2.2

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -28,7 +28,21 @@ Any versions not listed in the following table are no longer supported. Please [
 
   <tbody>
 
-      <tr>
+    <tr>
+      <td>
+        v9.2.2
+      </td>
+
+      <td>
+        May 1, 2023
+      </td>
+
+      <td>
+        May 1, 2024
+      </td>
+    </tr>
+
+    <tr>
       <td>
         v9.2.1
       </td>


### PR DESCRIPTION
## Give us some context

The Ruby agent needed to quickly follow the release of 9.2.1 with another bugfix, for version 9.2.2
This PR adds the new version to the EOL policy. A separate PR will be made for the release notes.