### PR TITLE
chore: update Node.js APM EOL page

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/nodejs-agent-eol-policy.mdx
@@ -28,6 +28,28 @@ Any versions not listed in the following table are no longer supported. Please [
   <tbody>
     <tr>
       <td>
+        v10.1.1
+      </td>
+      <td>
+        2023-05-15
+      </td>
+      <td>
+        2024-05-15
+      </td>
+    </tr>
+      <tr>
+      <td>
+        v10.1.0
+      </td>
+      <td>
+        2023-05-04
+      </td>
+      <td>
+        2024-05-04
+      </td>
+    </tr>
+    <tr>
+      <td>
         v10.0.0
       </td>
       <td>
@@ -690,61 +712,6 @@ Any versions not listed in the following table are no longer supported. Please [
     </tr>
     <tr>
       <td>
-        v7.4.0
-      </td>
-      <td>
-        2021-05-11
-      </td>
-      <td>
-        2023-05-11
-      </td>
-    </tr>
-    <tr>
-      <td>
-        v7.3.1
-      </td>
-      <td>
-        2021-04-14
-      </td>
-      <td>
-        2023-04-14
-      </td>
-    </tr>
-    <tr>
-      <td>
-        v7.3.0
-      </td>
-      <td>
-        2021-04-06
-      </td>
-      <td>
-        2023-04-06
-      </td>
-    </tr>
-    <tr>
-      <td>
-        v7.2.1
-      </td>
-      <td>
-        2021-03-29
-      </td>
-      <td>
-        2023-03-29
-      </td>
-    </tr>
-    <tr>
-      <td>
-        v7.2.0
-      </td>
-      <td>
-        2021-03-23
-      </td>
-      <td>
-        2023-03-23
-      </td>
-    </tr>
-    <tr>
-      <td>
         v6.13.1
       </td>
       <td>
@@ -829,28 +796,6 @@ Any versions not listed in the following table are no longer supported. Please [
       </td>
       <td>
         2023-05-21
-      </td>
-    </tr>
-    <tr>
-      <td>
-        v6.7.1
-      </td>
-      <td>
-        2020-05-14
-      </td>
-      <td>
-        2023-05-14
-      </td>
-    </tr>
-    <tr>
-      <td>
-        v6.7.0
-      </td>
-      <td>
-        2020-05-07
-      </td>
-      <td>
-        2023-05-07
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Adds our two newest Node.js agent versions and removes versions that have fallen into EOL