### PR TITLE
fix(usage dict): AWS guidance addition

### DIFF
--- a/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
+++ b/src/content/docs/style-guide/word-choice/usage-dictionary.mdx
@@ -76,7 +76,8 @@ For consistency across New Relic content, here are our general word usage guidel
   >
     * Generally referred to in conversation as `AWS`. Refer to `Amazon Web Services` in the first instance, then you may use `AWS` thereafter.
     * Amazon has a number of products like [Amazon EC2](https://aws.amazon.com/documentation-overview/ec2/) and [Amazon S3](https://aws.amazon.com/documentation-overview/s3/) that are almost always referred to by their abbreviated name, rather than the full name. You can abbreviate in the first instance if Amazon does.
-    * Some Amazon products use `Amazon` as the prefix (as in `Amazon EC2`), others `AWS` (as in `AWS Amplify`). Match the [AWS Documentation site](https://aws.amazon.com/documentation/).
+    * Some Amazon products use `Amazon` as the prefix (as in `Amazon EC2`), others `AWS` (as in `AWS Amplify`). Match the [AWS docs site](https://aws.amazon.com/documentation).
+    * Some Amazon product names also can be used in more informal ways to refer to data or configuration options. For example, for [AWS Metric Streams](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html), AWS formats that name in title case when referencing the product but, when referencing the data produced, they'll refer to it informally (for example, as `metric stream data` or `metric streams`). We should generally do what AWS does. 
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
A clarification in style guide about how we treat AWS product names that can also be used more informally. 