### PR TITLE
Update networks doc  - improved organization

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -184,23 +184,23 @@ If your organization uses a firewall that restricts outbound traffic, follow the
   </tbody>
 </table>
 
-## Data ingest endpoints [#data-ingest]
+## New Relic endpoints [#data-ingest]
 
-This table contains endpoints for data ingested to New Relic accounts. For more detail about specific agents and integrations, keep reading below the ingest tables. 
-
-### US data center ingest endpoints [#us-ingest]
-
-These are the default ingest endpoints unless you're using our [EU data center region endpoints](#eu-endpoints). For port details, see [Ports](#ports).
+This table contains the primary endpoints for the ingest of data to New Relic, and other platform-related functionality. For more detail on specific agents and integrations, keep reading below the ingest table. For port details, see [Ports](#ports).
 
 <table>
   <thead>
     <tr>
-      <th style={{ width: "310px" }}>
-        Endpoint
+      <th>
+        Purpose
       </th>
 
-      <th>
-        Purpose and notes
+      <th style={{ width: "310px" }}>
+        US data center endpoint
+      </th>
+
+      <th style={{ width: "310px" }}>
+        EU data center endpoint
       </th>
     </tr>
   </thead>
@@ -208,286 +208,229 @@ These are the default ingest endpoints unless you're using our [EU data center r
   <tbody>
     <tr>
       <td>
-       `aws-api.newrelic.com`
-      </td>
-
-      <td>
-        [AWS Metric Streams ingest](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/).
+       **APM**
       </td>
     </tr>
-    <tr>
-      <td>
-       `bam.nr-data.net`
-      </td>
-
-      <td>
-        [Browser ingest](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring). Recommended browser endpoint.
-      </td>
-    </tr>
+    
 
     <tr>
       <td>
-       `bam-cell.nr-data.net`
-      </td>
-      <td>
-        [Browser ingest](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring). Available if needed for older US region accounts that use the copy/paste method for browser monitoring.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-       `cloud-collector.newrelic.com`
-      </td>
-
-      <td>
-        Ingest for [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration).   </td>
-    </tr>
-
-    <tr>
+        APM agent ingest      
+      </td>      
       <td>
        `collector*.newrelic.com`
       </td>
-
       <td>
-        APM agent ingest.      </td>
+       `collector*.eu.newrelic.com` </br>
+       `collector*.eu01.nr-data.net`
+       </td>
     </tr>
 
     <tr>
       <td>
-       `infra-api.newrelic.com`
-      </td>
-
-      <td>
-        [Infrastructure agent ingest](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring).</td>
-    </tr>
-
-    <tr>
-      <td>
-       `insights-collector.newrelic.com`
-      </td>
-
-      <td>
-        [Event API ingest](/docs/data-apis/ingest-apis/event-api/introduction-event-api).</td>
-    </tr>
-
-    <tr>
-      <td>
-       `log-api.newrelic.com`
-      </td>
-
-      <td>
-        Our [Log API](/docs/logs/log-api/introduction-log-api), used by various agents and integrations. </td>
-    </tr>
-
-    <tr>
-      <td>
-       `metric-api.newrelic.com`
-      </td>
-      <td>
-        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api) for dimensional metrics, used by various agents and integrations.</td>
-    </tr>
-
-    <tr>
-      <td>
-       `mobile-collector.newrelic.com`
-      </td>
-
-      <td>
-        [Mobile agent ingest](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring).</td>
-    </tr>
-
-    <tr>
-      <td>
-       `mobile-crash.newrelic.com`
-      </td>
-
-      <td>
-        [Mobile agent crash report ingest](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report).</td>
-    </tr>
-
-    <tr>
-      <td>
-       `otlp.nr-data.net`
-      </td>
-
-      <td>
-        [OpenTelemetry ingest](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction). Configure using the [quick start guide](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-get-started-intro) with your account license key in the `api-key` header.</td>
-    </tr>
-
-    <tr>
-      <td>
-       `trace-api.newrelic.com`
-      </td>
-
-      <td>
-        [Trace API ingest](/docs/distributed-tracing/trace-api/introduction-trace-api).</td>
-    </tr>
-  </tbody>
-</table>
-
-### EU data center ingest endpoints [#eu-ingest]
-
-Here are data ingest endpoints for our [EU data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center). For port details, see [Ports](#ports).
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "310px" }}>
-        Endpoint
-      </th>
-
-      <th>
-        Purpose and notes
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-       `aws-api.eu.newrelic.com`
-      </td>
-
-      <td>
-        [AWS Metric Streams ingest](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/).
+       **Browser**
       </td>
     </tr>
-    <tr>
-      <td>
-       `aws-api.eu01.nr-data.net`
-      </td>
 
-      <td>
-        [Cloud integrations ingest](/docs/infrastructure/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud).
-      </td>
-    </tr>    
     <tr>
+      <td>
+        [Browser ingest](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring)
+      </td>      
+      <td>
+       `bam.nr-data.net`
+      </td>
       <td>
        `bam.eu01.nr-data.net`
       </td>
+    </tr>
 
+   <tr>
       <td>
-        [Browser ingest](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring) (recommended for browser).
+       **Cloud integrations**
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [AWS Metric Streams ingest](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/).
+      </td>      
+      <td>
+       `aws-api.newrelic.com`
+      </td>
+      <td>
+       `aws-api.eu.newrelic.com`
       </td>
     </tr>
 
     <tr>
+      <td>
+        Ingest for [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration). </td>      
+      <td>
+       `cloud-collector.newrelic.com`
+      </td>
       <td>
        `cloud-collector.eu01.newrelic.com`
       </td>
-      <td>
-        Ingest for [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration).      </td>
     </tr>
+
 
     <tr>
       <td>
-       `collector*.eu.newrelic.com`
+       **Ingest APIs**
       </td>
-
-
-      <td>
-        APM agent ingest.      </td>
     </tr>
 
     <tr>
       <td>
