### PR TITLE
fix: update manage-data-retention.mdx

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -21,11 +21,7 @@ On the **Data retention** UI page, located in the [data management hub](https://
 
 ## Extend your data retention for long-term analysis and compliance
 
-Extending your data retention allows you to do long-term analysis, visualization, and alerting for all your metrics, events, logs, and traces across all of your sources. However, it's important to manage that data for cost, performance, and in some cases, compliance reasons. Our data management hub provides the tools you need to understand and control where your data is coming from, and adjust what's stored and for how long. 
-
-New Relic will begin enforcing data retention limits on March 31, 2023. When your data retention exceeds the stated limits, it will be returned to default or contracted data retention, as applicable, and data retention exceeding the stated or contracted limits will be purged. The impacted data includes all data ingested prior to and after March 31, 2023, including for use in dashboards, data analysis, auditing, and reporting needs.
-
-When you adjust data retention beyond the stated limits, you'll be prompted (in the [data management hub](/docs/data-apis/manage-data/manage-your-data)) to upgrade your retention with new billing changes to reflect your extended retention.
+Extending your data retention allows you to do long-term analysis, visualization, and alerting for all your metrics, events, logs, and traces across all of your sources. However, it's important to manage that data for cost, performance, and in some cases, compliance reasons. Our data management hub provides the tools you need to understand and control where your data is coming from, and adjust what's stored and for how long.
 
 <Callout variant="tip">
 With [our Data Plus option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-plus), you get up to an additional 90 days of retention (for most data types) and other enterprise-grade capabilities, such as longer query durations, FedRAMP and HIPAA compliance, additional security features, and more.


### PR DESCRIPTION
Remove enforcing of retention limits on March 31st section since most accounts are already in compliance.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
In this PR, the section about capping retention at the contracted max by March 31st is removed since most accounts have already been capped and are in compliance.