### PR TITLE
Security Data API: Correct curl command to make it runnable

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/security-data-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/security-data-api.mdx
@@ -24,32 +24,32 @@ Here's an example POST request. We'll take a look at individual components in th
 
 ```
 curl -X POST https://security-api.newrelic.com/security/v1 \
-   -H “Content-Type: application/json” \
-   -H “Api-Key: <New Relic License Key>” \
-   -d '{"findings": [
-     {
-       "source": "Security Tool Name",
-       "title": "Short description of issue",
-       "message": "Long form description of the security issue including remediaton advice",
-       "issueType": "Library Vulnerability",
-       "issueId": "Well-known vulnerability identifier like CVE, CWE, CIS, etc.",
-       "issueVendorId": "Vendor-specific identifier if different from issueId",
-       "issueInstanceKey": "unique_path_to_this_instance_of_the_issue",
-       "disclosureUrl": "https://url/link/for/more/information",
-       "severity": "CRITICAL",
-       "remediationExists": true,
-       "remediationRecommendation": "upgrade TheComponent to 1.2.3",
-       "detectedAt": "1665610506000",
-       "entityType": "Host|Service|Repository|...",
-       "entityLookupValue": "a.hostname.com",
-       "entityGuid": "ABCDEFGH",
-       "customFields": {
-         "sourceDetailInfo": "DecadeCoffee",
-         ...
-       }
-     },
-     ...
-   ]}'
+  -H "Content-Type: application/json" \
+  -H "Api-Key: ${{ state.licenseKey.key }}" \
+  -d '{
+    "findings": [
+        {
+            "source": "Insert security tool name, such as Snyk",
+            "title": "Insert a short description of security issue",
+            "message": "Insert long description and remediation advice",
+            "issueType": "Insert Library|Container|Host Vulnerability",
+            "issueId": "Insert vulnerability identifier like CVE, CWE, CIS, etc.",
+            "issueVendorId": "Vendor-specific identifier if different from issueId",
+            "issueInstanceKey": "Insert the unique path to this instance of the issue",
+            "disclosureUrl": "Insert a URL to additional information on the issue",
+            "severity": "Insert CRITICAL|HIGH|MEDIUM|LOW|INFO",
+            "remediationExists": Insert boolean true | false (no quotation marks),
+            "remediationRecommendation": "Explain the action to take",
+            "detectedAt": "Insert timestamp when detected, in milliseconds since epoch",
+            "entityType": "Insert Host|Service|Repository|Image|AWS",
+            "entityLookupValue": "Insert a URL to find entity",
+            "entityGuid": "ABCDEFG",
+            "customFields": {
+                "sourceDetailInfo": "DecadeCoffee"
+            }
+        }
+    ]
+}'
 ```
 
 ## URL Parameters [#url-params]

--- a/src/content/docs/data-apis/ingest-apis/security-data-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/security-data-api.mdx
@@ -25,7 +25,7 @@ Here's an example POST request. We'll take a look at individual components in th
 ```
 curl -X POST https://security-api.newrelic.com/security/v1 \
   -H "Content-Type: application/json" \
-  -H "Api-Key: ${{ state.licenseKey.key }}" \
+  -H "Api-Key: INSERT_YOUR_API_KEY " \
   -d '{
     "findings": [
         {


### PR DESCRIPTION
The curl command to send data to the Security Data API had some formatting issues that prevented it from executing. I got some help from an SME to correct this. I used the version that's being placed in the Marketplace UI, so the prompts are slightly different than the original.

I've tested this on my own account. 