### PR TITLE
Update attribute-dictionary.json for MobileCrash diskAvailable

### DIFF
--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -7196,7 +7196,7 @@
         }
       },
       {
-        "definition": "<p>Space available on the device, in bytes.</p>\n",
+        "definition": "<p>There are two attributes, separated by comma: the root filesystem and the external filesystem space available on the device, in bytes. For example: 50491392,6523789312 or 0,1495339008.</p>\n",
         "events": [
           "MobileCrash"
         ],


### PR DESCRIPTION
** What problems does this PR solve?**
In real time on our UI we display two attributes one is root filesystem and another one is external filesystem. Android devices can have multiple disks (like sd cards, etc).