### PR TITLE
Remove Exception on AWS Metric Streams

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -218,7 +218,7 @@ To ensure FedRAMP compliance, all [APM agent configurations](/docs/using-new-rel
 
 If you have infrastructure agent version [1.15.0 or higher](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1150), simply enable the [FedRAMP configuration option](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings#fedramp). This enables FedRAMP compliancy for data reported by the infrastructure agent.
 
-This also enables FedRAMP compliancy for any [on-host integrations](/docs/integrations/host-integrations/host-integrations-list) that work with the infrastructure monitoring agent to report data. **Exception:** Currently the AWS CloudWatch Metric Streams integration is not FedRAMP compliant.
+This also enables FedRAMP compliancy for any [on-host integrations](/docs/integrations/host-integrations/host-integrations-list) that work with the infrastructure monitoring agent to report data.
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
The AWS Metric Streams is not listed on the Services Not In Scope on this page (https://docs.newrelic.com/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate/#not-scope) anymore, so I think we should remove it on the FEDRAMP Compliant Endpoint page too.  This PR removes that "EXCEPTION" verbiage to be consistent across the documentation.