### PR TITLE
add deprecated next to suggested responder

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/custom-variables-incident-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/custom-variables-incident-workflows.mdx
@@ -424,7 +424,7 @@ Here are the workflow variables and their descriptions:
       </td>
 
       <td>
-        A list of New Relic applied intelligence machine learning suggested responders. [DEPRECATED]
+        (Deprecated) A list of New Relic applied intelligence machine learning suggested responders.
       </td>
     </tr>
 

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/custom-variables-incident-workflows.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/custom-variables-incident-workflows.mdx
@@ -424,7 +424,7 @@ Here are the workflow variables and their descriptions:
       </td>
 
       <td>
-        A list of New Relic applied intelligence machine learning suggested responders.
+        A list of New Relic applied intelligence machine learning suggested responders. [DEPRECATED]
       </td>
     </tr>
 


### PR DESCRIPTION
this feature has been disabled for "a long long time", though the editor still shows the variable

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.