### PR TITLE
Update install-nodejs-agent.mdx

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -59,21 +59,35 @@ To install the Node.js agent:
 
 1. Create a New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup) No credit card required.
 2. Ensure you meet the [system requirements](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent). In particular, make sure you use a supported Node.js version.
-3. Use the command `npm install newrelic --save` for each application you want to monitor.
+3. Use the command `npm install newrelic` for each application you want to monitor.
+  <Callout variant="important">
+    If you're using Next.js use our standalone [`@newrelic/next` agent](https://github.com/newrelic/newrelic-node-nextjs) instead of the `newrelic` agent. [Here is an example Next.js app](https://github.com/newrelic-experimental/newrelic-nextjs-integration)
+  </Callout>
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.
 5. Configure agent via the `newrelic.js` file or via [environment variable](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#environment):
 
    * Customize the `license_key` setting with <InlinePopover type="licenseKey" />.
    * Customize the [`app_name`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#app_name) setting with one or more [meaningful app names](/docs/apm/new-relic-apm/installation-and-configuration/naming-your-application).
-6. Add `require('newrelic');` as the first line of your app's main module.
-
-<Callout variant="important">
-  If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler you can safeguard against any issues related to module load order by utilizing the [Node.js command line option `-r`](https://nodejs.org/api/cli.html#-r---require-module) to preload the `newrelic` module at application startup. For example, if your application's entry point is `./dist/server.js` then you would use the require flag like so:
-
+6. Add `-r newrelic` to your app's startup script. For example, if your application's entry point is `./dist/server.js` then you would use the require flag like so:
   ```bash
   node -r newrelic ./dist/server.js
   ```
-  If you are unable to `require('newrelic');` as the first line of your app's main module and you are unable to use the require flag as above (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
+  An example Docker command:
+  ```dockerfile
+  CMD ["node", "-r", "newrelic", "server.js"]
+  ```
+  <Callout variant="important">
+    For Next.js use `-r @newrelic/next` instead of `-r newrelic`.
+
+    If you're using Nest.JS and the `nest start` command to start the application, modify its startup binary to load the New Relic agent: `nest start --exec 'node -r newrelic'`. [Here is an example Nest.js application](https://github.com/newrelic/newrelic-node-examples/tree/main/nestjs)
+  </Callout>
+
+  More info about the [Node.js command line option `-r` here](https://nodejs.org/api/cli.html#-r---require-module).
+
+<Callout variant="important">
+  If you are unable to use the `-r` require flag you can also use `require('newrelic')` as the first line of your app's main module. **Note**   If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler `require('newrelic')` will cause instrumentation issues.
+
+If neither of these options work for you, (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
   
   ```js
   // module loaded before newrelic 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Node install instructions are out of date, using `-r newrelic` script is the preferred way because `require('newrelic')` causes instrumentation problems for many users. This PR is coming out of conversations with the Node team

I also removed `--save` from the install cmd, that's been the default npm behavior since at least 2019.

We also support Next.js and Nest.js now, but both require different steps in instrument which is not currently documented anywhere. I did my best to include **Important** call-outs where changes to the standard install are needed for these. This was the best I could do without rewriting the install doc for multiple scenarios. I also linked examples we provide customers in support pretty often, but are not anywhere in our public docs.

I've asked the node team to look this PR over for problems, so it's a draft for now.