### PR TITLE
fix(otlp metrics): clarify startTimeUnixNanos behavior for cumulative metrics

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics.mdx
@@ -81,9 +81,11 @@ Summary metric data points include count, sum, and quantile values, with 0.0 as 
 
 ### Start time [#start-time]
 
-The `startTimeUnixNano` field is optional according to the OpenTelemetry [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/metrics/datamodel.md#temporality). When this field is provided, it is used for the timestamp on the resulting New Relic metric, and the `duration` is calculated as `timeUnixNano - startTimeUnixNano`. The `duration` field is used to calculate the queryable `endTimeStamp` attribute on the New Relic metric, but it serves no other semantic purpose.
+The `startTimeUnixNano` field is optional according to the OpenTelemetry [specification](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#resets-and-gaps). For delta aggregation temporality, when present it is used for the timestamp on the resulting New Relic metric, and the `duration` is calculated as `timeUnixNano - startTimeUnixNano`. The `duration` field is used to calculate the queryable `endTimeStamp` attribute on the New Relic metric, but it serves no other semantic purpose.
 
 If `startTimeUnixNano` is not provided, then `timeUnixNano` is used for the timestamp field on the resulting New Relic metric, and the duration field is set to zero.
+
+For cumulative aggregation temporality, `startTimeUnixNano` represents the first observation of the time series and is used to detect resets. `timeUnixNano` is interpreted as the timestamp of the cumulative data point. Cumulative data points are then [converted to delta aggregation temporality](/docs/data-apis/understand-data/metric-data/cumulative-metrics/#delta-conversion).
 
 ### Array values for attributes [#array-values]
 


### PR DESCRIPTION
* What problems does this PR solve?

We received some feedback that the best practices for OTLP metrics ingest weren't clear with regard to the handling of the `startTimeUnixNanos` field for cumulative metrics. I've updated the docs to address the gap and refreshed the link to the relevant portion of the OpenTelemetry specification.