### PR TITLE
.NET Agent documentation updates for release version 10.12.0

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -502,7 +502,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.19.2
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * IMongoCollection.CountDocuments[Async]
@@ -554,7 +554,7 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
           <td>
 Minimum supported version: 1.0.488
 
-Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.111
+Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116
 		  </td>
         </tr>
 
@@ -745,7 +745,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             2.0.0
           </td>
           <td>
-            2.8.0, 2.10.0, 2.11.0, 2.12.0
+            2.8.0, 2.10.0, 2.11.0, 3.0.1
           </td>
         </tr>
         <tr>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -504,7 +504,14 @@ Minimum supported version: 2.3.0
 
 Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.19.2
 
-Known incompatible versions: New methods added in 2.7 and above are not currently instrumented. 
+Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
+* IMongoCollection.CountDocuments[Async]
+* IMongoCollection.EstimatedDocumentCount[Async]
+* IMongoCollection.AggregateToCollection[Async]
+* IMongoDatabase.ListCollectionNames[Async]
+* IMongoDatabase.Aggregate[Async]
+* IMongoDatabase.AggregateToCollection[Async]
+* IMongoDatabase.Watch[Async]
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -532,7 +532,7 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
 
 **MySql.Data**
 * Minimum supported version: 6.10.7
-* Verified compatible versions: 6.10.7, 8.0.15, 8.0.30, 8.0.31
+* Verified compatible versions: 6.10.7, 8.0.15, 8.0.30, 8.0.33
 
 **MySqlConnector**
 * Minimum supported version: 1.0.1

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -590,7 +590,7 @@ Known incompatible versions: Instance details aren't available in lower version 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.19.2
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * IMongoCollection.CountDocuments[Async]
@@ -694,7 +694,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           </td>
           <td>
             * Minimum supported version: 1.0.488
-            * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.111
+            * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116
           </td>
         </tr>
 
@@ -864,7 +864,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             1.0.0
           </td>
           <td>
-            1.5.14, 2.5.0, 2.10.0, 2.12.0
+            1.5.14, 2.5.0, 2.10.0, 3.0.1
           </td>
         </tr>
         <tr>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -592,7 +592,14 @@ Minimum supported version: 2.3.0
 
 Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.19.2
 
-Known incompatible versions: New methods added in 2.7 or higher aren't currently instrumented. 
+Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
+* IMongoCollection.CountDocuments[Async]
+* IMongoCollection.EstimatedDocumentCount[Async]
+* IMongoCollection.AggregateToCollection[Async]
+* IMongoDatabase.ListCollectionNames[Async]
+* IMongoDatabase.Aggregate[Async]
+* IMongoDatabase.AggregateToCollection[Async]
+* IMongoDatabase.Watch[Async]
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -620,7 +620,7 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
 
 **MySql.Data**
 * Minimum supported version: 6.10.7
-* Verified compatible versions: 6.10.7, 8.0.15, 8.0.30, 8.0.32
+* Verified compatible versions: 6.10.7, 8.0.15, 8.0.30, 8.0.33
 
 **MySqlConnector**
 * Minimum supported version: 1.0.1


### PR DESCRIPTION
This PR contains several updates to verified compatible versions of .NET libraries instrumented by the .NET agent.  One of the updates is specific to agent version 10.12.0, which is being released today (Monday, 6/26/23).