### PR TITLE
Remove "URL" as the address for endpoint

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -52,16 +52,16 @@ Notes on NerdGraph requirements:
 The endpoint depends on your [data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center):
 
 <CONTRIBUTOR_NOTE>
-  Do NOT change the URLs of these GraphQL endpoints below unless you have the approval of the Unified API team.
+  Do NOT change these GraphQL endpoints below unless you have the approval of the Unified API team.
 </CONTRIBUTOR_NOTE>
 
-* Main endpoint URL: `https://api.newrelic.com/graphql`
-* Endpoint URL for accounts using EU data center: `https://api.eu.newrelic.com/graphql`
+* Main endpoint: `https://api.newrelic.com/graphql`
+* Endpoint for accounts using EU data center: `https://api.eu.newrelic.com/graphql`
 
 To access the endpoint, you can use our [NerdGraph explorer](#explorer), or you can access it directly with a curl command similar to this:
 
 <CONTRIBUTOR_NOTE>
-  Do NOT change the URL of this GraphQL endpoint in this curl request unless you have the approval of the Unified API team.
+  Do NOT change the GraphQL endpoint in this curl request unless you have the approval of the Unified API team.
 </CONTRIBUTOR_NOTE>
 ```bash
 curl -X POST https://api.newrelic.com/graphql \


### PR DESCRIPTION
This is a short PR to remove "URL" as the address of and endpoint. We had some feedback that it's not necessary to distinguish between the endpoint (similar to a house) and its URL address (similar to the street address of a house).  This removes that distinction.