-       `collector*.eu01.nr-data.net`
+        Our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api)
+      </td>      
+      <td>
+       `insights-collector.newrelic.com`
       </td>
-
-      <td>
-        APM agent ingest.  </td>
-    </tr>
-
-    <tr>
-      <td>
-       `eu01.nr-data.net`
-      </td>
-
-      <td>
-        [Browser ingest](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring).</td>
-    </tr>
-
-    <tr>
-      <td>
-       `infra-api.eu.newrelic.com`
-      </td>
-
-      <td>
-        [Infrastructure agent ingest](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring).</td>
-    </tr>
-
-    <tr>
-      <td>
-       `infra-api.eu01.nr-data.net`
-      </td>
-
-
-      <td>
-        [Infrastructure agent ingest](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring).</td>
-    </tr>
-    <tr>
       <td>
        `insights-collector.eu01.nr-data.net`
       </td>
-
-      <td>
-        [Event API ingest](/docs/data-apis/ingest-apis/event-api/introduction-event-api).</td>
     </tr>
 
+
     <tr>
+      <td>
+        Our [Log API](/docs/logs/log-api/introduction-log-api)</td>      
+      <td>
+       `log-api.newrelic.com`
+      </td>
       <td>
        `log-api.eu.newrelic.com`
-      </td>
-
-      <td>
-        Our [Log API](/docs/logs/log-api/introduction-log-api), used by various agents and integrations. </td>
+       </td>
     </tr>
 
     <tr>
+      <td>
+        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api)</td>      
+      <td>
+       `metric-api.newrelic.com`
+      </td>
+
       <td>
        `metric-api.eu.newrelic.com`
       </td>
-
-      <td>
-        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api) for dimensional metrics, used by various agents and integrations.</td>
     </tr>
 
     <tr>
+      <td>
+        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)</td>      
+      <td>
+       `trace-api.newrelic.com`
+      </td>
+      <td>
+       `trace-api.eu.newrelic.com`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+       **Infrastructure**
+      </td>
+    </tr>
+
+    <tr>
+    <td>
+      [Infrastructure agent ingest](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring)
+    </td>
+      <td>
+       `infra-api.newrelic.com`
+      </td>
+      <td>
+       `infra-api.eu.newrelic.com` </br>
+       `infra-api.eu01.nr-data.net`
+      </td>
+    </tr>
+
+    <tr>
+    <td>
+      Infrastructure entity registration
+    </td>
+    <td>
+      `identity-api.newrelic.com`
+    </td>
+    <td>
+      `identity-api.eu.newrelic.com`
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+      Infrastructure agent control
+    </td>
+      <td>
+       `infrastructure-command-api.newrelic.com`
+      </td>
+      <td>
+       `infrastructure-command-api.eu.newrelic.com`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+       **Mobile**
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Mobile agent ingest](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring)</td>    
+      <td>
+       `mobile-collector.newrelic.com`
+      </td>
       <td>
        `mobile-collector.eu01.nr-data.net`
       </td>
 
-      <td>
-        [Mobile agent ingest](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring).</td>
     </tr>
 
     <tr>
+      <td>
+        [Mobile agent crash report ingest](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report)</td>    
+      <td>
+       `mobile-crash.newrelic.com`
+      </td>
       <td>
        `mobile-crash.eu01.nr-data.net`
       </td>
 
-      <td>
-        [Mobile agent crash report ingest](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report).</td>
     </tr>
 
     <tr>
