### PR TITLE
NR-85304 Document relationships ttl

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -288,6 +288,11 @@ Entities can be related to each other in various ways. The collapser below lists
 
 ### Which relationships are automatically created? [#relationship-created]
 
+
+<Callout variant="important">
+ Automatic relationships are created based on the telemetry that is being reported by the entities. These relationships have a Time To Live (TTL). This means that they will be automatically deleted if the metrics used to create the relationship are not reported in a given period of time. The default TTL for a relationship is <b>75 minutes</b>. The TTL is configurable for each relationship, and it can go <b>from 10 minutes up to 3 days</b>.
+</Callout>
+
 These are the relationships between entities that we create automatically:
 
 <CollapserGroup>


### PR DESCRIPTION
## Give us some context

* Relationships among entities have a ttl that is used to remove/expire relationships for entities that no longer exist or just relationships that are not valid anymore. This PR adds a small comment to provide this information.