### PR TITLE
Update .NET browser monitoring info

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2476,6 +2476,10 @@ The `browserMonitoring` element supports the following attributes:
     </table>
 
     By default the agent automatically injects the browser agent JavaScript. To turn off automatic injection, set this attribute to `false`.
+
+    <Callout variant="important">
+      Auto-instrumentation is only available for .NET Framework apps, .NET Core apps need to use [manual instrumentation](/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent/#manual_instrumentation). Auto-instrumentation is unavailable for ASP.NET Core applications whether they're monitored by the .NET Framework or Core agent.
+    </Callout>
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
@@ -22,7 +22,7 @@ Follow the [.NET agent requirements](/docs/agents/net-agent/getting-started/intr
 ## Auto-instrumentation [#auto_instrumentation]
 
 <Callout variant="important">
-  Auto-instrumentation is only availbalbe for .NET Framework apps, .NET Core apps need to use [manual instrumentation](manual_instrumentation). Auto-instrumentation is unavailbalbe for ASP.NET Core applications whether they're monitored by the .NET Framework or Core agent.
+  Auto-instrumentation is only available for .NET Framework apps, .NET Core apps need to use [manual instrumentation](#manual_instrumentation). Auto-instrumentation is unavailable for ASP.NET Core applications whether they're monitored by the .NET Framework or Core agent.
 </Callout>
 
 [Browser auto-instrumentation](/docs/agents/net-agent/configuration/net-agent-configuration#browsermon-autoInstrument) is enabled by default. With browser auto-instrumentation, the .NET Framework agent automatically injects the browser JavaScript header into any page that has a `content-type` of `text/html` and also has `<head>` tag within the page.

--- a/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
@@ -22,7 +22,7 @@ Follow the [.NET agent requirements](/docs/agents/net-agent/getting-started/intr
 ## Auto-instrumentation [#auto_instrumentation]
 
 <Callout variant="important">
-  This feature is not available for ASP.NET Core applications whether they're monitored by the .NET Framework or Core agent.
+  Auto-instrumentation is only availbalbe for .NET Framework apps, .NET Core apps need to use [manual instrumentation](manual_instrumentation). Auto-instrumentation is unavailbalbe for ASP.NET Core applications whether they're monitored by the .NET Framework or Core agent.
 </Callout>
 
 [Browser auto-instrumentation](/docs/agents/net-agent/configuration/net-agent-configuration#browsermon-autoInstrument) is enabled by default. With browser auto-instrumentation, the .NET Framework agent automatically injects the browser JavaScript header into any page that has a `content-type` of `text/html` and also has `<head>` tag within the page.


### PR DESCRIPTION
It's often missed that automatic browser monitoring only works for .NET framework