### PR TITLE
Add note on GraphQL usage limits

### DIFF
--- a/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
+++ b/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
@@ -32,5 +32,6 @@ If you are making concurrent requests to NerdGraph in your code it's important t
  * Implement a pooling solution to ensure requests are only made when a concurrent connection is "available."
  * Replace concurrent code with sequential code and only make a request after the previous request has completed.
 
- Also be mindful of code that is run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
-
+<Callout variant="important">
+  Also be mindful of code that is run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
+</Callout>

--- a/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
+++ b/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
@@ -1,0 +1,36 @@
+---
+title: 'NerdGraph Usage Limits'
+tags:
+  - APIs
+  - GraphQL API
+  - NerdGraph
+  - Rate Limit
+  - Concurrency Limit
+translate:
+  - kr
+  - jp
+metaDescription: 'NerdGraph limits the number of concurrent connections users make.'
+---
+
+## GraphQL API Usage Limits
+
+New Relic's GraphQL API (NerdGraph) enforces a limit of **25 concurrent GraphQL requests per user**.
+
+NerdGraph does not limit the rate of requests you can make, only the number of _concurrent_ requests you make.
+
+Concurrency is tracked and enforced per-user, _not_ per-API key. Requests made by the same user via multiple API keys will all contribute to a user's total concurrency.
+
+NerdGraph _may_ allow more than 25 concurrent connections per user based on the state of the system, but **only 25 concurrent requests are guaranteed.**
+
+Additional requests to the API that are made while you already have 25 concurrent requests in flight will be rejected with HTTP status code `429`. As your in-flight requests complete and your total concurrency drops, new requests will automatically begin to succeed again.
+
+### How to avoid hitting the concurrency limit
+
+If you are making concurrent requests to NerdGraph in your code it's important that you limit the total concurrency client-side. For example, if you need to make 100 requests you could:
+
+ * Send the requests in batches of 25 concurrent calls.
+ * Implement a pooling solution to ensure requests are only made when a concurrent connection is "available."
+ * Replace concurrent code with sequential code and only make a request after the previous request has completed.
+
+ Also be mindful of code that is run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
+

--- a/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
+++ b/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
@@ -10,13 +10,15 @@ translate:
 metaDescription: 'New Relic NerdGraph limits the number of concurrent connections users make.'
 ---
 
-## NerdGraph usage limits [#usage-limits]
+Our NerdGraph API enforces a limit on concurrent requests per user. 
 
-For NerdGraph, we enforce a limit of **25 concurrent requests per user**.
+## Limit details [#limit-enforcement]
 
-We don't limit the rate of requests you make, only the number of **concurrent** requests made.
+NerdGraph enforces a limit of **25 concurrent requests per user**.
 
-Concurrency is tracked and enforced per-user, **not** per-user key. Requests made by the same user using multiple user keys all contribute to their total concurrent requests.
+The rate of requests you make is not limited, only the number of **concurrent** requests.
+
+Concurrency is tracked and enforced per user, **not** per user key. Requests made by the same user using multiple user keys will all contribute to that user's total concurrent requests. 
 
 We may allow more than 25 concurrent requests per user, based on the state of the system, but **only 25 concurrent requests are guaranteed.**
 

--- a/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
+++ b/src/content/docs/apis/nerdgraph/nerdgraph-usage-limits.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'NerdGraph Usage Limits'
+title: 'NerdGraph usage limits'
 tags:
   - APIs
   - GraphQL API
@@ -7,31 +7,28 @@ tags:
   - Rate Limit
   - Concurrency Limit
 translate:
-  - kr
-  - jp
-metaDescription: 'NerdGraph limits the number of concurrent connections users make.'
+metaDescription: 'New Relic NerdGraph limits the number of concurrent connections users make.'
 ---
 
-## GraphQL API Usage Limits
+## NerdGraph usage limits [#usage-limits]
 
-New Relic's GraphQL API (NerdGraph) enforces a limit of **25 concurrent GraphQL requests per user**.
+For NerdGraph, we enforce a limit of **25 concurrent requests per user**.
 
