### PR TITLE
use `rem`s for right column width

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -87,7 +87,7 @@ const AttributeDictionary = ({ data, pageContext, location }) => {
             'page-title page-title'
             'page-description page-tools'
             'content page-tools';
-          grid-template-columns: minmax(0, 1fr) 205px;
+          grid-template-columns: minmax(0, 1fr) 12.8125rem;
           grid-column-gap: 2rem;
           @media (max-width: 1240px) {
             grid-template-areas:

--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -219,7 +219,7 @@ const InstallPage = ({ data, location }) => {
             'mt-disclaimer mt-disclaimer'
             'page-title page-title'
             'content page-tools';
-          grid-template-columns: minmax(0, 1fr) 205px;
+          grid-template-columns: minmax(0, 1fr) 12.8125rem;
           grid-column-gap: 2rem;
 
           @media screen and (max-width: 1240px) {

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -124,7 +124,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
             'mt-disclaimer mt-disclaimer'
             'page-title page-tools'
             'content page-tools';
-          grid-template-columns: minmax(0, 1fr) 205px;
+          grid-template-columns: minmax(0, 1fr) 12.8125rem;
           grid-column-gap: 2rem;
 
           ${bannerVisible &&


### PR DESCRIPTION
this improves readability when a user has a larger font size selected

my default font size is 20px so these have always been kinda squooshed

## screenshots

### docPage.js

#### before
![Screenshot 2023-06-23 at 11 31 50 AM](https://github.com/newrelic/docs-website/assets/14365008/e75be0c2-b67f-42a7-ade9-c0e38303e893)

#### after
![Screenshot 2023-06-23 at 11 31 23 AM](https://github.com/newrelic/docs-website/assets/14365008/2bf9dc1d-a4d0-4410-a536-8595c419f2a7)

### attribute-dictionary.js
#### before
![Screenshot 2023-06-23 at 11 32 01 AM](https://github.com/newrelic/docs-website/assets/14365008/b08eaf28-f108-4887-bdbc-ce8b3c75b6bc)

#### after
![Screenshot 2023-06-23 at 11 32 57 AM](https://github.com/newrelic/docs-website/assets/14365008/245c9bfe-42bb-4542-bfb6-fc5d34140fb3)

### {installConfig.agentName}.js

#### before
![Screenshot 2023-06-23 at 11 38 18 AM](https://github.com/newrelic/docs-website/assets/14365008/afe2ec89-dbfa-4151-9b38-240b171e1505)

#### after
![Screenshot 2023-06-23 at 11 38 39 AM](https://github.com/newrelic/docs-website/assets/14365008/cec03bf8-29c2-48fe-b748-db544af8d687)
