### PR TITLE
docs: Update setErrorHandler api for EI fingerprinting

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/seterrorhandler.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/seterrorhandler.mdx
@@ -1,12 +1,12 @@
 ---
 title: setErrorHandler
 type: apiDoc
-shortDescription: Allows selective ignoring of known errors that the browser agent captures.
+shortDescription: Allows selective ignoring and grouping of known errors that the browser agent captures.
 tags:
   - Browser
   - Browser monitoring
   - Browser agent and SPA API
-metaDescription: Browser monitoring API call to allow selective ignoring of known errors captured by the agent.
+metaDescription: Browser monitoring API call to allow selective ignoring and grouping of known errors captured by the agent.
 redirects:
   - /docs/browser/new-relic-browser/browser-agent-apis/browser-api-newrelicseterrorhandler
   - /docs/browser/new-relic-browser/browser-agent-api/browser-api-newrelicseterrorhandler
@@ -23,15 +23,19 @@ To use this API, you need either a Browser Pro or Pro+SPA edition of the browser
 newrelic.setErrorHandler(function $callback)
 ```
 
-Allows selective ignoring of known errors that the browser agent captures.
+Allows selective ignoring and grouping of known errors that the browser agent captures.
 
 ## Requirements
 
 Agent version [nr-974](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes) or higher.
 
+For error grouping capability, version [1.230.0](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.230.0) or higher is required.
+
 ## Description
 
 The `newrelic.setErrorHandler()` API call allows you to selectively ignore known errors that the browser agent captures. It takes a single error handler function, which will be called for each error that the browser agent captures. If the handler returns `true`, New Relic does **not** record the error. Otherwise the error will be processed normally.
+
+In addition, later versions of the agent support fingerprinting or grouping of exceptions with a custom provided label. To do this, return an object instead of a boolean with a `group` property set to the desired _string_. It's important to know that providing an empty string, or any object that does not conform to this exact spec, is treated the same as the `true` case, for which the error will be _ignored_. This behavior is backwards compatible with prior versions.
 
 ## Parameters
 
@@ -65,7 +69,7 @@ The `newrelic.setErrorHandler()` API call allows you to selectively ignore known
 
 ## Examples
 
-### Use a single error handler function [#include-error]
+### Use a basic error handler function [#include-error]
 
 Include the error object inside of the callback function to ignore specific errors that the browser agent captures.
 
@@ -77,4 +81,21 @@ newrelic.setErrorHandler(function(err) {
     return false;
   }
 });
+```
+
+### Fingerprinting errors in handler function
+
+Assign custom labels to specific errors for view in the Errors Inbox UI.
+
+```js
+newrelic.setErrorHandler(function(err) {
+  if (isReferenceError(err)) {
+    return { group: 'My reference errors' }; // error is included and tagged under this label
+  } else if (isSomeSpecificError(err)) {
+    return { group: '' }; // error will be excluded!
+    // return { Group: 'still excluded - prop name has capital G!' };
+  } else {
+    return false; // error is included without any label
+  }
+})
 ```


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Update browser setErrorHandler api page to account for new functionality post v1.230.0 rollout.