### PR TITLE
fix(Alerts): Replaced violation in the infrastructure section

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-alerts/infrastructure-alert-conditions/create-infrastructure-host-not-reporting-condition.mdx
+++ b/src/content/docs/infrastructure/infrastructure-alerts/infrastructure-alert-conditions/create-infrastructure-host-not-reporting-condition.mdx
@@ -21,7 +21,7 @@ Use infrastructure monitoring's **Host not reporting** [condition](/docs/infrast
 You can define conditions based on the sets of hosts most important to you, and configure thresholds appropriate for each filtered set of hosts. The **Host not reporting** event triggers when data from the infrastructure agent doesn't reach our [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector) within the time frame you specify.
 
 <Callout variant="caution">
-  If you have filtered your `Host not reporting` condition using tags or labels and then remove a critical tag or label from a targeted host, the system will open a `Host not reporting` violation, because it will characterize that host as having lost its connection.
+  If you have filtered your `Host Not Reporting` condition using tags or labels and then remove a critical tag or label from a targeted host, the system will open a Host Not Reporting incident, since it will characterize that host as having lost its connection.
 </Callout>
 
 This feature's flexibility allows you to easily customize what to monitor and when to notify selected individuals or teams. In addition, the email notification includes links to help you quickly troubleshoot the situation.
@@ -66,7 +66,7 @@ This feature's flexibility allows you to easily customize what to monitor and wh
       </td>
 
       <td>
