### PR TITLE
chore: add language identifiers to heroku docs

### DIFF
--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
@@ -84,7 +84,7 @@ After you install the [New Relic add-on for Heroku](https://devcenter.heroku.com
 
     If you are using our Ruby agent with a non-Rails application, Heroku users need to install the plugin in your repository manually. For example, in a Sinatra app, add the `newrelic` gem to your **Gemfile**, and then add the following code to your app:
 
-    ```
+    ```ruby
     configure :production do
      require 'newrelic_rpm'
      end
@@ -105,7 +105,7 @@ Every time you install the New Relic add-on for Heroku, New Relic will automatic
 
     1. From a command line, run:
 
-       ```
+       ```bash
        heroku config | grep -i relic
        ```
     2. Look for the value of `NEW_RELIC_LICENSE_KEY`.
@@ -130,7 +130,7 @@ Every time you install the New Relic add-on for Heroku, New Relic will automatic
   >
     You cannot change your add-on's [account ID](/docs/accounts-partnerships/accounts/account-setup/account-id) directly. If you need to change the New Relic account your Heroku app uses for reporting to New Relic, change the current license key environment variable in its config file so that it points to the license key of the New Relic account you want to use:
 
-    ```
+    ```bash
     heroku config:set NEW_RELIC_LICENSE_KEY=changed_account_license_key
     ```
   </Collapser>

--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/heroku-install-new-relic-add.mdx
@@ -86,8 +86,8 @@ After you install the [New Relic add-on for Heroku](https://devcenter.heroku.com
 
     ```ruby
     configure :production do
-     require 'newrelic_rpm'
-     end
+      require 'newrelic_rpm'
+      end
     ```
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/java-agent/heroku/java-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/java-agent/heroku/java-agent-heroku.mdx
@@ -58,7 +58,7 @@ After you [enable the New Relic agent add-on](#enable), pass the `javaagent` fla
     id="deploy-locally"
     title="Deploy locally"
   >
-    If you deploy locally, your jar file might be in a different directory. If it is, replace PATH/TO/NEWRELIC.JAR with the path to the jar file in your local directory.
+    If you deploy locally, your jar file might be in a different directory. If it is, replace `PATH/TO/NEWRELIC.JAR` with the path to the jar file in your local directory.
 
     Example:
 
@@ -79,54 +79,54 @@ After you [provide the path to the jar file](#provide-path), configure your Hero
   >
     1. Give your app a [meaningful name](/docs/agents/manage-apm-agents/app-naming/name-your-application) with this Heroku toolbelt command:
 
-       ```
+       ```bash
        heroku config:set NEW_RELIC_APP_NAME="APP_NAME"
        ```
     2. Add your <InlinePopover type="licenseKey" />:
 
-       ```
-       heroku config:set <a href="/docs/agents/java-agent/configuration/java-agent-configuration-config-file#ev-NEW_RELIC_LICENSE_KEY">NEW_RELIC_LICENSE_KEY</a>="LICENSE_KEY"
+       ```bash
+       heroku config:set NEW_RELIC_LICENSE_KEY="LICENSE_KEY"
        ```
     3. In your `pom.xml`, add the `newrelic-agent` dependency, substituting `X.Y.Z` with the [latest Java agent version](/docs/agents/java-agent/getting-started/java-release-notes). Recommended: To ensure proper formatting is applied and contents do not contain sensitive information, format the syntax using [http://codebeautify.org/xmlviewer](http://codebeautify.org/xmlviewer).
 
        ```xml
        <dependency> 
 
-        <groupId>com.newrelic.agent.java</groupId>
-        <artifactId>newrelic-java</artifactId>
-        <version>X.Y.Z</version>
-        <scope>provided</scope>
-        <type>zip</type>
+           <groupId>com.newrelic.agent.java</groupId>
+           <artifactId>newrelic-java</artifactId>
+           <version>X.Y.Z</version>
+           <scope>provided</scope>
+           <type>zip</type>
 
        </dependency>
        ```
     4. In the `<build>` element of `pom.xml`, customize the build so it downloads the agent:
 
-       ```xml
-             <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-dependency-plugin</artifactId>
-               <version>3.0.2</version>
-               <executions>
-                 <execution>
-                   <id>unpack-newrelic</id>
-                   <phase>package</phase>
-                   <goals>
-                     <goal>unpack-dependencies</goal>
-                   </goals>
-                   <configuration>
-                     <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
-                     <includeArtifactIds>newrelic-java</includeArtifactIds>
-                     <overWriteReleases>false</overWriteReleases>
-                     <overWriteSnapshots>false</overWriteSnapshots>
-                     <overWriteIfNewer>true</overWriteIfNewer>
-                     <outputDirectory>${project.basedir}</outputDirectory>
-                     <destFileName>newrelic</destFileName>
-                   </configuration>
-                 </execution>
-               </executions>
-             </plugin>
-       ```
+      ```xml
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.0.2</version>
+          <executions>
+              <execution>
+                <id>unpack-newrelic</id>
+                <phase>package</phase>
+                <goals>
+                    <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                    <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                    <includeArtifactIds>newrelic-java</includeArtifactIds>
+                    <overWriteReleases>false</overWriteReleases>
+                    <overWriteSnapshots>false</overWriteSnapshots>
+                    <overWriteIfNewer>true</overWriteIfNewer>
+                    <outputDirectory>${project.basedir}</outputDirectory>
+                    <destFileName>newrelic</destFileName>
+                </configuration>
+              </execution>
+          </executions>
+      </plugin>
+      ```
   </Collapser>
 
   <Collapser title="Manual configuration">
@@ -146,14 +146,14 @@ After you [configure your Heroku environment for New Relic](#configure-heroku-en
 
 1. Push your changes to the dyno with this Heroku toolbelt command:
 
-   ```
+   ```bash
    git add .
    git commit -m 'YOUR COMMIT MESSAGE'
    git push heroku master
    ```
 2. Open your app in your browser with this Heroku toolbelt command:
 
-   ```
+   ```bash
    heroku open
    ```
 3. Generate some traffic to your app and wait a few minutes.

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/php-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/php-agent-heroku.mdx
@@ -32,7 +32,7 @@ After deploying your PHP app on Heroku, install our PHP agent:
     2. From the **Select an app** dropdown, select your app.
     3. Give your application a [descriptive name](#naming) with this Heroku toolbelt command:
 
-       ```
+       ```bash
        heroku config:set NEW_RELIC_APP_NAME='YOUR_APP_NAME'
        ```
     4. Push a change to Heroku (for example, `git commit --allow-empty`) to enable the PHP extension during build.
@@ -47,12 +47,12 @@ After deploying your PHP app on Heroku, install our PHP agent:
 
     1. Via Heroku toolbelt, run the following command and substitute the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing):
 
-       ```
+       ```bash
        heroku addons:create newrelic:YOUR_PLAN_LEVEL
        ```
     2. Give your application a [descriptive name](#naming) with this Heroku toolbelt command:
 
-       ```
+       ```bash
        heroku config:set NEW_RELIC_APP_NAME='YOUR_APP_NAME'
        ```
     3. Push a change to Heroku (for example, `git commit --allow-empty`) to enable the PHP extension during build.
@@ -66,18 +66,18 @@ Within a few minutes, data should start appearing in your [APM **Summary** page]
 
 Heroku automatically configures default environment variables for your app. To customize your settings, create and upload a **newrelic.ini** file to Heroku:
 
-1. Download a "clean" copy of [**newrelic.ini\_.heroku**](./files/newrelic.ini_.heroku) [INI | 16KB].
-2. Rename the file from **newrelic.ini\_.heroku** to **newrelic.ini**.
-3. Copy **newrelic.ini** to the root directory of your project repository.
+1. Download a "clean" copy of [`newrelic.ini_.heroku`](./files/newrelic.ini_.heroku) [INI | 16KB].
+2. Rename the file from `newrelic.ini_.heroku` to `newrelic.ini`.
+3. Copy `newrelic.ini` to the root directory of your project repository.
 4. Customize your settings as described in [PHP agent configuration](/docs/agents/php-agent/configuration/php-agent-configuration).
 
    <Callout variant="caution">
-     Do not change **newrelic.license**, **newrelic.loglevel**, or **newrelic.appname**. These settings are configured by Heroku toolbelt.
+     Do not change `newrelic.license`, `newrelic.loglevel`, or `newrelic.appname`. These settings are configured by Heroku toolbelt.
    </Callout>
 5. Commit your config file changes to your repository, and push your changes to Heroku.
 6. Instruct Heroku to use your customized config file via this Heroku toolbelt command:
 
-   ```
+   ```bash
    heroku config:set NEW_RELIC_CONFIG_FILE=newrelic.ini
    ```
 
@@ -89,18 +89,18 @@ New Relic uses the app name to aggregate data. If you do not change this name, N
 
 1. To name your application, run this Heroku toolbelt command:
 
-   ```
-   heroku config:set NEW_RELIC_APP_NAME='YOUR_APP_NAME'
+   ```bash
+   heroku config:set NEW_RELIC_APP_NAME="YOUR_APP_NAME"
    ```
 2. To verify your app's name change, run:
 
-   ```
+   ```bash
    heroku run env | grep NEW_RELIC_APP_NAME
    ```
 
 Verify that the confirmation prompt returns the new app name:
 
-```
+```ini
 NEW_RELIC_APP_NAME=YOUR_APP_NAME
 ```
 
@@ -108,14 +108,14 @@ NEW_RELIC_APP_NAME=YOUR_APP_NAME
 
 To verify that Heroku has installed the New Relic add-on, run this Heroku toolbelt command:
 
-```
+```bash
 heroku run env | grep NEW_RELIC
 ```
 
 This will generate a list of New Relic environment variables in Heroku. The agent uses these environment variables to determine which account to report data to. You should see at least the following variables:
 
-```
-NEW_RELIC_LICENSE_KEY='YOUR_LICENSE_KEY'
+```ini
+NEW_RELIC_LICENSE_KEY="YOUR_LICENSE_KEY"
 NEW_RELIC_LOG_LEVEL="warning"
 NEW_RELIC_APP_NAME="YOUR_APP_NAME"
 ```
@@ -128,7 +128,7 @@ To troubleshoot the PHP agent on Heroku, examine your log file, which is stored 
 
 1. To view the web server log, run this Heroku toolbelt command:
 
-   ```
+   ```bash
    heroku logs -t | tee newrelic.log
    ```
 2. Use the log file to troubleshoot the issue.
@@ -136,14 +136,14 @@ To troubleshoot the PHP agent on Heroku, examine your log file, which is stored 
 
 The PHP agent defaults to the `warning` [log level](/docs/agents/php-agent/configuration/php-agent-configuration#inivar-loglevel). New Relic Support may also request logs at the `verbosedebug` log level. To change the log level to `verbosedebug`, run this Heroku toolbelt command:
 
-```
+```bash
 heroku config:set NEW_RELIC_LOG_LEVEL=verbosedebug
 ```
 
 <Callout variant="caution">
   The `verbosedebug` log level quickly generates a large volume of data. Use this setting only if New Relic Support requests it, and remove this setting as soon as you collect the output by running this Heroku toolbelt command:
 
-  ```
+  ```bash
   heroku config:unset NEW_RELIC_LOG_LEVEL
   ```
 </Callout>

--- a/src/content/docs/apm/agents/python-agent/hosting-services/python-agent-heroku.mdx
+++ b/src/content/docs/apm/agents/python-agent/hosting-services/python-agent-heroku.mdx
@@ -33,7 +33,7 @@ After deploying your Python app on Heroku, install the Python agent:
     2. From **Select an app**, select your New Relic app.
     3. Give your application a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) with this Heroku toolbelt command:
 
-       ```
+       ```bash
        heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
        ```
     4. Restart your dyno.
@@ -48,12 +48,12 @@ After deploying your Python app on Heroku, install the Python agent:
 
     1. Run the following command, where `$planlevel` is the [appropriate subscription plan](https://elements.heroku.com/addons/newrelic#pricing):
 
-       ```
+       ```bash
        heroku addons:create newrelic:$planlevel
        ```
     2. Give your application a [descriptive name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) with this toolbelt command:
 
-       ```
+       ```bash
        heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
        ```
     3. Restart your dyno.
@@ -67,7 +67,7 @@ Installing the add-on automatically creates a private New Relic account and conf
 
 If an agent is already installed, reinstall the add-on using the Heroku toolbelt command.
 
-```
+```bash
 heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
 ```
 
@@ -75,12 +75,12 @@ heroku config:set NEW_RELIC_APP_NAME='Your Application Name'
 
 To install a third party Python package such as our Python agent on Heroku, use **pip**. Heroku automatically looks for a **requirements.txt** file in the root directory of your project. It installs anything listed in that file when you push your project to Heroku.
 
-1. Create or edit the **requirements.txt** file, adding the line:
+1. Create or edit the `requirements.txt` file, adding the line:
 
    ```
    newrelic
    ```
-2. **Django users:** Modify the **web** entry of your Procfile, prefixing the value with `newrelic-admin run-program`. For example:
+2. **Django users:** Modify the `web` entry of your `Procfile`, prefixing the value with `newrelic-admin run-program`. For example:
 
    ```
    web: newrelic-admin run-program gunicorn mysite.wsgi
@@ -93,7 +93,7 @@ This will install the the Python agent package with the latest version listed on
 
 Heroku caches packages and does not detect when a newer version of the Python agent is available. To force an upgrade:
 
-1. Edit the **requirements.txt** file by including the specific Python agent version (`n.n.n.n`) with the package name:
+1. Edit the `requirements.txt` file by including the specific Python agent version (`n.n.n.n`) with the package name:
 
    ```
    newrelic==n.n.n.n
@@ -104,7 +104,7 @@ Heroku caches packages and does not detect when a newer version of the Python ag
 
 To verify that the New Relic add-on has been enabled, run:
 
-```
+```bash
 heroku run env | grep NEW_RELIC
 ```
 
@@ -112,7 +112,7 @@ This generates a list of New Relic-specific environment variables in Heroku. The
 
 At a minimum, you should see:
 
-```
+```ini
 NEW_RELIC_LOG=stdout
 NEW_RELIC_LICENSE_KEY=0000000000000000000000000000000000000000
 NEW_RELIC_APP_NAME=Your app name
@@ -124,7 +124,7 @@ The <InlinePopover type="licenseKey" /> is unique to your New Relic account.
 
 Within a few minutes of installing and configuring the agent, data should start appearing in your app's APM [Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page). If no data appears, test that environment variables are being detected properly by running:
 
-```
+```bash
 heroku run newrelic-admin validate-config - stdout
 ```
 
@@ -134,8 +134,8 @@ This will create a connection and report test transaction data under the applica
 
 To initialize the Python agent:
 
-1. From the root of your project, find the **Procfile**.
-2. Modify the `web` entry in your **Procfile** to define what to do to start up your Python web application.
+1. From the root of your project, find the `Procfile`
+2. Modify the `web` entry in your `Procfile` to define what to do to start up your Python web application.
 3. Refer to the following examples to insert `newrelic-admin run-program` at the start of the command.
 4. Run your Python web application under the control of the the Python agent's admin script.
 
@@ -231,7 +231,7 @@ For others, you must modify the Python code file with your WSGI application entr
       <td>
         Wrap it in a decorator:
 
-        ```
+        ```python
         import newrelic.agent
 
           @newrelic.agent.wsgi_application()
@@ -249,7 +249,7 @@ For others, you must modify the Python code file with your WSGI application entr
       <td>
         Wrap it in `pre` decorator style:
 
-        ```
+        ```python
         import myapp
           application = myapp.WSGIHandler()
           application = newrelic.agent.WSGIApplicationWrapper(application)
@@ -263,7 +263,7 @@ For others, you must modify the Python code file with your WSGI application entr
 
 To record execution time for Celery tasks as background tasks against your web application, wrap the startup of the Celery host with the `newrelic-admin` command.
 
-Prefix the existing startup command defined by the `worker` entry in your **Procfile**:
+Prefix the existing startup command defined by the `worker` entry in your `Procfile`:
 
 ```
 worker: newrelic-admin run-program python hellodjango/manage.py celeryd -E -B --loglevel=INFO
@@ -275,13 +275,13 @@ To begin debugging, collect the log output from the Python agent. Heroku sends P
 
 To get access to the web server log for Heroku, run:
 
-```
+```bash
 heroku logs
 ```
 
 By default the Python agent will log at `info` level. If New Relic Support requests an alternate level of logging, you must manually add a config variable. For example, to set logging output to `debug`, run:
 
-```
+```bash
 heroku config:add NEW_RELIC_LOG_LEVEL=debug
 ```
 
@@ -290,7 +290,7 @@ Your application automatically restarts when you change the log level.
 <Callout variant="caution">
   The `debug` log level produces large quantities of output. Be sure to remove this setting as soon as it is no longer required, by running:
 
-  ```
+  ```bash
   heroku config:remove NEW_RELIC_LOG_LEVEL
   ```
 </Callout>
@@ -303,16 +303,16 @@ Do not add core settings such as the license key, application name, etc. to the 
 
 To customize other settings, use the Python agent configuration file with Heroku:
 
-1. Add the **newrelic.ini** agent configuration file to the root directory of your project repository that you are pushing up to Heroku: In the `[newrelic]` section, include the specific configuration setting; for example:
+1. Add the `newrelic.ini` agent configuration file to the root directory of your project repository that you are pushing up to Heroku: In the `[newrelic]` section, include the specific configuration setting; for example:
 
-   ```
+   ```ini
    [newrelic]
    transaction_tracer.function_trace = mydbm:connect
    ```
 2. Commit the configuration file to your repository, and push the change up to Heroku.
-3. Use the `heroku config:add` command to set the **NEW_RELIC_CONFIG_FILE** environment variable for your deployed application:
+3. Use the `heroku config:add` command to set the `NEW_RELIC_CONFIG_FILE` environment variable for your deployed application:
 
-   ```
+   ```bash
    heroku config:add NEW_RELIC_CONFIG_FILE=newrelic.ini
    ```
 


### PR DESCRIPTION
I also fixed some formatting and put code/filenames in backticks instead of BOLD, which is more consistent with the rest of our docs