### PR TITLE
chore(style guide): Add/improve tabs example syntax

### DIFF
--- a/src/content/docs/style-guide/structure/tabs.mdx
+++ b/src/content/docs/style-guide/structure/tabs.mdx
@@ -8,15 +8,15 @@ redirects:
 
 Tabs, like `collapsers`, present various sets of information in a condensed space. Tabs present their information all at once, and unlike collapsers, you can't have multiple tabs from the same group visible at once. Tabs are framed by Tabs tags, with the `TabsBar` subgroup responsible for formatting the "tabs" themselves, and the TabsPages controlling the formatting and presentation of the copy under each individual tab. 
 
-You can set tab groups as either horizontal or vertical tabs. For vertical tabs, use `<Tabs stacked>` instead of `<Tabs>` as the header. For each TabsBarItem, set the title for the tab in the `id="YOUR_ID_HERE"` section, and match the content of the TabsPages by putting the `id="YOUR_ID_HERE"` entry in the appropriate `TabsPageItem id=""` section.
+You can set tab groups as either horizontal or vertical tabs. For vertical tabs, use `<Tabs stacked>` instead of `<Tabs>` as the header. For each `<TabsBarItem>`, set the ID for the tab in the `id="YOUR_ID_HERE"` section, and match the content of the `<TabsPages>` by putting a matching ID in the appropriate `<TabsPageItem id="YOUR_ID_HERE">` section.
 
 <Callout variant="tip">
 The Keyboard Maestro for the Tabs component is `kktabgroup`.
 </Callout>
 
-### Example: Horizontal tabs
+## Example: Horizontal tabs
 
-Code:
+### Code
 
 ```
 <Tabs>
@@ -34,13 +34,13 @@ Code:
       Contents for tab two
 		</TabsPageItem>
 		<TabsPageItem id="3">
-      Contents for tab 3
+      Contents for tab three
 		</TabsPageItem>
 	</TabsPages>
 </Tabs>
 ```
 
-Output:
+### Output
 
 <Tabs>
 	<TabsBar>
@@ -57,15 +57,15 @@ Output:
       Contents for tab two
 		</TabsPageItem>
 		<TabsPageItem id="3">
-      Contents for tab 3
+      Contents for tab three
 		</TabsPageItem>
 	</TabsPages>
 </Tabs>
 
 
-### Example: Vertical tabs
+## Example: Vertical tabs
 
-Code:
+### Code
 
 ```
 <Tabs stacked>
@@ -83,13 +83,13 @@ Code:
       Contents for tab two
 		</TabsPageItem>
 		<TabsPageItem id="3">
-      Contents for tab 3
+      Contents for tab three
 		</TabsPageItem>
 	</TabsPages>
 </Tabs>
 ```
 
-Output:
+### Output
 
 <Tabs stacked>
 	<TabsBar>
@@ -106,7 +106,7 @@ Output:
       Contents for tab two
 		</TabsPageItem>
 		<TabsPageItem id="3">
-      Contents for tab 3
+      Contents for tab three
 		</TabsPageItem>
 	</TabsPages>
 </Tabs>

--- a/src/content/docs/style-guide/structure/tabs.mdx
+++ b/src/content/docs/style-guide/structure/tabs.mdx
@@ -8,26 +8,105 @@ redirects:
 
 Tabs, like `collapsers`, present various sets of information in a condensed space. Tabs present their information all at once, and unlike collapsers, you can't have multiple tabs from the same group visible at once. Tabs are framed by Tabs tags, with the `TabsBar` subgroup responsible for formatting the "tabs" themselves, and the TabsPages controlling the formatting and presentation of the copy under each individual tab. 
 
-You can set tab groups as either horizontal or vertical tabs. For vertical tabs, use `<Tabs stacked>` instead of `<Tabs>` as the header. For each TabsBarItem, set the title for the tab in the `id=` section, and match the content of the TabsPages by putting the `id=` entry in the appropriate `TabsPageItem id=` section.
+You can set tab groups as either horizontal or vertical tabs. For vertical tabs, use `<Tabs stacked>` instead of `<Tabs>` as the header. For each TabsBarItem, set the title for the tab in the `id="YOUR_ID_HERE"` section, and match the content of the TabsPages by putting the `id="YOUR_ID_HERE"` entry in the appropriate `TabsPageItem id=""` section.
+
+<Callout variant="tip">
+The Keyboard Maestro for the Tabs component is `kktabgroup`.
+</Callout>
+
+### Example: Horizontal tabs
+
+Code:
 
 ```
 <Tabs>
 	<TabsBar>
-		<TabsBarItem id=""></TabsBarItem>
-		<TabsBarItem id=""></TabsBarItem>
-		<TabsBarItem id=""></TabsBarItem>
+		<TabsBarItem id="1">Tab one</TabsBarItem>
+		<TabsBarItem id="2">Tab two</TabsBarItem>
+		<TabsBarItem id="3">Tab three</TabsBarItem>
 	</TabsBar>
 
 	<TabsPages>
-		<TabsPageItem id="">
+		<TabsPageItem id="1">
+      Contents for tab one
 		</TabsPageItem>
-		<TabsPageItem id="">
+		<TabsPageItem id="2">
+      Contents for tab two
 		</TabsPageItem>
-		<TabsPageItem id="">
+		<TabsPageItem id="3">
+      Contents for tab 3
 		</TabsPageItem>
 	</TabsPages>
 </Tabs>
 ```
