### PR TITLE
Refactor redirect issues

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
@@ -8,6 +8,7 @@ tags:
 metaDescription: How to start writing NRQL alerts conditions with a step-by-step user case.
 redirects:
   - /docs/alerts/alert-policies/configuring-alerts/managing-your-alerts
+  - /docs/alerts/new-relic-alerts/getting-started/alerting-new-relic
 ---
 
 import alertsCreateanAlertConditionFromaChart from 'images/alerts_screenshot-crop_create-an-alert-condition-from-a-chart.webp'

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-1-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-1-0.mdx
@@ -6,7 +6,7 @@ downloadLink: 'https://rubygems.org/downloads/newrelic_rpm-9.1.0.gem'
 features: ["Error fingerprinting - supply your own errors inbox group names", "User tracking - associate errors with a user id"]
 bugs: ["Remove Distributed Tracing related warnings from agent logs when headers are not present in Sidekiq", "Log request headers in debug-level logs instead of human-readable Objects", "Fix undefined method `controller_path` logged in Action Controller Instrumentation", "Fix Transaction#finish exception and decrease log level for related warning during async transactions"]
 security: []
-redirect:
+redirects:
   - /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-910
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-2-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-2-0.mdx
@@ -6,7 +6,7 @@ downloadLink: https://rubygems.org/downloads/newrelic_rpm-9.2.0.gem
 features: ["Enhance performance for handling high numbers of nested actions", "Deprecate memcached and memcache-client instrumentation"]
 bugs: []
 security: []
-redirect:
+redirects:
   - /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-920
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-2-2.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-9-2-2.mdx
@@ -6,7 +6,7 @@ downloadLink: https://rubygems.org/downloads/newrelic_rpm-9.2.2.gem
 features: []
 bugs: ["Transaction#finished? no longer throws a NoMethodError when initial_segment is nil"]
 security: []
-redirect:
+redirects:
   - /docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-922
 ---
 

--- a/src/content/docs/tutorial-peak-demand/autoscale-your-infra.mdx
+++ b/src/content/docs/tutorial-peak-demand/autoscale-your-infra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Autoscale your infrastructure with Kubernetes
 metaDescription: "Automatically allocate and deallocate infrastructure resources to your pods with horizontal pod autoscaling."
-/redirects:
+redirects:
   - /docs/journey-demand/autoscale-your-infra/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/create-quality-alerts.mdx
+++ b/src/content/docs/tutorial-peak-demand/create-quality-alerts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reduce noise with quality alerts
 metaDescription: "Evaluate the quality of your alerts before a peak gameday event by installing the alert quality management dashboard."
-/redirects:
+redirects:
   - /docs/journey-demand/create-quality-alerts/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/find-your-baseline.mdx
+++ b/src/content/docs/tutorial-peak-demand/find-your-baseline.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create meaningful service levels for gameday
 metaDescription: "Learn to find important capabilities, define your baselines, and set up meaningful service levels for peak demand."
-/redirects:
+redirects:
   - /docs/journey-demand/find-your-baseline/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/get-started.mdx
+++ b/src/content/docs/tutorial-peak-demand/get-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Succeeding during peak demand days with New Relic 
 metaDescription: "Set up New Relic to get the data you need to plan for a peak demand event."
-/redirects:
+redirects:
   - /docs/journey-demand/get-started/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/organize-data-workloads.mdx
+++ b/src/content/docs/tutorial-peak-demand/organize-data-workloads.mdx
@@ -1,7 +1,7 @@
 ---
 title: Align your teams with workloads
 metaDescription: "If you're preparing for a peak event day, you can set up workloads that put the most relevant data in front of the teams that need it."
-/redirects:
+redirects:
   - /docs/journey-demand/organize-data-workloads/
 ---
 

--- a/src/i18n/content/jp/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
+++ b/src/i18n/content/jp/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
@@ -7,8 +7,6 @@ tags:
   - NRQL
 metaDescription: How to start writing NRQL alerts conditions with a step-by-step user case.
 translationType: machine
-redirect:
-  - /docs/alerts/new-relic-alerts/getting-started/alerting-new-relic
 ---
 
 import alertsCreateanAlertConditionFromaChart from 'images/alerts_screenshot-crop_create-an-alert-condition-from-a-chart.webp'

--- a/src/i18n/content/jp/docs/tutorial-peak-demand/autoscale-your-infra.mdx
+++ b/src/i18n/content/jp/docs/tutorial-peak-demand/autoscale-your-infra.mdx
@@ -1,8 +1,6 @@
 ---
 title: Kubernetes を使用してインフラストラクチャを自動スケールする
 metaDescription: Automatically allocate and deallocate infrastructure resources to your pods with horizontal pod autoscaling.
