### PR TITLE
Add new metrics to nri-postgresql

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -1250,6 +1250,46 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
+            `pgbouncer.pools.clientConnectionsWaitingCancelReq`
+          </td>
+
+          <td>
+            Client connections that have not forwarded query cancellations to the server yet.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `pgbouncer.pools.clientConnectionsActiveCancelReq`
+          </td>
+
+          <td>
+            Client connections that have forwarded query cancellations to the server and are waiting for the server response.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `pgbouncer.pools.serverConnectionsActiveCancel`
+          </td>
+
+          <td>
+            Server connections that are currently forwarding a cancel request.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `pgbouncer.pools.serverConnectionsBeingCancel`
+          </td>
+
+          <td>
+            Servers that normally could become idle but are waiting to do so until all in-flight cancel requests have completed that were sent to cancel a query on this server.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             `pgbouncer.pools.serverConnectionsActive`
           </td>
 


### PR DESCRIPTION
Add new metrics to the nri-postgresql integration. 

The new version has been released so the PR is ready to merge after review/approval.