-NerdGraph does not limit the rate of requests you can make, only the number of _concurrent_ requests you make.
+We don't limit the rate of requests you make, only the number of **concurrent** requests made.
 
-Concurrency is tracked and enforced per-user, _not_ per-API key. Requests made by the same user via multiple API keys will all contribute to a user's total concurrency.
+Concurrency is tracked and enforced per-user, **not** per-user key. Requests made by the same user using multiple user keys all contribute to their total concurrent requests.
 
-NerdGraph _may_ allow more than 25 concurrent connections per user based on the state of the system, but **only 25 concurrent requests are guaranteed.**
+We may allow more than 25 concurrent requests per user, based on the state of the system, but **only 25 concurrent requests are guaranteed.**
 
-Additional requests to the API that are made while you already have 25 concurrent requests in flight will be rejected with HTTP status code `429`. As your in-flight requests complete and your total concurrency drops, new requests will automatically begin to succeed again.
+If requests are limited, they'll be rejected with HTTP status code `429`. As your in-flight requests complete and your total concurrency drops, new requests will automatically begin to succeed again.
 
-### How to avoid hitting the concurrency limit
+## Avoid hitting the limit [#avoid-limit]
 
-If you are making concurrent requests to NerdGraph in your code it's important that you limit the total concurrency client-side. For example, if you need to make 100 requests you could:
+If you're making concurrent requests to NerdGraph in your code it's important that you limit the total concurrency client-side. For example, if you need to make 100 requests you could:
 
  * Send the requests in batches of 25 concurrent calls.
- * Implement a pooling solution to ensure requests are only made when a concurrent connection is "available."
+ * Implement a pooling solution to ensure requests are only made when a concurrent connection is detected as being available.
  * Replace concurrent code with sequential code and only make a request after the previous request has completed.
 
-<Callout variant="important">
-  Also be mindful of code that is run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
-</Callout>
+Be mindful of code run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
+

--- a/src/content/docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors.mdx
@@ -3,43 +3,15 @@ title: 'API overload protection: Handling 429 errors'
 tags:
   - APIs
   - REST API v2
-  - GraphQL API
-  - NerdGraph
-  - Rate Limit
-  - Concurrency Limit
   - Basic functions
 translate:
   - kr
-metaDescription: 'To prevent resource-intensive API calls from affecting other customers'' API calls, New Relic''s Graphql and REST APIs enforce usage limits.'
+metaDescription: 'To prevent resource-intensive API calls from affecting other customers'' API calls, New Relic''s REST API includes overload protection.'
 redirects:
   - /docs/apis/rest-api-v2/requirements/preventing-429-errors-api-overload-protection
   - /docs/apis/rest-api-v2/requirements/api-overload-protection-preventing-429-errors
   - /docs/apis/rest-api-v2/requirements/api-overload-protection-handling-429-errors
 ---
-
-New Relic's GraphQL and REST APIs enforce usage limits to ensure the APIs remain stable and responsive for all customers even when under heavy load. Usage limits differ between the GraphQL API and the REST API.
-
-## GraphQL API Usage Limits
-
-New Relic's GraphQL API (NerdGraph) enforces a limit of **25 concurrent GraphQL requests per user**. NerdGraph does not limit the rate of requests you can make, only the number of _concurrent_ requests you make.
-
-Concurrency is tracked and enforced per-user, _not_ per-API key. Requests made by the same user via multiple API keys will all contribute to a user's total concurrency.
-
-NerdGraph _may_ allow more than 25 concurrent connections per user based on the state of the system, but **only 25 concurrent requests are guaranteed.**
-
-Additional requests to the API that are made while you already have 25 concurrent requests in flight will be rejected with HTTP status code `429`. As your in-flight requests complete and your total concurrency drops, new requests will automatically begin to succeed again.
-
-### How to avoid hitting the concurrency limit
-
-If you are making concurrent requests to NerdGraph in your code it's important that you limit the total concurrency client-side. For example, if you need to make 100 requests you could:
-
- * Send the requests in batches of 25 concurrent calls.
- * Implement a pooling solution to ensure requests are only made when a concurrent connection is "available."
- * Replace concurrent code with sequential code and only make a request after the previous request has completed.
-
- Also be mindful of code that is run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
-
-## REST API Usage Limits
 
 In order to respond quickly to your REST API calls—even when other customers are running time-consuming queries—New Relic includes overload protection in the API.
 
