### PR TITLE
.NET Agent: add exception for Alpine Linux under ARM64 support statement

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -45,8 +45,8 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     * [.NET Core version 2.1](https://devblogs.microsoft.com/dotnet/net-core-2-1-will-reach-end-of-support-on-august-21-2021) on August 21, 2021
     * [.NET Core version 2.2](https://devblogs.microsoft.com/dotnet/net-core-2-2-will-reach-end-of-life-on-december-23-2019) on December 23, 2019
     * [.NET Core version 3.0](https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/) on March 3, 2020
-    * .NET Core version 3.1 on December 13, 2022
-    * .NET version 5 on May 10, 2022
+    * [.NET Core version 3.1](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/) on December 13, 2022
+    * [.NET version 5](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/) on May 10, 2022
 
     The official product lifecycle start and end dates can be found in the [Microsoft documentation](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). Our .NET agent support of these framework versions end with the latest 9.x New Relic .NET agent. Starting from the New Relic .NET agent version 10.0, we will target .NET Core 3.1 onwards.
   </Callout>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -54,8 +54,6 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, and 7.0.
 
     <table style={{ width: "500px" }}>
-      Table of minimum agent versions required per .NET Core version
-
       <thead>
         <tr>
           <th>
@@ -151,7 +149,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     </table>
 
     <Callout variant="important">
-      On Linux ARM64 platforms, the .NET agent **only** supports versions of .NET 5.0 or later.
+      On Linux ARM64 platforms, the .NET agent **only** supports versions of .NET 5.0 or higher.
     </Callout>
 
     The agent is **not** compatible with .NET Core versions 1.0 or 1.1. For .NET Core 2.1 or higher applications with tiered compilation enabled, the agent will disable tiered compilation. .NET Core 2.1 support requires .NET Core runtime 2.1.3 and .NET Core SDK 2.1.401 or higher due to [a bug in the .NET Core profiling API](https://github.com/dotnet/coreclr/issues/18448).
@@ -162,7 +160,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0 and 7.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application’s targeted version of .NET Core, please refer to the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, and 7.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, please refer to the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
 
     Supported:
 
@@ -199,7 +197,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     ```
 
     <Callout variant="important">
-      On Linux ARM64 platforms, the .NET agent **only** supports target frameworks of `net5.0` or later.
+      On Linux ARM64 platforms, the .NET agent **only** supports target frameworks of `net5.0` or higher.
     </Callout>
 
     Unsupported:
@@ -436,7 +434,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
           </td>
 
           <td>
-The .NET agent `v9.2.0` or later automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
+The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
 * Minimum supported version: 3.17.0
 * Verified compatible versions: 3.17.0, 3.23.0

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -45,6 +45,8 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     * [.NET Core version 2.1](https://devblogs.microsoft.com/dotnet/net-core-2-1-will-reach-end-of-support-on-august-21-2021) on August 21, 2021
     * [.NET Core version 2.2](https://devblogs.microsoft.com/dotnet/net-core-2-2-will-reach-end-of-life-on-december-23-2019) on December 23, 2019
     * [.NET Core version 3.0](https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/) on March 3, 2020
+    * .NET Core version 3.1 on December 13, 2022
+    * .NET version 5 on May 10, 2022
 
     The official product lifecycle start and end dates can be found in the [Microsoft documentation](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). Our .NET agent support of these framework versions end with the latest 9.x New Relic .NET agent. Starting from the New Relic .NET agent version 10.0, we will target .NET Core 3.1 onwards.
   </Callout>
@@ -281,7 +283,8 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
           </td>
 
           <td>
-            All ARM64 Linux distributions supported by the .NET 5+ runtime are supported by the .NET agent. For a full list, refer to Microsoft's documentation.
+            All ARM64 Linux distributions supported by the .NET 5+ runtime are supported by the .NET agent, with the following known exceptions:
+            * Alpine Linux
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
We've discovered the the ARM64 version of our .NET agent does not work on Alpine Linux.  This PR updates our documentation with that information.