### PR TITLE
PUBLISH: 7/18; Release notes: Create AWS-polling-to-AWS-CW-MetricStreams-Migration

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/AWS-polling-to-AWS-CW-MetricStreams-Migration
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/AWS-polling-to-AWS-CW-MetricStreams-Migration
@@ -1,0 +1,9 @@
+---
+title: Migration from AWS Polling integration to AWS Cloudwatch Metric Streams integration is available
+subject: Cloud integrations
+releaseDate: '2023-07-14'
+---
+
+## New
+
+* Seamless Migration from AWS Polling integration to AWS Cloudwatch Metric Streams integration is now available! You can migrate from Polling to Cloudwatch metric streams to collect and monitor AWS metrics by clicking on the "Migrate to AWS Cloudwatch Metric Streams" . Check out the [documentation](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/#migrating-from-poll-integrations) for more information.

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/AWS-polling-to-AWS-CW-MetricStreams-Migration
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/AWS-polling-to-AWS-CW-MetricStreams-Migration
@@ -1,9 +1,9 @@
 ---
-title: Migration from AWS Polling integration to AWS Cloudwatch Metric Streams integration is available
+title: Migration from AWS polling integration to AWS Cloudwatch Metric Streams integration is available
 subject: Cloud integrations
-releaseDate: '2023-07-14'
+releaseDate: '2023-07-17'
 ---
 
 ## New
 
-* Seamless Migration from AWS Polling integration to AWS Cloudwatch Metric Streams integration is now available! You can migrate from Polling to Cloudwatch metric streams to collect and monitor AWS metrics by clicking on the "Migrate to AWS Cloudwatch Metric Streams" . Check out the [documentation](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/#migrating-from-poll-integrations) for more information.
+* Seamless migration from AWS polling integration to AWS Cloudwatch Metric Streams integration is now available! You can migrate from polling to Cloudwatch metric streams by clicking on "Migrate to AWS Cloudwatch Metric Streams". For more information, see [the documentation](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/#migrating-from-poll-integrations).


### PR DESCRIPTION
This is the new feature for migrating AWS Polling integrations to AWS Cloudwatch Metric Streams through a migrate button which replicates AWS Polling namespaces for Cloudwatch Metric Streams through a customised CloudFormation Template

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.