### PR TITLE
Update global-technical-support-offerings.mdx

### DIFF
--- a/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
@@ -736,8 +736,8 @@ We want everyone to monitor their systems, and we're contributing our technology
 
 [New Relic Open Source](https://opensource.newrelic.com/explore-projects/) projects are assigned to one of five different categories. These categories determine the support options available for a project as listed below:
 
-* **Community plus projects**: Actively maintained by New Relic. Support requests can be made through Github, Community, and Case Support channels, depending on the service level associated with the New Relic account.
-* **Community projects**: Actively maintained by New Relic. Support requests can be made through Github or Community.
+* **Community plus projects**: New Relic-owned repositories with this designation are actively maintained by New Relic. Support requests can be made through Github, Community, and Case Support channels, depending on the service level associated with the New Relic account.
+* **Community projects**: New Relic-owned repositories with this designation are actively maintained by New Relic. Support requests can be made through Github or Community.
 * **New Relic catalog**: Support requests can be made through the Github channel. Issues/Pull Requests should be directed to the relevant Github repository.
 * **Example code**: Project support is through Github channel. Issues/Pull Requests should be directed to the relevant Github repository.
 * **New Relic experimental**: Projects have no ongoing maintenance, development or support.


### PR DESCRIPTION
Would like to clarify that only New Relic-owned repositories with those category designations (community & community plus) are supported by New Relic. Anyone can fork those repos, and NR would not support those forks (example: https://packagist.org/packages/marketredesign/newrelic-monolog-enricher)

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.