### PR TITLE
Fix p.o.v. and missing word in sentence

### DIFF
--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -31,7 +31,7 @@ First, we'll check for `enduser.id` according to the [OpenTelemetry standard](ht
 
 ### Querying for users impacted [#alerts]
 
-The number of users impacted on an error group is recorded as a [Metric data type](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/metric-data-type/) with the name `newrelic.error.group.userImpact`. One can use metric with the following NRQL string:
+The number of users impacted on an error group is recorded as a [Metric data type](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/metric-data-type/) with the name `newrelic.error.group.userImpact`. You can use this metric with the following NRQL string:
 
 ```
 SELECT uniqueCount(newrelic.error.group.userImpact) FROM Metric WHERE metricName='newrelic.error.group.userImpact'


### PR DESCRIPTION
This sentence used "one" rather than "you." It also was missing a word, and was therefore not grammatically correct.

