### PR TITLE
feat(dotnet): added troubleshooting doc and updated yml per PR13492

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/Minimal APIs endpoints appear as one transaction (.NET).mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/Minimal APIs endpoints appear as one transaction (.NET).mdx
@@ -1,5 +1,5 @@
 ---
-title: Minimal APIs endpoints appear as one transaction (.NET)
+title: Minimal APIs endpoints appear as one transaction
 type: troubleshooting
 tags:
   - Agents

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/Minimal APIs endpoints appear as one transaction (.NET).mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/Minimal APIs endpoints appear as one transaction (.NET).mdx
@@ -1,0 +1,39 @@
+---
+title: Minimal APIs endpoints appear as one transaction (.NET)
+type: troubleshooting
+tags:
+  - Agents
+  - NET agent
+  - Troubleshooting
+translate:
+  - jp
+metaDescription: Troubleshooting steps for using the New Relic .NET Agent in a Minimal APIs app with duplicate route paths but different HTTP request methods.
+redirects:
+  - /docs/agents/net-agent/troubleshooting/minimal-api-duplicate-routes-net
+---
+
+## Problem [#problem]
+
+If the .NET agent is monitoring an Asp.Net Core “Minimal APIs” application, multiple endpoints may appear as a single web transaction. This is because the endpoints share the same route path even if they have different HTTP request methods. 
+
+To differentiate these endpoints, we recommend applying the `SetTransactionName()` API call. 
+
+## Solution [#solution]
+
+Add `SetTransactionName()` to give each endpoint a unique transaction name. While your arguments for the API call may vary, we recommend adding `SetTransactionName()` like in the below example:
+
+```cs
+// map a minimal API with GET and POST endpoints on the same route
+app.MapGet(“/minimalApi”, () =>
+{
+  NewRelic.Api.Agent.NewRelic.SetTransactionName(null, name: “minimalApi/Get”);
+  return Results.Ok(“Get: minimalApi”);
+});
+app.MapPost(“/minimalApi”, () =>
+{
+  NewRelic.Api.Agent.NewRelic.SetTransactionName(null, name: “minimalApi/Post”);
+  return Results.Ok(“Post: minimalApi”);
+});
+```
+
+You can read about setting names to transactions in our [SetTransactionName doc](/docs/agents/net-agent/net-agent-api/settransactionname-net-agent-api).

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -469,6 +469,8 @@ pages:
                 path: /docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts
               - title: No stack traces
                 path: /docs/apm/agents/net-agent/troubleshooting/no-stack-traces-dotnet
+              - title: Minimal APIs endpoints appear as one transaction (.NET)
+                path: /docs/apm/agents/net-agent/troubleshooting/minimal-api-duplicate-routes-net
               - title: 'WCF apps: agent changes Content-Type header'
                 path: /docs/apm/agents/net-agent/troubleshooting/agent-changes-content-type-header-wcf-apps-net
       - title: Node.js monitoring


### PR DESCRIPTION
The original PR was giving Gatsby some build issues, maybe due to an out of date fork. Went ahead and added that content to a new branch to sidestep eng troubleshooting.

Existing PR:

https://github.com/newrelic/docs-website/pull/13492

I've already gotten SME approval on this content.

NOTE TO SELF FOR 6/14:

Need to change name of .mdx file in vs code so it aligns with the pathing in the yml file