### PR TITLE
Improve nginx docs for logs use case

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration.mdx
@@ -24,11 +24,11 @@ import osEcs from 'images/os_icon_ecs.webp'
 
 import osk8 from 'images/os_icon_k8.webp'
 
-Our NGINX [integration](/docs/integrations/host-integrations/getting-started/introduction-host-integrations) collects and sends inventory and metrics from your NGINX server to our platform, where you can see data on connections and client requests so that you can find the source of any problems.
+Our NGINX [integration](/docs/integrations/host-integrations/getting-started/introduction-host-integrations) collects and sends inventory, logs, and metrics from your NGINX server to our platform, where you can see data on connections and client requests so that you can find the source of any problems.
 
 To install the NGINX monitoring integration, you must run through the following steps:
 
-1. [Enabling your NGINX Server](#enable-instance).
+1. [Enable your NGINX Server](#enable-instance).
 2. [Install and activate the integration](#install).
 3. [Configure the integration](#config).
 4. [Find and use data](#find-and-use).
@@ -43,8 +43,8 @@ To install the NGINX monitoring integration, you must run through the following 
 Our integration is compatible with both NGINX Open Source and NGINX Plus. Before installing the integration, ensure you meet the following requirements:
 
 * A New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup) No credit card required.
-* NGINX extension enabled, as described in the [Configure the integration](#config) section.
-* If NGINX is not running on Kubernetes or Amazon ECS, you must [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux OS host that's running NGINX. Otherwise:
+* NGINX extension enabled, as described in the [Enable your NGINX Server](#enable-instance) section.
+* If NGINX is not running on Kubernetes or Amazon ECS, you must [install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) on a Linux or Windows OS host that's running NGINX. Otherwise:
   * If running on <img style={{ width: '32px', height: '32px'}} class="inline" title="Kubernetes" alt="Kubernetes" src={osk8}/>Kubernetes, see [these requirements](/docs/monitor-service-running-kubernetes#requirements).
   * If running on <img style={{ width: '32px', height: '32px'}} class="inline" title="ECS" alt="ECS" src={osEcs}/>Amazon ECS, see [these requirements](/docs/integrations/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs).
 
@@ -55,7 +55,7 @@ Our integration is compatible with both NGINX Open Source and NGINX Plus. Before
 
 For a comprehensive list of specific Windows and Linux versions, check the table of [compatible operating systems](/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/#operating-systems).
 
-## Enabling your NGINX Server [#enable-instance]
+## Enable your NGINX Server [#enable-instance]
 
 To capture data from the NGINX integration, you must first enable and configure the applicable extension module:
 
@@ -85,12 +85,9 @@ To install the NGINX integration, follow the instructions for your environment:
 5. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status/#linux).
 
 6. To enable automatic NGINX access and error log parsing and forwarding, copy (or rename) the `nginx-log.yml.example` file to `nginx-log.yml`. No need to restart the agent.
-
-**Example:**
-
-```shell
-sudo cp /etc/newrelic-infra/logging.d/nginx-log.yml.example /etc/newrelic-infra/logging.d/nginx-log.yml
-```
+   ```shell
+   sudo cp /etc/newrelic-infra/logging.d/nginx-log.yml.example /etc/newrelic-infra/logging.d/nginx-log.yml
+   ```
 
 ### Other environments [#other-env-install]
 
@@ -128,7 +125,11 @@ sudo cp /etc/newrelic-infra/logging.d/nginx-log.yml.example /etc/newrelic-infra/
     copy nginx-config.yml.sample nginx-config.yml
     ```
     4. Edit the `nginx-config.yml` file as described in the [configuration settings](#config-options).
-    5. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
+    5. To enable automatic NGINX access and error log parsing and forwarding, copy (or rename) the `nginx-log-win.yml.example` file to `nginx-log.yml`.
+       ```shell
+       copy nginx-log-win.yml.example nginx-log.yml
+       ```
+    6. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
 </CollapserGroup>
 
@@ -322,6 +323,7 @@ After you've configured and installed the integration, you can start monitoring:
 
 * Data from this service, which is reported to an [integration dashboard](/docs/infrastructure/infrastructure-integrations/get-started/use-integration-data-new-relic-dashboards/#nrql).
 * Metrics that are attached to the `NginxSample` [event type](/docs/using-new-relic/data/understand-data/new-relic-data-types#events-new-relic). You can [query this data](/docs/using-new-relic/data/understand-data/query-new-relic-data) for troubleshooting purposes or to create custom charts and dashboards.
+* Logs will be visible in the [Logs UI](docs/logs/ui-data/use-logs-ui/).
 
 For more on how to find and use your data, see how to [understand integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
 


### PR DESCRIPTION
- Mention up front that logs can be collected
- In "Compatibility and requirements"
  - Fix a bad link to the wrong section
  - Add a missing mention of Windows as a host OS
- Fix using an inconsistent verb tense ("Enable" rather than "Enabling")
- Line up the Linux log configuration command with the description of the step, rather than calling it out as an "Example", to be consistent with the other steps
- Added logs installation instructions to the Windows drop-down section
- Link to Logs UI in "Find and use data"

FYI @marcelschlapfer @lchapman4 @mculmone 