### PR TITLE
OpenTelemetry: Make "Collector" upper case when it follows "OpenTelemetry."

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-setup.mdx
@@ -265,7 +265,7 @@ If you’re not seeing the type of detail you want in the UI, you can increase t
 ### OpenTelemetry sampling [#otel-sampling]
 
 <Callout variant="tip">
-  This section only applies if your services are sending data to New Relic via an OpenTelemetry collector. This is because the data isn’t being sampled in an OpenTelemetry collector.
+  This section only applies if your services are sending data to New Relic via an OpenTelemetry Collector. This is because the data isn’t being sampled in an OpenTelemetry Collector.
 </Callout>
 
 For OpenTelemetry, all external services views are populated by sampled traces, which means that you may not see enough useful data. To resolve this, you can change the sampling in the collector to allow more data into New Relic.

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
@@ -19,7 +19,7 @@ After completing the steps below, you can use the New Relic UI to correlate appl
 The steps in this guide enable your application to inject infrastructure-specific metadata into the telemetry data. The result is that the New Relic UI is populated with actionable information. Here are the steps you'll take to get this going:
 
   * In each application container, define an environment variable to send telemetry data to the collector
-  * Deploy the OpenTelemetry collector as a `DaemonSet` in [agent mode](https://opentelemetry.io/docs/collector/getting-started/#agent) with `resourcedetection`, `resource`, `batch` and `k8sattributes` processors to inject relevant metadata (cluster, deployment, and namespace names)
+  * Deploy the OpenTelemetry Collector as a `DaemonSet` in [agent mode](https://opentelemetry.io/docs/collector/getting-started/#agent) with `resourcedetection`, `resource`, `batch` and `k8sattributes` processors to inject relevant metadata (cluster, deployment, and namespace names)
 
 ## Prerequisites [#prereqs]
 
@@ -33,12 +33,12 @@ To be successful with the steps below, you should already be familiar with OpenT
 
 If you have general questions about using collectors with New Relic, see our [Introduction to OpenTelemetry Collector with New Relic](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
-## Configure your application to send telemetry data to the OpenTelemetry collector [#instrument]
+## Configure your application to send telemetry data to the OpenTelemetry Collector [#instrument]
 
 To set this up, you need to add a custom snippet to the `env` stanza of your Kubernetes YAML file. We have an example below that shows the snippet for a sample frontend microservice (`Frontend.yaml`). The snippet includes two sections that do the following:
 
   * **Section 1:** Ensure that the telemetry data is sent to the collector. This sets the environment variable `OTEL_EXPORTER_OTLP_ENDPOINT` with the host IP. It does this by calling the downward API to pull the host IP.
-  * **Section 2:** Attach infrastructure-specific metadata. To do this, we capture `metadata.uid` using the downward API and add it to the OTEL_RESOURCE_ATTRIBUTES environment variable. This environment variable is used by the OpenTelemetry collector’s `resourcedetection` and `k8sattributes` processors to add additional infrastructure-specific context to telemetry data.
+  * **Section 2:** Attach infrastructure-specific metadata. To do this, we capture `metadata.uid` using the downward API and add it to the OTEL_RESOURCE_ATTRIBUTES environment variable. This environment variable is used by the OpenTelemetry Collector’s `resourcedetection` and `k8sattributes` processors to add additional infrastructure-specific context to telemetry data.
 
 For each microservice instrumented with OpenTelemetry, add the highlighted lines below to your manifest’s `env` stanza:
 
@@ -75,7 +75,7 @@ fieldPath: metadata.uid
       value: service.instance.id=$(POD_NAME),k8s.pod.uid=$(POD_UID)”
 ```
 
-## Configure and deploy the OpenTelemetry collector as an agent [#agent]
+## Configure and deploy the OpenTelemetry Collector as an agent [#agent]
 
 We recommend you deploy the [collector as an agent](https://opentelemetry.io/docs/collector/getting-started/#agent) on every node within a Kubernetes cluster. The agent can receive telemetry data as well as enrich telemetry data with metadata. For example, the collector can add custom attributes or infrastructure information through processors as well as handle batching, retry, compression and other more advanced features that are handled less efficiently at the client instrumentation level.
 
@@ -147,7 +147,7 @@ service:
 
 ### Step 1: Configure the OTLP exporter [#otlp-exporter]
 
-First, configure it by adding an OTLP exporter to your [OpenTelemetry collector configuration YAML file](https://opentelemetry.io/docs/collector/configuration/) along with your New Relic <InlinePopover type="licenseKey" /> as a header.
+First, configure it by adding an OTLP exporter to your [OpenTelemetry Collector configuration YAML file](https://opentelemetry.io/docs/collector/configuration/) along with your New Relic <InlinePopover type="licenseKey" /> as a header.
 
 ```yaml
 exporters:
@@ -187,7 +187,7 @@ Detectors: [ gke, gce ]
 
 ### Step 4: Configure the Kubernetes Attributes processor (general) [#attributes-general]
 
-When we run the `k8sattributes` processor as part of the OpenTelemetry collector running as an agent, it detects IP addresses of pods sending telemetry data to the OpenTelemetry collector agent, using them to extract pod metadata. Below is a basic Kubernetes manifest example with only a processors section. To deploy the OpenTelemetry collector as a `DaemonSet`, read this [comprehensive manifest example](https://github.com/newrelic-forks/microservices-demo/tree/main/src/otel-collector-agent).
+When we run the `k8sattributes` processor as part of the OpenTelemetry Collector running as an agent, it detects IP addresses of pods sending telemetry data to the OpenTelemetry Collector agent, using them to extract pod metadata. Below is a basic Kubernetes manifest example with only a processors section. To deploy the OpenTelemetry Collector as a `DaemonSet`, read this [comprehensive manifest example](https://github.com/newrelic-forks/microservices-demo/tree/main/src/otel-collector-agent).
 
 ```yaml
 processors:
@@ -218,7 +218,7 @@ You need to add configurations for role based access control (RBAC). The `k8satt
 
 When running the collector as an agent, you should apply a discovery filter so that the processor only discovers pods from the same host that it is running on. If you don’t use a filter, resource usage can be unnecessarily high, especially on very large clusters. Once the filter is applied, each processor will only query the Kubernetes API for pods running on its own node.
 
-To set the filter, use the downward API to inject the node name as an environment variable in the pod `env` section of the OpenTelemetry collector agent configuration YAML file (see [GitHub](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/examples/kubernetes/otel-collector-config.yml) for an example). This will inject a new environment variable to the OpenTelemetry collector agent’s container. The value will be the name of the node the pod was scheduled to run on.
+To set the filter, use the downward API to inject the node name as an environment variable in the pod `env` section of the OpenTelemetry Collector agent configuration YAML file (see [GitHub](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/examples/kubernetes/otel-collector-config.yml) for an example). This will inject a new environment variable to the OpenTelemetry Collector agent’s container. The value will be the name of the node the pod was scheduled to run on.
 
 ```yaml
 spec:

--- a/src/content/docs/logs/get-started/get-started-log-management.mdx
+++ b/src/content/docs/logs/get-started/get-started-log-management.mdx
@@ -62,7 +62,7 @@ To forward your log data to New Relic, you can use one or more of these options:
 * **[Use our infrastructure agent to report logs](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent).** With our infrastructure agent, you can capture any logs present on your host, including your app logs. Compared to using an APM agent to report logs, this can take a little more setting up but gives you much more powerful options (for example, ability to collect custom attributes, which you can't do with <InlinePopover type="apm" /> agents). 
 * **Use third-party log services.** We have [a wide range of integrations for other log services](/docs/logs/forward-logs/enable-log-management-new-relic), including Amazon, Microsoft, Fluentd, Fluent Bit, Kubernetes, Logstash, and more.
 * **Reports logs using the [Log API](/docs/logs/log-api/introduction-log-api/) or [TCP endpoint](/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic).**
-* **Use the OpenTelemetry SDK to send logs** from your apps to an [OpenTelemetry collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
+* **Use the OpenTelemetry SDK to send logs** from your apps to an [OpenTelemetry Collector](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs), which can forward them to New Relic via OTLP.
 
 For more on log forwarding options and specific use cases, see [Forward logs](/docs/logs/forward-logs/enable-log-management-new-relic).
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces.mdx
@@ -28,7 +28,7 @@ Trace data is the most mature OpenTelemetry data type. Because of this, New Reli
 You can configure sampling in a number of places:
 
 * **Service:** Use the OpenTelemetry SDK for your language.
-* **Collector:** If you're running your own instance of the OpenTelemetry collector, you can configure it to do more sophisticated forms of sampling, such as tail-based sampling ([see below](#infinite-tracing)).
+* **Collector:** If you're running your own instance of the OpenTelemetry Collector, you can configure it to do more sophisticated forms of sampling, such as tail-based sampling ([see below](#infinite-tracing)).
 
 Check out this documentation about how to configure different types of sampling:
 
@@ -46,7 +46,7 @@ Check out this documentation about how to configure different types of sampling:
     id="ot-tail-based"
     title="OpenTelemetry tail-based samplers"
   >
-    The OpenTelemetry collector has a [tail-based sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
+    The OpenTelemetry Collector has a [tail-based sampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-implementation-guide.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-implementation-guide.mdx
@@ -78,7 +78,7 @@ Before putting OpenTelemetry into production with an application, it's best to p
 
 * Measure the overhead of OpenTelemetry instrumentation on the application, by analyzing incremental CPU and memory utilization, as well as service latency.  
 * Measure the data egress volume from the collector and ingest volume into New Relic, as both will increase ingest and have potential billing impacts. 
-* This also provides an opportunity to load test the OpenTelemetry collector, and ensure it can sufficiently handle production-like load. For tips on scaling the Collector, see [the OpenTelemetry docs](https://opentelemetry.io/docs/collector/scaling).
+* This also provides an opportunity to load test the OpenTelemetry Collector, and ensure it can sufficiently handle production-like load. For tips on scaling the Collector, see [the OpenTelemetry docs](https://opentelemetry.io/docs/collector/scaling).
 
 ## 5. Define service level objectives [#slos]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq.mdx
@@ -5,9 +5,9 @@ tags:
   - Open source telemetry integrations
   - OpenTelemetry
   - HiveMQ
-metaDescription: You can collect HiveMQ metrics using the OpenTelemetry collector.
+metaDescription: You can collect HiveMQ metrics using the OpenTelemetry Collector.
 ---
-You can collect metrics about your HiveMQ MQTT messaging platform with the OpenTelemetry collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
+You can collect metrics about your HiveMQ MQTT messaging platform with the OpenTelemetry Collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
 
 <Callout variant="tip">
   If you're looking for help with other collector use cases, see the [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples) repository.
@@ -85,7 +85,7 @@ You may check [Opentelemetry Collector docs](https://opentelemetry.io/docs/colle
     </Step>
 
    <Step>
-  ## Run the OpenTelemetry collector [#run-collector]
+  ## Run the OpenTelemetry Collector [#run-collector]
 
 Run the Opentelemetry collector (the way to run it may vary depending on the choosen installation method). Example:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -6,9 +6,9 @@ tags:
   - OpenTelemetry
   - Kafka
   - Confluent Cloud
-metaDescription: You can collect Kafka metrics from Confluent using the OpenTelemetry collector.
+metaDescription: You can collect Kafka metrics from Confluent using the OpenTelemetry Collector.
 ---
-You can collect metrics about your Confluent Cloud-managed Kafka deployment with the OpenTelemetry collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
+You can collect metrics about your Confluent Cloud-managed Kafka deployment with the OpenTelemetry Collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
 
 <Callout variant="tip">
   If you're looking for help with other collector use cases, see the [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples) repository.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid.mdx
@@ -5,9 +5,9 @@ tags:
   - Open source telemetry integrations
   - OpenTelemetry
   - Squid
-metaDescription: You can collect Squid metrics using the OpenTelemetry collector.
+metaDescription: You can collect Squid metrics using the OpenTelemetry Collector.
 ---
-You can collect metrics about your Squid Cache Manager with the OpenTelemetry collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
+You can collect metrics about your Squid Cache Manager with the OpenTelemetry Collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
 
 <Callout variant="tip">
   If you're looking for help with other collector use cases, see the [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples) repository.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
@@ -4,10 +4,10 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Here is a simple Docker example to set up an OpenTelemetry collector with New Relic.
+metaDescription: Here is a simple Docker example to set up an OpenTelemetry Collector with New Relic.
 ---
 
-Instead of sending telemetry from your apps directly to New Relic, you can first send it to an OpenTelemetry collector. You can use the collector to process your telemetry data, and then export it to New Relic (or any other backend). To learn about what kinds of processing you can do in the collector, see our [introduction](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
+Instead of sending telemetry from your apps directly to New Relic, you can first send it to an OpenTelemetry Collector. You can use the collector to process your telemetry data, and then export it to New Relic (or any other backend). To learn about what kinds of processing you can do in the collector, see our [introduction](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
 The Docker example below is meant to serve as starting point from which you can extend, customize, and validate configurations before using them in production.
 
@@ -47,7 +47,7 @@ The collector setup is part of the larger process of setting up OpenTelemetry wi
         exporters: [otlp]
   ```
 
-2. Run the OpenTelemetry collector after you make the following changes:
+2. Run the OpenTelemetry Collector after you make the following changes:
    * Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
    * Replace `YOUR_KEY_HERE` with your <InlinePopover type="licenseKey" />.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-configs.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-configs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "General OpenTelemetry collector configurations"
+title: "General OpenTelemetry Collector configurations"
 tags:
   - Integrations
   - Open source telemetry integrations

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: The OpenTelemetry collector is a central tool to collect, process, and export your telemetry.
+metaDescription: The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry.
 ---
 
 You can collect metrics about your infrastructure hosts with OpenTelemetry if you set up the host receiver in a  collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
@@ -18,7 +18,7 @@ Make sure you've completed the following before going further:
 * If you haven't already done so, sign up for a free [New Relic account](https://newrelic.com/signup).
 * Get the <InlinePopover type="licenseKey" /> for the New Relic account to which you want to report data.
 
-## Step 2: Install the OpenTelemetry collector [#install-generic]
+## Step 2: Install the OpenTelemetry Collector [#install-generic]
 
 To do a basic installation for single hosts in the cloud or on-premises, see [OpenTelemetry's instructions](https://opentelemetry.io/docs/collector/getting-started/#linux-packaging) for up-to-date installation steps from the community. Instructions are available for the following:
 
@@ -30,7 +30,7 @@ To do a basic installation for single hosts in the cloud or on-premises, see [Op
 Your deployment experience might vary depending on which vendor-specific distributions you use. For example, installation via a package manager might be available for Linux hosts.
 
 <Callout variant="important">
-  To set up infrastructure monitoring, you need to install and configure components that are included in the `collector-contrib` release. For example, the host receiver is required to collect basic host metrics such as CPU, memory, disk, and network stats and is only available in the [OpenTelemetry collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) release.
+  To set up infrastructure monitoring, you need to install and configure components that are included in the `collector-contrib` release. For example, the host receiver is required to collect basic host metrics such as CPU, memory, disk, and network stats and is only available in the [OpenTelemetry Collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) release.
 </Callout>
 
 ## Step 3: Configure host monitoring using the host receiver [#host-receiver]

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro.mdx
@@ -1,15 +1,15 @@
 ---
-title: Introduction to the OpenTelemetry collector with New Relic
+title: Introduction to the OpenTelemetry Collector with New Relic
 tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: The OpenTelemetry collector is a central tool to collect, process, and export your telemetry to New Relic and beyond.
+metaDescription: The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry to New Relic and beyond.
 ---
 
 import opentelemetryNativeOtlpWithCollector from 'images/opentelemetry_diagram_native-otlp-with-collector.webp'
 
-The OpenTelemetry collector is a component you can implement to receive and process your telemetry data before exporting it to New Relic or another observability backend. Instead of sending data from your apps directly to New Relic, you can first route it to a central collector. This shifts the overhead of managing telemetry away from your apps and moves it into a single component.
+The OpenTelemetry Collector is a component you can implement to receive and process your telemetry data before exporting it to New Relic or another observability backend. Instead of sending data from your apps directly to New Relic, you can first route it to a central collector. This shifts the overhead of managing telemetry away from your apps and moves it into a single component.
 
 <img
   title="Diagram of OTLP with collector"

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s.mdx
@@ -4,10 +4,10 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: You can use the OpenTelemetry collector to monitor your Kubernetes clusters.
+metaDescription: You can use the OpenTelemetry Collector to monitor your Kubernetes clusters.
 ---
 
-If you already have apps instrumented with OpenTelemetry in a Kubernetes cluster, you can use an OpenTelemetry collector to enhance your current telemetry with metadata about Kubernetes. This can help you see the effects of Kubernetes on your apps. For example, tracing spans will show which Kubernetes cluster, node, pod, and container are involved.
+If you already have apps instrumented with OpenTelemetry in a Kubernetes cluster, you can use an OpenTelemetry Collector to enhance your current telemetry with metadata about Kubernetes. This can help you see the effects of Kubernetes on your apps. For example, tracing spans will show which Kubernetes cluster, node, pod, and container are involved.
 
 You can find more details about how to do this in [Link OpenTelemetry-instrumented applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes).
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-get-started-intro.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-get-started-intro.mdx
@@ -23,11 +23,11 @@ If you're familiar with OpenTelemetry and are ready to work with your own code, 
 
 ## Monitor a host [#otel-infra]
 
-You can monitor your hosts by using the OpenTelemetry collector. See [Collector for host monitoring](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts).
+You can monitor your hosts by using the OpenTelemetry Collector. See [Collector for host monitoring](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts).
 
 ## Monitor Kubernetes [#otel-kubernetes]
 
-Monitor your Kubernetes clusters with the OpenTelemetry collector. See the instructions in [Link OpenTelemetry-instrumented applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes/).
+Monitor your Kubernetes clusters with the OpenTelemetry Collector. See the instructions in [Link OpenTelemetry-instrumented applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes/).
 
 ## Try out a demo Java app [#demo-app-java]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app.mdx
@@ -68,7 +68,7 @@ You have two choices for exporting data to New Relic via OTLP:
   <figcaption>
     The OTLP exporter in your app or service can export directly to the New Relic OTLP receiver.
   </figcaption>
-* Export from an OpenTelemetry collector:
+* Export from an OpenTelemetry Collector:
 
   <img
     title="Diagram showing the export to New Relic from a collector"

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -73,7 +73,7 @@ While each tutorial uses the same demo app, they have different approaches to he
 <Callout variant="tip">
 You have two choices for exporting data from your application to New Relic via OTLP:
 * Directly from your app
-* Via an OpenTelemetry collector
+* Via an OpenTelemetry Collector
 
 This guide covers the first option. If you wish to export your data via a collector, check out this [collector documentation](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic/) for details.
 </Callout>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -218,7 +218,7 @@ We recommend you start with the table at the beginning that shows high-level com
         ✅
       </td>
       <td>
-        ✅ The OpenTelemetry collector is one powerful tool for this purpose, requiring additional management
+        ✅ The OpenTelemetry Collector is one powerful tool for this purpose, requiring additional management
       </td>
     </tr>
     <tr>
@@ -946,7 +946,7 @@ Any data reported directly using the New Relic ingest endpoints (MELT, OTLP, etc
   >
     New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ✅ 
 
-    Host entities with golden metrics are available independent of the data source: New Relic infrastructure agent vs. OpenTelemetry collector host receiver.
+    Host entities with golden metrics are available independent of the data source: New Relic infrastructure agent vs. OpenTelemetry Collector host receiver.
   </Collapser>
   <Collapser
     className="freq-link"
@@ -1129,7 +1129,7 @@ Conditions, violations, incidents, and issues all work for any entity.
   >
     New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: ❌
 
-    The restrictions on data enforced by New Relic agents' high security mode feature could be enforced by configuring or modifying the OpenTelemetry collector, but New Relic could not enforce them because OTLP does not specify such controls.
+    The restrictions on data enforced by New Relic agents' high security mode feature could be enforced by configuring or modifying the OpenTelemetry Collector, but New Relic could not enforce them because OTLP does not specify such controls.
   </Collapser>
   <Collapser
     className="freq-link"

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-ref-architecture.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-ref-architecture.mdx
@@ -13,7 +13,7 @@ If you need guidance implementing OpenTelemetry with New Relic, this reference a
 
 The diagram shows an implementation that ingests telemetry from OpenTelemetry, Prometheus, Jaeger, and a New Relic <InlinePopover type="apm" /> agent. The three services (A, B, and C) are instrumented to send metrics, traces, and logs.
 
-For data collected by OpenTelemetry, you can either send it directly to New Relic via the OTLP endpoint, or you can send it first to an optional OpenTelemetry collector. If you use the collector, it aggregates and enhances data pipelines before the telemetry is sent over to backends (Kafka for data analytics and New Relic for end-to-end observability).
+For data collected by OpenTelemetry, you can either send it directly to New Relic via the OTLP endpoint, or you can send it first to an optional OpenTelemetry Collector. If you use the collector, it aggregates and enhances data pipelines before the telemetry is sent over to backends (Kafka for data analytics and New Relic for end-to-end observability).
 
 Click on the diagram to enlarge it:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-troubleshooting.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-troubleshooting.mdx
@@ -90,7 +90,7 @@ For log management, you can use a structured log template to inject the `service
   For more OpenTelemetry examples with New Relic, visit the [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples) repository on GitHub.
 </Callout>
 
-## Troubleshooting the OpenTelemetry collector [#troubleshooting-collector]
+## Troubleshooting the OpenTelemetry Collector [#troubleshooting-collector]
 
 The best place for collector troubleshooting tips and monitoring practices is the up-to-date guidelines in the OpenTelemetry community. See the links below for community troubleshooting documents.
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq.mdx
@@ -5,7 +5,7 @@ tags:
   - Open source telemetry integrations
   - OpenTelemetry
   - HiveMQ
-metaDescription: You can collect HiveMQ metrics using the OpenTelemetry collector.
+metaDescription: You can collect HiveMQ metrics using the OpenTelemetry Collector.
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -6,7 +6,7 @@ tags:
   - OpenTelemetry
   - Kafka
   - Confluent Cloud
-metaDescription: You can collect Kafka metrics from Confluent using the OpenTelemetry collector.
+metaDescription: You can collect Kafka metrics from Confluent using the OpenTelemetry Collector.
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid.mdx
@@ -5,7 +5,7 @@ tags:
   - Open source telemetry integrations
   - OpenTelemetry
   - Squid
-metaDescription: You can collect Squid metrics using the OpenTelemetry collector.
+metaDescription: You can collect Squid metrics using the OpenTelemetry Collector.
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Here is a simple Docker example to set up an OpenTelemetry collector with New Relic.
+metaDescription: Here is a simple Docker example to set up an OpenTelemetry Collector with New Relic.
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: 'The OpenTelemetry collector is a central tool to collect, process, and export your telemetry.'
+metaDescription: 'The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry.'
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: 'The OpenTelemetry collector is a central tool to collect, process, and export your telemetry to New Relic and beyond.'
+metaDescription: 'The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry to New Relic and beyond.'
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s.mdx
+++ b/src/i18n/content/jp/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: You can use the OpenTelemetry collector to monitor your Kubernetes clusters.
+metaDescription: You can use the OpenTelemetry Collector to monitor your Kubernetes clusters.
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq.mdx
@@ -5,7 +5,7 @@ tags:
   - Open source telemetry integrations
   - OpenTelemetry
   - HiveMQ
-metaDescription: You can collect HiveMQ metrics using the OpenTelemetry collector.
+metaDescription: You can collect HiveMQ metrics using the OpenTelemetry Collector.
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -6,7 +6,7 @@ tags:
   - OpenTelemetry
   - Kafka
   - Confluent Cloud
-metaDescription: You can collect Kafka metrics from Confluent using the OpenTelemetry collector.
+metaDescription: You can collect Kafka metrics from Confluent using the OpenTelemetry Collector.
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid.mdx
@@ -5,7 +5,7 @@ tags:
   - Open source telemetry integrations
   - OpenTelemetry
   - Squid
-metaDescription: You can collect Squid metrics using the OpenTelemetry collector.
+metaDescription: You can collect Squid metrics using the OpenTelemetry Collector.
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Here is a simple Docker example to set up an OpenTelemetry collector with New Relic.
+metaDescription: Here is a simple Docker example to set up an OpenTelemetry Collector with New Relic.
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: 'The OpenTelemetry collector is a central tool to collect, process, and export your telemetry.'
+metaDescription: 'The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry.'
 translationType: machine
 ---
 
@@ -36,7 +36,7 @@ translationType: machine
 배포 환경은 사용하는 공급업체별 배포에 따라 다를 수 있습니다. 예를 들어 패키지 관리자를 통한 설치는 Linux 호스트에서 사용할 수 있습니다.
 
 <Callout variant="important">
-  인프라 모니터링을 설정하려면 `collector-contrib` 릴리스에 포함된 구성요소를 설치하고 구성해야 합니다. 예를 들어 호스트 수신기는 CPU, 메모리, 디스크 및 네트워크 통계와 같은 기본 호스트 메트릭을 수집하는 데 필요하며 [OpenTelemetry collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) 릴리스에서만 사용할 수 있습니다.
+  인프라 모니터링을 설정하려면 `collector-contrib` 릴리스에 포함된 구성요소를 설치하고 구성해야 합니다. 예를 들어 호스트 수신기는 CPU, 메모리, 디스크 및 네트워크 통계와 같은 기본 호스트 메트릭을 수집하는 데 필요하며 [OpenTelemetry Collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) 릴리스에서만 사용할 수 있습니다.
 </Callout>
 
 ## 3단계: 호스트 수신기를 사용하여 호스트 모니터링 구성 [#host-receiver]

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: 'The OpenTelemetry collector is a central tool to collect, process, and export your telemetry to New Relic and beyond.'
+metaDescription: 'The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry to New Relic and beyond.'
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s.mdx
+++ b/src/i18n/content/kr/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: You can use the OpenTelemetry collector to monitor your Kubernetes clusters.
+metaDescription: You can use the OpenTelemetry Collector to monitor your Kubernetes clusters.
 translationType: machine
 ---
 


### PR DESCRIPTION
To conform with the OpenTelemetry spec, we needed to make "Collector" upper case when it follows "OpenTelemetry" because this is the full name. When collector appears by itself, we can use lower case.