-        Email addresses (identified in the policy) will be notified automatically about [threshold](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-threshold) violations for any host matching the filters you have applied, depending on the policy's [incident preferences](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents).
+        Email addresses (identified in the policy) will be notified automatically about [threshold](/docs/using-new-relic/welcome-new-relic/get-started/glossary#alert-threshold) incidents for any host matching the filters you have applied, depending on the policy's [incident preferences](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents).
       </td>
     </tr>
 
@@ -91,15 +91,15 @@ To define the **Host not reporting** condition criteria:
 3. Define the **Critical** threshold for triggering the notification: minimum 5 minutes, maximum 60 minutes.
 4. Enable the **Don't trigger alerts for hosts that perform a clean shutdown** option, if you want to prevent false alerts when you have hosts set to shut down via command line. Currently, this feature is supported on all Windows systems and Linux systems using systemd.
     <Callout variant='tip'>
-      Alternatively, you can add the `hostStatus: shutdown` [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data/) to your host along with checking the option mentioned above. This will stop all **Host Not Reporting** violations from opening for that host, as long as that tag is on it, regardless of the agent version or OS. Removing the tag will allow the system to open **Host Not Reporting** violations for that host again.
+      Alternatively, you can add the `hostStatus: shutdown` [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/use-tags-help-organize-find-your-data/) to your host along with checking the option mentioned above. This will stop all **Host Not Reporting** incidents from opening for that host, as long as that tag is on it, regardless of the agent version or OS. Removing the tag will allow the system to open **Host Not Reporting** incidents for that host again.
     </Callout>
 
-Depending on the policy's [incident preferences](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents), it will define which notification channels to use when the defined **Critical** threshold for the condition passes. To avoid "false positives," the host must stop reporting for the entire time period before a violation is opened.
+Depending on the policy's [incident preferences](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents), it will define which notification channels to use when the defined **Critical** threshold for the condition passes. To avoid "false positives," the host must stop reporting for the entire time period before an incident is opened.
 
-**Example:** You create a condition to open a violation when any of the filtered set of hosts stop reporting data for **seven** minutes.
+**Example:** You create a condition to open an incident when any of the filtered set of hosts stop reporting data for **seven** minutes.
 
-* If any host stops reporting for five minutes, then resumes reporting, the condition **does not** open a violation.
-* If any host stops reporting for seven minutes, even if the others are fine, the condition **does** open a violation.
+* If any host stops reporting for five minutes, then resumes reporting, the condition **does not** open an incident.
+* If any host stops reporting for seven minutes, even if the others are fine, the condition **does** open an incident.
 
 ## Investigate the problem [#view-incidents]
 

--- a/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change.mdx
+++ b/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-events-page-live-feed-every-config-change.mdx
@@ -24,7 +24,7 @@ In our infrastructure monitoring UI, the **Events** UI page is a live feed of im
   Note that `event` here has an infrastructure-specific meaning that is different from our [event data type](/docs/data-apis/understand-data/new-relic-data-types/#event-data).
 </Callout>
 
-Find the **Events** page by going to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Events**.
+Find the **Events** page by going to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Events**.
 
 <img
   title="infra-events-ui.png"
@@ -76,7 +76,7 @@ New Relic collects a variety of change events so you can understand each change 
       </td>
 
       <td>
-        When a [violation](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-violation) is opened or closed, New Relic generates an event indicating the host and associated [alert condition](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information).
+        When an [incident](/docs/new-relic-solutions/get-started/glossary/#alert-incident) is opened or closed, New Relic generates an event indicating the host and associated [alert condition](/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-alerts-add-edit-or-view-host-alert-information).
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure.mdx
+++ b/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure.mdx
@@ -24,7 +24,7 @@ Use the **Inventory** page to:
 
 ## Find the inventory page [#find]
 
-To view and search your inventory data: Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Inventory**.
+To view and search your inventory data: Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Inventory**.
 
 ## What data does this page display? [#data]
 
@@ -126,9 +126,9 @@ Use **Inventory** page functions to find information about a particular item on 
 
   <Collapser
     id="alerts"
-    title="View host's alert threshold violations"
+    title="View host's alert threshold incidents"
   >
-    To view one or more host's [alert threshold violations](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-threshold), select the host's **Critical** <Icon name="fe-x-circle"/>
+    To view one or more host's [alert threshold incidents](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-threshold), select the host's **Critical** <Icon name="fe-x-circle"/>
     icon or **Warning** <Icon name="fe-alert-triangle"/>
     icon.
   </Collapser>

--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/apm-data-infrastructure-monitoring.mdx
@@ -15,9 +15,9 @@ redirects:
   - /docs/apm/apm-ui-pages/monitoring/apm-data-infrastructure
 ---
 
-import apmCriticalViolationsinApdex from 'images/apm_screenshot-full_critical-violations-in-Apdex.webp'
+import apmCriticalIncidentsinApdex from 'images/apm_screenshot-full_critical-violations-in-Apdex.webp'
 
-import apmCPUPercentageViolationinAPM from 'images/apm_screenshot-crop_CPU-percentage-violation-in-APM.webp'
+import apmCPUPercentageIncidentinAPM from 'images/apm_screenshot-crop_CPU-percentage-violation-in-APM.webp'
 
 import apmToggleBetweenHistogramViews from 'images/apm_screenshot-crop_toggle-between-histogram-views.webp'
 
@@ -48,16 +48,16 @@ If the integration is not working, see [Troubleshooting the APM-infrastructure i
 
     In this example, let's say that you're the engineer responsible for the `Billing Service` application and you get an alert that says, "Error percentage > 45% for at least five minutes on `Billing Service`." 
     
-    * The first thing you're going to do is go to the `Billing Service` application in APM and open the **Summary** page to get an overview of the health of your system.  A high Apdex score, which is a measure of user satisfaction, can indicate that there's a problem in your system. Here you can see that the score is .79 and has triggered a critical violation. 
+    * The first thing you're going to do is go to the `Billing Service` application in APM and open the **Summary** page to get an overview of the health of your system.  A high Apdex score, which is a measure of user satisfaction, can indicate that there's a problem in your system. Here you can see that the score is .79 and has triggered a critical incident. 
     * Next you're going to check your error rate. Here you can see that the error rate has hit 100%. 
 
 Based on these two indicators, you know you have a problem. Now you just have to figure out where and why.  
 
 
   <img
-    title="Apdex violations"
-    alt="A screenshot depicting critical violations in apdex"
-    src={apmCriticalViolationsinApdex}
+    title="Apdex incidents"
+    alt="A screenshot depicting critical incidents in apdex"
+    src={apmCriticalIncidentsinApdex}
     />
     </Step>
     <Step>
@@ -78,19 +78,19 @@ Based on these two indicators, you know you have a problem. Now you just have to
     When you look at the CPU histogram, you can see that the CPU % for all of your hosts skyrocketed around 11:30 am. You can also see that this change in CPU occurred at the same time as a recent deployment. If you click on the [deployment marker](/docs/apm/apm-ui-pages/events/record-deployments/) it will tell you who released a change and what that change entailed. 
 
     <img
-    title="CPU violation in APM"
-    alt="A screenshot depicting a CPU violation that corresponds to a deployment marker."
-    src={apmCPUPercentageViolationinAPM}
+    title="CPU incident in APM"
+    alt="A screenshot depicting a CPU incident that corresponds to a deployment marker."
+    src={apmCPUPercentageIncidentinAPM}
     />
   </Step>
     <Step>
      ## Dig deep into a specific host
       
-      Now that you know that a recent deployment in your `Billing Service` application caused a spike in errors and critical Apdex violations you might want to look into a specific host for more clarity. Click the name of the host you want to inspect. It will reveal a sidebar that imports all relevant information from the **Infrastructure** page. This allows you to access all the information you need regarding your host and any service errors without leaving the rest of your data. 
+      Now that you know that a recent deployment in your `Billing Service` application caused a spike in errors and critical Apdex incidents you might want to look into a specific host for more clarity. Click the name of the host you want to inspect. It will reveal a sidebar that imports all relevant information from the **Infrastructure** page. This allows you to access all the information you need regarding your host and any service errors without leaving the rest of your data. 
 
   <img
-    title="host with critical violations"
-    alt="A gif depicting a deeper inspection of a host with critical violations"
+    title="host with critical incidents"
+    alt="A gif depicting a deeper inspection of a host with critical incidents"
     src={apmExploringaSpecificHostinAPM}
   />
 

--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/alert-infrastructure-processes.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/alert-infrastructure-processes.mdx
@@ -24,14 +24,14 @@ This feature's flexibility allows you to easily filter what hosts and processes 
 
 ## Examples [#features]
 
-By applying filters to the hosts and processes that are important to your business, you can define [alerting thresholds](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-threshold) to decide when violations open and New Relic sends an email notification to you depending on the policy's [incident preferences](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents). These examples illustrate how to use infrastructure monitoring's **Process running** condition to monitor your processes.
+By applying filters to the hosts and processes that are important to your business, you can define [alerting thresholds](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-threshold) to decide when incidents open and New Relic sends an email notification to you depending on the policy's [incident preferences](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents). These examples illustrate how to use infrastructure monitoring's **Process running** condition to monitor your processes.
 
 <CollapserGroup>
   <Collapser
     id="processes-load"
     title="Ensure enough processes are running to satisfy load"
   >
-    **Problem:** Some load balancers and application servers work by running many worker processes in parallel. Here, for example, you may want an alert violation when fewer than eight processes are running for a service like gunicorn.
+    **Problem:** Some load balancers and application servers work by running many worker processes in parallel. Here, for example, you may want an alert incident when fewer than eight processes are running for a service like gunicorn.
 
     **Solution:** Depending on the situation, use any of these **Process running** thresholds options as needed:
 
@@ -55,14 +55,14 @@ By applying filters to the hosts and processes that are important to your busine
   >
     **Problem:** You have processes requiring special attention due to security or potential performance impact.
 
-    **Solution:** Use the **At least one process is running** threshold with condition filters set to a username and specific executable so that New Relic can open a violation when the process is running.
+    **Solution:** Use the **At least one process is running** threshold with condition filters set to a username and specific executable so that New Relic can open an incident when the process is running.
   </Collapser>
 
   <Collapser
     id="one-job-length"
     title="Make sure a job doesn't take too long"
   >
-    **Problem:** You have a job that runs periodically, and you want to open a violation when it has been running longer than an expected number of minutes.
+    **Problem:** You have a job that runs periodically, and you want to open an incident when it has been running longer than an expected number of minutes.
 
     **Solution:** Use the **At least one process is running** threshold.
   </Collapser>

--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information.mdx
@@ -37,7 +37,7 @@ Alert conditions apply to alert [policies](/docs/alerts/new-relic-alerts/getting
 
 To add an infrastructure alert condition to an alerts policy:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure**. Mouse over a chart you want to alert on, select the ellipses <Icon name="fe-more-horizontal"/> icon, and then select **Create alert condition**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure**. Mouse over a chart you want to alert on, select the ellipses <Icon name="fe-more-horizontal"/> icon, and then select **Create alert condition**.
 2. Type a meaningful condition name.
 3. Select the **Alert type**, or refer to the [examples](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerting-examples) to decide which type to select.
 4. Create individual filters, or copy all the filters from the [entity filter bar](/docs/new-relic-solutions/new-relic-one/core-concepts/search-filter-entities) to identify the hosts that you want the alert condition to use.
@@ -49,7 +49,7 @@ To add an infrastructure alert condition to an alerts policy:
 
    Select the option to create a new policy and identify the email for alert notifications.
 8. Optional: Add a [runbook url](#runbook-url-infrastructure).
-9. Optional: Set [**Violation time limit** for violations](#violation-time-limit) (this defaults to 24 hours).
+9. Optional: Set [**Close open incidents after** for incidents](#incident-time-limit) (this defaults to 24 hours for infrastructure conditions).
 10. Select **Create**.
 
 <Callout variant="important">
@@ -66,7 +66,7 @@ You can also use these other methods to create an infrastructure alert condition
     id="alerts-ui"
     title="Use the alerts UI"
   >
-    Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alerts & AI > Alert policies > New alert policy > Create new condition**, then select **Infrastructure** as the product.
+    Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alerts & AI > Alert policies > New alert policy > Create new condition**, then select **Infrastructure** as the product.
   </Collapser>
 
   <Collapser
@@ -74,7 +74,7 @@ You can also use these other methods to create an infrastructure alert condition
     id="infrastructure-ui"
     title="Use the Infrastructure UI"
   >
-    1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Hosts**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Hosts**.
     3. Mouse over the chart you want to alert on, select the ellipses <Icon name="fe-more-horizontal"/> icon, and then select **Create alert**.
   </Collapser>
 
@@ -87,7 +87,7 @@ You can also use these other methods to create an infrastructure alert condition
       Use this method to create an alert condition for infrastructure integrations.
     </Callout>
 
-    1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts**, and then click **Create alert condition**.
+    1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts**, and then click **Create alert condition**.
     2. Name and describe the alert condition.
     3. Click the **Integrations** alert type, and then select the integration data source you'd like to use.
     4. Use the **Filter entities** dropdown to limit your condition to specific attributes.
@@ -99,9 +99,9 @@ You can also use these other methods to create an infrastructure alert condition
 
 ## View host alert events [#view-alerts]
 
-Anyone included in the policy's [notification channels](#notification) receive alert notifications directly. In addition, anyone with permissions for your New Relic account can view infrastructure alert incidents and individual violations through the user interface.
+Anyone included in the policy's [notification channels](#notification) receive alert notifications directly. In addition, anyone with permissions for your New Relic account can view infrastructure alert incidents and individual incidents through the user interface.
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Events**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Events**.
 2. To change the hosts or time frame, use the search window, entity filter bar, or time functions.
 3. From the **Events** list, select the alert violation.
 4. To [view detailed information in alerts](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/view-incident-violation-details) about the selected violation, select the link.
@@ -110,7 +110,7 @@ Anyone included in the policy's [notification channels](#notification) receive a
 
 To edit, disable (or re-enable), or delete host alert information:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts**.
 2. Optional: Use the search window or **Select all** checkbox to locate one or more alert conditions.
 3. Select any of the available functions to <Icon name="fe-edit-2"/>
    edit, disable, enable, or <Icon name="fe-trash-2"/>
@@ -152,7 +152,7 @@ To edit, disable (or re-enable), or delete host alert information:
 
       <td>
         * View summary information about [events](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#event): Use the [Infrastructure **Events**](#view-alerts) UI.
-        * View detailed information about [alert incidents](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-incident) or [individual violations](/docs/alerts/new-relic-alerts/getting-started/alerts-glossary#alert-violation): Use the [alerts](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/explore-incident-history-incidents-index) UI or the [notification channel](#notification) integrated with the associated policy.
+        * View detailed information about [alert incidents](/docs/new-relic-solutions/get-started/glossary/#alert-incident): Use the [alerts](/docs/alerts/new-relic-alerts/reviewing-alert-incidents/explore-incident-history-incidents-index) UI or the [notification channel](#notification) integrated with the associated policy.
       </td>
     </tr>
 
@@ -165,7 +165,7 @@ To edit, disable (or re-enable), or delete host alert information:
         View, add, change, disable, or delete:
 
         * For policies with a variety of notification channels: Use the [alerts](/docs/alerts/new-relic-alerts/updating-alert-policies/change-alert-policies) UI.
-        * For policies only needing [email notifications](#notification): Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts & AI > Create a new policy**, and add one or more email addresses as needed.
+        * For policies only needing [email notifications](#notification): Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts & AI > Create a new policy**, and add one or more email addresses as needed.
 
           Add host conditions to an existing policy: Use the [Infrastructure](#create-condition) UI.
       </td>
@@ -179,7 +179,7 @@ To edit, disable (or re-enable), or delete host alert information:
       <td>
         To view, add, change, or delete [available notification options](#notification):
 
-        1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts**.
+        1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Settings > Alerts**.
         2. Optional: Search for the condition or policy name.
         3. From the list of conditions, select the policy link to view notification channel information in the alerts UI.
       </td>
@@ -194,24 +194,24 @@ The use of the **Description** field is available for these alert condition type
 * NRQL conditions: add a description using the [NerdGraph API](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-alerts-nrql-conditions).
 * Infrastructure conditions: add a description using the UI or the REST API.
 
-The text you place in an alert condition's **Description** field is passed downstream to associated violations and notifications. A description can be used for several purposes, including:
+The text you place in an alert condition's **Description** field is passed downstream to associated incidents and notifications. A description can be used for several purposes, including:
 
 * Capturing the reason for the alert condition.
 * Defining the signal being monitored.
 * Defining next steps.
 * Add metadata to downstream systems.
 
-You can use template substitution to insert values from the attributes in the associated violation event. The template format is `{{attributeName}}`. For the attributes you can use when creating a description, see [Violation event attributes](/docs/alerts/new-relic-alerts/defining-conditions/violation-event-attributes).
+You can use template substitution to insert values from the attributes in the associated incident event. The template format is `{{attributeName}}`. For the attributes you can use when creating a description, see [incident event attributes](/docs/alerts/new-relic-alerts/defining-conditions/violation-event-attributes).
 
 One available attribute is the special `{{tag.*}}` attribute. This attribute prefix is used to access any of the tag values that are included with the target signal, or any of the entity tags that are associated with the target signal.
 
-If there are entity tags associated with your violation, then they can be accessed using the entity tag name. An example of this would be `{{tag.aws.awsRegion}}`. When entity tags are available to use, you see them included with the violation, and displayed when you view the violations in an incident.
+If there are entity tags associated with your incident, then they can be accessed using the entity tag name. An example of this would be `{{tag.aws.awsRegion}}`. When entity tags are available to use, you see them included with the incident, and displayed when you view the incident.
 
 This field has a maximum character size of 4,000.
 
 ## Add or edit a runbook URL [#runbook-url-infrastructure]
 
-The [alert condition creation process](#create-condition) includes an option for setting a URL for runbook instructions. This lets you link to information or standard procedures for handling a violation. Before adding or updating the link, make sure you use a valid URL.
+The [alert condition creation process](#create-condition) includes an option for setting a URL for runbook instructions. This lets you link to information or standard procedures for handling an incident. Before adding or updating the link, make sure you use a valid URL.
 
 To add, update, or delete an alert condition's runbook URL:
 
@@ -220,13 +220,13 @@ To add, update, or delete an alert condition's runbook URL:
 
 In order to be saved, the URL must be a valid URL.
 
-## Violation time limit for violations [#violation-time-limit]
+## Incident time limit [#incident-time-limit]
 
-The violation time limit allows you to define a time period after which violations will be force-closed. By default, violation time limit is 24 hours.
+The incident time limit allows you to define a time period after which incidents will be force-closed. By default, incident time limit is 24 hours for insfrastructure conditions.
 
-To add or update an alert condition's violation time limit:
+To add or update an alert condition's incident time limit:
 
-1. Select an alert condition, and make changes to the violation time limit.
+1. Select an alert condition, and make changes to the incident time limit.
 2. Save the condition.
 
 ## Alert conditions that generate too-long NRQL queries [#alert-nrql-error]

--- a/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -460,7 +460,7 @@ When formatting your cURL commands, use these values as needed. These are listed
       <td>
         **Condition type:** all
 
-        This object identifies the threshold value before opening a violation.
+        This object identifies the threshold value before opening an incident.
 
         * The `critical_threshold` is required.
         * The `warning_threshold` is optional and may only be used with `infra_metric` conditions.
@@ -499,21 +499,21 @@ When formatting your cURL commands, use these values as needed. These are listed
               id="value"
               title={<InlineCode>value</InlineCode>}
             >
-              The numeric value that must be breached for the condition to open a violation
+              The numeric value that must be breached for the condition to open an incident
             </Collapser>
 
             <Collapser
               id="duration-minutes"
               title={<InlineCode>duration_minutes</InlineCode>}
             >
-              The number of minutes the `value` must be passed or met for the condition to open a violation
+              The number of minutes the `value` must be passed or met for the condition to open an incident
             </Collapser>
 
             <Collapser
               id="time-function"
               title={<InlineCode>time_function</InlineCode>}
             >
-              Indicates if the condition needs to be sustained for a certain period of time to create a violation, or if it only needs to break the threshold once within a certain period of time. If you're setting up a `for at least x minutes` threshold, use `all`; for an `at least once in x minutes` threshold, use `any`.
+              Indicates if the condition needs to be sustained for a certain period of time to create an incident, or if it only needs to break the threshold once within a certain period of time. If you're setting up a `for at least x minutes` threshold, use `all`; for an `at least once in x minutes` threshold, use `any`.
             </Collapser>
           </CollapserGroup>
       </td>
@@ -680,13 +680,13 @@ When formatting your cURL commands, use these values as needed. These are listed
       <td>
         **Condition type:** all
 
-        The [Violation time limit](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information#violation-time-limit) setting, expressed as hours. Possible values are `0`, `1`, `2`, `4`, `8`,`12`, `24`, `48`, `72`. This determines how much time will pass before a violation is automatically closed.
+        The [incident time limit](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information/#incident-time-limit) setting, expressed as hours. Possible values are `0`, `1`, `2`, `4`, `8`,`12`, `24`, `48`, `72`. This determines how much time will pass before an incident is automatically closed.
 
         For new conditions, if a value is not provided, the following default values are used:
 
         * All conditions: `24 hours`
 
-          When updating existing conditions, if a value is provided, it overrides the existing value, but does not affect already opened violations.
+          When updating existing conditions, if a value is provided, it overrides the existing value, but does not affect already opened incidents.
       </td>
     </tr>
 


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the infrastructure section for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.