### PR TITLE
Capitalize Callout component tag

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/nvidia-gpu-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/nvidia-gpu-integration.mdx
@@ -36,9 +36,9 @@ You can install the infrastructure agent two different ways:
 
 Flex comes bundled with the New Relic infrastructure agent and it can be integrated with the [NVIDIA SMI](https://developer.nvidia.com/nvidia-management-library-nvml), a command line utility to monitor NVIDIA GPU devices.
 
-<callout variant="important">
+<Callout variant="important">
 NVIDIA-smi ships pre-installed with NVIDIA GPU display drivers on Linux and Windows Server. 
-</callout>
+</Callout>
 
 To configure Flex follow these steps:
 


### PR DESCRIPTION
This Callout tag was uncapitalized which meant it didn't render an actual callout. It also broke the translation workflow since it doesn't recognize that tag