### PR TITLE
More accurately reflect entity TTL for customers

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -290,7 +290,7 @@ Entities can be related to each other in various ways. The collapser below lists
 
 
 <Callout variant="important">
- Automatic relationships are created based on the telemetry that is being reported by the entities. These relationships have a Time To Live (TTL). This means that they will be automatically deleted if the metrics used to create the relationship are not reported in a given period of time. The default TTL for a relationship is <b>75 minutes</b>. The TTL is configurable for each relationship, and it can go <b>from 10 minutes up to 3 days</b>.
+ Automatic relationships are created based on the telemetry that is being reported by the entities. These relationships have a Time To Live (TTL). This means that they will be automatically deleted if the metrics used to create the relationship are not reported in a given period of time. The default TTL for a relationship is <b>75 minutes</b>. The TTL can vary <b>from 10 minutes up to 3 days depending on the relationship type</b>.
 </Callout>
 
 These are the relationships between entities that we create automatically:


### PR DESCRIPTION
The ability to configure TTL is only for New Relic internal teams that are publishing relationships. For customers it would be more accurate rephrasing this as "The TTL can vary from 10 minutes up to 3 days depending on the relationship type."

https://newrelic.slack.com/archives/CH5MLECNN/p1686557214192059?thread_ts=1686080986.483239&cid=CH5MLECNN

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.