### PR TITLE
chore: add additional pages to VWO script

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -15,11 +15,16 @@ const METADATA = [
 
 const visualWebsiteOptimizer = (location) => {
   const { pathname } = location;
-  const homepage = '/';
-  const signup =
-    '/docs/accounts/accounts-billing/account-setup/create-your-new-relic-account/';
+  const vwoPaths = [
+    /docs\/accounts\/accounts-billing\/account-setup\/create-your-new-relic-account/,
+    /docs\/accounts\/accounts-billing\/new-relic-one-pricing-billing\/new-relic-one-pricing-billing/,
+    /docs\/licenses\/license-information\/usage-plans\/new-relic-usage-plan/,
+    /docs\/accounts\/accounts-billing\/new-relic-one-pricing-billing\/data-ingest-billing/,
+    /docs\/accounts\/accounts-billing\/new-relic-one-user-management\/user-type/,
+  ];
+  const withVWO = vwoPaths.some((path) => path.test(pathname));
 
-  if (pathname === homepage || pathname === signup) {
+  if (withVWO || pathname === '/') {
     return (
       <script type="text/javascript" id="vwoCode">
         {`window._vwo_code=window._vwo_code || (function() {


### PR DESCRIPTION
adds extra urls for pages that will have VWO script:

- /docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing
- /docs/licenses/license-information/usage-plans/new-relic-usage-plan
- /docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing
- /docs/accounts/accounts-billing/new-relic-one-user-management/user-type

In the build preview, you can see this script on these pages but not others. 👍
<img width="603" alt="Screen Shot 2023-05-23 at 3 42 05 PM" src="https://github.com/newrelic/docs-website/assets/47728020/0079b503-a719-4e80-ab65-d7013fe57fc7">
