### PR TITLE
fix(NerdGraph): Removed an outdated video

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -11,12 +11,7 @@ redirects:
 
 Do you need to schedule reports that contain charts or dashboards? Do you want to automate how you share dashboards? You can obtain your <InlinePopover type="dashboards" /> as PDF or PNG files programmatically with a [GraphQL](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) mutation. You can also [export dashboards as PDF files using the UI](/docs/dashboards/manage-your-dashboard/manage-your-dashboard#dash-export).
 
-For example, You can generate static, snapshot versions of your New Relic dashboards and send them to Slack or download as files. To learn how, watch this short YouTube video (approx. 4 minutes).
-
-<Video
-  id="v5vBGV2Yy_0"
-  type="youtube"
-/>
+For example, you can generate static, [snapshot versions](/docs/apis/nerdgraph/examples/nerdgraph-dashboards/#other-operations) of your New Relic dashboards and send them to [Slack](/docs/alerts-applied-intelligence/notifications/notification-integrations/#slack) or [download as files](/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api/). 
 
 ## Export dashboard pages [#dash-multiple]
 
@@ -46,9 +41,9 @@ For example, You can generate static, snapshot versions of your New Relic dashbo
 3. Run the **dashboardCreateSnapshotURL** mutation in the [NerdGraphQL explorer](https://api.newrelic.com/graphiql) as many times as dashboard pages you want to export. You just need to provide the desired dashboard page GUID as a parameter.
 4. Get the link to retrieve your dashboard page as a PDF. The link looks similar to:
 
-```
-https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
-```
+  ```
+  https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
+  ```
 
 5. [Configure](#configure) the exported file, if necessary.
 


### PR DESCRIPTION
Removed an outdated video from this page: [NerdGraph tutorial: Export dashboards as files](https://docs.newrelic.com/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api/)