### PR TITLE
fix(Alerts): Replaced violation in apm

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/agent-data/triage-run-diagnostics.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/agent-data/triage-run-diagnostics.mdx
@@ -105,7 +105,7 @@ For this example, [your last deployment](/docs/apm/apm-ui-pages/events/record-de
 
 ### Service levels [#service-levels]
 
-Service levels are used to measure the performance of a service from the end user's point of view. When a service level's error budget is exceeded, you'll see these violation types:
+Service levels are used to measure the performance of a service from the end user's point of view. When a service level's error budget is exceeded, you'll see these incident types:
 
   * **Non-compliant** means you've consumed all of the error budget for this period. So be careful if you need to deploy, and plan some work to improve your SLs.
   * **At risk** means your error budget is nearly consumed, and you should be more cautious for the rest of the period.

--- a/src/content/docs/apm/apm-ui-pages/monitoring/transactions-page-find-specific-performance-problems.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/transactions-page-find-specific-performance-problems.mdx
@@ -56,15 +56,15 @@ The host can execute requests in parallel, so you may see percentages over 100. 
 To view information about your app's transaction requests:
 
 1. Do one of the following:
-   * Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > Transactions**.
-   * Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & Services > (select an app) > Monitor > Transactions**.
+   * Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > Transactions**.
+   * Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & Services > (select an app) > Monitor > Transactions**.
 2. If applicable: To change which available [types](#tx_types) of transactions appear, select the **Type**.
 3. Select the [sort order](#sort-definitions), or keep the default.
 4. Select the [type of view](/docs/using-new-relic/user-interface-functions/view-your-data/select-chart-views) as a chart (default), histogram, or percentile, if available.
 5. To view additional details, use any of the transaction [drill-down functions](#tx_functions).
 6. To add a chart to a dashboard, mouse over the chart, then select the **Add to a dashboard** link that appears below it.
 
-If a chart's background is light red, this indicates a time period when an alert condition's [**Critical** threshold](/docs/alerts/new-relic-alerts/defining-conditions/define-thresholds-trigger-alert) has been violated. To view the [incident details](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/view-violation-event-details-incidents) in [alerts](/docs/alerts/new-relic-alerts/getting-started/introduction-new-relic-alerts), click the chart.
+If a chart's background is light red, this indicates a time period when an alert condition's [**Critical** threshold](/docs/alerts/new-relic-alerts/defining-conditions/define-thresholds-trigger-alert) has been breached. To view the [incident details](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/view-violation-event-details-incidents) in [alerts](/docs/alerts/new-relic-alerts/getting-started/introduction-new-relic-alerts), click the chart.
 
 For more information, see the documentation about [navigating core UI components](/docs/new-relic-one/use-new-relic-one/get-started/new-relic-one-core-ui-components).
 
@@ -213,7 +213,7 @@ Use any of New Relic's standard [user interface functions](/docs/new-relic-solut
     In order to view browser information, you must [install the browser agent](/docs/new-relic-browser/browser-settings). Then, to view corresponding [browser request](/docs/browser/new-relic-browser/additional-standard-features/page-views-understanding-your-sites-popularity) data, use either of these options:
 
     * Select the **Browser drill-down** link if available.
-    * Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Browser > (select an app) > Page views**.
+    * Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Browser > (select an app) > Page views**.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/new-relic-apm/getting-started/view-app-alert-information-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/view-app-alert-information-apm.mdx
@@ -3,7 +3,7 @@ title: View app alert information in APM
 tags:
   - APM
   - Getting started
-metaDescription: How to view alert policies, conditions, violations, and other activity and events directly from APM.
+metaDescription: How to view alert policies, conditions, incidents, and other activity and events directly from APM.
 redirects:
   - /docs/apm/new-relic-apm/installation-configuration/view-apps-alert-policies-conditions
   - /docs/apm/new-relic-apm/installation-configuration/view-apps-alert-information
@@ -19,8 +19,8 @@ After you [set up one or more alert policies](/docs/alerts/new-relic-alerts-beta
 To view alert policy and condition information for a specific app or key transaction directly from APM:
 
 1. Do one of the following:
-   * App: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > (select an app) > Settings > Alert conditions**.
-   * Key transaction: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > More > Key transactions > (select a key transaction) > Settings > Alert conditions**.
+   * App: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > (select an app) > Settings > Alert conditions**.
+   * Key transaction: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > More > Key transactions > (select a key transaction) > Settings > Alert conditions**.
 2. From the **Alert conditions** page, use the available tools to search, sort, view, or update the alert conditions and their associated policies.
 
 ## View events and activities from APM [#activity]
@@ -33,27 +33,27 @@ To view summary information about [events](/docs/alerts/new-relic-alerts-beta/ge
 
 1. Do one of the following:
    * App: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**.
-   * Key transaction: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > More > Key transactions**.
+   * Key transaction: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > More > Key transactions**.
 2. From the index, mouse over the entity's [color-coded health status](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#health-status), select a link from the **Application activity** list, or select a specific browser app or key transaction to view additional details.
 
-For example, if a Critical alert violation occurs:
+For example, if a critical alert incident occurs:
 
 * The health status indicator turns red on the APM index and on the selected app.
 * The background color for various charts changes to pink.
-* The **Application activity** list on the APM index and on the selected app's **Summary** page shows Warning (yellow) and Critical (red) violations as applicable.
+* The **Application activity** list on the APM index and on the selected app's **Summary** page shows Warning (yellow) and Critical (red) incidents as applicable.
 
-To learn more about the violation in alerts, mouse over or select any pink area on a chart. For more information and examples, see [View events from their products](/docs/alerts/new-relic-alerts-beta/reviewing-events/view-events-their-products).
+To learn more about the incident in alerts, mouse over or select any pink area on a chart. For more information and examples, see [View events from their products](/docs/alerts/new-relic-alerts-beta/reviewing-events/view-events-their-products).
 
-## View alert violations from APM [#violations]
+## View alert incidents from APM [#incidents]
 
-If an alert condition has [thresholds](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-threshold) set up for Warning (yellow) or Critical (red) violations, the color-coded [health status](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#health-status) for an entity will change to indicate a violation. You can view the violations directly from the page for the app or key transaction in APM:
+If an alert condition has [thresholds](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-threshold) set up for Warning (yellow) or Critical (red) incidents, the color-coded [health status](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#health-status) for an entity will change to indicate an incident. You can view the incidents directly from the page for the app or key transaction in APM:
 
 1. Do one of the following:
-   * App: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > (select an app) > Events > Violations**.
-   * Key transaction: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > More > Key transactions > (select a key transaction) > Events > Violations**.
-2. From the **Violations** index, use the available tools to search, sort, or view violations for the selected app or key transaction.
-3. Optional: To view or update the alert policies, conditions, or thresholds that triggered the violations, select the corresponding link.
+   * App: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > (select an app) > Issues & Activity** and click the **Incidents** tab.
+   * Key transaction: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Key Transactions > (select a key transaction) > Issues & Activity** and click the **Incidents** tab.
+2. From the **Incidents** index, use the available tools to search, sort, or view incidents for the selected app or key transaction.
+3. Optional: To view or update the alert policies, conditions, or thresholds that triggered the incidents, select the corresponding link.
 
 <Callout variant="tip">
-  You can also view Warning and Critical violations from the alerts UI for [specific incidents](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/explore-incident-history) or for [incidents and events across all products](/docs/alerts/new-relic-alerts-beta/reviewing-events/review-events-across-products). Alerts sends [alert notifications](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts) only for Critical (red) violations.
+  You can also view Warning and Critical incidents from the alerts UI for [specific incidents](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/explore-incident-history) or for [incidents and events across all products](/docs/alerts/new-relic-alerts-beta/reviewing-events/review-events-across-products). Alerts sends [alert notifications](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts) only for Critical (red) incidents.
 </Callout>

--- a/src/content/docs/apm/transactions/transaction-traces/introduction-transaction-traces.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/introduction-transaction-traces.mdx
@@ -54,7 +54,7 @@ In APM, a transaction trace records the segments that make up a [transaction](/d
 
 Here are the default rules that govern which transactions a New Relic agent traces:
 
-* Over the minute-long [harvest cycle](/docs/new-relic-solutions/get-started/glossary/#harvest-cycle), all transactions that violate the threshold (either four times your [Apdex T value](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) or a specific number of seconds) are added to a pool of transactions.
+* Over the minute-long [harvest cycle](/docs/new-relic-solutions/get-started/glossary/#harvest-cycle), all transactions that breach the threshold (either four times your [Apdex T value](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) or a specific number of seconds) are added to a pool of transactions.
 * At the end of that minute, the New Relic agent selects the slowest transaction in that pool and performs a transaction trace on it.
 
 These are the general rules, but there are some agent-specific differences. For example:


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the APM section for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.