### PR TITLE
Fix large code snippet in "What's new" instructions

### DIFF
--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-template.mdx
@@ -68,7 +68,9 @@ Here are some tips to ensure a smooth process:
 
 2. Copy the sample template below and paste it into the new, empty file.
 
+
    ```md
+
    ---
    title: 'Insert a title here'
    summary: 'Insert a brief description of the feature'
@@ -76,7 +78,6 @@ Here are some tips to ensure a smooth process:
    learnMoreLink: 'https://example.com'
    getStartedLink: 'https://example.com'
    ---
-   ```
 
    ## Front matter tips (remove this section before publishing)
 
@@ -159,6 +160,7 @@ Here are some tips to ensure a smooth process:
    * Important detail
    * Important detail
    * Important detail
+
    ```
 
 3. Replace the template examples with your copy. When you finish, it might look something like this finished post:


### PR DESCRIPTION
For our large code snippet, we need an additional line return to enable the back tick formatting. We have added this line return. Without this extra line return, the code snippet was being rendered as regular text (with headings). So, step #2 should have a large code snippet showing a markdown file--not rendered markdown.