### PR TITLE
Java agent 8.2.0 release (Aiming for May 3, 2024)

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -253,7 +253,21 @@ Before you install the Java agent, ensure your system meets these requirements:
           </td>
 
           <td>
-            v7.11.0
+            v7.11.0 to current
+          </td>
+
+          <td>
+            NA
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Java 20
+          </td>
+
+          <td>
+            v8.2.0
           </td>
 
           <td>

--- a/src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -30,6 +30,20 @@ Any versions not listed in the following table are no longer supported. Please [
 
   <tr>
     <td>
+      v8.2.0
+    </td>
+
+    <td>
+      May 3, 2023
+    </td>
+
+    <td>
+      May 3, 2024
+    </td>
+  </tr>
+
+  <tr>
+    <td>
       v8.1.0
     </td>
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
@@ -2,9 +2,9 @@
 subject:  Java agent
 releaseDate:  '2023-05-03'
 version:  8.2.0
-downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.2.0/'
-features: [“Added support for Java 20”]
-bugs: [“Prevented a NullPointerException from the lettuce instrumentation ”, “Fix failure with browser agent auto injection for tomcat versions 8.5.87+ and 9.0.74+ ”]
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.2.0'
+features: ["Added support for Java 20"]
+bugs: ["Prevented a NullPointerException from the lettuce instrumentation", "Fix failure with browser agent auto injection for tomcat versions 8.5.87+ and 9.0.74+"]
 security: []
 ---
 <ButtonGroup>

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
@@ -1,6 +1,6 @@
 ---
 subject:  Java agent
-releaseDate:  2023-05-03'
+releaseDate:  '2023-05-03'
 version:  8.2.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.2.0/'
 features: [“Added support for Java 20”]

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
@@ -1,0 +1,78 @@
+---
+subject:  Java agent
+releaseDate:  2023-05-03'
+version:  8.2.0
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.2.0/'
+features: [“Added support for Java 20”]
+bugs: [“Prevented a NullPointerException from the lettuce instrumentation ”, “Fix failure with browser agent auto injection for tomcat versions 8.5.87+ and 9.0.74+ ”]
+security: []
+---
+<ButtonGroup>
+  <ButtonLink
+    role="button"
+    to="https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.2.0/"
+    variant="primary"
+  >
+    Download this agent version
+  </ButtonLink>
+</ButtonGroup>
+
+## New features and improvements
+
+Added support for Java 20 [1226](https://github.com/newrelic/newrelic-java-agent/pull/1226)
+
+## Fixes
+
+Prevented a NullPointerException from the lettuce instrumentation [1204](https://github.com/newrelic/newrelic-java-agent/pull/1204) 
+Fix failure with browser agent auto injection for tomcat versions 8.5.87+ and 9.0.74+ [1225](https://github.com/newrelic/newrelic-java-agent/pull/1225)
+
+## Update to latest version [#procedures]
+
+To identify which version of the Java agent you're currently using, run `java -jar newrelic.jar -v`. Your Java agent version will be printed to your console.
+
+Then, to update to the latest Java agent version:
+
+1. Back up the **entire** [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent) to another location. Rename that directory to `NewRelic_Agent#.#.#`, where `#.#.#` is the agent version number.
+2. [Download the agent.](/docs/release-notes/agent-release-notes/java-release-notes)
+3. Unzip the new agent download file, then copy `newrelic-api.jar` and `newrelic.jar` into the original [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent).
+4. Compare your old `newrelic.yml` with the newly downloaded `newrelic.yml` from the zip, and [update the file if needed](#diff).
+5. Restart your Java dispatcher.
+
+If you experience issues after the Java agent update, restore from the backed-up New Relic agent directory.
+
+## Update agent config differences [#diff]
+
+We add new settings to `newrelic.yml` as we release new versions of the agent. You can use `diff` or another diffing utility to see what's changed, and add the new config settings to your old file. Make sure not to overwrite any customizations you've made to the file, such as your license key, app name, or changes to default settings.
+
+For example, if you `diff` the default `newrelic.yml` files for Java agent versions 7.10.0 and 7.11.0, the results printed to the console will be like:
+
+```
+➜ diff newrelic_7.10.0.yml newrelic_7.11.0.yml
+...
+107a108,119
+>       # Whether the log events should include context from loggers with support for that.
+>       include_context_data:
+>
+>         # When true, application logs will contain context data.
+>         enabled: false
+>
+>         # A comma separated list of attribute keys whose values should be sent to New Relic.
+>         #include:
+>
+>         # A comma separated list of attribute keys whose values should not be sent to New Relic.
+>         #exclude:
+>
+125a138
+>
+128c141
+<     enabled: false
+---
+>     enabled: true
+...
+```
+
+In this example, these lines were added to the default `newrelic.yml` in Java agent version 7.11.0. If you are moving to 7.11.0 or higher, you should add these new lines to your original `newrelic.yml`.
+
+## Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-811.mdx
@@ -19,12 +19,12 @@ security: []
 
 ## New features and improvements
 
-Added support for Java 20 [1226](https://github.com/newrelic/newrelic-java-agent/pull/1226)
+- Added support for Java 20 [1226](https://github.com/newrelic/newrelic-java-agent/pull/1226)
 
 ## Fixes
 
-Prevented a NullPointerException from the lettuce instrumentation [1204](https://github.com/newrelic/newrelic-java-agent/pull/1204) 
-Fix failure with browser agent auto injection for tomcat versions 8.5.87+ and 9.0.74+ [1225](https://github.com/newrelic/newrelic-java-agent/pull/1225)
+- Prevented a NullPointerException from the lettuce instrumentation [1204](https://github.com/newrelic/newrelic-java-agent/pull/1204) 
+- Fix failure with browser agent auto injection for tomcat versions 8.5.87+ and 9.0.74+ [1225](https://github.com/newrelic/newrelic-java-agent/pull/1225)
 
 ## Update to latest version [#procedures]
 


### PR DESCRIPTION
from @zuluecho9 May 3: still draft, they'll let us know when ready.

These are updated docs for the Java Agent 8.2.0 release