### PR TITLE
Document additional CDN in network prereqs

### DIFF
--- a/src/install/npm/network-flow/linux-eu.mdx
+++ b/src/install/npm/network-flow/linux-eu.mdx
@@ -101,7 +101,7 @@ headingText: Network flow security prerequisites
       </td>
 
       <td>
-        packagecloud.io for downloading rpm or deb packages 
+        `packagecloud.io` for downloading rpm or deb packages 
       </td>
 
       <td>
@@ -111,6 +111,32 @@ headingText: Network flow security prerequisites
       <td>
         TCP
       </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
+        </td>
+
+        <td>
+        TCP
+        </td>
 
         <td>
         ✓

--- a/src/install/npm/network-flow/linux-us.mdx
+++ b/src/install/npm/network-flow/linux-us.mdx
@@ -102,7 +102,7 @@ headingText: Network flow security prerequisites
       </td>
 
       <td>
-        packagecloud.io for downloading rpm or deb packages
+        `packagecloud.io` for downloading rpm or deb packages
       </td>
 
       <td>
@@ -112,6 +112,32 @@ headingText: Network flow security prerequisites
       <td>
         TCP
       </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
+        </td>
+
+        <td>
+        TCP
+        </td>
 
         <td>
         ✓

--- a/src/install/npm/snmp/linux-eu.mdx
+++ b/src/install/npm/snmp/linux-eu.mdx
@@ -154,7 +154,7 @@ headingText: SNMP security prerequisites
         </td>
 
         <td>
-        packagecloud.io for downloading rpm or deb packages 
+        `packagecloud.io` for downloading rpm or deb packages 
         </td>
 
         <td>
@@ -169,7 +169,32 @@ headingText: SNMP security prerequisites
         ✓
         </td>
     </tr>
-    
+
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
+        </td>
+
+        <td>
+        TCP
+        </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>    
 
     <tr>
         <td>

--- a/src/install/npm/snmp/linux-us.mdx
+++ b/src/install/npm/snmp/linux-us.mdx
@@ -154,7 +154,7 @@ headingText: SNMP security prerequisites
         </td>
 
         <td>
-        packagecloud.io for downloading rpm or deb packages
+        `packagecloud.io` for downloading rpm or deb packages
         </td>
 
         <td>
@@ -169,7 +169,32 @@ headingText: SNMP security prerequisites
         ✓
         </td>
     </tr>
-    
+
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
+        </td>
+
+        <td>
+        TCP
+        </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
 
     <tr>
         <td>

--- a/src/install/npm/snmp/linux-usfedramp.mdx
+++ b/src/install/npm/snmp/linux-usfedramp.mdx
@@ -154,11 +154,37 @@ headingText: SNMP security prerequisites
         </td>
 
         <td>
-        packagecloud.io for downloading rpm or deb packages
+        `packagecloud.io` for downloading rpm or deb packages
         </td>
 
         <td>
         443 (default)
+        </td>
+
+        <td>
+        TCP
+        </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
         </td>
 
         <td>

--- a/src/install/npm/syslog/linux-eu.mdx
+++ b/src/install/npm/syslog/linux-eu.mdx
@@ -97,11 +97,36 @@ headingText: Network syslog security prerequisites
         </td>
 
         <td>
-        packagecloud.io for downloading rpm or deb packages
+        `packagecloud.io` for downloading rpm or deb packages
         </td>
 
         <td>
         443 (default)
+        </td>
+
+        <td>
+        TCP
+        </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
         </td>
 
         <td>

--- a/src/install/npm/syslog/linux-us-fedramp.mdx
+++ b/src/install/npm/syslog/linux-us-fedramp.mdx
@@ -99,11 +99,36 @@ headingText: Network syslog security prerequisites
         </td>
 
         <td>
-        packagecloud.io for downloading rpm or deb packages 
+        `packagecloud.io` for downloading rpm or deb packages 
         </td>
 
         <td>
         443 (default)
+        </td>
+
+        <td>
+        TCP
+        </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
         </td>
 
         <td>

--- a/src/install/npm/syslog/linux-us.mdx
+++ b/src/install/npm/syslog/linux-us.mdx
@@ -98,11 +98,36 @@ headingText: Network syslog security prerequisites
         </td>
 
         <td>
-        packagecloud.io for downloading rpm or deb packages 
+        `packagecloud.io` for downloading rpm or deb packages 
         </td>
 
         <td>
         443 (default)
+        </td>
+
+        <td>
+        TCP
+        </td>
+
+        <td>
+        ✓
+        </td>
+    </tr>
+    <tr>
+        <td>
+        Outbound
+        </td>
+
+        <td>
+        Linux host
+        </td>
+
+        <td>
+        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        </td>
+
+        <td>
+        443
         </td>
 
         <td>


### PR DESCRIPTION
## Give us some context

The package manager installation for KTranslate uses packagecloud.io for hosting deb and RPM packages but packagecloud.io will sometimes returns redirects to a specific CloudFront distribution (should remain consistent per [their docs](https://packagecloud.io/docs/security#:~:text=d28dx6y1hfq314.cloudfront.net)).

Customers who want to use the package manager installation method with minimum network permissions will also need to add that CloudFront distribution