### PR TITLE
fix: Remove Incorrect "You are here" Label

### DIFF
--- a/src/content/docs/tutorial-large-logs/get-started-managing-large-logs.mdx
+++ b/src/content/docs/tutorial-large-logs/get-started-managing-large-logs.mdx
@@ -181,7 +181,7 @@ For more on log forwarding options and specific use cases, see [Forward logs](/d
 
 <DocTiles numbered>
   <DocTile title='Get started' label={{text: 'You are here', color: '#FCD672'}}  path="/docs/tutorial-large-logs/get-started-managing-large-logs" ></DocTile>
-  <DocTile title='Filter and reduce your log ingest'  label={{text: 'You are here', color: '#FCD672'}}   path="/docs/tutorial-large-logs/filter-large-logs" ></DocTile>
+  <DocTile title='Filter and reduce your log ingest' path="/docs/tutorial-large-logs/filter-large-logs" ></DocTile>
   <DocTile title='Organize your logs' path="/docs/tutorial-large-logs/organize-large-logs" ></DocTile>
 </DocTiles>
 

--- a/src/i18n/content/jp/docs/tutorial-large-logs/get-started-managing-large-logs.mdx
+++ b/src/i18n/content/jp/docs/tutorial-large-logs/get-started-managing-large-logs.mdx
@@ -198,7 +198,6 @@ import logsPartition from 'images/logs_screenshot_full-partition.webp'
 
   <DocTile
     title="Filter and reduce your log ingest"
-    label={{text: 'You are here', color: '#FCD672'}}
     path="/docs/tutorial-large-logs/filter-large-logs"
   />
 

--- a/src/i18n/content/kr/docs/tutorial-large-logs/get-started-managing-large-logs.mdx
+++ b/src/i18n/content/kr/docs/tutorial-large-logs/get-started-managing-large-logs.mdx
@@ -198,7 +198,6 @@ import logsPartition from 'images/logs_screenshot_full-partition.webp'
 
   <DocTile
     title="Filter and reduce your log ingest"
-    label={{text: 'You are here', color: '#FCD672'}}
     path="/docs/tutorial-large-logs/filter-large-logs"
   />
 


### PR DESCRIPTION
Remove a duplicate label that does not belong to [the page it is on](https://docs.newrelic.com/docs/tutorial-large-logs/get-started-managing-large-logs/).
![image](https://github.com/newrelic/docs-website/assets/3212673/a65c7570-d04c-4197-bf50-7ba304d3b1c6)
