### PR TITLE
Updating incident_id expectations

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
@@ -41,10 +41,8 @@ Notifications will not substantially change during the migration. They will cont
 ### incident_id
 The `incident_id` on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id. The classic incident id is deprecated. Consumers should start using the `issue_id` instead.  
 
-The `incident_id` was present on every notification sent by the classic notification system. On workflows, it will only be available on accounts using the [Decisions](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/change-applied-intelligence-correlation-logic-decisions/) [grace period](https://docs.newrelic.com/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/user-settings/#grace-period).
-
 `Incident_id` changes:
-* To avoid generating invalid json on custom webhooks, a value of -1 will be used when the classic incident id is not available.
+* A unique `incident_id` will still be generated for every issue.  The value will be different than that used in the deprecated Incident API.
 * To limit the impact to VictorOps, OpsGenie and xMatters notifications, the incident_id will be populated by the issue id. That will cause the New Relic steps to acknowledge or close an incident in xMatters to no longer work.
 
 ## Configuring custom payloads [#configure-custom-payloads]

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/migration-to-workflows.mdx
@@ -42,7 +42,7 @@ Notifications will not substantially change during the migration. They will cont
 The `incident_id` on PagerDuty, Webhook, VictorOps, OpsGenie and xMatters notifications refers to the classic incident id. The classic incident id is deprecated. Consumers should start using the `issue_id` instead.  
 
 `Incident_id` changes:
-* A unique `incident_id` will still be generated for every issue.  The value will be different than that used in the deprecated Incident API.
+* A unique `incident_id` will still be generated for every issue.  The value will be different than those used in the deprecated Incident API.
 * To limit the impact to VictorOps, OpsGenie and xMatters notifications, the incident_id will be populated by the issue id. That will cause the New Relic steps to acknowledge or close an incident in xMatters to no longer work.
 
 ## Configuring custom payloads [#configure-custom-payloads]


### PR DESCRIPTION
The incident_id is now being generated differently, to ensure it's on all notifications.