### PR TITLE
update hybrid plugins to be called agents

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started-with-cordova-monitoring.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started-with-cordova-monitoring.mdx
@@ -72,7 +72,7 @@ To add optional configuration options, add them to the `--variable` argument, wh
 cordova plugin add https://github.com/newrelic/newrelic-cordova-plugin.git --variable IOS_APP_TOKEN="{ios-app-token}" --variable ANDROID_APP_TOKEN="{android-app-token}" --variable CRASH_REPORTING_ENABLED="false"
 ```
 
-These configuration options are only available on Cordova plugin v6.2.1 and higher.
+These configuration options are only available on Cordova agent v6.2.1 and higher.
 
 Currently, the agent supports these configuration options:
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
@@ -4,7 +4,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile Capacitor
   - Get started
-metaDescription: "New Relic's Capacitor plugin for Android and iOS: Features, compatibility, requirements, installation, and upgrade procedures."
+metaDescription: "New Relic's Capacitor agent for Android and iOS: Features, compatibility, requirements, installation, and upgrade procedures."
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-capacitor/get-started
 ---
@@ -12,11 +12,11 @@ redirects:
 import mobileQueryExample from 'images/mobile_screenshot-full_query-example.webp'
 
 
-The official New Relic Capacitor plugin for iOS and Android allows developers to easily embed the mobile agents into [Capacitor applications](https://capacitorjs.com/). Written in JavaScript, the plugin automatically includes New Relic's native agents to provide mobile monitoring and performance visibility.
+The official New Relic Capacitor agent for iOS and Android allows developers to easily embed the mobile agents into [Capacitor applications](https://capacitorjs.com/). Written in JavaScript, the plugin automatically includes New Relic's native agents to provide mobile monitoring and performance visibility.
 
 ## Features
 
-The New Relic Capacitor plugin will:
+The New Relic Capacitor agent will:
 
 
 * Automatically instrument mobile applications built via Capacitor
@@ -27,11 +27,11 @@ The New Relic Capacitor plugin will:
 * Capture interactions and their sequences
 * Track user sessions
 
-For more information, see [New Relic Capacitor Plugin on Github](https://github.com/newrelic/newrelic-capacitor-plugin).
+For more information, see [New Relic Capacitor agent on Github](https://github.com/newrelic/newrelic-capacitor-plugin).
 
 ## Requirements [#requirements]
 
-Before you install the Capacitor plugin, ensure your app meets these requirements:
+Before you install the Capacitor agent, ensure your app meets these requirements:
 
 * Android API 24+
 * iOS 10
@@ -159,7 +159,7 @@ ionic capacitor run ios
 
 ## API calls [#api-calls]
 
-Our Capacitor plugin utilizes the same API calls as our iOS and Android SDK agents. Please refer to our [iOS SDK doc](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api) or [Android SDK doc](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api).
+Our Capacitor agent utilizes the same API calls as our iOS and Android SDK agents. Please refer to our [iOS SDK doc](/docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api) or [Android SDK doc](/docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api).
 
 For errors specific to Capacitor, you can call `NewRelicCapacitorPlugin.recordError` as follows:
 
@@ -178,7 +178,7 @@ For errors specific to Capacitor, you can call `NewRelicCapacitorPlugin.recordEr
 
 ## JavaScript errors [#javascript-errors]
 
-### Capacitor Plugin v1.2.0 and above:
+### Capacitor agent v1.2.0 and above:
 JavaScript errors can be seen in the `Handled Exceptions` tab or as a `MobileHandledException` event. You can also see these errors in the NRQL explorer using this query:
 
 You can also find these errors by running this query:
