### PR TITLE
chore: adding notes on CIDR sizing recommendations

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -682,7 +682,7 @@ global:
           </td>
 
           <td>
-            Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation).
+            Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation). *Care should be taken to control the size of these ranges to [avoid a timeout](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices).
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -682,7 +682,8 @@ global:
           </td>
 
           <td>
-            Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation). *Care should be taken to control the size of these ranges to [avoid a timeout](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices).*
+            Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation).
+            Be mindful with the size of these ranges to [avoid a timeout](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices).
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -682,7 +682,7 @@ global:
           </td>
 
           <td>
-            Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation). *Care should be taken to control the size of these ranges to [avoid a timeout](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices).
+            Array of target IP ranges in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation). *Care should be taken to control the size of these ranges to [avoid a timeout](/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices).*
           </td>
         </tr>
 

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
@@ -9,21 +9,30 @@ metaDescription: SNMP monitoring discovery does not find any devices, or you did
 
 ## Problem [#problem]
 
-You launched an SNMP discovery run but didn't find any devices.
+You launched an SNMP discovery run but didn't find all of the expected devices.
 
 ## Solutions [#solutions]
 
-The SNMP discovery process will run against every IP address in your list from the `cidr` section in the discovery configuration. During the scan, there is a TCP port check to ensure the target IP address is responsive. If successful, `ktranslate` will then attempt to communicate with the IP address via SNMP.
+The SNMP discovery process will run against every IP address in your list from the [cidr](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) section in the discovery configuration. During the scan, there is a TCP port check to ensure the target IP address is responsive. If successful, `ktranslate` will then attempt to communicate with the IP address via SNMP.
 
 Common failure points in the discovery process include:
 
