### PR TITLE
fix(Alerts): Replaced violation in the conditions and NRQL sections

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions.mdx
@@ -19,7 +19,7 @@ redirects:
   - /docs/alerts-and-applied-intelligence/new-relic-alerts/alert-conditions
 ---
 
-A condition describes a monitored data source and the behavior of that data source that will be considered a violation. This document will explain the types of conditions available, how to create a condition, and how to view existing conditions.
+A condition describes a monitored data source and the behavior of that data source that will be considered an incident. This document will explain the types of conditions available, how to create a condition, and how to view existing conditions.
 
 Related documentation:
 
@@ -92,10 +92,10 @@ Here are descriptions of the different types of conditions:
   </Collapser>
 
   <Collapser
-    id="instance-violations"
+    id="instance-incidents"
     title="Java instance conditions"
   >
-    You can set thresholds that open a violation when they are breached by any of your Java app's instance metrics.
+    You can set thresholds that open an incident when they are breached by any of your Java app's instance metrics.
 
     By [scoping thresholds to specific instances](/docs/alerts/new-relic-alerts/configuring-alert-policies/scope-alert-thresholds-specific-instances), you can more quickly identify where potential problems are originating. This is useful, for example, to detect anomalies that are occurring only in a subset of your app's instances. These sorts of anomalies are easy to miss for apps that aggregate metrics across a large number of instances.
   </Collapser>
@@ -104,16 +104,16 @@ Here are descriptions of the different types of conditions:
     id="jvm-metrics"
     title="JVM health metric conditions (Java apps)"
   >
-    For Java apps monitored by APM, you can set [thresholds](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-threshold) that open a violation when the heap size or number of threads for a single JVM is out of the expected operating range.
+    For Java apps monitored by APM, you can set [thresholds](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-threshold) that open an incident when the heap size or number of threads for a single JVM is out of the expected operating range.
 
-    We calculate alerting threshold violations individually for each of the app's [selected instances](#instance-violations). When creating your condition, select **JVM health metric** as the type of condition for your Java app's alert policy, then select any of the available thresholds:
+    We evaluate alerting threshold breaches individually for each of the app's [selected instances](#instance-incidents). When creating your condition, select **JVM health metric** as the type of condition for your Java app's alert policy, then select any of the available thresholds:
 
     * Deadlocked threads
     * Heap memory usage
     * CPU utilization time
     * Garbage collection CPU time
 
