### PR TITLE
fix(Alerts): Replaced violation in the advanced techniques section

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions.mdx
@@ -58,7 +58,7 @@ The hostname is : ip-123-45-67-89.us-west-1.compute.internal
 />
 
 <figcaption>
-  **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy) > (select a condition)**: Click **+ Add custom incident description** to open the field.
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy) > (select a condition)**: Click **+ Add custom incident description** to open the field.
 </figcaption>
 
 You can create a custom incident description using [the dedicated field for NRQL alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/), or the [Describe this condition section for infrastructure alerts](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information/).

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/define-custom-metrics-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/define-custom-metrics-alert-condition.mdx
@@ -27,14 +27,14 @@ Use the policy's **Thresholds** section to define the custom metric values. Thes
 * The exact custom metric name for the selected product category and [targets](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition). Note: wildcard characters are not allowed.
 * Selected threshold value function. The options are average, minimum, maximum, count, and rate.
 * Selected threshold level. The options are above, below, and equal to.
-* Critical and Warning threshold value and duration that will open a violation. For example, `5 units for at least 5 minutes`.
+* Critical and warning threshold value and duration that will open an incident. For example, `5 units for at least 5 minutes`.
 * Condition name (required) for the custom metric.
 
 ## Create a custom metric condition [#custom-metrics-threshold]
 
 To define the custom metric values for your condition:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy)** or [add a new alert policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy).
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy)** or [add a new alert policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/name-or-rename-alert-policy).
 2. From the policy's **Alert conditions** page, click **Add a condition**.
 3. From the **Categorize** section, select the [product and type of condition](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) for the custom metric.
 4. From the **Select entities** section, add one or more [targets (entities)](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition) that use your custom metric.