-* timeouts due to either network latency or device response times to SNMP requests. Meraki Cloud Controllers [recommend at least a 10s timeout](https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/SNMP_Overview_and_Configuration) value, for instance.
-* initial failures on the responsiveness check from devices that are generally under tighter security postures, like firewalls.
+* Timeouts due to either network latency or device response times to SNMP requests. Meraki Cloud Controllers [recommend at least a 10s timeout](https://documentation.meraki.com/General_Administration/Monitoring_and_Reporting/SNMP_Overview_and_Configuration) value, for instance.
+* Initial failures on the responsiveness check from devices that are generally under tighter security postures, like firewalls.
+* Timeouts due to excessively large IP range presented in the `cidr` section of the discovery configuration.
 
-To work around these problems, try one or both of the following solutions:
+<Callout variant="important">
+  By default, the SNMP discovery uses 4 threads to run async with a 3 second timeout per IP address. For a `/22` CIDR block with 1,024 total IP addresses, you should expect ~13 minutes for a discovery job to complete.
+  *1,024 IPs / 4 threads = 256 per thread * 3 seconds per IP = 768 seconds / 60 = 12.8 minutes*
+
+  For a `/16` CIDR block with 65,536 total IP addresses, it would take ~13.65 hours.
+</Callout>
+
+To work around these problems, try one or all of the following solutions:
 
 1. Edit the `snmp-base.yaml` and increase the timeout value for the `timeout_ms` variable.
 2. For devices that still seem unresponsive, set all the `cidrs` values to a length of `/32`, which forces the discovery process to skip the responsiveness check and only attempts the SNMP connection.
+3. If you are receiving timeouts on the entire job, ensure that you are limiting the provided CIDR blocks to 1,024 or less total IPs. (e.g.; a CIDR range between `/22` and `/32`) It is acceptable to provide multiple blocks of `/22` in a single configuration file, but overall the recommendation is to horizontally scale into multiple containers when you have large target environment versus trying to do all of the work in a single container.
 
 <Callout variant="tip">
   If you have a large set of devices that are being skipped because of the port scan you can edit the `snmp-base.yaml` file and enable the option for [check_all_ips](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) to skip the port scan and just go directly to testing SNMP credentials against every address in your discovery. Keep in mind that this option will dramatically increase the time it takes to complete a discovery.

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
@@ -23,7 +23,8 @@ Common failure points in the discovery process include:
 
 <Callout variant="important">
   By default, the SNMP discovery uses 4 threads to run async with a 3 second timeout per IP address. For a `/22` CIDR block with 1,024 total IP addresses, you should expect ~13 minutes for a discovery job to complete.
-  *1,024 IPs / 4 threads = 256 per thread * 3 seconds per IP = 768 seconds / 60 = 12.8 minutes*
+
+  *1,024 IPs / 4 threads = 256 per thread \* 3 seconds per IP = 768 seconds / 60 = 12.8 minutes*
 
   For a `/16` CIDR block with 65,536 total IP addresses, it would take ~13.65 hours.
 </Callout>

--- a/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/snmp-discovery-no-devices.mdx
@@ -13,7 +13,7 @@ You launched an SNMP discovery run but didn't find all of the expected devices.
 
 ## Solutions [#solutions]
 
-The SNMP discovery process will run against every IP address in your list from the [cidr](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) section in the discovery configuration. During the scan, there is a TCP port check to ensure the target IP address is responsive. If successful, `ktranslate` will then attempt to communicate with the IP address via SNMP.
+The SNMP discovery process will run against every IP address in your list from the [`cidr`](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) section in the discovery configuration. During the scan, there's a TCP port check to ensure the target IP address is responsive. If successful, `ktranslate` will then attempt to communicate with the IP address via SNMP.
 
 Common failure points in the discovery process include:
 
@@ -22,18 +22,22 @@ Common failure points in the discovery process include:
 * Timeouts due to excessively large IP range presented in the `cidr` section of the discovery configuration.
 
 <Callout variant="important">
-  By default, the SNMP discovery uses 4 threads to run async with a 3 second timeout per IP address. For a `/22` CIDR block with 1,024 total IP addresses, you should expect ~13 minutes for a discovery job to complete.
+  By default, the SNMP discovery uses 4 threads to run asynchronously with a 3 second timeout per IP address. For a `/22` CIDR block with 1,024 total IP addresses, you should expect aproximately 13 minutes for a discovery job to complete:
+  
+  ```
+  1,024 IPs / 4 threads = 256 IPs per thread 
+  256 IPs per thread * 3 seconds per IP = 768 seconds
+  768 seconds / 60 = 12.8 minutes
+  ```
 
-  *1,024 IPs / 4 threads = 256 per thread \* 3 seconds per IP = 768 seconds / 60 = 12.8 minutes*
-
-  For a `/16` CIDR block with 65,536 total IP addresses, it would take ~13.65 hours.
+  For a `/16` CIDR block with 65,536 total IP addresses, it'd take aproximately 13,65 hours.
 </Callout>
 
 To work around these problems, try one or all of the following solutions:
 
 1. Edit the `snmp-base.yaml` and increase the timeout value for the `timeout_ms` variable.
 2. For devices that still seem unresponsive, set all the `cidrs` values to a length of `/32`, which forces the discovery process to skip the responsiveness check and only attempts the SNMP connection.
-3. If you are receiving timeouts on the entire job, ensure that you are limiting the provided CIDR blocks to 1,024 or less total IPs. (e.g.; a CIDR range between `/22` and `/32`) It is acceptable to provide multiple blocks of `/22` in a single configuration file, but overall the recommendation is to horizontally scale into multiple containers when you have large target environment versus trying to do all of the work in a single container.
+3. If you are receiving timeouts on the entire job, ensure that you're limiting the provided CIDR blocks to 1,024 or less total IPs. For example, a CIDR range between `/22` and `/32`. You can provide multiple blocks of `/22` in a single configuration file, but overall we recommend you to horizontally scale into multiple containers when you have large target environment versus trying to do all of the work in a single container.
 
 <Callout variant="tip">
   If you have a large set of devices that are being skipped because of the port scan you can edit the `snmp-base.yaml` file and enable the option for [check_all_ips](/docs/network-performance-monitoring/advanced/advanced-config/#discovery) to skip the port scan and just go directly to testing SNMP credentials against every address in your discovery. Keep in mind that this option will dramatically increase the time it takes to complete a discovery.


### PR DESCRIPTION
adding some notes to better explain issues with discovery job timeouts using the network monitoring agent.