### PR TITLE
chore(redirects): Fix all 404s with 20+ hits/month

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy.mdx
@@ -27,6 +27,7 @@ redirects:
   - /docs/alerts/new-relic-alerts/configuring-alert-policies/name-or-rename-alert-policy
   - /docs/alerts/new-relic-alerts/configuring-alert-policies/create-or-rename-alert-policy
   - /docs/alerts/new-relic-alerts/configuring-alert-policies/create-edit-or-find-alert-policy
+  - /docs/alerts/new-relic-alerts-beta/configuring-alert-policies/alert-policy-workflow
 ---
 
 import accountsGreenQuestionMark from 'images/accounts_icon_green-question-mark.webp'

--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -27,6 +27,7 @@ redirects:
   - /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/introduction-alerts
   - /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow
   - /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence/
+  - /docs/alerts/new-relic-alerts/getting-started/alerting-new-relic
 signupBanner:
   text: Monitor and improve your entire stack. 100GB free. Forever.
 ---

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -10,6 +10,7 @@ redirects:
   - /docs/mongodb3-integration-new-relic-infrastructure
   - /docs/infrastructure/host-integrations/host-integrations-list/mongodb-monitoring-integration
   - /docs/integrations/host-integrations/host-integrations-list/mongodb-monitoring-integration
+  - /docs/mongodb-integration-new-relic-infrastructure
 ---
 
 import infrastructureMongoDashboard from 'images/infrastructure_screenshot-crop_mongodb-dashboard.webp'

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-batchaccount-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-batchaccount-monitoring-integration.mdx
@@ -1,6 +1,8 @@
 ---
 title: Azure Batch Account service for Azure Monitor integration
 metaDescription: "New Relic's Microsoft Azure Batch Account integration: what data it reports and how to enable it."
+redirects:
+  - /docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-batch-monitoring-integration
 ---
 
 [New Relic's integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your [Microsoft Azure Batch Account](https://azure.microsoft.com/en-us/services/batch/) metrics and other data to New Relic. This document explains how to activate the integration and describes the data reported.

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -24,6 +24,8 @@ redirects:
   - /docs/new-relic-solutions/new-relic-one/install-configure/install-new-relic
   - /docs/new-relic-solutions/get-started/quick-launch-guide
   - /docs/using-new-relic/welcome-new-relic/get-started/get-started-full-stack-observability
+  - /docs/agents/manage-apm-agents/installation/install-agent
+  - /docs/new-relic-one/use-new-relic-one/cross-product-functions/install-configure/install-new-relic
 signupBanner:
   text: Monitor and improve your entire stack. 100GB free. Forever.
 ---

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-2-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-2-2.mdx
@@ -6,6 +6,8 @@ downloadLink: https://rubygems.org/downloads/newrelic_rpm-9.2.2.gem
 features: []
 bugs: ["Transaction#finished? no longer throws a NoMethodError when initial_segment is nil"]
 security: []
+redirects:
+  - docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-922
 ---
 
 <Callout variant="important">


### PR DESCRIPTION
From this dashboard: **Docs Site Instrumentation Dashboard > 404 hits**

Fixes all 404s with more than 20 hits per month