### PR TITLE
feat: Update docs for infra/apm linkage on APM summary page

### DIFF
--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring.mdx
@@ -36,8 +36,10 @@ First, this doc will walk you through the process of resolving infrastructure is
     For <InlinePopover type="apm" /> and infrastructure data to be integrated, all of the following must be true:
 
     * The APM agent and the infrastructure agent must be installed on the same host.
-    * Both agents must use the same <InlinePopover type="licenseKey" />.
+    * Both agents must use the same <InlinePopover type="licenseKey" /> or use license keys from accounts in the same organization.
+      * A user viewing the APM **Summary** page must have access to both accounts if separate license keys are used for APM and infrastructure agents.
     * They must use the [same hostname](/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure#hostnames).
+    * For Kubernetes hosted applications, additional integration steps to [link APM-instrumented applications to Kubernetes](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/) are also required.
 
 If the integration is not working, see [Troubleshooting the APM-infrastructure integration](/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure).
     </Step>
@@ -120,6 +122,6 @@ When your <InlinePopover type="apm" /> and infrastructure data is linked, you ca
 
 ## Troubleshoot missing APM data [#troubleshooting]
 
-APM/Infrastructure integration should happen automatically if you have both the <InlinePopover type="apm" /> agent and the infrastructure agent installed on the same host(s) and they use the same <InlinePopover type="licenseKey" /> and have the same hostname set. 
+APM/Infrastructure integration should happen automatically if you have both the <InlinePopover type="apm" /> agent and the infrastructure agent installed on the same host(s) and they use the same <InlinePopover type="licenseKey" /> or a pair of license keys from the same oganization and have the same hostname set. 
 
 If you do not see APM data in infrastructure monitoring, see [Troubleshooting](/docs/infrastructure/new-relic-infrastructure/troubleshooting/troubleshooting-apm-data-not-infrastructure).

--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring.mdx
@@ -39,7 +39,7 @@ First, this doc will walk you through the process of resolving infrastructure is
     * Both agents must use the same <InlinePopover type="licenseKey" /> or use license keys from accounts in the same organization.
       * A user viewing the APM **Summary** page must have access to both accounts if separate license keys are used for APM and infrastructure agents.
     * They must use the [same hostname](/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure#hostnames).
-    * For Kubernetes hosted applications, additional integration steps to [link APM-instrumented applications to Kubernetes](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/) are also required.
+    * For Kubernetes hosted applications, additional integration steps to [link APM-instrumented applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/) are also required.
 
 If the integration is not working, see [Troubleshooting the APM-infrastructure integration](/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure).
     </Step>

--- a/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure.mdx
@@ -12,7 +12,9 @@ redirects:
 
 ## Problem
 
-When APM and infrastructure agents are installed on the same hosts and use the same New Relic <InlinePopover type="licenseKey" />, APM data should appear in **infrastructure**, and vice versa. If you do not see this APM-infrastructure linkage, follow these troubleshooting tips.
+When APM and infrastructure agents are installed on the same hosts and use the same New Relic <InlinePopover type="licenseKey" /> or license keys from accounts in the same organization, APM data should appear in **infrastructure**, and vice versa. If you do not see this APM-infrastructure linkage, follow these troubleshooting tips.
+
+Please note if license keys from separate accounts within an organization are used a user must have access to both accounts to see the linked data.
 
 ## Solution
 
@@ -49,5 +51,14 @@ If you completed the [APM/Infrastructure integration](/docs/infrastructure/new-r
 
     * To solve this problem, get help at [support.newrelic.com](https://support.newrelic.com/tickets/new).
     * To prevent this problem, make sure there is a time gap between taking down an old server going down and creating a new server.
+  </Collapser>
+
+  <Collapser
+    id="gap-fqdn-issue"
+    title="Ensure the Kubernetes integration steps have been completed."
+  >
+    If you're hosting your APM-monitored application on Kubernetes, there are some additional integration steps that must be completed to link your data.
+
+    * To ensure your data is linked, follow the steps provided to [link APM-instrumented applications to Kubernetes](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/).
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/troubleshooting/apm-data-missing-infrastructure.mdx
@@ -59,6 +59,6 @@ If you completed the [APM/Infrastructure integration](/docs/infrastructure/new-r
   >
     If you're hosting your APM-monitored application on Kubernetes, there are some additional integration steps that must be completed to link your data.
 
-    * To ensure your data is linked, follow the steps provided to [link APM-instrumented applications to Kubernetes](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/).
+    * To ensure your data is linked, follow the steps provided to [link APM-instrumented applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/).
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * The documentation around requirements for the infra-table on the APM Summary page were out of date, leading some users to not complete required steps and sometimes to not realize they can access the feature.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
 * This feature now uses the related entities feature similar to service maps to fetch relationships across accounts, thus eliminating the requirement that a host and APM agent are on the same account
 * This feature now covers k8s entities as well, however [additional integration](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes/) is needed for kubernetes only