@@ -52,5 +52,5 @@ After you save the condition, you can view the selected policy's **Alert conditi
 
 The **Condition name** does not appear in the **Thresholds** section for a saved condition. If you want to [change the condition name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions#rename-condition) for a custom metric, edit it from the selected policy's **Alert conditions** page:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
 2. Click a condition name to edit it, and then type a meaningful name for the condition.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/monitor-scheduled-jobs.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/monitor-scheduled-jobs.mdx
@@ -21,12 +21,12 @@ This only works for **Static** or **Anomaly** [threshold types](/docs/alerts-app
 
 ## How it works
 
-Typically, conditions use critical thresholds to trigger incidents. However, you can also trigger incidents with a loss of signal. To monitor a scheduled job and be notified if it doesn't happen, set your condition's threshold high or low enough so that it won't trigger a violation. That way, only a loss of signal will trigger a violation.
+Typically, conditions use critical thresholds to trigger incidents. However, you can also trigger incidents with a loss of signal. To monitor a scheduled job and be notified if it doesn't happen, set your condition's threshold high or low enough so that it won't trigger an incident. That way, only a loss of signal will trigger an incident.
 
 ## Monitor a scheduled job
 
 1. [Create a condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions) related to the job you want to monitor.
 2. In **Set your condition thresholds**, set the **Critical** threshold above or below where it would ever trigger.
 3. Click **+ Add lost signal threshold**, then set the signal expiration duration time longer than your monitored job's scheduled cycle.
-4. Check **Open new "lost signal" violation**.
+4. Check **Add lost signal threshold**.
 5. Make sure you name your condition before you save it.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/multi-location-synthetic-monitoring-alert-conditions.mdx
@@ -22,7 +22,7 @@ With multi-location Synthetic monitoring alert conditions, you can create a moni
 
 For [Synthetic monitoring](/docs/synthetics/new-relic-synthetics/getting-started/introduction-new-relic-synthetics) that runs in multiple [locations](/docs/synthetics/new-relic-synthetics/using-monitors/add-edit-monitors#setting-location), a single location will sometimes temporarily fail for a wide variety of reasons. In many cases, a single, short-lived failure does not indicate a problem that would require a notification.
 
-With multi-location conditions, you can set the number of locations that must simultaneous fail in order to trigger a violation and send you a notification. For example, if your monitor is running in six locations, you might set a condition requiring four locations to fail before you receive a notification.
+With multi-location conditions, you can set the number of locations that must simultaneous fail in order to trigger an incident and send you a notification. For example, if your monitor is running in six locations, you might set a condition requiring four locations to fail before you receive a notification.
 
 <Callout variant="important">
   Multi-location alerts do **not** affect alerts policies for a Synthetic monitor. For example, [muting a Multi-location alert](/docs/alerts-applied-intelligence/new-relic-alerts/alert-notifications/muting-rules-suppress-notifications) will **not** mute a [Synthetic monitor's alerts.](/docs/synthetics/synthetic-monitoring/using-monitors/alerts-synthetic-monitoring#alerts-existing-monitor)
@@ -97,14 +97,14 @@ Here's a diagram that shows how a four-location condition will be triggered for 
 />
 
 <figcaption>
-  This diagram shows an example of how a four-failed-locations setting will trigger a violation for failures that occur one after the other. Note that failed location checks will be viewed as failed until they next have a successful check.
+  This diagram shows an example of how a four-failed-locations setting will trigger an incident for failures that occur one after the other. Note that failed location checks will be viewed as failed until they next have a successful check.
 </figcaption>
 
 ## Create condition from Alerts UI [#create]
 
 Before creating a condition, read the [rules for multi-location conditions](#rules).
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, and start the process to [create a condition](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#create-condition).
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, and start the process to [create a condition](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions#create-condition).
 2. Click **Synthetics**, then click **Multiple location failures**.
 
 <Callout variant="important">

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/scope-alert-thresholds-specific-instances.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/scope-alert-thresholds-specific-instances.mdx
@@ -4,7 +4,7 @@ tags:
   - Alerts and applied intelligence
   - Alerts
   - Alert conditions
-metaDescription: How to to set alert condition thresholds that trigger when they are violated by any of your Java app's instances.
+metaDescription: How to to set alert condition thresholds that trigger when they are breached by any of your Java app's instances.
 redirects:
   - /docs/new-relic-alerts-alert-specific-hosts-or-jvms
   - /docs/new-relic-alerts-alert-specific-servers-or-hosting-services
@@ -15,7 +15,7 @@ redirects:
   - /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/scope-alert-thresholds-specific-instances
 ---
 
-You can set alert [thresholds](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-threshold) that trigger when they're violated by any of your Java app's instances. Scoping the condition to instances of your app is helpful for detecting anomalies that occur only in a subset of your app's instances.
+You can set alert [thresholds](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-threshold) that trigger when they're breached by any of your Java app's instances. Scoping the condition to instances of your app is helpful for detecting anomalies that occur only in a subset of your app's instances.
 
 These sorts of anomalies are easy to miss for apps that aggregate metrics across a large number of instances. By looking at each instance, you can more quickly identify where potential problems are originating.
 
@@ -41,7 +41,7 @@ During a five-minute time period the three instances have these error rates:
       </th>
 
       <th>
-        **Violation opened?**
+        **Incident opened?**
       </th>
     </tr>
   </thead>
@@ -97,7 +97,7 @@ During a five-minute time period the three instances have these error rates:
       </td>
 
       <td>
-        No. The threshold value must be breached for [at least five consecutive minutes](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-thresholds-trigger-alert#threshold-triggers) to open a violation.
+        No. The threshold value must be breached for [at least five consecutive minutes](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-thresholds-trigger-alert#threshold-triggers) to open an incident.
 
         However, if you had set the threshold for **at least once** in five minutes, then the threshold value must be breached [at least once](/docs/alerts/new-relic-alerts/configuring-alert-policies/minimum-maximum-values#violation) during the five-minute period.
       </td>
@@ -112,7 +112,7 @@ To create a policy that triggers notifications for incidents by your app's indiv
 1. Follow the [basic workflow process](/docs/alerts/new-relic-alerts/configuring-alert-policies/alert-policy-workflow#alert-policy-process) to set up a policy.
 2. When creating a [condition](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-alert-conditions) (step 2), select [**APM**](/docs/alerts/new-relic-alerts/configuring-alert-policies/select-product-targets-alert-condition).
 3. Select **Application metric** as the type of condition.
-4. To calculate alert threshold violations **individually** for each of the app's selected instances, select **Scope to Java application instances**.
+4. To evaluate alert threshold incidents **individually** for each of the app's selected instances, select **Scope to Java application instances**.
 5. Select **Next, select entities**, then identify one or more apps for this condition.
 6. Optional: Change the time when alerts will force-close the incidents (default is 24 hours).
 7. Use **By condition** or **By condition and signal** [incident preference](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/specify-when-new-relic-creates-incidents).

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/select-product-targets-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/select-product-targets-alert-condition.mdx
@@ -43,7 +43,7 @@ For your convenience, the user interface organizes targeted entities into logica
 
 To identify which entities or components monitored by the selected product will be the targets for the selected condition:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
 2. In the conditions list, select a condition and click **Notification channels**.
 3. Click **Add notification channels**, and then choose your notification channels.
 4. When you're done, click **Update policy**.
@@ -56,7 +56,7 @@ After you select the targeted entities for the alert condition, select **Define 
 
 The policies index lists them in alphabetical order. To view or search for existing entities for an alert condition:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**
 2. To select a policy name: Use the search box, sort any column, or scroll the list.
 3. Optional: From the **Alert conditions** page, use the search box to locate a specific condition.
 4. To view detailed information about entities associated with a condition, click **Notification channels**.
@@ -69,7 +69,7 @@ The policies index lists them in alphabetical order. To view or search for exist
 
 To change the list of selected targeted entities for an existing condition:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
 2. From the list of existing conditions, select the entity name (for example, `My app - Production`) or number of entities (for example, `3 Targets`).
 3. Click **Notification channels**.
 4. In the channels list, click a channel to edit it.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/set-thresholds-alert-condition.mdx
@@ -24,7 +24,7 @@ When you create a condition, you set personalized **thresholds** that determine 
 
 ## What is a threshold? [#threshold-definition]
 
-For a [condition](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-condition), thresholds are the settings that determine what opens an [incident](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-violation). Depending on a policy's [issue creation preference](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents), and any [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) you may have configured, an incident may result in:
+For a [condition](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-condition), thresholds are the settings that determine what opens an [incident](/docs/new-relic-solutions/get-started/glossary/#alert-incident). Depending on a policy's [issue creation preference](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents), and any [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) you may have configured, an incident may result in:
 
 * The creation of an issue.
 * Notifications being sent.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/view-events-their-products.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/view-events-their-products.mdx
@@ -22,7 +22,7 @@ import accountsCropApmIndexHealth from 'images/accounts_screenshot-full_crop-apm
 
 import accountsApmIndexActivity from 'images/accounts_screenshot-full_apm-index-activity.webp'
 
-You can view [events](/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-concepts-workflow#terminology) and other activity for a specific entity from the New Relic product index. For example, to find more information about a specific app in APM: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM**, then mouse over the listed apps, or select an event from the **Applications activity** list.
+You can view [events](/docs/alerts/new-relic-alerts/getting-started/new-relic-alerts-concepts-workflow#terminology) and other activity for a specific entity from the New Relic product index. For example, to find more information about a specific app in APM: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM**, then mouse over the listed apps, or select an event from the **Applications activity** list.
 
 For instructions on how to view these details in Infrastructure, see the [Infrastructure](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information#view-alerts) documentation.
 
@@ -40,7 +40,7 @@ To view information about the current status for an entity (alert condition targ
 />
 
 <figcaption>
-  **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM** : This example shows the violations for all of the <InlinePopover type="apm" /> applications for a specific account. The color-coded health states indicate Critical (red) conditions.
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM** : This example shows the incidents for all of the <InlinePopover type="apm" /> applications for a specific account. The color-coded health states indicate Critical (red) conditions.
 </figcaption>
 
 ## View events and activity lists from products [#products]
@@ -48,13 +48,13 @@ To view information about the current status for an entity (alert condition targ
 You can [view a list of events and other activity](/docs/apm/applications-menu/monitoring/viewing-your-applications-list) from the index for the selected product. By selecting an event from the list, you can go directly to the selected entity's **Summary** page, where you can view detailed information.
 
 <img
-  title="screen-apm-index-activity.png"
-  alt="screen-apm-index-activity.png"
+  title="APM - Activity stream"
+  alt="APM - Activity stream"
   src={accountsApmIndexActivity}
 />
 
 <figcaption>
-  **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**: Here's an example of a Summary of **Application activity**. It includes errors and violations.
+  Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & Services**: Here's an example of a Summary of **Activity stream**. Use filters to delimit your search.
 </figcaption>
 
 Depending on the product, the recent events and activity list also may appear on the selected entity's **Overview** page.
@@ -63,24 +63,25 @@ Depending on the product, the recent events and activity list also may appear on
   **Exception:** The index for dashboards and Synthetic monitoring doesn't include a list of recent events and other activity.
 </Callout>
 
-## View event incidents [#violations-dashboard]
+## View event incidents [#incidents-dashboard]
 
 
-To view an index of events resulting in alert incidents across all available products: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Events > Violations**.
+To view a list of events resulting in alert incidents across all available products: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI** and click the **Incidents** tab.
 
+The **Incidents** list provides summary information about alerting events across all products. From here, follow standard procedures to sort filter or sort. 
 
-The **Incidents** index provides summary information about alerting events across all products. From here, follow standard procedures to sort any column or select available links on any row to view drill-down details. For example:
+Select an incident to open an **Incident overview**:
 
-* To view the **Overview** page for the entity associated with the violation (if available), select the **Target**.
-* To view the condition that triggered the violation, select the **Condition**.
-* To view incident details, select the **Incident ID**.
+* If the incident is associated to an entity, clicking its name in the title will open the **Overview** page for this entity.
+
+* The incident 'metadata' section will provide links to the condition and policy that triggered the incident as well as to the issue the incident belongs to.
 
 ## View all event types [#events-dashboard]
 
-To view an index of events for all available products: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Events > All events**.
+To view an index of events for all available products: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Events > All events**.
 
 The **All events** index provides summary information about alerting events across available products. From here, follow standard procedures to sort any column or select available links on any row to view drill-down details. For example:
 
-* To view the **Overview** page for the entity associated with the violation, select its name from the **Description**.
-* To view the condition that triggered the violation, select the condition's name from the **Description**.
+* To view the **Overview** page for the entity associated with the incident, select its name from the **Description**.
+* To view the condition that triggered the incident, select the condition's name from the **Description**.
 * To view incident details, select the **Incident ID**.


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in [the advanced techniques section of alerts](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/customize-your-webhook-payload/) for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.