### PR TITLE
docs: fix NEW_RELIC_TRUSTED_ACCOUNT_KEY variable name

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -467,7 +467,7 @@ On this page, you will learn how to manually instrument your lambda function. It
     7. The following environment variables are not required for Lambda monitoring to function but they are required if you want your Lambda functions to be included in distributed traces. To enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing), set these [environment variables](https://docs.aws.amazon.com/amplify/latest/userguide/environment-variables.html) in the AWS console:
        * `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`. Set to true.
        * `NEW_RELIC_ACCOUNT_ID`. Your [account ID](/docs/accounts/install-new-relic/account-setup/account-id).
-       * `NEW_RELIC_TRUSTED_ACCOUNT_KEY.` This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this needs to be the account ID for the root/parent account.
+       * `NEW_RELIC_TRUSTED_ACCOUNT_KEY`. This is also your [account ID](/docs/accounts/install-new-relic/account-setup/account-id). If your account is a child account, this needs to be the account ID for the root/parent account.
 
     8. Optional: To configure logging, use the [`NEW_RELIC_LOG` and `NEW_RELIC_LOG_LEVEL` environment variables](/docs/agents/python-agent/configuration/python-agent-configuration#environment-variables) in the AWS Console.
 


### PR DESCRIPTION
Fixing the `NEW_RELIC_TRUSTED_ACCOUNT_KEY` so it doesn't include a period at the end.