### PR TITLE
Remove 2k limit

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
@@ -257,8 +257,6 @@ The Event API accepts specific formats for attributes included in the payload. O
   >
     The following size and rate limits apply to events sent via the Event API:
 
-    * Max events per API call: 2K
-
     * Payload total size: **1MB(10^6 bytes) maximum per POST**. We highly recommend using compression.
 
     * The payload must be encoded as **UTF-8**.


### PR DESCRIPTION
The limit is strictly on bytes now; there's no longer a limit on the number of events in a request.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.