### PR TITLE
[chore] Update upgrading-kubernetes.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/upgrading-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/upgrading-kubernetes.mdx
@@ -28,7 +28,7 @@ If you want to manually upgrade your Kubernetes integration installed via Helm:
 2. Update the release by running again the appropriate `helm upgrade --install ...` command in the section above:
 
    ```bash
-   helm upgrade --install newrelic newrelic/nri-bundle \
+   helm upgrade --install newrelic-bundle newrelic/nri-bundle \
    --namespace newrelic --create-namespace \
    -f values-newrelic.yaml
    ```


### PR DESCRIPTION
Standardize release name to match guided install, as `newrelic-bundle`


* What problems does this PR solve?
The release name must be used when referring to a Helm chart in the CLI. If the release name doesn't match the initial installation, it could cause confusion.

Other docs seem to also use `newrelic-bundle`, agreeing with the guided install.