### PR TITLE
feat: add documentation for setApplicationVersion

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/setApplicationVersion.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setApplicationVersion.mdx
@@ -30,7 +30,7 @@ Agent version [1.238.0](/docs/release-notes/new-relic-browser-release-notes/brow
 
 Upon executing this function with a valid value, the browser agent appends an `application.version` attribute to all subsequent events until the attribute is manually unset or the page is unloaded. If the function is called more than once, only the most recent value provided will be sent on subsequent events. If this function is called with a value of `null`, any existing application version will cease to send on subsequent events.
 
-The application version string can help group errors within the [Errors Inbox](/docs/errors-inbox/errors-inbox/) tool. If you are using [SPA monitoring](/docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring) with a compatible agent version, application version will also be included in [`newrelic.interaction`](/docs/browser/new-relic-browser/browser-agent-apis/browser-spa-api-newrelicinteraction) events.
+Setting the `application.version` attribute will help you identify which versions of your software are producing the errors. An upcoming release of errors inbox will automatically track which versions of your software are producing errors. If you are using [SPA monitoring](/docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring) with a compatible agent version, application version will also be included in [`newrelic.interaction`](/docs/browser/new-relic-browser/browser-agent-apis/browser-spa-api-newrelicinteraction) events.
 
 ## Parameters
 

--- a/src/content/docs/browser/new-relic-browser/browser-apis/setApplicationVersion.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setApplicationVersion.mdx
@@ -1,5 +1,5 @@
 ---
-title: setUserId
+title: setApplicationVersion
 type: apiDoc
 shortDescription: Adds a user-defined application version string to subsequent events on the page.
 tags:

--- a/src/content/docs/browser/new-relic-browser/browser-apis/setApplicationVersion.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setApplicationVersion.mdx
@@ -1,0 +1,79 @@
+---
+title: setUserId
+type: apiDoc
+shortDescription: Adds a user-defined application version string to subsequent events on the page.
+tags:
+  - Browser
+  - Browser monitoring
+  - Browser agent and SPA API
+metaDescription: Browser API call to add an application version string to subsequent events on the page.
+redirects:
+---
+
+<Callout variant="important">
+This API will work for any browser edition (Browser Lite, Pro, or Pro+SPA).
+</Callout>  
+
+## Syntax
+
+```js
+newrelic.setApplicationVersion(value: string|null)
+```
+
+Adds a user-defined application version string to subsequent events on the page.
+
+## Requirements
+
+Agent version [1.238.0](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes) or higher.
+
+## Description
+
+Upon executing this function with a valid value, the browser agent appends an `application.version` attribute to all subsequent events until the attribute is manually unset or the page is unloaded. If the function is called more than once, only the most recent value provided will be sent on subsequent events. If this function is called with a value of `null`, any existing application version will cease to send on subsequent events.
+
+The application version string can help group errors within the [Errors Inbox](/docs/errors-inbox/errors-inbox/) tool. If you are using [SPA monitoring](/docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring) with a compatible agent version, application version will also be included in [`newrelic.interaction`](/docs/browser/new-relic-browser/browser-agent-apis/browser-spa-api-newrelicinteraction) events.
+
+## Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `value`
+
+        _string_ OR _null_
+      </td>
+
+      <td>
+        Required. A string representing the web application's version, useful for tying all browser events to specific release tags. The `value` parameter does not have to be unique. If IDs should be unique, the caller is responsible for that validation.
+
+        Passing a `null` value unsets any existing application version.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Decorating events with an application version
+
+```js
+newrelic.setApplicationVersion('1.2.3') // decorates events with the property 'application.version':'1.2.3'
+```
+
+### Stopping events from decorating application version
+
+```js
+newrelic.setApplicationVersion(null) // events will no longer have an 'application.version' property set
+```

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -118,6 +118,8 @@ pages:
         path: /docs/browser/new-relic-browser/browser-apis/finished
       - title: noticeError
         path: /docs/browser/new-relic-browser/browser-apis/noticeerror
+      - title: setApplicationVersion
+        path: /docs/browser/new-relic-browser/browser-apis/setapplicationversion
       - title: setCustomAttribute
         path: /docs/browser/new-relic-browser/browser-apis/setcustomattribute
       - title: setErrorHandler


### PR DESCRIPTION

## Give us some context

This PR adds documentation for a new browser agent API method: `setApplicationVersion`.  This method is being released as part of 1.238.0, which will roll out to end this week.

* What problems does this PR solve?
    - This a new method that currently has no usage documented
* If your issue relates to an existing GitHub issue, please link to it.
    - https://issues.newrelic.com/browse/NR-150940