### PR TITLE
Update manage-data-retention.mdx

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -51,7 +51,7 @@ Permission-related requirements for viewing and editing retention:
 * [Newer user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models): 
   * Setting a contract with longer data retention for your entire organization requires the [**Billing** administration setting](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings)
   * Adjusting retention within the bounds of a contract for specific types of data or for a specific account requires the [**Insights event retention** capability](/docs/accounts/accounts-billing/new-relic-one-user-management/user-capabilities/#data-retention) 
-* [Original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model): requires the **Insights event retention** capability.
+* [Original user model](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model): requires the Owner role or Data Retention Manager Add-On role.
 
 ## The data retention UI [#find-ui]
 


### PR DESCRIPTION
I do not think the previous information was correct. On the original user model, the Owner is the only role that can edit retention unless a Full user with the Data Retention Manager Add-On role can edit retention.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.