### PR TITLE
feat: otel host monitoring updates

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -53,6 +53,8 @@ Here is a sample configuration YAML file for a linux host. Be sure to do the fol
 
 * Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
 * Replace `YOUR_KEY_HERE` with your <InlinePopover type="licenseKey" />
+* Adjust the target log files in the filelog receiver section based on your requirements.
+* Adjust the `memory_limiter` default values based on your environment requirements.
 
 ```yaml
 extensions:
@@ -162,7 +164,7 @@ You can view your collector data in a variety of places in the New Relic UI.
 
 ### Browse host data in infrastructure UI [#using-ui]
 
-By using the recommended configuration in the collector, you can view data through the standard features in the [Infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities#access-new-ui) (New Host UI) experience.
+By using the recommended configuration in the collector, you can view data through the standard features in the [Infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities#access-new-ui) experience.
 
 ### Query host metrics and logs [#query-host-metrics]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -162,11 +162,11 @@ You can view your collector data in a variety of places in the New Relic UI.
 
 ### Browse host data in infrastructure UI [#using-ui]
 
-By using the recommended configuration for the host receiver, you can view data through the standard features in the [Infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities#access-new-ui) (New Host UI) experience.
+By using the recommended configuration in the collector, you can view data through the standard features in the [Infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities#access-new-ui) (New Host UI) experience.
 
-### Query host metrics [#query-host-metrics]
+### Query host metrics and logs [#query-host-metrics]
 
-Once metrics are successfully ingested in New Relic, they are available in [metrics and events](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer) and [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder).
+Once telemetry is successfully ingested in New Relic, they are available in [metrics and events](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer) and [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder).
 
 The following NRQL queries show examples to help you explore the metrics you received:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -52,7 +52,7 @@ Learn more about available metrics and advanced configurations from the [OpenTel
 Here is a sample configuration YAML file for a linux host. Be sure to do the following:
 
 * Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
-* Replace `YOUR_KEY_HERE` with your <InlinePopover type="licenseKey" />
+* Replace `YOUR_KEY_HERE` with your <InlinePopover type="licenseKey" />.
 * Adjust the target log files in the filelog receiver section based on your requirements.
 * Adjust the `memory_limiter` default values based on your environment requirements.
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -7,7 +7,8 @@ tags:
 metaDescription: The OpenTelemetry Collector is a central tool to collect, process, and export your telemetry.
 ---
 
-You can collect metrics about your infrastructure hosts with OpenTelemetry if you set up the host receiver in a  collector. The collector is a component of OpenTelemetry that collects, processes, and exports telemetry data to New Relic (or any observability backend).
+You can collect metrics and logs from your infrastructure hosts with OpenTelemetry and leverage the same infrastructure experiences that are available for New Relic agents.
+Specific receivers and processors are required in the OTel collector to collect and report host telemetry.
 
 If you're looking for help with other collector use cases, see the [newrelic-opentelemetry-examples](https://github.com/newrelic/newrelic-opentelemetry-examples) repository.
 
@@ -33,11 +34,13 @@ Your deployment experience might vary depending on which vendor-specific distrib
   To set up infrastructure monitoring, you need to install and configure components that are included in the `collector-contrib` release. For example, the host receiver is required to collect basic host metrics such as CPU, memory, disk, and network stats and is only available in the [OpenTelemetry Collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) release.
 </Callout>
 
-## Step 3: Configure host monitoring using the host receiver [#host-receiver]
+## Step 3: Configure host metrics and logs [#host-receiver]
 
 This collector example is meant to serve as a starting point from which you can extend, customize, and validate configurations before using them in production.
 
-The `collector-contrib` release provides a `hostreceiver` that generates metrics about the system scraped from various sources. Deploy the collector as an agent when you use a `hostreceiver`.
+The `collector-contrib` release includes:
+* The `hostreceiver` that generates metrics about the system scraped from various sources. Deploy the collector as an agent when you use a `hostreceiver`.
+* The `filelogreceiver` that tails and parses logs from files.
 
 When using the host receiver as part of the collector configuration, New Relic automatically detects host metrics as part of a `Host` entity and will synthesize its golden metrics providing the same experience as with the New Relic infrastructure agent. The following are the configuration requirements to enable the `Host` entity experience in New Relic UI:
 
@@ -46,113 +49,10 @@ When using the host receiver as part of the collector configuration, New Relic a
 
 Learn more about available metrics and advanced configurations from the [OpenTelemetry documentation in GitHub](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver).
 
-Adapt the `config.yaml` with these recommended parameters:
+Here is a sample configuration YAML file for a linux host. Be sure to do the following:
 
-<Callout variant="important">
-  CPU, load, memory, and disk utilization metrics require otelcol-contrib release `v0.47.0` or greater.
-</Callout>
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "290px" }}>
-        Configuration
-      </th>
-
-      <th>
-        Description
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        `receivers::hostmetrics`
-      </td>
-
-      <td>
-        Enable host metrics.
-
-        * A 20 second interval is recommended (same default as the Infrastructure agent).
-        * It should not be greater than 60 seconds to avoid issues with “host not responding” alerts.
-        * Process instrumentation is optional.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `processors::resourcedetection`
-      </td>
-
-      <td>
-        Keep the following in mind:
-
-        * `env`: Reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` environment variable.
-        * `system`: Adds `host.name` and `os.type`.
-        * For cloud environments, configure a specific resource detection processor so that metrics are decorated with `host.id` (required to identify the host entity in New Relic). Common cloud detectors are `gce` for GCP machines, `ec2` for AWS EC2, and `azure` for Azure VMs. Additional processors are available for orchestrated environments.
-        * For on-premises systems (or unsupported cloud environments), a `host.id` attribute is required. Use the `resource` processor to copy the `host.name` value (from `system`) as a new `host.id` attribute. Note this value should be unique across all instrumented hosts:
-          ```yaml
-          resource:
-              attributes:
-                - key: host.id
-                  from_attribute: host.name
-                  action: upsert
-          ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `processors::batch`
-      </td>
-
-      <td>
-        The [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md) accepts spans, metrics, or logs and places them into batches. Batching helps better compress the data and reduce the number of outgoing connections required to transmit the data. This processor supports both size and time based batching.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `processors::memory_limiter`
-      </td>
-
-      <td>
-        The [memory limiter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/memorylimiterprocessor) processor is used to prevent out of memory situations on the collector.
-
-        Putting checks in place is important because:
-
-        * The amount and type of data the collector processes is specific to its environment.
-        * The collector's resource utilization is dependent on the configured processors.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `processors::cumulative_delta`
-      </td>
-
-      <td>
-        The [cumulative delta](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor) processor converts cumulative sum metrics to cumulative delta. This helps you query system metric rates more easily in New Relic.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `service::pipelines::metrics`
-      </td>
-
-      <td>
-        Make sure `hostreceiver` and `resourcedetection` are included.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-Here is a sample configuration YAML file. Be sure to do the following:
-
-* Replace OTLP_ENDPOINT_HERE with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
-* Replace YOUR_KEY_HERE with your <InlinePopover type="licenseKey" />
+* Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
+* Replace `YOUR_KEY_HERE` with your <InlinePopover type="licenseKey" />
 
 ```yaml
 extensions:
