### PR TITLE
feat(NRQL): Updated the facet order by clause

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -441,6 +441,9 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
     FROM Transaction SELECT average(duration) TIMESERIES FACET appName ORDER BY max(responseSize)
     ```
 
+    Keep in mind that if you use the `FACET ... ORDER BY` clause, you can't change the sort order by adding the `ASC` and `DESC` modifiers. By default, this clause uses `DESC`.
+
+
     <Callout variant="tip">
       Because the operations are performed before the `LIMIT` clause is applied, `FACET ... ORDER BY` does not impact the sort of the final query results, which will be particularly noticeable in the results for non-timeseries queries.
     </Callout>
@@ -2999,16 +3002,16 @@ Note that comments aren't displayed everywhere. Some views, like "recent queries
 
 Some example queries that include comments:
 
-```
+```sql
 FROM Transaction SELECT uniqueCount(appId) -- This will return the number of unique App IDs
 ```
 
-```
+```sql
 FROM TransactionError
 SELECT count(*) SINCE 1 day ago // Transaction Error for the past day
 ```
 
-```
+```sql
 FROM TransactionTrace /* This data may be incomplete;
 If so, run a query of Transaction */
 SELECT count(*)


### PR DESCRIPTION
Updated the `facet...order by` clause to specify the `ASC` and `DESC` modifiers can't be used.

Request added in the help-documentation channel.