### PR TITLE
Usage dictionary: clarifying account/org

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -57,9 +57,9 @@ By default, a New Relic organization and its accounts can only be in a single da
 * Prior to October, 2022, organizations with accounts in both regions were only billed for the usage from US region accounts. Starting in mid October, 2022, these organizations will be billed for usage in both regions. The usage UI doesn't show data ingest from across data center regions: it shows only the ingest for the current account you're in and any of its [child accounts](/docs/accounts/original-accounts-billing/original-users-roles/mastersub-account-structure).
 * The top-level account for your entire partnership organization resides in a single region. When you view the usage for that account, you'll see only the data usage from the accounts in that region. To view usage for the other data center region, switch to any [parent accounts](/docs/accounts/original-accounts-billing/original-users-roles/mastersub-account-structure) in the other region and view the usage UI for those accounts.
 
-## Create an EU region account [#create-eu-account]
+## Create an EU region organization [#create-eu-account]
 
-To create a New Relic account in the EU region:
+To create a New Relic organization in the EU region:
 
 1. Go to the New Relic [signup page](https://newrelic.com/signup/).
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -239,7 +239,7 @@ If you have an EU region account, use the appropriate endpoints to access the fo
 
 ## Access New Relic [#access]
 
-If your accounts report data to the [EU data center](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center), use the following link to go to New Relic: **[one.eu.newrelic.com](https://one.eu.newrelic.com)**.
+If your New Relic organization reports data to the [EU data center](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center), use the following link to go to New Relic: **[one.eu.newrelic.com](https://one.eu.newrelic.com)**.
 
 ## Billing and pricing [#billing-pricing]
 

--- a/src/content/docs/accounts/accounts-billing/general-account-settings/intro-account-settings.mdx
+++ b/src/content/docs/accounts/accounts-billing/general-account-settings/intro-account-settings.mdx
@@ -15,7 +15,7 @@ import accountsUserMenu from 'images/accounts_screenshot-crop_user-menu.webp'
 
 import accountsUserMenuLocation from 'images/accounts_screenshot-full_user-menu-location.webp'
 
-In the bottom left of New Relic, you'll find your user menu, which gives you access to features related to managing your organization and users, managing your data, and more. 
+In the bottom left of the New Relic platform UI, you'll find your user menu, which gives you access to features related to managing your organization and users, managing your data, and more. 
 
 ## Find your account settings [#find]
 
@@ -38,7 +38,7 @@ Here's a short video (2:30) with a tour of the administration UI. Note that this
 
 ## Popular admin-related topics [#popular-topics] 
 
-Here are some of the most popular topics related to New Relic account administration:
+Here are some of the most popular topics related to New Relic administration:
 
 * [Manage billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing#usage-ui)
 * [Manage users](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users)

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -353,7 +353,7 @@ To understand your usage, see the [usage UI](/docs/accounts/accounts-billing/new
 ## Other calculation details [#calculation-details]
 
 * In the context of our pricing model, a GB is defined as 1 billion bytes.
-* Monthly data ingested is rounded down to the nearest integer. For example, if your account uses 100.9 GBs during a month, that's counted as 100 GBs.
+* Monthly data ingested is rounded down to the nearest integer. For example, if your organization uses 100.9 GBs during a month, that's counted as 100 GBs.
 
 ## Free tier [#free-tier-limits]
 

--- a/src/content/docs/accounts/accounts/account-maintenance/change-your-new-relic-account-name.mdx
+++ b/src/content/docs/accounts/accounts/account-maintenance/change-your-new-relic-account-name.mdx
@@ -21,13 +21,8 @@ Note that if a user is managed via [automated user management](/docs/accounts/ac
 
 ## Change account name [#account-name]
 
-A Pro or Enterprise edition organization can have one or more accounts. How to change the name of an account differs depending on which [user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models) you're on: 
+Pro and Enterprise edition organizations can have more than one account.
 
-<CollapserGroup>
-  <Collapser
-    id="new-user-model"
-    title="Our newer user model"
-  >
 To add and rename accounts: 
 
 * From the [Access management UI](https://one.newrelic.com/admin-portal/organizations/organization-detail), click **Accounts**. 
@@ -35,20 +30,9 @@ To add and rename accounts:
 
 You can also use [our NerdGraph API](/docs/apis/nerdgraph/examples/manage-accounts-nerdgraph). 
 
-  </Collapser>
-
-
-  <Collapser
-    id="original-user-model"
-    title="Our original user model"
-  >
-To change the name of an account:
-1. From the [user menu](/docs/accounts/accounts-billing/general-account-settings/intro-account-settings/), select **Account settings**.
-2. On the right side, edit the **Name** field.
-  </Collapser>
-</CollapserGroup>
-
 If you can't change an account name, it may be because: 
+
 * You don't have required permissions
+* You're on our original user model: in that case you'd use the **Account settings** UI, available from the user menu
 * You have a partnership account structure: in that case, use [the Partnership API](/docs/new-relic-partnerships/partnerships/partner-api/partnership-api-account-object) 
 

--- a/src/content/docs/accounts/install-new-relic/partner-based-installation/rackspace-cloud-load-balancer-plugin.mdx
+++ b/src/content/docs/accounts/install-new-relic/partner-based-installation/rackspace-cloud-load-balancer-plugin.mdx
@@ -53,7 +53,7 @@ bundle install -binstubs
 
 After the plugin installs successfully, you can select it in New Relic:
 
-1. Sign in to your New Relic account at **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**.
+1. Sign in to New Relic at **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**.
 2. From the New Relic UI, select the Rackspace Cloud Load Balancer icon.
 
 From here you can select load balancer(s), view traffic, configure alerts, and more.

--- a/src/content/docs/accounts/original-accounts-billing/original-product-based-pricing/switch-new-models.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-product-based-pricing/switch-new-models.mdx
@@ -9,13 +9,13 @@ Some of our older customers are still on our **original pricing model**. Our new
 
 ## How free accounts switch
 
-Have a free account on the original pricing model? You currently have access to a wide range of New Relic features. We currently don't have a way to convert free, non-paying customer accounts to the new pricing model. So to get on the newer pricing model, and take advantage of the those benefits, you'll need to [sign up for a new account](https://newrelic.com/signup). 
+Using New Relic for free on our original pricing model? You currently have access to a wide range of New Relic features. We currently don't have a way to convert free, non-paying customer accounts to the new pricing model. So to get on the newer pricing model, and take advantage of the those benefits, you'll need to [sign up for a new account](https://newrelic.com/signup). 
 
 [Learn what you get for free on the new pricing model.](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#free)
 
 ## How paying accounts switch to new pricing [#transition-paid]
 
-If your organization is on our [original pricing model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models) and you are paying us, you may only switch to our newer usage-based pricing if one of these is true:
+If your organization is on our [original pricing model](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-user-models) and you are paying us, you can only switch to our newer usage-based pricing if one of these is true:
 
 * You're on month-to-month billing.
 * You're within 60 days of your subscription renewal.

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/anomaly-detection/automatic-anomalies.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/anomaly-detection/automatic-anomalies.mdx
@@ -55,13 +55,9 @@ To configure an anomaly detection:
 </figcaption>
 
 3. Choose a name for your configuration that helps you easily identify it from others in your account.
-
 4. Select the account you want to use for this configuration.
-
 5. Select the applications and services you want to include.
-
 6. Select the metrics you want to be notified on.
-
 7. Select how you want to be notified. These are the options:
 
     * **Slack**. You need to select a Slack channel and the time zone the charts will use.

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/Issues-and-Incident-management-and-response.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/Issues-and-Incident-management-and-response.mdx
@@ -82,19 +82,19 @@ We've created a quick demo here to walk you through the issue page user interfac
 
 The **Issues page** includes the following sections:
 
-* **Issue Payload:** This provides you the issue payload details and lets you copy the payload with a click of a button.
-* **Issue Destinations:** Under the issue name, you'll see a category called Notified, which will showcase your destinations. Hover over the destinations and you'll see a detailed presentation of the destinations and a link to the ticket that has been opened.
-* **Issue Duration:** At the top of the Issue name, you'll see the duration that the issue lasted.
-* **Number of Incidents:** At the top of the incident activity section, you'll see the total number of incidents within the issue.
-* **Incident List:** On the left side of the incident activity section, you'll see the incident activity list, which displays the most relevant information about each incident such as the priority, state, name of the incident, the date and time it was created, and the duration. You can also sort the list by duration, incidents that are muted, newest to oldest and critical to low incidents. Finally, you can filter by only open incidents by enabling the **Show open only** button.
-* **Incident Activity Chosen:** Clicking on an incident from the incident activity list will open the incident on the right in a full view mode, which will include information like alert policy, the alert condition, and the alert condition type.
-* **Incident Graph:** Clicking on an incident from the incident activity list will also open up the incident chart in full scope, which will allow you to better visualize the degradation, violation, and recovery periods.
+* **Issue payload:** This provides you the issue payload details and lets you copy the payload with a click of a button.
+* **Issue destinations:** Under the issue name, you'll see a category called Notified, which will showcase your destinations. Hover over the destinations and you'll see a detailed presentation of the destinations and a link to the ticket that has been opened.
+* **Issue duration:** At the top of the Issue name, you'll see the duration that the issue lasted.
+* **Number of incidents:** At the top of the incident activity section, you'll see the total number of incidents within the issue.
+* **Incident list:** On the left side of the incident activity section, you'll see the incident activity list, which displays the most relevant information about each incident such as the priority, state, name of the incident, the date and time it was created, and the duration. You can also sort the list by duration, incidents that are muted, newest to oldest and critical to low incidents. Finally, you can filter by only open incidents by enabling the **Show open only** button.
+* **Incident activity chosen:** Clicking on an incident from the incident activity list will open the incident on the right in a full view mode, which will include information like alert policy, the alert condition, and the alert condition type.
+* **Incident graph:** Clicking on an incident from the incident activity list will also open up the incident chart in full scope, which will allow you to better visualize the degradation, violation, and recovery periods.
 * **User actions (above the chart):** Clicking on an incident from the incident activity list will display certain actions that you can take:
     * A Runbook URL will appear here if this condition has a Runbook URL defined.
     * An entity overview button that redirects you to the entity summary page with the incident time window (any entity type).
     * A **See errors** button appears only when there are error groups from errors inbox that are related to the same entity and occurred on the same time window as the incident.
     * The icon with three dots has a dropdown menu that contains the option to close a certain incident (only when the issue has more than 1 incident) and also displays the incident payload.
-* **Incident Entity Section (below the chart):** If you click on an incident from the incident activity list, you will see the following:
+* **Incident entity section (below the chart):** If you click on an incident from the incident activity list, you will see the following:
     * The impacted entity, entity type, and the account name of this incident belongs to.
     * A list of tags (entity & condition tags) and their values. Click on the **Show all** button to display all the tags.
 
@@ -164,7 +164,7 @@ In the **Impacted entities** section, an issue map is available for any issue in
 Depending on the data in an issue, all four of these sections can show up together for each issue or separately. All you've to do is click on the 3 dots next to the entity to open the dropdown menu with options as follow:
 
 * **See dashboards** helps users in your account look at and interact with [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) you've created that are related to an entity. The queries you've run to power the various widgets are automatically mapped to entities whenever possible and are presented back to you here for quick access and discovery.
-* **Entity View** will open the application's anomalies page. This is only available for applications that are set up for proactive detection.
+* **Entity view** will open the application's anomalies page. This is only available for applications that are set up for proactive detection.
 * There are two types of **deployment events**: deployments and related deployments. Click **[Show all deployments](/whats-new/applied-intelligence-deployment-events-issue-feed)** to see all your deployment events when they arrive, or click a specific deployment to see its <InlinePopover type="apm" /> deployments page. The [APM deployment page](/docs/change-tracking/change-tracking-view-analyze/#deployment-details) lists recent deployments and their impact on your end user and app server's Apdex scores, response times, throughput, and errors. This section will only show up if New Relic has identified applications under the impacted entities that have deployments.
 
 
@@ -227,13 +227,15 @@ To view the issues in a text format, in the right hand corner, click **Switch to
   src={accountsIssueSummary}
 />
 
-**Golden Signals**
-- Here you will find an indication about which of the 4 golden signals is related to issue, it means that there is a problem affecting the performance or availability of your distributed system in one or more of the key areas.
+**Golden signals**
 
-**Related Componants**
-- We're analyzing the title and based on that we get value from the list components.
+Here you will find an indication about which of the 4 golden signals is related to issue, it means that there is a problem affecting the performance or availability of your distributed system in one or more of the key areas.
+
+**Related components**
+
+We're analyzing the title and based on that we get value from the list components.
+
 We also present a list of tags that are derived from the stack trace, based on Stack Overflow tags analysis.
-
 
 ## Use decisions [#decisions]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions.mdx
@@ -72,7 +72,7 @@ Rules for [creating a multi-location condition](#):
       </td>
 
       <td>
-        This feature has a limit of 1000 conditions per account, but some types of Infrastructure alert conditions also count towards this limit. If you get a notification that you've exceeded your limit, contact your account representative or [Support](https://support.newrelic.com/) for assistance.
+        This feature has a limit of 1000 conditions per account, but some types of Infrastructure alert conditions also count towards this limit. If you get a notification that you've exceeded your limit, contact your New Relic representative or [Support](https://support.newrelic.com/) for assistance.
       </td>
     </tr>
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/disable-enable-alerts-conditions-using-api.mdx
@@ -26,7 +26,7 @@ Modifying any attribute in a condition using the API requires:
 
 * An [API key](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key) and permissions to manage alerts
 * The condition's `id` (available from [API Explorer:](https://rpm.newrelic.com/api/explore/alerts_condition/list) **Alerts Conditions > GET > List**)
-* If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+* If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 
 ## Enable and disable a condition
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -134,7 +134,7 @@ These types of conditions do not have available endpoints in the API:
 These API functions include links to the API Explorer, where you can create, delete, or list [policies](/docs/alerts/new-relic-alerts-beta/getting-started/best-practices-alert-policies).
 
 <Callout variant="important">
-  If your account hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organiation hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>
@@ -314,7 +314,7 @@ These API functions include links to the API Explorer, where you can create, del
 These API functions include links to the API Explorer, where you can create, delete, or list alerts [notification channels](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts).
 
 <Callout variant="important">
-  If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>
@@ -743,7 +743,7 @@ These API functions include links to the API Explorer, where you can create, upd
 **Exception:** NRQL anomaly conditions are **not available** from this endpoint.
 
 <Callout variant="important">
-  If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>
@@ -880,7 +880,7 @@ These API functions include links to the API Explorer, where you can create, upd
 These API functions include links to the API Explorer, where you can create, update, delete, or list policy [conditions](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions). These calls are for conditions for external services. The API calls can be used with <InlinePopover type="apm" /> and mobile monitoring apps.
 
 <Callout variant="important">
-  If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>
@@ -1219,7 +1219,7 @@ These API functions include links to the API Explorer, where you can create, upd
 These API functions include links to the API Explorer, where you can view information about events, violations, and incidents for your alert policies.
 
 <Callout variant="important">
-  If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>
@@ -1341,7 +1341,7 @@ These API functions include links to the API Explorer, where you can view inform
 These API functions include links to the API Explorer, where you can list, add and remove entities in the conditions for your alert policies.
 
 <Callout variant="important">
-  If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -134,7 +134,7 @@ These types of conditions do not have available endpoints in the API:
 These API functions include links to the API Explorer, where you can create, delete, or list [policies](/docs/alerts/new-relic-alerts-beta/getting-started/best-practices-alert-policies).
 
 <Callout variant="important">
-  If your organiation hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 <CollapserGroup>

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/notification-channels-control-where-send-alerts.mdx
@@ -30,14 +30,13 @@ redirects:
   - /docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts
 ---
 
-You can use [alerts](/docs/alerts) to set up notification channels, and attach those channels to [policies](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy). Your selected channels provide fast and consistent ways for the right personnel to be notified about incidents. For example, notifications allow you to include charts about the incident to provide context and share them with your team.
+You can use [alerts](/docs/alerts) to set up notification channels, and attach those channels to [policies](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy). 
 
-Alerts offers several notification channels, including webhooks, Slack rooms, email, and more. You'll be notified by your notification channels when incidents are opened, acknowledged, or closed. This document explains the available notification channels and how to set them up.
+<Callout variant="important" title="EOL NOTICE">
+We're replacing notification channels with the more powerful [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows) feature. Existing notifications will be automatically migrated to workflows that provide more options, flexibility, and control and you can enrich notifications with additional data.
+</Callout> 
 
-   <Callout variant="important" title="EOL NOTICE">
-   We're replacing notification channels with more powerful workflows. Existing notifications will be automatically migrated to workflows that provide      more options, flexibility, and control and you can enrich notifications with additional data.
-  [Learn about workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/)
-  </Callout>
+We offer several notification channels, including webhooks, Slack rooms, email, and more. You'll be notified by your notification channels when incidents are opened, acknowledged, or closed. 
 
 ## View notification channels [#view-channels]
 

--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -46,7 +46,7 @@ New Relic's alerts and applied intelligence were designed for busy DevOps teams 
 
 To get started using alerts:
 
-1. Sign up for your free account if you haven't already
+1. Sign up to New Relic for free if you haven't already
 
 <InlineSignup/>
 2. Use our [agents and integrations](https://newrelic.com/instant-observability/?category=infrastructure-and-os) to begin ingesting data into New Relic

--- a/src/content/docs/apis/insights-apis/query-insights-event-data-api.mdx
+++ b/src/content/docs/apis/insights-apis/query-insights-event-data-api.mdx
@@ -36,9 +36,9 @@ The New Relic Insights query API is a REST API for making NRQL queries.
 
 Use of this API may be restricted by role-related user permissions.
 
-To add custom data to New Relic, you'd use our [data ingest APIs](/docs/telemetry-data-platform/get-data-new-relic/getting-started/introduction-new-relic-data-ingest-apis-sdks/).
+To add custom data to New Relic, see [Report custom data](/docs/data-apis/custom-data/get-custom-data-from-any-source).
 
-If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+If your organization hosts data in the EU data center, ensure you're using the proper [EU region endpoints](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 
 ## 1. Register an API key [#register]
 

--- a/src/content/docs/apis/nerdgraph/get-started/nerdgraph-explorer.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/nerdgraph-explorer.mdx
@@ -23,8 +23,8 @@ NerdGraph is our main API for querying data and making configurations to New Rel
 
 To find the NerdGraph explorer: 
 
-* In the EU: If your New Relic account uses an [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), go to [api.eu.newrelic.com/graphiql](https://api.eu.newrelic.com/graphiql).
-* Outside the EU: If your account is outside the EU, use [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
+* EU: If your New Relic organization uses an [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), go to [api.eu.newrelic.com/graphiql](https://api.eu.newrelic.com/graphiql).
+* Outside EU: If your organization doesn't use an EU data center, go to [api.newrelic.com/graphiql](https://api.newrelic.com/graphiql).
 
 ## What is the NerdGraph explorer? [#overview]
 

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process.mdx
@@ -124,7 +124,7 @@ Here are descriptions of the activity included in the browser load time chart se
     id="h3-request"
     title="Request queuing"
   >
-    **Request queuing** will be displayed in the load time chart if your account has both browser and APM linked. In New Relic, [request queuing](/docs/apm/applications-menu/features/request-queuing-tracking-frontend-time) refers to the time between a request entering your production systems and it reaching your application. Depending on the specifics of your production infrastructure, this time may include an actual queue that requests enter, or it may represent other functions that take time (such as load balancing or internal network latency).
+    **Request queuing** will be displayed in the load time chart if that account has browser monitoring and APM linked. In New Relic, [request queuing](/docs/apm/applications-menu/features/request-queuing-tracking-frontend-time) refers to the time between a request entering your production systems and it reaching your application. Depending on the specifics of your production infrastructure, this time may include an actual queue that requests enter, or it may represent other functions that take time (such as load balancing or internal network latency).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -276,9 +276,9 @@ Here are some troubleshooting tips:
       </td>
 
       <td>
-        If your `PageAction` events do not appear when you query, check that your account [is compatible](#requirements).
+        If your `PageAction` events do not appear when you query, review the [requirements](#requirements).
 
-        If your account is compatible, check that you are not using [reserved attribute names or invalid values](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api#limits).
+        If the requirements are met, check that you're not using [reserved attribute names or invalid values](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api#limits).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/event-api/introduction-event-api.mdx
@@ -121,13 +121,13 @@ SELECT count(*) FROM CLIRun FACET errors SINCE 1 week ago
 The Event API is an asynchronous endpoint. This allows you to send a very large volume of POSTS, reliably, with very low response latency.
 
 <Callout variant="tip">
-  If your account hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you're using the proper [EU region endpoints](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 To send a custom event to a New Relic account:
 
 1. Get a <InlinePopover type="licenseKey" /> for the account you want to report data to.
-2. Before creating custom events or attributes, review New Relic's list of [reserved terms used by NRQL](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-words).
+2. Before creating custom events or attributes, review our list of [reserved terms used by NRQL](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-words).
 3. [Generate JSON](#instrument) for the event by instrumenting your application, querying an API, or some other method.
 4. [Submit a compressed JSON payload](#submit-event) (for example, `gzip` or `deflate`) to the HTTPS endpoint using curl in a **POST** request.
 5. **Recommendation:** Set up [NRQL alert conditions](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries) to notify you when [parsing errors](#errors-parsing) occur.

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -62,7 +62,7 @@ https://metric-api.newrelic.com/metric/v1
 ```
 
 <Callout variant="tip">
-  If your account hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, ensure you're using the [EU region endpoints](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 ## HTTP request headers [#headers-query-parameters]

--- a/src/content/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events.mdx
@@ -177,7 +177,7 @@ To programmatically retrieve these errors:
 2. Create an HTTP request as shown below:
 
    <Callout variant="tip">
-     If your account hosts data in the EU data center, ensure you're using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+     If your organization hosts data in the EU data center, ensure you're using the [EU region endpoints](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
    </Callout>
 
    ```bash

--- a/src/content/docs/infrastructure/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-no-data-appears.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/troubleshooting/ecs-integration-troubleshooting-no-data-appears.mdx
@@ -21,9 +21,9 @@ You installed our [on-host ECS integration](/docs/introduction-amazon-ecs-integr
 
 ## Solution
 
-If your New Relic account had previously installed the infrastructure agent or an infrastructure on-host integration, your data should appear in [the UI](/docs/ecs-integration-understand-use-data) within a few minutes.
+If you'd previously installed the infrastructure agent or an infrastructure on-host integration, your data should appear in [the UI](/docs/ecs-integration-understand-use-data) within a few minutes.
 
-If your account had not previously done either of those things before installing the on-host ECS integration, it may take tens of minutes for data to appear in the UI. In that case, we recommend waiting up to an hour before doing the following troubleshooting steps or contacting support.
+If you had not previously done either of those things before installing the on-host ECS integration, it may take tens of minutes for data to appear in the UI. In that case, we recommend waiting up to an hour before doing the following troubleshooting steps or contacting support.
 
 There are several options for troubleshooting no data appearing:
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/statsd-monitoring-integration-version-2.mdx
@@ -27,7 +27,7 @@ Want to try out our StatsD integration? [Create a New Relic account](https://new
 
 This integration uses our [Metric API](/docs/data-ingest-apis/get-data-new-relic/metric-api/introduction-metric-api) and our [Event API](/docs/insights/insights-data-sources/custom-data/introduction-event-api) to ingest data. To use these APIs, you'll need a <InlinePopover type="licenseKey" />.
 
-The integration adheres to the Metric API [requirements and data limits](/docs/data-ingest-apis/get-data-new-relic/metric-api/metric-api-limits-restricted-attributes). To see if your account is hitting the rate limit, run the following NRQL query of the [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror):
+The integration adheres to the Metric API [requirements and data limits](/docs/data-ingest-apis/get-data-new-relic/metric-api/metric-api-limits-restricted-attributes). To see if you might be hitting the rate limit, run the following NRQL query of the [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror):
 
 ```sql
 SELECT count(*) FROM NrIntegrationError 
@@ -54,7 +54,7 @@ docker run \
   newrelic/nri-statsd:latest
 ```
 
-If your account is in the [EU data center region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center), add this to the above command:
+If your organization is in the [EU data center region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center), add this to the above command:
 
 ```shell
 -e NR_EU_REGION=true \

--- a/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
@@ -17,7 +17,7 @@ redirects:
 
 If you haven't already, [sign up for a free New Relic account](https://newrelic.com/signup) so you can instrument your systems and send telemetry data to New Relic. Our guided install creates a customized CLI command for your environment that downloads and installs the New Relic CLI and the infrastructure agent.
 
-Ready to get started? Click the **Guided install** button. Or, if your account reports data through our [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers/), click **EU Guided install**.
+Ready to get started? Click the **Guided install** button. Or, if your organization is located in an [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), click **EU Guided install**.
 
 <ButtonGroup>
   <ButtonLink

--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -80,7 +80,7 @@ In order to use the Infrastructure REST API, you need:
 * The condition `id`, available via [GET list of conditions](#get-conditions), or via the condition's URL in the Infrastructure monitoring UI
 
 <Callout variant="tip">
-  If your account hosts data in the EU data center, make sure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
+  If your organization hosts data in the EU data center, make sure you are using the [EU region endpoints](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
 </Callout>
 
 ## Using infrastructure API calls

--- a/src/content/docs/logs/forward-logs/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluentd-plugin-log-forwarding.mdx
@@ -105,7 +105,7 @@ To configure your Fluentd plugin:
 
 ## Configure the Fluentd Plugin for EU accounts [#eu-configuration]
 
-By default the Fluentd plugin forwards logs to New Relic's US endpoint: `https://log-api.newrelic.com/log/v1`. If your account is in New Relic's [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), you must manually set the `base_uri` property to the EU endpoint. For example:
+By default the Fluentd plugin forwards logs to our US endpoint: `https://log-api.newrelic.com/log/v1`. If your New Relic organization is in our [EU data center](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers), you must manually set the `base_uri` property to the EU endpoint. For example:
 
 ```
 #Tail one or more log files

--- a/src/content/docs/logs/ui-data/obfuscation-ui.mdx
+++ b/src/content/docs/logs/ui-data/obfuscation-ui.mdx
@@ -302,14 +302,13 @@ To obfuscate your logs:
     * Define which obfuscation actions need to be applied to each of them. Ask yourself: Will I need to query my logs using this sensitive information later (consider using `HASH`), or do I need to remove this information entirely from my logs (consider using `MASK`)?
 
 
-
 <Callout variant="tip">
-  The **Logs Obfuscation** UI includes a **Hashing tool** so that you can find a hash from a known value and copy it for use with other expressions and rules.
+  The **Logs obfuscation** UI includes a **Hashing tool** so that you can find a hash from a known value and copy it for use with other expressions and rules.
 </Callout>
 
 ## CPU limits [#cpu-limits]
 
-Obfuscation has per-minute CPU limits. If your account hits your resource limits, logs won't be obfuscated as expected. To check your CPU limits, go to your [system **Limits** page](/docs/data-apis/manage-data/view-system-limits/#limits-ui) in the New Relic **Data management** UI.
+Obfuscation has per-minute CPU limits. If an account hits these resource limits, logs won't be obfuscated as expected. To check your CPU limits, go to your [system **Limits** page](/docs/data-apis/manage-data/view-system-limits/#limits-ui) in the **Data management** UI.
 
 If you exceed the obfuscation per-minute CPU limits and logs cannot be obfuscated or hashed, the attribute the obfuscation rule was applied to will be **dropped** and replaced with text indicating why the attribute was dropped. For example, if the obfuscation rule is applied to the `message` field, and the CPU per-minute limit is reached, the resulting log will look like this:
 
@@ -463,7 +462,7 @@ You can create, read, update, or delete obfuscation expressions by using the New
 
 ## Sample expressions [#samples]
 
-Below, we've provided some sample regex expressions to obfuscate some of the most common sensitive data types. Note, obfuscation expressions must be created for each account where those expressions will be in use.
+Below, we've provided some sample regex expressions to obfuscate some of the most common sensitive data types. Obfuscation expressions must be created for each New Relic account where those expressions will be in use.
 
 <Callout variant="tip">
   The following examples are regular expressions you could use in the UI. To use these in GraphQL, you'd need to escape them as shown in this [example](#expressions-create).

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/cumulative-metrics-transition-guide.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/cumulative-metrics-transition-guide.mdx
@@ -26,7 +26,7 @@ If you were ingesting cumulative monotonic sums prior to {gaDate}, this 180 day 
 
 The sections below will teach you:
 
-* How to know if your account is impacted
+* How to know if you're impacted
 * How to prepare for the EoL
 * How to opt-in to the `cumulativeCount` functionality prior to the EoL date
 
@@ -34,11 +34,11 @@ The sections below will teach you:
 Cumulative sums that are non-monotonic will **not** be affected.
 </Callout>
 
-## Check your account for impact [#impact]
+## Check for impact [#impact]
 
-If your New Relic account was sending OTLP cumulative sum metrics to New Relic before {gaDateAndYear}, then you'll be impacted by the EoL on {eolDateAndYear}.
+If your account was sending OTLP cumulative sum metrics to New Relic before {gaDateAndYear}, then you'll be impacted by the EoL on {eolDateAndYear}.
 
-To check if your account is impacted, run the following NRQL query:
+To see if you've been impacted, run the following NRQL query for the relevant account:
 
 ```
 FROM NrIntegrationError SELECT count(*)

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app.mdx
@@ -83,7 +83,7 @@ You have two choices for exporting data to New Relic via OTLP:
 Whether you export directly from your app or from a collector, you'll need to:
 
 1. Be ready to configure the OTLP exporter to add a header (`api-key`). The value is the license key for the New Relic account you want to send data to.
-2. Based on your integration, be ready to configure the endpoint where the exporter sends data to New Relic. Endpoints are region-specific, so use the one according to where your account is based. For example, use an EU endpoint if your account is based in Europe. Use the table below as a guide, and see the additional considerations about [ports](#note-ports) and [endpoints](#note-endpoints) that follow:
+2. Based on your integration, be ready to configure the endpoint where the exporter sends data to New Relic. Endpoints are region-specific, so use the one where your New Relic organiation is based. For example, if you're using the EU data center region, use an EU endpoint. Use the table below as a guide, and see the additional considerations about [ports](#note-ports) and [endpoints](#note-endpoints) that follow:
 
 <table>
   <thead>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app.mdx
@@ -83,7 +83,7 @@ You have two choices for exporting data to New Relic via OTLP:
 Whether you export directly from your app or from a collector, you'll need to:
 
 1. Be ready to configure the OTLP exporter to add a header (`api-key`). The value is the license key for the New Relic account you want to send data to.
-2. Based on your integration, be ready to configure the endpoint where the exporter sends data to New Relic. Endpoints are region-specific, so use the one where your New Relic organiation is based. For example, if you're using the EU data center region, use an EU endpoint. Use the table below as a guide, and see the additional considerations about [ports](#note-ports) and [endpoints](#note-endpoints) that follow:
+2. Based on your integration, be ready to configure the endpoint where the exporter sends data to New Relic. Endpoints are region-specific, so use the one where your New Relic organization is based. For example, if you're using the EU data center region, use an EU endpoint. Use the table below as a guide, and see the additional considerations about [ports](#note-ports) and [endpoints](#note-endpoints) that follow:
 
 <table>
   <thead>

--- a/src/content/docs/more-integrations/terraform/terraform-intro.mdx
+++ b/src/content/docs/more-integrations/terraform/terraform-intro.mdx
@@ -17,7 +17,7 @@ In this guide, you learn how to set up New Relic alerts with Terraform. More spe
 
 ## Before you begin
 
-To use this guide, you should have some basic knowledge of both New Relic and Terraform. If you haven't deployed a New Relic open source agent yet, [install New Relic](https://docs.newrelic.com/docs/agents/manage-apm-agents/installation/install-agent) for your application. Also, [install the Terraform CLI](https://learn.hashicorp.com/collections/terraform/cli).
+To use this guide, you should have some basic knowledge of both New Relic and Terraform. If you haven't deployed a New Relic open source agent yet, [install New Relic](/docs/agents/manage-apm-agents/installation/install-agent) for your application. Also, [install the Terraform CLI](https://learn.hashicorp.com/collections/terraform/cli).
 
 <Steps>
 
@@ -62,9 +62,9 @@ Now that you've set your Terraform and New Relic provider versions, you need to 
 
 With `terraform` all set, configure the New Relic `provider` with the following items:
 
-1. Your [New Relic Account ID](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id).
+1. Your [New Relic account ID](/docs/accounts/install-new-relic/account-setup/account-id).
 2. Your New Relic <InlinePopover type="userKey" />. Most user keys begin with the prefix `NRAK-`.
-3. Your [New Relic region](https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers#verifying-account). Your region is `US` if your account settings page is located at `one.newrelic.com`, and `EU` if your account is located at `one.eu.newrelic.com`.
+3. Your [New Relic region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers#verifying-account). Your region is `US` if your New Relic URL is `one.newrelic.com`, and `EU` if your URL is at `one.eu.newrelic.com`.
 
 In **main.tf**, set those values on the provider:
 

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
@@ -293,7 +293,7 @@ When planning your strategy for collecting network flows at scale, New Relic rec
        kentik/ktranslate:v2 \
          -snmp /snmp-base.yaml \
          -nr_account_id=$YOUR_NR_ACCOUNT_ID \
-         ## If your account is located in Europe, add the following flag:
+         ## If your organization is located in Europe, add the following flag:
          ## -nr_region=EU \
          ## If you want to use FedRAMP, add the following flag to use the FedRAMP authorized endpoints:
          ## -nr_region=GOV \

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
@@ -143,7 +143,7 @@ If you prefer to do the setup manually, see the instructions below.
          kentik/ktranslate:v2 \
            -snmp /snmp-base.yaml \
            -nr_account_id=$YOUR_NR_ACCOUNT_ID \
-           ## If your account is located in Europe, add the following option:
+           ## If your organization is located in Europe, add the following option:
            ## -nr_region=EU \
            ## If you want to use FedRAMP, add the following flag to use the FedRAMP authorized endpoints:
            ## -nr_region=GOV \

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -351,7 +351,7 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
        kentik/ktranslate:v2 \
          -snmp /snmp-base.yaml \
          -nr_account_id=$YOUR_NR_ACCOUNT_ID \
-         ## If your account is located in Europe, add the following flag:
+         ## If your organization is located in Europe, add the following flag:
          ## -nr_region=EU \
          ## If you want to use FedRAMP, add the following flag to use the FedRAMP authorized endpoints:
          ## -nr_region=GOV \

--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -26,7 +26,7 @@ For consistency across New Relic content, here are our general word usage guidel
 
   In general usage, outside of New Relic, `account` is often used in a more broad sense. For example, it might be used in the same way we use `organization,` or it might be used to refer to someone's user record. We should try to be as precise as possible when using these terms. This is especially true when we're documenting aspects that apply only to a New Relic account, and not to a New Relic organization (for example, account-level data and query limits). 
 
-  That said, the more general the usage is, the more it's acceptable to use `account`. For example, New Relic sometimes uses a phrase like, "Sign up for a New Relic account," and because this jibes with common `account` language use, and because it's not referencing something specific to New Relic's concept of accounts, it's not a problem. 
+  That said, the more general the usage is, the more it's acceptable to use `account` as a synonym for `organization`. For example, New Relic sometimes uses a phrase like, "Sign up for a New Relic account." This substitution of `account` for `organization` is okay because it jibes with the way `account` is commonly used and is not referencing something specific to our definition of `account`. 
   
   </Collapser>
 

--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -22,7 +22,7 @@ For consistency across New Relic content, here are our general word usage guidel
     id="account"
     title="account"
   >
-  When someone signs up for New Relic, they get a New Relic organization (represented by an organiation ID). That organization can contain one or more accounts (with each account having an account ID). For more about the distinction between "organization" and "account," see [Organization and account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
+  When someone signs up for New Relic, they get a New Relic organization (represented by an organization ID). That organization can contain one or more accounts (with each account having an account ID). For more about the distinction between "organization" and "account," see [Organization and account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
 
   In general usage, outside of New Relic, "account" is often used in a more broad sense. For example, it might be used in the same way we use "organization," or it might be used to refer to someone's user record. We should try to be as precise as possible when using these terms. This is especially true when we're documenting aspects that apply only to a New Relic account, and not to a New Relic organization (for example, account-level data and query limits). 
 

--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -22,11 +22,11 @@ For consistency across New Relic content, here are our general word usage guidel
     id="account"
     title="account"
   >
-  When someone signs up for New Relic, they get a New Relic organization (represented by an organization ID). That organization can contain one or more accounts (with each account having an account ID). For more about the distinction between "organization" and "account," see [Organization and account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
+  When someone signs up for New Relic, they get a New Relic organization (represented by an organization ID). That organization can contain one or more accounts (with each account having an account ID). For more about the distinction between `organization` and `account,` see [Organization and account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
 
-  In general usage, outside of New Relic, "account" is often used in a more broad sense. For example, it might be used in the same way we use "organization," or it might be used to refer to someone's user record. We should try to be as precise as possible when using these terms. This is especially true when we're documenting aspects that apply only to a New Relic account, and not to a New Relic organization (for example, account-level data and query limits). 
+  In general usage, outside of New Relic, `account` is often used in a more broad sense. For example, it might be used in the same way we use `organization,` or it might be used to refer to someone's user record. We should try to be as precise as possible when using these terms. This is especially true when we're documenting aspects that apply only to a New Relic account, and not to a New Relic organization (for example, account-level data and query limits). 
 
-  That said, the more general the usage is, the more it's acceptable to use "account." For example, New Relic sometimes uses a phrase like, "Sign up for a New Relic account," and because this jibes with common "account" language use, and because it's not referencing something specific to our account concept, it's not a problem. 
+  That said, the more general the usage is, the more it's acceptable to use `account`. For example, New Relic sometimes uses a phrase like, "Sign up for a New Relic account," and because this jibes with common `account` language use, and because it's not referencing something specific to New Relic's concept of accounts, it's not a problem. 
   
   </Collapser>
 

--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -17,6 +17,19 @@ For consistency across New Relic content, here are our general word usage guidel
 * For terminology specific to New Relic, we use the [product glossary](/docs/using-new-relic/welcome-new-relic/getting-started/glossary).
 
 <CollapserGroup>
+
+  <Collapser
+    id="account"
+    title="account"
+  >
+  When someone signs up for New Relic, they get a New Relic organization (represented by an organiation ID). That organization can contain one or more accounts (with each account having an account ID). For more about the distinction between "organization" and "account," see [Organization and account structure](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
+
+  In general usage, outside of New Relic, "account" is often used in a more broad sense. For example, it might be used in the same way we use "organization," or it might be used to refer to someone's user record. We should try to be as precise as possible when using these terms. This is especially true when we're documenting aspects that apply only to a New Relic account, and not to a New Relic organization (for example, account-level data and query limits). 
+
+  That said, the more general the usage is, the more it's acceptable to use "account." For example, New Relic sometimes uses a phrase like, "Sign up for a New Relic account," and because this jibes with common "account" language use, and because it's not referencing something specific to our account concept, it's not a problem. 
+  
+  </Collapser>
+
   <Collapser
     id="account-id"
     title="account ID"
@@ -686,6 +699,15 @@ For either term, in the UI, use the [badge component](https://one-core.newrelic.
   >
    Don't hyphenate when using as a noun; hyphenate when using as a compound adjective.
   </Collapser>
+
+<Collapser
+    id="organization"
+    title="organization"
+  >
+  See [account](#account).
+
+  </Collapser>
+
 
   <Collapser
     id="oxford-comma"

--- a/src/content/docs/tutorial-create-alerts/improve-with-alerts.mdx
+++ b/src/content/docs/tutorial-create-alerts/improve-with-alerts.mdx
@@ -82,7 +82,7 @@ After two weeks, you should have enough data to analyze and begin your alert imp
     </Step>
 </Steps>
 
-After completing the procedure above, you're well on your way to using your alerts to improve your system and provide a positive impact to your organiation. This is only the beginning though: there's a lot more possibilities for using alerts than what we've covered here. For more detailed information on alert quality and KPIs, see our [Alert quality management docs](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/alert-quality-management-guide/#perform-enablement-one).
+After completing the procedure above, you're well on your way to using your alerts to improve your system and provide a positive impact to your organization. This is only the beginning though: there's a lot more possibilities for using alerts than what we've covered here. For more detailed information on alert quality and KPIs, see our [Alert quality management docs](/docs/new-relic-solutions/observability-maturity/uptime-performance-reliability/alert-quality-management-guide/#perform-enablement-one).
 
 <UserJourneyControls
 previousStep={{path: "/docs/tutorial-create-alerts/create-an-alert/", title: "Previous step", body: "Learn how to create alerts using New Relic"}}


### PR DESCRIPTION
NR-128644

Main change: adding tips for account/organization language in the style guide usage dictionary. 

While at it, I edited some uses of 'account' to be more clear. 