### PR TITLE
chore: add Node.js Agent v10.2.0 Release Notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-10-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-10-2-0.mdx
@@ -1,0 +1,34 @@
+---
+subject: Node.js agent
+releaseDate: '2023-06-06'
+version: 10.2.0
+downloadLink: 'https://www.npmjs.com/package/newrelic'
+security: []
+bugs: []
+features: ["added supportability metrics to indicate how agent was loaded and if --enable-source-maps was passed to Node.js runtime", "log execArgs at the debug level"]
+---
+
+## Notes
+
+#### Features
+
+* Added supportability metrics to indicate how agent was loaded and if source maps were enabled ([#1657](https://github.com/newrelic/node-newrelic/pull/1657)) ([6f6f7e6](https://github.com/newrelic/node-newrelic/commit/6f6f7e68bf382c6082550306aee30a670652347d))
+    * `Supportability/Features/CJS/Preload` - recorded if `-r newrelic` was used to load agent  
+    * `Supportability/Features/CJS/Require` - recorded if `require('newrelic')` was used to load agent  
+    * `Supportability/Features/EnableSourceMaps` - recorded if `node --enable-source-maps` was present to start application
+
+* Added logging of `process.execArgs` at the debug level ([#1654](https://github.com/newrelic/node-newrelic/pull/1654)) ([c85c006](https://github.com/newrelic/node-newrelic/commit/c85c006e722fce1271795b2613e1dd2a96983046))
+
+#### Miscellaneous Chores
+
+* Updated c8 to merge v8 coverage reports asynchronously to avoid OOM issues ([#1652](https://github.com/newrelic/node-newrelic/pull/1652)) ([34376d7](https://github.com/newrelic/node-newrelic/commit/34376d7d51c0e0d34a5c94b53785d153341f06b8))
+* Updated explorer hub link in readme ([#1656](https://github.com/newrelic/node-newrelic/pull/1656)) ([c1e81a7](https://github.com/newrelic/node-newrelic/commit/c1e81a7d04c113dc3659dad3c777d0ce2dd21162))
+
+#### Tests
+
+* Added unit tests for MySQL instrumentation ([#1649](https://github.com/newrelic/node-newrelic/pull/1649)) ([b693ba0](https://github.com/newrelic/node-newrelic/commit/b693ba039a42f9034f5206692e6d7a0523e23e51))
+
+
+### Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software).

--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-10-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-10-2-0.mdx
@@ -19,7 +19,7 @@ features: ["added supportability metrics to indicate how agent was loaded and if
 
 * Added logging of `process.execArgs` at the debug level ([#1654](https://github.com/newrelic/node-newrelic/pull/1654)) ([c85c006](https://github.com/newrelic/node-newrelic/commit/c85c006e722fce1271795b2613e1dd2a96983046))
 
-#### Miscellaneous Chores
+#### Miscellaneous chores
 
 * Updated c8 to merge v8 coverage reports asynchronously to avoid OOM issues ([#1652](https://github.com/newrelic/node-newrelic/pull/1652)) ([34376d7](https://github.com/newrelic/node-newrelic/commit/34376d7d51c0e0d34a5c94b53785d153341f06b8))
 * Updated explorer hub link in readme ([#1656](https://github.com/newrelic/node-newrelic/pull/1656)) ([c1e81a7](https://github.com/newrelic/node-newrelic/commit/c1e81a7d04c113dc3659dad3c777d0ce2dd21162))


### PR DESCRIPTION
Supersedes #13376, this has the corrected frontmatter for 10.2.0 release notes