### PR TITLE
docs(python): fix typo in agent installation instructions

### DIFF
--- a/src/install/python/python-agent-uvicorn-docker.mdx
+++ b/src/install/python/python-agent-uvicorn-docker.mdx
@@ -112,5 +112,5 @@ Note the following about this command:
 * The `-p` is for the port: It tells the container to pass port 8000 to your computer's port 8000. Change if necessary.
 
 <Callout variant="tip">
-  Since this example uses Uvicorn, check the next two steps if you need infomration about other frameworks or servers.
+  Since this example uses Uvicorn, check the next two steps if you need information about other frameworks or servers.
 </Callout>


### PR DESCRIPTION
Just a trivial typo fix PR.