### PR TITLE
docs(Alerts): Amended details for violation_close_timer

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -800,19 +800,7 @@ Not every field listed in this glossary is required for every condition type. Th
     id="violation_close_timer"
     title="violation_close_timer"
   >
-    Use to automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be one of these values:
-
-    * 1
-
-    * 2
-
-    * 4
-
-    * 8
-
-    * 12
-
-    * 24
+    Use to automatically close instance-based incidents, including JVM health metric incidents, after the number of hours specified. Must be between 1 and 720 hours. Defaults to 72 hours.
 
       Used for:
 


### PR DESCRIPTION
## Give us some context

Updates behavior of `violation_close_timer` field in the alert condition REST API to reflect the actual behavior. Validation looks for a number of hours between 1 and 720, and defaults to 72.

Related: https://github.com/newrelic/terraform-provider-newrelic/pull/2402
