### PR TITLE
Update net-configure-logs-context-all.mdx

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -100,7 +100,7 @@ You have three options to configure <InlinePopover type="apm" /> logs in context
 
   The .NET logging libraries we instrument typically store context data key-value pairs on each log event as a `Dictionary<string,object>`. To convert the values to strings before being sent to New Relic, we first attempt to use `Newtonsoft.Json.JsonConvert.SerializeObject`. If that fails, we attempt to call `.ToString()` on the object; as a last resort we will send the type name.
 
-  You can filter context data using the `include` and `exclude` configuration options. These are comma-separated lists of attribute names. The default values for both are empty strings; an empty `include` field means "include everything". These include/exclude options follow the same rules as other [agent attribute configuration options](docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls).
+  You can filter context data using the `include` and `exclude` configuration options. These are comma-separated lists of attribute names. The default values for both are empty strings; an empty `include` field means "include everything". These include/exclude options follow the same rules as other [agent attribute configuration options](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls).
   
   For example, to include all attributes that start with "a" except "apple", and exclude all attributes that start with "b" except "banana", use the following configuration:
 


### PR DESCRIPTION
The use of _relative_ path leads to https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls/, which is wrong.