### PR TITLE
fix: clean up metrics table contents and mis-matched row

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-media-services-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-media-services-monitoring-integration.mdx
@@ -65,7 +65,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       Number of assets allowed for current media service account.
+        Number of assets allowed for current media service account.
       </td>
     </tr>
 
@@ -75,7 +75,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       Asset used percentage in current media service account.
+        Asset used percentage in current media service account.
       </td>
     </tr>
 
@@ -85,7 +85,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       The total number of live events in the current media services account.
+        The total number of live events in the current media services account.
       </td>
     </tr>
 
@@ -95,7 +95,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       Number of content key policies already created in current media service account.
+        Number of content key policies already created in current media service account.
       </td>
     </tr>
 
@@ -105,7 +105,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       How many content key polices are allowed for current media service account.
+        How many content key polices are allowed for current media service account.
       </td>
     </tr>
 
@@ -115,7 +115,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       Content Key Policy used percentage in current media service account.
+        Content Key Policy used percentage in current media service account.
       </td>
     </tr>
 
@@ -125,7 +125,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-      The Job quota for the current media service account.
+        The Job quota for the current media service account.
       </td>
     </tr>
 
@@ -135,7 +135,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       The number of jobs in the `Scheduled` state.
+        The number of jobs in the `Scheduled` state.
       </td>
     </tr>
 
@@ -145,7 +145,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       The key delivery request status and latency in milliseconds for the current Media Service account.
+        The key delivery request status and latency in milliseconds for the current Media Service account.
       </td>
     </tr>
 
@@ -155,7 +155,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       The maximum number of live events allowed in the current media services account.
+        The maximum number of live events allowed in the current media services account.
       </td>
     </tr>
 
@@ -185,16 +185,17 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       The number of streaming policies already created in the current media service account.
+        The number of streaming policies already created in the current media service account.
       </td>
     </tr>
+    
     <tr>
       <td>
         `StreamingPolicyQuota`
       </td>
 
       <td>
-       The number of streaming policies allowed for current media service accounts.
+        The number of streaming policies allowed for current media service accounts.
       </td>
     </tr>
 
@@ -204,7 +205,7 @@ This integration collects the following [metric data](/docs/infrastructure/integ
       </td>
 
       <td>
-       Streaming Policy used percentage in current media service account.
+        Streaming Policy used percentage in current media service account.
       </td>
     </tr>
 
@@ -215,11 +216,6 @@ This integration collects the following [metric data](/docs/infrastructure/integ
 
       <td>
        	The `Transform` quota for the current media service account.
-      </td>
-    </tr>
-    <tr>
-      <td>
-       Successful twin queries.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Cleaning up the metrics table

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? - just cleaning up an html table list of metrics that had an erroneous malformed row.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.