### PR TITLE
May 23 - Update the Azure Monitor doc for the Azure Monitor release

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -39,6 +39,7 @@ Requirements for using the Azure Monitor integration:
 * Create a New Relic application and key in Azure.
 * Grant this application access to the Azure services you want to monitor.
 * Place required information in the integrations UI.
+* New Relic generated traffic for Azure Monitor integration does not use designated [IP address](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#webhooks). Please do not set IP address based filtering when using Azure Monitor integration.
 
 Note that this integration can also be used by setting up the [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native).
 

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -39,7 +39,7 @@ Requirements for using the Azure Monitor integration:
 * Create a New Relic application and key in Azure.
 * Grant this application access to the Azure services you want to monitor.
 * Place required information in the integrations UI.
-* New Relic generated traffic for Azure Monitor integration does not use designated [IP address](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#webhooks). Please do not set IP address based filtering when using Azure Monitor integration.
+* New Relic generated traffic for Azure Monitor integration doesn't use designated [IP addresses](/docs/new-relic-solutions/get-started/networks/#webhooks). Don't set up filtering based on IP address when using Azure Monitor integration.
 
 Note that this integration can also be used by setting up the [Azure Native New Relic Service](/docs/infrastructure/microsoft-azure-integrations/get-started/azure-native).
 


### PR DESCRIPTION
IP address range mentioned in https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#webhooks does not apply for Azure Monitor integration. Azure monitor integration is going GA on May 23rd. Please approve this change on May 23rd.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.