-      Violations will automatically close when the inverse of the threshold is met, but by using the UI you can also change the time when a [violation](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-violation) force-closes for a JVM health metric. Default is 24 hours.
+      Incidents will automatically close when the inverse of the threshold is met, but by using the UI you can also change the time when an [incident](/docs/new-relic-solutions/get-started/glossary/#alert-incident) force-closes for a JVM health metric. Default is 24 hours.
   </Collapser>
 
   <Collapser
@@ -129,7 +129,7 @@ Here are descriptions of the different types of conditions:
     To define the percentile threshold:
 
     1. Select **Web transactions percentiles** as the type of condition for your <InlinePopover type="apm" /> app's condition, then select a single app. (To alert on more than one app, create an individual **Web transactions percentiles** condition for each.)
-    2. To define the thresholds that open the violation, type the **Percentile nth** response time value, then select its frequency (above, below, or equal to this value).
+    2. To define the thresholds that open the incident, type the **Percentile nth** response time value, then select its frequency (above, below, or equal to this value).
 
        We store the transaction time in milliseconds, although the user interface shows the Critical and Warning values as seconds. If you want to define milliseconds, be sure to include the decimal point in your value.
   </Collapser>
@@ -142,7 +142,7 @@ Here are descriptions of the different types of conditions:
 
     A single label identifies **all** entities associated with that label (maximum 10,000 entities). Multiple labels only identify entities which share all the selected labels.
 
-    Using dynamic targeting with your condition also requires that you set a [violation close timer](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/how-alert-condition-violations-are-closed#time-limit).
+    Using dynamic targeting with your condition also requires that you set an [incident close timer](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/how-alert-condition-violations-are-closed#time-limit).
 
     To add, edit, or remove up to ten labels for a condition:
 
@@ -164,18 +164,18 @@ Here are descriptions of the different types of conditions:
 
 ## Apdex and response time conditions [#alert_response]
 
-You can open violations and send notifications for response times. However, [Apdex scores](/docs/apm/new-relic-apm/apdex/view-your-apdex-score) are almost always more meaningful and provide a better reflection of application performance. For example, average response times can be skewed by outliers, while the Apdex score gives a more accurate assessment of acceptable response time rates that your users experience.
+You can open incidents and send notifications for response times. However, [Apdex scores](/docs/apm/new-relic-apm/apdex/view-your-apdex-score) are almost always more meaningful and provide a better reflection of application performance. For example, average response times can be skewed by outliers, while the Apdex score gives a more accurate assessment of acceptable response time rates that your users experience.
 
 ## Change a condition name [#rename-condition]
 
 If you want to change the default condition name, make it short and descriptive. Provide useful information for notification messages that have limited characters, such as email subject lines, online chat, etc.
 
 * Use camel case or dotted decimal notation.
-* Describe the essence of what is being violated.
+* Describe the essence of what is being breached.
 
 To change an existing condition's name:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (policies) > (select a policy)**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (policies) > (select a policy)**.
 2. Click a condition name to edit it, and then type a meaningful name for the condition.
 
 You can't edit the product and condition type associated with a condition. Instead, you must delete the condition and create a new one with a different product and condition type.
@@ -197,7 +197,7 @@ You may also manage your policies via [the policies NerdGraph API](/docs/alerts/
 
 The policies index lists them in alphabetical order. To view or search for existing conditions:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (policies)**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (policies)**.
 2. Use the search box, sort any column, or scroll the list, then select a policy's name to see its conditions.
 
 To view [policy and condition information for a specific entity](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/view-policy-conditions-new-relic-products): From that entity's product UI, select **Settings**, then click **Alert conditions**.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions.mdx
@@ -28,7 +28,7 @@ You can use [NRQL queries](/docs/insights/new-relic-insights/using-new-relic-que
 
 ## Create a NRQL alert condition from a policy [#alert-condition-from-policy]
 
-Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert Conditions & Policies** to create a NRQL alert condition from a policy. Then, click **+ New alert condition**.
+Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert Conditions & Policies** to create a NRQL alert condition from a policy. Then, click **+ New alert condition**.
 
 <img
   width="80%;"
@@ -38,7 +38,7 @@ Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capab
 />
 
 <figcaption>
-  Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert Conditions & Policies > + New alert condition**. 
+  Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert Conditions & Policies > + New alert condition**. 
 </figcaption>
 
 
@@ -102,7 +102,7 @@ Most of our charts, with the exception of a few older ones, allow you to create 
 
 To create a NRQL alert condition from a chart:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & Services** and select an app.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > APM & Services** and select an app.
 2. In the left pane, select **Metrics explorer** and add your configuration.
 3. In the chart's right corner, click the <Icon name="fe-more-horizontal"/> icon and select **Create alert condition**.
 
@@ -764,7 +764,7 @@ Loss of signal occurs when no data matches the NRQL condition over a specific pe
 />
 
 <figcaption>
-  Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then **+ New alert condition**. Loss of signal is only available for NRQL conditions.
+  Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then **+ New alert condition**. Loss of signal is only available for NRQL conditions.
 </figcaption>
 
 You may also manage these settings using the GraphQL API (recommended), or the REST API. Go here for specific [GraphQL API examples](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling).
@@ -791,7 +791,7 @@ To create a NRQL alert configured with loss of signal detection in the UI:
 2. Write a [NRQL query](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries#syntax) that returns the values you want to alert on.
 3. For **Threshold type**, select **Static** or **Anomaly**.
 4. Click **+ Add lost signal threshold**, then set the signal expiration duration time in minutes or seconds in the **Consider the signal lost after** field.
-5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open incidents** and **Open new "lost signal" incidents**. These control how loss of signal incidents will be handled for the condition.
+5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open incidents** and **Open new "lost signal" incident**. These control how loss of signal incidents will be handled for the condition.
 6. Make sure you name your condition before you save it.
 
 Incidents open due to loss of signal close when:

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/queries-nrql_screenshot-full_nrql-alert-conditions
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/queries-nrql_screenshot-full_nrql-alert-conditions
@@ -35,7 +35,7 @@ Read on to learn more about how to do this.
 />
 
 <figcaption>
-  **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy) > Add a condition**. Click **NRQL**, and then **Next, define thresholds**.
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy) > Add a condition**. Click **NRQL**, and then **Next, define thresholds**.
 </figcaption>
 
 <Callout variant="tip">
@@ -48,7 +48,7 @@ Ready to get started? If you haven't already, be sure to [sign up for a New Reli
 
 To create a NRQL alert condition for a policy:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (policies)**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (policies)**.
 2. Select an existing policy or click **New alert policy** to [create a new policy](/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/create-edit-or-find-alert-policy).
 3. Click **Add a condition**.
 4. Under **Select a product** click **NRQL**, and then click **Next, define thresholds**.
@@ -523,7 +523,7 @@ Here are some tips for creating and using a NRQL condition:
       </td>
 
       <td>
-        For NRQL conditions, you can create a custom [description](/docs/alerts/new-relic-alerts/defining-conditions/alert-condition-descriptions) to add to each violation. Descriptions can be enhanced with variable substitution based on metadata in the specific violation.
+        For NRQL conditions, you can create a custom [description](/docs/alerts/new-relic-alerts/defining-conditions/alert-condition-descriptions) to add to each incident. Descriptions can be enhanced with variable substitution based on metadata in the specific incident.
 
         For details, see [Description](/docs/alerts/new-relic-alerts/defining-conditions/alert-condition-descriptions)
       </td>
@@ -563,7 +563,7 @@ Here are some tips for creating and using a NRQL condition:
       </td>
 
       <td>
-        You can use loss of signal detection to alert on when your data (a telemetry signal) should be considered lost. A signal loss can indicate that a service or entity is no longer online or that a periodic job failed to run. You can also use this to make sure that violations for sporadic data, such as error counts, are closed when no signal is coming in.
+        You can use loss of signal detection to alert on when your data (a telemetry signal) should be considered lost. A signal loss can indicate that a service or entity is no longer online or that a periodic job failed to run. You can also use this to make sure that incidents for sporadic data, such as error counts, are closed when no signal is coming in.
       </td>
     </tr>
 
@@ -586,8 +586,8 @@ Here are some tips for creating and using a NRQL condition:
         Use the **Condition settings** to:
 
         * Create a concise, descriptive [condition name](/docs/alerts/new-relic-alerts/configuring-alert-policies/define-alert-conditions#rename-condition).
-        * Provide a [custom violation description for the condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions) that will be included in violations and notifications.
-        * Add the runbook URL to include your organization's procedures for handling incidents. You may also add this information to the [custom violation description](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions).
+        * Provide a [custom incident description for the condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions) that will be included in incidents and notifications.
+        * Add the runbook URL to include your organization's procedures for handling incidents. You may also add this information to the [custom incident description](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions).
       </td>
     </tr>
 
@@ -634,14 +634,14 @@ When you edit an existing NRQL condition, you have the option to add or remove t
 
 When you edit NRQL alert conditions in some specific ways (detailed below), their evaluations are reset, meaning that any evaluation up until that point is lost, and the evaluation starts over from that point. The two ways this will affect you are:
 
-* For "for at least x minutes" thresholds: because the evaluation window has been reset, there will be a delay of at least x minutes before any violations can be reported.
+* For "for at least x minutes" thresholds: because the evaluation window has been reset, there will be a delay of at least x minutes before any incidents can be reported.
 * For [anomaly conditions](#threshold-types): the condition starts over again and all anomaly learning is lost.
 
 The following actions cause an evaluation reset for NRQL conditions:
 
 * Changing the query
 * Changing the aggregation window, aggregation method, or aggregation delay/timer setting
-* Changing the "close violations on signal loss" setting
+* Changing the "Add lost signal threshold" setting
 * Changing any gap fill settings
 * Changing the anomaly direction (if applicable) – higher, lower, or higher/lower
 * Change the threshold value, threshold window, or threshold operator
@@ -650,8 +650,8 @@ The following actions cause an evaluation reset for NRQL conditions:
 The following actions (along with any other actions not covered in the above list) will **not** reset the evaluation:
 
 * Changing the loss of signal time window (expiration duration)
-* Changing the time function (switching "for at least" to "at least once in," or vice-versa)
-* Toggling the "open violation on signal loss" setting
+* Changing the time function (switching **for at least** to **at least once in**, or vice-versa)
+* Setting the **Add lost signal threshold**.
 
 ## Alert condition types [#threshold-types]
 
@@ -712,7 +712,7 @@ Loss of signal occurs when no data matches the NRQL condition over a specific pe
 />
 
 <figcaption>
-  Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy)**, then **Add a condition**. Loss of signal is only available for NRQL conditions.
+  Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies) > (select a policy)**, then **Add a condition**. Loss of signal is only available for NRQL conditions.
 </figcaption>
 
 You may also manage these settings using the GraphQL API (recommended), or the REST API. Go here for specific [GraphQL API examples](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling).
@@ -728,10 +728,10 @@ Loss of signal settings include a time duration and two possible actions.
   * The loss of signal expiration time is independent of the threshold duration and triggers as soon as the timer expires.
   * The maximum expiration duration is 48 hours. This is helpful when monitoring for the execution of infrequent jobs. The minimum is 30 seconds, but we recommend using at least 3-5 minutes.
 * **Loss of signal actions**
-  Once a signal is considered lost, you can close open violations, open new violations, or both.
-  * Close all current open violations: This closes all open violations that are related to a specific signal. It won't necessarily close all violations for a condition. If you're alerting on an ephemeral service, or on a sporadic signal, you'll want to choose this action to ensure that violations are closed properly. The GraphQL node name for this is ["closeViolationsOnExpiration](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling)"
-  * Open new violations: This will open a new violation when the signal is considered lost. These violations will indicate that they are due to a loss of signal. Based on your incident preferences, this should trigger a notification. The graphQL node name for this [is "openViolationOnExpiration](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling)"
-  * When you enable both actions, we'll close all open violations first, and then open a new violation for loss of signal.
+  Once a signal is considered lost, you can close open incidents, open new incidents, or both.
+  * Close all current open incidents: This closes all open incidents that are related to a specific signal. It won't necessarily close all incidents for a condition. If you're alerting on an ephemeral service, or on a sporadic signal, you'll want to choose this action to ensure that incidents are closed properly. The GraphQL node name for this is ["closeViolationsOnExpiration](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling)"
+  * Open new incidents: This will open a new incident when the signal is considered lost. These incidents will indicate that they are due to a loss of signal. Based on your incident preferences, this should trigger a notification. The graphQL node name for this [is "openViolationOnExpiration](/docs/alerts-applied-intelligence/new-relic-alerts/alerts-nerdgraph/nerdgraph-api-loss-signal-gap-filling)"
+  * When you enable both actions, we'll close all open incidents first, and then open a new incident for loss of signal.
 
 To create a NRQL alert configured with loss of signal detection in the UI:
 
@@ -739,14 +739,14 @@ To create a NRQL alert configured with loss of signal detection in the UI:
 2. Write a [NRQL query](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions-nrql-queries#syntax) that returns the values you want to alert on.
 3. For **Threshold type**, select **Static** or **Anomaly**.
 4. Click **+ Add lost signal threshold**, then set the signal expiration duration time in minutes or seconds in the **Signal is lost after** field.
-5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open violations** and **Open new "lost signal" violation**. These control how loss of signal violations will be handled for the condition.
+5. Choose what you want to happen when the signal is lost. You can check one or both of **Close all current open incidents** and **Open new "lost signal" incident**. These control how loss of signal incidents will be handled for the condition.
 6. Make sure you name your condition before you save it.
 
-Violations open due to loss of signal close when
+Incidents open due to loss of signal close when:
 
-* the signal comes back. Newly opened lost signal violations will close immediately when new data is evaluated.
+* the signal comes back. Newly opened lost signal incidents will close immediately when new data is evaluated.
 * the condition they belong to expires. By default, conditions expire after 3 days.
-* you manually close the violation with the **Close all current open violations** option.
+* you manually close the incident with the **Close all current open incidents** option.
 
 <Callout variant="tip">
   Loss of signal detection doesn't work on NRQL queries that use nested aggregation or sub-queries.
@@ -792,7 +792,7 @@ Learn how to set sliding windows in this short video (2:30 minutes):
 Once enabled, set the "slide by interval" to control how much overlap time your aggregated windows have. The interval must be shorter than the aggregation window while also dividing evenly into it.
 
 <Callout variant="important">
-  Immediately after you create a new sliding windows alert condition or perform any action that can cause an [evaluation reset](#evaluation-resets), your condition will need time build up an "aggregated buffer" for the duration of the first aggregation window. During that time, no violations will trigger. Once that single aggregation window has passed, a complete "buffer" will have been built and the condition will function normally.
+  Immediately after you create a new sliding windows alert condition or perform any action that can cause an [evaluation reset](#evaluation-resets), your condition will need time build up an "aggregated buffer" for the duration of the first aggregation window. During that time, no incidents will trigger. Once that single aggregation window has passed, a complete "buffer" will have been built and the condition will function normally.
 </Callout>
 
 ### Streaming method [#streaming]
@@ -815,7 +815,7 @@ If the data type comes from an [APM language agent](/docs/apm/new-relic-apm/gett
 
 Gap filling lets you customize the values to use when your signals don't have any data. You can fill gaps in your data streams with one of these settings:
 
-* **None**: (Default) Choose this if you don't want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won't be in violation.
+* **None**: (Default) Choose this if you don't want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won't open an incident.
 * **Custom static value**: Choose this if you'd like to insert a custom static value into the empty aggregation windows before they're evaluated. This option has an additional, required parameter of `fillValue` (as named in the API) that specifies what static value should be used. This defaults to `0`.
 * **Last known value**: This option inserts the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/get-started/your-first-nrql-condition.mdx
@@ -85,7 +85,7 @@ So, in this case, if you want to make sure that web transactions never take long
 <Step>
 ## Set thresholds for alert conditions
 
-If an alert condition is a container, then thresholds are the rules that each alert condition contains. As data streams into your system, the alert condition searches for any violations of these rules. If the alert condition sees data coming in from your system that has met all the conditions you've set, then it will create an incident. An incident is a signal that something is off in your system and you should take a look. 
+If an alert condition is a container, then thresholds are the rules that each alert condition contains. As data streams into your system, the alert condition searches for any incidents of these rules. If the alert condition sees data coming in from your system that has met all the conditions you've set, then it will create an incident. An incident is a signal that something is off in your system and you should take a look. 
 
 Your team is creating an alert condition to look for any latency issues in web transaction time. Now, you're going to create the rules this condition is going to look for. 
 
@@ -228,7 +228,7 @@ The delay feature protects you against inconsistent data collection. It gives th
  
   This alert condition is a container that holds all the rules—are we using static or anomaly thresholds, are we using a sliding-window aggregation or just leaving the evaluation period as normal? 
 
-  At this point in the process we now have a fully defined container and we've set all the rules to make sure an incident is opened when we want it to be. Based on the settings above, if our alert condition recognizes this behavior in our system that "violates" the thresholds that we've set, it will create an incident. Now, all we need to do is to attach this container to a policy. 
+  At this point in the process we now have a fully defined container and we've set all the rules to make sure an incident is opened when we want it to be. Based on the settings above, if our alert condition recognizes this behavior in our system that breaches the thresholds that we've set, it will create an incident. Now, all we need to do is to attach this container to a policy. 
   
   The policy is the sorting system for the incident. When you create a policy, you're creating the tool that organizes all of your incoming incidents. You can connect policies to **[workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/)** that tell New Relic where you want all this incoming information to go, how often you want it to be sent, and where. 
 
@@ -272,9 +272,9 @@ The delay feature protects you against inconsistent data collection. It gives th
     id="close-open-incidents"
     title="Close open incidents"
   >
-  An incident will automatically close when the targeted signal returns to a non-violating state for the time period indicated in the condition's thresholds. This wait time is called the recovery period.
+  An incident will automatically close when the targeted signal returns to a non-breaching state for the time period indicated in the condition's thresholds. This wait time is called the recovery period.
 
-  For example, if the violating behavior is "web transaction time is longer than .50 seconds at least once in 5 minutes," then the incident will automatically close when web transaction time is equal to or lower than .50 for 5 consecutive minutes. 
+  For example, if the breaching behavior is "web transaction time is longer than .50 seconds at least once in 5 minutes," then the incident will automatically close when web transaction time is equal to or lower than .50 for 5 consecutive minutes. 
 
   When an incident closes automatically:
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -10,7 +10,7 @@ import queriesnrqlEventCountinQueryBuilder from 'images/queries-nrql_screenshot-
 
 Our New Relic query language, NRQL, has rate limits in place to ensure a high level of availability and reliability for all users. 
 
-## Understand query limit violations [#limit-violations]
+## Understand query limit breaches [#limit-breaches]
 
 To see if you're hitting query-related limits, use the [Limits UI](/docs/data-apis/manage-data/view-system-limits/). 
 


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the conditions and NRQL sections for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.