### PR TITLE
Fix NG endpoint typo

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -51,8 +51,8 @@ Notes on NerdGraph requirements:
 
 The endpoint depends on your [data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center):
 
-* Main endpoint: [https://api.newrelic.com/graphiql](https://api.newrelic.com/graphiql)
-* Endpoint for accounts using EU data center: [https://api.eu.newrelic.com/graphiql](https://api.eu.newrelic.com/graphiql)
+* Main endpoint: [https://api.newrelic.com/graphql](https://api.newrelic.com/graphql)
+* Endpoint for accounts using EU data center: [https://api.eu.newrelic.com/graphql](https://api.eu.newrelic.com/graphql)
 
 To access the endpoint, you can use our [NerdGraph explorer](#explorer), or you can access it directly with a curl command similar to this:
 


### PR DESCRIPTION
Hi! I'm a New Relic engineer on Unified API. 

PR #11176 was an incorrect change. `/graphql` is the API endpoint and `/graphiql` is the API explorer user interface. 

I see that #11389 partially reverted it, but this endpoint was still wrong. We had a customer report the issue. Feel free to reach out to me internally (epoley on Slack) if needed to discuss this further.