### PR TITLE
Make workflow run on a cron

### DIFF
--- a/.github/workflows/agent-release-notes.yml
+++ b/.github/workflows/agent-release-notes.yml
@@ -1,9 +1,9 @@
 name: Generate Agent Release Notes
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # 7PM PDT
 
 jobs:
   generate-json:


### PR DESCRIPTION
the release notes workflow runs on merge to main which results in the json being immediately updated and builds taking up to 40min. this means in the product a release note can show up with a link to a docs page that hasn't gone live yet. this makes the workflow run around 7pm pdt which should be well after the last release of the day and hopefully avoid any more temporary 404s