### PR TITLE
fix: remove out of context sign-up note

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
@@ -46,8 +46,6 @@ If you need to uninstall the infrastructure agent, see [Uninstall the Infrastruc
 
 ## View the infrastructure agent version [#version]
 
-Want to try out our infrastructure agent? [Create a New Relic account](https://newrelic.com/signup) for free! No credit card required.
-
 The infrastructure agent does not update itself automatically. Check the [infrastructure agent release notes](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes) to make sure you have the latest agent version.
 
 To view the current infrastructure agent version for a host, use any of these options:


### PR DESCRIPTION
## Give us some context

* There's a sign-up note that seems to be out of context in the Infra Agent upgrade documentation. Removed. 