### PR TITLE
fix: remove plain text escape chars `\`

### DIFF
--- a/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
+++ b/src/content/docs/codestream/how-use-codestream/pull-requests.mdx
@@ -239,7 +239,7 @@ All searches are done using `attribute=value` format with an `&` between each pa
     id="merge-request-search-syntax"
     title="Merge request search syntax"
   >
-    ```
+    ```ini
     state=opened&author_id=@me
     state=closed&assignee_username=@me&labels=help wanted
     assignee_id=5&scope=created_by_me
@@ -288,7 +288,7 @@ All searches are done using `attribute=value` format with an `&` between each pa
     id="issue-search-syntax"
     title="Issue search syntax"
   >
-    ```
+    ```ini
     state=opened&author_id=@me
     state=closed&assignee_username=@me&labels=help wanted
     assignee_id=5&scope=created_by_me
@@ -336,7 +336,7 @@ All searches are done using `attribute=value` format with an `&` between each pa
   >
     To search in a specific project use parameter `project_id=X`. Project IDs are listed when viewing the project on GitLab. Searching through a project, by default, uses `scope=all` and will return all merge requests or issues for the project specified. Only one `project_id` may be listed at a time.
 
-    ```
+    ```ini
     project_id=23&state=opened&assignee_id=@me
     iids[]=1&project_id=473&labels=bug
     ```
@@ -349,7 +349,7 @@ All searches are done using `attribute=value` format with an `&` between each pa
   >
     To search in a specific group use parameter `group_id=X`. Group IDs are listed when viewing the group on GitLab. Searching through a group, by default, uses `scope=all` and will return all merge request or issues for the group specified. Only one `group_id` may be listed at a time.
 
-    ```
+    ```ini
     group_id=23&state=opened&assignee_id=@me
     iids[]=1&group_id=473&labels=bug
     ```
@@ -362,15 +362,15 @@ All searches are done using `attribute=value` format with an `&` between each pa
   >
     By default, custom filters use `scope=all` which searches across all of GitLab. To avoid pulling all merge requests or issues listed on GitLab, you will need to refine this search using at least one of the following qualifiers:
 
-    * `scope=assigned\_to\_me`
-    * `scope=created\_by\_me`
+    * `scope=assigned_to_me`
+    * `scope=created_by_me`
     * `project_id`
     * `group_id`
     * `author_id`
     * `author_username`
     * `assignee_id`
     * `assignee_username`
-    * `my\_reaction\_emoji`
+    * `my_reaction_emoji`
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
+++ b/src/content/docs/codestream/troubleshooting/jira-server-integration.mdx
@@ -35,13 +35,13 @@ In a terminal, use `openssl` to generate your public/private key pair, using the
 
 1. Generate a 1024-bit private key:
 
-   ```
+   ```sh
    openssl genrsa -out jira_privatekey.pem 1024
    ```
 
 2. Create an X509 certificate:
 
-   ```
+   ```sh
    openssl req -newkey rsa:1024 -x509 -key jira_privatekey.pem -out jira_publickey.cer -days 365
    ```
 
@@ -49,13 +49,13 @@ In a terminal, use `openssl` to generate your public/private key pair, using the
 
 3. Extract the private key (PKCS8 format) to the `jira_privatekey.pcks8` file:
 
-   ```
+   ```sh
    openssl pkcs8 -topk8 -nocrypt -in jira_privatekey.pem -out jira_privatekey.pcks8
    ```
 
 4. Extract the public key from the certificate to the `jira_publickey.pem` file:
 
-   ```
+   ```sh
    openssl x509 -pubkey -noout -in jira_publickey.cer > jira_publickey.pem
    ```
 


### PR DESCRIPTION
when `wrapping text in backticks` escape chars like `\` show up as plain text.

I also add lang identifiers to codeblock. `ini` works well on github, not sure how well it will work on docs-website

<img width="617" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/40f10740-ffcd-4a1e-95b9-895714d35845">
