### PR TITLE
fix: add back tessen tracking to nav open/close clicks

### DIFF
--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -94,6 +94,10 @@ const MainLayout = ({ children, pageContext }) => {
         }
       `}
       onClick={() => {
+        tessen.track({
+          eventName: sidebar ? 'closeNav' : 'openNav',
+          category: 'NavCollapserClick',
+        });
         setSidebar(!sidebar);
       }}
     >


### PR DESCRIPTION
The nav icon click tracking was added while we were using the personal homepage layout and so this got lost when we switched back to the video layout. 