### PR TITLE
fix (node agent): mention Nest.js as another supported framework

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -453,6 +453,7 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
 * [Hapi](https://www.npmjs.com/package/hapi)
 * [Koa](https://www.npmjs.com/package/koa) 2.0.0 or higher ([external module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent)
 * [Fastify](https://www.npmjs.com/package/fastify)
+* [Nest.js](https://nestjs.com/) 8.0.0 or higher (if using the `nest start` command to start the application, modify its startup binary to load the New Relic agent: `nest start --exec 'node -r newrelic'`)
 * [Next.js](https://www.npmjs.com/package/next) 12.0.9 - 13.3.0 (12.2.0 or higher required for middleware instrumentation)
 
 If you are using a supported framework with default routers, the Node.js agent can read these frameworks' route names as is. However, if you want more specific names than are provided by your framework, you may want to use one or more of the tools New Relic provides with the [Node.js transaction naming API](/docs/nodejs/nodejs-transaction-naming-api).


### PR DESCRIPTION
Nest.js is actually already mostly supported, we just never really tried to see if it works or not.