### PR TITLE
fix: Update regex in serializer to only convert outer quotes

### DIFF
--- a/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
+++ b/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
@@ -503,6 +503,17 @@ exports[`serializes var to html 1`] = `"<var data-type=\\"component\\"><p>JAVA_A
 
 exports[`serializing CONTRIBUTOR_NOTE removes it from translated files 1`] = `""`;
 
+exports[`serializing components with apostrophes in their props 1`] = `
+"
+<div data-type=\\"UserJourneyControls\\" data-value=\\"eyJ0eXBlIjoibWR4QmxvY2tFbGVtZW50IiwibmFtZSI6IlVzZXJKb3VybmV5Q29udHJvbHMiLCJhdHRyaWJ1dGVzIjpbeyJ0eXBlIjoibWR4QXR0cmlidXRlIiwibmFtZSI6Im5leHRTdGVwIiwidmFsdWUiOnsidHlwZSI6Im1keFZhbHVlRXhwcmVzc2lvbiIsInZhbHVlIjoie1wicGF0aFwiOiBcIi9kb2NzL3R1dG9yaWFsLWRkLW1pZ3JhdGlvbi9tYWtpbmctdGhlLXN3aXRjaC9cIiwgXCJ0aXRsZVwiOiBcIk5leHQgc3RlcFwiLCBcImJvZHlcIjogXCJMZWFybiBtb3JlIGFib3V0IE5ldyBSZWxpYydzIG90aGVyIGZlYXR1cmVzIGFuZCB3aGF0IHlvdSBuZWVkIHRvIG1ha2UgdGhlIHN3aXRjaCBmcm9tIERhdGFkb2dcIn0iLCJwb3NpdGlvbiI6eyJzdGFydCI6eyJsaW5lIjozLCJjb2x1bW4iOjE0LCJvZmZzZXQiOjM5fSwiZW5kIjp7ImxpbmUiOjMsImNvbHVtbiI6MjAxLCJvZmZzZXQiOjIyNn19fSwicG9zaXRpb24iOnsic3RhcnQiOnsibGluZSI6MywiY29sdW1uIjo1LCJvZmZzZXQiOjMwfSwiZW5kIjp7ImxpbmUiOjMsImNvbHVtbiI6MjAxLCJvZmZzZXQiOjIyNn19fSx7InR5cGUiOiJtZHhBdHRyaWJ1dGUiLCJuYW1lIjoicHJldmlvdXNTdGVwIiwidmFsdWUiOnsidHlwZSI6Im1keFZhbHVlRXhwcmVzc2lvbiIsInZhbHVlIjoie1wicGF0aFwiOiBcIi9kb2NzL3R1dG9yaWFsLWRkLW1pZ3JhdGlvbi9pbnN0YWxsaW5nLW1vbml0b3IvXCIsIFwidGl0bGVcIjogXCJQcmV2aW91cyBzdGVwXCIsIFwiYm9keVwiOiBcIkxlYXJuIG1vcmUgYWJvdXQgaW5nZXN0aW5nIGRhdGEgdG8gbW9uaXRvclwifSIsInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjQsImNvbHVtbiI6MTgsIm9mZnNldCI6MjQ0fSwiZW5kIjp7ImxpbmUiOjQsImNvbHVtbiI6MTU5LCJvZmZzZXQiOjM4NX19fSwicG9zaXRpb24iOnsic3RhcnQiOnsibGluZSI6NCwiY29sdW1uIjo1LCJvZmZzZXQiOjIzMX0sImVuZCI6eyJsaW5lIjo0LCJjb2x1bW4iOjE1OSwib2Zmc2V0IjozODV9fX1dLCJjaGlsZHJlbiI6W10sInBvc2l0aW9uIjp7InN0YXJ0Ijp7ImxpbmUiOjIsImNvbHVtbiI6MSwib2Zmc2V0IjoxfSwiZW5kIjp7ImxpbmUiOjQsImNvbHVtbiI6MTYyLCJvZmZzZXQiOjM4OH0sImluZGVudCI6WzEsMV19fQ==\\">
+  <div data-key=\\"nextStep-title\\">Next step</div>
+  <div data-key=\\"nextStep-body\\">Learn more about New Relic's other features and what you need to make the switch from Datadog</div>
+  <div data-key=\\"previousStep-title\\">Previous step</div>
+  <div data-key=\\"previousStep-body\\">Learn more about ingesting data to monitor</div>
+</div>
+"
+`;
+
 exports[`test <InlineCode> element serializes and adds 'notranslate' class to element 1`] = `"<code data-type=\\"component\\" data-component=\\"InlineCode\\" class=\\"notranslate\\">This is a test</code>"`;
 
 exports[`test <b> element serializes 1`] = `

