### PR TITLE
chore: add syntax highlighting

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
+++ b/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
@@ -67,20 +67,20 @@ You can use the New Relic REST API v2 to record deployments and get a list of pa
 
     For example:
 
-    ```
-    curl -X POST "https://api.newrelic.com/v2/applications/<a href="/docs/apis/rest-api-v2/requirements/finding-product-id#apm">$APP_ID</a>/deployments.json" \
-         -H "X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+    ```bash
+    curl -X POST "https://api.newrelic.com/v2/applications/$APP_ID/deployments.json" \
+         -H "X-Api-Key:$API_KEY" \
          -i \
          -H "Content-Type: application/json" \
          -d \
     '{
-      "deployment": {
-        "revision": "REVISION",
-        "changelog": "Added: /v2/deployments.rb, Removed: None",
-        "description": "Added a deployments resource to the v2 API",
-        "user": "datanerd@example.com",
-        "timestamp": "2019-10-08T00:15:36Z"
-      }
+        "deployment": {
+            "revision": "REVISION",
+            "changelog": "Added: /v2/deployments.rb, Removed: None",
+            "description": "Added a deployments resource to the v2 API",
+            "user": "datanerd@example.com",
+            "timestamp": "2019-10-08T00:15:36Z"
+        }
     }'
     ```
   </Collapser>
@@ -94,35 +94,35 @@ You can use the New Relic REST API v2 to record deployments and get a list of pa
 
     This example uses PowerShell version 3 or higher:
 
-    ```
-    Invoke-WebRequest -Uri https://api.newrelic.com/v2/applications/<a href="/docs/apis/rest-api-v2/requirements/finding-product-id#apm">YOUR_APP_ID</a>/deployments.json -Method POST -Headers @{'X-Api-Key'='<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>'} -ContentType 'application/json' -Body '{
+    ```powershell
+    Invoke-WebRequest -Uri https://api.newrelic.com/v2/applications/YOUR_APP_ID/deployments.json -Method POST -Headers @{'X-Api-Key'='$API_KEY'} -ContentType 'application/json' -Body '{
         "deployment": {
-        "revision": "REVISION",
-        "changelog": "Added: /v2/deployments.rb, Removed: None",
-        "description": "Added a deployments resource to the v2 API",
-        "user": "datanerd@example.com",
-        "timestamp": "2019-10-08T00:15:36Z"
-    }
+            "revision": "REVISION",
+            "changelog": "Added: /v2/deployments.rb, Removed: None",
+            "description": "Added a deployments resource to the v2 API",
+            "user": "datanerd@example.com",
+            "timestamp": "2019-10-08T00:15:36Z"
+        }
     }'
     ```
 
     This example uses PowerShell version 2 (requires .NET framework 3.5 or higher):
 
-    ```
+    ```powershell
     $encoding = [System.Text.Encoding]::GetEncoding("ASCII")
     $data ='{
-    "deployment": {
-        "revision": "REVISION",
-        "changelog": "Added: /v2/deployments.rb, Removed: None",
-        "description": "Added a deployments resource to the v2 API",
-        "user": "datanerd@example.com",
-        "timestamp": "2019-10-08T00:15:36Z"
-    }
+        "deployment": {
+            "revision": "REVISION",
+            "changelog": "Added: /v2/deployments.rb, Removed: None",
+            "description": "Added a deployments resource to the v2 API",
+            "user": "datanerd@example.com",
+            "timestamp": "2019-10-08T00:15:36Z"
+        }
     }'
     $postData = $encoding.GetBytes($data)
-    $request = [System.Net.WebRequest]::Create('https://api.newrelic.com/v2/applications/<a href="/docs/apis/rest-api-v2/requirements/finding-product-id#apm">$APP_ID</a>/deployments.json')
+    $request = [System.Net.WebRequest]::Create('https://api.newrelic.com/v2/applications/$APP_ID/deployments.json')
     $request.Method = 'POST'
-    $request.Headers.add('X-Api-Key','<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>')
+    $request.Headers.add('X-Api-Key','$API_KEY')
     $request.ContentType='application/json'
     $stream = $request.GetRequestStream()
     $stream.Write($postData,0,$postData.Length)
@@ -139,9 +139,9 @@ You can use the New Relic REST API v2 to record deployments and get a list of pa
 
     For example:
 
-    ```
-    curl -X GET "https://api.newrelic.com/v2/applications/<a href="/docs/apis/rest-api-v2/requirements/finding-product-id#apm">$APP_ID</a>/deployments.json" \
-         -H "X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" \
+    ```bash
+    curl -X GET "https://api.newrelic.com/v2/applications/$APP_ID/deployments.json" \
+         -H "X-Api-Key:$API_KEY" \
          -i
     ```
 
@@ -152,7 +152,7 @@ You can use the New Relic REST API v2 to record deployments and get a list of pa
       >
         This example requests a list of deployments for app ID `9999999`:
 
-        ```
+        ```bash
         curl -X GET "https://api.newrelic.com/v2/applications/9999999/deployments.json" \
              -H "X-Api-Key:ABCDEFGHIJKLMNOPQRSTUVWXabcdefghijklmnopqrstuvwx" \
              -i


### PR DESCRIPTION
Removed in-code hyperlinks, the docs team told me we don't do that anymore so I figured it's ok. Most links were elsewhere in the doc