### PR TITLE
use qualified names in attribute map

### DIFF
--- a/scripts/transformDataDictionary.mjs
+++ b/scripts/transformDataDictionary.mjs
@@ -75,18 +75,18 @@ let attributeStrs = await Promise.all(
 );
 attributeStrs
   .map(([path, attributeStr]) => [path, frontmatter(attributeStr)])
-  .forEach(([path, { attributes: mdAttributes, body }]) =>
-    attributes.set(mdAttributes.name, {
+  .forEach(([path, { attributes: mdAttributes, body }]) => {
+    const qualifiedName = `${getParentFromPath(path)}/${mdAttributes.name}`
+    attributes.set(qualifiedName, {
       ...mdAttributes,
       body,
-      parentEvent: getParentFromPath(path),
       fsPath: path,
     })
+  }
   );
 
-for (const [name, attribute] of attributes) {
-  const parent = attribute.parentEvent;
-  const qualifiedName = `${parent}/${name}`;
+for (const [qualifiedName, attribute] of attributes) {
+  const parent = qualifiedName.split('/')[0]
 
   attribute.events
     .filter((event) => event !== parent)
@@ -95,7 +95,6 @@ for (const [name, attribute] of attributes) {
 
   let path = attribute.fsPath;
   delete attribute.fsPath;
-  delete attribute.parentEvent;
 
   let yaml = constructYaml(attribute);
   const parentFolder = path.split('/').slice(0, -1).join('/');
@@ -103,7 +102,7 @@ for (const [name, attribute] of attributes) {
   fs.writeFile(path, yaml);
 }
 
-for (const [name, event] of events) {
+for (const [_name, event] of events) {
   let path = event.fsPath;
   delete event.fsPath;
   event.attributes = Array.from(event.attributes).sort();


### PR DESCRIPTION
several attributes have the same name across different events, so there were collisions here that meant some events had missing attributes and some events had extra attributes