### PR TITLE
Remove table row saying we do not support JOINS

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-how-nrql-works.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-how-nrql-works.mdx
@@ -144,16 +144,6 @@ NRQL's basic rules are as follows:
         NRQL supports [subqueries](/docs/query-your-data/nrql-new-relic-query-language/get-started/subqueries-in-nrql).
       </td>
     </tr>
-
-    <tr>
-      <td>
-        `JOIN` clauses
-      </td>
-
-      <td>
-        NRQL does not have the equivalent of the SQL `JOIN` clause, but you can [simulate a `JOIN` with custom attributes](/docs/insights/new-relic-insights/using-new-relic-query-language/simulate-sql-join-functions-insights).
-      </td>
-    </tr>
     <tr>
       <td>
         Comments
@@ -162,7 +152,7 @@ NRQL's basic rules are as follows:
       <td>
         You can add comments to your NRQL queries. [Learn more about comments](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions#comments). 
       </td>
-    </tr>    
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
We had a legacy comment about how we didn't support JOINS in NRQL, but we've been supporting these for a while. 