### PR TITLE
Update .NET Performance Metrics documentation to point to new UI page

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-features/net-performance-metrics.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/net-performance-metrics.mdx
@@ -13,7 +13,12 @@ New Relic's .NET Agent collects metrics from the .NET runtime about the performa
 
 The full suite of .NET Performance Metrics is available .NET Agent versions 8.20 and higher.
 
-To view these metrics, create a custom [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards). Alternatively, you may use the **Metric explorer** under **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > More views**.
+These metrics can be viewed in the **Dotnet VMs** page in [New Relic](https://one.newrelic.com/all-capabilities) under **APM & services > (select an app) > More views**.
+
+Other ways to view these metrics include:
+
+* Create a custom [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards). 
+* Use the **Metric explorer** under **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > More views**.
 
 ## CPU metrics [#cpu-metrics]
 

--- a/src/content/docs/apm/agents/net-agent/other-features/net-performance-metrics.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/net-performance-metrics.mdx
@@ -13,12 +13,12 @@ New Relic's .NET Agent collects metrics from the .NET runtime about the performa
 
 The full suite of .NET Performance Metrics is available .NET Agent versions 8.20 and higher.
 
-These metrics can be viewed in the **Dotnet VMs** page in [New Relic](https://one.newrelic.com/all-capabilities) under **APM & services > (select an app) > More views**.
+You can see these metrics **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & services**, select an application and go to **More views** > **Dotnet VMs**.
 
-Other ways to view these metrics include:
+You can also view these metrics by:
 
-* Create a custom [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards). 
-* Use the **Metric explorer** under **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > More views**.
+* Creating a custom [dashboard](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards). 
+* Using the **Metric explorer** in **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & services** > select an application, and go to **More views**.
 
 ## CPU metrics [#cpu-metrics]
 


### PR DESCRIPTION
We finally have a real APM UI page for .NET CLR (VM) performance metrics.  This PR updates the documentation about these metrics to point users to the new UI.