@@ -183,29 +83,51 @@ receivers:
             enabled: true
       processes:
       process:
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.cpu.time:
+            enabled: false
+
+  filelog:
+    include:
+      - /var/log/alternatives.log
+      - /var/log/cloud-init.log
+      - /var/log/auth.log
+      - /var/log/dpkg.log
+      - /var/log/syslog
+      - /var/log/messages
+      - /var/log/secure
+      - /var/log/yum.log
 
 processors:
+  
+  transform/truncate:
+    trace_statements:
+      - context: span
+        statements:
+          - truncate_all(attributes, 4095)
+          - truncate_all(resource.attributes, 4095)
+    log_statements:
+      - context: log
+        statements:
+          - truncate_all(attributes, 4095)
+          - truncate_all(resource.attributes, 4095)
+
   memory_limiter:
     check_interval: 1s
     limit_mib: 1000
     spike_limit_mib: 200
+  
   batch:
-  cumulativetodelta:
-    include:
-      metrics:
-        - system.network.io
-        - system.disk.operations
-        - system.network.dropped
-        - system.network.packets
-        - process.cpu.time
-      match_type: strict
-  resource:
-    attributes:
-      - key: host.id
-        from_attribute: host.name
-        action: upsert
+  
   resourcedetection:
     detectors: [env, system]
+  
+  resourcedetection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: false
 
 exporters:
   otlp:
@@ -215,10 +137,21 @@ exporters:
 
 service:
   pipelines:
+    
     metrics:
       receivers: [hostmetrics]
-      processors: [batch, resourcedetection, resource, cumulativetodelta]
-      exporters: [otlp]
+      processors: [memory_limiter, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [logging, otlp]
+    
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [logging, otlp]
+    
+    logs:
+      receivers: [otlp, filelog]
+      processors: [memory_limiter, transform/truncate, resourcedetection, resourcedetection/cloud, batch]
+      exporters: [logging, otlp]
 
   extensions: [health_check]
 ```
@@ -253,6 +186,11 @@ The following NRQL queries show examples to help you explore the metrics you rec
 
   ```sql
   SELECT keyset() FROM Metric WHERE metricName = 'system.disk.operations'
+  ```
+
+* Querying number of log events per host
+  ```sql
+  SELECT count(*) FROM Log FACET host.name TIMESERIES
   ```
 
 Learn more about [querying the metric data type](/docs/data-apis/understand-data/metric-data/query-metric-data-type).


### PR DESCRIPTION
## Give us some context
Updating the config example and recommendations based on latest developments from the community:
* Adding example showing how to also capture host logs via filelogreceiver (linux)
* Removing the table with recommendations that are almost all included in the default config now.
* Removing callouts related to older versions of the collector.