### PR TITLE
docs: Add explicit eolDate to frontmatter for .NET Agent v6.26.0 (publish with EOL dev feature from doc eng)

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-62600.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-62600.mdx
@@ -1,6 +1,7 @@
 ---
 subject: .NET agent
 releaseDate: '2020-09-15'
+eolDate: '2029-01-09'
 version: 6.26.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/6.x_release/'
 ---


### PR DESCRIPTION
Overrides the default `eolDate` for the .NET Agent v6.26.0 release to reflect extended support for that version.
