### PR TITLE
fix(workloads): some improvements

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -259,9 +259,9 @@ Whether you're considering New Relic or you're already using our capabilities, t
 
     Examples:
 
-    * APM reports a `Transaction` event. This includes timing data for the transaction in a `duration` attribute, which might have a value of `.002`.
-    * Our Infrastructure Monitoring reports a `ProcessSample` event. This includes a variety of CPU usage attributes, including a `cpuSystemPercent` attribute, which might have a value of `.01`.
-    * Our Telemetry SDK reports a `Metric` data type for storing metrics, with attached attributes like `metricName` and `newrelic.source`.
+      * APM reports a `Transaction` event. This includes timing data for the transaction in a `duration` attribute, which might have a value of `.002`.
+      * Our Infrastructure Monitoring reports a `ProcessSample` event. This includes a variety of CPU usage attributes, including a `cpuSystemPercent` attribute, which might have a value of `.01`.
+      * Our Telemetry SDK reports a `Metric` data type for storing metrics, with attached attributes like `metricName` and `newrelic.source`.
 
     Some New Relic tools allow you to report [custom attributes](/docs/apm/other-features/attributes/collecting-custom-attributes) to enhance your monitoring.
 

--- a/src/content/docs/new-relic-solutions/new-relic-one/workloads/create-workloads.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/workloads/create-workloads.mdx
@@ -22,7 +22,7 @@ These concepts will only be relevant if your [New Relic organization](/docs/acco
 
 The **workload account** is where data specific to that workload is stored. For example, a workload might generate [`NrAuditEvent` data](/docs/insights/insights-data-sources/default-data/nrauditevent-event-data-query-examples), and you'd find that data in the workload account. 
 
-This account determines the user permissions that govern which users can see and manage the workload, through the account roles. Once created, the workload account can't be changed.
+This account determines which users can see and manage the workload, based on what account permissions they've been assigned. Once created, the workload account can't be changed.
 
 ### Scope accounts [#scope-accounts]
 
@@ -34,17 +34,16 @@ Scope accounts can be updated at any point in time by any user with workload man
 
 There are a few ways to create a workload. 
 
+### Create a workload in the UI [#create]
+
 <img
   title="new-relic-create-workload.png"
   alt="New Relic - workload creation UI"
   src={workloadsCreateWorkload}
 />
-
 <figcaption>
   **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > Workloads > Create a workload:** When you [create a workload](#create), you choose the associated accounts and monitored entities.
 </figcaption>
-
-### Create a workload in the UI [#create]
 
 Here's how to create a workload from the workloads UI:
 
@@ -54,7 +53,7 @@ Here's how to create a workload from the workloads UI:
 4. Click [Choose the scope accounts](#scope-accounts) to check all of the accounts this workload will use data from.
 5. Find and choose the entities that make up the workload. When you have the results you're looking for, you can add specific entities or add the query to dynamically update the entities in the workload.
 
-   * You can search by entity type, [tags](#tags), or [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) (like entity name, account ID, and AWS region).
+   * You can search by entity type, [tags](#tags), or [attributes](/docs/new-relic-solutions/get-started/glossary#attribute) (like entity name, account ID, and AWS region).
    * Click **+ Add this query** to create a list of dynamically updated entities for your workload. We recommend this if you want your workload to update its entities as your system changes.
    * Click **+ Add** next to an entity to add it to your workload. This is a good choice if you know that the entities will stay useful even as your system changes.
 6. You can add both queries and specific entities to the workload, which work together according to the [query logic](#query-logic).
@@ -79,7 +78,7 @@ Below are some details and tips about some aspects of defining workloads:
     id="tags"
     title="Use tags to define the workload content"
   >
-    You can query and select workload entities using both [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) and [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute). Therefore, to optimize your use of workloads, it helps to have a good entity-tagging strategy. We recommend reading the [tagging documentation](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
+    You can query and select workload entities using both [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) and [attributes](/docs/new-relic-solutions/get-started/glossary#attribute). Therefore, to optimize your use of workloads, it helps to have a good entity-tagging strategy. We recommend reading the [tagging documentation](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/new-relic-solutions/new-relic-one/workloads/create-workloads.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/workloads/create-workloads.mdx
@@ -1,0 +1,109 @@
+---
+title: 'Create and define workloads'
+tags:
+  - New Relic 
+  - Use New Relic 
+  - Workloads
+metaDescription: 'In New Relic, create a workload, which helps you group together monitored entities that are related.'
+redirects:
+---
+
+import workloadsCreateWorkload from 'images/workloads_screenshot-full_create-workload.webp'
+
+The entities you'll add to a workload will depend on your organization structure and goals. For example workloads, see [Workloads](/docs/new-relic-solutions/new-relic-one/workloads/workloads-isolate-resolve-incidents-faster).
+
+## Accounts and permissions [#accounts]
+
+Before creating a workload, you should understand the difference between a  **workload account** and **scope accounts**.
+
+These concepts will only be relevant if your [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) has more than one account. For how to find an account's ID, see [Account ID](/docs/accounts/install-new-relic/account-setup/account-id).
+
+### The workload account [#workload-account]
+
+The **workload account** is where data specific to that workload is stored. For example, a workload might generate [`NrAuditEvent` data](/docs/insights/insights-data-sources/default-data/nrauditevent-event-data-query-examples), and you'd find that data in the workload account. 
+
+This account determines the user permissions that govern which users can see and manage the workload, through the account roles. Once created, the workload account can't be changed.
+
+### Scope accounts [#scope-accounts]
+
+The **scope accounts** are the accounts from which a workload fetches the telemetry data that makes up that workload. Users who don't have access to all of a workload's scope accounts may not be able to see all the data in a workload. For team members who'll be using a workload, you should ensure you add all of them to the relevant accounts that workload pulls data from. 
+
+Scope accounts can be updated at any point in time by any user with workload management capabilities on the workload account. By default, all accounts that the workload creator has access to at the moment of the workload creation are set as scope accounts.
+
+## Create a workload [#create]
+
+There are a few ways to create a workload. 
+
+<img
+  title="new-relic-create-workload.png"
+  alt="New Relic - workload creation UI"
+  src={workloadsCreateWorkload}
+/>
+
+<figcaption>
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > Workloads > Create a workload:** When you [create a workload](#create), you choose the associated accounts and monitored entities.
+</figcaption>
+
+### Create a workload in the UI [#create]
+
+Here's how to create a workload from the workloads UI:
+
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Workloads**, and then click **+ Create a workload**.
+2. Give the workload a name that will be meaningful for you and your team.
+3. From the **Select an account** dropdown, select the [workload account](#accounts) you'd like to use.
+4. Click [Choose the scope accounts](#scope-accounts) to check all of the accounts this workload will use data from.
+5. Find and choose the entities that make up the workload. When you have the results you're looking for, you can add specific entities or add the query to dynamically update the entities in the workload.
+
+   * You can search by entity type, [tags](#tags), or [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) (like entity name, account ID, and AWS region).
+   * Click **+ Add this query** to create a list of dynamically updated entities for your workload. We recommend this if you want your workload to update its entities as your system changes.
+   * Click **+ Add** next to an entity to add it to your workload. This is a good choice if you know that the entities will stay useful even as your system changes.
+6. You can add both queries and specific entities to the workload, which work together according to the [query logic](#query-logic).
+7. Click **Create a workload** to save it. 
+
+If your workload contains one or more dashboards, you can [set filters on those dashboard links](#filter-dashboards).
+
+### Create workload in errors inbox [#errors]
+
+To create a workload from errors inbox, see [Errors inbox](/docs/errors-inbox/getting-started/#global-workload).
+
+### Create workload via API [#api]
+
+To create a workload via our API, see the [NerdGraph workload tutorial](/docs/nerdgraph-workloads-tutorials). 
+
+## Tips on defining workloads [#details]
+
+Below are some details and tips about some aspects of defining workloads:
+
+<CollapserGroup>
+  <Collapser
+    id="tags"
+    title="Use tags to define the workload content"
+  >
+    You can query and select workload entities using both [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) and [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute). Therefore, to optimize your use of workloads, it helps to have a good entity-tagging strategy. We recommend reading the [tagging documentation](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
+  </Collapser>
+
+  <Collapser
+    id="query-logic"
+    title="How the dynamic query logic works"
+  >
+    You can add several individual entities and queries to define a workload.
+
+    * Queries can include multiple search terms. These are combined with an AND operator.
+    * Separate queries within a workload are combined with an OR operator.
+    * You can wrap strings between percent signs (`%`) to match exact substrings within a query. If you use substrings in entity names to categorize those entities (for example, `<team>-<env>-<appName>`), consider using [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) complementarily, which are more powerful for filtering and grouping (for example, `team:awesome`, `env:production`).
+    * We recommend not to use percent signs (`%`) in dynamic queries that might return over 500 entities. This way, you get a more consistent experience in the user interface.
+  </Collapser>
+
+  <Collapser
+    id="add-dashboards"
+    title="Add dashboards to workloads"
+  >
+If you have [custom dashboards](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards) and you already know which data is relevant to your team for observing and operating their workloads, you can link those <InlinePopover type="dashboards" /> from your workload.
+
+To add <InlinePopover type="dashboards" /> to a workload: After you've created a workload, go to the **Activity** page for a workload and click **Add dashboard**.
+  </Collapser>
+</CollapserGroup>
+
+## Use the workloads UI [#workloads-ui]
+
+Next, you can [learn how to use the workloads UI](/docs/new-relic-solutions/new-relic-one/workloads/use-workloads). 

--- a/src/content/docs/new-relic-solutions/new-relic-one/workloads/use-workloads.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/workloads/use-workloads.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use workloads
+title: The workloads UI
 tags:
   - New Relic
   - Use New Relic
@@ -17,13 +17,13 @@ import workloadsWorkloadsActivityTabLabeled from 'images/workloads_screenshot-fu
 
 import workloadsWorkloadsOwnerTab from 'images/workloads_screenshot-full_workloads-owner-tab.webp'
 
-import workloadsCreateWorkload from 'images/workloads_screenshot-full_create-workload.webp'
-
 import workloadsWorkloadsDashboardEntities from 'images/workloads_screenshot-full_workloads-dashboard-entities.webp'
 
 import workloadsWorkloadsOmnimap from 'images/workloads_screenshot-full_workloads-omnimap.webp'
 
-To view [workloads](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-workloads-isolate-resolve-incidents-faster), go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** and find them on the **Explorer**. There are three main tabs (Health, Activity, and Owner) plus the header.
+To view your workloads, go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** and click **Workloads**. 
+
+Here's an explanation of the tabs in the workloads UI. 
 
 ## Health [#health]
 
@@ -91,68 +91,6 @@ You can create workloads that update dynamically by leveraging tags. To learn ho
   id="nXCH_3XjGkQ"
   type="youtube"
 />
-
-## Create a workload [#create]
-
-A workload should contain the entities you and your team want to see. Your choice of entities depends on your organization structure and goals.
-
-<img
-  title="new-relic-create-workload.png"
-  alt="New Relic - workload creation UI"
-  src={workloadsCreateWorkload}
-/>
-
-<figcaption>
-  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > Workloads > Create a workload:** When you [create a workload](#create), you choose the associated accounts and monitored entities.
-</figcaption>
-
-You can use the UI or [the NerdGraph API](/docs/nerdgraph-workloads-tutorials) to create a workload. Follow these steps to create a workload using the UI:
-
-1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** and click on the **Explorer**, and then click **+ Create a workload**.
-2. Give the workload a name that will be meaningful for you and your team later.
-3. From the **Select an account** dropdown, select the [workload account](#accounts) you'd like to use.
-4. Click [Choose the scope accounts](#scope-accounts) to check all of the accounts related to this workload.
-5. Find and choose the entities that make up the workload. When you have the results you're looking for, you can add specific entities or add the query to dynamically update the entities in the workload.
-
-   * You can search by entity type, [tags](#tags), or [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) (like entity name, account ID, and AWS region).
-   * Click **+ Add this query** to create a list of dynamically updated entities for your workload. We recommend this if you want your workload to update its entities as your system changes.
-   * Click **+ Add** next to an entity to add it to your workload. This is a good choice if you know that the entities will stay useful even as your system changes.
-6. You can add a combination of queries and specific entities to the workload, which combine according to the [query logic](#query-logic).
-7. Click **Create a workload** to save the workload. Once you've created the workload, you can edit it at any time
-
-If your workload contains one or more dashboards, you can [set filters on those dashboard links](#filter-dashboards).
-
-Below are more details about some aspects of how to define workloads:
-
-<CollapserGroup>
-  <Collapser
-    id="tags"
-    title="Use tags to define the workload content"
-  >
-    You can query and select workload entities using both [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) and [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute). Therefore, to optimize your use of workloads, it helps to have a good entity-tagging strategy. We recommend reading the [tagging documentation](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor).
-  </Collapser>
-
-  <Collapser
-    id="query-logic"
-    title="How the dynamic query logic works"
-  >
-    You can add several individual entities and queries to define a workload.
-
-    * Queries can include multiple search terms. These are combined with an AND operator.
-    * Separate queries within a workload are combined with an OR operator.
-    * You can wrap strings between percent signs (`%`) to match exact substrings within a query. If you use substrings in entity names to categorize those entities (for example, `<team>-<env>-<appName>`), consider using [tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) complementarily, which are more powerful for filtering and grouping (for example, `team:awesome`, `env:production`).
-    * We recommend not to use percent signs (`%`) in dynamic queries that might return over 500 entities. This way, you get a more consistent experience in the user interface.
-  </Collapser>
-
-  <Collapser
-    id="add-dashboards"
-    title="Add dashboards to workloads"
-  >
-If you have [custom dashboards](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards) and you already know which data is relevant to your team for observing and operating their workloads, you can link those <InlinePopover type="dashboards" /> from your workload.
-
-To add <InlinePopover type="dashboards" /> to a workload: After you've created a workload, go to the **Activity** page for a workload and click **Add dashboard**.
-  </Collapser>
-</CollapserGroup>
 
 ## View workloads maps [#maps]
 

--- a/src/content/docs/new-relic-solutions/new-relic-one/workloads/workload-status-views-notifications.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/workloads/workload-status-views-notifications.mdx
@@ -16,7 +16,7 @@ redirects:
 
 import solutionsWorkloadViews from 'images/solutions_screenshot-crop_workload-views.webp'
 
-The workload status, which is derived from the alerting status of the entities in your [workload](/docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-workloads-isolate-resolve-incidents-faster), informs you about how your workload is behaving.
+The workload **Health status** view, which is derived from the alerting status of the entities in your workload, informs you about how your workload is behaving.
 
 ## Why it matters [#why-matters]
 
@@ -24,13 +24,13 @@ Workload status:
 
 * Is a quick indicator of how your system is doing, and tells you if you need to take action on any of your workloads in just a glance.
 * Adapts to your needs and to how important each entity is.
-* Allows you to share the status of your workloads. Other teams that depend on your services or infrastructure can learn the status of the workload without them needing to understand your system’s architecture details, or look at custom dashboards.
+* Allows you to share the status of your workloads. Other teams that depend on your services or infrastructure can learn the status of the workload without them needing to understand your system's architecture details, or look at custom dashboards.
 
 ## Get started with workload status [#get-started]
 
 [Our platform](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one) provides a status value for all entities, which is based on the results of [New Relic alerts](/docs/alerts). You can check the [color-coded alert status](/docs/alerts/new-relic-alerts/configuring-alert-policies/identify-entities-without-alert-policies#colors) for each entity on the [New Relic Explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts), or consume the alert status value through the API. For example, you may see a red alert status indicating that a critical violation is in progress.
 
-With Workloads you can **group entities that are part of a complex system and obtain a single, global value that summarizes** the status of all the entities in your workload. Thus, you can quickly detect when the workload stops being operational, or anticipate any potential incident or loss of quality of service.
+With workloads you can group entities that are part of a complex system and obtain a single, global value that summarizes the status of all the entities in your workload. Thus, you can quickly detect when the workload stops being operational, or anticipate any potential incident or loss of quality of service.
 
 ### Obtain your workload status [#obtain-status]
 
@@ -38,7 +38,7 @@ A workload can have one of the following status values:
 
 * **Operational**: The workload is working fine.
 * **Degraded**: The workload is showing some degradation in performance or errors, but it’s still providing an acceptable level of service, and you don’t need to take any urgent action.
-* **Critical or Disrupted**: The workload is not providing an acceptable level of service, and you need to take urgent action.
+* **Critical** or **Disrupted**: The workload is not providing an acceptable level of service, and you need to take urgent action.
 * **Unknown**: You haven’t configured how to calculate workload status, or there aren’t any alert conditions set up that can determine the status of the workload entities.
 
 To learn how to define or edit the workload status, refer to [Workload status configuration](/docs/workload-status-configuration).

--- a/src/content/docs/new-relic-solutions/new-relic-one/workloads/workloads-isolate-resolve-incidents-faster.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/workloads/workloads-isolate-resolve-incidents-faster.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Workloads: Isolate and resolve incidents faster'
+title: 'Workloads: Group related entities'
 tags:
   - New Relic 
   - Use New Relic 
   - Workloads
-metaDescription: 'Use workloads in New Relic to group together entities that make up a specific business service, making it easier to isolate and troubleshoot issues.'
+metaDescription: 'Use workloads in New Relic to group together related entities that make up a business unit or team unit, making it easier to isolate and troubleshoot issues.'
 redirects:
   - /docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-workloads-create-groupings-entities
   - /docs/new-relic-one/use-new-relic-one/core-concepts/new-relic-one-workloads-observe-your-full-stack
@@ -19,13 +19,21 @@ redirects:
 
 import solutionsWorkloadHealthTab from 'images/solutions_screenshot-crop_workload-health-tab.webp'
 
-Our workloads feature gives you the ability to group and monitor entities based on a team or a set of responsibilities, providing aggregated health and activity data from frontend to backend services across your entire stack. Workloads help you [understand the status of complex systems](/docs/workloads/use-workloads/workloads/use-workloads), [detect issues](/docs/workloads/use-workloads/workloads/workload-status), understand the cause and impact of an incident, and resolve those issues quickly. Want to try it? [Create a New Relic account](https://newrelic.com/signup) for free, forever!
+Our workloads feature gives you the ability to group and monitor entities in whatever way you want. This gives you the power to organize your telemetry data in ways that make the most sense for your business.
 
-## What is a workload in New Relic? [#definition]
+Want to try New Relic workloads? [Create a New Relic account](https://newrelic.com/signup) for free, forever!
+
+## What is a workload? [#definition]
 
 New Relic monitors a wide range of entities and data, from client-side applications and backend APIs, to the underlying infrastructure. To make sense of this large data set, we give you the ability to create and monitor workloads.
 
-Workloads give you the ability to group and monitor entities based on a team or a set of responsibilities, and provide an aggregated view of the health and activity of the entities in the workload. Thus, you can understand better how your business logic is working, from frontend to backend services, across your entire stack.
+Our **workloads** feature lets you group and monitor entities in whatever way makes sense to you. For example, you could create a workload for a specific business unit or team. Our workloads UI provides an aggregated view of the health and activity of the entities in that workload. Thus, you can better understand how your business logic is working, from frontend to backend services, across your entire stack.
+
+A workload can include:
+
+* Any New Relic-monitored entity, including applications, browser apps, mobile apps, databases, and hosts.
+* [Dashboards](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards).
+* Other workloads: this is useful for complex teams who need to divide and overlap workloads.
 
 Here are some workload examples:
 
@@ -33,7 +41,7 @@ Here are some workload examples:
 * A browser application and the backend APIs that support it.
 * A collection of Java microservices and the infrastructure they run on.
 
-Here's a workload:
+Here's an example of a workload in our workloads UI:
 
 <img
   title="workload_health_tab.png"
@@ -44,42 +52,3 @@ Here's a workload:
 <figcaption>
   **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > Workloads > (selected workload):** The workloads UI provides a curated view of how the entities in your workload are performing. The charts you see will depend on the types of entities you've included to the workload.
 </figcaption>
-
-<Callout variant="tip">
-  Learn [how to use workloads](/docs/workloads/use-workloads/workloads/use-workloads).
-</Callout>
-
-## Why it matters [#why-matters]
-
-Workloads give you visibility into the end-to-end availability and consumption of resources across an entire service, and provide you a way to define what’s relevant to you. You can use workloads to group together entities that are important to a specific team or project, so you can better browse and isolate the most relevant data for that service.
-
-Because our UI gives you [cross-account access](/docs/new-relic-one/use-new-relic-one/core-concepts/cross-account-features-security-new-relic-one), you can add entities to your workload from any of the accounts you have access to.
-
-A workload can include:
-
-* Any New Relic-monitored entity, including services, browser apps, mobile apps, databases, and hosts.
-* [Dashboards](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards).
-* Other workloads: this is useful for complex teams who need to divide and overlap workloads.
-
-## Impact of accounts on the workload permissions and content [#accounts]
-
-Workloads can group and display entities from multiple accounts to provide complete observability of complex systems. When [creating a workload](/docs/new-relic-one/use-new-relic-one/workloads/use-workloads/#create), you must set:
-
-* The [workload account](#workload-account)
-* [Scope accounts](#scope-accounts)
-
-[Learn how to find a New Relic account ID](/docs/accounts/install-new-relic/account-setup/account-id).
-
-### Workload account
-
-The workload account is where any workload-specific data is stored. For example, a workload might generate [`NrAuditEvent` data](/docs/insights/insights-data-sources/default-data/nrauditevent-event-data-query-examples), and you would find that data by querying the workload account.
-
-The workload account determines the user permissions that govern which users can see and manage the workload, through the account roles.
-
-Once created, the workload account can’t be changed.
-
-### Scope accounts
-
-Scope accounts are the accounts from which a workload fetches entity data. In other words, the scope accounts provide the content for a workload. Users who don’t have access to all of a workload's scope accounts may not be able to see complete workload data.
-
-Scope accounts can be updated at any point in time by any user with workload management capabilities on the workload account. By default, all accounts that the workload creator has access to at the moment of the workload creation are set as scope accounts.

--- a/src/content/docs/service-level-management/alerts-slm.mdx
+++ b/src/content/docs/service-level-management/alerts-slm.mdx
@@ -24,9 +24,9 @@ One of the promised outcomes of implementing service levels is that you'll be ab
 
 When you set service level objectives, you can configure alerts that will inform you in case of exhaustion of your error budget before the end of the compliance period. These alerts will show you when high business impact incidents occur. When triggered, they should be given priority, and you should engage the relevant teams to start diagnosing the source of the problem.
 
-## Understand the Service Levels default alert policy [#alert-policy]
+## Understand the service levels default alert policy [#alert-policy]
 
-The Service Levels default alert policy was introduced, at account level, so that the service levels health status is based on its remaining error budget. This improves your experience when using other New Relic products such as the Navigator, Workloads and others.
+The service levels default alert policy was introduced, at account level, so that the service levels health status is based on its remaining error budget. This improves your experience when using other New Relic products, such as New Relic Navigator and workloads.
 
 <img
   title="SLM Alert policy"

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -47,19 +47,19 @@ pages:
             path: /docs/new-relic-solutions/new-relic-one/ui-data/explore-downstream-dependencies-new-relic-one
           - title: Automaps
             path: /docs/new-relic-solutions/new-relic-one/ui-data/automaps
-      - title: Organize your data
+      - title: Tag your data
+        path: /docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data
+      - title: Workloads
         pages:
-          - title: Tag your data
-            path: /docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data
           - title: 'Workloads: Group related entities'
             path: /docs/new-relic-solutions/new-relic-one/workloads/workloads-isolate-resolve-incidents-faster
           - title: Create workloads
             path: /docs/new-relic-solutions/new-relic-one/workloads/create-workloads
-          - title: Workloads UI
+          - title: The workloads UI
             path: /docs/new-relic-solutions/new-relic-one/workloads/use-workloads
-          - title: Workload status configuration
+          - title: Status configuration
             path: /docs/new-relic-solutions/new-relic-one/workloads/workload-status-configuration
-          - title: Workload status views and notifications
+          - title: Status views and notifications
             path: /docs/new-relic-solutions/new-relic-one/workloads/workload-status-views-notifications
       - title: Technical platform details
         pages:

--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -51,9 +51,11 @@ pages:
         pages:
           - title: Tag your data
             path: /docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data
-          - title: 'Workloads: group related entities'
+          - title: 'Workloads: Group related entities'
             path: /docs/new-relic-solutions/new-relic-one/workloads/workloads-isolate-resolve-incidents-faster
-          - title: Use workloads
+          - title: Create workloads
+            path: /docs/new-relic-solutions/new-relic-one/workloads/create-workloads
+          - title: Workloads UI
             path: /docs/new-relic-solutions/new-relic-one/workloads/use-workloads
           - title: Workload status configuration
             path: /docs/new-relic-solutions/new-relic-one/workloads/workload-status-configuration


### PR DESCRIPTION
Work done: 

Related to NR-126848, which was about adding mention of errors inbox aspect of workloads, but also while I was in there, decided to: 

* Improve some confusing wordings about workloads and simplify it
* Move 'create workloads' content into its own doc, and separate it from 'workloads UI'

Also will be creating jira because I noticed the docs are quite out of date with new workloads UI