### PR TITLE
New use-ansi config parameter for infra-agent and Fluent Bit

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -36,7 +36,7 @@ import infrastructureWindows from 'images/infrastructure_logo_windows.webp'
 
 import osAnsibleRed from 'images/os_icon_ansible-red.webp'
 
-Forwarding your logs to New Relic makes all of your logging data available in one location, providing deeper visibility into both your application and your platform performance data. With your logs in one spot, you can collect, process, explore, query, and alert on errors or anomalies found in your log data. 
+Forwarding your logs to New Relic makes all of your logging data available in one location, providing deeper visibility into both your application and your platform performance data. With your logs in one spot, you can collect, process, explore, query, and alert on errors or anomalies found in your log data.
 
 <img
   title="Logs in context for a host"
@@ -75,7 +75,7 @@ When you use our guided install to install the infrastructure agent, the log for
 
 <InlineSignup/>
 
-To initiate your install, choose your deployment method: 
+To initiate your install, choose your deployment method:
 
 <TechTileGrid>
   <TechTile
@@ -129,9 +129,9 @@ To initiate your install, choose your deployment method:
 
 ## Enable log forwarding on agent installed manually [#manual]
 
-To install the infrastructure agent manually, follow our [tutorial to install the package manager](/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux-using-package-manager), or check out our [MSI installer](/docs/infrastructure/install-configure-manage-infrastructure/windows-installation/install-infrastructure-windows-server-using-msi-installer) (Windows). 
+To install the infrastructure agent manually, follow our [tutorial to install the package manager](/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-agent-linux-using-package-manager), or check out our [MSI installer](/docs/infrastructure/install-configure-manage-infrastructure/windows-installation/install-infrastructure-windows-server-using-msi-installer) (Windows).
 
