### PR TITLE
feat(style): add label syntax + style guide structure edits

### DIFF
--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-edit-content.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create and edit content
+title: Create and edit docs
 contentType: page
 template: basicDoc
 topics:

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure.mdx
@@ -1,5 +1,5 @@
 ---
-title: Understand and edit the docs site structure 
+title: Frontmatter and page templates
 redirects: 
   - /docs/style-guide/processes-procedures/include-a-doc-in-multiple-menus
   - /docs/style-guide/processes-procedures/update-left-navigation-pane
@@ -161,6 +161,12 @@ Here are important elements of the nav file:
         </p>
       </td>
     </tr>
+
+<tr>
+  <td>`label`</td>  
+  <td>no</td>
+  <td>Creates a label next to the title. Useful for tutorials. </td>
+ </tr>
 
     <tr>
       <td>

--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -93,23 +93,21 @@ pages:
             path: /docs/style-guide/writing-strategies/install-docs-guidance
           - title: Docs site mechanics
             pages:
-              - title: Understand and edit docs structure
+              - title: Edit the docs site structure and nav
                 path: /docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure
-              - title: Use content types and text formats
+              - title: Frontmatter and page templates
                 path: /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats
-              - title: Create and edit content
+              - title: Create and edit docs
                 path: /docs/style-guide/writing-docs/processes-procedures/create-edit-content
               - title: Create release notes
                 path: /docs/style-guide/writing-docs/processes-procedures/create-release-notes
-              - title: Edit checklist
-                path: /docs/style-guide/writing-docs/processes-procedures/docs-site-edit-checklist
               - title: Rename or redirect docs
                 path: /docs/style-guide/writing-docs/processes-procedures/rename-or-redirect-document
               - title: Delete a document
                 path: /docs/style-guide/writing-docs/processes-procedures/delete-document
               - title: Update the home page
                 path: /docs/style-guide/writing-docs/processes-procedures/edit-homepage
-              - title: Create preview content
+              - title: Using the preview site
                 path: /docs/style-guide/writing-docs/processes-procedures/create-preview-document
           - title: Tech writer processes
             pages:
@@ -133,6 +131,8 @@ pages:
                 path: /docs/style-guide/writing-docs/writer-workflow/github-history
               - title: Swiftype internal search
                 path: /docs/style-guide/writing-docs/writer-workflow/swiftype-search
+              - title: Edit checklist
+                path: /docs/style-guide/writing-docs/processes-procedures/docs-site-edit-checklist
           - title: Doc types and templates
             pages:
               - title: Agent API guide template


### PR DESCRIPTION
Adds the syntax for left nav labels and rearranges some of the style guide nav. The style guide needs larger edits, but I think the nav edits make it a bit easier to find content and improve the titles by making them closer to the actual content of the doc. 