### PR TITLE
May 23 - Update networks doc for the Azure Monitor release

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -628,7 +628,7 @@ Network blocks for EU region accounts:
 * `161.156.125.32/28` (Private Data Center)
 * `3.77.79.0/25` (AWS, EU-CENTRAL-1, effective July 1st, 2023)
 
-These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations).
+These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations) except [Azure Monitor Integration](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor/).
 
 ## Pixie integration [#pixie-integration]
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -628,7 +628,7 @@ Network blocks for EU region accounts:
 * `161.156.125.32/28` (Private Data Center)
 * `3.77.79.0/25` (AWS, EU-CENTRAL-1, effective July 1st, 2023)
 
-These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations) except [Azure Monitor Integration](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor/).
+These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations). However, they don't apply to the [Azure Monitor integration](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor/).
 
 ## Pixie integration [#pixie-integration]
 


### PR DESCRIPTION
IP range limitations does not apply for Azure Monitor integration. Azure Monitor GA is going live on May 23rd. Please approve this change on the GA date.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.