### PR TITLE
Update compare-rw-data-sent-billed-bytes.mdx

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/troubleshooting/compare-rw-data-sent-billed-bytes.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/troubleshooting/compare-rw-data-sent-billed-bytes.mdx
@@ -120,7 +120,7 @@ FROM Metric SELECT rate(bytecountestimate(), 1 minute) AS 'bytecountestimate()' 
 To monitor Prometheus bytes sent to New Relic:
 
 ```
-FROM Metric SELECT rate(sum(prometheus_remote_storage_samples_bytes_total), 1 minute)  AS 'Prometheus sent bytes rate' WHERE prometheus_server = INSERT_PROMETHEUS_SERVER_NAME SINCE 1 hour ago TIMESERIES  AUTO 
+FROM Metric SELECT rate(sum(prometheus_remote_storage_bytes_total), 1 minute)  AS 'Prometheus sent bytes rate' WHERE prometheus_server = INSERT_PROMETHEUS_SERVER_NAME SINCE 1 hour ago TIMESERIES  AUTO 
 ```
 
 ## External references [#references]


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The example query under the paragraph that starts with the text "To monitor Prometheus bytes sent to New Relic:" is incorrect as it references the outdated  "prometheus_remote_storage_samples_bytes_total" metric:
https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/troubleshooting/compare-rw-data-sent-billed-bytes/#nrql-queries


* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.