### PR TITLE
chore(kafka): Remove old version requirement

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -247,9 +247,6 @@ The values for these settings can be defined in several ways:
 
 - Adding the value directly in the config file. This is the most common way.
 - Replacing the values from environment variables using the `{{ }}` notation. Read more about [using environment variable passthroughs with on-host integrations](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/#passthrough) or see the example for [environment variables replacement](/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-integration#envvar-replacement).
-<Callout variant="important">
-  This requires infrastructure agent v1.14.0+.
-</Callout>
 
 - Using secrets management. Use this to protect sensitive information, such as passwords that would be exposed in plain text on the configuration file. For more information, see [secrets management](/docs/integrations/host-integrations/installation/secrets-management).
 


### PR DESCRIPTION
1.14.0 was released in Dec 2020