### PR TITLE
docs: Remove Fedramp exception for AWS Metric Streams in fedramp-compliant-endpoints.mdx

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -218,7 +218,7 @@ To ensure FedRAMP compliance, all [APM agent configurations](/docs/using-new-rel
 
 If you have infrastructure agent version [1.15.0 or higher](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1150), simply enable the [FedRAMP configuration option](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings#fedramp). This enables FedRAMP compliancy for data reported by the infrastructure agent.
 
-This also enables FedRAMP compliancy for any [on-host integrations](/docs/integrations/host-integrations/host-integrations-list) that work with the infrastructure monitoring agent to report data. **Exception:** Currently the AWS CloudWatch Metric Streams integration is not FedRAMP compliant.
+This also enables FedRAMP compliancy for any [on-host integrations](/docs/integrations/host-integrations/host-integrations-list) that work with the infrastructure monitoring agent to report data. 
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
AWS Metric streams is now FedRAMP authorized

Per the product manager, AWS Metric Streams is now FedRAMP authorized. This PR removed the exception notice for AWS metric streams not being FedRAMP compliant.