### PR TITLE
Deprecate docker storage metrics (NR-108207)

### DIFF
--- a/src/data-dictionary/events/ContainerSample/StorageDataAvailableBytes.md
+++ b/src/data-dictionary/events/ContainerSample/StorageDataAvailableBytes.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Data space available in the Storage Driver. Only Device Mapper driver is supported.
+Data space available in the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageDataTotalBytes.md
+++ b/src/data-dictionary/events/ContainerSample/StorageDataTotalBytes.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Total Data space in the Storage Driver. Only Device Mapper driver is supported.
+Total Data space in the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageDataUsagePercent.md
+++ b/src/data-dictionary/events/ContainerSample/StorageDataUsagePercent.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Percent of Data space used in the Storage Driver. Only Device Mapper driver is supported.
+Percent of Data space used in the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageDataUsedBytes.md
+++ b/src/data-dictionary/events/ContainerSample/StorageDataUsedBytes.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Data space used by the Storage Driver. Only Device Mapper driver is supported.
+Data space used by the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageMetadataAvailableBytes.md
+++ b/src/data-dictionary/events/ContainerSample/StorageMetadataAvailableBytes.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Metadata space available in the Storage Driver. Only Device Mapper driver is supported.
+Metadata space available in the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageMetadataTotalBytes.md
+++ b/src/data-dictionary/events/ContainerSample/StorageMetadataTotalBytes.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Total Metadata space in the Storage Driver. Only Device Mapper driver is supported.
+Total Metadata space in the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageMetadataUsagePercent.md
+++ b/src/data-dictionary/events/ContainerSample/StorageMetadataUsagePercent.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Percent of Metadata space used in the Storage Driver. Only Device Mapper driver is supported.
+Percent of Metadata space used in the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).

--- a/src/data-dictionary/events/ContainerSample/StorageMetadataUsedBytes.md
+++ b/src/data-dictionary/events/ContainerSample/StorageMetadataUsedBytes.md
@@ -6,4 +6,4 @@ events:
   - ContainerSample
 ---
 
-Metadata space used by the Storage Driver. Only Device Mapper driver is supported.
+Metadata space used by the Storage Driver. Only available while using Docker's `devicemapper` storage driver [that is deprecated](https://docs.docker.com/storage/storagedriver/select-storage-driver/#supported-storage-drivers-per-linux-distribution).


### PR DESCRIPTION
A few metrics from `ContainerSample` data dictionary are based on a Docker storage backend that is deprecated.