### PR TITLE
Java agent eol old versions

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -488,7 +488,6 @@ Any versions not listed in the following table are no longer supported. Please [
       <td>
         May 5, 2023
       </td>
-
     </tr>
 
   </tbody>

--- a/src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -406,6 +406,91 @@ Any versions not listed in the following table are no longer supported. Please [
       </td>
     </tr>
 
+    <tr>
+      <td>
+        v6.1.0
+      </td>
+
+      <td>
+        Sep 30, 2020
+      </td>
+
+      <td>
+        Sep 30, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v6.0.0
+      </td>
+
+      <td>
+        Aug 26, 2020
+      </td>
+
+      <td>
+        Aug 26, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v5.14.0
+      </td>
+
+      <td>
+        Jul 27, 2020
+      </td>
+
+      <td>
+        Jul 27, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v5.13.0
+      </td>
+
+      <td>
+        Jun 16, 2020
+      </td>
+
+      <td>
+        Jun 16, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v5.12.1
+      </td>
+
+      <td>
+        May 15, 2020
+      </td>
+
+      <td>
+        May 15, 2023
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        v5.12.0
+      </td>
+
+      <td>
+        May 5, 2020
+      </td>
+
+      <td>
+        May 5, 2023
+      </td>
+
+    </tr>
+
   </tbody>
 </table>
 


### PR DESCRIPTION
There are earlier Java Agent versions that are still supported that are not listed. This PR will re-list them.