### PR TITLE
chore: Add MooTools compatibility info

### DIFF
--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -146,7 +146,7 @@ The browser agent collects data on sites that use many popular frontend framewor
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
-        Compabibility Exception
+        Compabibility Exceptions
       </th>
 
       <th>

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -146,7 +146,7 @@ The browser agent collects data on sites that use many popular frontend framewor
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
-        Compabibility Exceptions
+        Compatibility exceptions
       </th>
 
       <th>

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -138,15 +138,15 @@ If you're deploying browser for an app using APM, make sure your agent supports 
 * [Python](/docs/release-notes/agent-release-notes/python-release-notes): Version 2.10.1.9 or higher
 * [Ruby](/docs/release-notes/agent-release-notes/ruby-release-notes): Version 3.7.0.177 or higher
 
-## Supported frameworks [#frameworks]
+## Supported frameworks and libraries [#frameworks-and-libraries]
 
-The browser agent collects data on all frontend frameworks. However, the monitoring occurs on lower-level "primitives" that JavaScript frameworks use, so the level of detail collected by the instrumentation may vary depending on your specific framework.
+The browser agent collects data on sites that use many popular frontend frameworks and libraries. The browser agent monitors low-level JavaScript objects and methods, which may be wrapped or modified by other libraries and frameworks. As a result, the level of detail collected may vary from one framework to the next, and conflicts may occur with any library that modifies native JavaScript mechanics.
 
 <table>
   <thead>
     <tr>
       <th style={{ width: "150px" }}>
-        Exceptions
+        Compabibility Exception
       </th>
 
       <th>
@@ -189,6 +189,16 @@ The browser agent collects data on all frontend frameworks. However, the monitor
 
       <td>
         This library is not compatible with our [Pro+SPA agent](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types) due to the way this library wraps promises. If you're using this library, we recommend selecting the [Pro agent type](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        MooTools
+      </td>
+
+      <td>
+        The browser agent is not compatible with MooTools versions older than `1.6.0` or with any version that includes the mootools compatibility layer. If migrating from MooTools is not an option, we recommend using version `1.6.0-nocompat`.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/mootools-related-errors.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/mootools-related-errors.mdx
@@ -26,4 +26,4 @@ The MooTools library (especially its compatibility layer) mutates a number of na
 
 2. If migrating from MooTools is not an option, we recommend updating to a `nocompat` build of the latest MooTools version, `1.6.0`.
 
-3. If you use a custom build of MooTools, you may need to disable the compatibility layer when generating the custom download.
+3. If you use a custom build of MooTools, you may need to disable the compatibility layer when generating the custom build.

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/mootools-related-errors.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/mootools-related-errors.mdx
@@ -1,0 +1,29 @@
+---
+title: MooTools related errors encountered
+type: troubleshooting
+tags:
+  - Browser
+  - Browser monitoring
+  - Troubleshooting
+metaDescription: 'If you use the MooTools library, you may need to update to the nocompat build of MooTools version 1.6.0 to address conflicts.'
+---
+
+## Problem
+
+You're using the MooTools library and notice errors like the ones below showing up in the browser console or on the [**JavaScript errors** page](/docs/browser/new-relic-browser/browser-pro-features/js-errors-dashboard-examining-errors-over-time).
+
+- `Uncaught TypeError: t is not a function`
+
+- `Uncaught (in promise) TypeError: Failed to execute 'removeEventListener' on 'EventTarget': 2 arguments required, but only 0 present.`
+
+## Cause
+
+The MooTools library (especially its compatibility layer) mutates a number of native JavaScript objects and methods, which can cause conflicts with newer libraries, including the New Relic browser agent.
+
+## Solutions
+
+1. Because the last version of MooTools was released in 2016, migrating from MooTools to other actively maintained libraries may be the best strategic choice when possible.
+
+2. If migrating from MooTools is not an option, we recommend updating to a `nocompat` build of the latest MooTools version, `1.6.0`.
+
+3. If you use a custom build of MooTools, you may need to disable the compatibility layer when generating the custom download.

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -183,6 +183,8 @@ pages:
         path: /docs/browser/single-page-app-monitoring/troubleshooting/missing-route-changes-spa-agent
       - title: Navigation start time unknown
         path: /docs/browser/new-relic-browser/page-load-timing-resources/navigation-start-time-unknown
+      - title: MooTools related errors encountered
+        path: /docs/browser/new-relic-browser/troubleshooting/mootools-related-errors
   - title: Release notes
     pages:
       - title: Browser agent release notes


### PR DESCRIPTION
This PR adds info about browser agent compatibility with the MooTools library, and about troubleshooting errors encountered when using the MooTools library in combination with the browser agent. Compatibility language is updated to address both frameworks and libraries, and to address general conflicts with libraries that modify native JavaScript mechanics.

See [NEWRELIC-8754](https://issues.newrelic.com/browse/NEWRELIC-8754).