### PR TITLE
Update opentelemetry-best-practices-attributes.mdx with attribute array limits

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-attributes.mdx
@@ -11,6 +11,7 @@ New Relic's limits on attributes apply to data from any source, including OTLP-s
 
 * Maximum length of attribute name: 255 characters
 * Maximum length of attribute value: 4095 characters
+* Maximum size of attribute array value: 64 entries
 
 If a span attribute exceeds the limit, you can use [span limits environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#span-limits-) to configure the maximum length(s). If a [resource attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/d6bcc0cb072d8d6f6ced856f1f23c451648a3caa/specification/sdk-environment-variables.md#general-sdk-configuration) is the offender, you can set `OTEL_RESOURCE_ATTRIBUTES=<offending-attribute>=unset` to override it.
 


### PR DESCRIPTION
This behavior is currently undocumented and has come up in support cases. Documenting it to help users self discover the limit.

cc @alanwest 