### PR TITLE
Update UNTIL documentation text

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -739,7 +739,7 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
 
     The **default** value is **1 hour ago**.
 
-    Use the `SINCE` clause to define the beginning of a time range for the returned data. You can specify a time zone for the query but not for the results. NRQL results are based on your system time.
+    Use the `SINCE` clause to define the inclusive beginning of a time range for the returned data. You can specify a time zone for the query but not for the results. NRQL results are based on your system time.
 
     When using NRQL, you can set a UTC timestamp or a relative time range:
 
@@ -749,6 +749,8 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
       ```
     * We support the following relative time ranges: `YESTERDAY`, `TODAY`, `SUNDAY`, `MONDAY`, `TUESDAY`, `WEDNESDAY`, `THURSDAY`, `FRIDAY`, `SATURDAY`. For example, `SINCE YESTERDAY UNTIL NOW`.
     * We also support `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`. For these cases, you can combine `SINCE` with `THIS` or `LAST`. For instance, `SINCE LAST MONTH UNTIL THIS WEEK`. You can also include `AGO`, as in `SINCE 3 WEEKS AGO UNTIL 10 MINUTES AGO`.
+
+    See also: [UNTIL](#sel-until)
   </Collapser>
 
   <Collapser
@@ -875,10 +877,11 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
       ...
     ```
 
-    Use the `UNTIL` clause to define the end of the time range to query.
+    Use the `UNTIL` clause to define the end of the time range to query. The value is exclusive, meaning the time range will go to the specified instant in time, but not include it.
 
     The **default** value is **NOW**. Only use `UNTIL` to specify an end point other than the default.
 
+    See also: [SINCE](#sel-since)
     See [Use the time picker to adjust time settings](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) for detailed information and examples.
   </Collapser>
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -875,9 +875,9 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
       ...
     ```
 
-    The **default** value is **NOW**. Only use `UNTIL` to specify an end point other than the default.
+    Use the `UNTIL` clause to define the end of the time range to query.
 
-    Use the `UNTIL` clause to define the end of a time range across which to return data. Once a time range has been specified, the data will be preserved and can be reviewed after the time range has ended.
+    The **default** value is **NOW**. Only use `UNTIL` to specify an end point other than the default.
 
     See [Use the time picker to adjust time settings](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) for detailed information and examples.
   </Collapser>

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -882,6 +882,7 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
     The **default** value is **NOW**. Only use `UNTIL` to specify an end point other than the default.
 
     See also: [SINCE](#sel-since)
+    
     See [Use the time picker to adjust time settings](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker) for detailed information and examples.
   </Collapser>
 


### PR DESCRIPTION
The old text was a bit confusing, and could lead some to believe querying with an UNTIL clause would change the retention of the queried data. This shortened description simply describes what the UNTIL clause does.

This also moves the default value reference below the general description.  

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.