### PR TITLE
[chore]  - Update get-pixie-logs to updated pixie diag repo

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/troubleshooting/get-pixie-logs.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/troubleshooting/get-pixie-logs.mdx
@@ -7,6 +7,6 @@ tags:
 metaDescription: "How to debug New Relic's Pixie integration."
 ---
 
-To check the health of a cluster with Pixie installed, run the [diagnostics script](https://github.com/wreckedred/pixie-diag).
+To check the health of a cluster with Pixie installed, run the [diagnostics script](https://github.com/newrelic-experimental/k8s-diag-utilities/tree/main/pixie-diag).
 
 This simple bash script runs standard Kubernetes commands in the namespace that Pixie is installed in. The output of this script can be used to do a more in-depth investigation on your own or with New Relic Support.


### PR DESCRIPTION
Updated the permalink from: https://github.com/wreckedred/pixie-diag

To:
https://github.com/newrelic-experimental/k8s-diag-utilities/tree/main/pixie-diag

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.