### PR TITLE
Update nested-aggregation-make-ordered-computations-single-query.mdx

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nested-aggregation-make-ordered-computations-single-query.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nested-aggregation-make-ordered-computations-single-query.mdx
@@ -93,7 +93,7 @@ Here are some examples of nested queries.
       SELECT average(cpuPercent) as cpu
       FROM SystemSample
       FACET hostname
-      TIMESERIES integer units
+      TIMESERIES 1 minute
     )
     WHERE cpu > 90
     ```


### PR DESCRIPTION
The first codeblock shows syntax with `integer units` as a way to indicate that it should be a number and unit of time. 

The following code blocks after are examples... therefore should use an actual integer and unit. One of these is already doing this correctly with Transaction, but this CPU one needs to also have a real integer and unit.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.