-/redirects:
-  - /docs/journey-demand/autoscale-your-infra/
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/tutorial-peak-demand/create-quality-alerts.mdx
+++ b/src/i18n/content/jp/docs/tutorial-peak-demand/create-quality-alerts.mdx
@@ -1,8 +1,6 @@
 ---
 title: 品質アラートでノイズを軽減
 metaDescription: Evaluate the quality of your alerts before a peak gameday event by installing the alert quality management dashboard.
-/redirects:
-  - /docs/journey-demand/create-quality-alerts/
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/tutorial-peak-demand/find-your-baseline.mdx
+++ b/src/i18n/content/jp/docs/tutorial-peak-demand/find-your-baseline.mdx
@@ -1,8 +1,6 @@
 ---
 title: 試合当日に向けて意味のあるサービスレベルを作成する
 metaDescription: 'Learn to find important capabilities, define your baselines, and set up meaningful service levels for peak demand.'
-/redirects:
-  - /docs/journey-demand/find-your-baseline/
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/tutorial-peak-demand/get-started.mdx
+++ b/src/i18n/content/jp/docs/tutorial-peak-demand/get-started.mdx
@@ -1,8 +1,6 @@
 ---
 title: New Relic で需要のピーク時に成功する
 metaDescription: Set up New Relic to get the data you need to plan for a peak demand event.
-/redirects:
-  - /docs/journey-demand/get-started/
 translationType: machine
 ---
 

--- a/src/i18n/content/jp/docs/tutorial-peak-demand/organize-data-workloads.mdx
+++ b/src/i18n/content/jp/docs/tutorial-peak-demand/organize-data-workloads.mdx
@@ -1,8 +1,6 @@
 ---
 title: チームをワークロードに合わせて調整する
 metaDescription: 'If you''re preparing for a peak event day, you can set up workloads that put the most relevant data in front of the teams that need it.'
-/redirects:
-  - /docs/journey-demand/organize-data-workloads/
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/tutorial-peak-demand/autoscale-your-infra.mdx
+++ b/src/i18n/content/kr/docs/tutorial-peak-demand/autoscale-your-infra.mdx
@@ -1,8 +1,6 @@
 ---
 title: Kubernetes로 인프라 자동 확장
 metaDescription: Automatically allocate and deallocate infrastructure resources to your pods with horizontal pod autoscaling.
-/redirects:
-  - /docs/journey-demand/autoscale-your-infra/
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/tutorial-peak-demand/create-quality-alerts.mdx
+++ b/src/i18n/content/kr/docs/tutorial-peak-demand/create-quality-alerts.mdx
@@ -1,8 +1,6 @@
 ---
 title: 품질 경고로 소음 감소
 metaDescription: Evaluate the quality of your alerts before a peak gameday event by installing the alert quality management dashboard.
-/redirects:
-  - /docs/journey-demand/create-quality-alerts/
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/tutorial-peak-demand/find-your-baseline.mdx
+++ b/src/i18n/content/kr/docs/tutorial-peak-demand/find-your-baseline.mdx
@@ -1,8 +1,6 @@
 ---
 title: 게임 데이를 위한 의미 있는 서비스 수준 생성
 metaDescription: 'Learn to find important capabilities, define your baselines, and set up meaningful service levels for peak demand.'
-/redirects:
-  - /docs/journey-demand/find-your-baseline/
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/tutorial-peak-demand/get-started.mdx
+++ b/src/i18n/content/kr/docs/tutorial-peak-demand/get-started.mdx
@@ -1,8 +1,6 @@
 ---
 title: New Relic으로 피크 수요일에 성공
 metaDescription: Set up New Relic to get the data you need to plan for a peak demand event.
-/redirects:
-  - /docs/journey-demand/get-started/
 translationType: machine
 ---
 

--- a/src/i18n/content/kr/docs/tutorial-peak-demand/organize-data-workloads.mdx
+++ b/src/i18n/content/kr/docs/tutorial-peak-demand/organize-data-workloads.mdx
@@ -1,8 +1,6 @@
 ---
 title: 워크로드에 맞춰 팀 조정
 metaDescription: 'If you''re preparing for a peak event day, you can set up workloads that put the most relevant data in front of the teams that need it.'
-/redirects:
-  - /docs/journey-demand/organize-data-workloads/
 translationType: machine
 ---
 


### PR DESCRIPTION
found a few redirect issues:

1) a few release notes were using `redirect` instead of `redirects`
2) a number of files had a slash in front of `redirects` which both broke them and added them to translated docs
3) a redirect was randomly added to a translated file but not its english version, i assume we want it in the english version but i'm not sure 🤷‍♀️  
that's `src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx` with a redirect of `/docs/alerts/new-relic-alerts/getting-started/alerting-new-relic`