### PR TITLE
Update php-agent-compatibility-requirements.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -21,10 +21,10 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 
 
 
-New Relic supports PHP versions 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
+New Relic supports PHP versions 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, and 8.2.
 
 <Callout variant="important">
-  Compatibility note: When PHP 8.0, 8.1 or 8.2 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
+  Compatibility note: When PHP 8.0, 8.1, or 8.2 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.
 
   Support for PHP 8.1 and 8.2 does not include Fibers.
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -21,7 +21,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 
 
 
-New Relic supports PHP versions 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
+New Relic supports PHP versions 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1 and 8.2.
 
 <Callout variant="important">
   Compatibility note: When PHP 8.0, 8.1 or 8.2 detects an observability extension, like the New Relic agent, PHP disables Just-In-Time compilation.


### PR DESCRIPTION
Support for PHP versions 5.5 and 5.6 will end June 2023.

Therefore, we believe that 5.5 and 5.6 should be removed from New Relic supports PHP versions.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.