--- a/scripts/actions/__tests__/serialize-mdx.test.js
+++ b/scripts/actions/__tests__/serialize-mdx.test.js
@@ -1,5 +1,6 @@
 import serializeMDX from '../serialize-mdx';
 import fs from 'fs';
+import deserializeHTML from '../deserialize-html';
 
 test('serializes DoNotTranslate wrapping a Collapser', async () => {
   const html = await serializeMDX(`
@@ -409,4 +410,16 @@ test('serializing CONTRIBUTOR_NOTE removes it from translated files', async () =
   `);
 
   expect(html).toMatchSnapshot();
+});
+
+test('serializing components with apostrophes in their props', async () => {
+  const input = `
+    <UserJourneyControls
+    nextStep={{"path": "/docs/tutorial-dd-migration/making-the-switch/", "title": "Next step", "body": "Learn more about New Relic's other features and what you need to make the switch from Datadog"}}
+    previousStep={{"path": "/docs/tutorial-dd-migration/installing-monitor/", "title": "Previous step", "body": "Learn more about ingesting data to monitor"}} />
+    `;
+  const html = await serializeMDX(input);
+  const str = await deserializeHTML(html);
+  expect(html).toMatchSnapshot();
+  expect(str.replace(/ |\n/g, '')).toBe(input.replace(/ |\n/g, ''));
 });

--- a/scripts/actions/utils/serialization-helpers.js
+++ b/scripts/actions/utils/serialization-helpers.js
@@ -15,13 +15,13 @@ const removeParagraphs = () => (tree) => {
 };
 
 // this converts the string version of props to a json string so we can use JSON.parse on it
-const matchSingleOuterQuotesRegex = /(')([^,]*)(')/g;
+const matchSingleOuterQuotesRegex = /'([^,]*)'/g;
 const createJsonStr = (str) =>
   str
     .replace(/(\w+:)|(\w+ :)/g, function (matchedStr) {
       return `"${matchedStr.substring(0, matchedStr.length - 1)}":`;
     })
-    .replace(matchSingleOuterQuotesRegex, '"$2"');
+    .replace(matchSingleOuterQuotesRegex, '"$1"');
 
 const attributeProcessor = unified()
   .use(toMDAST)

--- a/scripts/actions/utils/serialization-helpers.js
+++ b/scripts/actions/utils/serialization-helpers.js
@@ -15,12 +15,13 @@ const removeParagraphs = () => (tree) => {
 };
 
 // this converts the string version of props to a json string so we can use JSON.parse on it
+const matchSingleOuterQuotesRegex = /(')([^,]*)(')/g;
 const createJsonStr = (str) =>
   str
     .replace(/(\w+:)|(\w+ :)/g, function (matchedStr) {
       return `"${matchedStr.substring(0, matchedStr.length - 1)}":`;
     })
-    .replace(/'/g, '"');
+    .replace(matchSingleOuterQuotesRegex, '"$2"');
 
 const attributeProcessor = unified()
   .use(toMDAST)


### PR DESCRIPTION
This serializer was breaking because an apostrophe was getting changed into a double quote. this updates the regex to only change the outer most quotes of the prop values into double quotes

You can test this by serializing and deserializing this component (previously broken)

```
<UserJourneyControls
    nextStep={{path: "/docs/tutorial-dd-migration/making-the-switch/", title: "Next step", body: "Learn more about New Relic's other features and what you need to make the switch from Datadog"}}
    previousStep={{path: "/docs/tutorial-dd-migration/installing-monitor/", title: "Previous step", body: "Learn more about ingesting data to monitor"}}
/>
```