### PR TITLE
Update browser-javascript-injection-causes-problems-page.mdx

### DIFF
--- a/src/content/docs/browser/new-relic-browser/troubleshooting/browser-javascript-injection-causes-problems-page.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/browser-javascript-injection-causes-problems-page.mdx
@@ -16,7 +16,7 @@ Browser monitoring is inserting its JavaScript instrumentation in a location tha
 
 New Relic agents attempt to inject the JavaScript in the optimum location, but if you encounter problems, try these troubleshooting steps.
 
-1. Verify whether browser monitoring is the cause by [disabling browser monitoring](/docs/browser/new-relic-browser/installation-configuration/browser-settings-ui-options-browser-monitoring#disabling).
+1. Verify whether browser monitoring is the cause by [disabling browser monitoring](/docs/browser/new-relic-browser/installation/disable-browser-monitoring/).
 2. If disabling browser monitoring solves the problem, investigate the source code for the page. Re-enable browser monitoring and check for the following possible issues:
 
    * More than one instance of the `<html>` tag in the page (not in an iFrame).


### PR DESCRIPTION
Correcting page path to disable browser monitoring from incorrect path. More info below.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

## Give us some context

On the Browser "JavaScript injection causes problems with a page" doc page, step 1 is to disable browser monitoring, but when you click the link, it goes to Browser settings: UI options for Apdex and geography, when it should go to Disable browser monitoring. I corrected this link.