### PR TITLE
chore: add oss tips to integrations

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/active-directory-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/active-directory-integration.mdx
@@ -13,7 +13,7 @@ With our Active Directory integration, you can easily monitor the health of your
 Built with our infrastructure agent, the Active Directory integration gives you a set of pre-built <InlinePopover type="dashboards" /> and <InlinePopover type ="alerts" /> that let you view your most critical performance data, all in one place.
 
 <Callout variant="tip">
-  This integration falls under the **Community project** designation in our [Open Source categories](https://opensource.newrelic.com/oss-category). This code is developed in the open with input from the community through issues and PRs. There is an active maintainer team within New Relic, troubleshooting support in the New Relic Explorers Hub, and the documentation is available in the project repository.
+  This integration falls under the **Community project** designation in our [Open Source categories](https://opensource.newrelic.com/oss-category). This code is developed in the open with input from the community through issues and PRs. There is an active maintainer team within New Relic, as well as troubleshooting support in the New Relic Explorers Hub and documentation available in the project repository.
 </Callout>
 
 <img

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/active-directory-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/active-directory-integration.mdx
@@ -12,6 +12,10 @@ With our Active Directory integration, you can easily monitor the health of your
 
 Built with our infrastructure agent, the Active Directory integration gives you a set of pre-built <InlinePopover type="dashboards" /> and <InlinePopover type ="alerts" /> that let you view your most critical performance data, all in one place.
 
+<Callout variant="tip">
+  This integration falls under the **Community project** designation in our [Open Source categories](https://opensource.newrelic.com/oss-category). This code is developed in the open with input from the community through issues and PRs. There is an active maintainer team within New Relic, troubleshooting support in the New Relic Explorers Hub, and the documentation is available in the project repository.
+</Callout>
+
 <img
     src={infrastructureActiveDirectoryDashboard}
     title="Active Directory dashboard"

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/snowflake-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/snowflake-integration.mdx
@@ -13,7 +13,7 @@ With our Snowflake dashboard, you can easily monitor the health of your storage 
 Built with our infrastructure agent, the Snowflake integration gives you a set of pre-built <InlinePopover type="dashboards" /> that let you view your most critical query data, all in one place.
 
 <Callout variant="tip">
-  This integration falls under the **Community project** designation in our [Open Source categories](https://opensource.newrelic.com/oss-category). This code is developed in the open with input from the community through issues and PRs. There is an active maintainer team within New Relic, troubleshooting support in the New Relic Explorers Hub, and the documentation is available in the project repository.
+  This integration falls under the **Community project** designation in our [Open Source categories](https://opensource.newrelic.com/oss-category). This code is developed in the open with input from the community through issues and PRs. There is an active maintainer team within New Relic, as well as troubleshooting support in the New Relic Explorers Hub and documentation available in the project repository.
 </Callout>
 
 <img

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/snowflake-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/snowflake-integration.mdx
@@ -12,6 +12,10 @@ With our Snowflake dashboard, you can easily monitor the health of your storage 
 
 Built with our infrastructure agent, the Snowflake integration gives you a set of pre-built <InlinePopover type="dashboards" /> that let you view your most critical query data, all in one place.
 
+<Callout variant="tip">
+  This integration falls under the **Community project** designation in our [Open Source categories](https://opensource.newrelic.com/oss-category). This code is developed in the open with input from the community through issues and PRs. There is an active maintainer team within New Relic, troubleshooting support in the New Relic Explorers Hub, and the documentation is available in the project repository.
+</Callout>
+
 <img
     src={infrastructureSnowflakeDashboard}
     title="Snowflake dashboard"


### PR DESCRIPTION
adding callouts to infrastructure integrations that have open source categorization