### PR TITLE
fix(Alerts): Replaced violation in the mobile monitoring section

### DIFF
--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/crashes/investigate-mobile-app-crash-report.mdx
@@ -28,7 +28,7 @@ Mobile monitoring's **Crash report** provides a summary and in-depth details on 
 
 To view a crash report:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app) > Exceptions > Crash analysis**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile > (select an app) > Exceptions > Crash analysis**.
 2. From the [**Crash list** table](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/view-mobile-app-crashes), select any row.
 3. Review the selected crash report's [summary and detail information](#dashboard-drilldown).
 4. Optional: [Query or share the chart data](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/crash-analysis-group-filter-your-crashes#insights).
@@ -77,7 +77,7 @@ Use any of New Relic's [standard UI functions](/docs/data-analysis/user-interfac
 />
 
 <figcaption>
-  **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select a mobile app) > Crash analysis > (selected crash type) > Event trail**: The crash event trail shows the activity leading up to a mobile app crash.
+  **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile > (select a mobile app) > Crash analysis > (selected crash type) > Event trail**: The crash event trail shows the activity leading up to a mobile app crash.
 </figcaption>
  
   </Collapser>
@@ -116,7 +116,7 @@ Use any of New Relic's [standard UI functions](/docs/data-analysis/user-interfac
 
 ## Android-native crash reporting [#android-native-reporting]
 
-Starting with [New Relic Android agent version 6.7.0](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/android-release-notes/android-670), to help track and diagnose native crashes, reporting and analysis has been enhanced to include signal violations and other faults that occur at the [native code](https://developer.android.com/ndk/guides) level during runtime.
+Starting with [New Relic Android agent version 6.7.0](/docs/release-notes/mobile-release-notes/android-release-notes/android-670), to help track and diagnose native crashes, reporting, and analysis has been enhanced to include signal violations and other faults that occur at the [native code](https://developer.android.com/ndk/guides) level during runtime.
 
 These enhancements include:
 
@@ -128,10 +128,10 @@ These enhancements include:
   * Signal 11 (Segmentation violation/invalid memory reference)
 
 * Native runtime exceptions
-The native agent will report any unhandled C++ exceptions thrown by the app during runtime, and report them as [handled exceptions](https://docs.newrelic.com/docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions/). Unhandled exceptions are usually fatal and will crash the application.
+The native agent will report any unhandled C++ exceptions thrown by the app during runtime, and report them as [handled exceptions](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions/). Unhandled exceptions are usually fatal and will crash the application.
 
 * Application Not Responding (ANR) conditions
-The native agent will detect and report [Application Not Responding](https://developer.android.com/topic/performance/vitals/anr) conditions where an Activity or service thread has been blocked for longer than Android's allowable time, which is 5 seconds for foreground activities, and 5 to 200 seconds for services. ANR conditions will be reported as a [handled exception](https://docs.newrelic.com/docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions/) (rather than crashes), since these are not considered fatal conditions.
+The native agent will detect and report [Application Not Responding](https://developer.android.com/topic/performance/vitals/anr) conditions where an Activity or service thread has been blocked for longer than Android's allowable time, which is 5 seconds for foreground activities, and 5 to 200 seconds for services. ANR conditions will be reported as a [handled exception](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/introduction-mobile-handled-exceptions/) (rather than crashes), since these are not considered fatal conditions.
 
 
 <Callout variant="important">

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-crash-reporting.mdx
@@ -151,6 +151,6 @@ To manually upload a ProGuard or DexGuard map file:
 
 ## Android Native Crash Reporting [#native-crash-reporting]
 
-Starting with [New Relic Android agent version 6.7.0](https://docs.newrelic.com/docs/release-notes/mobile-release-notes/android-release-notes/android-670), to help track and diagnose native crashes, reporting and analysis has been enhanced to include signal violations and other faults that occur at the native code level during runtime.
+Starting with [New Relic Android agent version 6.7.0](/docs/release-notes/mobile-release-notes/android-release-notes/android-670), to help track and diagnose native crashes, reporting and analysis has been enhanced to include signal violations and other faults that occur at the native code level during runtime.
 
 Learn more about Android native crash reporting [here](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/android-agent-native-crash-reporting).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-monitoring-alert-information.mdx
@@ -62,27 +62,31 @@ Use any of the following conditions and thresholds when you set up alerts for yo
 
 To view alert policy and condition information for a specific mobile app:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > Alert conditions**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile > Alert conditions**.
 2. From the **Alert conditions** page, use the available tools to search, sort, view, or update the alert conditions and their associated policies.
 
 ## View events and activities [#activity]
 
 To view summary information about [events](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#event) and other activity directly from the mobile monitoring UI:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile**.
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile**.
 2. From the index, mouse over the entity's [color-coded health status](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#health-status), select a link from the **Mobile activity** list, or select a mobile app to view additional details.
 
-For example, if a **Critical** alert violation occurs:
+For example, if a **Critical** alert incident occurs:
 
 * The health status indicator turns red on the mobile index and on the selected app.
 * The background color for various charts changes to pink.
-* On your list of monitored mobile apps, the **Application activity** section shows **Warning** (yellow) and **Critical** (red) violations as applicable.
+* On your list of monitored mobile apps, the **Application activity** section shows **Warning** (yellow) and **Critical** (red) incidents as applicable.
 
-To learn more about an alert violation, mouse over or select any pink area on a chart.
+To learn more about an alert incident, mouse over or select any pink area on a chart.
 
-## View alert violations [#violations]
+## View alert incidents [#incidents]
 
-If an alert condition has [thresholds](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-threshold) set up for **Warning** (yellow) or **Critical** (red) violations, the color-coded [health status](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#health-status) for a product entity will change to indicate a violation. You can view the violations directly from the mobile app's page in New Relic:
+<Callout variant="important">
+  In July 2020, we transitioned alert incidents for browser apps, mobile apps, fand synthetic monitors to a new format in **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**. For more information, see the [applied intelligence and alerting](/docs/new-relic-one/use-new-relic-one/new-relic-ai/introduction-new-relic-ai) docs.
+</Callout>
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile**.
-2. Select a mobile app, and then review its **Open violations**.
+If an alert condition has [thresholds](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-threshold) set up for **Warning** (yellow) or **Critical** (red) incidents, the color-coded [health status](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#health-status) for a product entity will change to indicate an incident. You can view the incidents directly from the mobile app's page in New Relic:
+
+1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Mobile**.
+2. Select a mobile app, and then review its **Open incidents**.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/get-started/security-mobile-apps.mdx
@@ -106,7 +106,7 @@ Our mobile SDK agent assigns a unique identifier to each installed app instance 
         The security measures used for iOS depend on the agent version.
 
         * In versions 5.3.5 or higher, the iOS agent uses the `IdentifierForVendor` property to provide a unique device ID.
-        * In versions 5.3.4 or lower, the iOS agent used the SecureUDID open source library. SecureUDID is used by many third party libraries and is an accepted industry standard that does not violate Apple App store guidelines. SecureUDID does not use device hardware identifiers such as IMEI.
+        * In versions 5.3.4 or lower, the iOS agent used the SecureUDID open source library. SecureUDID is used by many third party libraries and is an accepted industry standard that does not breach Apple App store guidelines. SecureUDID does not use device hardware identifiers such as IMEI.
 
           Note that our mobile SDK does not collect IDFA (Identity For Advertisers). For more information, see our [iOS compatibility and requirements documentation](/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements).
       </td>


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the mobile monitoring section for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.