### PR TITLE
fix(Alerts): Fixed code inside the Microsoft Teams example

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload.mdx
@@ -579,7 +579,7 @@ The following examples show a webhook payload using both the default dynamic var
           }],
         "markdown": true
         }, {
-          "text": "<img src="{{ violationChartUrl }}" alt="Incident Chart">"
+          "text": "{{#if violationChartUrl}} <img src=\"{{ violationChartUrl }}\" alt=\"Incident Chart\"> {{else}} N/A {{/if}}"
         }],
         "potentialAction": [{
           "@type": "OpenUri",


### PR DESCRIPTION
Fixing code inside the [Webhook format example](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload/#MS-Teams-example) section.

Replaced this:
`"text": "<img src="{{ violationChartUrl }}" alt="Incident Chart">"`
with this:
`"text": "{{#if violationChartUrl}} <img src=\"{{ violationChartUrl }}\" alt=\"Incident Chart\"> {{else}} N/A {{/if}}"`