### PR TITLE
fix: Remove event query param for attribute dictionary link

### DIFF
--- a/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
+++ b/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
@@ -207,7 +207,7 @@ After you create a marker using GraphQL, you can use NRQL in the [query builder]
 Try these examples or create your own queries:
 
 <Callout variant="tip">
-  For details about the data structure and attribute definitions, see our [data dictionary](/attribute-dictionary/?dataSource=Change+tracking&event=Deployments).
+  For details about the data structure and attribute definitions, see our [data dictionary](/attribute-dictionary/?dataSource=Change+tracking).
 </Callout>
 
 <CollapserGroup>


### PR DESCRIPTION
Removes the event query param that was sending users to a blank attribute dictionary