### PR TITLE
Android agent v7.0.0 release notes & doc updates

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -51,7 +51,7 @@ Make sure your Android app meets these requirements:
       <td>
 HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 3.5+, 4.0+), OkIO (version 1.11), AndroidHttpClient, Volley (version 1.0.0), and Apache HTTP Client networking APIs
 
-<Callout variant="important">
+  <Callout variant="important">
   AndroidHttpClient was removed from the SDK in version 23, and as such only supported in Android agent version 6.5.0 and lower.
   </Callout>
 
@@ -61,6 +61,9 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
 * Gradle 7.1
 * Android Gradle plugin 7.0.0
 * DexGuard 9.0 and higher
+  <Callout variant="important">
+  DexGuard 9 doesn't yet support Gradle 8 or AGP 8
+  </Callout>
 
 **Android agent version 6.6.0 or higher** requires **Android SDK Tools version 24 or higher**. For Android SDK Tools version 24 or higher, you also need to meet the following requirements:
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -57,7 +57,7 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
 
 **Android agent version 7.0.0 or higher** requires:
 
-* Android Studio Flamingo 2022.2.1 RC 1
+* Android Studio Flamingo
 * Gradle 7.1
 * Android Gradle plugin 7.0.0
 * DexGuard 9.0 and higher

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -55,7 +55,7 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
   AndroidHttpClient was removed from the SDK in version 23, and as such only supported in Android agent version 6.5.0 and lower.
   </Callout>
 
-**Android agent version 7.0.0 or higher** needs to meet the following requirements:
+**Android agent version 7.0.0 or higher** requires:
 
 * Android Studio Flamingo 2022.2.1 RC 1
 * Gradle 7.1

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -61,9 +61,6 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
 * Gradle 7.1
 * Android Gradle plugin 7.0.0
 * DexGuard 9.0 and higher
-  <Callout variant="important">
-  DexGuard 9 doesn't yet support Gradle 8 or AGP 8
-  </Callout>
 
 **Android agent version 6.6.0 or higher** requires **Android SDK Tools version 24 or higher**. For Android SDK Tools version 24 or higher, you also need to meet the following requirements:
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -58,8 +58,9 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
 **Android agent version 7.0.0 or higher** requires to meet the following requirements:
 
 * Android Studio
-* Gradle 7.1.0
-* Gradle plugin 7.0
+* Gradle 7.0
+* Gradle plugin 7.0.0
+* DexGuard 9.0 and higher
 
 **Android agent version 6.6.0 or higher** requires **Android SDK Tools version 24 or higher**. For Android SDK Tools version 24 or higher, you also need to meet the following requirements:
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -55,6 +55,12 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
   AndroidHttpClient was removed from the SDK in version 23, and as such only supported in Android agent version 6.5.0 and lower.
   </Callout>
 
