### PR TITLE
Update thread-profiler-tool.mdx to show Java-specific notes

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/events/thread-profiler-tool.mdx
+++ b/src/content/docs/apm/apm-ui-pages/events/thread-profiler-tool.mdx
@@ -152,6 +152,40 @@ Depending on which agent you use, the thread profiling feature has additional co
 
 <CollapserGroup>
   <Collapser
+    id="java"
+    title="Java-specific notes"
+  >
+    When using thread profiling with the Java agent, be aware of the following.
+
+    <table>
+      <thead>
+        <tr>
+          <th width={200}>
+            **Java agent**
+          </th>
+
+          <th>
+            **Thread profiler notes**
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Tree settings show **Other** category only
+          </td>
+
+          <td>
+            All threads are put in the **Other** category. The **Web Request** and **Background** categories are not supported.
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
     id="net"
     title=".NET-specific notes"
   >


### PR DESCRIPTION
In Tree settings, show: Web Request and Background options have been deprecated for a long time: see Slack thread in NR-115632 called "Reference to how bucketing hasn't worked since Java agent 3.21". There is a fix in the backlog to remove these options: NR-115632. Will need to remove this note about Other when fix is deployed. But in the meantime we should mention that these two options don't work for Java.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.