### PR TITLE
Add max height on MDX images

### DIFF
--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -33,14 +33,14 @@ const defaultComponents = {
   a: (props) => <MDXLink {...props} displayExternalIcon />,
   img: ({
     alt = 'Docs site',
-    class: className,
+    className,
     src,
     style = {},
     title,
     variant,
     width,
   }) =>
-    console.log('className', className) || style || variant === 'TechTile' ? (
+    style || variant === 'TechTile' ? (
       <img
         width={width || 'inherit'}
         src={src}

--- a/src/components/MDXContainer.js
+++ b/src/components/MDXContainer.js
@@ -31,40 +31,38 @@ import WhatsNextTile from './WhatsNextTile';
 
 const defaultComponents = {
   a: (props) => <MDXLink {...props} displayExternalIcon />,
-  img: (props) =>
-    props.style || props.variant === 'TechTile' ? (
+  img: ({
+    alt = 'Docs site',
+    class: className,
+    src,
+    style = {},
+    title,
+    variant,
+    width,
+  }) =>
+    console.log('className', className) || style || variant === 'TechTile' ? (
       <img
-        width={props.width ? props.width : 'inherit'}
-        src={props.src}
-        alt={props.alt ? props.alt : 'Docs site'}
-        title={props.title}
-        style={
-          props.style
-            ? { ...props.style, margin: '0 0.25rem' }
-            : { margin: '0 0.25rem' }
-        }
+        width={width || 'inherit'}
+        src={src}
+        alt={alt}
+        title={title}
+        className={className}
+        style={{ ...style, margin: '0 0.25rem' }}
       />
     ) : (
       <Lightbox>
         <img
-          width={props.width ? props.width : 'auto'}
-          src={props.src}
-          alt={props.alt ? props.alt : 'Docs site'}
-          title={props.title}
-          style={
-            props.style
-              ? {
-                  ...props.style,
-                  borderRadius: '0.25rem',
-                  maxWidth: '100%',
-                  margin: '0 0.25rem',
-                }
-              : {
-                  borderRadius: '0.25rem',
-                  maxWidth: '100%',
-                  margin: '0 0.25rem',
-                }
-          }
+          width={width || 'auto'}
+          src={src}
+          alt={alt}
+          title={title}
+          className={className}
+          style={{
+            ...style,
+            borderRadius: '0.25rem',
+            maxWidth: '100%',
+            margin: '0 0.25rem',
+          }}
         />
       </Lightbox>
     ),


### PR DESCRIPTION
- small refactor on img props, including styling, in MDX Container

features added via theme update*:
- Add max height for MDX images at 550px
- Provides 'unbound' class  for `<img>` to unset this style

*Docs will be updated with these theme changes along with the upcoming upgrade to Gatsby v5