### PR TITLE
Replace 'elasticsearch' with 'open search'

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration.mdx
@@ -4,22 +4,23 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS Athena monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS Athena monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/amazon-cognito-monitoring-integration
   - /aws-aws_cognito
   - /docs/aws-aws_cognito
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Cognito data to our products. Here we explain how to activate the integration and what data it collects.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's Amazon Simple Queue Service (SQS) monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic Amazon Simple Queue Service (SQS) monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration
   - /docs/aws-sqs-integration
@@ -13,11 +13,7 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-sqs-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
-[New Relic's infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon SQS data to New Relic. This document explains how to activate the integration and describes the data reported.
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon SQS data to New Relic. This document explains how to activate the integration and describes the data reported.
 
 ## Features [#features]
 
@@ -25,7 +21,11 @@ redirects:
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration.mdx
@@ -4,19 +4,20 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS Athena monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS Athena monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/amazon-transit-gateway-monitoring-integration
   - /docs/aws-aws_transitgateway-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Transit Gateway data to New Relic. Here we explain how to activate the integration and what data it collects.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's ALB/NLB monitoring integration: the data it reports and how to enable it."
+metaDescription: "The New Relic ALB/NLB monitoring integration: the data it reports and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-albnlb-monitoring-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-alb-integration
@@ -13,17 +13,15 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-alb-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
-[Amazon Application Load Balancing](http://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) (ALB) distributes incoming application traffic across multiple targets, such as EC2 instances, in multiple availability zones. [Amazon Network Load Balancer](http://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) (NLB) distributes incoming traffic across multiple targets, such as Amazon EC2 instances.
-
-[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS ALB/NLB data to New Relic products. This document explains how to activate this integration and describes the data that can be captured.
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your [AWS ALB/NLB](http://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html) data to New Relic. 
 
 New Relic also offers an [integration for Amazon's Elastic Load Balancing (ELB) service](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-elb-monitoring-integration).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration.mdx
@@ -4,16 +4,12 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS API Gateway monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS API Gateway monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration
   - /docs/aws-apigateway-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-api-gateway-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon API Gateway data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
@@ -22,6 +18,14 @@ redirects:
 [Amazon's API Gateway](https://aws.amazon.com/api-gateway/) is a fully managed service that allows you to create, publish, maintain, monitor, and secure APIs at any scale. With the New Relic API Gateway integration, you get more data about how your API layer is working behind the scenes. You'll receive metric data about the number of API calls, the requests served, the number of errors, latency counts, and more.
 
 You can monitor and alert on your API Gateway data directly from [New Relic](/docs/infrastructure), and query data and create dashboards.
+
+## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Requirements [#requierments]
 
@@ -35,10 +39,6 @@ To enable CloudWatch metrics, use either of these options:
 
 * Go to the AWS Management Console, select the **Settings** option for CloudWatch, then select the option to enable detailed CloudWatch metrics.
 * Call the `stage:update` action of the Amazon API Gateway REST API to update the [`metricsEnabled`](https://docs.aws.amazon.com/apigateway/api-reference/resource/stage/#metricsEnabled) property to `true`.
-
-## Activate integration [#activate]
-
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration.mdx
@@ -4,21 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS AppSync monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS AppSync monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-appsync-monitoring-integration
   - /docs/aws-aws_appsync-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 New Relic offers an integration for reporting your [AWS AppSync](https://aws.amazon.com/appsync/) data. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration.mdx
@@ -4,21 +4,22 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS Athena monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS Athena monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-athena-monitoring-integration
   - /docs/aws-aws_athena-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 New Relic offers an integration for reporting your [Amazon Athena](https://aws.amazon.com/athena/) data. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration.mdx
@@ -4,21 +4,22 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS Auto Scaling integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS Auto Scaling integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-auto-scaling-monitoring-integration
   - /docs/aws-autoscaling-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 The [AWS Auto Scaling](https://aws.amazon.com/autoscaling/) service allows launching or terminating Amazon EC2 instances automatically. It helps dynamically adapt Amazon EC2 capacity based on user-defined policies, schedules, and health checks.
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an AWS Auto Scaling integration that reports data about groups from your Auto Scaling service to New Relic products. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration:
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration.mdx
@@ -4,17 +4,13 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic AWS CloudFront monitoring integration: how to enable it, and what data it reports.'
+metaDescription: 'The New Relic AWS CloudFront monitoring integration: how to enable it, and what data it reports.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-cloudfront-monitoring-integration
   - /docs/aws-cloudfront-integration
   - /docs/infrastructure/infrastructure-integrations/amazon-integrations/aws-cloudfront-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-cloudfront-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting Amazon CloudFront service data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
@@ -24,7 +20,11 @@ redirects:
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration.mdx
@@ -4,20 +4,20 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Connect monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Connect monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-connect-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Connect data to New Relic. Here we explain how to activate the integration and what data it collects.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration.mdx
@@ -4,21 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Direct Connect monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Direct Connect monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-direct-connect-monitoring-integration
   - /docs/aws-aws_directconnect-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 New Relic offers an integration for reporting your [AWS Direct Connect](https://aws.amazon.com/directconnect/) data. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration.mdx
@@ -4,21 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS DocumentDB monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS DocumentDB monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-documentdb-monitoring-integration
   - /docs/aws-aws_docdb-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 New Relic offers an integration for reporting your [Amazon DocumentDB](https://aws.amazon.com/documentdb/) data. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS DynamoDB monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS DynamoDB monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration
   - /docs/aws-dynamodb-integration
@@ -12,9 +12,6 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-dynamodb-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting Amazon DynamoDB data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
@@ -23,6 +20,10 @@ redirects:
 Amazon DynamoDB is a fully managed NoSQL cloud database that supports both document and key-value store models. With the New Relic DynamoDB Integration, you can quickly understand how request latency or errors are affecting your environment. You'll receive [metrics](#metrics) about how the database is performing, service status, and host metadata.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration.mdx
@@ -4,17 +4,13 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS EBS monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS EBS monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration
   - /docs/aws-ebs-integration
   - /docs/infrastructure/infrastructure-integrations/amazon-integrations/aws-ebs-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-ebs-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an Amazon EBS integration for reporting your EBS data to New Relic. Here we explain how to activate our integration and what data can be reported.
 
@@ -23,6 +19,10 @@ redirects:
 [Amazon Elastic Block Store](https://aws.amazon.com/ebs/) (EBS) provides block level storage volumes for your Amazon EC2 instances. With New Relic's EBS integration, you'll be able to monitor writes per volume, volume counts, configuration options, and more. You'll be able to create custom charts of your data and [create alert conditions](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information) based on changes in EBS data or configuration.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration.mdx
@@ -6,7 +6,7 @@ tags:
   - AWS integrations list
 translate:
   - jp
-metaDescription: "New Relic's Amazon EC2 integration: how to enable it, and what data it reports."
+metaDescription: "The New Relic Amazon EC2 integration: how to enable it, and what data it reports."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration
   - /docs/infrastructure/infrastructure-integrations/amazon-integrations/aws-ec2-integration
@@ -15,7 +15,7 @@ redirects:
 ---
 
 <Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/). We no longer recommend using this polling-based integration.
 </Callout>
 
 [New Relic infrastructure monitoring integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an Amazon Elastic Compute Cloud (EC2) integration for reporting your EC2 metadata to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration.mdx
@@ -4,16 +4,12 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon EFS monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon EFS monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-efs-monitoring-integration
   - /docs/aws-efs-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-efs-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic's integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an Amazon EFS integration for reporting your EFS data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.
 
@@ -24,6 +20,10 @@ With New Relic's integration for monitoring [AWS Elastic File System (EFS)](http
 If connected through a [VPC](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-vpc-monitoring-integration), you can also use the EFS file system with your own on-premise servers, which allows you to share file systems across different applications hosted on hybrid solutions.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Elastic Beanstalk monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Elastic Beanstalk monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration
   - /docs/aws-elasticbeanstalk-integration
@@ -15,7 +15,7 @@ redirects:
 ---
 
 <Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/). We no longer recommend using this polling-based integration.
 </Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an AWS [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk) integration for reporting your Beanstalk data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon ElastiCache monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon ElastiCache monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration
   - /docs/aws-elasticcache-integration
@@ -13,10 +13,6 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-elasticache-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon ElastiCache data to New Relic. This document explains how the integration works and what data can be reported.
 
 ## Features [#features]
@@ -24,6 +20,10 @@ redirects:
 Amazon [ElastiCache](https://aws.amazon.com/elasticache/) is a web service that makes it easy to deploy, operate, and scale an in-memory data store or cache in the cloud. New Relic's ElastiCache integration reports data from your Amazon ElastiCache instances, including CPU data, bytes in and out, memory, and data specific to the Redis and Memcached services. New Relic integrations give you the ability to [create alert conditions](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information) for your data, as well as [query and create charts](/docs/infrastructure/new-relic-infrastructure/share-charts/share-infrastructure-data-view-insights).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's Amazon OpenSearch Service monitoring integration: what data it reports, and how to enable it.'
+metaDescription: "New Relic's Amazon OpenSearch Service monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration
   - /docs/aws-elasticsearch-integration

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
@@ -1,20 +1,16 @@
 ---
-title: Amazon OpenSearch Service monitoring integration
+title: "Amazon OpenSearch Service (Elasticsearch) monitoring integration"
 tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's Amazon OpenSearch Service monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic Amazon OpenSearch Service monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration
   - /docs/aws-elasticsearch-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-elasticsearch-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-elasticsearch-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting Amazon OpenSearch Service data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.
 
@@ -23,6 +19,10 @@ redirects:
 [Amazon OpenSearch Service](https://aws.amazon.com/elasticsearch-service/) (formerly Amazon Elasticsearch) is a fully managed service that delivers OpenSearch's easy-to-use APIs and real-time capabilities along with the availability, scalability, and security required by production workloads. Our OpenSearch monitoring integration allows you to track cluster status, CPU utilization, read/write latency, throughput, and other metrics, at specific points in time. This data is also available [to query, analyze, and chart your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
@@ -246,7 +246,7 @@ The OpenSearch integration collects these metrics for clusters:
       </td>
 
       <td>
-        The remaining CPU credits available for data nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metrics is available only for the t2.micro.search, t2.small.search, and t2.medium.search instance types.
+        The remaining CPU credits available for data nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metrics is available only for the `t2.micro.search`, `t2.small.search`, and `t2.medium.search` instance types.
       </td>
     </tr>
 
@@ -372,7 +372,7 @@ The OpenSearch integration collects these metrics for clusters:
       </td>
 
       <td>
-        The remaining CPU credits available for dedicated master nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metric is available only for the t2.micro.search, t2.small.search, and t2.medium.search instance types.
+        The remaining CPU credits available for dedicated master nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metric is available only for the `t2.micro.search`, `t2.small.search`, and `t2.medium.search` instance types.
       </td>
     </tr>
 
@@ -492,7 +492,7 @@ The OpenSearch integration collects these metrics for clusters:
   </tbody>
 </table>
 
-The following metrics are collected for Elasticsearch clusters, and optionally for each instance or node in a domain as well:
+The following metrics are collected for OpenSearch clusters, and optionally for each instance or node in a domain as well:
 
 <table>
   <thead>

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration.mdx
@@ -1,10 +1,10 @@
 ---
-title: Amazon Elasticsearch monitoring integration
+title: Amazon OpenSearch Service monitoring integration
 tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon Elasticsearch monitoring integration: what data it reports, and how to enable it.'
+metaDescription: "New Relic's Amazon OpenSearch Service monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration
   - /docs/aws-elasticsearch-integration
@@ -16,11 +16,11 @@ redirects:
   Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
 </Callout>
 
-[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting Amazon Elasticsearch data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting Amazon OpenSearch Service data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.
 
 ## Features [#features]
 
-[Amazon Elasticsearch Service](https://aws.amazon.com/elasticsearch-service/) is a fully managed service that delivers Elasticsearch’s easy-to-use APIs and real-time capabilities along with the availability, scalability, and security required by production workloads. New Relic's Elasticsearch monitoring integration allows you to track cluster status, CPU utilization, read/write latency, throughput, and other metrics, at specific points in time. Elasticsearch data is also available [to query, analyze, and chart your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/).
+[Amazon OpenSearch Service](https://aws.amazon.com/elasticsearch-service/) (formerly Amazon Elasticsearch) is a fully managed service that delivers OpenSearch's easy-to-use APIs and real-time capabilities along with the availability, scalability, and security required by production workloads. Our OpenSearch monitoring integration allows you to track cluster status, CPU utilization, read/write latency, throughput, and other metrics, at specific points in time. This data is also available [to query, analyze, and chart your data](/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data/).
 
 ## Activate integration [#activate]
 
@@ -37,7 +37,7 @@ You can change the polling frequency and filter data using [configuration option
 
 ## View and use data [#find-data]
 
-To [view and use](/docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations/) this integration's data, go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS** and select one of the Elasticsearch integration links.
+To [view and use](/docs/integrations/infrastructure-integrations/get-started/understand-use-data-infrastructure-integrations/) this integration's data, go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS** and select one of the OpenSearch integration links.
 
 To [query and explore your data](/docs/using-new-relic/data/understand-data/query-new-relic-data), use the `DatastoreSample` event type with the appropriate `provider` value:
 
@@ -46,7 +46,7 @@ To [query and explore your data](/docs/using-new-relic/data/understand-data/quer
 
 ## Metric data [#metrics]
 
-The Elasticsearch integration collects these metrics for clusters:
+The OpenSearch integration collects these metrics for clusters:
 
 <table>
   <thead>
@@ -246,7 +246,7 @@ The Elasticsearch integration collects these metrics for clusters:
       </td>
 
       <td>
-        The remaining CPU credits available for data nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metrics is available only for the t2.micro.elasticsearch, t2.small.elasticsearch, and t2.medium.elasticsearch instance types.
+        The remaining CPU credits available for data nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metrics is available only for the t2.micro.search, t2.small.search, and t2.medium.search instance types.
       </td>
     </tr>
 
@@ -302,7 +302,7 @@ The Elasticsearch integration collects these metrics for clusters:
       </td>
 
       <td>
-        The number of HTTP requests made to the Elasticsearch cluster that included an invalid (or missing) host header.
+        The number of HTTP requests made to the OpenSearch cluster that included an invalid (or missing) host header.
       </td>
     </tr>
 
@@ -316,7 +316,7 @@ The Elasticsearch integration collects these metrics for clusters:
       </td>
 
       <td>
-        The number of requests made to the Elasticsearch cluster.
+        The number of requests made to the cluster.
       </td>
     </tr>
 
@@ -372,7 +372,7 @@ The Elasticsearch integration collects these metrics for clusters:
       </td>
 
       <td>
-        The remaining CPU credits available for dedicated master nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metric is available only for the t2.micro.elasticsearch, t2.small.elasticsearch, and t2.medium.elasticsearch instance types.
+        The remaining CPU credits available for dedicated master nodes in the cluster. A CPU credit provides the performance of a full CPU core for one minute. This metric is available only for the t2.micro.search, t2.small.search, and t2.medium.search instance types.
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon Classic ELB monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon Classic ELB monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration
   - /docs/aws-elb-integration
@@ -12,10 +12,6 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-elb-monitoring-integration
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elb-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an Amazon Elastic Classic Load Balancing (ELB) integration for reporting Classic ELB data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.
 
@@ -26,6 +22,10 @@ New Relic's integration for [Amazon Elastic Classic Load Balancing](https://aws.
 Amazon offers three types of load balancers: [Classic Load Balancer](https://aws.amazon.com/elasticloadbalancing/classicloadbalancer/), [Application Load Balancer](https://aws.amazon.com/elasticloadbalancing/) (ALB), and [Network Load Balancer](https://aws.amazon.com/elasticloadbalancing/) (NLB). New Relic also offers an [ALB/NLB integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-alb-monitoring-integration) to monitor the last two types of load balancers.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elemental-mediaconvert-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elemental-mediaconvert-monitoring-integration.mdx
@@ -4,14 +4,14 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Elemental MediaConvert monitoring integration: the data it reports and how to enable it.'
+metaDescription: 'The New Relic AWS Elemental MediaConvert monitoring integration: the data it reports and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediaconvert-monitoring-integration
   - /docs/aws-aws_mediaconvert-integration
 ---
 
 <Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/). We no longer recommend using this polling-based integration.
 </Callout>
 
 [New Relic includes an integration](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) for reporting your AWS Elemental MediaConvert data to our platform. Here we explain how to activate the integration and what data it collects.

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration.mdx
@@ -4,20 +4,20 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Elemental MediaPackage VOD monitoring integration: the data it reports and how to enable it.'
+metaDescription: 'The New Relic AWS Elemental MediaPackage VOD monitoring integration: the data it reports and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-elemental-mediapackage-vod-monitoring-integration
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-mediapackage-vod-monitoring-integration
   - /docs/aws-aws_mediapackagevod-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 We offer a cloud integration for reporting your AWS MediaPackage VOD data to our platform. Here we explain how to activate the integration and what data it collects.
 
 ## Activate the integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration.mdx
@@ -4,16 +4,12 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon EMR monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon EMR monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration
   - /docs/aws-emr-integration
   - /docs/aws-emr-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your [Amazon EMR (Elastic MapReduce)](https://aws.amazon.com/emr/) data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
@@ -22,6 +18,10 @@ redirects:
 You can monitor and alert on your EMR data directly from [New Relic](/docs/infrastructure), and query data and create dashboards.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration.mdx
@@ -4,20 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS FSx monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS FSx monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-fsx-monitoring-integration
   - /docs/integrations/amazon-integrations/aws-integrations-list/amazon-fsx-integration
   - /docs/aws-aws_fsx-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 We offer a cloud integration for reporting your AWS FSx data to our platform. Here we explain how to activate the integration and what data it collects.
 
 ## Activate the integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration.mdx
@@ -4,21 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Glue monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Glue monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-glue-monitoring-integration
   - /docs/aws-aws_glue-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 New Relic offers an integration for reporting your [AWS Glue](https://aws.amazon.com/glue/) data. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS IAM monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS IAM monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration
   - /docs/aws-iam-integration
@@ -12,9 +12,6 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-iam-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an AWS Identity and Access Management (IAM) integration for reporting your IAM data to New Relic. This document explains the integration's features, how to activate it, and what data can be reported.
 
@@ -25,6 +22,10 @@ Amazon's [Identity and Access Management (IAM)](https://aws.amazon.com/iam/) ena
 New Relic's IAM monitoring integration lets you capture the state of policies, users, groups, and roles at specific points in time. IAM data is also available [for analysis](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure#insights).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration.mdx
@@ -4,16 +4,12 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS IoT monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS IoT monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-iot-monitoring-integration
   - /docs/aws-iot-integration
   - /docs/aws-iot-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 New Relic offers an [integration](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) for reporting your AWS IoT [metric data](/docs/telemetry-data-platform/understand-data/new-relic-data-types/#metrics-new-relic).
 
@@ -24,6 +20,10 @@ New Relic offers an [integration](/docs/infrastructure/integrations-getting-star
 * Set alert conditions on your AWS IoT integration data directly from the New Relic **Integrations** page.
 
 ## Activate integration [#connect]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-analytics-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-analytics-monitoring-integration.mdx
@@ -11,13 +11,14 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/amazon-kinesis-data-analytics-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 Our [infrastructure monitoring integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Kinesis Data Analytics data to our products. Read on to learn more about how to activate the integration and what data it collects.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to Infrastructure](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Kinesis Data Firehose integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Kinesis Data Firehose integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration
   - /docs/infrastructure/infrastructure-integrations/amazon-integrations/aws-kinesis-firehose-integration
@@ -15,9 +15,6 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-firehose-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) includes an integration for collecting your Amazon Kinesis Data Firehose data. This document explains how to activate this integration and describes the data that can be reported.
 
@@ -28,6 +25,10 @@ redirects:
 New Relic's Kinesis Data Firehose integration reports data such as indexed records and bytes, counts of data copied to AWS services, the age and freshness of records, and other [metric data](#metrics).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's integration with AWS Kinesis Data Streams: How to activate it and what data it reports."
+metaDescription: "The New Relic integration with AWS Kinesis Data Streams: How to activate it and what data it reports."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-data-streams-monitoring-integration
   - /docs/aws-kinesis-integration
@@ -14,9 +14,6 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-kinesis-streams-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) includes an integration for monitoring Amazon Kinesis Data Streams. This document explains how to activate the integration and describes the data that can be reported.
 
@@ -32,7 +29,11 @@ You also have an option for [enabling shard data collection](#polling). AWS data
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Polling and configuration [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Lambda monitoring integration: How to activate it and what data it reports.'
+metaDescription: 'The New Relic AWS Lambda monitoring integration: How to activate it and what data it reports.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration
   - /docs/aws-lambda-integration
@@ -12,23 +12,18 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-lambda-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
-[New Relic infrastructure integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Lambda data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
-
-**We also offers a more in-depth Lambda monitoring feature**. For more information, see [New Relic Serverless monitoring for AWS Lambda](/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/introduction-new-relic-monitoring-aws-lambda).
+[New Relic infrastructure integrations](/docs/integrations/new-relic-integrations/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Lambda data to New Relic. 
 
 ## Features [#features]
 
-[AWS Lambda](https://aws.amazon.com/lambda/) is a zero-administration compute platform for backend web developers. It runs your code for you in the AWS cloud and provides you with a fine-grained pricing structure.
-
-Lambda functions are pieces of custom code that run when a certain event happens. In order to identify the events that invoke a particular Lambda function, AWS Lambda users define event source mappings. Optionally, aliases can be used to point to a specific version of a Lambda function.
-
-New Relic's AWS Lambda integration reports data such as invocation counts, error counts, function timers, and other [metrics](#metrics). You can view your Lambda data in pre-built <InlinePopover type="dashboards" /> and also [create custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights).
+Our integration for [AWS Lambda](https://aws.amazon.com/lambda/) reports data such as invocation counts, error counts, function timers, and other [metrics](#metrics). You can view your Lambda data in pre-built <InlinePopover type="dashboards" /> and also [create custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lex-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lex-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS Lex monitoring integration: what data it reports, and how to enable it."
+metaDescription: "The New Relic AWS Lex monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-lex-monitoring-integration
   - /docs/aws-lex-integration
@@ -12,9 +12,7 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-lex-monitoring-integration
 ---
 
-[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an Amazon Lex integration for reporting your Lex data to New Relic. Here we explain how to activate our integration and what data can be reported.
-
-Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an Amazon Lex integration for reporting your Lex data to New Relic. 
 
 ## Features [#features]
 
@@ -22,7 +20,11 @@ Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amaz
 
 ## Activate integration [#activate]
 
-To enable this integration, see how to [connect AWS services to New Relic](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/#set-up-metric-stream).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, see [Connect AWS services to New Relic](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/#set-up-metric-stream).
 
 ## Find and use data [#find-data]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration.mdx
@@ -11,13 +11,14 @@ redirects:
   - /docs/aws-aws_msk-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 New Relic offers an integration for collecting your [Amazon Web Services Managed Streaming for Apache Kafka](https://aws.amazon.com/msk/) data. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-mq-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-mq-integration.mdx
@@ -4,21 +4,23 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS MQ monitoring integration: what data it reports, and how to enable it.'
+metaDescription: "The New Relic AWS MQ monitoring integration: what data it reports, and how to enable it."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-mq-integration
   - /docs/aws-aws_mq-integration
 ---
 
+New Relic offers an integration for reporting your [Amazon Web Services MQ](https://aws.amazon.com/amazon-mq) data. 
+
 <Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-  
  ActiveMQ is the only MQ engine supported by this integration. If you're using RabbitMQ, see our [RabbitMQ integration](/docs/infrastructure/host-integrations/host-integrations-list/rabbitmq-monitoring-integration/) on how to get metrics from your instance.
 </Callout>
 
-New Relic offers an integration for reporting your [Amazon Web Services MQ](https://aws.amazon.com/amazon-mq) data. This document explains how to activate this integration and describes the data that can be reported.
-
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration.mdx
@@ -4,19 +4,19 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Neptune monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Neptune monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-neptune-monitoring-integration
   - /docs/aws-aws_neptune-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon Neptune data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-qldb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-qldb-monitoring-integration.mdx
@@ -4,20 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS QLDB monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS QLDB monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-qldb-monitoring-integration
   - /docs/integrations/amazon-integrations/aws-integrations-list/qldb-monitoring-integration
   - /docs/aws-aws_qldb-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 New Relic offers an integration for reporting your [Amazon Quantum Ledger Database (QLDB)](https://aws.amazon.com/qldb/) data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to Infrastructure](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s RDS monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic RDS monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-rds-monitoring-integration
   - /docs/aws-rds-integration
@@ -12,23 +12,22 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-rds-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon Web Services RDS data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
-New Relic also offers an [integration for enhanced RDS monitoring](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration).
+We also have an [integration for enhanced RDS monitoring](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration).
 
 ## Features [#features]
 
-Amazon's [Relational Database Service (RDS)](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html) is a web service that makes it easier to set up, operate, and scale a relational database in the cloud. It provides cost-efficient, resizable capacity for an industry-standard relational database and manages common database administration tasks.
-
-New Relic's RDS monitoring integration gathers metric and configuration data for the relational databases associated with your Amazon RDS account. Your RDS data is available in pre-built <InlinePopover type="dashboards" /> and you can also create [custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights). You can create [alert conditions](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information) for RDS data, and use the reported data to plan for future RDS capacity.
+Our [RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html) monitoring integration gathers metric and configuration data for the relational databases associated with your Amazon RDS account. Your RDS data is available in pre-built <InlinePopover type="dashboards" /> and you can also create [custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights). You can create [alert conditions](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information) for RDS data, and use the reported data to plan for future RDS capacity.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-redshift-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-redshift-integration.mdx
@@ -4,16 +4,12 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon Redshift monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon Redshift monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-redshift-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-redshift-integration
   - /docs/aws-redshift-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon Redshift data to New Relic. This document explains how to activate the integration and describes the data reported.
 
@@ -24,6 +20,10 @@ redirects:
 Reported data includes bytes received and bytes transmitted, health status, database connections, latency, and other [metrics](#metrics)). Your Redshift data is available in pre-built <InlinePopover type="dashboards" /> and you can also create [custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights).
 
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon Route 53 monitoring integration: how to activate it and a description of the data reported.'
+metaDescription: 'The New Relic Amazon Route 53 monitoring integration: how to activate it and a description of the data reported.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration
   - /docs/aws-route-53-integration
@@ -13,10 +13,6 @@ redirects:
   - /docs/aws-route53-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-route-53-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon Route 53 data to New Relic. This document explains how to activate the integration and describes the data reported.
 
@@ -34,7 +30,11 @@ Data reported to New Relic includes connection time, health checks, time to firs
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration.mdx
@@ -4,21 +4,21 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS WAF monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS WAF monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-route53-resolver-monitoring-integration
   - /docs/aws-aws_route53resolver-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your AWS Route53 Resolver data to our. Here we explain how to activate the integration and what data it collects.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration.mdx
@@ -4,17 +4,13 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon S3 monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon S3 monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration
   - /docs/aws-s3-integration
   - /docs/infrastructure/infrastructure-integrations/amazon-integrations/aws-s3-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-s3-monitoring-integration
 ---
-
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon S3 data to New Relic. This document explains how to activate the integration and describes the data reported.
 
@@ -27,10 +23,14 @@ With New Relic's Amazon S3 integration, data reported includes S3 bucket size, b
 ## Activate integration [#activate]
 
 <Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+<Callout variant="important">
   [Request and Data Transfer](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/configure-metrics.html) metrics are premium metrics and paid for separately through AWS. For CloudWatch pricing information, see Amazon's [S3 enhanced monitoring](https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html) documentation.
 </Callout>
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon Simple Email Service (SES) monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic Amazon Simple Email Service (SES) monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-simple-email-service-ses-monitoring-integration
   - /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ses-monitoring-integration
@@ -12,15 +12,16 @@ redirects:
   - /docs/aws-simple-email-service-ses-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
 
 [Amazon Simple Email Service (SES)](https://aws.amazon.com/ses/) is a cloud-based service for sending and receiving email. With New Relic's integration with Amazon SES, you can gather metrics and configuration options related to emails sent and received.
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: "New Relic's AWS Simple Notification Service (SNS) monitoring integration: How to activate it and a description of the data reported."
+metaDescription: "The New Relic AWS Simple Notification Service (SNS) monitoring integration: How to activate it and a description of the data reported."
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-sns-monitoring-integration
   - /docs/aws-sns-integration
@@ -12,11 +12,7 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-sns-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
-[Our infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon Web Services Simple Notification Service (SNS) data to New Relic. This document explains how to activate the integration and describes the data reported.
+[Our infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon Web Services Simple Notification Service (SNS) data to New Relic. 
 
 ## Features [#features]
 
@@ -26,9 +22,11 @@ redirects:
 * Subscriptions confirmed and deleted
 * Additional [metrics](#metrics)
 
-SNS data is available in pre-built <InlinePopover type="dashboards" /> in New Relic. You can also create [custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights), and create [alert conditions](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information) to notify you of changes in SNS data.
-
 ## Activate integration [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration.mdx
@@ -4,14 +4,14 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s AWS Step Functions monitoring integration: what data it reports, and how to enable it.'
+metaDescription: 'The New Relic AWS Step Functions monitoring integration: what data it reports, and how to enable it.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-step-functions-monitoring-integration
   - /docs/aws-aws_states-integration
 ---
 
 <Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/). We no longer recommend using this polling-based integration.
 </Callout>
 
 New Relic offers an integration for reporting your AWS Step Functions data. This document explains how to activate this integration and describes the data that can be reported.

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Amazon integrations
   - AWS integrations list
-metaDescription: 'New Relic''s Amazon VPC monitoring integration: how to enable it, and the data it reports.'
+metaDescription: 'The New Relic Amazon VPC monitoring integration: how to enable it, and the data it reports.'
 redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration
   - /docs/aws-vpc-integration
@@ -12,21 +12,19 @@ redirects:
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-vpc-monitoring-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
-[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon VPC data to New Relic. This document explains how to activate the integration and describes the data reported.
+[New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon VPC data to New Relic. 
 
 ## Features [#features]
 
 The Amazon [Virtual Private Cloud (VPC)](https://aws.amazon.com/vpc/) is a virtual network that utilizes the scalable infrastructure of Amazon Web Services (AWS). With New Relic's VPC integration, you can gain visibility into configuration event changes that are overlaid across your Amazon services.
 
-VPC data is available in pre-built dashboards, and you can create [custom queries and charts](/docs/infrastructure/integrations-getting-started/getting-started/use-integration-data-new-relic-insights). You can also create alert conditions to notify you about changes in the VPC.
-
 Additionally, [Enhanced Amazon VPC Flow Logs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) enables you to capture information about IP traffic to and from network interfaces in your VPC.
 
 ## Activate [#activate]
+
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
 
 To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-waf-monitoring-integration.mdx
@@ -11,15 +11,15 @@ redirects:
   - /docs/aws-aws_wafv2-integration
 ---
 
-<Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
-</Callout>
-
-New Relic offers an integration for reporting your [AWS Web Application Firewall](https://aws.amazon.com/waf/) data. This document explains how to activate this integration and describes the data that can be reported.
+New Relic offers an integration for reporting your [AWS Web Application Firewall](https://aws.amazon.com/waf/) data. 
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+<Callout variant="important">
+  To monitor all CloudWatch metrics from your AWS services, including custom namespaces, enable our [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream). We no longer recommend using this polling-based integration.
+</Callout>
+
+To enable this integration, follow standard procedures to [connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 

--- a/src/content/docs/infrastructure/amazon-integrations/connect/connect-aws-govcloud-new-relic.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/connect-aws-govcloud-new-relic.mdx
@@ -44,7 +44,7 @@ The AWS CloudWatch metric stream capability isn't available on GovCloud regions.
   * [DynamoDB](/docs/integrations/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration)
   * [EBS](/docs/integrations/amazon-integrations/aws-integrations-list/aws-ebs-monitoring-integration)
   * [EC2](/docs/integrations/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration)
-  * [Elasticsearch](/docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration)
+  * [OpenSearch](/docs/integrations/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration)
   * [ELB (Classic)](/docs/integrations/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration)
   * [EMR](/docs/integrations/amazon-integrations/aws-integrations-list/aws-emr-monitoring-integration)
   * [IAM](/docs/integrations/amazon-integrations/aws-integrations-list/aws-iam-monitoring-integration)

--- a/src/content/docs/infrastructure/amazon-integrations/connect/polling-intervals-aws-integrations.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/polling-intervals-aws-integrations.mdx
@@ -233,7 +233,7 @@ You can also monitor polling intervals by viewing that data in New Relic:
 
     <tr>
       <td>
-        [Elasticsearch](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-elasticsearch-integration)
+        [OpenSearch](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-elasticsearch-integration)
       </td>
 
       <td>

--- a/src/content/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies.mdx
@@ -434,7 +434,7 @@ The following permissions are used by New Relic to retrieve data for specific AW
 
   <Collapser
     id="elasticsearch-permissions"
-    title="ElasticSearch permissions"
+    title="OpenSearch permissions"
   >
     Additional [ElasticSearch](/docs/infrastructure/amazon-integrations/amazon-integrations/aws-elasticsearch-integration) permissions:
 

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -317,7 +317,7 @@ pages:
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elastic-beanstalk-monitoring-integration
           - title: ElastiCache integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration
-          - title: Elasticsearch integration
+          - title: OpenSearch Service integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration
           - title: ELB (Classic) integration
             path: /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elb-classic-monitoring-integration


### PR DESCRIPTION
Amazon renamed 'ElasticSearch' to 'OpenSearch Service'. Trying to update docs for this. There are still likely some 'elasticsearch' wordings in the codebase (event names, configs) but not entirely sure what's changed, will need more input. 

There is an eng ticket for this: NR-153630 