### PR TITLE
content: re-add vwo on signup pages to repro issue

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -15,7 +15,13 @@ const METADATA = [
 
 const visualWebsiteOptimizer = (location) => {
   const { pathname } = location;
-  const vwoPaths = [];
+  const vwoPaths = [
+    /docs\/accounts\/accounts-billing\/account-setup\/create-your-new-relic-account/,
+    /docs\/accounts\/accounts-billing\/new-relic-one-pricing-billing\/new-relic-one-pricing-billing/,
+    /docs\/licenses\/license-information\/usage-plans\/new-relic-usage-plan/,
+    /docs\/accounts\/accounts-billing\/new-relic-one-pricing-billing\/data-ingest-billing/,
+    /docs\/accounts\/accounts-billing\/new-relic-one-user-management\/user-type/,
+  ];
   const withVWO = vwoPaths.some((path) => path.test(pathname));
 
   if (withVWO || pathname === '/') {


### PR DESCRIPTION
## Summary

Applies same changes as this [PR](https://github.com/newrelic/docs-website/pull/13182/files) that adds VWO script on four signups pages. 

We will also need to either remove gatsby cloud auth on docs-dev temporarily OR give VWO engineers the auth key to access that site.

## Helpful links
- https://github.com/newrelic/docs-website/pull/13217
- https://github.com/newrelic/docs-website/pull/13182/files