### PR TITLE
fix(Alerts): Replaced violation in the kubernetes section

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-recommended-alert-policy.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-recommended-alert-policy.mdx
@@ -254,7 +254,7 @@ While we try to tackle the most common use cases across all the environments, th
           </td>
 
           <td>
-            `Open violation when the query returns a value > 1 at least once in 1 minute`
+            `Open incident when the query returns a value > 1 at least once in 1 minute`
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/kubernetes-cluster-explorer.mdx
@@ -145,7 +145,7 @@ Capacity and utilization metrics are colored using a blue gradient which indicat
     />
 
 
-When selecting the `Alert status` metric, entities are colored according to alert violations that are currently open in the New Relic platform.
+When selecting the `Alert status` metric, entities are colored according to alert incidents that are currently open in the New Relic platform.
 
 * Red for critical
 * Yellow for warning
@@ -206,7 +206,7 @@ The cluster **Overview** dashboard can be an essential tool for monitoring and m
   src={clusterExplorerDashboardDetail}
 />
 <figcaption>
-  Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Kubernetes**. Select your cluster and click **Overview Dashboard** in the left navigation pane. It shows useful overview data about the status and performance of the cluster and its containerized workloads.
+  Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Kubernetes**. Select your cluster and click **Overview Dashboard** in the left navigation pane. It shows useful overview data about the status and performance of the cluster and its containerized workloads.
 </figcaption>
 
 


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the kubernetes section for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.