### PR TITLE
.NET Agent API usage guide: update links for DT APIs to non-obsolete versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.mdx
@@ -195,7 +195,7 @@ For supported frameworks, the .NET agent usually detects async work and instrume
 
 ## View calls to external services [#externals]
 
-For .NET agent version 8.9 or higher, you can use the following [distributed tracing payload APIs](/docs/apm/distributed-tracing/enable-configure/enable-distributed-tracing#agent-apis) to manually pass distributed tracing context between New Relic-monitored services that don't automatically connect to one another in a [distributed trace](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
+For .NET agent version 8.9 or higher, you can use the following [distributed tracing payload APIs](/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent/#manual-instrumentation) to manually pass distributed tracing context between New Relic-monitored services that don't automatically connect to one another in a [distributed trace](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
 
 <table>
   <thead>
@@ -217,7 +217,7 @@ For .NET agent version 8.9 or higher, you can use the following [distributed tra
       </td>
 
       <td>
-        Create a distributed trace payload to attach to an outgoing request using [`CreateDistributedTracePayload()`](/docs/agents/net-agent/net-agent-api/itransaction#createdistributedtracepayload).
+        Add a distributed trace payload to an outgoing request using [`InsertDistributedTraceHeaders()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#insertdistributedtraceheaders).
       </td>
     </tr>
 
@@ -227,7 +227,7 @@ For .NET agent version 8.9 or higher, you can use the following [distributed tra
       </td>
 
       <td>
-        Receive a payload on an incoming request using [`AcceptDistributedTracePayload()`](/docs/agents/net-agent/net-agent-api/itransaction#acceptdistributedtracepayload).
+        Receive a payload on an incoming request using [`AcceptDistributedTraceHeaders()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#acceptdistributedtraceheaders).
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Give us some context

This PR updates some links in the .NET Agent's public API usage guide to point to current (non-deprecated) APIs.