### PR TITLE
Fix variable expansion in curl commands

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/scope-alert-thresholds-specific-instances.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/scope-alert-thresholds-specific-instances.mdx
@@ -149,7 +149,7 @@ Here is an example of the API request format and JSON response.
 
     ```
     curl -X PUT 'https://api.newrelic.com/v2/alerts_entity_conditions/12345.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -H 'Content-Type: application/json' \
          -G -d 'entity_type=application&condition_id=234567'
     ```

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api.mdx
@@ -88,7 +88,7 @@ The following example shows how to disable a condition for an `apm_app_metric` c
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_policies.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -G --data-urlencode 'filter[name]= Logjam Alert'    <---<<<  {policy_name}
    ```
 
@@ -111,7 +111,7 @@ The following example shows how to disable a condition for an `apm_app_metric` c
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_conditions.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -G -d 'policy_id=85'
    ```
 
@@ -152,7 +152,7 @@ The following example shows how to disable a condition for an `apm_app_metric` c
 
    ```
    curl -X PUT 'https://api.newrelic.com/v2/alerts_conditions/12345.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -H 'Content-Type: application/json' \
         -d \
    '{

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/manage-entities-alerts-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/manage-entities-alerts-conditions.mdx
@@ -53,7 +53,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
    ```
 
    OR
@@ -62,7 +62,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -d 'filter[name]=TimberTime'
    ```
 2. Review the output to find the `{application_id}`, and use it as the `{entity_id}`:
@@ -82,7 +82,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_policies.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -G -d 'filter[name]= Logjam Alert'    <---<<<  {policy_name}
    ```
 4. Review the policy output; for example:
@@ -102,7 +102,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X GET 'https://api.newrelic.com/v2/alerts_conditions.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -G -d 'policy_id=85'
    ```
 
@@ -139,7 +139,7 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X PUT 'https://api.newrelic.com/v2/alerts_entity_conditions/12345.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -H 'Content-Type: application/json' \
         -G -d 'entity_type=Application&condition_id=234567'
    ```
