### PR TITLE
fix(Alerts): Replaced violation in the open-source-telemetry section

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts.mdx
@@ -13,11 +13,11 @@ import opentelemetryAlertsConditionList from 'images/opentelemetry_screenshot-cr
 
 Alerts is a tool you can use to notify yourself and others if your telemetry exceeds some particular thresholds. Thresholds are defined by conditions you create, and you can group those conditions into policies.
 
-Depending on your role, you may use conditions to define the violations you and your team are notified about or you may be responding to those violations and want to know the condition that caused it.
+Depending on your role, you may use conditions to define the incidents you and your team are notified about or you may be responding to those incidents and want to know the condition that caused it.
 
 ## Create alert conditions [#create-alerts]
 
-Conditions use NRQL queries to define what you want to be notified about. Use the condition UI to set the specific thresholds that generate a violation and its notification. Writing a NRQL query from scratch might seem daunting, but if you create a condition from a New Relic chart, we'll populate the condition with the NRQL used to generate the chart. Then, you can modify the query if you want and then set the condition thresholds.
+Conditions use NRQL queries to define what you want to be notified about. Use the condition UI to set the specific thresholds that generate an incident and its notification. Writing a NRQL query from scratch might seem daunting, but if you create a condition from a New Relic chart, we'll populate the condition with the NRQL used to generate the chart. Then, you can modify the query if you want and then set the condition thresholds.
 
 Here's how to try this:
 
@@ -36,7 +36,7 @@ For more help creating alerts, see [Create your first alert](/docs/alerts-applie
 
 ## See your current alerts [#see-alerts-list]
 
-If you are responsible for responding to violations, you may also want to know what alerts are set up for each of your services. You can quickly get a list of all the conditions and their related policies from the UI:
+If you are responsible for responding to incidents, you may also want to know what alerts are set up for each of your services. You can quickly get a list of all the conditions and their related policies from the UI:
 
 1. From **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**, click **All entities**.
 2. In the left navigation pane, select **Services - OpenTelemetry**.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-implementation-guide.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-implementation-guide.mdx
@@ -94,9 +94,9 @@ You can also monitor the error budget for each SLO, which indicates what percent
 
 It's also important to configure alert policies, so you can detect and remediate problems before they impact end users of the application. 
 
-At a high-level, alerts are configured via alert policies, which include one or more alert conditions. Violations of alert conditions result in incidents, and similar incidents are grouped together as issues. Finally, issues can trigger workflows that include logic to turn issues into notifications. For a diagram to help you understand these concepts, see [Alerting concepts](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts).
+At a high-level, alerts are configured via alert policies, which include one or more alert conditions. Incidents of alert conditions are grouped together as issues. Finally, issues can trigger workflows that include logic to turn issues into notifications. For a diagram to help you understand these concepts, see [Alerting concepts](/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts).
 
-For example, you might define an alert condition to open an incident if the response time of an OpenTelemetry-instrumented service exceeds 500 ms. You could then define a workflow that sends an email notification to a distribution list when the alert condition violation occurs, or notify an on-call team using Slack. 
+For example, you might define an alert condition to open an incident if the response time of an OpenTelemetry-instrumented service exceeds 500 ms. You could then define a workflow that sends an email notification to a distribution list when the alert condition incident occurs, or notify an on-call team using Slack. 
 
 You can also [configure alerting on service levels](/docs/service-level-management/alerts-slm), to notify you when significant business impact incidents occur. 
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-comparison.mdx
@@ -870,7 +870,7 @@ You can now [record a deployment](/docs/change-tracking/change-tracking-introduc
 
 New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 👀 Limited support
 
-Alert violations will be shown for all types of entities.
+Alert incidents will be shown for all types of entities.
 
 Service deployments, related deployments, and Java agent circuit breaker events will be shown only for New Relic APM agent entities.
 
@@ -1002,7 +1002,7 @@ New Relic agents: ✅ &nbsp; &nbsp; &nbsp; OpenTelemetry in New Relic: 🟡 Limi
 
 You can configure alerts on OpenTelemetry data using conditions written in NRQL. Click any chart's “**...**” menu to get started.
 
-Conditions, violations, incidents, and issues all work for any entity.
+Conditions, incidents, and issues all work for any entity.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-summary-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-summary-page.mdx
@@ -10,7 +10,7 @@ metaDescription: Tips for understanding the OpenTelemetry service Summary page i
 After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, the **Summary** page offers an overview of your service's health. Here you can see:
 * The **golden signals** for your service: response time, throughput, and error rate
 * Entities this service depends on, with their health status, appear in **Related entities**. This includes other services communicating with this service and the infrastructure hosting the service.
-* When alerting thresholds are violated, those events appear in the **Activity** sidebar
+* When alerting thresholds are breached, those events appear in the **Activity** sidebar
 
 By using this information, you can quickly decide whether there's a problem with this service and where you can begin diagnosing the problem.
 


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the open-source-telemetry section for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.