@@ -47,7 +19,7 @@ If you are querying a large enough amount of data to consume significant resourc
 
 Customers will be limited to 1000 API calls per minute.
 
-### API responses [#api_response]
+## API responses [#api_response]
 
 Under normal operation, the API does not add any overload protection status to responses. You need not take any action.
 
@@ -64,7 +36,7 @@ In a case where rate limiting occurs, the following things will happen:
 * The headers and body of the HTTP responses may or may not contain more information about the error.
 * API calls will be allowed again at the end of the reporting period.
 
-### Headers [#api_headers]
+## Headers [#api_headers]
 
 Here are the HTTP headers that will appear in API responses if you have exceeded your API key's individual limit:
 
@@ -152,7 +124,7 @@ Here are the HTTP headers that will appear in API responses if there is a genera
   </tbody>
 </table>
 
-### Example [#api_example]
+## Example [#api_example]
 
 Here is an example API request indicating that the caller has consumed all of the available resources, and that further API calls will be allowed again at noon on Feb. 1, 2016:
 
@@ -170,7 +142,7 @@ X-RateLimit-Limit: 1000
 {}
 ```
 
-### Preventing rate limiting errors [#preventing-errors]
+## Preventing rate limiting errors [#preventing-errors]
 
 The simplest remedy for a 429 error is to wait until the reporting period ends before sending your next API request. However, with careful management of your queries, you can avoid overload protection errors in the first place.
 

--- a/src/content/docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/api-overload-protection-handling-429-errors.mdx
@@ -3,15 +3,43 @@ title: 'API overload protection: Handling 429 errors'
 tags:
   - APIs
   - REST API v2
+  - GraphQL API
+  - NerdGraph
+  - Rate Limit
+  - Concurrency Limit
   - Basic functions
 translate:
   - kr
-metaDescription: 'To prevent resource-intensive API calls from affecting other customers'' API calls, New Relic''s REST API includes overload protection.'
+metaDescription: 'To prevent resource-intensive API calls from affecting other customers'' API calls, New Relic''s Graphql and REST APIs enforce usage limits.'
 redirects:
   - /docs/apis/rest-api-v2/requirements/preventing-429-errors-api-overload-protection
   - /docs/apis/rest-api-v2/requirements/api-overload-protection-preventing-429-errors
   - /docs/apis/rest-api-v2/requirements/api-overload-protection-handling-429-errors
 ---
+
+New Relic's GraphQL and REST APIs enforce usage limits to ensure the APIs remain stable and responsive for all customers even when under heavy load. Usage limits differ between the GraphQL API and the REST API.
+
+## GraphQL API Usage Limits
+
+New Relic's GraphQL API (NerdGraph) enforces a limit of **25 concurrent GraphQL requests per user**. NerdGraph does not limit the rate of requests you can make, only the number of _concurrent_ requests you make.
+
+Concurrency is tracked and enforced per-user, _not_ per-API key. Requests made by the same user via multiple API keys will all contribute to a user's total concurrency.
+
+NerdGraph _may_ allow more than 25 concurrent connections per user based on the state of the system, but **only 25 concurrent requests are guaranteed.**
+
+Additional requests to the API that are made while you already have 25 concurrent requests in flight will be rejected with HTTP status code `429`. As your in-flight requests complete and your total concurrency drops, new requests will automatically begin to succeed again.
+
+### How to avoid hitting the concurrency limit
+
+If you are making concurrent requests to NerdGraph in your code it's important that you limit the total concurrency client-side. For example, if you need to make 100 requests you could:
+
+ * Send the requests in batches of 25 concurrent calls.
+ * Implement a pooling solution to ensure requests are only made when a concurrent connection is "available."
+ * Replace concurrent code with sequential code and only make a request after the previous request has completed.
+
+ Also be mindful of code that is run in multiple places at once. Even non-concurrent code will create concurrency if it's being run in multiple places.
+
+## REST API Usage Limits
 
 In order to respond quickly to your REST API calls—even when other customers are running time-consuming queries—New Relic includes overload protection in the API.
 
@@ -19,7 +47,7 @@ If you are querying a large enough amount of data to consume significant resourc
 
 Customers will be limited to 1000 API calls per minute.
 
-## API responses [#api_response]
+### API responses [#api_response]
 
 Under normal operation, the API does not add any overload protection status to responses. You need not take any action.
 
@@ -36,7 +64,7 @@ In a case where rate limiting occurs, the following things will happen:
 * The headers and body of the HTTP responses may or may not contain more information about the error.
 * API calls will be allowed again at the end of the reporting period.
 
-## Headers [#api_headers]
+### Headers [#api_headers]
 
 Here are the HTTP headers that will appear in API responses if you have exceeded your API key's individual limit:
 
@@ -124,7 +152,7 @@ Here are the HTTP headers that will appear in API responses if there is a genera
   </tbody>
 </table>
 
-## Example [#api_example]
+### Example [#api_example]
 
 Here is an example API request indicating that the caller has consumed all of the available resources, and that further API calls will be allowed again at noon on Feb. 1, 2016:
 
@@ -142,7 +170,7 @@ X-RateLimit-Limit: 1000
 {}
 ```
 
