### PR TITLE
Logs: Left-justify two sentences by removing spaces

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -1143,7 +1143,7 @@ The following instructions summarize how to increase these limits if you want to
     - Open Suse (SLES) 15.4
     - Amazon Linux 2023
 
-    
+
     If you wish to revert to td-agent-bit, you can follow the steps outlined below:
 
     1. Open the file `/etc/newrelic-infra.yml` using your preferred text editor.
@@ -1151,7 +1151,7 @@ The following instructions summarize how to increase these limits if you want to
     3. Save the changes.
     4. Restart the infrastructure agent by executing the following command: `sudo systemctl restart newrelic-infra`.
 
-    
+
     By completing these steps, the infrastructure agent will be configured to use td-agent-bit instead of fluent-bit.
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
I had pushed up a fix earlier to left-justify two sentences, but alas, the fix didn't work. This should fix them.