### PR TITLE
fix(NR One): Fixed a broken link

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts.mdx
@@ -149,10 +149,10 @@ Read more about [New Relic Lookout](/docs/new-relic-one/use-new-relic-one/core-c
 
 ## Understand the state of your system with the health (alert) status [#alert-status]
 
-The New Relic Explorer shows a color-coded [health](/docs/alerts/new-relic-alerts/getting-started/introduction-new-relic-alerts) status for entities. For example, you may see a red alert status indicating a critical violation in progress.
+The New Relic Explorer shows a color-coded [health status](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/view-entity-health-status-find-entities-without-alert-conditions/) for entities. For example, you may see a red alert status indicating a critical incident in progress.
 
 <img
-  title="new-relic-one-entity-alert-status.png"
+  title="New Relic entity alert status"
   alt="New Relic entity alert status"
   src={alertsEntityAlertStatusRed}
 />


### PR DESCRIPTION
Fixed a broken link on the [Understand the state of your system with the health (alert) status](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/#alert-status) section.