### PR TITLE
add: config option for 8T span resevoir

### DIFF
--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -37,7 +37,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        id="nuget-framework"
        title="Environment variables for monitoring .NET Framework applications"
      >
-       ```
+       ```ini
        COR_ENABLE_PROFILING=1
        COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
        COR_PROFILER_PATH=APP_DEPLOYMENT_DIRECTORY\newrelic\NewRelic.Profiler.dll
@@ -47,7 +47,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        ```
 
        <Callout variant="important">
-         To monitor 32-bit applications, COR_PROFILER_PATH should be set to APP_DEPLOYMENT_DIRECTORY\\newrelic\\x86\\NewRelic.Profiler.dll
+         To monitor 32-bit applications, `COR_PROFILER_PATH` should be set to `APP_DEPLOYMENT_DIRECTORY\newrelic\x86\NewRelic.Profiler.dll`
        </Callout>
 
        The <InlinePopover type="licenseKey" /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
@@ -57,7 +57,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        id="nuget-windows"
        title="Environment variables for monitoring .NET Core applications on Windows"
      >
-       ```
+       ```ini
        CORECLR_ENABLE_PROFILING=1
        CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
        CORECLR_PROFILER_PATH=APP_DEPLOYMENT_DIRECTORY\newrelic\NewRelic.Profiler.dll
@@ -67,7 +67,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        ```
 
        <Callout variant="important">
-         To monitor 32-bit applications, CORECLR_PROFILER_PATH should be set to APP_DEPLOYMENT_DIRECTORY\\newrelic\\x86\\NewRelic.Profiler.dll
+         To monitor 32-bit applications, `CORECLR_PROFILER_PATH` should be set to `APP_DEPLOYMENT_DIRECTORY\newrelic\x86\NewRelic.Profiler.dll`
        </Callout>
 
        The <InlinePopover type="licenseKey" /> and app name aren't required environment variables; they [can be set in other ways](/docs/agents/net-agent/installation/net-agent-install-resources#env-variables).
@@ -77,7 +77,7 @@ Here's an example of using NuGet via Visual Studio to install the .NET agent:
        id="nuget-linux"
        title="Environment variables for monitoring .NET Core applications on Linux"
      >
-       ```
+       ```ini
        CORECLR_ENABLE_PROFILING=1
        CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
        CORECLR_PROFILER_PATH=APP_DEPLOYMENT_DIRECTORY/newrelic/libNewRelicProfiler.so

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3888,7 +3888,51 @@ Additionally, distributed tracing must be [enabled](/docs/apm/agents/nodejs-agen
 
     For help getting a valid Infinite Tracing trace observer host entry, see [Find or create a trace observer endpoint](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer).
   </Collapser>
+
+<CollapserGroup>
+  <Collapser
+    id="infinite-tracing-queue-size"
+    title="span_events.queue_size"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Number
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_QUEUE_SIZE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The amount of infinite tracing spans the agent will hold in memory before dropping them. If the agent is dropping infinite tracing spans try increasing this number to `100000`.
+
+  </Collapser>
 </CollapserGroup>
+
 
 ## Application logging [#app-logging]
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3927,7 +3927,9 @@ Additionally, distributed tracing must be [enabled](/docs/apm/agents/nodejs-agen
       </tbody>
     </table>
 
-    The amount of infinite tracing spans the agent will hold in memory before dropping them. If the agent is dropping infinite tracing spans try increasing this number to `100000`.
+    The amount of infinite tracing spans the agent will hold in memory before dropping them. 
+
+    This setting should rarely need to changed from the default as the queue is not in use the majority of the time. The queue is in use only during reconnections to the infinite tracing endpoint while the agent is unable to stream data. It's possible the agent will drop infinite tracing spans during these periods, in that case increasing this number can help.
 
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3889,7 +3889,6 @@ Additionally, distributed tracing must be [enabled](/docs/apm/agents/nodejs-agen
     For help getting a valid Infinite Tracing trace observer host entry, see [Find or create a trace observer endpoint](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer).
   </Collapser>
 
-<CollapserGroup>
   <Collapser
     id="infinite-tracing-queue-size"
     title="span_events.queue_size"

--- a/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
+++ b/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
@@ -111,7 +111,7 @@ Here are some causes and solutions for missing trace data:
           </td>
 
           <td>
-            ```
+            ```ini
             NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_QUEUE_SIZE=100000
             ```
           </td>
@@ -151,7 +151,7 @@ Here are some causes and solutions for missing trace data:
           </td>
 
           <td>
-            ```
+            ```ini
             NEW_RELIC_INFINITE_TRACING_SPAN_QUEUE_SIZE = 100000
             ```
           </td>


### PR DESCRIPTION
Added info about an undocumented configuration option to set the amount of infinite tracing spans the agent will hold in memory before dropping them. [Other agents suggest setting this to 100k](https://docs.newrelic.com/docs/distributed-tracing/troubleshooting/missing-trace-data/#spans), so that's the number I used in this doc.

- https://github.com/newrelic/node-newrelic/blob/9be213963938ba9bbfac251ba594952a964631bc/lib/config/default.js#L1103-L1124

I'd like to include a maximum value and the time period for these queues (it might be 60 seconds or 5 seconds (12 times a minute), different agents send on different periods).

Maximum value seems to not be a regular number, but a payload size so I'm not sure I can add one. I'm requesting that the node team look this over to confirm my changes.