### PR TITLE
fix(alerting): new limit, structure

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy.mdx
@@ -36,9 +36,6 @@ A [policy](/docs/alerts-applied-intelligence/applied-intelligence/incident-intel
 
 For an explanation of how policies interact with conditions and other components, see [concepts](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts/) and [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/).
 
-<Callout variant="tip">
-  The [basic setup process](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition/) is the same, regardless of which product (APM, browser, etc.) uses the policy. The types of metrics and thresholds for conditions vary depending on the monitored data source.
-</Callout>
 
 ## Best practices for naming policies [#best-practices-policies]
 
@@ -106,7 +103,9 @@ We recommend three common patterns and practices for structuring and naming poli
 
 ## Create an alert policy [#alert-policy-name]
 
-As part of the policy workflow, start by giving the policy a meaningful name:
+Alert policies only apply to one account. If your New Relic organization has multiple accounts, you must create alert policies for each account. 
+
+To create a policy: 
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies).**
 2. On the policy index page, click <Icon name="fe-plus-circle"/>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -54,7 +54,7 @@ This document contains some technical rules and limits for New Relic alerting fu
       </td>
 
       <td>
-        300K
+        300M
       </td>
     </tr>
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -19,7 +19,7 @@ This document contains some technical rules and limits for New Relic alerting fu
 <table>
   <thead>
     <tr>
-      <th width={250}>
+      <th width={275}>
         **Limited condition**
       </th>
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -354,7 +354,7 @@ Limits and rules pertaining to New Relic alerts and applied intelligence:
 
 ## NRDB alert query matched data points per minute [#query-limit]
 
-The alert condition 'Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+The alert condition `Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
 
 If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -97,20 +97,6 @@ This document contains some technical rules and limits for New Relic alerting fu
     </tr>
 
     <tr>
-      <td>
-        [Products per policy](/docs/alerts/new-relic-alerts-beta/getting-started/new-relic-alerts)
-      </td>
-
-      <td>
-        any New Relic product (APM, mobile monitoring, synthetic monitoring, etc.)
-      </td>
-
-      <td>
-        any New Relic product
-      </td>
-    </tr>
-
-    <tr>
       <td id="condition">
         **Alert conditions:**
       </td>
@@ -247,7 +233,7 @@ This document contains some technical rules and limits for New Relic alerting fu
 
     <tr>
       <td>
-        Incidents per Issue
+        Incidents per issue
       </td>
 
       <td>
@@ -263,7 +249,7 @@ This document contains some technical rules and limits for New Relic alerting fu
 
     <tr>
       <td>
-        Incident Search API - Page Size
+        Incident search API: page size
       </td>
 
       <td>
@@ -274,7 +260,7 @@ This document contains some technical rules and limits for New Relic alerting fu
         1000 pages (25K incidents)
 
         <Callout variant="tip">
-          Only use the `only-open` parameter to retrieve all open incidents. If you have more than 25K open incidents and need to retrieve them via the REST API, please contact New Relic Support.
+          Only use the `only-open` parameter to retrieve all open incidents. If you have more than 25K open incidents and need to retrieve them via the REST API, contact support.
         </Callout>
       </td>
     </tr>
@@ -379,9 +365,9 @@ This document contains some technical rules and limits for New Relic alerting fu
 
 ## Matched data points limit [#query-limit]
 
