### PR TITLE
Updating supported Amazon Linux versions

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-aws-elastic-beanstalk.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/config-management-tools/configure-infrastructure-agent-aws-elastic-beanstalk.mdx
@@ -30,34 +30,7 @@ To install the infrastructure agent on instances launched with AWS Elastic Beans
 2. Based on the operating system, add the following content to the file, replacing `YOUR_LICENSE_KEY` with your New Relic <InlinePopover type="licenseKey" />.
 
    <CollapserGroup>
-     <Collapser
-       id="linux-ami"
-       title="Amazon Linux AMI"
-     >
-       ```
-       files:
-         "/etc/newrelic-infra.yml" :
-           mode: "000644"
-           owner: root
-           group: root
-           content: |
-             license_key: YOUR_LICENSE_KEY
-
-       commands:
-       # Create the agent’s yum repository
-         "01-agent-repository":
-           command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo
-       #
-       # Update your yum cache
-         "02-update-yum-cache":
-           command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
-       #
-       # Run the installation script
-         "03-run-installation-script":
-           command: sudo yum install newrelic-infra -y
-       ```
-     </Collapser>
-
+     
      <Collapser
        id="linux-2"
        title="Amazon Linux 2"
@@ -75,6 +48,34 @@ To install the infrastructure agent on instances launched with AWS Elastic Beans
        # Create the agent’s yum repository
          "01-agent-repository":
            command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2/x86_64/newrelic-infra.repo
+       #
+       # Update your yum cache
+         "02-update-yum-cache":
+           command: yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
+       #
+       # Run the installation script
+         "03-run-installation-script":
+           command: sudo yum install newrelic-infra -y
+       ```
+     </Collapser>
+
+     <Collapser
+       id="linux-2023"
+       title="Amazon Linux 2023"
+     >
+       ```
+       files:
+         "/etc/newrelic-infra.yml" :
+           mode: "000644"
+           owner: root
+           group: root
+           content: |
+             license_key: YOUR_LICENSE_KEY
+
+       commands:
+       # Create the agent’s yum repository
+         "01-agent-repository":
+           command: sudo curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2023/x86_64/newrelic-infra.repo
        #
        # Update your yum cache
          "02-update-yum-cache":


### PR DESCRIPTION
## Give us some context

* Updating based on customer feedback, Amazon Linux 1 is EOL, Amazon Linux 2023 is now GA. 