+      <td>
+        [Mobile symbol upload](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps)</td>    
+      <td>
+       `mobile-symbol-upload.newrelic.com`
+      </td>
+      <td>
+       `mobile-symbol-upload.eu01.nr-data.net`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+       **OpenTelemetry**
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [OpenTelemetry ingest](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
+      </td>    
+      <td>
+       `otlp.nr-data.net`
+      </td>
       <td>
        `otlp.eu01.nr-data.net`
       </td>
 
-      <td>
-        [OpenTelemetry ingest](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction). Configure using the [quick start guide](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-get-started-intro) with your account license key in the `api-key` header.</td>
-    </tr>
-    <tr>
-      <td>
-       `trace-api.eu.newrelic.com`
-      </td>
-
-      <td>
-        [Trace API ingest](/docs/distributed-tracing/trace-api/introduction-trace-api).</td>
     </tr>
   </tbody>
 </table>
+
 
 ### FedRAMP ingest endpoints [#fedramp]
 
@@ -524,10 +467,12 @@ In order to report data to New Relic, our [infrastructure monitoring](/docs/infr
 
 If your system needs a proxy to connect to New Relic, use the [Infrastructure `proxy` setting](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#proxy).
 
-Our infrastructure monitoring makes use of several other ingest endpoints, including the Metric API endpoint and the Log API endpoint (included in [the endpoint table](#data-ingest)). It also uses these non-ingest-related endpoints: 
+Our infrastructure monitoring makes use of several other ingest endpoints, including the Metric API endpoint and the Log API endpoint (included in [the endpoint table](#data-ingest)). 
 
-* `identity-api.newrelic.com`: Required for entity registration (for example, a `host` entity). EU endpoint: `identity-api.eu.newrelic.com`.
-* `infrastructure-command-api.newrelic.com`: Used by the agent to control aspects of agent behavior (for example, use of feature flags). EU endpoint: `infrastructure-command-api.eu.newrelic.com`.
+Details about the non-ingest-related endpoints: 
+
+* `identity-api.newrelic.com` | `identity-api.eu.newrelic.com`: Required for entity registration (for example, a `host` entity).
+* `infrastructure-command-api.newrelic.com` | `infrastructure-command-api.eu.newrelic.com`: Used by the agent to control aspects of agent behavior (for example, use of feature flags).
 
 ## APM agent details [#apm]
 
@@ -540,12 +485,6 @@ To enhance network performance and [data security](/docs/security/new-relic-secu
 In addition to the [endpoints used by our browser agent and our APM agents](#data-ingest), applications monitored by our browser agent use outgoing connections to `js-agent.newrelic.com`.
 
 For more information about CDN access for the `js-agent.newrelic.com` file to the domain `bam.nr-data.net` or to one of the New Relic beacons, see [Security for browser monitoring](/docs/browser/new-relic-browser/performance-quality/security-new-relic-browser).
-
-[TLS](#tls) is required for all domains.
-
-## Mobile monitoring details [#mobile-specific]
-
-In addition to the [ingest endpoints](#data-ingest), apps monitored by our [mobile agents](/docs/mobile-monitoring) use outgoing connections to `mobile-symbol-upload.newrelic.com` (EU endpoint: `mobile-symbol-upload.eu01.nr-data.net`).
 
 [TLS](#tls) is required for all domains.
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -67,7 +67,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
        `collector*.newrelic.com`
       </td>
       <td>
-       `collector*.eu.newrelic.com` </br>
+       `collector*.eu.newrelic.com` <br/>
        `collector*.eu01.nr-data.net`
        </td>
     </tr>
@@ -188,7 +188,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
        `infra-api.newrelic.com`
       </td>
       <td>
-       `infra-api.eu.newrelic.com` </br>
+       `infra-api.eu.newrelic.com` <br/>
        `infra-api.eu01.nr-data.net`
       </td>
     </tr>

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -303,6 +303,8 @@ For more detail on specific agents and integrations, and about ports, keep readi
   </tbody>
 </table>
 
+### Endpoints in simple list format [#endpoint-list]
+
 The endpoints in the table above are included below in easy-to-copy lists:
 
 <CollapserGroup>

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -30,160 +30,6 @@ To ensure data security for our customers and to be in compliance with [FedRAMP]
 
 For future updates to required and supported protocol versions, follow the [`Security Notifications` tag in New Relic's Support Forum](https://discuss.newrelic.com/t/security-notifications/45862).
 
-## User-facing domains [#user-facing-domains]
-
-Your browser must be able to communicate with a number of domains for New Relic to work properly. Update your allow list to ensure New Relic can communicate with a number of integral domains listed in this section. Blocking domains can cause issues with individual product features or prevent pages from loading altogether.
-
-This list doesn't cover domains that New Relic connects to that can be blocked without affecting your usage of the product. It also doesn't cover Nerdpacks or other features that communicate with external services that have additional domain requirements.
-
-If your organization uses a firewall that restricts outbound traffic, follow the specific procedures for the operating system and the firewall you use to add the following domains to the allow list.
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "290px" }}>
-        Domain
-      </th>
-
-      <th>
-        Description
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        `\*.newrelic.com`
-      </td>
-
-      <td>
-        New Relic and supporting services
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `\*.nr-assets.net`
-      </td>
-
-      <td>
-        Static New Relic assets
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `\*.nr-ext.net`
-      </td>
-
-      <td>
-        New Relic Nerdpacks and assets
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `\*.amazonaws.com`
-      </td>
-
-      <td>
-        New Relic catalog assets behind AWS S3
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `\*.cloudfront.net`
-      </td>
-
-      <td>
-        Static New Relic assets behind AWS CloudFront CDN
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `secure.gravatar.com`
-      </td>
-
-      <td>
-        Support for Gravatar avatars
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `fonts.googleapis.com`
-      </td>
-
-      <td>
-        Support for Google Fonts
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `fonts.gstatic.com`
-      </td>
-
-      <td>
-        Support for Google Fonts
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `[www.google.com](http://www.google.com)`
-      </td>
-
-      <td>
-        Support for reCAPTCHA
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `[www.gstatic.com](http://www.gstatic.com)`
-      </td>
-
-      <td>
-        Support for reCAPTCHA
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `\*.nr-data.net`
-      </td>
-
-      <td>
-        OpenTelemetry and Pixie
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-       `onenr.io`
-      </td>
-
-      <td>
-        New Relic sharing permalinks
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `\*.typescript.azureedge.net`
-      </td>
-
-      <td>
-        Synthetics code editor autocompletion functionality
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ## New Relic endpoints [#new-relic-endpoints]
 
 This table contains the primary endpoints for the ingest of data to New Relic, and other platform-related functionality. For more detail on specific agents and integrations, keep reading below the ingest table. For port details, see [Ports](#ports).
@@ -258,6 +104,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
       </td>
       <td>
        `aws-api.eu.newrelic.com`
+       `aws-api.eu01.nr-data.net`
       </td>
     </tr>
 
@@ -431,7 +278,6 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
   </tbody>
 </table>
 
-
 ### FedRAMP ingest endpoints [#fedramp]
 
 See [FedRAMP endpoints](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints).
@@ -456,6 +302,160 @@ New Relic uses these blocks for data ingestion:
 
 * US data center endpoints: `162.247.240.0/22` 
 * EU data center endpoints: `185.221.84.0/22` 
+
+## User-facing domains [#user-facing-domains]
+
+Your browser must be able to communicate with a number of domains for New Relic to work properly. Update your allow list to ensure New Relic can communicate with a number of integral domains listed in this section. Blocking domains can cause issues with individual product features or prevent pages from loading altogether.
+
+This list doesn't cover domains that New Relic connects to that can be blocked without affecting your usage of the product. It also doesn't cover Nerdpacks or other features that communicate with external services that have additional domain requirements.
+
+If your organization uses a firewall that restricts outbound traffic, follow the specific procedures for the operating system and the firewall you use to add the following domains to the allow list.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "290px" }}>
+        Domain
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `\*.newrelic.com`
+      </td>
+
+      <td>
+        New Relic and supporting services
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `\*.nr-assets.net`
+      </td>
+
+      <td>
+        Static New Relic assets
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `\*.nr-ext.net`
+      </td>
+
+      <td>
+        New Relic Nerdpacks and assets
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `\*.amazonaws.com`
+      </td>
+
+      <td>
+        New Relic catalog assets behind AWS S3
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `\*.cloudfront.net`
+      </td>
+
+      <td>
+        Static New Relic assets behind AWS CloudFront CDN
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `secure.gravatar.com`
+      </td>
+
+      <td>
+        Support for Gravatar avatars
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `fonts.googleapis.com`
+      </td>
+
+      <td>
+        Support for Google Fonts
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `fonts.gstatic.com`
+      </td>
+
+      <td>
+        Support for Google Fonts
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `[www.google.com](http://www.google.com)`
+      </td>
+
+      <td>
+        Support for reCAPTCHA
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `[www.gstatic.com](http://www.gstatic.com)`
+      </td>
+
+      <td>
+        Support for reCAPTCHA
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `\*.nr-data.net`
+      </td>
+
+      <td>
+        OpenTelemetry and Pixie
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+       `onenr.io`
+      </td>
+
+      <td>
+        New Relic sharing permalinks
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `\*.typescript.azureedge.net`
+      </td>
+
+      <td>
+        Synthetics code editor autocompletion functionality
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Agent downloads [#agent-download]
 
@@ -506,7 +506,7 @@ To configure your firewall to allow synthetic monitors to access your monitored 
 
 Synthetic private minions report to a specific endpoint based on region. To allow the private minion to access the endpoint or the static IP addresses associated with the endpoint, follow the specific procedures for the operating system and the firewall you use. These IP addresses may change in the future.
 
-[TLS](#tls) is required for all domains. Use the IP connections for account data in the US or [EU region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center) as appropriate:
+[TLS](#tls) is required for all domains. Use the IP connections for your [data center region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center) (US or EU):
 
 <table>
   <thead>
@@ -528,11 +528,11 @@ Synthetic private minions report to a specific endpoint based on region. To allo
       </td>
 
       <td>
-  For US region accounts:
-    * `https://synthetics-horde.nr-data.net/`
+US data center region:
+  * `https://synthetics-horde.nr-data.net/`
 
-  For EU region accounts:
-    * `https://synthetics-horde.eu01.nr-data.net/`
+EU data center region:
+  * `https://synthetics-horde.eu01.nr-data.net/`
       </td>
     </tr>
 
@@ -542,13 +542,13 @@ Synthetic private minions report to a specific endpoint based on region. To allo
       </td>
 
       <td>
-    For US data center region accounts:
-      * `13.248.153.51`
-      * `76.223.21.185`
+US data center region:
+  * `13.248.153.51`
+  * `76.223.21.185`
 
-    For EU data center region accounts:
-      * `185.221.86.57`
-      * `185.221.86.25`
+EU data center region:
+  * `185.221.86.57`
+  * `185.221.86.25`
       </td>
     </tr>
   </tbody>
@@ -558,13 +558,13 @@ Synthetic private minions report to a specific endpoint based on region. To allo
 
 Endpoints that use `api.newrelic.com` (such as our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph)) and our New Relic-generated [webhooks for alert policies](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-controlling-where-send-alerts#webhook) use an IP address from designated network blocks for the US or [EU region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center). [TLS is required](#tls) for all addresses in these blocks.
 
-Network blocks for US region accounts:
+Network blocks for US data center region:
 
 * `162.247.240.0/22`
 * `18.246.82.0/25` (effective August 20, 2023)
 * `3.145.244.128/25` (effective August 20, 2023)
 
-Network blocks for EU region accounts:
+Network blocks for EU data center region:
 
 * `158.177.65.64/29`
 * `159.122.103.184/29`
@@ -581,8 +581,8 @@ The Pixie integration requires outbound network access to the following:
 
 * `work.withpixie.ai:443`
 * `withpixie.ai:443`
-* `otlp.nr-data.net:4317` (US data center accounts)
-* `otlp.eu01.nr-data.net:4317` (EU data center accounts)
+* `otlp.nr-data.net:4317` (US data center)
+* `otlp.eu01.nr-data.net:4317` (EU data center)
 
 <Callout variant="tip">
   If the `4317` port doesn't work, you can use port `443`.

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -32,14 +32,13 @@ For future updates to required and supported protocol versions, follow the [`Sec
 
 ## New Relic endpoints [#new-relic-endpoints]
 
-This table contains the primary endpoints for the ingest of data to New Relic, and other platform-related functionality. For more detail on specific agents and integrations, keep reading below the ingest table. For port details, see [Ports](#ports).
+This table contains the primary endpoints for New Relic data ingest, and other platform-related functionality. (For an easy-to-copy list of these endpoints, see [Endpoint list](#endpoint-list).)
+
+For more detail on specific agents and integrations, and about ports, keep reading below the table. 
 
 <table>
   <thead>
     <tr>
-      <th>
-        Capability
-      </th>
 
       <th style={{ width: "310px" }}>
         US data center endpoint
@@ -49,20 +48,22 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
         EU data center endpoint
       </th>
     </tr>
+      <th>
+        Purpose and details
+      </th>    
   </thead>
 
-  <tbody>
+  <thead>
     <tr>
-      <td>
+      <th>
        **APM**
-      </td>
+      </th>
     </tr>
+  </thead>
     
+  <tbody>
 
-    <tr>
-      <td>
-        APM agent ingest      
-      </td>      
+    <tr>    
       <td>
        `collector*.newrelic.com`
       </td>
@@ -70,17 +71,20 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
        `collector*.eu.newrelic.com` <br/>
        `collector*.eu01.nr-data.net`
        </td>
+      <td>
+        APM agent ingest      
+      </td>  
     </tr>
-
+</tbody>
+  <thead>
    <tr>
-      <td>
+      <th>
        **AWS**
-      </td>
+      </th>
     </tr>
-    <tr>
-      <td>
-        [AWS Metric Streams](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream) ingest
-      </td>      
+  </thead>
+<tbody>
+    <tr>     
       <td>
        `aws-api.newrelic.com`
       </td>
@@ -88,72 +92,79 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
        `aws-api.eu.newrelic.com`
        `aws-api.eu01.nr-data.net`
       </td>
+      <td>
+        [AWS Metric Streams](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream) ingest
+      </td> 
     </tr>
 
     <tr>
-      <td>
-        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest</td>      
       <td>
        `cloud-collector.newrelic.com`
       </td>
       <td>
        `cloud-collector.eu01.newrelic.com`
       </td>
-    </tr>
-
-    <tr>
       <td>
-       **Browser**
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Browser ingest](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring)
+        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest
       </td>      
+    </tr>
+</tbody>
+
+  <thead>
+   <tr>
+      <th>
+       **Browser**
+      </th>
+    </tr>
+  </thead>
+<tbody>
+    <tr>   
       <td>
        `bam.nr-data.net`
       </td>
       <td>
        `bam.eu01.nr-data.net`
       </td>
-    </tr>
-
-
-
-    <tr>
       <td>
+        [Browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring) ingest
+      </td>   
+    </tr>
+</tbody>
+
+  <thead>
+   <tr>
+      <th>
        **Ingest APIs**
-      </td>
+      </th>
     </tr>
+  </thead>
 
-    <tr>
-      <td>
-        Our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api)
-      </td>      
+<tbody>
+    <tr>    
       <td>
        `insights-collector.newrelic.com`
       </td>
       <td>
        `insights-collector.eu01.nr-data.net`
       </td>
+      <td>
+        Our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api)
+      </td>  
     </tr>
 
-
-    <tr>
-      <td>
-        Our [Log API](/docs/logs/log-api/introduction-log-api)</td>      
+    <tr>     
       <td>
        `log-api.newrelic.com`
       </td>
       <td>
        `log-api.eu.newrelic.com`
        </td>
+      <td>
+        Our [Log API](/docs/logs/log-api/introduction-log-api)
+      </td> 
     </tr>
 
-    <tr>
-      <td>
-        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api)</td>      
+    <tr>    
       <td>
        `metric-api.newrelic.com`
       </td>
@@ -161,30 +172,33 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
       <td>
        `metric-api.eu.newrelic.com`
       </td>
+      <td>
+        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api)
+      </td>  
     </tr>
 
-    <tr>
-      <td>
-        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)
-        </td>      
+    <tr>     
       <td>
        `trace-api.newrelic.com`
       </td>
       <td>
        `trace-api.eu.newrelic.com`
       </td>
-    </tr>
-
-    <tr>
       <td>
-       **Infrastructure**
-      </td>
+        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)
+      </td> 
     </tr>
+</tbody>
 
+  <thead>
+   <tr>
+      <th>
+       **Infrastructure**
+      </th>
+    </tr>
+  </thead>
+<tbody>
     <tr>
-    <td>
-      [Infrastructure agent](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring) ingest
-    </td>
       <td>
        `infra-api.newrelic.com`
       </td>
@@ -192,102 +206,161 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
        `infra-api.eu.newrelic.com` <br/>
        `infra-api.eu01.nr-data.net`
       </td>
+      <td>
+        [Infrastructure agent](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring) ingest
+      </td>
     </tr>
 
     <tr>
-    <td>
-      Infrastructure entity registration
-    </td>
     <td>
       `identity-api.newrelic.com`
     </td>
     <td>
       `identity-api.eu.newrelic.com`
     </td>
+    <td>
+      Infrastructure entity registration
+    </td>
     </tr>
 
     <tr>
-    <td>
-      Infrastructure agent control
-    </td>
       <td>
        `infrastructure-command-api.newrelic.com`
       </td>
       <td>
        `infrastructure-command-api.eu.newrelic.com`
       </td>
-    </tr>
-
-    <tr>
       <td>
-       **Mobile**
+        Infrastructure agent control
       </td>
     </tr>
+</tbody>
 
-    <tr>
-      <td>
-        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest
-      </td>    
+  <thead>
+   <tr>
+      <th>
+       **Mobile**
+      </th>
+    </tr>
+  </thead>
+<tbody>
+    <tr>   
       <td>
        `mobile-collector.newrelic.com`
       </td>
       <td>
        `mobile-collector.eu01.nr-data.net`
       </td>
-
+      <td>
+        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest
+      </td> 
     </tr>
 
-    <tr>
-      <td>
-        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest
-      </td>    
+    <tr>  
       <td>
        `mobile-crash.newrelic.com`
       </td>
       <td>
        `mobile-crash.eu01.nr-data.net`
       </td>
-
+      <td>
+        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest
+      </td>  
     </tr>
 
-    <tr>
-      <td>
-        Symbol upload ([iOS](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps) and [Android](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting))
-      </td>    
+    <tr>   
       <td>
        `mobile-symbol-upload.newrelic.com`
       </td>
       <td>
        `mobile-symbol-upload.eu01.nr-data.net`
       </td>
-    </tr>
-
-    <tr>
       <td>
+        Symbolication, deobfuscation, and related
+      </td> 
+    </tr>
+</tbody>
+
+  <thead>
+   <tr>
+      <th>
        **OpenTelemetry**
-      </td>
+      </th>
     </tr>
-
-    <tr>
-      <td>
-        [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction) ingest
-      </td>    
+  </thead>
+<tbody>
+    <tr>  
       <td>
        `otlp.nr-data.net`
       </td>
       <td>
        `otlp.eu01.nr-data.net`
       </td>
-
+      <td>
+        [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction) ingest
+      </td>  
     </tr>
   </tbody>
 </table>
+
+<CollapserGroup>
+    <Collapser
+    id="us-endpoint-list"
+    title="List of US endpoints"
+    >
+
+Here's a list of the US data center region endpoints included in the endpoint table above in an easy-to-copy list: 
+
+* `collector*.newrelic.com`
+* `aws-api.newrelic.com`
+* `cloud-collector.newrelic.com`
+* `bam.nr-data.net`
+* `insights-collector.newrelic.com`
+* `log-api.newrelic.com`
+* `metric-api.newrelic.com`
+* `trace-api.newrelic.com`
+* `infra-api.newrelic.com`
+* `identity-api.newrelic.com`
+* `infrastructure-command-api.newrelic.com`
+* `mobile-collector.newrelic.com`
+* `mobile-crash.newrelic.com`
+* `mobile-symbol-upload.newrelic.com`
+* `otlp.nr-data.net`
+
+</Collapser>
+
+    <Collapser
+    id="eu-endpoint-list"
+    title="List of EU endpoints"
+    >
+Here's a list of the EU data center region endpoints included in the endpoint table above in an easy-to-copy list: 
+
+* `collector*.eu.newrelic.com`
+* `collector*.eu01.nr-data.net`
+* `aws-api.eu.newrelic.com`
+* `aws-api.eu01.nr-data.net`
+* `cloud-collector.eu01.newrelic.com`
+* `bam.eu01.nr-data.net`
+* `insights-collector.eu01.nr-data.net`
+* `log-api.eu.newrelic.com`
+* `metric-api.eu.newrelic.com`
+* `trace-api.eu.newrelic.com`
+* `infra-api.eu.newrelic.com`
+* `infra-api.eu01.nr-data.net`
+* `identity-api.eu.newrelic.com`
+* `infrastructure-command-api.eu.newrelic.com`
+* `mobile-collector.eu01.nr-data.net`
+* `mobile-crash.eu01.nr-data.net`
+* `mobile-symbol-upload.eu01.nr-data.net`
+* `otlp.eu01.nr-data.net`
+</Collapser>
+</CollapserGroup>
 
 ### FedRAMP ingest endpoints [#fedramp]
 
 See [FedRAMP endpoints](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints).
 
-### Port details [#ports]
+### Ports [#ports]
 
 For all data ingest applications, with the [exception of OpenTelemetry](#otel-ports), use port 443, a secure channel for encrypted HTTPS traffic and our default. 
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -184,7 +184,7 @@ If your organization uses a firewall that restricts outbound traffic, follow the
   </tbody>
 </table>
 
-## New Relic endpoints [#data-ingest]
+## New Relic endpoints [#new-relic-endpoints]
 
 This table contains the primary endpoints for the ingest of data to New Relic, and other platform-related functionality. For more detail on specific agents and integrations, keep reading below the ingest table. For port details, see [Ports](#ports).
 
@@ -463,11 +463,11 @@ New Relic uses these blocks for data ingestion:
 
 ## Infrastructure details [#infrastructure]
 
-In order to report data to New Relic, our [infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/getting-started/welcome-new-relic-infrastructure) needs outbound access to endpoints in [the endpoints table](#data-ingest). [TLS](#tls) is required for all domains.
+In order to report data to New Relic, our [infrastructure monitoring](/docs/infrastructure/new-relic-infrastructure/getting-started/welcome-new-relic-infrastructure) needs outbound access to endpoints in [the endpoints table](#new-relic-endpoints). [TLS](#tls) is required for all domains.
 
 If your system needs a proxy to connect to New Relic, use the [Infrastructure `proxy` setting](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#proxy).
 
-Our infrastructure monitoring makes use of several other ingest endpoints, including the Metric API endpoint and the Log API endpoint (included in [the endpoint table](#data-ingest)). 
+Our infrastructure monitoring makes use of several other ingest endpoints, including the Metric API endpoint and the Log API endpoint (included in [the endpoint table](#new-relic-endpoints)). 
 
 Details about the non-ingest-related endpoints: 
 
@@ -476,13 +476,13 @@ Details about the non-ingest-related endpoints:
 
 ## APM agent details [#apm]
 
-To enhance network performance and [data security](/docs/security/new-relic-security/data-privacy/new-relic-security-protecting-your-data-content), New Relic uses a CDN and DDoS prevention service with a large IP range. New Relic agents require your firewall to allow outgoing connections to the APM-related endpoints in the [ingest endpoints table](#data-ingest). To add them to your allow list, follow the specific procedures for the operating system and the firewall you use.
+To enhance network performance and [data security](/docs/security/new-relic-security/data-privacy/new-relic-security-protecting-your-data-content), New Relic uses a CDN and DDoS prevention service with a large IP range. New Relic agents require your firewall to allow outgoing connections to the APM-related endpoints in the [ingest endpoints table](#new-relic-endpoints). To add them to your allow list, follow the specific procedures for the operating system and the firewall you use.
 
 [TLS](#tls) is required for all domains. 
 
 ## Browser monitoring details [#browser]
 
-In addition to the [endpoints used by our browser agent and our APM agents](#data-ingest), applications monitored by our browser agent use outgoing connections to `js-agent.newrelic.com`.
+In addition to the [endpoints used by our browser agent and our APM agents](#new-relic-endpoints), applications monitored by our browser agent use outgoing connections to `js-agent.newrelic.com`.
 
 For more information about CDN access for the `js-agent.newrelic.com` file to the domain `bam.nr-data.net` or to one of the New Relic beacons, see [Security for browser monitoring](/docs/browser/new-relic-browser/performance-quality/security-new-relic-browser).
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -48,7 +48,7 @@ For more detail on specific agents and integrations, and about ports, keep readi
         EU data center endpoint
       </th>
       <th>
-        Purpose and details
+        Capability
       </th>  
    </tr>  
   </thead>
@@ -63,17 +63,17 @@ For more detail on specific agents and integrations, and about ports, keep readi
     
   <tbody>
 
-    <tr>    
+    <tr>   
+      <td>
+        APM agent ingest      
+      </td>  
       <td>
        `collector*.newrelic.com`
       </td>
       <td>
        `collector*.eu.newrelic.com` <br/>
        `collector*.eu01.nr-data.net`
-       </td>
-      <td>
-        APM agent ingest      
-      </td>  
+       </td> 
     </tr>
 </tbody>
   <thead>
@@ -86,27 +86,29 @@ For more detail on specific agents and integrations, and about ports, keep readi
 <tbody>
     <tr>     
       <td>
+        [AWS Metric Streams](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream) ingest
+      </td> 
+      <td>
        `aws-api.newrelic.com`
       </td>
       <td>
        `aws-api.eu.newrelic.com`
        `aws-api.eu01.nr-data.net`
       </td>
-      <td>
-        [AWS Metric Streams](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream) ingest
-      </td> 
+
     </tr>
 
     <tr>
+      <td>
+        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest
+      </td> 
       <td>
        `cloud-collector.newrelic.com`
       </td>
       <td>
        `cloud-collector.eu01.newrelic.com`
       </td>
-      <td>
-        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest
-      </td>      
+     
     </tr>
 </tbody>
 
@@ -118,16 +120,17 @@ For more detail on specific agents and integrations, and about ports, keep readi
     </tr>
   </thead>
 <tbody>
-    <tr>   
+    <tr> 
+      <td>
+        [Browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring) ingest
+      </td>   
       <td>
        `bam.nr-data.net`
       </td>
       <td>
        `bam.eu01.nr-data.net`
       </td>
-      <td>
-        [Browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring) ingest
-      </td>   
+  
     </tr>
 </tbody>
 
@@ -142,29 +145,34 @@ For more detail on specific agents and integrations, and about ports, keep readi
 <tbody>
     <tr>    
       <td>
+        Our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api)
+      </td> 
+      <td>
        `insights-collector.newrelic.com`
       </td>
       <td>
        `insights-collector.eu01.nr-data.net`
       </td>
-      <td>
-        Our [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api)
-      </td>  
+ 
     </tr>
 
-    <tr>     
+    <tr>   
+      <td>
+        Our [Log API](/docs/logs/log-api/introduction-log-api)
+      </td>   
       <td>
        `log-api.newrelic.com`
       </td>
       <td>
        `log-api.eu.newrelic.com`
        </td>
-      <td>
-        Our [Log API](/docs/logs/log-api/introduction-log-api)
-      </td> 
+
     </tr>
 
     <tr>    
+      <td>
+        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api)
+      </td> 
       <td>
        `metric-api.newrelic.com`
       </td>
@@ -172,21 +180,20 @@ For more detail on specific agents and integrations, and about ports, keep readi
       <td>
        `metric-api.eu.newrelic.com`
       </td>
-      <td>
-        Our [Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api)
-      </td>  
+ 
     </tr>
 
-    <tr>     
+    <tr>   
+      <td>
+        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)
+      </td>   
       <td>
        `trace-api.newrelic.com`
       </td>
       <td>
        `trace-api.eu.newrelic.com`
       </td>
-      <td>
-        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)
-      </td> 
+
     </tr>
 </tbody>
 
@@ -200,39 +207,41 @@ For more detail on specific agents and integrations, and about ports, keep readi
 <tbody>
     <tr>
       <td>
+        [Infrastructure agent](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring) ingest
+      </td>
+      <td>
        `infra-api.newrelic.com`
       </td>
       <td>
        `infra-api.eu.newrelic.com` <br/>
        `infra-api.eu01.nr-data.net`
       </td>
-      <td>
-        [Infrastructure agent](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring) ingest
-      </td>
     </tr>
 
     <tr>
+    <td>
+      Infrastructure entity registration
+    </td>
     <td>
       `identity-api.newrelic.com`
     </td>
     <td>
       `identity-api.eu.newrelic.com`
     </td>
-    <td>
-      Infrastructure entity registration
-    </td>
+
     </tr>
 
     <tr>
+      <td>
+        Infrastructure agent control
+      </td>
       <td>
        `infrastructure-command-api.newrelic.com`
       </td>
       <td>
        `infrastructure-command-api.eu.newrelic.com`
       </td>
-      <td>
-        Infrastructure agent control
-      </td>
+
     </tr>
 </tbody>
 
@@ -244,40 +253,43 @@ For more detail on specific agents and integrations, and about ports, keep readi
     </tr>
   </thead>
 <tbody>
-    <tr>   
+    <tr> 
+      <td>
+        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest
+      </td>   
       <td>
        `mobile-collector.newrelic.com`
       </td>
       <td>
        `mobile-collector.eu01.nr-data.net`
       </td>
-      <td>
-        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest
-      </td> 
+
     </tr>
 
     <tr>  
+      <td>
+        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest
+      </td> 
       <td>
        `mobile-crash.newrelic.com`
       </td>
       <td>
        `mobile-crash.eu01.nr-data.net`
       </td>
-      <td>
-        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest
-      </td>  
+ 
     </tr>
 
     <tr>   
+      <td>
+        Symbolication, deobfuscation, and related
+      </td> 
       <td>
        `mobile-symbol-upload.newrelic.com`
       </td>
       <td>
        `mobile-symbol-upload.eu01.nr-data.net`
       </td>
-      <td>
-        Symbolication, deobfuscation, and related
-      </td> 
+
     </tr>
 </tbody>
 
@@ -291,14 +303,15 @@ For more detail on specific agents and integrations, and about ports, keep readi
 <tbody>
     <tr>  
       <td>
+        [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction) ingest
+      </td> 
+      <td>
        `otlp.nr-data.net`
       </td>
       <td>
        `otlp.eu01.nr-data.net`
       </td>
-      <td>
-        [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction) ingest
-      </td>  
+
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -47,10 +47,10 @@ For more detail on specific agents and integrations, and about ports, keep readi
       <th style={{ width: "310px" }}>
         EU data center endpoint
       </th>
-    </tr>
       <th>
         Purpose and details
-      </th>    
+      </th>  
+   </tr>  
   </thead>
 
   <thead>
@@ -303,13 +303,15 @@ For more detail on specific agents and integrations, and about ports, keep readi
   </tbody>
 </table>
 
+The endpoints in the table above are included below in easy-to-copy lists:
+
 <CollapserGroup>
     <Collapser
     id="us-endpoint-list"
-    title="List of US endpoints"
+    title="US data center endpoints"
     >
 
-Here's a list of the US data center region endpoints included in the endpoint table above in an easy-to-copy list: 
+Here's a list of the [US data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center) endpoints included in the endpoint table above in an easy-to-copy list: 
 
 * `collector*.newrelic.com`
 * `aws-api.newrelic.com`
@@ -331,9 +333,9 @@ Here's a list of the US data center region endpoints included in the endpoint ta
 
     <Collapser
     id="eu-endpoint-list"
-    title="List of EU endpoints"
+    title="EU data center endpoints"
     >
-Here's a list of the EU data center region endpoints included in the endpoint table above in an easy-to-copy list: 
+Here's a list of the [EU data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center) endpoints included in the endpoint table above in an easy-to-copy list: 
 
 * `collector*.eu.newrelic.com`
 * `collector*.eu01.nr-data.net`

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -39,7 +39,9 @@ For more detail on specific agents and integrations, and about ports, keep readi
 <table>
   <thead>
     <tr>
-
+      <th>
+        Capability
+      </th>  
       <th style={{ width: "310px" }}>
         US data center endpoint
       </th>
@@ -47,9 +49,6 @@ For more detail on specific agents and integrations, and about ports, keep readi
       <th style={{ width: "310px" }}>
         EU data center endpoint
       </th>
-      <th>
-        Capability
-      </th>  
    </tr>  
   </thead>
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -92,6 +92,17 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
+        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest</td>      
+      <td>
+       `cloud-collector.newrelic.com`
+      </td>
+      <td>
+       `cloud-collector.eu01.newrelic.com`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
        **Browser**
       </td>
     </tr>
@@ -108,16 +119,6 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
       </td>
     </tr>
 
-    <tr>
-      <td>
-        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest</td>      
-      <td>
-       `cloud-collector.newrelic.com`
-      </td>
-      <td>
-       `cloud-collector.eu01.newrelic.com`
-      </td>
-    </tr>
 
 
     <tr>
@@ -225,7 +226,8 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest</td>    
+        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest
+      </td>    
       <td>
        `mobile-collector.newrelic.com`
       </td>
@@ -237,7 +239,8 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest</td>    
+        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest
+      </td>    
       <td>
        `mobile-crash.newrelic.com`
       </td>
@@ -249,7 +252,8 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [Symbol upload](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps)</td>    
+        Symbol upload ([iOS](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps) and [Android](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting))
+      </td>    
       <td>
        `mobile-symbol-upload.newrelic.com`
       </td>

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -38,7 +38,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
   <thead>
     <tr>
       <th>
-        Purpose
+        Capability
       </th>
 
       <th style={{ width: "310px" }}>
@@ -72,6 +72,24 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
        </td>
     </tr>
 
+   <tr>
+      <td>
+       **AWS**
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [AWS Metric Streams](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream) ingest
+      </td>      
+      <td>
+       `aws-api.newrelic.com`
+      </td>
+      <td>
+       `aws-api.eu.newrelic.com`
+       `aws-api.eu01.nr-data.net`
+      </td>
+    </tr>
+
     <tr>
       <td>
        **Browser**
@@ -90,27 +108,9 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
       </td>
     </tr>
 
-   <tr>
-      <td>
-       **Cloud integrations**
-      </td>
-    </tr>
     <tr>
       <td>
-        [AWS Metric Streams ingest](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/).
-      </td>      
-      <td>
-       `aws-api.newrelic.com`
-      </td>
-      <td>
-       `aws-api.eu.newrelic.com`
-       `aws-api.eu01.nr-data.net`
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Ingest for [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration). </td>      
+        [AWS VPC Flow Logs](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-monitoring-integration) and [RDS Enhanced](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-rds-enhanced-monitoring-integration) ingest</td>      
       <td>
        `cloud-collector.newrelic.com`
       </td>
@@ -164,7 +164,8 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)</td>      
+        Our [Trace API](/docs/distributed-tracing/trace-api/introduction-trace-api)
+        </td>      
       <td>
        `trace-api.newrelic.com`
       </td>
@@ -181,7 +182,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
     <td>
-      [Infrastructure agent ingest](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring)
+      [Infrastructure agent](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring) ingest
     </td>
       <td>
        `infra-api.newrelic.com`
@@ -224,7 +225,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [Mobile agent ingest](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring)</td>    
+        [Mobile agent](/docs/mobile-monitoring/new-relic-mobile/get-started/introduction-mobile-monitoring) ingest</td>    
       <td>
        `mobile-collector.newrelic.com`
       </td>
@@ -236,7 +237,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [Mobile agent crash report ingest](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report)</td>    
+        [Mobile agent crash report](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report) ingest</td>    
       <td>
        `mobile-crash.newrelic.com`
       </td>
@@ -248,7 +249,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [Mobile symbol upload](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps)</td>    
+        [Symbol upload](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps)</td>    
       <td>
        `mobile-symbol-upload.newrelic.com`
       </td>
@@ -265,7 +266,7 @@ This table contains the primary endpoints for the ingest of data to New Relic, a
 
     <tr>
       <td>
-        [OpenTelemetry ingest](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction)
+        [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction) ingest
       </td>    
       <td>
        `otlp.nr-data.net`
@@ -298,7 +299,7 @@ The ports used for `otlp.nr-data.net` and `otlp.eu01.nr-data.net` are:
 
 ### Data ingest IP blocks [#ingest-blocks]
 
-New Relic uses these blocks for data ingestion:
+We use these blocks for data ingestion:
 
 * US data center endpoints: `162.247.240.0/22` 
 * EU data center endpoints: `185.221.84.0/22` 


### PR DESCRIPTION
NR-144829

work done: 
Reformatted table to have different capability sections. 
Added an easy-to-copy list of endpoints below the table (although redundant, this will apparently help customers who just want a list of things to enable)
Moved up the main endpoints to be at the top. 

Build: https://docswebsitedevelop-updatenetworksdocimprovedorgan.gatsbyjs.io/docs/new-relic-solutions/get-started/networks/#new-relic-endpoints 