### PR TITLE
May 3 - Update compatibility-requirements-java-agent.mdx to list Java 20 support

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -260,6 +260,20 @@ Before you install the Java agent, ensure your system meets these requirements:
             NA
           </td>
         </tr>
+        
+        <tr>
+          <td>
+            Java 20
+          </td>
+
+          <td>
+            v8.2.0
+          </td>
+
+          <td>
+            NA
+          </td>
+        </tr>
 
       </tbody>
     </table>
@@ -268,13 +282,13 @@ Before you install the Java agent, ensure your system meets these requirements:
 
     * IBM JVM versions 8 for Linux
     * Eclipse OpenJ9 versions 8 to 19 for Linux, Windows, and macOS
-    * OpenJDK versions 8 to 19 for Linux, Windows, and macOS
+    * OpenJDK versions 8 to 20 for Linux, Windows, and macOS
     * AdoptOpenJDK versions 8 to 16 for Linux, Windows, and macOS
-    * Temurin version 17 to 19 for Linux, Windows, and macOS
-    * Oracle Hotspot JVM versions 8 to 19 for Linux, Solaris, Windows, and macOS
+    * Temurin version 17 to 20 for Linux, Windows, and macOS
+    * Oracle Hotspot JVM versions 8 to 20 for Linux, Solaris, Windows, and macOS
     * Azul Zing JVM versions 8 and 11 for Linux, Windows, and macOS
-    * Azul Zulu JVM versions 8 to 19 for Linux, Windows, and macOS
-    * Amazon Corretto JVM versions 8, 11, and 17 to 19 for Linux, Windows, and macOS
+    * Azul Zulu JVM versions 8 to 20 for Linux, Windows, and macOS
+    * Amazon Corretto JVM versions 8, 11, and 17 to 20 for Linux, Windows, and macOS
     * Alibaba Dragonwell JVM versions 8 and 11 for Linux, Windows, and macOS
 
     (Java 1.7) Compatible only with [Java agent 6.5.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.3/newrelic-java-6.5.3.zip) \[ZIP | 16.8 MB] legacy agent:


### PR DESCRIPTION
Update to list Java 20 support for Agent v8.2.0 which will be release Wed May 3, 2023

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.