### PR TITLE
fix: link to monitor services in k8s

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
@@ -50,7 +50,7 @@ To install the JMX integration, follow the instructions for your environment:
     title="Kubernetes"
   >
     See [Monitor service running on
-    Kubernetes](/docs/monitor-service-running-kubernetes).
+    Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/monitor-services/monitor-services-running-kubernetes).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Currently, the link is going to [this k8s documentation](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements/), but it should go to the corresponding [monitoring services section](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/monitor-services/monitor-services-running-kubernetes), where JMX is listed as one of the compatible services.