### PR TITLE
fix: Remove #config-format

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format.mdx
+++ b/src/content/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format.mdx
@@ -711,7 +711,7 @@ The properties of this section modify the way the Infrastructure agent executes 
 
 ## Update older integration configuration [#update]
 
-In December 2019, the [Infrastructure agent version 1.8.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes) began using a different configuration format. For details, see [Config format differences](#config-formats).
+In December 2019, the [Infrastructure agent version 1.8.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes) began using a different configuration format.
 
 The main difference between these formats is that the older configuration format uses two separate configuration files (a `INTEGRATION_NAME-definition.yml` file and a `INTEGRATION_NAME-config.yml` file) and the newer version uses a single configuration file.
 


### PR DESCRIPTION
Removed a nonexistent anchor tag link in the 'Update older integration configuration' section of the page. Jira: NR-87663