### PR TITLE
Remove manual proxy configuration step

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -263,21 +263,7 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
    **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Add more data > Network > SNMP** to set up SNMP data monitoring.
    </figcaption>
 
-4. If you have a proxy, add it to the `ktranslate.env` file in `/etc/default/` after installation, but before starting the `ktranslate` service. The `ktranslate.env` file needs to be similar to:
-  ```
-    NR_ACCOUNT_ID=12345678
-    NEW_RELIC_API_KEY=****************************************
-    HTTPS_PROXY=https://user:password@hostname:port
-    KT_FLAGS="-snmp /etc/ktranslate/snmp-base.yaml \
-    -metrics=jchf \
-    -tee_logs=true \
-    -service_name=snmp-collector \
-    -snmp_discovery_on_start=true \
-    -snmp_discovery_min=180 \
-    nr1.snmp"
-  ```
-
-5. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).
+4. [Visualize your network performance data in New Relic](/docs/network-performance-monitoring/monitoring-network-data/visualize-network-data).
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
This step is no longer needed as the in-product wizard will properly populate the proxy settings into the necessary file