### PR TITLE
Added missing recipes on guided install page

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
@@ -135,6 +135,16 @@ The table below lists the integrations supported by the guided install CLI comma
 
     <tr>
       <td>
+        .NET
+      </td>
+
+      <td>
+        `newrelic install -n dotnet-agent-installer`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         ElasticSearch
       </td>
 
@@ -160,6 +170,26 @@ The table below lists the integrations supported by the guided install CLI comma
 
       <td>
         `newrelic install -n hashicorp-consul-open-source-integration`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Infrastructure agent
+      </td>
+
+      <td>
+        `newrelic install -n infrastructure-agent-installer`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Java
+      </td>
+
+      <td>
+        `newrelic install -n java-agent-installer`
       </td>
     </tr>
 
@@ -221,6 +251,26 @@ The table below lists the integrations supported by the guided install CLI comma
 
       <td>
         `newrelic install -n nginx-open-source-integration`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Node.JS
+      </td>
+
+      <td>
+        `newrelic install -n node-agent-installer`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        PHP
+      </td>
+
+      <td>
+        `newrelic install -n php-agent-installer`
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/new-relic-guided-install-overview.mdx
@@ -57,14 +57,14 @@ Customize and debug your installation with CLI flags. Use the "assume yes" flag 
 
 The New Relic guided install uses open source installation recipes to instrument on-host integrations. These recipes include installation and setup commands, information about logs, and metadata related to what’s being installed. They are written in YAML format for each type of system to be instrumented and have all of the installation details necessary to install the infrastructure agent for a specific integration. Additional information is available in our open source repo on [GitHub](https://github.com/newrelic/open-install-library/blob/main/docs/README.md).
 
-## On-host integration (OHI) recipes [#ohi-recipes]
+## Recipes [#recipes]
 
-The guided install automates the discovery, configuration, and installation of OHIs. However, there may be times when you want to instrument them one-by-one using the CLI install command.
+The guided install automates the discovery, configuration, and installation of New Relic agents and integrations. However, there may be times when you want to instrument them one-by-one using the CLI install command.
 
-To install any individual on-host integration, you would use a command similar to the following, which specifies the type of integration you want to install. This is the syntax for Linux:
+To install any individual agents and integrations, you would use a command similar to the following, which specifies the type of integration you want to install. This is the syntax for Linux:
 
 ```bash
-curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n INSERT_THE_INTEGRATION_NAME
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n INSERT_THE_RECIPE_NAME
 ```
 
 For example, to install the Apache integration:
@@ -85,9 +85,9 @@ This is the syntax for Windows:
   All other integrations are only supported on Linux.
 </Callout>
 
-Our open source integrations send performance metrics and inventory data from your servers and applications to the New Relic platform. You can view pre-built <InlinePopover type="dashboards" /> of your metric data, create alert policies, and create your own custom queries and charts.
+Our open source agent and integrations send performance metrics and inventory data from your servers and applications to the New Relic platform. You can view pre-built <InlinePopover type="dashboards" /> of your metric data, create alert policies, and create your own custom queries and charts.
 
-The table below lists the integrations supported by the guided install CLI command. The specific on-host integration commands are provided for your reference:
+The table below lists the agents and integrations supported by the guided install CLI command. The specific on-host integration commands are provided for your reference:
 
 <table>
   <thead>


### PR DESCRIPTION
Adds a couple of recipes and updates the text to match the new recipes. It used to be only on host integrations but now also contains some agents (infra, APM)