### PR TITLE
docs: Adding note that Logging parsing rules are unordered

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -89,7 +89,8 @@ Here's an overview of how New Relic implements parsing of logs:
       </td>
 
       <td>
-        * Parsing will only be applied once to each log message. If multiple parsing rules match the log, only the first that succeeds will be applied.
+        * Parsing will only be applied once to each log message. If multiple parsing rules match the log, only the first that succeeds will be applied. 
+        * Parsing rules are unordered. If more than one parsing rules matches a log, one is chosen at random. Be sure to build your parsing rules so that they do not match the same logs.
         * Parsing takes place during log ingestion, before data is written to NRDB. Once data has been written to storage, it can no longer be parsed.
         * Parsing occurs in the pipeline **before** data enrichments take place. Be careful when defining the matching criteria for a parsing rule. If the criteria is based on an attribute that doesn't exist until after parsing or enrichment take place, that data won't be present in the logs when matching occurs. As a result, no parsing will happen.
       </td>


### PR DESCRIPTION
Clarifying that log parsing rules are unordered.