### PR TITLE
chore(php): update compatibility support callout

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -28,7 +28,7 @@ New Relic supports PHP versions 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, and 8.2.
 
   Support for PHP 8.1+ does not include Fibers.
 
-  Support for PHP versions 5.5 and 5.6 **is EOLed**.
+  Support for PHP versions 7.0 and 7.1 will EOL in December, 2023.
 </Callout>
 
 * We highly recommend using a [supported release](http://php.net/supported-versions.php) of PHP.


### PR DESCRIPTION
Update the PHP Agent Compatibility page support Callout with EOL notice for PHP 7.0 and 7.1. 
Remove message regarding 5.5 and 5.6 EOL.