@@ -186,8 +186,8 @@ You can also find these errors by running this query:
   SELECT * FROM `MobileHandledException` SINCE 24 hours ago
 ```
 
-### Capacitor Plugin v1.1.1 and below:
-The Capacitor plugin creates custom events for JavaScript errors and reports them to New Relic. In the UI, you can track these JavaScript error events with a custom dashboard.
+### Capacitor agent v1.1.1 and below:
+The Capacitor agent creates custom events for JavaScript errors and reports them to New Relic. In the UI, you can track these JavaScript error events with a custom dashboard.
 
 To create a custom dashboard:
 1. Go to [one.newrelic.com](https://one.newrelic.com/all-capabilities).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy.mdx
@@ -665,13 +665,13 @@ The following are the specific policies and dates for support of our mobile moni
 
 ## Cordova [#cordova-eol]
 
-The following are the specific policies and dates for support of our mobile monitoring agent for Cordova. Any versions not listed in the following table are no longer supported. Please [update your Cordova plugin version](https://github.com/newrelic/newrelic-cordova-plugin) to the [latest release](/docs/release-notes/mobile-release-notes/cordova-release-notes).
+The following are the specific policies and dates for support of our mobile monitoring agent for Cordova. Any versions not listed in the following table are no longer supported. Please [update your Cordova agent version](https://github.com/newrelic/newrelic-cordova-plugin) to the [latest release](/docs/release-notes/mobile-release-notes/cordova-release-notes).
 
 <table>
   <thead>
     <tr>
       <th>
-        [Cordova Plugin release](https://github.com/newrelic/newrelic-cordova-plugin)
+        [Cordova agent release](https://github.com/newrelic/newrelic-cordova-plugin)
       </th>
 
       <th>
@@ -769,13 +769,13 @@ The following are the specific policies and dates for support of our mobile moni
 
 ## Capacitor [#capacitor-eol]
 
-The following are the specific policies and dates for support of our mobile monitoring agent for Ionic Capacitor. Any versions not listed in the following table are no longer supported. Please [update your Capacitor plugin version](https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin) to the [latest release](/docs/release-notes/mobile-release-notes/capacitor-release-notes).
+The following are the specific policies and dates for support of our mobile monitoring agent for Ionic Capacitor. Any versions not listed in the following table are no longer supported. Please [update your Capacitor agent version](https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin) to the [latest release](/docs/release-notes/mobile-release-notes/capacitor-release-notes).
 
 <table>
   <thead>
     <tr>
       <th>
-        [Ionic Capacitor Plugin release](https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin?activeTab=versions)
+        [Ionic Capacitor agent release](https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin?activeTab=versions)
       </th>
 
       <th>

--- a/src/content/docs/release-notes/index.mdx
+++ b/src/content/docs/release-notes/index.mdx
@@ -21,7 +21,7 @@ To take full advantage of New Relic's latest features, enhancements, and importa
   />
 
   <TechTile
-    name="Capacitor plugin"
+    name="Capacitor agent"
     icon="logo-newrelic"
     to="/docs/release-notes/mobile-release-notes/capacitor-release-notes"
   />

--- a/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-100.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-100.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Capacitor plugin
+subject: Capacitor agent
 releaseDate: '2023-01-11'
 version: 1.0.0
 downloadLink: 'https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin'
@@ -20,4 +20,4 @@ downloadLink: 'https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin
 * Capture interactions and their sequences
 * Track user sessions
 
-To learn more, see our [Capacitor plugin documentation](/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor).
+To learn more, see our [Capacitor agent documentation](/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor).

--- a/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-110.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-110.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Capacitor plugin
+subject: Capacitor agent
 releaseDate: '2023-03-17'
 version: 1.1.0
 downloadLink: 'https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin/v/1.1.0'

--- a/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-111.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-111.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Capacitor plugin
+subject: Capacitor agent
 releaseDate: '2023-03-24'
 version: 1.1.1
 downloadLink: 'https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin/v/1.1.1'

--- a/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-120.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-120.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Capacitor plugin
+subject: Capacitor agent
 releaseDate: '2023-05-17'
 version: 1.2.0
 downloadLink: 'https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin/v/1.2.0'

--- a/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-121.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-121.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Capacitor plugin
+subject: Capacitor agent
 releaseDate: '2023-06-09'
 version: 1.2.0
 downloadLink: 'https://www.npmjs.com/package/@newrelic/newrelic-capacitor-plugin/v/1.2.1'

--- a/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/capacitor-release-notes/index.mdx
@@ -1,3 +1,3 @@
 ---
-subject: Capacitor plugin
+subject: Capacitor agent
 ---

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-600.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-600.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agent
 releaseDate: '2022-11-05'
 version: 6.0.0
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-601.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-601.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agent
 releaseDate: '2023-01-11'
 version: 6.0.1
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-602.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-602.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agent
 releaseDate: '2023-01-19'
 version: 6.0.2
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-610.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-610.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agent
 releaseDate: '2023-03-17'
 version: 6.1.0
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'
@@ -14,5 +14,5 @@ downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'
 
 * Fixed issue to handle null errors given by Cordova's event listener.
 * Fixed issue where large cyclical structures printed to console would cause out-of-memory issues on Android.
-* Fixed issue where plugin would fail to load on iOS devices with Safari 14.1 or lower.
+* Fixed issue where agent would fail to load on iOS devices with Safari 14.1 or lower.
 

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-620.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-620.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agent
 releaseDate: '2023-05-17'
 version: 6.2.0
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-621.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-621.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova agnet
+subject: Cordova agent
 releaseDate: '2023-06-09'
 version: 6.2.1
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-621.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-621.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agnet
 releaseDate: '2023-06-09'
 version: 6.2.1
 downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'
@@ -7,7 +7,7 @@ downloadLink: 'https://github.com/newrelic/newrelic-cordova-plugin'
 
 # New in this release
 * Upgrade native iOS agent to v7.4.5
-* Added agent configuration options when adding the plugin to your project.
+* Added agent configuration options when adding the agent to your project.
 
 # Fixed in this release
 * Fixed an issue where certain JS errors were improperly parsed on iOS.

--- a/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/index.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/cordova-release-notes/index.mdx
@@ -1,3 +1,3 @@
 ---
-subject: Cordova Plugin
+subject: Cordova agent
 ---

--- a/src/i18n/content/jp/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
+++ b/src/i18n/content/jp/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
@@ -4,7 +4,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile Capacitor
   - Get started
-metaDescription: 'New Relic''s Capacitor plugin for Android and iOS: Features, compatibility, requirements, installation, and upgrade procedures.'
+metaDescription: 'New Relic''s Capacitor agent for Android and iOS: Features, compatibility, requirements, installation, and upgrade procedures.'
 translationType: machine
 ---
 
@@ -24,7 +24,7 @@ New Relic Capacitor プラグインは次のことを行います。
 * インタラクションとそのシーケンスをキャプチャ
 * ユーザー セッションの追跡
 
-詳細については[、Github の New Relic Capacitor Plugin を](https://github.com/newrelic/newrelic-capacitor-plugin)参照してください。
+詳細については[、Github の New Relic Capacitor agent を](https://github.com/newrelic/newrelic-capacitor-plugin)参照してください。
 
 ## 要件 [#requirements]
 

--- a/src/i18n/content/kr/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
+++ b/src/i18n/content/kr/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
@@ -4,7 +4,7 @@ tags:
   - Mobile monitoring
   - New Relic Mobile Capacitor
   - Get started
-metaDescription: 'New Relic''s Capacitor plugin for Android and iOS: Features, compatibility, requirements, installation, and upgrade procedures.'
+metaDescription: 'New Relic''s Capacitor agent for Android and iOS: Features, compatibility, requirements, installation, and upgrade procedures.'
 translationType: machine
 ---
 

--- a/src/i18n/nav/jp.json
+++ b/src/i18n/nav/jp.json
@@ -7770,7 +7770,7 @@
     "locale": "jp"
   },
   {
-    "englishTitle": "Capacitor plugin",
+    "englishTitle": "Capacitor",
     "title": "Capacitorプラグイン",
     "locale": "jp"
   },

--- a/src/i18n/nav/kr.json
+++ b/src/i18n/nav/kr.json
@@ -7770,7 +7770,7 @@
     "locale": "kr"
   },
   {
-    "englishTitle": "Capacitor plugin",
+    "englishTitle": "Capacitor",
     "title": "Capacitor 플러그인",
     "locale": "kr"
   },

--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -101,7 +101,7 @@ pages:
                 path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/event-limits-sampling
               - title: Firebase incompatibility
                 path: /docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/firebase-incompatibility-android
-      - title: Capacitor plugin
+      - title: Capacitor
         path: /docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor/
       - title: Cordova
         path: /docs/mobile-monitoring/new-relic-mobile-cordova-phonegap/get-started-with-cordova-monitoring/


### PR DESCRIPTION
Replaces all references from Cordova plugin/Capacitor plugin to be Cordova agent/Capacitor agent.