### PR TITLE
add `--upload` flag to releaseNotes script

### DIFF
--- a/.github/workflows/agent-release-notes.yml
+++ b/.github/workflows/agent-release-notes.yml
@@ -24,4 +24,4 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - name: generate and upload
-        run: scripts/releaseNotes.mjs
+        run: scripts/releaseNotes.mjs --upload

--- a/.github/workflows/agent-release-notes.yml
+++ b/.github/workflows/agent-release-notes.yml
@@ -10,8 +10,8 @@ jobs:
     name: Generate JSON
     runs-on: ubuntu-latest
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.S3_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
also updated the names of the secrets, since we were already using the old names for different access keys