### PR TITLE
fix: remove lint warning about exhaustive deps

### DIFF
--- a/src/hooks/usePosition.js
+++ b/src/hooks/usePosition.js
@@ -20,6 +20,7 @@ const usePosition = () => {
     if (!measureEl || dimensions != null) return;
 
     setDimensions(measureEl.getBoundingClientRect());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return [


### PR DESCRIPTION
Just a line to remove a file from being included in all PR diffs about it not having a dep that we're not using

<img width="1252" alt="Screenshot 2023-06-29 at 11 48 37 AM" src="https://github.com/newrelic/docs-website/assets/26727669/12bfdba0-9d6f-477b-9692-598242d911fc">
