### PR TITLE
fix: CORECLR_ENABLE_PROFILING env var for Core apps

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/debugging-agent-azure.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/debugging-agent-azure.mdx
@@ -79,15 +79,15 @@ These examples all assume that your Azure Web App uses a `D:` file system root. 
 
   The environment variables that appear in the **Environment** tab in Kudu's **Process Explorer** should be similar to these:
 
-  ```env
+  ```ini
   COR_ENABLE_PROFILING = 1
   COR_PROFILER = {71DA0A04-7777-4EC6-9643-7D28B46A8A41}
   COR_PROFILER_PATH = D:\home\NewRelicAgent\Framework\NewRelic.Profiler.dll
   COR_PROFILER_PATH_32 = D:\home\NewRelicAgent\Framework\x86\NewRelic.Profiler.dll
   COR_PROFILER_PATH_64 = D:\home\NewRelicAgent\Framework\NewRelic.Profiler.dll
   NEWRELIC_HOME = D:\home\NewRelicAgent\Framework
-  NEW_RELIC_LICENSE_KEY = insert_ingest_license_key_here
-  NEW_RELIC_APP_NAME = insert_app_name_here
+  NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
+  NEW_RELIC_APP_NAME = YOUR_APP_NAME
   ```
 
   If the environment variables don't match what you see above, try re-installing the New Relic Azure Site extension.
@@ -109,13 +109,13 @@ These examples all assume that your Azure Web App uses a `D:` file system root. 
 
   The environment variables that appear in the **Environment** tab in Kudu's **Process Explorer** should be similar to these:
 
-  ```env
+  ```ini
   COR_ENABLE_PROFILING = 1
   COR_PROFILER = {71DA0A04-7777-4EC6-9643-7D28B46A8A41}
   COR_PROFILER_PATH = D:\Home\site\wwwroot\newrelic\NewRelic.Profiler.dll
   NEWRELIC_HOME = D:\Home\site\wwwroot\newrelic
-  NEW_RELIC_LICENSE_KEY = insert_ingest_license_key_here
-  NEW_RELIC_APP_NAME = insert_app_name_here
+  NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
+  NEW_RELIC_APP_NAME = YOUR_APP_NAME
   ```
 
   If the environment variables don't match what you see above, you can try re-installing the New Relic Azure Site extension.
@@ -135,14 +135,14 @@ These examples all assume that your Azure Web App uses a `D:` file system root. 
 
   The environment variables that appear in the **Environment** tab in Kudu's **Process Explorer** should be similar to these:
 
