### PR TITLE
fix(tutorial): fix redirects

### DIFF
--- a/src/content/docs/tutorial-peak-demand/autoscale-your-infra.mdx
+++ b/src/content/docs/tutorial-peak-demand/autoscale-your-infra.mdx
@@ -1,7 +1,7 @@
 ---
 title: Autoscale your infrastructure with Kubernetes
 metaDescription: "Automatically allocate and deallocate infrastructure resources to your pods with horizontal pod autoscaling."
-/redirects:
+redirects:
   - /docs/journey-demand/autoscale-your-infra/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/create-quality-alerts.mdx
+++ b/src/content/docs/tutorial-peak-demand/create-quality-alerts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reduce noise with quality alerts
 metaDescription: "Evaluate the quality of your alerts before a peak gameday event by installing the alert quality management dashboard."
-/redirects:
+redirects:
   - /docs/journey-demand/create-quality-alerts/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/find-your-baseline.mdx
+++ b/src/content/docs/tutorial-peak-demand/find-your-baseline.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create meaningful service levels for gameday
 metaDescription: "Learn to find important capabilities, define your baselines, and set up meaningful service levels for peak demand."
-/redirects:
+redirects:
   - /docs/journey-demand/find-your-baseline/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/get-started.mdx
+++ b/src/content/docs/tutorial-peak-demand/get-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Succeeding during peak demand days with New Relic 
 metaDescription: "Set up New Relic to get the data you need to plan for a peak demand event."
-/redirects:
+redirects:
   - /docs/journey-demand/get-started/
 ---
 

--- a/src/content/docs/tutorial-peak-demand/organize-data-workloads.mdx
+++ b/src/content/docs/tutorial-peak-demand/organize-data-workloads.mdx
@@ -1,7 +1,7 @@
 ---
 title: Align your teams with workloads
 metaDescription: "If you're preparing for a peak event day, you can set up workloads that put the most relevant data in front of the teams that need it."
-/redirects:
+redirects:
   - /docs/journey-demand/organize-data-workloads/
 ---
 


### PR DESCRIPTION
Fixes some broken redirects by removing an extra `/` at the beginning of the redirect frontmatter.