### PR TITLE
feat(Data Dictionary): Add entityGuid to more Browser events

### DIFF
--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -3390,7 +3390,12 @@
       {
         "definition": "<p>The unique identifier of the monitor referenced in New Relic One.</p>\n",
         "events": [
+          "AjaxRequest",
+          "BrowserInteraction",
           "JavaScriptError",
+          "PageAction",
+          "PageView",
+          "PageViewTiming",
           "SyntheticCheck",
           "SyntheticRequest"
         ],


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Documents that the `entityGuid` attribute exists on various other Browser-related event types as exemplified by [this query](https://onenr.io/0ERzoOzLAjr)