-  ```env
+  ```ini
   CORECLR_ENABLE_PROFILING = 1
   CORECLR_PROFILER = {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
   CORECLR_NEWRELIC_HOME = D:\home\NewRelicAgent\Core
   CORECLR_PROFILER_PATH_32 = D:\home\NewRelicAgent\Core\x86\NewRelic.Profiler.dll
   CORECLR_PROFILER_PATH_64 = D:\home\NewRelicAgent\Core\NewRelic.Profiler.dll
-  NEW_RELIC_LICENSE_KEY = insert_ingest_license_key_here
-  NEW_RELIC_APP_NAME = insert_app_name_here
+  NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
+  NEW_RELIC_APP_NAME = YOUR_APP_NAME
   ```
 
   </Collapser>
@@ -154,14 +154,14 @@ These examples all assume that your Azure Web App uses a `D:` file system root. 
 
   For the NuGet package, the environment variables [must be added as application settings](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps/#nuget-install-net-core). The environment variables that appear in the **Environment** tab in Kudu's **Process Explorer** should be similar to these:
 
-  ```env
+  ```ini
   CORECLR_ENABLE_PROFILING = 1
   CORECLR_PROFILER = {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
   CORECLR_PROFILER_PATH_32 = D:\Home\site\wwwroot\newrelic\x86\NewRelic.Profiler.dll
   COR_PROFILER_PATH_64 = D:\Home\site\wwwroot\newrelic\NewRelic.Profiler.dll
   CORECLR_NEWRELIC_HOME = D:\Home\site\wwwroot\newrelic
-  NEW_RELIC_LICENSE_KEY = insert_ingest_license_key_here
-  NEW_RELIC_APP_NAME = insert_app_name_here
+  NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
+  NEW_RELIC_APP_NAME = YOUR_APP_NAME
   ```
 
   Ensure your `newrelic.config` file's log node includes a directory attribute. If Visual Studio prevents you from editing the `newrelic.config` file that was added to your project by NuGet, you need to make a local copy of this in your application:
@@ -188,8 +188,8 @@ These examples all assume that your Azure Web App uses a `D:` file system root. 
   CORECLR_PROFILER = {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
   CORECLR_PROFILER_PATH = /home/site/wwwroot/newrelic/libNewRelicProfiler.so
   CORECLR_NEWRELIC_HOME = /home/site/wwwroot/newrelic
-  NEW_RELIC_LICENSE_KEY = insert_ingest_license_key_here
-  NEW_RELIC_APP_NAME = insert_app_name_here
+  NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
+  NEW_RELIC_APP_NAME = YOUR_APP_NAME
   ```
 
   Ensure your `newrelic.config` file's **log** node includes a directory attribute. If Visual Studio prevents you from editing the `newrelic.config` file that was added to your project by NuGet, you need to make a local copy of this in your application:

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -40,7 +40,7 @@ There is a set of three environment variables used to tell the .NET runtime whet
 
 Typical values:
 
-```
+```ini
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll"
@@ -56,7 +56,7 @@ COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.P
 
 Typical values:
 
-```
+```ini
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
 CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
@@ -118,7 +118,7 @@ The MSI installer installs both framework and Core versions of the agent side-by
 Assuming you don't specifiy a custom installation path when using the MSI installer, these are the correct environment variable values:
 
 ##### For .NET framework applications:
-```
+```ini
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll" # may not be necessary due to profiler being registered with the system
@@ -127,8 +127,8 @@ NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due t
 ```
 
 ##### For .NET Core applications:
-```
-CORCLR_ENABLE_PROFILING=1
+```ini
+CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netcore\NewRelic.Profiler.dll"
 NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
@@ -140,7 +140,7 @@ CORECLR_NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent"
 The ZIP archive of the agent for Windows contains both the framework and Core versions of the agent in side-by-side directories. Replace CUSTOM_AGENT_PATH with the path wherever you unzip the archive on your system.
 
 ##### For .NET framework applications:
-```
+```ini
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="CUSTOM_AGENT_PATH\netframework\NewRelic.Profiler.dll"
@@ -148,8 +148,8 @@ NEWRELIC_HOME="CUSTOM_AGENT_PATH\netframework"
 ```
 
 ##### For .NET Core applications:
-```
-CORCLR_ENABLE_PROFILING=1
+```ini
+CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="CUSTOM_AGENT_PATH\netcore\NewRelic.Profiler.dll"
 CORECLR_NEWRELIC_HOME="CUSTOM_AGENT_PATH\netcore"
@@ -159,8 +159,8 @@ CORECLR_NEWRELIC_HOME="CUSTOM_AGENT_PATH\netcore"
 
 The Linux install package (.deb or .rpm, as appropriate for your Linux distribution) installs the .NET Core agent. By default, it installs everything in `/usr/local/newrelic-dotnet-agent`.  
 
-```
-CORCLR_ENABLE_PROFILING=1
+```ini
+CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="/usr/local/newrelic-dotnet-agent"
@@ -173,7 +173,7 @@ There is also a `.tar.gz` archive of the agent for manual installation on Linux.
 When added to your application's project, the NewRelic.Agent NuGet package adds the agent to a `newrelic` subdirectory of your application. The correct version of the agent is added for .NET framework or .NET Core depending on the type of your application. The profilers for both Windows and Linux are added, including both 64- and 32-bit versions of the Windows profiler and x64 and arm64 versions of the Linux profiler. Using `<YOUR_APPLICATION_PATH>` as a placeholder for whever your application is deployed on the system, these are the correct environment variable values.
 
 ##### For .NET framework applications (64-bit):
-```
+```ini
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
@@ -181,7 +181,7 @@ NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
 ##### For .NET framework applications (32-bit):
-```
+```ini
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 COR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\x86\NewRelic.Profiler.dll"
@@ -189,24 +189,24 @@ NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
 ##### For .NET Core applications (Windows):
-```
-CORCLR_ENABLE_PROFILING=1
+```ini
+CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>\newrelic\NewRelic.Profiler.dll"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>\newrelic"
 ```
 
 ##### For .NET Core applications (Linux, x64):
-```
-CORCLR_ENABLE_PROFILING=1
+```ini
+CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
 
 ##### For .NET Core applications (Linux, arm64):
-```
-CORCLR_ENABLE_PROFILING=1
+```ini
+CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/linux-arm64/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/cocreateinstance-errors-no-profiler-log.mdx
@@ -82,7 +82,7 @@ To verify whether New Relic has the necessary permissions and resolve the proble
   >
     Verify that the `w3wp.exe` environment details are this:
 
-    ```
+    ```ini
     COR_ENABLE_PROFILING=1
     COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
     NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\
@@ -155,7 +155,7 @@ To verify whether New Relic has the necessary permissions and resolve the proble
           <td>
             To add permissions to `HKLM\SOFTWARE\New Relic` by using the PowerShell script:
 
-            ```
+            ```shell
             $key = "HKLM:\SOFTWARE\New Relic"
             $acl = Get-Acl $key
             $AddACL = New-Object System.Security.AccessControl.RegistryAccessRule ("Everyone","FullControl","ObjectInherit,ContainerInherit","None","Allow")

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-core-agent-linux.mdx
@@ -42,7 +42,7 @@ After installing New Relic's .NET agent in Linux, you don't see any data, notice
 
 In the console, execute the following, replacing `pid` with your process ID:
 
-```
+```bash
 sudo cat /proc/PID/maps | grep "libNewRelicProfiler.so"
 ```
 
@@ -55,7 +55,7 @@ Based on the output, here's what you need to do:
 
 Execute the following, replacing `PID` with your process ID.
 
-```
+```bash
 xargs --null --max-args=1 < /proc/PID/environ | grep "CORECLR_"
 ```
 
@@ -64,9 +64,9 @@ Based on the output, here's what you need to do:
 * If you get no results, set your [environment variables](https://discuss.newrelic.com/t/relic-solution-net-core-agent-required-environment-variables/68972), restart your application, and go back to Step 1.
 * If you get results, make sure all four required variables are set and have valid values:
   * `CORECLR_ENABLE_PROFILING`: Must always be set to 1.
-  * `CORECLR_PROFILER`: Must always be set to &#x7B;36032161-FFC0-4B61-B559-F6C5D41BAE5A}.
+  * `CORECLR_PROFILER`: Must always be set to `{36032161-FFC0-4B61-B559-F6C5D41BAE5A}`.
   * `CORECLR_NEWRELIC_HOME`: Must be set to the fully qualified path to the agent directory for .NET Core (the directory where `newrelic.config`, `libNewRelicProfiler.so`, and the extensions directory are located).
-  * `CORECLR_PROFILER_PATH`: Must be set to the fully qualified path to the file `libNewRelicProfiler.so`. This is almost always equal to `CORECLR_NEWRELIC_HOME + /libNewRelicProfiler.so`.
+  * `CORECLR_PROFILER_PATH`: Must be set to the fully qualified path to the file `libNewRelicProfiler.so`. This is almost always equal to `CORECLR_NEWRELIC_HOME` + `/libNewRelicProfiler.so`.
 * If you made any changes to your environment variables, restart your app and go back to [Step 1](#step-one).
 
 For more details on these variables please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-windows.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/debugging-net-windows.mdx
@@ -80,7 +80,7 @@ If the correct variables are set and the application you're trying to monitor ha
 
 Assuming you installed the agent using the .msi installer, the environment variables that appear in the environment tab should be similar to these:
 
-```
+```ini
 COR_ENABLE_PROFILING = 1
 COR_PROFILER = {71DA0A04-7777-4EC6-9643-7D28B46A8A41}
 NEWRELIC_INSTALL_PATH = C:\Program Files\New Relic\.NET Agent
@@ -115,7 +115,7 @@ If your application does not use one of those compatible app frameworks, you may
 
 Assuming you installed the agent using the .msi installer, the environment variables that appear in the environment tab should be similar to these:
 
-```
+```ini
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
 NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\
@@ -136,7 +136,7 @@ If your application does not use one of those compatible app frameworks, you may
 
 If the application you want to monitor is not hosted in IIS (such as a self-hosted Windows service), you must configure your application to be monitored by setting the following environment variable:
 
-```cs
+```ini
 CORECLR_ENABLE_PROFILING=1
 ```
 

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/lock-contention-appdomain-getdata.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/lock-contention-appdomain-getdata.mdx
@@ -16,7 +16,7 @@ When the .NET agent is attached to high throughput **.NET Framework** applicatio
 
 In [version 9.7 of the .NET agent](/docs/release-notes/agent-release-notes/net-release-notes), a new environment variable was introduced that disables the use of `AppDomain` storage by the .NET agent:
 
-```
+```ini
 NEW_RELIC_DISABLE_APPDOMAIN_CACHING=true
 ```
 

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -33,7 +33,7 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
     2. To find your app's process, right-click the app, then select **Properties > Environment**.
     3. Verify that the New Relic CLSID and environment variables are included in the `w3wp.exe`, `service`, or `non-IIS app` environment details:
 
-       ```
+       ```ini
        COR_ENABLE_PROFILING=1
        COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
        NEWRELIC_INSTALL_PATH=path\to\agent\directory


### PR DESCRIPTION
I added some syntax highlighting to other docs while I was at it