-<Callout variant="tip">
-The Keyboard Maestro for the Tabs component is `kktabgroup`.
-</Callout>
+
+Output:
+
+<Tabs>
+	<TabsBar>
+		<TabsBarItem id="1">Tab one</TabsBarItem>
+		<TabsBarItem id="2">Tab two</TabsBarItem>
+		<TabsBarItem id="3">Tab three</TabsBarItem>
+	</TabsBar>
+
+	<TabsPages>
+		<TabsPageItem id="1">
+      Contents for tab one
+		</TabsPageItem>
+		<TabsPageItem id="2">
+      Contents for tab two
+		</TabsPageItem>
+		<TabsPageItem id="3">
+      Contents for tab 3
+		</TabsPageItem>
+	</TabsPages>
+</Tabs>
+
+
+### Example: Vertical tabs
+
+Code:
+
+```
+<Tabs stacked>
+	<TabsBar>
+		<TabsBarItem id="1">Tab one</TabsBarItem>
+		<TabsBarItem id="2">Tab two</TabsBarItem>
+		<TabsBarItem id="3">Tab three</TabsBarItem>
+	</TabsBar>
+
+	<TabsPages>
+		<TabsPageItem id="1">
+      Contents for tab one
+		</TabsPageItem>
+		<TabsPageItem id="2">
+      Contents for tab two
+		</TabsPageItem>
+		<TabsPageItem id="3">
+      Contents for tab 3
+		</TabsPageItem>
+	</TabsPages>
+</Tabs>
+```
+
+Output:
+
+<Tabs stacked>
+	<TabsBar>
+		<TabsBarItem id="1">Tab one</TabsBarItem>
+		<TabsBarItem id="2">Tab two</TabsBarItem>
+		<TabsBarItem id="3">Tab three</TabsBarItem>
+	</TabsBar>
+
+	<TabsPages>
+		<TabsPageItem id="1">
+      Contents for tab one
+		</TabsPageItem>
+		<TabsPageItem id="2">
+      Contents for tab two
+		</TabsPageItem>
+		<TabsPageItem id="3">
+      Contents for tab 3
+		</TabsPageItem>
+	</TabsPages>
+</Tabs>

--- a/src/content/docs/style-guide/structure/tabs.mdx
+++ b/src/content/docs/style-guide/structure/tabs.mdx
@@ -6,7 +6,7 @@ tags:
 redirects:
 ---
 
-Tabs, like `collapsers`, present various sets of information in a condensed space. Tabs present their information all at once, and unlike collapsers, you can't have multiple tabs from the same group visible at once. Tabs are framed by Tabs tags, with the `TabsBar` subgroup responsible for formatting the "tabs" themselves, and the TabsPages controlling the formatting and presentation of the copy under each individual tab. 
+Tabs, like [collapsers](/docs/style-guide/structure/collapsers/), present various sets of information in a condensed space. They're particularly helpful as a way to present options, or to show off product functionality. Tabs present their information all at once, and unlike collapsers, you can't have multiple tabs from the same group visible at once. Tabs are framed by `<Tabs>` tags, with the `<TabsBar>` subgroup responsible for formatting the "tabs" themselves, and the `<TabsPages>` controlling the formatting and presentation of the copy under each individual tab. 
 
 You can set tab groups as either horizontal or vertical tabs. For vertical tabs, use `<Tabs stacked>` instead of `<Tabs>` as the header. For each `<TabsBarItem>`, set the ID for the tab in the `id="YOUR_ID_HERE"` section, and match the content of the `<TabsPages>` by putting a matching ID in the appropriate `<TabsPageItem id="YOUR_ID_HERE">` section.
 
@@ -18,7 +18,7 @@ The Keyboard Maestro for the Tabs component is `kktabgroup`.
 
 ### Code
 
-```
+```jsx
 <Tabs>
 	<TabsBar>
 		<TabsBarItem id="1">Tab one</TabsBarItem>
@@ -67,7 +67,7 @@ The Keyboard Maestro for the Tabs component is `kktabgroup`.
 
 ### Code
 
-```
+```jsx
 <Tabs stacked>
 	<TabsBar>
 		<TabsBarItem id="1">Tab one</TabsBarItem>


### PR DESCRIPTION
Noticed with @ally-sassman that we didn't have practical examples of tabs

Preview link: https://docswebsitedevelop-austinschaeferpatch9.gatsbyjs.io/docs/style-guide/structure/tabs/