### PR TITLE
feat: [NR-79737] Document Azure Monitor dimensional metric naming convention

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/azure-integration-metrics.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/azure-integration-metrics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Azure integration metrics
+title: Azure integrations metrics
 tags:
   - Integrations
   - Microsoft Azure integrations
@@ -9,9 +9,29 @@ redirects:
   - /docs/azure-metrics
 ---
 
-## Azure Metrics [#azure-metrics-table]
+## Dimensional metric naming convention [#metric-naming-convention]
 
-These are the metrics we collect for Azure:
+Metrics fetched from the Azure Monitor API are stored in New Relic as [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) according to the following pseudocode: 
+
+Metrics are prefixed by the AWS namespace, all lowercase, where / is replaced with . :
+
+* Metrics are prefixed by their Azure resource type, all lowercase, where / is replaced with ., and `Microsoft.` is replaces with `azure.`
+  * `Microsoft.Compute/virtualMachines -> azure.compute.virtualmachines`
+  * `Microsoft.Network/loadBalancers -> azure.network.loadbalancers`
+
+* The original Azure metric name with its original case, stripped of all whitespaces:
+  * `Microsoft.Compute/virtualMachines + Percentage CPU -> azure.compute.virtualmachines.PercentageCPU`
+  * `Microsoft.Network/loadBalancers + ByteCount -> azure.network.loadbalancers.ByteCount`
+
+If the resulting metric name does not start with `azure` after these transformations, an additional prefix `azure.` will be added. 
+
+For more information about resource types supported by Azure, see the [Azure Monitor Metrics documentation website](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/metrics-index).
+
+## API Polling Metrics [#azure-metrics-table]
+
+For a reference on what metrics are available from each one of the polling integrations and their names, [check each of the individual integrations documentation](https://docs.newrelic.com/docs/infrastructure/microsoft-azure-integrations/get-started/activate-azure-integrations/).
+
+The following table is a noncomprehensive list of the metrics collected by the Azure Polling integrations and their [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) translations. 
 
 <table>
   <tbody>


### PR DESCRIPTION

## Give us some context

* What problems does this PR solve?
Adds context on how Azure Metrics are renamed during ingestion into NR. 

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
The new Azure Monitor integration uses dimensional metrics natively, and does so in a programatic way. There is not a table that maps AZ to NR names. This PR describes the process we follow to transform AZ metric names into NR metric names. 

* If your issue relates to an existing GitHub issue, please link to it.
Internal jira ticket in commit/PR title