### PR TITLE
Remove IP range specific labels from Network Traffic doc

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -617,16 +617,16 @@ Endpoints that use `api.newrelic.com` (such as our [NerdGraph API](/docs/apis/ne
 
 Network blocks for US region accounts:
 
-* `162.247.240.0/22` (Private Data Center)
-* `18.246.82.0/25` (AWS, US-WEST-2 , effective July 1st, 2023)
-* `3.145.244.128/25` (AWS, US-EAST-2, effective July 1st, 2023)
+* `162.247.240.0/22`
+* `18.246.82.0/25` (effective July 1st, 2023)
+* `3.145.244.128/25` (effective July 1st, 2023)
 
 Network blocks for EU region accounts:
 
-* `158.177.65.64/29` (Private Data Center)
-* `159.122.103.184/29` (Private Data Center)
-* `161.156.125.32/28` (Private Data Center)
-* `3.77.79.0/25` (AWS, EU-CENTRAL-1, effective July 1st, 2023)
+* `158.177.65.64/29`
+* `159.122.103.184/29`
+* `161.156.125.32/28`
+* `3.77.79.0/25` (effective July 1st, 2023)
 
 These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations). However, they don't apply to the [Azure Monitor integration](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor/).
 


### PR DESCRIPTION
This removes the "Private Data Center" vs "AWS" labels from the "Alerts webhooks, api.newrelic.com, cloud integrations, and ticketing integrations" section. The origin of outbound hooks is not directly controlled by the customer, so the labels are unnecessary and can be a source of confusion. 