### PR TITLE
[chore] remove old reference to non-alpine image

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring.mdx
@@ -353,8 +353,6 @@ Once the infrastructure agent is running in a Docker container, it can collect t
 
 The containerized agent image is built from an Alpine base image.
 
-Alpine is used as the base image since version 0.0.55. This is the one pointed by `latest` tag. Earlier versions used CentOS 7 as base image.
-
 ## Check the source code [#source-code]
 
 This integration is open source software. You can [browse its source code](https://github.com/newrelic/infrastructure-bundle) and send improvements, or create your own fork and build it.


### PR DESCRIPTION
## Give us some context

* We've been using Alpine as base image for many years now, this old note is not needed anymore. 