-The `Matched data points per minute` limit is on the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) detected for a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+The `Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
 
-If this limit is exceeded, the account won't be able to register new alerts or update existing alerts, until the account goes below that limit. Existing registrations are **not** affected.
+If this limit is exceeded, that account won't be able to detect new incidents or update existing incidents, until the account goes below that limit. Incidents already reported are **not** affected.
 
 You can see your matched data points and any limit violations in the [limits UI](/docs/data-apis/manage-data/view-system-limits). 
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Rules and limits for alerts
+title: Alerting rules and limits
 tags:
   - Alerts and applied intelligence
   - Alerts
@@ -16,15 +16,11 @@ redirects:
 
 This document contains some technical rules and limits for New Relic alerting functionality.
 
-Note that if your New Relic organization has multiple accounts, **an account does not inherit the alert policies of other accounts.** You must create alert policies separately for each account.
-
-The following rules apply both to the New Relic user interface and to the REST API (v2).
-
 <table>
   <thead>
     <tr>
       <th width={250}>
-        **Alerts**
+        **Limited condition**
       </th>
 
       <th>
@@ -38,6 +34,30 @@ The following rules apply both to the New Relic user interface and to the REST A
   </thead>
 
   <tbody>
+    <tr>
+      <td id="policy">
+        **Queries**
+      </td>
+
+      <td/>
+
+      <td/>
+    </tr>
+
+    <tr>
+      <td>
+        Matched data points per minute for alert queries ([learn more](#query-limit))
+      </td>
+
+      <td>
+        N/A
+      </td>
+
+      <td>
+        250K
+      </td>
+    </tr>
+
     <tr>
       <td id="policy">
         **Alert policies:**
@@ -260,6 +280,46 @@ The following rules apply both to the New Relic user interface and to the REST A
     </tr>
 
     <tr>
+      <td id="workflows">
+        **Workflows:**
+      </td>
+
+      <td/>
+
+      <td/>
+    </tr>
+
+    <tr>
+      <td>
+        [Workflows per account](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows)
+      </td>
+
+      <td>
+        n/a
+      </td>
+
+      <td>
+        Initial limit 1000 
+      </td>
+    </tr>
+    
+
+    <tr>
+      <td>
+        Workflow filter size
+      </td>
+
+      <td>
+        1 character
+      </td>
+
+      <td>
+        4096 characters per workflow
+      </td>
+    </tr>
+
+
+    <tr>
       <td id="channel">
         **Notification channels (Legacy):**
       </td>
@@ -312,45 +372,31 @@ The following rules apply both to the New Relic user interface and to the REST A
         [Depends on channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#channel-types)
       </td>
     </tr>
-
-    <tr>
-      <td id="workflows">
-        **Workflows:**
-      </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
-      <td>
-        [Workflows per account](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/add-or-remove-policy-channels)
-      </td>
-
-      <td>
-        n/a
-      </td>
-
-      <td>
-        Initial limit 1000 
-      </td>
-    </tr>
-    
-
-    <tr>
-      <td>
-        Workflow filter size
-      </td>
-
-      <td>
-        1 character
-      </td>
-
-      <td>
-        4096 characters per workflow
-      </td>
-    </tr>
     
   </tbody>
 </table>
+
+
+## Matched data points limit [#query-limit]
+
+The `Matched data points per minute` limit is on the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) detected for a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+
+If this limit is exceeded, the account won't be able to register new alerts or update existing alerts, until the account goes below that limit. Existing registrations are **not** affected.
+
+You can see your matched data points and any limit violations in the [limits UI](/docs/data-apis/manage-data/view-system-limits). 
+
+To understand what conditions are leading to the most throughput, you can perform a query like: 
+
+```sql
+FROM NrAiSignal 
+SELECT sum(aggregatedDataPointsCount) AS 'alert matched events' 
+FACET conditionId
+```
+
+Some tips on optimizing your matched data points: 
+
+* [Sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) have a multiplicative impact. Consider removing or increasing the sliding window number. 
+* Use `WHERE` clauses to scope down the amount of data being alerted on. Using `WHERE` instead of `FACET` can produce more efficient alerts in some cases.
+* Combine similar alerts. If you have several alert conditions that are similar, consider grouping them together with combined filters. 
+
+To request a limit increase, talk to your New Relic account representative. 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -367,7 +367,7 @@ This document contains some technical rules and limits for New Relic alerting fu
 
 The `Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
 
-If this limit is exceeded, that account won't be able to detect new incidents or update existing incidents, until the account goes below that limit. Incidents already reported are **not** affected.
+If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
 
 You can see your matched data points and any limit violations in the [limits UI](/docs/data-apis/manage-data/view-system-limits). 
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -14,7 +14,7 @@ redirects:
   - /docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-alerts/
 ---
 
-This document contains some technical rules and limits for New Relic alerting functionality.
+Limits and rules pertaining to New Relic alerts and applied intelligence:
 
 <table>
   <thead>
@@ -375,7 +375,7 @@ To understand what conditions are leading to the most throughput, you can perfor
 
 ```sql
 FROM NrAiSignal 
-SELECT sum(aggregatedDataPointsCount) AS 'alert matched events' 
+SELECT sum(aggregatedDataPointsCount) AS 'alert matched data points' 
 FACET conditionId
 ```
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -381,7 +381,7 @@ FACET conditionId
 
 Some tips on optimizing your matched data points: 
 
