### PR TITLE
Removed deprecated experimental networking flag

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-agent-configuration-feature-flags.mdx
@@ -59,7 +59,7 @@ To configure feature flags, use the following method defined in `NewRelic.h:`
         * `NSURLSession` instrumentation and crash reporting are disabled.
 
         ```
-        [NewRelic enableFeatures:NRFeatureFlag_SwiftInteractionTracing | NRFeatureFlag_ExperimentalNetworkingInstrumentation];
+        [NewRelic enableFeatures:NRFeatureFlag_SwiftInteractionTracing | NRFeatureFlag_FedRampEnabled];
         [NewRelic disableFeatures:NRFeatureFlag_NSURLSessionInstrumentation | NRFeatureFlag_CrashReporting]; 
         [NewRelic startWithApplicationToken:...];
         ```
@@ -382,7 +382,7 @@ If used, be sure to call the feature flag before the New Relic iOS agent start c
     title="NRFeatureFlag_ExperimentalNetworkingInstrumentation"
   >
     <Callout variant="caution">
-      Enabling this feature flag call may decrease the stability of applications. Avoid using unless instructed by New Relic.
+      This feature is deprecated, enabling this feature flag call may decrease the stability of applications. Avoid using unless instructed by New Relic.
     </Callout>
 
     Enable or disable (default) experimental networking instrumentation. This forces all `NSURLConnection` network requests through the `NRMAURProtocol`.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
This PR addresses [this](https://issues.newrelic.com/browse/NR-96383) ticket for removing an experimental networking feature flag from the documentation.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.