### PR TITLE
chore: Doctile uses correct background colors

### DIFF
--- a/scripts/verify_mdx.js
+++ b/scripts/verify_mdx.js
@@ -1,16 +1,27 @@
+const frontmatter = require('@github-docs/frontmatter');
 const mdx = require('@mdx-js/mdx');
 const fs = require('fs');
 const glob = require('glob');
 
 const readFile = async (filePath) => {
+  let failed = false;
+  console.log(`reading ${filePath}`);
+
+  const mdxText = fs.readFileSync(filePath, 'utf8');
   try {
-    console.log(`reading ${filePath}`);
-    const mdxText = fs.readFileSync(filePath, 'utf8');
     const jsx = mdx.sync(mdxText);
   } catch (exception) {
     console.log(JSON.stringify(exception, null, 4));
-    return filePath;
+    failed = true;
   }
+
+  const { errors } = frontmatter(mdxText);
+  if (errors.length > 0) {
+    console.log(JSON.stringify(errors, null, 4));
+    failed = true;
+  }
+
+  return failed ? filePath : null;
 };
 
 const main = async () => {

--- a/src/components/DocTile.js
+++ b/src/components/DocTile.js
@@ -68,6 +68,7 @@ export const DocTile = ({
       className={className}
       css={css`
         color: var(--primary-text-color);
+        background: var(--secondary-background-color);
         display: block;
         min-height: 130px;
         border-radius: 4px;
@@ -81,6 +82,9 @@ export const DocTile = ({
         }
 
         .doc-tiles-default & {
+          background: var(--secondary-background-color);
+        }
+        .dark-mode & {
           background: var(--secondary-background-color);
         }
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -63,7 +63,7 @@ Here's a brief summary of the capabilities of each user type:
   <tbody>
     <tr>
       <td>
-        Basic users are free. Basic users can set up our observability tools, run queries of your data, use custom <InlinePopover type="dashboards" /> (quickstart dashboards up to 7 days), use some basic alerting features, and more. They **can't** use our curated experiences (for example, our <InlinePopover type="apm" /> UI, browser UI, or mobile UI).
+        Basic users are free. Basic users can set up our observability tools, run queries on their data, use custom <InlinePopover type="dashboards" /> (quickstart dashboards up to 7 days), use some basic alerting features, and more. They **can't** use our curated experiences (for example, our <InlinePopover type="apm" /> UI, browser UI, or mobile UI).
 
       </td>
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -63,7 +63,7 @@ Here's a brief summary of the capabilities of each user type:
   <tbody>
     <tr>
       <td>
-        Basic users are free. Basic users can set up our observability tools, run queries on their data, use custom <InlinePopover type="dashboards" /> (quickstart dashboards up to 7 days), use some basic alerting features, and more. They **can't** use our curated experiences (for example, our <InlinePopover type="apm" /> UI, browser UI, or mobile UI).
+        Basic users are free. Basic users can set up our observability tools, run queries on your data, use custom <InlinePopover type="dashboards" /> (quickstart dashboards up to 7 days), use some basic alerting features, and more. Basic users **can't** use our curated experiences (for example, our <InlinePopover type="apm" /> UI, browser UI, or mobile UI).
 
       </td>
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -63,7 +63,7 @@ Here's a brief summary of the capabilities of each user type:
   <tbody>
     <tr>
       <td>
-        Basic users are free. Basic users can set up our observability tools, run queries of your data, use custom <InlinePopover type="dashboards" />, use some basic alerting features, and more. They **can't** use our curated experiences (for example, our <InlinePopover type="apm" /> UI, browser UI, or mobile UI).
+        Basic users are free. Basic users can set up our observability tools, run queries of your data, use custom <InlinePopover type="dashboards" /> (quickstart dashboards up to 7 days), use some basic alerting features, and more. They **can't** use our curated experiences (for example, our <InlinePopover type="apm" /> UI, browser UI, or mobile UI).
 
       </td>
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/noticeerror-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/noticeerror-python-agent-api.mdx
@@ -79,7 +79,7 @@ If called outside of the context of a monitored web request or background task, 
         `expected`
 
         _boolean_, _iterable[String]_, _callable(exception_class, exception_instance, traceback)->boolean_
-      </td>_
+      </td>
 
       <td>
         Optional. Errors to mark as expected can be passed in as an iterable of strings in the form `module:class`. This value can also be a callable or a Boolean indicating whether the error is expected. These errors will be reported to the UI but will not affect Apdex score or error rate.


### PR DESCRIPTION
This reverts the light/dark mode colors for the default DocTile to be like they were before we added variants during VSU work. Like [here](https://docswebsite-dailyreleasedec192022216.gatsbyjs.io/). We needed to be a little extra explicit in our background definitions so the tile wasn't falling back to the Surface component styling in some cases. 