### PR TITLE
Correct typo in if() function example

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2689,7 +2689,7 @@ Note: `aparse()` is case-insensitive.
         ```sql
         FROM Log
           SELECT count(*)
-          FACET if(level_name = 'INFO’ OR level_name = ‘WARNING’, 'NOT_ERROR', 'ERROR’)
+          FACET if(level_name = 'INFO' OR level_name = 'WARNING', 'NOT_ERROR', 'ERROR')
         ```
       </Collapser>
       <Collapser title={<>Nested <InlineCode>If()</InlineCode></>}>


### PR DESCRIPTION
Fixes a typo in the if() statement nrql example: [Use with AND and OR](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#func-if).

Replace non-standard apostrophes: ’ with '.  This allows the query to run without error.