### PR TITLE
fix nav collapser div covering content

### DIFF
--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -76,7 +76,12 @@ const MainLayout = ({ children, pageContext }) => {
         padding: 1.5rem 0;
         position: sticky;
         top: var(--global-header-height);
+        width: 0;
         z-index: 1;
+
+        @media (max-width: 760px) {
+          display: none;
+        }
       `}
     >
       <Button
@@ -87,10 +92,6 @@ const MainLayout = ({ children, pageContext }) => {
           padding: 0;
           border-radius: 50%;
           transition: 300ms translate ease;
-
-          @media (max-width: 760px) {
-            display: none;
-          }
 
           ${!sidebar && `translate: calc(var(--sidebar-width) / 4);`}
 

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -82,6 +82,10 @@ const MainLayout = ({ children, pageContext }) => {
         @media (max-width: 760px) {
           display: none;
         }
+
+        @media (max-width: 1240px) {
+          left: 208px;
+        }
       `}
     >
       <Button


### PR DESCRIPTION
on mobile, the div was covering the entire screen,
making the site unusable.
on desktop, the div had a fairly wide width that was preventing
clicks on anything under it, either in the nav or on the page

this fix hides it completely on mobile and makes the width 0px
on desktop, which doesn't cover anything underneath