### PR TITLE
fix(login): new Github social login

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
@@ -11,18 +11,16 @@ redirects:
 There are several ways a New Relic user can log into a New Relic organization: 
 
 * Email and password: The default login method, which requires a user's email address and a password.
-* Social login: You can use one of several third-party services to sign up to New Relic and to log in, including: Google, Google Workplace, GitHub, GitLab, and BitBucket. For some details about using social login, see [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems#social-login).
+* Social login: You can use Google, Google Workplace, and GitHub to sign up for and log into New Relic. 
 * Single sign-on: For identity provider login options, see [Introduction to SAML SSO and SCIM](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim). 
 
 Having trouble logging in? See [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems/).
 
 For managing how your users log in, see [Authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more).
 
-## How we differentiate and track users [#email]
+## We track users based on email address [#email]
 
-A [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) can have multiple accounts, and can assign users to one or more accounts with our [user management solutions](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users). 
-
-We differentiate users in an organization by their email address. This means if you add a user to multiple accounts, as long as those user records have the same email address, they're treated as a single user. For more on user rules, see [User billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing). 
+We calculate billable users in an organization based on email address. This means if you add a full platform user to [more than one account in an organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure), as long as those user records have the same email address, we'll regard them as a single user. For more on user rules, see [User billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing). 
 
 ## Switch between user records [#switch]
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
@@ -18,9 +18,9 @@ Having trouble logging in? See [Login troubleshooting](/docs/accounts/accounts-b
 
 For managing how your users log in, see [Authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more).
 
-## We track users based on email address [#email]
+## Billable user count is based on email address [#email]
 
-We calculate billable users in an organization based on email address. This means if you add a full platform user to [more than one account in an organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure), as long as those user records have the same email address, we'll regard them as a single user. For more on user rules, see [User billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing). 
+Within a [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure), user records with the same email address will be considered a single user. For example: if you add a full platform user to more than one account in an organization, as long as those user records have the same email address, we regard them as representing a single user. For more on user rules, see [User billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing). 
 
 ## Switch between user records [#switch]
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
@@ -10,18 +10,20 @@ redirects:
 
 There are several ways a New Relic user can log into a New Relic organization: 
 
-* Email and password: The default login method. This involves inputting your email address and a password.
-* Google: Use an existing Google or Google Workplace account to log in to New Relic.
+* Email and password: The default login method, which requires a user's email address and a password.
+* Social login: You can use a Google account, a Google Workplace account, or a GitHub account to log into New Relic. For details about using these options, see [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems#social-login).
 * Single sign-on: For identity provider login options, see [Introduction to SAML SSO and SCIM](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim). 
 
 Having trouble logging in? See [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems/).
 
 For managing how your users log in, see [Authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more).
 
-## How users are tracked in an organization [#email]
+## How we differentiate and track users [#email]
 
-A [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) can have multiple accounts, and can assign users to one or more accounts with our [user management solutions](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users). We track users by email address, so if you add a user to multiple accounts, as long as those user records have the same email address, they're treated as a single user. For more on this, see [User billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing). 
+A [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) can have multiple accounts, and can assign users to one or more accounts with our [user management solutions](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-managing-users). 
+
+We differentiate users in an organization by their email address. This means if you add a user to multiple accounts, as long as those user records have the same email address, they're treated as a single user. For more on user rules, see [User billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing). 
 
 ## Switch between user records [#switch]
 
-For users with access to more than one user record, see [Switch between user records](/docs/accounts/accounts-billing/account-setup/multiple-logins-found).
+For users with access to more than one New Relic user record, see [Switch between users](/docs/accounts/accounts-billing/account-setup/multiple-logins-found).

--- a/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/login-options.mdx
@@ -11,7 +11,7 @@ redirects:
 There are several ways a New Relic user can log into a New Relic organization: 
 
 * Email and password: The default login method, which requires a user's email address and a password.
-* Social login: You can use a Google account, a Google Workplace account, or a GitHub account to log into New Relic. For details about using these options, see [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems#social-login).
+* Social login: You can use one of several third-party services to sign up to New Relic and to log in, including: Google, Google Workplace, GitHub, GitLab, and BitBucket. For some details about using social login, see [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems#social-login).
 * Single sign-on: For identity provider login options, see [Introduction to SAML SSO and SCIM](/docs/accounts/accounts-billing/new-relic-one-user-management/introduction-saml-scim). 
 
 Having trouble logging in? See [Login troubleshooting](/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems/).

--- a/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
@@ -107,7 +107,7 @@ See [Multiple logins found](/docs/accounts/accounts-billing/account-setup/multip
     id="social-login"
     title="Social login (Google, GitHub) email issues"
   >
-    You can sign up and log into New Relic via several third-party [social login options](/docs/accounts/accounts-billing/account-setup/login-options), including Google and GitHub. Because our social login feature works based on your email address, if you change your email address in the third-party service, or in New Relic (or in our associated products Pixie or Codestream) that will break the associated New Relic social login. 
+    You can sign up and log into New Relic via several third-party [social login options](/docs/accounts/accounts-billing/account-setup/login-options), including Google and GitHub. Because our social login feature works based on your email address, if you change your email address in either the third-party service, in New Relic, or in our associated products Pixie or Codestream, that will result in that login no longer working. 
 
   </Collapser>
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
@@ -107,13 +107,13 @@ See [Multiple logins found](/docs/accounts/accounts-billing/account-setup/multip
     id="social-login"
     title="Social login (Google, GitHub) email issues"
   >
-    You can sign up and log into New Relic via several third-party [social login options](/docs/accounts/accounts-billing/account-setup/login-options), including Google and GitHub. Because our social login feature works based on your email address, if you change your email address in either the third-party service, in New Relic, or in our associated products Pixie or Codestream, that will result in that login no longer working. 
+    You can sign up for and log into New Relic via several third-party service [social login options](/docs/accounts/accounts-billing/account-setup/login-options), including Google and GitHub. Because our social login feature works based on your email address, if you change your email address in either the third-party service, in New Relic, or in our associated products Pixie or Codestream, that will result in that login no longer working. If you want to fix that, you'll have to change your email address back to what it was originally.
 
   </Collapser>
 
   <Collapser
     id="account-exists"
-    title="Received message email already exists"
+    title="Received message that email already exists"
   >
     If you're trying to create a new New Relic organization and receive a message that your email already exists, get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>

--- a/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/troubleshoot-new-relics-password-email-address-login-problems.mdx
@@ -23,15 +23,15 @@ If you encounter problems logging in to New Relic or using your password, here a
 
 Don't have a New Relic account yet? [Sign up here](https://newrelic.com/signup). It's free!
 
-## Can't find data or accounts you expect? [#account-access]
+## Can't find data or accounts you expect to see? [#account-access]
 
-If you've successfully logged into New Relic but don't see the accounts or data you expect, see [Factors affecting access](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data#account-access).
+If you've successfully logged into New Relic but don't see the accounts or data you expect, see [Permissions and access factors](/docs/accounts/accounts-billing/general-account-settings/factors-affecting-access-features-data#account-access).
 
 ## Password-related troubleshooting [#solution]
 
 For general information about New Relic passwords, including password requirements, see [our password docs](/docs/accounts/accounts/account-maintenance/change-passwords-user-preferences). 
 
-Here are some tips for [password](/docs/accounts-partnerships/accounts/account-maintenance/change-passwords-user-preferences#requirements)-related issues.
+Here are some tips for password-related issues:
 
 <CollapserGroup>
 
@@ -39,30 +39,26 @@ Here are some tips for [password](/docs/accounts-partnerships/accounts/account-m
     id="forgot-password"
     title="Forgot your password, or password doesn't work"
   >
-    If you have forgotten your New Relic account password, or if your password does not work, request a password reset from New Relic. If you have access to multiple New Relic logins, also ensure you are using the correct password for the login method you're using
+    If you've forgotten your password, or if your password doesn't work, request a password reset from New Relic. If you have multiple New Relic logins, ensure you're using the correct password. To reset your password: 
 
     1. Go to [New Relic's login page](https://login.newrelic.com/login).
-    2. Select **Forgot your password**.
-    3. Type your account email address, and select **Send my reset link**.
-    4. When you receive a confirmation email from New Relic, select the password reset link, and [follow New Relic's password requirements](/docs/accounts-partnerships/accounts/account-maintenance/change-passwords-user-preferences#requirements) to complete the process to reset your password.
+    2. Select **Forgot your password** and follow the instructions.
 
-       <Callout variant="important">
-         The password reset link expires after 12 hours. If you do not quickly receive an email from New Relic, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, get support at [support.newrelic.com](https://support.newrelic.com).
-       </Callout>
+    The password reset link expires after 12 hours. If you don't quickly receive an email from New Relic, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, or get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser
     id="reset-password"
     title="Reset password"
   >
-    If you forgot your own password or need to request a password reset for your account email, you can use New Relic's [self-service options](#forgot-password). Admin-level users cannot reset passwords for other users. If you need to reset someone else's password, get support at [support.newrelic.com](https://support.newrelic.com).
+    If you forgot your own password or need to request a password reset, you can use our [self-service options](#forgot-password). Admin-level users cannot reset passwords for other users. If you need to reset another user's password, get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser
     id="account-login-errors"
     title="Password error messages"
   >
-    If you complete the signup process and are unable to log in to your account due to password error messages, get support at [support.newrelic.com](https://support.newrelic.com).
+    If you complete the signup process and are unable to log in due to password error messages, get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser
@@ -71,39 +67,26 @@ Here are some tips for [password](/docs/accounts-partnerships/accounts/account-m
   >
     If you want to change your password but you see a message that the password reset link expired, try using a private browser or clearing your browser cache and cookies.
 
-  <Callout variant="important">
-    The password reset link expires after 12 hours. If you do not quickly receive an email from New Relic after you select the reset link, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, get support at [support.newrelic.com](https://support.newrelic.com).
-  </Callout>
+    The password reset link expires after 12 hours. If you don't quickly receive an email from New Relic after you select the reset link, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist), contact your organization's email administrator for troubleshooting suggestions, or get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
-  <Collapser
-    id="existing-user"
-    title="User added to another New Relic account"
-  >
-    If you're an existing New Relic user and you've been [added to another account](/docs/accounts/install-new-relic/account-setup/use-multiple-accounts), you don't need to create a new password. Your existing password will work for both accounts, and you can [switch between accounts](/docs/accounts/install-new-relic/account-setup/use-multiple-accounts#switch-accounts) after logging in.
-  </Collapser>
 </CollapserGroup>
 
-## Email solutions [#solution-email]
+## Email-related troubleshooting [#solution-email]
 
-For general information about New Relic email settings, see [our email settings docs](/docs/accounts/accounts/account-maintenance/account-email-settings). Here are some tips for email-related issues.
+For general information about New Relic email settings, see [our email settings docs](/docs/accounts/accounts/account-maintenance/account-email-settings). Here are some tips for email-related issues:
 
 <CollapserGroup>
   <Collapser
     id="no-confirmation-email"
     title="Didn't receive new account confirmation email"
   >
-    When you first create your account, New Relic sends a confirmation email so you can complete the setup process and sign in. If you cannot locate your original account confirmation email:
-
+    When you first sign up, we send a confirmation email so you can complete the setup process and sign in. If you cannot locate your original account confirmation email: 
+    
     1. Go to New Relic's login page at **[login.newrelic.com/login](https://login.newrelic.com/login)**.
-    2. Select **Forgot your password**.
-    3. Type your account email address, and select **Send my password**.
-    4. When New Relic's system returns an email message, select the link in it to confirm your account again.
+    2. Select **Forgot your password** and complete those steps. 
 
-    If you don't receive an email from New Relic:
-
-    * Check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist). If applicable, [add New Relic to your email allow list](/docs/accounts/accounts/account-maintenance/account-email-settings#email-whitelist).
-    * Get support at [support.newrelic.com](https://support.newrelic.com).
+    If you don't receive an email, check your [spam filters](/docs/accounts-partnerships/accounts/account-setup/create-your-new-relic-account#email-whitelist). If applicable, [add New Relic to your email allow list](/docs/accounts/accounts/account-maintenance/account-email-settings#email-whitelist). If you need more help, get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser
@@ -121,10 +104,18 @@ See [Multiple logins found](/docs/accounts/accounts-billing/account-setup/multip
   </Collapser>
 
   <Collapser
+    id="social-login"
+    title="Social login (Google, GitHub) email issues"
+  >
+    You can sign up and log into New Relic via several third-party [social login options](/docs/accounts/accounts-billing/account-setup/login-options), including Google and GitHub. Because our social login feature works based on your email address, if you change your email address in the third-party service, or in New Relic (or in our associated products Pixie or Codestream) that will break the associated New Relic social login. 
+
+  </Collapser>
+
+  <Collapser
     id="account-exists"
     title="Received message email already exists"
   >
-    If you're trying to create a new account and receive a message that your email already exists, get support at [support.newrelic.com](https://support.newrelic.com).
+    If you're trying to create a new New Relic organization and receive a message that your email already exists, get support at [support.newrelic.com](https://support.newrelic.com).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -46,7 +46,6 @@ Some user management requirements and restrictions:
   * Most user management capabilities require the organization- and authentication domain-related [administration settings](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#admin-settings). 
 * To avoid configuration conflicts, try to ensure that only one person in your organization is managing users at a time.
 
-
 ## User management UI [#user-mgmt]
 
 Here's a screenshot of the **User management** UI. We'll explain the column headers below. 


### PR DESCRIPTION
New option for creating NR org or logging in via GitHub, alongside Google options. Along with this, we wanted to document some caveats for social login, which we added to the login troubleshooting doc. 