### PR TITLE
fix(Alerts): Replaced violation in the rest-api-alerts section

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -474,8 +474,8 @@ Not every field listed in this glossary is required for every condition type. Th
   >
     For sporadic data, you can avoid false alerts by filling the gaps (empty windows) with synthetic data.
 
-    * `none`: (Default) Use this if you don’t want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won’t be in violation.
-    * `static`: Use this if you’d like to insert a custom static value into the empty aggregation windows before they’re evaluated. This option has an additional, required parameter of `fillValue` that specifies what static value should be used. This defaults to 0.
+    * `none`: (Default) Use this if you don't want to take any action on empty aggregation windows. On evaluation, an empty aggregation window will reset the threshold duration timer. For example, if a condition says that all aggregation windows must have data points above the threshold for 5 minutes, and 1 of the 5 aggregation windows is empty, then the condition won't open an incident.
+    * `static`: Use this if you'd like to insert a custom static value into the empty aggregation windows before they're evaluated. This option has an additional, required parameter of `fillValue` that specifies what static value should be used. This defaults to 0.
     * `last_value`: Use this to insert the last seen value before evaluation occurs. We maintain the state of the last seen value for 2 hours.
 
       In the UI, under **Advanced signal settings**, this is the **Fill data gaps with** field.

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts.mdx
@@ -105,7 +105,7 @@ Also, if you haven't already, create your free New Relic account below to start 
         * Conditions for [Multi-location synthetic monitoring](#multilocation-synthetics-conditions)
         * Conditions for NRQL ([Some limitations apply.](#excluded))
         * [Events](#events)
-        * [Violations](#violations)
+        * [Incidents](#incidents)
         * [Incidents](#incidents)
       </td>
     </tr>
@@ -164,7 +164,7 @@ These API functions include links to the API Explorer, where you can create, del
           </td>
 
           <td>
-            Determines how alerts will [create incidents and group violations](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents). This must be one of the following:
+            Determines how alerts will [create incidents](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents). This must be one of the following:
 
             * `PER_POLICY` (default): Roll up by [policy](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents#preference-policy).
             * `PER_CONDITION`: Roll up by [condition](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents#preference-condition).
@@ -239,7 +239,7 @@ These API functions include links to the API Explorer, where you can create, del
           </td>
 
           <td>
-            Determines how alerts will [create incidents and group violations](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents). Must be one of the following:
+            Determines how alerts will [create incidents](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents). Must be one of the following:
 
             * `PER_POLICY` (default): Roll up by [policy](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents#preference-policy).
             * `PER_CONDITION`: Roll up by [condition](/docs/alerts/new-relic-alerts-beta/reviewing-alert-incidents/specify-when-new-relic-creates-incidents#preference-condition).
@@ -1214,9 +1214,9 @@ These API functions include links to the API Explorer, where you can create, upd
   </Collapser>
 </CollapserGroup>
 
-## Alert activity: Events, violations, incidents [#alert-activity]
+## Alert activity: Events, incidents [#alert-activity]
 
-These API functions include links to the API Explorer, where you can view information about events, violations, and incidents for your alert policies.
+These API functions include links to the API Explorer, where you can view information about events and incidents for your alert policies.
 
 <Callout variant="important">
   If your organization hosts data in the EU data center, ensure you are using the proper [API endpoints for EU region accounts](/docs/using-new-relic/welcome-new-relic/getting-started/introduction-eu-region-data-center#endpoints).
@@ -1242,16 +1242,16 @@ These API functions include links to the API Explorer, where you can view inform
   </Collapser>
 
   <Collapser
-    id="violations"
-    title="List Violations"
+    id="incidents"
+    title="List of incidents"
   >
-    To view [violations](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-violation) for any [entity](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-entity) monitored for your account, include these values in the API call:
+    To view [incidents](/docs/new-relic-solutions/get-started/glossary/#alert-incident) for any [entity](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-entity) monitored for your account, include these values in the API call:
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key)
-    * An optional flag to show only those violations that are currently open
+    * An optional flag to show only those incidents that are currently open
     * An optional [pagination](/docs/apis/rest-api-v2/requirements/pagination-api-output) value
 
-      **[API Explorer](https://rpm.newrelic.com/api/explore/alerts_violations/list) > Alerts Violations > GET > List**
+      **[API Explorer](https://rpm.newrelic.com/api/explore/alerts_violations/list) > Alerts Incidents > GET > List**
 
       ```
       curl -X GET 'https://api.newrelic.com/v2/alerts_violations.json' \
@@ -1271,7 +1271,7 @@ These API functions include links to the API Explorer, where you can view inform
 
     * Your [user key](/docs/apis/get-started/intro-apis/types-new-relic-api-keys#user-api-key) or [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key)
     * An optional flag to show only those incidents that are currently open
-    * An optional flag to exclude violation data from response
+    * An optional flag to exclude incident data from response
     * An optional [pagination](/docs/apis/rest-api-v2/requirements/pagination-api-output) value
 
       **[API Explorer](https://rpm.newrelic.com/api/explore/alerts_incidents/list) > Alerts Incidents > GET > List**

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-alert-notification-channels.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-alert-notification-channels.mdx
@@ -277,7 +277,7 @@ The `notificationChannels` query allows you to paginate through all of your [ale
 
 ## Create a notification channel [#create-channel]
 
-In order to create an alert notification channel, you need to know the specific type of notification channel you want to create (for example email, Slack, etc.), as well as the details necessary to configure it (which will depend on the channel type). Once a notification channel has been created, it can be associated with one or more [alert policies][alert-policies]. Once associated, those channels will receive notifications from those policies when conditions are violated.
+In order to create an alert notification channel, you need to know the specific type of notification channel you want to create (for example email, Slack, etc.), as well as the details necessary to configure it (which will depend on the channel type). Once a notification channel has been created, it can be associated with one or more [alert policies][alert-policies]. Once associated, those channels will receive notifications from those policies when conditions are breached.
 
 <Callout variant="caution">
   While you can query for any existing notification channel type, you can only create a subset of them. Specifically, the **user** channel type has no editable fields, and the **Campfire** and **HipChat** channel types are both deprecated.
@@ -790,7 +790,7 @@ mutation {
 
 ## Associate channels to a policy [#associate-channel]
 
-Creating an alert notification channel is not enough: Once the channel has been created, it needs to be associated to one or more [policies][alert-policies]. Once associated to a policy, the channel can recieve alert notifications when conditions on that policy go into violation.
+Creating an alert notification channel is not enough: Once the channel has been created, it needs to be associated to one or more [policies][alert-policies]. Once associated to a policy, the channel can receive alert notifications when conditions on that policy exceed the threshold.
 
 In this example, we associate two channels with a policy:
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-loss-signal-gap-filling.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-loss-signal-gap-filling.mdx
@@ -14,7 +14,7 @@ redirects:
 
 You can customize New Relic alerting loss of signal detection and gap filling using our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph). For example, you can configure how long to wait before considering the signal lost, or what value should be used for filling gaps in the time series. 
 
-Loss of signal occurs when New Relic stops receiving data for a while; technically, we detect loss of signal after a significant amount of time has elapsed since data was last received in a time series. Loss of signal can be used to trigger or resolve a violation, which you can use to set up alerts.
+Loss of signal occurs when New Relic stops receiving data for a while; technically, we detect loss of signal after a significant amount of time has elapsed since data was last received in a time series. Loss of signal can be used to trigger or resolve an incident, which you can use to set up alerts.
 
 Gap filling can help you solve issues caused by lost data points. When gaps are detected between valid data points, we automatically fill those gaps with replacement values, such as the last known values or a static value. Gap filling can prevent alerts from triggering or resolving when they shouldn't.
 
@@ -31,13 +31,13 @@ In this guide we cover the following:
 
 ## Customize your loss of signal detection [#loss-of-signal]
 
-Loss of signal detection opens or closes violations if no data is received after a certain amount of time. For example, if you set the duration of the expiration period to 60 seconds and an integration doesn't seem to send data for more than a minute, a loss of signal violation would be triggered.
+Loss of signal detection opens or closes incidents if no data is received after a certain amount of time. For example, if you set the duration of the expiration period to 60 seconds and an integration doesn't seem to send data for more than a minute, a loss of signal threshold would be triggered.
 
-You can configure the duration of the signal loss and whether to open a violation or close it by using these three fields in NerdGraph:
+You can configure the duration of the signal loss and whether to open an incident or close it by using these three fields in NerdGraph:
 
 * `expiration.expirationDuration`: How long to wait, in seconds, after the last data point is received by our platform before considering the signal as lost. This is based on the time when data arrives at our platform and not on data timestamps. The default is to leave this null, and therefore this wouldn't enable Loss of Signal Detection.
-* `expiration.openViolationOnExpiration`: If `true`, a new violation is opened when a signal is lost. Default is `false`. To use this field, a duration must be specified.
-* `expiration.closeViolationsOnExpiration`: If `true`, open violations related to the signal are closed on expiration. Default is `false`. To use this field, a duration must be specified.
+* `expiration.openViolationOnExpiration`: If `true`, a new incident is opened when a signal is lost. Default is `false`. To use this field, a duration must be specified.
+* `expiration.closeViolationsOnExpiration`: If `true`, open incidents related to the signal are closed on expiration. Default is `false`. To use this field, a duration must be specified.
 
 ### View loss of signal settings for an existing condition
 
@@ -96,7 +96,7 @@ You should see a result like this:
 
 ### Create a new condition with loss of signal settings
 
-Let's say that you want to create a new [create a NRQL static condition](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-nrql-condition-alerts#static-condition) that triggers a loss of signal violation after no data is received for two minutes. You would set `expirationDuration` to 120 seconds and set `openViolationOnExpiration` to `true`, like in the example below.
+Let's say that you want to create a new [create a NRQL static condition](/docs/alerts/alerts-nerdgraph/nerdgraph-examples/nerdgraph-api-nrql-condition-alerts#static-condition) that triggers a loss of signal threshold after no data is received for two minutes. You would set `expirationDuration` to 120 seconds and set `openViolationOnExpiration` to `true`, like in the example below.
 
 ```
 mutation {

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-issues-api-via-github.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-issues-api-via-github.mdx
@@ -277,7 +277,7 @@ You can learn more about data types of New Relic here:
       </td>
 
       <td>
-        A list of origins of incidents like violations, anomalies, and external.
+        A list of origins of incidents like incidents, anomalies, and external.
       </td>
     </tr>
 

--- a/src/content/docs/apis/rest-api-v2/basic-functions/pagination-api-output.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/pagination-api-output.mdx
@@ -48,7 +48,7 @@ The API call returns the `Link` header if the data is paginated. This indicates 
 </Callout>
 
 <Callout variant="tip">
-  The `rel="last"` reference will not be shown when making calls to the Violations endpoint (`https://api.newrelic.com/v2/alerts_violations.json`). To determine the final page when making calls to this endpoint, look for the absence of a `rel="next"` reference.
+  The `rel="last"` reference will not be shown when making calls to the violations endpoint (`https://api.newrelic.com/v2/alerts_violations.json`). To determine the final page when making calls to this endpoint, look for the absence of a `rel="next"` reference.
 </Callout>
 
 To obtain this line using some implementations of `curl`, you may need to include the `-v` option.

--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -231,13 +231,13 @@ The following default limits apply only to data collected via the Prometheus Rem
 
 Metric API limits apply at the individual account level. The default limits for DPM and cardinality range from 3M for organizations on our free tier, up to 10.2M for some paying organizations. To understand your organization's limits, see the [Limits UI](/docs/data-apis/manage-data/view-system-limits). DPM and cardinality can be increased to 15M on request for paying organizations. Max payloads per minute can be adjusted above 100k on a case-by-case basis. To request changes to your metric rate limits, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com/).
 
-## Rate limit violations [#rate-limit-violations]
+## Rate limit incidents [#rate-limit-incidents]
 
 This section describes how the Metric API behaves when you exceed the rate limits, and how to respond if limits are exceeded.
 
 <CollapserGroup>
   <Collapser
-    id="violation-dpm-exceeded"
+    id="incident-dpm-exceeded"
     title="Max data points per minute (DPM)"
   >
     Data points per minute refers to the per minute rate at which individual metric values are sent to the Metric API.
@@ -250,29 +250,29 @@ This section describes how the Metric API behaves when you exceed the rate limit
   </Collapser>
 
   <Collapser
-    id="violation-unique-timeseries"
+    id="incident-unique-timeseries"
     title="Max unique timeseries per account per day"
   >
     A timeseries is a single, unique combination of a metric name and any attributes assigned to that metric. For example, if a `CPU utilization` metric with a single attribute `hostname` is sent from ten different hosts, this equals ten distinct values for the `hostname` attribute and ten unique metric timeseries.
 
     If the per-account, per-day unique metric timeseries (cardinality) limit is exceeded during a 24 hour period, the endpoint will continue to receive and store raw metric data. However, New Relic will stop creating additional aggregate rollups (1 minute, 5 minutes, etc.) for the remainder of the 24 hour period. (These rollups are used used by default to query time windows longer than 60 minutes.)
 
-    You can continue to query your data when such a violation occurs by specifying a 60 minute or shorter time window or specifying the RAW keyword (for more on that, see [High cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics)). This can be helpful in identifying potential causes for the violation.
+    You can continue to query your data when such an incident occurs by specifying a 60 minute or shorter time window or specifying the RAW keyword (for more on that, see [High cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics)). This can be helpful in identifying potential causes for the incident.
   </Collapser>
 
   <Collapser
-    id="violation-unique-timeseries"
+    id="incident-unique-timeseries"
     title="Max unique timeseries per metric name per day"
   >
     A timeseries is a single, unique combination of a metric name and any attributes assigned to that metric. For example, if a `CPU utilization` metric with a single attribute `hostname` is sent from ten different hosts, this equals ten distinct values for the `hostname` attribute and ten unique metric timeseries.
 
     If the per-metric name, per-day unique metric timeseries (cardinality) limit is exceeded during a 24 hour period, the endpoint will continue to receive and store raw metric data. However, New Relic will stop creating additional aggregate rollups (1 minute, 5 minutes, etc.) for the remainder of the 24 hour period. (These rollups are used used by default to query time windows longer than 60 minutes.)
 
-    You can continue to query your data when such a violation occurs by specifying a 60 minute or shorter time window or specifying the RAW keyword (for more on that, see [High cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics)). This can be helpful in identifying potential causes for the violation.
+    You can continue to query your data when such an incident occurs by specifying a 60 minute or shorter time window or specifying the RAW keyword (for more on that, see [High cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics)). This can be helpful in identifying potential causes for the incident.
   </Collapser>
 
   <Collapser
-    id="violation-payloads"
+    id="incident-payloads"
     title="Max payloads per minute"
   >
     If you make more than 100k POST requests to the Metric API endpoint within a minute, the endpoint will return a `429` response for the remainder of the minute. The response will include a `Retry-After` header indicating how long to wait in seconds before resubmitting or sending new data.

--- a/src/content/docs/data-apis/manage-data/query-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/query-limits.mdx
@@ -22,7 +22,7 @@ This page describes the limit metrics and [`NrIntegrationError` events](/docs/te
 
 ## What happens when you reach a limit
 
-Our response to reaching a limit depends on a handful of factors: the [type of limit that's reached](/docs/telemetry-data-platform/manage-data/view-system-limits/#violations), as well as the duration, frequency, and amount at which you exceed the limit. Exceeding a limit doesn't always mean you experience a limit event, such as dropped data, rejected traffic, or having your data turned off for the rest of the day. We sometimes allow a small buffer before enforcing a limit. That said, any resource consumed above 100% is at risk for limit impact at any time.
+Our response to reaching a limit depends on a handful of factors: the [type of limit that's reached](/docs/telemetry-data-platform/manage-data/view-system-limits/#incidents), as well as the duration, frequency, and amount at which you exceed the limit. Exceeding a limit doesn't always mean you experience a limit event, such as dropped data, rejected traffic, or having your data turned off for the rest of the day. We sometimes allow a small buffer before enforcing a limit. That said, any resource consumed above 100% is at risk for limit impact at any time.
 
 Many of our rate limits apply proportionally. That means if you're barely exceeding the limit, we will take less action than if you're exceeding by 200%.
 

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -17,10 +17,10 @@ To ensure our systems are always up and ready to support you, and to keep you fr
 
 To find the limits UI: from the [user menu](/docs/accounts/accounts-billing/general-account-settings/intro-account-settings), click **Manage your data** and click **Limits**.
 
-This UI displays information about how close an account is to hitting rate limits (both data ingest-related limits and query limits), and violations of those limits. The data displayed here is generated from:
+This UI displays information about how close an account is to hitting rate limits (both data ingest-related limits and query limits), and incidents of those limits. The data displayed here is generated from:
 
 * [Resource use metrics](/docs/data-apis/manage-data/query-limits/#limit-metrics)
-* Limit violations reported in [`NrIntegrationError` events](/docs/data-apis/manage-data/nrintegrationerror)
+* Limit incidents reported in [`NrIntegrationError` events](/docs/data-apis/manage-data/nrintegrationerror)
 
 <img
   title="Data limits UI screenshot"
@@ -29,25 +29,25 @@ This UI displays information about how close an account is to hitting rate limit
 />
 
 <figcaption>
-  The limits UI displays information related to an account's data ingest rate and query rate, and violations of limits.
+  The limits UI displays information related to an account's data ingest rate and query rate, and incidents of limits.
 </figcaption>
 
-What the color-coding in the violation table means:
+What the color-coding in the incident table means:
 
 * Red: exceeded a limit
 * Yellow: 80-100% of a limit
 * Green: below 80%
-* Gray: limits that don't have reported usage or violations for the given time range
+* Gray: limits that don't have reported usage or incidents for the given time range
 
 Some tips on using the limits UI:
 
 * To get more detail about a table entry, try clicking it. Some entries have more detail, including associated NRQL queries.
 * When you select a time range greater than six hours, the chart uses average values, which may smooth out spikes. This is the reason you may see the message "For the time window chosen, the 'Max limit usage' value represents the average of your usage limits." To see more accurate results, use a time range below six hours.
-* It's possible for the use of a resource to be over a limit while not generating a violation. For example, query limit events are generated for a one-minute level, but violations are only generated for continually exceeding that limit at the 5-minute level.
+* It's possible for the use of a resource to be over a limit while not generating an incident. For example, query limit events are generated for a one-minute level, but incidents are only generated for continually exceeding that limit at the 5-minute level.
 
 If you want more detail than the UI provides, see [Query your resource use](/docs/data-apis/manage-data/query-limits).
 
-## Responses to limit violations [#violations]
+## Responses to limit incidents [#incidents]
 
 Limits are enforced per account (not per [organization](/docs/glossary/glossary/#organization)). You might reach a limit if you start monitoring a new high-traffic application, or have a sudden data spike. When you do reach a limit, New Relic responds according to the type of data and the limit that's reached. Some examples of responses:
 
@@ -55,7 +55,7 @@ Limits are enforced per account (not per [organization](/docs/glossary/glossary/
 * For queries, we place limits on the number of queries per minute and the number of records inspected (see [query limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). When the number of queries per minute limit is reached, New Relic will begin rejecting queries until the number of queries is below the limit. When the records inspected limit is reached, New Relic will reject traffic from the source scanning the largest number of records and attempt to allow traffic from other sources.
 * For metrics, we place a limit on the number of unique timeseries (cardinality) per account and per metric. When this limit is reached, aggregated data is turned off for the rest of the UTC day.
 
-For every major limit violation, New Relic creates an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) for that account, which has these limit-related attributes:
+For every major limit incident, New Relic creates an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) for that account, which has these limit-related attributes:
 
 <table>
   <thead>
@@ -311,7 +311,8 @@ This table includes general max limits that apply across all New Relic accounts.
 
 \* NRDB records refers to database records for our [core data types](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types), which includes events, metrics (dimensional), logs, and distributed tracing (span) data, all stored in the [New Relic database](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-your-data) (NRDB). This does **not** include [metric timeslice data](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types#timeslice-data).
 
-## Data ingest API limits [#data-ingest-limits]
+
+## Data ingest API limits
 
 Our ingest APIs have additional limits that may override the more general [account-level limits](#all_products). Note that these limits also apply for our tools that use these APIs.
 
@@ -319,10 +320,6 @@ Our ingest APIs have additional limits that may override the more general [accou
 * [Event API](/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/introduction-event-api)
 * [Log API](/docs/logs/log-management/log-api/introduction-log-api)
 * [Trace API](/docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits)
-
-## NerdGraph API limits [#nerdgraph-limits]
-
-See [NerdGraph usage limits](/docs/apis/nerdgraph/nerdgraph-usage-limits). 
 
 ## Finding other agent and integration limits [#other-limits]
 

--- a/src/content/docs/data-apis/understand-data/metric-data/cumulative-metrics.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/cumulative-metrics.mdx
@@ -76,7 +76,7 @@ OpenTelemetry provides a way to reduce cardinality client side using [**Views**]
 
 ### Cardinality limits [#card-limits]
 
-During translation, we also loosely enforce metric cardinality limits that are based on your metric entitlements as a system protection. Rather than enforcing the limit [per day, as we do with rollups](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/#violation-unique-timeseries), this limit is enforced as the number of concurrent timeseries being tracked. Once there are too many concurrent [unique metric timeseries](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/#what-why), we will drop new incoming timeseries until an old one ages out (see [Stale data](#stale-data)).
+During translation, we also loosely enforce metric cardinality limits that are based on your metric entitlements as a system protection. Rather than enforcing the limit [per day, as we do with rollups](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/#incident-unique-timeseries), this limit is enforced as the number of concurrent timeseries being tracked. Once there are too many concurrent [unique metric timeseries](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/#what-why), we will drop new incoming timeseries until an old one ages out (see [Stale data](#stale-data)).
 
 ### Cumulative metric resets [#cumulative-resets]
 


### PR DESCRIPTION
The word "violation" and its derivatives have been replaced in the rest-api-alerts section for not being used in the UI anymore.

The variables that include this word remain because they haven't been replaced in the code.