### PR TITLE
Publish 5/31: Added feature flags and release notes for Mobile 7.4.5 release May 31 2023

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
@@ -545,3 +545,77 @@ If used, be sure to call the feature flag before the New Relic iOS agent start c
     </table>
   </Collapser>
 </CollapserGroup>
+
+<CollapserGroup>
+  <Collapser
+    id="ff-fedramp"
+    title="NRFeatureFlag_FedRampEnabled"
+  >
+    Enable or disable (default) using the FedRAMP endpoints.
+
+    Available for iOS agent version 7.4.5 or higher.
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+
+            Disabled by default as of agent version 7.4.5
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+</CollapserGroup>
+
+<CollapserGroup>
+  <Collapser
+    id="ff-asyncurlsession"
+    title="NRFeatureFlag_SwiftAsyncURLSessionSupport"
+  >
+    Enable or disable (default) instrumention for async await URL sessions.
+
+    Available for iOS agent version 7.4.5 or higher.
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+
+            Disabled by default as of agent version 7.4.5
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
@@ -503,6 +503,41 @@ If used, be sure to call the feature flag before the New Relic iOS agent start c
       </tbody>
     </table>
   </Collapser>
+
+  <Collapser
+    id="ff-asyncurlsession"
+    title="NRFeatureFlag_SwiftAsyncURLSessionSupport"
+  >
+    Enable or disable (default) instrumention for async await URL sessions.
+
+    Available for iOS agent version 7.4.5 or higher.
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+
+            Disabled by default as of agent version 7.4.5
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
 </CollapserGroup>
 
 ## App launch time settings [#applaunchtime]
@@ -546,49 +581,14 @@ If used, be sure to call the feature flag before the New Relic iOS agent start c
   </Collapser>
 </CollapserGroup>
 
+## FedRAMP endpoints settings [#fedramp]
+
 <CollapserGroup>
   <Collapser
     id="ff-fedramp"
     title="NRFeatureFlag_FedRampEnabled"
   >
     Enable or disable (default) using the FedRAMP endpoints.
-
-    Available for iOS agent version 7.4.5 or higher.
-
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `false`
-
-            Disabled by default as of agent version 7.4.5
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
-</CollapserGroup>
-
-<CollapserGroup>
-  <Collapser
-    id="ff-asyncurlsession"
-    title="NRFeatureFlag_SwiftAsyncURLSessionSupport"
-  >
-    Enable or disable (default) instrumention for async await URL sessions.
 
     Available for iOS agent version 7.4.5 or higher.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
@@ -28,9 +28,23 @@ The following are the specific policies and dates for support of our iOS agent. 
 
   <tbody>
 
+   <tr>
+      <td>
+        [v7.4.5 (latest iOS agent release)](/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745/)
+      </td>
+
+      <td>
+        May 31, 2023
+      </td>
+
+      <td>
+        May 31, 2024
+      </td>
+    </tr>
+
     <tr>
       <td>
-        [v7.4.4 (latest iOS agent release)](/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-744/)
+        v7.4.4
       </td>
 
       <td>
@@ -193,20 +207,6 @@ The following are the specific policies and dates for support of our iOS agent. 
 
       <td>
         Jun 17, 2023
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        v7.3.1
-      </td>
-
-      <td>
-        Apr 30, 2021
-      </td>
-
-      <td>
-        Apr 30, 2023
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
@@ -10,7 +10,7 @@ downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agen
 * Added a feature flag for FedRAMP support.
 * Fixed Mac catalyst support.
 * Fixed an issue with tvOS not reporting carrier type as wifi.
-* Fixed an issue were the iOS agent prevented webView:decidePolicyForNavigationAction:decisionHandler: from getting called.
+* Fixed an issue where the iOS agent prevented webView:decidePolicyForNavigationAction:decisionHandler: from getting called.
 * Fixed a bug that stopped http error data from getting uploaded.
 
 ### Other notes

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
@@ -8,7 +8,6 @@ downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agen
 ## Fixed in this release
 
 * Added a feature flag for FedRAMP support.
-* Fixed Mac catalyst support.
 * Fixed an issue with tvOS not reporting carrier type as wifi.
 * Fixed an issue where the iOS agent prevented webView:decidePolicyForNavigationAction:decisionHandler: from getting called.
 * Fixed a bug that stopped http error data from getting uploaded.

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
@@ -1,6 +1,6 @@
 ---
 subject: iOS agent
-releaseDate: '2023-05-29'
+releaseDate: '2023-05-31'
 version: 7.4.5
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.4.5.zip'
 ---

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-745.mdx
@@ -1,0 +1,27 @@
+---
+subject: iOS agent
+releaseDate: '2023-05-29'
+version: 7.4.5
+downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.4.5.zip'
+---
+
+## Fixed in this release
+
+* Added a feature flag for FedRAMP support.
+* Fixed Mac catalyst support.
+* Fixed an issue with tvOS not reporting carrier type as wifi.
+* Fixed an issue were the iOS agent prevented webView:decidePolicyForNavigationAction:decisionHandler: from getting called.
+* Fixed a bug that stopped http error data from getting uploaded.
+
+### Other notes
+* Instrumentation of async await url sessions that was added in v7.4.1 has been moved behind a feature flag. To use that feature include the `NRFeatureFlag_SwiftAsyncURLSessionSupport` flag in the `enableFeatures` function.
+
+* Deprecation notice: The 7.4.0 version introduced a new Swift symbol upload script. See [installation instructions](/docs/mobile-monitoring/new-relic-mobile-ios/installation/spm-installation#configure-using-swift-package-manager) for details on how to update to the new script. In a future version of the iOS agent, the Python-based symbol upload scripts will be removed.
+* This artifact was built using Xcode 14.2 with a minimum deployment target of iOS version 9.0. Compatible with CocoaPods 1.10 or higher and Swift Package Manager. The agent should be used with the latest Xcode version (Xcode 14.2 at the time of release).
+* For Mac Catalyst, the zip file installation may integrate more easily than using CocoaPods.
+
+### Support statement
+
+* As of iOS agent version 7.4.1, the iOS agent will consolidate previously separate XCFramework and tvOS agents into a singular iOS agent. 
+* As of this release, the oldest supported version of the [XCFramework](/docs/release-notes/mobile-release-notes/xcframework-release-notes/xcframework-agent-732) is 7.3.2.
+


### PR DESCRIPTION
I added the iOS agent 7.4.5 release notes and some information about new feature flags in the release.
Release to go out on May 31 2023