-## Preventing rate limiting errors [#preventing-errors]
+### Preventing rate limiting errors [#preventing-errors]
 
 The simplest remedy for a 429 error is to wait until the reporting period ends before sending your next API request. However, with careful management of your queries, you can avoid overload protection errors in the first place.
 

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -311,8 +311,7 @@ This table includes general max limits that apply across all New Relic accounts.
 
 \* NRDB records refers to database records for our [core data types](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types), which includes events, metrics (dimensional), logs, and distributed tracing (span) data, all stored in the [New Relic database](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data) (NRDB). This does **not** include [metric timeslice data](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types#timeslice-data).
 
-
-## Data ingest API limits
+## Data ingest API limits [#data-ingest-limits]
 
 Our ingest APIs have additional limits that may override the more general [account-level limits](#all_products). Note that these limits also apply for our tools that use these APIs.
 
@@ -320,6 +319,10 @@ Our ingest APIs have additional limits that may override the more general [accou
 * [Event API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-event-api)
 * [Log API](/docs/logs/log-management/log-api/introduction-log-api)
 * [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits)
+
+## NerdGraph API limits [#nerdgraph-limits]
+
+See [NerdGraph usage limits](/docs/apis/nerdgraph/nerdgraph-usage-limits). 
 
 ## Finding other agent and integration limits [#other-limits]
 

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -101,6 +101,8 @@ pages:
             path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph
           - title: Use the NerdGraph explorer
             path: /docs/apis/nerdgraph/get-started/nerdgraph-explorer
+          - title: NerdGraph usage limits
+            path: /docs/apis/nerdgraph/nerdgraph-usage-limits
           - title: See all NerdGraph tutorials
             path: /docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials
           - title: 'NerdGraph: agent configuration'
@@ -110,7 +112,7 @@ pages:
               - title: Browser monitoring
                 path: /docs/apis/nerdgraph/examples/browser-monitoring-config-nerdgraph
               - title: "Browser: instrument multiple apps"
-                path: /docs/apis/nerdgraph/examples/combining-npm-nerdgraph        
+                path: /docs/apis/nerdgraph/examples/combining-npm-nerdgraph
               - title: Mobile monitoring
                 path: /docs/apis/nerdgraph/examples/mobile-monitoring-config-nerdgraph
           - title: 'NerdGraph: queries and charts'


### PR DESCRIPTION
NerdGraph will be enforcing concurrent request limits soon, this documentation is a reference for customers and support in the event they see a 429 response from the GraphQL API.

@vosechu, a review would be welcome if you have a moment to spare.