### PR TITLE
Update nrql-group-results-across-time.mdx

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -356,6 +356,20 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
         Cohort analysis is a way to group results together based on timestamps. You can separate them into buckets that cover a specified range of dates and times.
       </Collapser>
     </CollapserGroup>
+    <Callout variant="important">
+      When using functions to aggregate attribute values, it's important the attribute being aggregated in the first function of your query contains non-null values. Facets will only be chosen for rows which contain a non-null value for the attribute in the first function. 
+
+      Example:
+      ```sql
+      FROM Event SELECT average(attribute) FACET name
+      ```
+      Names will only be chosen from rows where attribute is not null. 
+
+      To check if the attribute you're using in your function contains non-null values, run the following query:
+      ```sql
+      FROM Event SELECT attribute, name WHERE attribute IS NOT NULL
+      ```
+    </Callout>
   </Collapser>
 
   <Collapser

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time.mdx
@@ -31,9 +31,6 @@ With [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/intro
 When using [time functions](/docs/insights/use-insights-ui/time-settings/set-time-range-insights-dashboards-charts) in NRQL queries, the results are returned in UTC. To adjust the results to your time zone, include the [`WITH TIMEZONE` clause](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-timezone) in your query.
 
 ## Facet your NRQL query time range [#cohorts]
-<Callout variant="important">
-  Note the first aggregation within a `FACET` query must have a result to receive results from the query.
-</Callout>
 
 To create your NRQL query, use a [`FACET` clause](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-facett) with a bucket function that works with a timestamp attribute. Run a standard `FACET` query, but instead of faceting by an attribute, facet by time. For example:
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/nrql-group-results-across-time.mdx
@@ -31,6 +31,9 @@ With [NRQL](/docs/query-data/nrql-new-relic-query-language/getting-started/intro
 When using [time functions](/docs/insights/use-insights-ui/time-settings/set-time-range-insights-dashboards-charts) in NRQL queries, the results are returned in UTC. To adjust the results to your time zone, include the [`WITH TIMEZONE` clause](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-timezone) in your query.
 
 ## Facet your NRQL query time range [#cohorts]
+<Callout variant="important">
+  Note the first aggregation within a `FACET` query must have a result to receive results from the query.
+</Callout>
 
 To create your NRQL query, use a [`FACET` clause](/docs/insights/nrql-new-relic-query-language/nrql-resources/nrql-syntax-components-functions#sel-facett) with a bucket function that works with a timestamp attribute. Run a standard `FACET` query, but instead of faceting by an attribute, facet by time. For example:
 


### PR DESCRIPTION
Adding Callout block to "NRQL: Facet results by time" documentation to warn customers that the first aggregation within their FACET queries must contain a result for in order for the query to produce results.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? 
  * This PR calls out an edge case when grouping results across time. 
