### PR TITLE
APIs: Insert Markdown comments about changing URLs

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -51,10 +51,14 @@ Notes on NerdGraph requirements:
 
 The endpoint depends on your [data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center):
 
+[//]: # (Do NOT change these GraphQL URL endpoints unless you have the approval of the Unified API team)
+
 * Main endpoint: [https://api.newrelic.com/graphql](https://api.newrelic.com/graphql)
 * Endpoint for accounts using EU data center: [https://api.eu.newrelic.com/graphql](https://api.eu.newrelic.com/graphql)
 
 To access the endpoint, you can use our [NerdGraph explorer](#explorer), or you can access it directly with a curl command similar to this:
+
+[//]: # (Do NOT change the GraphQL URL endpoint in this curl request unless you have the approval of the Unified API team)
 
 ```bash
 curl -X POST https://api.newrelic.com/graphql \


### PR DESCRIPTION
I inserted some Markdown comments to warn us not to change the URL for these GraphQL endpoints.