### PR TITLE
Remove sum's incorrect "ignored" argument reference

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2169,7 +2169,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
   >
     Use the `sum()` function to return the sum recorded values of a numeric attribute over the time range specified.
 
-    It takes a single argument. Arguments after the first will be ignored. If the attribute is not numeric, it will return a value of zero.
+    It takes a single argument. If the attribute is not numeric, it will return a value of zero.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -2446,7 +2446,7 @@ Note: `aparse()` is case-insensitive.
   >
     Use the `earliest()` function to return the earliest value for an attribute over the specified time range.
 
-    It takes a single argument. Arguments after the first will be ignored.
+    It takes a single argument.
 
     If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
 
@@ -2783,7 +2783,7 @@ Note: `aparse()` is case-insensitive.
   >
     Use the `latest()` function to return the most recent value for an attribute over a specified time range.
 
-    It takes a single argument. Arguments after the first will be ignored.
+    It takes a single argument.
 
     If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
 
@@ -2805,7 +2805,7 @@ Note: `aparse()` is case-insensitive.
   >
     Use the `length()` function to return the length of a string value or the number of elements in an array value.
 
-    It takes a single argument. Arguments after the first will be ignored.
+    It takes a single argument.
 
     <CollapserGroup>
       <Collapser title="Get the URL length from PageView">


### PR DESCRIPTION
Extra arguments on the sum() function will cause the query to fail. Removing the incorrect "Arguments after the first will be ignored." stement.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.