### PR TITLE
fix(APM): Removed Explorer option from the all capabilities section

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-ui.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/external-services/external-services-ui.mdx
@@ -17,10 +17,7 @@ The UI for external services is a great place to analyze a single service along 
 
 ## How to find the external services feature [#where-externals]
 
-The external services feature is available from the left navigation pane once you select a service in Explorer. Do one of the following:
-
-* New Relic Explorer: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > (select an app) > Monitor > External services**.
-* APM: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > External services**.
+The external services feature is available from the left navigation pane once you select a service in Explorer. You can open it by going to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & Services**. Then, click your app and, under the **Monitor** section, click **External services**.
 
 ## The external services map [#use-the-map]
 

--- a/src/content/docs/apm/apm-ui-pages/monitoring/view-slow-query-details.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/view-slow-query-details.mdx
@@ -37,9 +37,7 @@ When [transaction traces](/docs/apm/transactions/transaction-traces/introduction
 
 To see your slow query data:
 
-1. Do one of the following:
-   * New Relic Explorer: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > (select an app) > Monitor > Databases**.
-   * APM: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > Databases**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & Services**. Then, click your app and, under the **Monitor** section, click **Databases**.
 2. Select a database transaction.
 3. If available, select any available [slow queries](#slowsql_details) listed on the page.
 

--- a/src/content/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions.mdx
+++ b/src/content/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions.mdx
@@ -143,8 +143,7 @@ To create new non-web transactions, follow the procedures for your APM language 
 
 ## View non-web transactions [#ui]
 
-To view non-web transaction data in the New Relic UI, go to the main chart on the following pages, and then select the **Non-web** option in the dropdown:
+To view non-web transaction data in the New Relic UI, go to the main chart on the following pages, and then select the **Non-web** option in the transaction type dropdown:
 
-* New Relic Explorer: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > (select an app) > Summary**.
-* APM: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Summary**.
-* Transactions: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > Transactions**.
+* APM: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & services** > (select an app) > **Summary**.
+* Transactions: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & Services**. Then, click your app and, under the **Monitor** section, click **Transactions**.

--- a/src/content/docs/apm/transactions/transaction-traces/introduction-transaction-traces.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/introduction-transaction-traces.mdx
@@ -80,10 +80,8 @@ To configure or edit trace settings, see the procedures for:
 
 To view transaction traces:
 
-1. Do one of the following:
-   * New Relic Explorer: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > (select an app) > Monitor > Transactions**.
-   * APM: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > Transactions**.
-2. In the **Transaction traces** section, click transaction traces to view [additional details](/docs/apm/transactions/transaction-traces/transaction-traces-summary-page).
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** > **APM & Services**. Then, click your app and, under the **Monitor** section, click **Transactions**.
+2. In the **Transaction traces** section, click a transaction trace to view [additional details](/docs/apm/transactions/transaction-traces/transaction-traces-summary-page).
 
 ## Examine logs for trace details [#logs-context]
 

--- a/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/full-stack-observability/synthetic-monitoring-best-practices-guide.mdx
@@ -75,7 +75,7 @@ To get quickly discover failing monitors, you can use the [index of synthetic mo
   >
     To view a list of monitors::
 
-    Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > Synthetic monitors**.
+    Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)** >  **Synthetic Monitoring**.
 
     For more information, see the documentation about [navigating core UI components](/docs/new-relic-one/use-new-relic-one/get-started/new-relic-one-core-ui-components).
   </Collapser>


### PR DESCRIPTION
Because of a request in the #help-documentation channel, all mentions to `Go to [one.newrelic.com](https://one.newrelic.com/all-capabilities) > Explorer > ` have been removed or modified from the docs site.