### PR TITLE
Steps headers in PageTools

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,6 +3,11 @@ const { prop } = require('./scripts/utils/functional.js');
 const externalRedirects = require('./src/data/external-redirects.json');
 const { createFilePath } = require('gatsby-source-filesystem');
 const createSingleNav = require('./scripts/createSingleNav');
+const generateTOC = require('mdast-util-toc');
+// are needed for our tableOfContents override
+const genMDX = require('gatsby-plugin-mdx/utils/gen-mdx.js');
+const defaultOptions = require('gatsby-plugin-mdx/utils/default-options.js');
+const getTableOfContents = require('gatsby-plugin-mdx/utils/get-table-of-content.js');
 
 const TEMPLATE_DIR = 'src/templates/';
 const TRAILING_SLASH = /\/$/;
@@ -311,7 +316,20 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   });
 };
 
-exports.createSchemaCustomization = ({ actions }) => {
+exports.createSchemaCustomization = (
+  {
+    getNode,
+    getNodes,
+    pathPrefix,
+    reporter,
+    cache,
+    actions,
+    schema,
+    store,
+    ...helpers
+  },
+  pluginOptions
+) => {
   const { createTypes } = actions;
 
   const typeDefs = `
@@ -350,7 +368,64 @@ exports.createSchemaCustomization = ({ actions }) => {
 
   `;
 
-  createTypes(typeDefs);
+  // this was taken from gatsby-plugin-mdx/gatsby/create-schema-customization.js
+  const options = defaultOptions(pluginOptions);
+
+  const pendingPromises = new WeakMap();
+  const processMDX = ({ node }) => {
+    let promise = pendingPromises.get(node);
+    if (!promise) {
+      promise = genMDX({
+        node,
+        options,
+        store,
+        pathPrefix,
+        getNode,
+        getNodes,
+        cache,
+        reporter,
+        actions,
+        schema,
+        ...helpers,
+      });
+      pendingPromises.set(node, promise);
+      promise.then(() => {
+        pendingPromises.delete(node);
+      });
+    }
+    return promise;
+  };
+
+  const tocExtension = schema.buildObjectType({
+    name: `Mdx`,
+    fields: {
+      tableOfContents: {
+        type: `JSON`,
+        args: {
+          maxDepth: {
+            type: `Int`,
+            default: 6,
+          },
+        },
+        async resolve(mdxNode, { maxDepth }) {
+          const { mdast } = await processMDX({ node: mdxNode });
+          const toc = generateTOC(mdast, {
+            maxDepth,
+
+            // override gatsby-plugin-mdx tableOfContents options
+            // to allow Step headers to show in PageTools
+            parents: [
+              (node) => node.type === 'mdxBlockElement' && node.name === 'Step',
+              'root',
+            ],
+          });
+
+          return getTableOfContents(toc.map, {});
+        },
+      },
+    },
+  });
+  createTypes([typeDefs, tocExtension]);
 };
 
 exports.createResolvers = ({ createResolvers }) => {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "7.0.3",
+    "@newrelic/gatsby-theme-newrelic": "7.1.2",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,10 +3572,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-7.0.3.tgz#69ddaf2ad5178185da665a174aa1207731c906d5"
-  integrity sha512-WciNpaIU1kyNxWjMlpiIG7XwyItAEXh318pKiZLBvosOzDb3vJRrmyDDGfBXee0p7KwXZywG3AYFtPFYUmHytA==
+"@newrelic/gatsby-theme-newrelic@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-7.1.2.tgz#d22de0dc505f45b8b0ecacf537a231a1f618c73e"
+  integrity sha512-Q4zIhldVmC5TwD9vgwvCDR+LN/xED8UoX6Xg6t36uMVfq6zRIsW9lXmrzdCsAVDXKWY0KzZKv6wUpCtsJ8sOfQ==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
override graphql tableOfContents
- gatsby-plugin-mdx does not provide a way to configure options for mdast-util-toc
- this lets us pass in a parents option so we can include headings under JSX, in this case Steps

