### PR TITLE
fix: powershell, not shell

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/profiler-conflicts.mdx
@@ -104,7 +104,7 @@ To avoid a profiler conflict, fully remove the other profiler from the environme
 
     To resolve the profiler conflict for IIS applications, either re-run the installer and use the `Repair` feature, or restore the registry settings manually using PowerShell:
 
-    ```sh
+    ```powershell
     $HKLM = 2147483650 #HKEY_LOCAL_MACHINE
     $reg = [wmiclass]"\\.\root\default:StdRegprov"
     $key = "SYSTEM\CurrentControlSet\Services\W3SVC"

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/resolve-net-scom-conflicts.mdx
@@ -29,7 +29,7 @@ To resolve SCOM profiler conflicts:
 1. Remove the SCOM profiler: Uninstall SCOM, or re-install SCOM and disable the `APM` portion in the install wizard.
 2. To resolve the SCOM conflict, restore the registry settings using PowerShell:
 
-   ```shell
+   ```powershell
    $HKLM = 2147483650 #HKEY_LOCAL_MACHINE
    $reg = [wmiclass]"\\.\root\default:StdRegprov"
    $key = "SYSTEM\CurrentControlSet\Services\W3SVC"


### PR DESCRIPTION
powershell and shell have slightly different syntax rules, and this codeblock was displaying the strings as broken, because of missing escape chars `\` before the `"`. I tested this command in powershell and it's valid though without the escape. So to correct the highlighting I changed it to a powershell cmd. 

<img width="1328" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/168ed1b0-49cd-461a-b35e-cab3460cfda8">

Examples:

Shelll:

```shell
$value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\","CORECLR_ENABLE_PROFILING=1","CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}","CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\"
```

Powershell:
```powershell
$value = "COR_ENABLE_PROFILING=1","COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}","NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\","CORECLR_ENABLE_PROFILING=1","CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}","CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\"
```

