### PR TITLE
feat: update nri-cassandra metrics description

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
@@ -868,7 +868,7 @@ Cassandra node metrics are attached to the `CassandraSample` [event type](/docs/
         `db.threadpool.<pool>PendingTasks`
       </td>
 
-      <td><<
+      <td>
         Number of queued tasks queued up on this pool. `pool` can be any of the items in the list provided in the description of `db.threadpool.<pool>ActiveTasks`.
       </td>
     </tr>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/cassandra-monitoring-integration.mdx
@@ -832,7 +832,7 @@ Cassandra node metrics are attached to the `CassandraSample` [event type](/docs/
 
     <tr>
       <td>
-        `db.threadpool.poolActiveTasks`
+        `db.threadpool.<pool>ActiveTasks`
       </td>
 
       <td>
@@ -853,6 +853,7 @@ Cassandra node metrics are attached to the `CassandraSample` [event type](/docs/
         * internalSampler
         * internalSecondaryIndexManagement
         * internalValidationExecutor
+        * nativeTransportRequest
         * requestCounterMutationStage
         * requestMutationStage
         * requestReadRepairStage
@@ -864,11 +865,41 @@ Cassandra node metrics are attached to the `CassandraSample` [event type](/docs/
 
     <tr>
       <td>
-        `db.threadpool.pool.PendingTasks`
+        `db.threadpool.<pool>PendingTasks`
+      </td>
+
+      <td><<
+        Number of queued tasks queued up on this pool. `pool` can be any of the items in the list provided in the description of `db.threadpool.<pool>ActiveTasks`.
+      </td>
+    </tr>
+    
+     <tr>
+      <td>
+        `db.threadpool.<pool>CompletedTasks`
       </td>
 
       <td>
-        Number of tasks being actively worked on by this pool. `pool` can be any of the items in the list provided in the description of `db.threadpool.poolActiveTasks`.
+        Number of tasks completed. `pool` can be any of the items in the list provided in the description of `db.threadpool.<pool>ActiveTasks`.
+      </td>
+    </tr>
+    
+     <tr>
+      <td>
+        `db.threadpool.<pool>TotalBlockedTasks`
+      </td>
+
+      <td>
+        Number of tasks that were blocked due to queue saturation. `pool` can be any of the items in the list provided in the description of `db.threadpool.<pool>ActiveTasks`.
+      </td>
+    </tr>
+    
+     <tr>
+      <td>
+        `db.threadpool.<pool>CurrentlyBlockedTask`
+      </td>
+
+      <td>
+        Number of tasks that are currently blocked due to queue saturation but on retry will become unblocked. `pool` can be any of the items in the list provided in the description of `db.threadpool.<pool>ActiveTasks`.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This PR updates nri-cassandra metrics description in order to clarify which part of the metric name is the `<pool>` in _threadpool_ metrics and it includes some metrics that weren't documented previously. It was noticed after merging [nri-cassandra#117](https://github.com/newrelic/nri-cassandra/pull/117) in the corresponding integration.