### PR TITLE
Publish 06/29: feat: update nodejs lambda docs to include NEW_RELIC_USE_ESM

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -404,9 +404,9 @@ On this page, you will learn how to manually instrument your lambda function. It
        * Set `NEW_RELIC_LOG` to `stdout` for output to CloudWatch, or set to any writeable file location.
        * `NEW_RELIC_LOG_LEVEL` is set to `info` by default, and it's only used when sending function logs in your Lamba. See [other log levels](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config).
 
-    9. Optional: If your Lambda function is using ES Modules, set the environment variable `NEW_RELIC_USE_ESM` to `true`. Note that if using ES Modules, you must use async/await or promises for your function, callback based functions are not supported.
+    9. Optional: If your Lambda function is using ES Modules, set the environment variable `NEW_RELIC_USE_ESM` to `true`. Note that if using ES Modules, you must use async/await or promises for your function. Callback-based functions are not supported.
 
-    9. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
+    10. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
         Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy.mdx
@@ -404,6 +404,8 @@ On this page, you will learn how to manually instrument your lambda function. It
        * Set `NEW_RELIC_LOG` to `stdout` for output to CloudWatch, or set to any writeable file location.
        * `NEW_RELIC_LOG_LEVEL` is set to `info` by default, and it's only used when sending function logs in your Lamba. See [other log levels](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#logging_config).
 
+    9. Optional: If your Lambda function is using ES Modules, set the environment variable `NEW_RELIC_USE_ESM` to `true`. Note that if using ES Modules, you must use async/await or promises for your function, callback based functions are not supported.
+
     9. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
         Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -30,6 +30,7 @@ Besides these basic enablement problems, there are some additional problems that
 
   * If you're instrumenting with layers: make sure in your function configuration that the New Relic layer is merged before other layers (though if your function uses webpack, the New Relic layer should be merged after the webpack layer).
   * If you're instrumenting a Node.js function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports **newrelic** before it imports any dependencies you expect to monitor.
+  * If you're using ES Modules with a Node.js function, make sure that the environment variable `NEW_RELIC_USE_ESM` is set to `true`. Additionally, make sure you're using async/await or promises for handling asynchronous behavior in your function, as callback based functions are not supported when using ES Modules.
 
 If none of these solutions help you, contact our [support team](https://support.newrelic.com/). The following information will help you when you talk to support technicians:
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -30,7 +30,7 @@ Besides these basic enablement problems, there are some additional problems that
 
   * If you're instrumenting with layers: make sure in your function configuration that the New Relic layer is merged before other layers (though if your function uses webpack, the New Relic layer should be merged after the webpack layer).
   * If you're instrumenting a Node.js function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports **newrelic** before it imports any dependencies you expect to monitor.
-  * If you're using ES Modules with a Node.js function, make sure that the environment variable `NEW_RELIC_USE_ESM` is set to `true`. Additionally, make sure you're using async/await or promises for handling asynchronous behavior in your function, as callback based functions are not supported when using ES Modules.
+  * If you're using ES Modules with a Node.js function, make sure that the environment variable `NEW_RELIC_USE_ESM` is set to `true`. Additionally, make sure you're using async/await or promises for handling asynchronous behavior in your function, as callback-based functions are not supported when using ES Modules.
 
 If none of these solutions help you, contact our [support team](https://support.newrelic.com/). The following information will help you when you talk to support technicians:
 


### PR DESCRIPTION
DO NOT MERGE without coordinating with @jmartin4563, dependent on release of https://github.com/newrelic/newrelic-lambda-layers/pull/156

* What problems does this PR solve?
Documents the newly added NEW_RELIC_USE_ESM environment variable. This variable is used by the Node.js Lambda Layer to determine whether or not to use `require` vs `import` when wrapping a customer's function to capture instrumentation. When set to `true`, the wrapper will use `import` and will be asynchronous, and when absent or `false`, will use `require` and by synchronous.
* If your issue relates to an existing GitHub issue, please link to it.
  * https://github.com/newrelic/newrelic-lambda-layers/pull/156