### PR TITLE
Create install-with-operator.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-with-operator.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/install-with-operator.mdx
@@ -1,0 +1,49 @@
+---
+title: Install the Kubernetes integration using the New Relic operator
+tags:
+  - Integrations
+  - Kubernetes integration
+  - Installation
+translate:
+  - kr
+metaDescription: How to install the K8s integration using the operator.
+---
+
+Kubernetes applications can consist of many deployments, services, pods, and more. Managing so many different resources individually can be overwhelming, especially if you are not the application developer. This is where the operator comes in.
+
+## What is an operator? [#what-is-operator]
+Kubernetes operators help manage these complex applications by abstracting those Kubernetes resources into a set of custom configurations, or custom resources. This reduces the burden on you as a user, as you would only need to interface with the custom resources to manage the application. You can then rely on the operator to deploy, upgrade, and manage the application for you.
+
+## Why use New Relic’s Kubernetes operator? [#why-use-nr-operator]
+New Relic’s [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/) is packed with many different modules to help you monitor your cluster. From Prometheus, to logging, to Pixie, and more, it can be difficult to manage and configure all of these moving parts. Whether you are trying to update a configuration for one of these modules or upgrade to the latest versions, the operator can do it all for you. 
+
+## Guided Install [#guided-install]
+To install the New Relic Kubernetes operator, first add the operator:
+
+```shell
+helm repo add nr-operator https://newrelic.github.io/newrelic-k8s-operator && helm repo update
+```
+
+Then, follow the directions for [the Kubernetes guided install](https://onenr.io/0Y8wpoYJJQO). When presented with options to deploy via `Guided Install`, `Helm 3`, or `Manifest`, choose `Helm 3`. Currently, you need to replace one line in the generated command. Replace line 5 with the following, replacing [YOUR_NAMESPACE] with the name of your namespace:
+
+```shell
+kubectl create namespace [YOUR_NAMESPACE] ; helm upgrade --install newrelic-bundle nr-operator/newrelic-k8s-operator \
+```
+
+Running the Helm command should then deploy New Relic’s operator to your cluster, which will then help deploy the rest of the Kubernetes integration.
+
+## Configure the integration [#configure-integration]
+The operator manages two custom resources that you can edit and configure: 
+
+* Monitor
+* NRIBundle
+
+Changes to these custom resources will automatically be updated and applied to your Kubernetes cluster. When installing the operator via Helm 3, you should use Helm to modify the configuration. 
+
+To upgrade to the latest version of New Relic’s bundle, run:
+
+```shell
+helm upgrade newrelic-k8s-operator newrelic/newrelic-k8s-operator --set version=<version>
+```
+
+Other configuration options that can be set mirror the configuration options of `nri-bundle`, which can be found [here](/docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm/#configure). 

--- a/src/nav/kubernetes-pixie.yml
+++ b/src/nav/kubernetes-pixie.yml
@@ -11,6 +11,8 @@ pages:
     pages:
       - title: Get started with Kubernetes
         path: /docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure
+      - title: Install with the operator
+        path: /docs/kubernetes-pixie/kubernetes-integration/installation/install-with-operator
       - title: Manual install using Helm
         path: /docs/kubernetes-pixie/kubernetes-integration/installation/install-kubernetes-integration-using-helm
       - title: Install EKS Fargate


### PR DESCRIPTION
This is a net new doc about our new K8s operator, which offers an additional way to install our K8s integration while also providing automation for other k8s application management processes.

I intend for it to be organized as such:
- Kubernetes and Pixie
  - Install Kubernetes integration
    - Get started with Kubernetes
    - **Install with the operator**
    - Manual install using helm
    - Install EKS Fargate
    - ... 
