### PR TITLE
add tranform for data-dictionary events

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "mdast-util-heading-range": "^2.1.4",
     "mdast-util-to-hast": "^10.1.0",
     "mdast-util-to-string": "^1.1.0",
+    "mkdirp": "^3.0.1",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.6.1",
     "node-html-parser": "^5.3.3",

--- a/scripts/transformDataDictionary.mjs
+++ b/scripts/transformDataDictionary.mjs
@@ -1,0 +1,116 @@
+#! /usr/bin/env node
+
+import frontmatter from 'front-matter';
+import * as fs from 'fs/promises';
+import { glob } from 'glob10';
+import yaml from 'js-yaml';
+import _ from 'lodash';
+import { mkdirp } from 'mkdirp';
+
+/**
+ * this script transforms the events and attributes Markdown in
+ * `src/data-dictionary/events` into a new structure.
+ *
+ * ## before
+
+ * previously, attributes specified which events they belonged to via
+ * an `events` field in their frontmatter. this included specifying 
+ * the parent event in their containing folder.
+ *
+ * ## after
+ * 
+ * running this script removes the `events` field from all attributes
+ * and adds an `attributes` field to all events.
+ * events now specify which attributes belong to them with a qualified name.
+ * for example, for the BrowserTiming event to use an attribute from PageView,
+ * it would have `PageView/deviceType` in its `attributes` list.
+ * attributes in the same folder automatically belong to their parent event,
+ * so PageView.event-definition.md MUST NOT specify `PageView/deviceType`.
+ */
+
+const constructYaml = ({ body, ...attributes }) => {
+  let str = '---\n';
+  str += yaml.dump(attributes);
+  str += '---\n\n';
+  str += body;
+  return str;
+};
+
+const getParentFromPath = (path) => {
+  const parts = path.split('/').slice(0, -1);
+  return parts[parts.length - 1];
+};
+
+const markdownPaths = await glob('src/data-dictionary/events/**/*.md');
+
+const events = new Map();
+const attributes = new Map();
+
+const eventPaths = markdownPaths.filter((path) =>
+  path.includes('.event-definition')
+);
+const eventStrs = await Promise.all(
+  eventPaths.map((path) =>
+    fs.readFile(path, 'utf-8').then((str) => [path, str])
+  )
+);
+eventStrs
+  .map(([path, eventStr]) => [path, frontmatter(eventStr)])
+  .forEach(([path, { attributes, body }]) =>
+    events.set(attributes.name, {
+      ...attributes,
+      body,
+      attributes: new Set(),
+      fsPath: path,
+    })
+  );
+
+let attributePaths = markdownPaths.filter(
+  (path) => !path.includes('.event-definition')
+);
+let attributeStrs = await Promise.all(
+  attributePaths.map((path) =>
+    fs.readFile(path, 'utf-8').then((str) => [path, str])
+  )
+);
+attributeStrs
+  .map(([path, attributeStr]) => [path, frontmatter(attributeStr)])
+  .forEach(([path, { attributes: mdAttributes, body }]) =>
+    attributes.set(mdAttributes.name, {
+      ...mdAttributes,
+      body,
+      parentEvent: getParentFromPath(path),
+      fsPath: path,
+    })
+  );
+
+for (const [name, attribute] of attributes) {
+  const parent = attribute.parentEvent;
+  const qualifiedName = `${parent}/${name}`;
+
+  attribute.events
+    .filter((event) => event !== parent)
+    .forEach((event) => events.get(event).attributes.add(qualifiedName));
+  delete attribute.events;
+
+  let path = attribute.fsPath;
+  delete attribute.fsPath;
+  delete attribute.parentEvent;
+
+  let yaml = constructYaml(attribute);
+  const parentFolder = path.split('/').slice(0, -1).join('/');
+  await mkdirp(parentFolder);
+  fs.writeFile(path, yaml);
+}
+
+for (const [name, event] of events) {
+  let path = event.fsPath;
+  delete event.fsPath;
+  event.attributes = Array.from(event.attributes).sort();
+  if (event.attributes.length === 0) {
+    delete event.attributes;
+  }
+
+  let yaml = constructYaml(event);
+  fs.writeFile(path, yaml);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14061,6 +14061,11 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mkdirp@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
+  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
+
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"


### PR DESCRIPTION
this script transforms the data for events and attributes so that events list attributes they have, rather than individual attributes listing different events they belong to

it also assumes that attributes inside a folder automatically belong to their parent event, so the event definition doesn't need to specify attributes within its own folder

## testing

- from the root project dir, run `scripts/transformDataDictionary.mjs`
- `src/data-dictionary/events/` should be updated with the new format
