### PR TITLE
chore: Update browser-agent-v1.232.1.mdx

### DIFF
--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.232.1.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.232.1.mdx
@@ -9,10 +9,6 @@ security: []
 
 ## v1.232.1
 
-<Callout variant="important">
-  As of May 18, 2023, version 1.232.1 is no longer automatically deployed to customers due to a compatibility bug with some versions of MooTools. Until the next version (1.232.2) is released, version 1.232.0 is again the current version.
-</Callout>
-
 ### Bug Fixes
 
 #### Add X-NewRelic-ID header only if defined


### PR DESCRIPTION
The un-deploy note is no longer needed with the release of 1.233.0.