### PR TITLE
`excerpt` -> `body` on releaseNoteLandingPage

### DIFF
--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -102,6 +102,10 @@ const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
       <Layout.Content
         css={css`
           max-width: 850px;
+
+          & img {
+            max-height: 460px;
+          }
         `}
       >
         <MDXContainer body={body} />

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -7,6 +7,7 @@ import Timeline from '../components/Timeline';
 import SEO from '../components/SEO';
 import { Button, Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import { TYPES } from '../utils/constants';
+import MDXContainer from '../components/MDXContainer';
 
 const sortByVersion = (
   { frontmatter: { version: versionA } },
@@ -138,7 +139,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
                           margin-bottom: 0;
                         `}
                       >
-                        {post.excerpt}
+                        <MDXContainer body={post.body} />
                       </p>
                     </div>
                   );
@@ -239,7 +240,7 @@ export const pageQuery = graphql`
           version
           releaseDate(formatString: "MMMM D, YYYY")
         }
-        excerpt
+        body
       }
     }
     mdx(fields: { slug: { eq: $slug } }) {

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -103,7 +103,13 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
           />
         </Link>
       </PageTitle>
-      <Layout.Content>
+      <Layout.Content
+        css={css`
+          & img {
+            max-height: 460px;
+          }
+        `}
+      >
         <Timeline>
           {postsByDate.map(([date, posts], idx) => {
             const isLast = idx === postsByDate.length - 1;


### PR DESCRIPTION
`excerpt` was only 140 characters.
some release notes on the summary page are v similar at the beginning, this should help to differentiate them