@@ -148,6 +148,6 @@ Only the first step in this example is unique to choosing the Ruby app as the en
 
    ```
    curl -X DELETE 'https://api.newrelic.com/v2/alerts_entity_conditions/8288171.json' \
-        -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+        -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
         -G -d 'entity_type=Application&condition_id=234567'
    ```

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -188,7 +188,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X POST 'https://api.newrelic.com/v2/alerts_policies.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -H 'Content-Type: application/json' \
          -d \
     '{
@@ -265,7 +265,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X PUT 'https://api.newrelic.com/v2/alerts_policies/{id}.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -H 'Content-Type: application/json' \
          -d \
     '{
@@ -287,7 +287,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X DELETE 'https://api.newrelic.com/v2/alerts_policies/$POLICY_ID.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
     ```
   </Collapser>
 
@@ -304,7 +304,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_policies.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 </CollapserGroup>
@@ -334,7 +334,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_channels.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -528,7 +528,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X DELETE 'https://api.newrelic.com/v2/alerts_channels/{channel_id}.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
     ```
   </Collapser>
 
@@ -542,7 +542,7 @@ These API functions include links to the API Explorer, where you can create, del
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_channels.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
     ```
   </Collapser>
 
@@ -559,7 +559,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_policy_channels.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -G -d 'policy_id=$POLICY_ID&channel_ids=channel_id'
       ```
@@ -580,7 +580,7 @@ These API functions include links to the API Explorer, where you can create, del
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_policy_channels.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -d 'channel_id=CHANNEL_ID&policy_id=POLICY_ID'
       ```
   </Collapser>
@@ -619,7 +619,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_conditions/policies/$POLICY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -669,7 +669,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -717,7 +717,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -731,7 +731,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_conditions.json?policy_id=$POLICY_ID' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
     ```
   </Collapser>
 </CollapserGroup>
@@ -759,7 +759,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X POST 'https://api.newrelic.com/v2/alerts_nrql_conditions/policies/$POLICY_ID.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -H 'Content-Type: application/json' \
          -d \
     '{
@@ -816,7 +816,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_nrql_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -855,7 +855,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_nrql_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -869,7 +869,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_nrql_conditions.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -d 'policy_id=$POLICY_ID'
     ```
   </Collapser>
@@ -898,7 +898,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_external_service_conditions/policies/$POLICY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -942,7 +942,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_external_service_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -983,7 +983,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_external_service_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -997,7 +997,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_external_service_conditions.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -d 'policy_id=$POLICY_ID'
     ```
   </Collapser>
@@ -1022,7 +1022,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_synthetics_conditions/policies/$POLICY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1052,7 +1052,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_synthetics_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1079,7 +1079,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_synthetics_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -1093,7 +1093,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_synthetics_conditions.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -d 'policy_id=$POLICY_ID'
     ```
   </Collapser>
@@ -1118,7 +1118,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X POST 'https://api.newrelic.com/v2/alerts_location_failure_conditions/policies/$POLICY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1158,7 +1158,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_location_failure_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
@@ -1195,7 +1195,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_location_failure_conditions/$CONDITION_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -1209,7 +1209,7 @@ These API functions include links to the API Explorer, where you can create, upd
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/alerts_location_failure_conditions/policies/$POLICY_ID.json' \
-         -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+         -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
     ```
   </Collapser>
 </CollapserGroup>
@@ -1237,7 +1237,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_events.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -1255,7 +1255,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_violations.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
 
       <Callout variant="tip">
@@ -1278,7 +1278,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_incidents.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -1295,7 +1295,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_incidents/{id}.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
       ```
   </Collapser>
 
@@ -1312,7 +1312,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_incidents/{id}/acknowledge.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json'
       ```
   </Collapser>
@@ -1330,7 +1330,7 @@ These API functions include links to the API Explorer, where you can view inform
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_incidents/{id}/close.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json'
       ```
   </Collapser>
@@ -1364,7 +1364,7 @@ These API functions include links to the API Explorer, where you can list, add a
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_entity_conditions/$ENTITY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -G -d 'entity_type=$ENTITY_TYPE'
       ```
   </Collapser>
@@ -1389,7 +1389,7 @@ These API functions include links to the API Explorer, where you can list, add a
 
       ```
       curl -X PUT 'https://api.newrelic.com/v2/alerts_entity_conditions/$ENTITY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -H 'Content-Type: application/json' \
            -G -d 'entity_type=$ENTITY_TYPE&condition_id=$CONDITION_ID'
       ```
@@ -1415,7 +1415,7 @@ These API functions include links to the API Explorer, where you can list, add a
 
       ```
       curl -X DELETE 'https://api.newrelic.com/v2/alerts_entity_conditions/$ENTITY_ID.json' \
-           -H 'X-Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
            -G -d 'entity_type=$ENTITY_ID&condition_id=$CONDITION_ID'
       ```
   </Collapser>

--- a/src/content/docs/apis/rest-api-v2/account-examples-v2/listing-users-your-account.mdx
+++ b/src/content/docs/apis/rest-api-v2/account-examples-v2/listing-users-your-account.mdx
@@ -28,7 +28,7 @@ To obtain a list of all users on the [original user model](/docs/accounts/origin
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/users.json' \
-     -H "x-api-key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i
+     -H "x-api-key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
 ```
 
 The output will appear similar to this:
@@ -71,7 +71,7 @@ If you know all or part of the user's email, you can use this command to return 
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/users.json' \
-     -H "x-api-key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \
+     -H "x-api-key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d 'filter[email]=my.name'
 ```
 
@@ -83,7 +83,7 @@ If you know the user `id`, you can use this command to return the role, name, an
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/users.json' \
-     -H "x-api-key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \
+     -H "x-api-key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d 'filter[ids]=123456'
 ```
 
@@ -91,7 +91,7 @@ You can also use this command, which embeds the user `id` in the URL and omits t
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/users/123456.json' \
-     -H "x-api-key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i
+     -H "x-api-key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
 ```
 
 The output for this command will be the same as the first entry in the [Listing all account users](#list_all_users) example.

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/get-web-transaction-time-data-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/get-web-transaction-time-data-v2.mdx
@@ -42,7 +42,7 @@ Use the following command to obtain this metric:
 
 ```bash
 curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-     -H 'X-Api-Key:${APIKEY}' -i \
+     -H "X-Api-Key:${APIKEY}" -i \
      -d 'names[]=HttpDispatcher&values[]=average_response_time'
 ```
 
@@ -140,7 +140,7 @@ The `WebTransactionTotalTime` is the total execution time for your web applicati
 
 ```bash
 curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \ 
-     -H 'X-Api-Key:${APIKEY}' -i \ 
+     -H "X-Api-Key:${APIKEY}" -i \ 
      -d 'names[]=WebTransactionTotalTime&values[]=average_response_time'
 ```
 
@@ -168,21 +168,21 @@ To obtain the data for this calculation, use the following commands.
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${API_KEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=HttpDispatcher&values[]=call_count'
   ```
 * Datastore/$&#x7B;DBTYPE}/allWeb:call_count
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=Datastore/${DBTYPE}/allWeb&values[]=call_count'
   ```
 * Datastore/$&#x7B;DBTYPE}/allWeb:average_response_time
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=Datastore/${DBTYPE}/allWeb&values[]=average_response_time'
   ```
 
@@ -190,7 +190,7 @@ You can also perform this operation in a single command:
 
 ```bash
 curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-     -H 'X-Api-Key:${APIKEY}' -i \
+     -H "X-Api-Key:${APIKEY}" -i \
      -d 'names[]=Datastore/MongoDB/allWeb&names[]=HttpDispatcher&values[]=average_response_time&values[]=call_count'
 ```
 
@@ -210,21 +210,21 @@ To obtain the data for this calculation, use the following commands.
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=HttpDispatcher&values[]=call_count'
   ```
 * Database/allWeb:call_count
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=Database/allWeb&values[]=call_count'
   ```
 * Database/allWeb:average_response_time
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=Database/allWeb&values[]=average_response_time'
   ```
 
@@ -244,21 +244,21 @@ To obtain the data for this calculation, use the following commands.
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=HttpDispatcher&values[]=call_count'
   ```
 * ActiveRecord/all:call_count
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=ActiveRecord/all&values[]=call_count'
   ```
 * ActiveRecord/all:average_response_time
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=ActiveRecord/all&values[]=average_response_time'
   ```
 
@@ -276,21 +276,21 @@ To obtain the data for this calculation, use the following commands.
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=HttpDispatcher&values[]=call_count'
   ```
 * Memcache/allWeb:call_count
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/$(APPID)/metrics/data.xml' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=Memcache/allWeb&values[]=call_count'
   ```
 * Memcache/allWeb:average_response_time
 
   ```bash
   curl -X GET https://api.newrelic.com/v2/applications/${APPID}/metrics/data.xml" \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=Memcache/allWeb&values[]=average_response_time'
   ```
 
@@ -308,20 +308,20 @@ To obtain the data for this calculation, use the following commands.
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=HttpDispatcher&values[]=call_count'
   ```
 * External/allWeb:call_count
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=External/allWeb&values[]=call_count'
   ```
 * External/allWeb:average_response_time
 
   ```bash
   curl -X GET 'https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json' \
-       -H 'X-Api-Key:${APIKEY}' -i \
+       -H "X-Api-Key:${APIKEY}" -i \
        -d 'names[]=External/allWeb&values[]=average_response_time'
   ```

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2.mdx
@@ -55,7 +55,7 @@ To view a specific app's ID if you know the name, substitute the name for `$NAME
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-     -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d "filter[name]=$NAME"
 ```
 
@@ -109,7 +109,7 @@ To view the metric names available for your application:
 
 ```
 curl -X GET "https://api.newrelic.com/v2/applications/$APP_ID/metrics.json" \
-     -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i "
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i "
 ```
 
 The output will be similar to the following. This shows two of the many metric names available and their values. These lists may be long. Please consider the [guidelines](#name_list_guidelines) for listing your metric names.
@@ -152,7 +152,7 @@ Filter your metric name output, to return a smaller list, by specifying the **na
 
 ```
 curl -X GET "https://api.newrelic.com/v2/applications/$APP_ID/metrics.json" \
-     -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d 'name=Controller/welcome/index'
 ```
 
@@ -162,7 +162,7 @@ To view the metric timeslice data for your application:
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications/$APP_ID/metrics/data.json' \
-     -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d 'names[]=EndUser&values[]=call_count&values[]=average_response_time&summarize=true'
 ```
 
@@ -206,7 +206,7 @@ curl -X GET 'https://api.newrelic.com/v2/applications/$APP_ID/metrics/data.json'
 
     ```
     curl -X GET 'https://api.newrelic.com/v2/applications/$APP_ID/metrics/data.json' \
-         -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -d 'names[]=EndUser&names[]=EndUser/Apdex&values[]=call_count&values[]=average_response_time&values[]=score&summarize=true'
     ```
 

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2.mdx
@@ -26,7 +26,7 @@ To view all of your apps' IDs, use the following command.
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-     -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
 ```
 
 The output will be an array of data where the element is an application and the data associated with it. For example, here are the first two elements for app ID 96785 ("GreatTimes Staging") and 1622 ("GreatTimes Prod"):

--- a/src/content/docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors.mdx
@@ -130,7 +130,7 @@ Here is an example API request indicating that the caller has consumed all of th
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-     -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
 HTTP/1.1 429 Too Many Requests
 Content-Type: application/json
 ...

--- a/src/content/docs/apis/rest-api-v2/basic-functions/extract-metric-timeslice-data.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/extract-metric-timeslice-data.mdx
@@ -253,7 +253,7 @@ Sometimes the output data's granularity may be too fine, or the time period for 
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications/$APPID/metrics/data.xml' \
-     -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d'names[]=CPU/User+Time&from=2018-02-13T04:00:00+00:00&to=2018-02-17T04:00:00+00:00&period=3600'
 ```
 

--- a/src/content/docs/apis/rest-api-v2/basic-functions/pagination-api-output.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/pagination-api-output.mdx
@@ -34,7 +34,7 @@ To specify a page, add the `page=` parameter to the query. Here's an example:
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/alerts_incidents.json?page=3' \
-     -H 'Api-Key:<a href="/docs/apis/get-started/intro-apis/types-new-relic-api-keys">$API_KEY</a>' -i
+     -H "Api-Key:<a href='/docs/apis/get-started/intro-apis/types-new-relic-api-keys'>$API_KEY</a>" -i
 ```
 
 In the REST API Explorer, you can quickly [change the page being viewed](/docs/apm/apis/api-explorer-v2/parts-api-explorer#data_page).

--- a/src/content/docs/apis/rest-api-v2/basic-functions/specify-time-range-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/specify-time-range-v2.mdx
@@ -29,7 +29,7 @@ The default time range for an API call is the last 30 minutes. To modify the tim
 **Example:**
 
 ```
-curl -X GET "https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json" \ -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \ -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00+00:00&to=2014-08-11T15:12:00+00:00'
+curl -X GET "https://api.newrelic.com/v2/applications/${APPID}/metrics/data.json" \ -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \ -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00+00:00&to=2014-08-11T15:12:00+00:00'
 ```
 
 The time period returned for each data point depends on the [time range](/docs/apm/apis/requirements/extracting-metric-data#time) you specify. To modify the time period, include the [period parameter](/docs/apm/apis/requirements/extracting-metric-data#period) in your query.
@@ -51,7 +51,7 @@ By default the API time input uses Universal Time Coordinated (UTC). To offset t
   >
     ```
     curl -X GET "https://api.newrelic.com/v2/applications/$APP_ID/metrics/data.json" \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00-02:00&to=2014-08-11T15:12:00-02:00'
     ```
   </Collapser>
@@ -62,7 +62,7 @@ By default the API time input uses Universal Time Coordinated (UTC). To offset t
   >
     ```
     curl -X GET "https://api.newrelic.com/v2/applications/$APP_ID/metrics/data.json" \
-         -H "Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" -i \
+         -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
          -d 'names[]=Agent/MetricsReported/count&from=2014-08-11T14:42:00%2B08:00&to=2014-08-11T15:12:00%2B08:00
     ```
   </Collapser>

--- a/src/content/docs/apis/rest-api-v2/browser-examples-v2/average-browser-end-user-page-throughput-example-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/browser-examples-v2/average-browser-end-user-page-throughput-example-v2.mdx
@@ -19,6 +19,6 @@ To obtain the [average](/docs/apm/apis/requirements/calculating-average-metric-v
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications/${APP_ID}/metrics/data.json' \
-     -H 'X-Api-Key:${API_KEY}' -i \
+     -H "X-Api-Key:${API_KEY}" -i \
      -d 'names[]=EndUser&values[]=requests_per_minute&summarize=true'
 ```

--- a/src/content/docs/apis/rest-api-v2/get-started/list-application-id-host-id-instance-id.mdx
+++ b/src/content/docs/apis/rest-api-v2/get-started/list-application-id-host-id-instance-id.mdx
@@ -62,7 +62,7 @@ Use the `$HOST_ID` to retrieve summary metrics for the host as well as specific 
 
        ```
        curl -X GET 'https://api.newrelic.com/v2/applications/$APP_ID/hosts.json' \
-            -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+            -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
        ```
 
        If you have an [EU region account](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center), the endpoint begins with `https://api.eu.newrelic.com`.
@@ -220,7 +220,7 @@ You can retrieve summary metrics for the instance as well as specific metric tim
 
        ```
        curl -X GET 'https://api.newrelic.com/v2/applications/$APP_ID/hosts.json' \
-            -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i
+            -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i
        ```
 
        If you have an [EU region account](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center), the endpoint begins with `https://api.eu.newrelic.com`.
@@ -292,7 +292,7 @@ The following example shows how to locate all the ID information for an applicat
 
 ```
 curl -X GET 'https://api.newrelic.com/v2/applications.json' \
-     -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i \
+     -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
      -d 'filter[ids]=1441'    <----<<<< {APP_ID}
 ```
 

--- a/src/content/docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis.mdx
@@ -48,7 +48,7 @@ API requirements and rules include:
 
     ```
     curl -v \
-         -X POST -H 'Api-Key:<a href="/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api">$API_KEY</a>' \
+         -X POST -H "Api-Key:<a href='/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api'>$API_KEY</a>" \
          -H 'Content-Type: application/json' https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials \
          -d  '{ "key": "MYKEY", "value": "my value", "description": "Description of MYKEY" }'
     ```
@@ -67,7 +67,7 @@ API requirements and rules include:
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api">$API_KEY</a>' https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials
+         -H "Api-Key:<a href='/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api'>$API_KEY</a>" https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials
     ```
 
     A successful request will return a `200 OK` response. The data returned will be a JSON object in the following format:
@@ -100,7 +100,7 @@ API requirements and rules include:
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api">$API_KEY</a>' https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials/$KEY
+         -H "Api-Key:<a href='/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api'>$API_KEY</a>" https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials/$KEY
     ```
 
     A successful request will return a `200 OK` response. The [data returned](/docs/apis/synthetics-rest-api/monitor-examples/payload-attributes-synthetics-rest-api#api-attributes) will be a JSON object in the following format:
@@ -125,7 +125,7 @@ API requirements and rules include:
 
     ```
     curl -v \
-         -X PUT -H 'Api-Key:<a href="/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api">$API_KEY</a>' \
+         -X PUT -H "Api-Key:<a href='/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api'>$API_KEY</a>" \
          -H 'Content-Type: application/json' https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials/$KEY \
          -d  '{ "key": "MYKEY", "value": "my value", "description": "Description of MYKEY" }'
     ```
@@ -141,7 +141,7 @@ API requirements and rules include:
 
     ```
     curl -v \
-         -H 'Api-Key:<a href="/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api">$API_KEY</a>' \
+         -H "Api-Key:<a href='/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api#use-api'>$API_KEY</a>" \
          -X DELETE https://synthetics.newrelic.com/synthetics/api/v1/secure-credentials/$KEY
     ```
 

--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -103,7 +103,7 @@ You can either [GET a list of infrastructure conditions](#get-condition-list) or
 ### GET a list of infrastructure conditions [#get-condition-list]
 
 ```
-curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions?policy_id=111111"
+curl -v -X GET --header "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions?policy_id=111111"
 ```
 
 <CollapserGroup>
@@ -173,7 +173,7 @@ curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-starte
 To get a list of the 10 Infrastructure conditions beyond the 50 limit:
 
 ```
-curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions?policy_id=111111&offset=50&limit=10"
+curl -v -X GET --header "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions?policy_id=111111&offset=50&limit=10"
 ```
 
 ### GET a specific infrastructure condition [#get-one-condition]
@@ -181,7 +181,7 @@ curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-starte
 To get information about a single Infrastructure condition:
 
 ```
-curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions/condition-id"
+curl -v -X GET --header "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions/condition-id"
 ```
 
 <CollapserGroup>
@@ -223,7 +223,7 @@ curl -v -X GET --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-starte
 To add an infrastructure condition, use this basic cURL command:
 
 ```
-curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i -H 'Content-Type: application/json' -d '{"data":{DATA object details}}'
+curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i -H 'Content-Type: application/json' -d '{"data":{DATA object details}}'
 ```
 
 Include details in the `DATA` object (`-d \` section) for the type of infrastructure condition you are adding:
@@ -248,7 +248,7 @@ To update an infrastructure condition, use this basic cURL command. To indicate 
     title="Example update (PUT) a condition"
   >
     ```
-    curl -X PUT 'https://infra-api.newrelic.com/v2/alerts/conditions/condition-id' -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i -H 'Content-Type: application/json' -d '{"data":{DATA object details}}'
+    curl -X PUT 'https://infra-api.newrelic.com/v2/alerts/conditions/condition-id' -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i -H 'Content-Type: application/json' -d '{"data":{DATA object details}}'
     ```
   </Collapser>
 </CollapserGroup>
@@ -264,7 +264,7 @@ Include details in the `DATA` object (`-d \` section) for the type of infrastruc
 To delete an infrastructure condition, use this basic cURL command:
 
 ```
-curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions/condition_id"
+curl -v -X DELETE --header "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" "https://infra-api.newrelic.com/v2/alerts/conditions/condition_id"
 ```
 
 ## Types of conditions [#condition-types]
@@ -284,7 +284,7 @@ curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-sta
         For example:
 
         ```
-        curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i -H 'Content-Type: application/json' -d
+        curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i -H 'Content-Type: application/json' -d
         '{
            "data":{
               "type":"infra_process_running",
@@ -350,7 +350,7 @@ curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-sta
           For example:
 
           ```
-          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i -H 'Content-Type: application/json' -d
+          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i -H 'Content-Type: application/json' -d
           '{
              "data":{
                 "type":"infra_metric",
@@ -398,7 +398,7 @@ curl -v -X DELETE --header "Api-Key: <a href="/docs/apis/rest-api-v2/getting-sta
           For example:
 
           ```
-          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H 'Api-Key:<a href="/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key">$API_KEY</a>' -i -H 'Content-Type: application/json' -d
+          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i -H 'Content-Type: application/json' -d
           '{
              "data":{
                 "type":"infra_host_not_reporting",


### PR DESCRIPTION
(NR-107961) Fixed quotations in `curl` commands to enable variable expansion for API-Keys. Verified changes w/ @toffer 