### PR TITLE
Aws chatbot

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
@@ -109,7 +109,7 @@ To find your integration's metrics, go to **[one.newrelic.com](https://one.newre
     </tbody>
 </table>
 
-Data have one dimensions: `ConfigurationName`.
+Data have one dimension: `ConfigurationName`.
 
 ## How to use your data
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
@@ -109,7 +109,7 @@ To find your integration's metrics, go to **[one.newrelic.com](https://one.newre
     </tbody>
 </table>
 
-Data have up to two dimensions: `Language pair` and `Operation`.
+Data have one dimensions: `ConfigurationName`.
 
 ## How to use your data
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
@@ -1,13 +1,13 @@
 ---
-title: Amazon ChatBot integration
+title: Amazon Chatbot integration
 tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's Amazon ChatBot integration: what data it reports, and how to enable it."
+metaDescription: "New Relic's Amazon Chatbot integration: what data it reports, and how to enable it."
 ---
 
-[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) now include an integration for AWS ChatBot, sending its metrics data to New Relic.
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) now include an integration for AWS Chatbot, sending its metrics data to New Relic.
 
 This document explains the integration's features, how to activate it, and what data can be reported.
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
@@ -19,16 +19,16 @@ Collect and send telemetry data to New Relic from your [Translate app](https://a
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
-## Configuration and data transfer
+## Configure and transfer your data 
 
-We recommend you to [stream data](/docs/apis/nerdgraph/examples/nerdgraph-streaming-export) rather than using [polling](/docs/infrastructure/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations), though currently both options are supported.
+We recommend that you [stream data](/docs/apis/nerdgraph/examples/nerdgraph-streaming-export) instead of using [polling](/docs/infrastructure/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations), though currently both options are supported.
 
 If you choose to use polling, you can adjust the polling frequency using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
 
-This is the [default polling information](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-polling-intervals-infrastructure-integrations) for the AWS integrations:
+Our [default polling information](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-polling-intervals-infrastructure-integrations) for the AWS integrations are:
 
-- New Relic polling interval: 5 minutes
-- Amazon CloudWatch data interval: 1 minute or 5 minutes
+* New Relic polling interval: 5 minutes
+* Amazon CloudWatch data interval: 1 minute or 5 minutes
 
 ## Find and use data
 
@@ -109,12 +109,10 @@ To find your integration's metrics, go to **[one.newrelic.com](https://one.newre
     </tbody>
 </table>
 
-Data have one dimension: `ConfigurationName`.
-
-## How to use your data
+All imported data has one dimension: `ConfigurationName`.
 
 ### Create alerts
 
-You can set up alerts to notify you of breaking changes. For example, you can set up an alert to notify relevant parties of critical or fatal errors.
+You can set up alerts to notify you if there are any changes. For example, you can set up an alert to notify relevant parties of critical or fatal errors.
 
 Learn more about creating alerts [here](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts/).

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitor-integration.mdx
@@ -1,0 +1,120 @@
+---
+title: Amazon ChatBot integration
+tags:
+  - Integrations
+  - Amazon integrations
+  - AWS integrations list
+metaDescription: "New Relic's Amazon ChatBot integration: what data it reports, and how to enable it."
+---
+
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) now include an integration for AWS ChatBot, sending its metrics data to New Relic.
+
+This document explains the integration's features, how to activate it, and what data can be reported.
+
+## Features
+
+Collect and send telemetry data to New Relic from your [Translate app](https://aws.amazon.com/chatbot/) using our integration. Monitor your services, query incoming data, and build dashboards to observe everything at a glance.
+
+## Activate integration
+
+To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+
+## Configuration and data transfer
+
+We recommend you to [stream data](/docs/apis/nerdgraph/examples/nerdgraph-streaming-export) rather than using [polling](/docs/infrastructure/infrastructure-integrations/cloud-integrations/configure-polling-frequency-data-collection-cloud-integrations), though currently both options are supported.
+
+If you choose to use polling, you can adjust the polling frequency using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+
+This is the [default polling information](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-polling-intervals-infrastructure-integrations) for the AWS integrations:
+
+- New Relic polling interval: 5 minutes
+- Amazon CloudWatch data interval: 1 minute or 5 minutes
+
+## Find and use data
+
+To find your integration's metrics, go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Metrics and events** and filter by `aws.chatbot`.
+
+## Metric data
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+      Metric (min, max, average, count, sum)  
+      </th>
+      <th>
+      Unit  
+      </th>
+      <th>
+      Description
+      </th>
+    </tr>
+  </thead>
+    <tbody>
+    <tr>
+      <td>
+      `EventsThrottled`
+      </td>
+      <td>
+      count
+      </td>
+      <td>
+      The number of throttled notifications.
+      </td>
+    </tr>
+    <tr>
+      <td>
+      `EventsProcessed`     
+      </td>
+      <td>
+      count
+      </td>
+      <td>
+      The number of event notifications received by AWS Chatbot.
+      </td>
+    </tr> 
+    <tr>
+      <td>
+      `UnsupportedEvents`     
+      </td>
+      <td>
+      count
+      </td>
+      <td>
+      The number of unsupported events or messages attempted.
+      </td>
+    </tr> 
+    <tr>
+      <td>
+      `MessageDeliverySuccess`     
+      </td>
+      <td>
+      count
+      </td>
+      <td>
+      The number of messages successfully delivered to the chat client.
+      </td>
+    </tr> 
+    <tr>
+      <td>
+      `MessageDeliveryFailure`     
+      </td>
+      <td>
+      count
+      </td>
+      <td>
+        The number of messages that failed to deliver to the chat client.
+      </td>
+    </tr>
+    </tbody>
+</table>
+
+Data have up to two dimensions: `Language pair` and `Operation`.
+
+## How to use your data
+
+### Create alerts
+
+You can set up alerts to notify you of breaking changes. For example, you can set up an alert to notify relevant parties of critical or fatal errors.
+
+Learn more about creating alerts [here](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts/).

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -275,6 +275,8 @@ pages:
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration
           - title: CloudTrail integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration
+          - title: Chatbot
+            path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot
           - title: CloudWatch Internet monitor integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-internet-monitor-integration
           - title: Cognito integration

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -276,7 +276,7 @@ pages:
           - title: CloudTrail integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration
           - title: Chatbot
-            path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot
+            path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-chatbot-monitoring-integration
           - title: CloudWatch Internet monitor integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-internet-monitor-integration
           - title: Cognito integration


### PR DESCRIPTION
## Related Task

Asana Task - https://app.asana.com/0/1202974982230192/1202975068291765

## Background

Partnership Engineering Team - 

- Added AWS-chatbot Entity
- AWS Chatbot is an AWS service that enables DevOps and software development teams to use messaging program chat rooms to monitor and respond to operational events in their AWS Cloud.
- Entity PR Which is raised & Merged -
  - https://github.com/newrelic/entity-definitions/pull/1083
  - https://source.datanerd.us/entity-platform/entity-type-ui-definitions-service/pull/370
