### PR TITLE
fix(attribute-dictionary): apply alpha sort to attribute tables

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -189,15 +189,35 @@ const EventDefinition = memo(
     let filteredAttributes = [];
 
     if (searchedAttribute) {
-      filteredAttributes = event.attributes.filter(({ name }) =>
-        name.toLowerCase().includes(searchedAttribute.toLowerCase())
-      );
+      filteredAttributes = event.attributes
+        .filter(({ name }) =>
+          name.toLowerCase().includes(searchedAttribute.toLowerCase())
+        )
+        .sort((a, b) => {
+          const nameA = a.name.toUpperCase();
+          const nameB = b.name.toUpperCase();
+          if (nameA < nameB) return -1;
+          if (nameA > nameB) return 1;
+          return 0;
+        });
     } else if (filteredAttribute) {
-      filteredAttributes = event.attributes.filter(
-        ({ name }) => name === filteredAttribute
-      );
+      filteredAttributes = event.attributes
+        .filter(({ name }) => name === filteredAttribute)
+        .sort((a, b) => {
+          const nameA = a.name.toUpperCase();
+          const nameB = b.name.toUpperCase();
+          if (nameA < nameB) return -1;
+          if (nameA > nameB) return 1;
+          return 0;
+        });
     } else {
-      filteredAttributes = event.attributes;
+      filteredAttributes = event.attributes.sort((a, b) => {
+        const nameA = a.name.toUpperCase();
+        const nameB = b.name.toUpperCase();
+        if (nameA < nameB) return -1;
+        if (nameA > nameB) return 1;
+        return 0;
+      });
     }
 
     return (

--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -184,6 +184,14 @@ AttributeDictionary.propTypes = {
 
 const pluralize = (word, count) => (count === 1 ? word : `${word}s`);
 
+const sortAttributes = (a, b) => {
+  const nameA = a.name.toUpperCase();
+  const nameB = b.name.toUpperCase();
+  if (nameA < nameB) return -1;
+  if (nameA > nameB) return 1;
+  return 0;
+};
+
 const EventDefinition = memo(
   ({ location, event, searchedAttribute, filteredAttribute }) => {
     let filteredAttributes = [];
@@ -193,31 +201,13 @@ const EventDefinition = memo(
         .filter(({ name }) =>
           name.toLowerCase().includes(searchedAttribute.toLowerCase())
         )
-        .sort((a, b) => {
-          const nameA = a.name.toUpperCase();
-          const nameB = b.name.toUpperCase();
-          if (nameA < nameB) return -1;
-          if (nameA > nameB) return 1;
-          return 0;
-        });
+        .sort(sortAttributes);
     } else if (filteredAttribute) {
       filteredAttributes = event.attributes
         .filter(({ name }) => name === filteredAttribute)
-        .sort((a, b) => {
-          const nameA = a.name.toUpperCase();
-          const nameB = b.name.toUpperCase();
-          if (nameA < nameB) return -1;
-          if (nameA > nameB) return 1;
-          return 0;
-        });
+        .sort(sortAttributes);
     } else {
-      filteredAttributes = event.attributes.sort((a, b) => {
-        const nameA = a.name.toUpperCase();
-        const nameB = b.name.toUpperCase();
-        if (nameA < nameB) return -1;
-        if (nameA > nameB) return 1;
-        return 0;
-      });
+      filteredAttributes = event.attributes.sort(sortAttributes);
     }
 
     return (


### PR DESCRIPTION
## Description

Sort each event's table by attribute name in alph order.

## Screenshot(s)
**Before**
![2023-07-13_14-52-21](https://github.com/newrelic/docs-website/assets/2952843/abe9f40f-cb07-4363-b8d4-61342928b277)

**After**
![2023-07-13_14-52-37](https://github.com/newrelic/docs-website/assets/2952843/e16b5238-60a4-4ce9-b308-c7fa5f08f6a2)