+**Android agent version 7.0.0 or higher** requires to meet the following requirements:
+
+* Android Studio
+* Gradle 7.1.0
+* Gradle plugin 7.0
+
 **Android agent version 6.6.0 or higher** requires **Android SDK Tools version 24 or higher**. For Android SDK Tools version 24 or higher, you also need to meet the following requirements:
 
   * Android Studio

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/new-relic-android-compatibility-requirements.mdx
@@ -55,18 +55,18 @@ HttpURLConnection, OkHttp2 (except versions 2.0 and 2.4), OkHttp (versions 2.8, 
   AndroidHttpClient was removed from the SDK in version 23, and as such only supported in Android agent version 6.5.0 and lower.
   </Callout>
 
-**Android agent version 7.0.0 or higher** requires to meet the following requirements:
+**Android agent version 7.0.0 or higher** needs to meet the following requirements:
 
-* Android Studio
-* Gradle 7.0
-* Gradle plugin 7.0.0
+* Android Studio Flamingo 2022.2.1 RC 1
+* Gradle 7.1
+* Android Gradle plugin 7.0.0
 * DexGuard 9.0 and higher
 
 **Android agent version 6.6.0 or higher** requires **Android SDK Tools version 24 or higher**. For Android SDK Tools version 24 or higher, you also need to meet the following requirements:
 
   * Android Studio
   * Gradle 5.1.1
-  * Gradle plugin 3.4
+  * Android Gradle plugin 3.4
   * Proguard 5.0
   * DexGuard 8.0 through 9.x
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-new-relic-gradle-plugin.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-new-relic-gradle-plugin.mdx
@@ -40,7 +40,7 @@ The New Relic Gradle plugin extension allows you to configure the behavior of pl
 
     <tr>
       <td>
-        `uploadMapsForVariant` (Deprecated)
+        `uploadMapsForVariant`
       </td>
 
       <td>
@@ -50,7 +50,7 @@ The New Relic Gradle plugin extension allows you to configure the behavior of pl
 
     <tr>
       <td>
-        `excludeVariantInstrumentation` (Deprecated)
+        `excludeVariantInstrumentation`
       </td>
 
       <td>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
@@ -29,6 +29,16 @@ To add support for [ProGuard](http://proguard.sourceforge.net/manual/usage.html)
    -keep class com.newrelic.** { *; }
    -dontwarn com.newrelic.**
    -keepattributes Exceptions, Signature, InnerClasses, LineNumberTable, SourceFile, EnclosingMethod
+
+  ##
+  ## NewRelic Gradle plugin 7.x requires the following additions:
+  ##
+  # Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+  -keepattributes Signature
+  -keep class com.newrelic.com.google.gson.reflect.TypeToken { *; }
+  -keep class * extends com.newrelic.com.google.gson.reflect.TypeToken
+  # For using GSON @Expose annotation
+  -keepattributes *Annotation*
    ```
 3. Clean and rebuild your project.
 4. Run your app in an emulator or device to start seeing data on your mobile app's [**Overview** page](/docs/mobile-apps/mobile-apps-dashboard).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps.mdx
@@ -31,9 +31,9 @@ To add support for [ProGuard](http://proguard.sourceforge.net/manual/usage.html)
    -keepattributes Exceptions, Signature, InnerClasses, LineNumberTable, SourceFile, EnclosingMethod
 
   ##
-  ## NewRelic Gradle plugin 7.x requires the following additions:
+  ## NewRelic Gradle plugin 7.x may require the following additions:
   ##
-  # Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+  # Retain generic signatures of TypeToken and its subclasses if [R8 version 3.0 full-mode](https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode) is enabled.
   -keepattributes Signature
   -keep class com.newrelic.com.google.gson.reflect.TypeToken { *; }
   -keep class * extends com.newrelic.com.google.gson.reflect.TypeToken

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
@@ -250,7 +250,7 @@ The following are the specific policies and dates for support of our mobile moni
     </tr>
     <tr>
       <td>
-        [v6.11.1]
+        v6.11.1
       </td>
 
       <td>
@@ -263,7 +263,7 @@ The following are the specific policies and dates for support of our mobile moni
     </tr>
     <tr>
       <td>
-        [v6.11.0]
+        v6.11.0
       </td>
 
       <td>
@@ -276,7 +276,7 @@ The following are the specific policies and dates for support of our mobile moni
     </tr>
     <tr>
       <td>
-        [v6.10.0]
+        v6.10.0
       </td>
 
       <td>
@@ -289,7 +289,7 @@ The following are the specific policies and dates for support of our mobile moni
     </tr>
     <tr>
       <td>
-        [v6.9.2]
+        v6.9.2
       </td>
 
       <td>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
@@ -237,7 +237,20 @@ The following are the specific policies and dates for support of our mobile moni
   <tbody>
     <tr>
       <td>
-        [v6.11.1 (last Android agent release)](/docs/release-notes/mobile-release-notes/android-release-notes/)
+        [v7.0.0 (last Android agent release)](/docs/release-notes/mobile-release-notes/android-release-notes/)
+      </td>
+
+      <td>
+        Jun 8, 2023
+      </td>
+    
+      <td>
+        Jun 8, 2024
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [v6.11.1]
       </td>
 
       <td>

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Android agent
-releaseDate: '2023-06-08'
+releaseDate: '2023-07-10'
 version: 7.0.0
 downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_7.0.0.zip'
 ---

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
@@ -10,7 +10,7 @@ downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_
   * Gradle 6.x
   * Android Gradle Plugin (AGP) 4.x
 
-  Android agent 7.x is increasing the minimum Gradle version to 7.0. Customers will be required to upgrade to Android Gradle Plugin (AGP) 7.0.0 and higher.
+  Android agent 7.x is increasing the minimum Gradle version to 7.1. Customers will be required to upgrade to Android Gradle Plugin (AGP) 7.0.0 and higher.
 </Callout>
 
 ## New
@@ -20,10 +20,6 @@ downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_
 * Adds support for Gradle configuration caching
 * Adds support for JDK 17 when used with Gradle 8
 
-
-## Fixed
-
-* Tighten the exception handling of HarvestTimer to prevent NullPointerException
 
 ## Support statement
 

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
@@ -1,0 +1,26 @@
+---
+subject: Android agent
+releaseDate: '2023-06-08'
+version: 7.0.0
+downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_7.0.0.zip'
+---
+
+
+## New
+
+* AGP 8 support
+* Configuration cache support
+
+## Fixed
+
+* Tighten the exception handling of HarvestTimer to prevent NullPointerException
+
+## Support statement
+
+We recommend you to upgrade the agent regularly, at least every 3 months.
+
+As of this release, the oldest supported version is [6.1.0](/docs/release-notes/mobile-release-notes/android-release-notes/android-610).
+
+<Callout variant="important">
+  Please note, the Android agent is increasing the minimum Gradle versions since agent release 7.0.0. Customers will be required to upgrade to Android Gradle Plugin 7.1 at minimum.
+</Callout>

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-700.mdx
@@ -5,11 +5,21 @@ version: 7.0.0
 downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_Agent_7.0.0.zip'
 ---
 
+<Callout variant="important">
+  Welcome to the New Relic Android agent version 7.0. This major release breaks compatibility with versions of 
+  * Gradle 6.x
+  * Android Gradle Plugin (AGP) 4.x
+
+  Android agent 7.x is increasing the minimum Gradle version to 7.0. Customers will be required to upgrade to Android Gradle Plugin (AGP) 7.0.0 and higher.
+</Callout>
 
 ## New
 
-* AGP 8 support
-* Configuration cache support
+* Adds support for Gradle 8.0 and higher
+* Adds support for the Android Gradle Plugin 8.0 and higher
+* Adds support for Gradle configuration caching
+* Adds support for JDK 17 when used with Gradle 8
+
 
 ## Fixed
 
@@ -20,7 +30,3 @@ downloadLink: 'https://download.newrelic.com/android_agent/ant/NewRelic_Android_
 We recommend you to upgrade the agent regularly, at least every 3 months.
 
 As of this release, the oldest supported version is [6.1.0](/docs/release-notes/mobile-release-notes/android-release-notes/android-610).
-
-<Callout variant="important">
-  Please note, the Android agent is increasing the minimum Gradle versions since agent release 7.0.0. Customers will be required to upgrade to Android Gradle Plugin 7.1 at minimum.
-</Callout>


### PR DESCRIPTION

* What problems does this PR solve? - Android agent v7.0.0 release notes & doc updates

1. AGP 8 support
2. Config cache support
3. Compatibility doc update
4. Release note callout to indicate minimum Gradle and AGP version upgrades