### PR TITLE
Updated supported runtimes list for lambdas.

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -11,8 +11,8 @@ Before [enabling serverless monitoring](/docs/serverless-function-monitoring/aws
 
 ## Recommended AWS Lambda language runtimes [#languages]
 
-* Node.js: `nodejs12.x`, `nodejs14.x`, `nodejs16.x`, `nodejs18.x`
-* Python: `python3.7`, `python3.8`, `python3.9`
+* Node.js: `nodejs14.x`, `nodejs16.x`, `nodejs18.x`
+* Python: `python3.7`, `python3.8`, `python3.9`, `python3.10`, `python3.11`
 * Go: `provided`, `provided.al2`
 * Java: `java8.al2`, `java11`
 * .NET Core: `dotnetcore3.1`


### PR DESCRIPTION
This PR updates the compatibility docs for lambda with supported runtimes for Node and Python. 