### PR TITLE
fix(Synthetics): Fixed broken links

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
@@ -63,7 +63,7 @@ We have expanded support for synthetic monitors to [our NerdGraph API](/docs/api
 * The ability to attach scripts to scripted monitors with only one call, rather than the two calls needed with REST APIs.
 * The ability to add tags to your monitors. 
 
-Unlike with REST APIs, NerdGraph lets you programatically create [broken links](#create-broken-links), [step](#create-step), and [certificate check](create-certificate-check) monitors.
+Unlike with REST APIs, NerdGraph lets you programatically create [broken links](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#create-broken-links), [step](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#create-step), and [certificate check](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#create-certificate-check) monitors.
 
 ## Get custom timing details with your scripted API monitors
 


### PR DESCRIPTION
Fixed broken links on the [New runtime transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime) page after receiving [this issue: 13290](https://github.com/newrelic/docs-website/issues/13290)