-* [Sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) have a multiplicative impact. Consider removing or increasing the sliding window number. 
+* [Sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) have a multiplicative impact. Consider removing or increasing the [sliding window number](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#sliding-window-aggregation). 
 * Use `WHERE` clauses to scope down the amount of data being alerted on. Using `WHERE` instead of `FACET` can produce more efficient alerts in some cases.
 * Combine similar alerts. If you have several alert conditions that are similar, consider grouping them together with combined filters. 
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -54,7 +54,7 @@ This document contains some technical rules and limits for New Relic alerting fu
       </td>
 
       <td>
-        250K
+        300K
       </td>
     </tr>
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -381,7 +381,7 @@ FACET conditionId
 
 Some tips on optimizing your matched data points: 
 
-* [Sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) have a multiplicative impact. Consider removing or increasing the [sliding window number](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#sliding-window-aggregation). 
+* Note that using [sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) can increase the number of data points. Consider removing sliding windows or decreasing its value. 
 * Use `WHERE` clauses to scope down the amount of data being alerted on. Using `WHERE` instead of `FACET` can produce more efficient alerts in some cases.
 * Combine similar alerts. If you have several alert conditions that are similar, consider grouping them together with combined filters. 
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -363,9 +363,9 @@ This document contains some technical rules and limits for New Relic alerting fu
 </table>
 
 
-## Matched data points limit [#query-limit]
+## NRDB alert query matched data points per minute [#query-limit]
 
-The `Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+The `NRDB alert query matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
 
 If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -381,8 +381,10 @@ FACET conditionId
 
 Some tips on optimizing your matched data points: 
 
-* Note that using [sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) can increase the number of data points. Consider removing sliding windows or decreasing its value. 
+* If you're using [sliding windows](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#sliding-window-aggregation), note that this can significantly increase the number of data points. To lower the number of data points, you can use a longer aggregation duration. 
 * Use `WHERE` clauses to scope down the amount of data being alerted on. Using `WHERE` instead of `FACET` can produce more efficient alerts in some cases.
 * Combine similar alerts. If you have several alert conditions that are similar, consider grouping them together with combined filters. 
 
 To request a limit increase, talk to your New Relic account representative. 
+
+Note that using [sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) can significantly increase the number of data points. Consider using a longer duration of Sliding window aggregation to reduce the number of data points produced.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts.mdx
@@ -34,29 +34,6 @@ Limits and rules pertaining to New Relic alerts and applied intelligence:
   </thead>
 
   <tbody>
-    <tr>
-      <td id="policy">
-        **Queries**
-      </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
-      <td>
-        Matched data points per minute for alert queries ([learn more](#query-limit))
-      </td>
-
-      <td>
-        N/A
-      </td>
-
-      <td>
-        300M
-      </td>
-    </tr>
 
     <tr>
       <td id="policy">
@@ -105,7 +82,19 @@ Limits and rules pertaining to New Relic alerts and applied intelligence:
 
       <td/>
     </tr>
+    <tr>
+      <td>
+        Matched data points per minute, per account ([learn more](#query-limit))
+      </td>
 
+      <td>
+        N/A
+      </td>
+
+      <td>
+        300M
+      </td>
+    </tr>
     <tr>
       <td>
         [Condition name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions)
@@ -365,7 +354,7 @@ Limits and rules pertaining to New Relic alerts and applied intelligence:
 
 ## NRDB alert query matched data points per minute [#query-limit]
 
-The `NRDB alert query matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
+The alert condition 'Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure). 
 
 If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
 

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -296,6 +296,16 @@ This table includes general max limits that apply across all New Relic accounts.
        See [NRQL query limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries) 
       </td>
     </tr>
+
+    <tr>
+      <td>
+        Alert query limits
+      </td>
+
+      <td>
+       See [Alerting rules and limits](/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts#query-limit)
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/alert-quality-management-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/alert-quality-management-guide.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/new-relic-solutions/observability-maturity/aqm-implementation-guide
   - /docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/aqm-implementation-guide
 ---
-This guide walks you through improving and optimizing the quality of your alerting. It's part of our [series on observability maturity](/docs/new-relic-solutions/observability-maturity/introduction). It has been updated to reflect the changed alerting architecture and to use the stock `NrAiIncident` and `NrAiIssue` event types.
+This guide walks you through improving and optimizing the quality of your alerting. It's part of our [series on observability maturity](/docs/new-relic-solutions/observability-maturity/introduction). 
 
 ## Overview [#overview]
 
@@ -20,6 +20,7 @@ Teams suffer from alert fatigue when they experience high alert volumes and aler
 **Alert quality management** (AQM) focuses on reducing the number of nuisance incidents so that you focus only on alerts with true business impact. This reduces alert fatigue and ensures that you and your team focus your attention on the right places at the right times.
 
 You're a good candidate for AQM if:
+
 * You have too many alerts.
 * You have alerts that stay open for long time periods.
 * Your alerts are not relevant.

--- a/src/nav/alerts-applied-intelligence.yml
+++ b/src/nav/alerts-applied-intelligence.yml
@@ -81,8 +81,6 @@ pages:
         path: /docs/alerts-applied-intelligence/applied-intelligence/postmortems-applied-intelligence
   - title: Classic alerting features
     pages:
-      - title: Technical rules and limits
-        path: /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts
       - title: Understand your violations
         pages:
           - title: View violations and events
@@ -165,7 +163,9 @@ pages:
                 path: /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition
               - title: View events from their products
                 path: /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/view-events-their-products
-  - title: Settings
+  - title: Administration and limits
     pages:
-      - title: General settings
+      - title: Alert limits and rules
+        path: /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts
+      - title: General settings UI
         path: /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/user-settings


### PR DESCRIPTION
NR-129249

Preview builds for relevant pages:
Alert limit doc: https://docswebsitedevelop-newalertlimit.gatsbyjs.io/docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts/
Main system limit doc (at bottom of table): https://docswebsitedevelop-newalertlimit.gatsbyjs.io/docs/data-apis/manage-data/view-system-limits/#all_products

Work done: 
Add alerting limit to the 'alert limits/rules' doc. Added it to table, and then added more info in a new section at bottom of page. 
Add ref to that from the general 'system limits' doc. 
Restructured the org of alert nav a bit, because: a) the rules/limits doc was under the 'classic' category and that seemed a mistake. Moved that into a section with the 'General settings UI' and named that section 'Administration and limits' for lack of a better idea. 