### PR TITLE
fix(nerdgraph): add 'agent config' cat

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/browser-monitoring-config-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/browser-monitoring-config-nerdgraph.mdx
@@ -6,7 +6,7 @@ tags:
   - Examples
   - Browser
   - Mobile
-metaDescription: Use the New Relic NerdGraph API to configure our browser monitoring agent.
+metaDescription: Use the New Relic NerdGraph API to configure the browser monitoring agent.
 ---
 
 You can create browser applications in the NerdGraph API instead of using the UI. The advantage to this is that when it's time to instrument your browser application with New Relic, you can programmatically create and retrieve the JavaScript snippet to copy and paste into your browser app.

--- a/src/content/docs/apis/nerdgraph/examples/mobile-monitoring-config-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/mobile-monitoring-config-nerdgraph.mdx
@@ -5,14 +5,14 @@ tags:
   - NerdGraph
   - Examples
   - Mobile
-metaDescription: Examples of using New Relic NerdGraph API to adjust a mobile agent
+metaDescription: For New Relic mobile monitoring, how to use our NerdGraph API to configure a mobile agent.
 ---
 
 You can create mobile applications in the NerdGraph API instead of using the UI. The advantage to this is that when it's time to instrument your mobile application with New Relic, you can programmatically create and retrieve the application token to copy and paste into your mobile application.
 
 ## Create a new mobile application [#create-mobile]
 
-Here is an example mutation to create a new mobile application. You must provide an account id and a name for the application.
+Here is an example mutation to create a new mobile application. You must provide an account ID and a name for the application.
 
 Mutation:
 
@@ -101,7 +101,7 @@ Variables:
 
 ## Examples of configuring mobile monitoring [#configure-mobile-application]
 
-Here's an example of how to configure mobile settings via NerdGraph:
+Here's an example of how to configure mobile monitoring settings via NerdGraph:
 
 Mutation:
 

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -103,6 +103,16 @@ pages:
             path: /docs/apis/nerdgraph/get-started/nerdgraph-explorer
           - title: See all NerdGraph tutorials
             path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials
+          - title: 'NerdGraph: agent configuration'
+            pages:
+              - title: APM agents
+                path: /docs/apis/nerdgraph/examples/apm-config-nerdgraph
+              - title: Browser monitoring
+                path: /docs/apis/nerdgraph/examples/browser-monitoring-config-nerdgraph
+              - title: "Browser: instrument multiple apps"
+                path: /docs/apis/nerdgraph/examples/combining-npm-nerdgraph        
+              - title: Mobile monitoring
+                path: /docs/apis/nerdgraph/examples/mobile-monitoring-config-nerdgraph
           - title: 'NerdGraph: queries and charts'
             pages:
               - title: NRQL queries
@@ -125,22 +135,6 @@ pages:
                 path: /docs/apis/nerdgraph/examples/export-import-dashboards-using-api
               - title: Managing live chart URLs
                 path: /docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api
-          - title: 'NerdGraph: admin & data management'
-            pages:
-              - title: Manage API keys
-                path: /docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
-              - title: Streaming export of New Relic data
-                path: /docs/apis/nerdgraph/examples/nerdgraph-streaming-export
-              - title: Manage accounts
-                path: /docs/apis/nerdgraph/examples/manage-accounts-nerdgraph
-              - title: Manage users
-                path: /docs/apis/nerdgraph/examples/nerdgraph-manage-users
-              - title: Manage user groups
-                path: /docs/apis/nerdgraph/examples/nerdgraph-manage-groups
-              - title: Manage tags
-                path: /docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial
-              - title: Workloads
-                path: /docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials
           - title: 'NerdGraph: alerting'
             pages:
               - title: 'Applied intelligence: destinations'
@@ -167,13 +161,24 @@ pages:
                 path: /docs/apis/nerdgraph/examples/nerdgraph-log-parsing-rules-tutorial
               - title: Logs data partition
                 path: /docs/apis/nerdgraph/examples/nerdgraph-data-partition-rules-tutorial
+          - title: 'NerdGraph: admin & data management'
+            pages:
+              - title: Manage API keys
+                path: /docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys
+              - title: Streaming export of New Relic data
+                path: /docs/apis/nerdgraph/examples/nerdgraph-streaming-export
+              - title: Manage accounts
+                path: /docs/apis/nerdgraph/examples/manage-accounts-nerdgraph
+              - title: Manage users
+                path: /docs/apis/nerdgraph/examples/nerdgraph-manage-users
+              - title: Manage user groups
+                path: /docs/apis/nerdgraph/examples/nerdgraph-manage-groups
+              - title: Manage tags
+                path: /docs/apis/nerdgraph/examples/nerdgraph-tagging-api-tutorial
+              - title: Workloads
+                path: /docs/apis/nerdgraph/tutorials/nerdgraph-workloads-api-tutorials
           - title: Other NerdGraph tutorials
             pages:
-              - title: APM agents
-                path: /docs/apis/nerdgraph/examples/apm-config-nerdgraph
-              - title: Browser monitoring
-                path: /docs/apis/nerdgraph/examples/browser-monitoring-config-nerdgraph
-              - title: "Browser install for multiple apps"
               - title: Cloud integration tutorial
                 path: /docs/apis/nerdgraph/examples/nerdgraph-cloud-integrations-api-tutorial
               - title: Distributed tracing
@@ -182,8 +187,6 @@ pages:
                 path: /docs/apis/nerdgraph/examples/configure-infinite-tracing-graphql
               - title: Golden metrics
                 path: /docs/apis/nerdgraph/examples/golden-metrics-entities-nerdgraph-api-tutorial
-              - title: Mobile monitoring
-                path: /docs/apis/nerdgraph/examples/mobile-monitoring-config-nerdgraph
               - title: Service levels
                 path: /docs/apis/nerdgraph/examples/nerdgraph-slm
               - title: Synthetic monitoring tutorial


### PR DESCRIPTION
Moved some docs into a new subcategory of 'Agent config' in NerdGraph for easier findability. 