### PR TITLE
Update opentelemetry-tutorial-java.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -1023,7 +1023,7 @@ This is a list of the environment variables you should export if you're doing tu
         </tr>
         <tr>
           <td>
-            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=EXPONENTIAL_BUCKET_HISTOGRAM
+            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM
 
             * (Recommended) Histogram aggregation: Use exponential histogram instead of default explicit bucket histogram for better data compression.
           </td>


### PR DESCRIPTION
Fix environment variable note for `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=BASE2_EXPONENTIAL_BUCKET_HISTOGRAM`

This environment variable was changed here: https://github.com/open-telemetry/opentelemetry-java/pull/5143