### PR TITLE
fix: Make cardinality() doc more clear and consistent

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1631,7 +1631,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-cardinality"
-    title={<InlineCode>cardinality(attribute)</InlineCode>}
+    title={<InlineCode>cardinality([metric_name, include:{attribute_list}, exclude:{attribute_list}])</InlineCode>}
   >
     Use the `cardinality()` function to obtain the number of combinations of all the dimensions (attributes) on a [metric](/docs/using-new-relic/data/understand-data/new-relic-data-types#metrics).
 
@@ -1641,9 +1641,6 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     * Include: if present, the include list restricts the cardinality computation to those attributes.
     * Exclude: if present, the exclude list causes those attributes to be ignored in the cardinality computation.
 
-      ```sql
-      SELECT cardinality(metric_name, include:{attribute_list}, exclude:{attribute_list})
-      ```
   </Collapser>
 
   <Collapser

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1631,7 +1631,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   <Collapser
     className="freq-link"
     id="func-cardinality"
-    title={<InlineCode>cardinality([metric_name, include:{attribute_list}, exclude:{attribute_list}])</InlineCode>}
+    title={<InlineCode>cardinality([metric_name, include:{'{attribute_list}'}, exclude:{'{attribute_list}'}])</InlineCode>}
   >
     Use the `cardinality()` function to obtain the number of combinations of all the dimensions (attributes) on a [metric](/docs/using-new-relic/data/understand-data/new-relic-data-types#metrics).
 


### PR DESCRIPTION
`attribute` is confusing here when it really should be `metric_name`.  Also including all args in the top level example like the other functions in this list instead of a separate nested example.