### PR TITLE
Update update-or-disable-policies-conditions.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
@@ -52,7 +52,7 @@ Here's a quick reference for maintaining conditions. This includes the condition
     4. Optional: Change the condition's name if necessary.
     5. Select **Save**.
 
-       By default, the copied condition will be added to the selected alert policy in a **Disabled** state. Follow standard procedures to [add](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) or copy additional conditions to the alert policy, and then [**Enable** the condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#condition-on-off) as needed.
+       By default, the copied condition will be added to the selected alert policy in a **Disabled** state. Follow standard procedures to [add](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) or copy additional conditions to the alert policy, and then [**Enable** the condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#condition-on-off) as needed. Additionally, any [tags](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-via-ui-api) added to the original condition will not be copied to the new condition.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
This update simply clarifies that copying a condition does not copy any tags that have been added to the original condition.