### PR TITLE
Fix missing quote and add a helpful query

### DIFF
--- a/src/content/docs/logs/troubleshooting/log-message-truncated.mdx
+++ b/src/content/docs/logs/troubleshooting/log-message-truncated.mdx
@@ -14,7 +14,7 @@ redirects:
 
 ## Problem
 
-Not all log data in a message or for a specific attribute is being displayed. The log data ends with an ellipses (`...`) and the remaining data isn't shown.
+Not all log data in a message or for a specific attribute is being displayed. The log data ends with an ellipsis (`...`) and the remaining data isn't shown.
 
 ## Solution
 
@@ -64,16 +64,16 @@ If you have values exceeding the character limit, here are some options to try:
       <td>
         The first 4,094 characters in a log message are stored as a string. The next 128,000 bytes are stored as a `blob`.
 
-        To query for any log data in New Relic, run the following query:
+        To query for logs that have likely exceeded this storage limit in New Relic, run the following query:
 
         ```
-        SELECT * FROM Log
+        SELECT * FROM Log WHERE length(message) >= 4094
         ```
 
         To expand the blob data, run the following query, using `message` or any other attribute. Be sure to enclose the blob's attribute with backticks. For example:
 
         ```
-        SELECT message, another-attribute, blob(`newrelic.ext.message`), blob(`newrelic.ext.another-attribute) FROM Log
+        SELECT message, another-attribute, blob(`newrelic.ext.message`), blob(`newrelic.ext.another-attribute`) FROM Log
         ```
 
         For more information, see our documentation about [long messages stored as blobs](https://docs.newrelic.com/docs/logs/log-management/ui-data/long-logs-blobs/).


### PR DESCRIPTION
Add query to show how to find those logs that might have a truncated message field.

Responsive to a customer feedback request.