-### Step 1. Configure the infrastructure agent 
+### Step 1. Configure the infrastructure agent
 
 Configuration files direct your system to forward the log sources you want to appear in New Relic. You can add as many config files as you want. Our infrastructure agent uses `.yml` files to configure logging. If you install the infrastructure agent via [Add data](https://one.newrelic.com/marketplace?state=78678a7f-91c5-ca40-ac55-e6b74a50085c) in the UI, the file `logging.yml` is created automatically.
 
@@ -191,7 +191,7 @@ The agent automatically processes new configuration files without having to rest
 
 ### Step 2. Set log forwarding parameters [#parameters]
 
-You're required to set up a `name` and log source parameter in the log forwarding `.yml` config file. To start, define a `name` of the log or logs you want to forward to New Relic. 
+You're required to set up a `name` and log source parameter in the log forwarding `.yml` config file. To start, define a `name` of the log or logs you want to forward to New Relic.
 
 What you use for the log source depends on the location your logs are sourced from. Available options for the log source include:
 
@@ -326,6 +326,7 @@ What you use for the log source depends on the location your logs are sourced fr
     * `channel:` name of the channel logs will be collected from.
     * `collect-eventids:` a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
     * `exclude-eventids:` a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
+    * `use-ansi:` use ANSI encoding on winevtlog messages. We use ANSI encoding by default on Windows Server 2016 and older versions, and UTF-8 on newer ones. You can override this behaviour with this configuration parameter if these defaults do not suit your use case.
 
       All events are collected from the specified channel by default. Configure the `collect-eventids` and `exclude-eventids` sections to avoid sending unwanted logs to your New Relic account.
 
@@ -386,6 +387,7 @@ What you use for the log source depends on the location your logs are sourced fr
     * `channel:` name of the channel logs will be collected from. It doesn't work for custom channels.
     * `collect-eventids:` a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
     * `exclude-eventids:` a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
+    * `use-ansi:` use ANSI encoding on winlog messages. We use ANSI encoding by default on Windows Server 2016 and older versions, and UTF-8 on newer ones. You can override this behaviour with this configuration parameter if these defaults do not suit your use case.
 
       All events are collected from the specified channel by default. Configure the `collect-eventids` and `exclude-eventids` sections to avoid sending unwanted logs to your New Relic account.
 
@@ -922,9 +924,9 @@ If you encounter problems with configuring your log forwarder, try these trouble
     You can configure the infrastructure agent to send its own logs to New Relic. This is useful for troubleshooting issues with log forwarding, the agent, or when contacting [support](https://support.newrelic.com/).
 
 <Callout variant="important">
-  Trace logging generates a lot of data very quickly. To reduce disk space consumption and data ingest, when finished generating logs, be sure to set `level: info` (or lower). 
+  Trace logging generates a lot of data very quickly. To reduce disk space consumption and data ingest, when finished generating logs, be sure to set `level: info` (or lower).
 </Callout>
-    
+
     To forward the infrastructure agent logs to New Relic:
 
     1. Edit your `newrelic-infra.yml` file.
@@ -940,23 +942,23 @@ If you encounter problems with configuring your log forwarder, try these trouble
 
  This configuration sets up the agent in troubleshooting mode, but the log forwarder (based on [Fluent Bit](https://fluentbit.io/)) will continue in a non-verbose mode.
   </Collapser>
-  
+
   <Collapser
     className="freq-link"
     id="fluentbit-logs"
     title="Enabling verbose mode in the log forwarder (Fluent Bit)"
   >
     Sometimes you can have issues with the log forwarder itself. For example, there may be problems accessing a specific channel when shipping Windows log events or when accessing a particular log file. In these situations, you can also enable the verbose mode for the log forwarder.
-    
+
 <Callout variant="important">
-  Trace logging generates a lot of data very quickly. To reduce disk space consumption and data ingest, when finished generating logs, be sure to set `level: info` (or lower). 
+  Trace logging generates a lot of data very quickly. To reduce disk space consumption and data ingest, when finished generating logs, be sure to set `level: info` (or lower).
 </Callout>
-    
+
     1. Edit your `newrelic-infra.yml` file.
     2. Enable Fluent Bit verbose logs by adding the following config snippet
        ```yml
        log:
-         level: trace 
+         level: trace
          forward: true # Enables sending logs to New Relic
          format: json # Recommended: Enable agent logging in JSON format
          stdout: false # On Windows and systems that don't use `systemd` or where `journald` is inaccessible
@@ -992,7 +994,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
        ```
 
     3. If you get the following error, update OpenSSL to 1.1.0 or higher:
-    
+
        ```
        error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
        ```

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -326,7 +326,7 @@ What you use for the log source depends on the location your logs are sourced fr
     * `channel:` name of the channel logs will be collected from.
     * `collect-eventids:` a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
     * `exclude-eventids:` a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
-    * `use-ansi:` use ANSI encoding on winevtlog messages. We use ANSI encoding by default on Windows Server 2016 and older versions, and UTF-8 on newer ones. You can override this behaviour with this configuration parameter if these defaults do not suit your use case.
+    * `use-ansi:` use ANSI encoding on winevtlog messages. We use ANSI encoding by default on Windows Server 2016 and older versions, and UTF-8 on newer ones. You can override this behavior with this configuration parameter if these defaults do not suit your use case.
 
       All events are collected from the specified channel by default. Configure the `collect-eventids` and `exclude-eventids` sections to avoid sending unwanted logs to your New Relic account.
 
@@ -387,7 +387,7 @@ What you use for the log source depends on the location your logs are sourced fr
     * `channel:` name of the channel logs will be collected from. It doesn't work for custom channels.
     * `collect-eventids:` a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
     * `exclude-eventids:` a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
-    * `use-ansi:` use ANSI encoding on winlog messages. We use ANSI encoding by default on Windows Server 2016 and older versions, and UTF-8 on newer ones. You can override this behaviour with this configuration parameter if these defaults do not suit your use case.
+    * `use-ansi:` use ANSI encoding on winlog messages. We use ANSI encoding by default on Windows Server 2016 and older versions, and UTF-8 on newer ones. You can override this behavior with this configuration parameter if these defaults do not suit your use case.
 
       All events are collected from the specified channel by default. Configure the `collect-eventids` and `exclude-eventids` sections to avoid sending unwanted logs to your New Relic account.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Added a new configuration parameter `use-ansi` for infrastructure agent and Fluent Bit integration.

* If your issue relates to an existing GitHub issue, please link to it.
The new parameter is related to this [pull-request](https://github.com/newrelic/infrastructure-agent/pull/1661) pending on reviewing and merging by CAOS team.