### PR TITLE
remove redirects to same page URL

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -15,7 +15,6 @@ redirects:
   - /docs/agents/net-agent/installation-and-configuration/net-agent-configuration
   - /docs/agents/net-agent/installation-configuration/net-agent-configuration
   - /docs/agents/net-agent/configuration/environment-variables
-  - /docs/apm/agents/net-agent/configuration/net-agent-configuration
 ---
 
 import apmNetAgentConfigurationHierarchy from 'images/apm_diagram_net-agent-configuration-hierarchy.webp'

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -12,7 +12,6 @@ redirects:
   - /docs/php/php-agent-phpini-settings
   - /docs/agents/php-agent/configuration/php-agent-newrelicini-settings
   - /docs/agents/php-agent/troubleshooting/troubleshooting-ssl-certificate-errors
-  - /docs/apm/agents/php-agent/configuration/php-agent-configuration
 ---
 
 import apmPhpAgentConfigurationHierarchy from 'images/apm_diagram_php-agent-configuration-hierarchy.webp'


### PR DESCRIPTION
these redirects cause a `too much recursion` error because they redirect to the same path as the file
