### PR TITLE
Add release notes for Kubernetes integration v.3.12.0

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-12-0.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-3-12-0.mdx
@@ -1,0 +1,15 @@
+---
+subject: Kubernetes integration
+releaseDate: '2023-05-15'
+version: 3.12.0
+---
+
+### Changed
+
+* Added support for scraping metrics for Cronjobs, Jobs, PersistentVolumes and PersistentVolumeClaims
+* Added KSM metrics recently promoted to stable category
+* Added more workload name fields to K8sContainerSample, K8sPodSample
+* Performance improvements
+* Updated dependencies
+
+Full Changelog: https://github.com/newrelic/nri-kubernetes/compare/v3.9.0...v3.12.0


### PR DESCRIPTION
This PR updates the release notes for the Kubernetes integration docs.