### PR TITLE
fix: Move aggregators out of non-aggregators section and vice versa

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions.mdx
@@ -1926,6 +1926,164 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
   <Collapser
     className="freq-link"
+    id="earliest-func"
+    title={<InlineCode>earliest(attribute)</InlineCode>}
+  >
+    Use the `earliest()` function to return the earliest value for an attribute over the specified time range.
+
+    It takes a single argument.
+
+    If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
+
+    <CollapserGroup>
+      <Collapser title="Get earliest country per user agent from PageView">
+        This query returns the earliest country code per each user agent from the `PageView` event.
+
+        ```sql
+        SELECT earliest(countryCode) FROM PageView FACET userAgentName
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="func-filter"
+    title={<InlineCode>filter(function(attribute), WHERE condition)</InlineCode>}
+  >
+    Use the `filter()` function to limit the results for one of the aggregator functions in your SELECT statement. You can use `filter()` in conjunction with `FACET` or `TIMESERIES`. Filter is only useful when selecting multiple different aggregations such as:
+    ```sql
+    SELECT filter(sum(x), WHERE attribute='a') AS 'A', filter(sum(x), WHERE attribute='b') AS 'B' ...
+    ```
+    Otherwise, it's better to just use the standard `WHERE` clause.
+
+    <CollapserGroup>
+      <Collapser title="Analyze purchases that used offer codes">
+        You could use `filter()` to compare the items bought in a set of transactions for those using an offer code versus those who aren't:
+
+        <img
+          title="screenshot insights filter"
+          alt="screenshot insights filter"
+          src={queriesnrqlFilterNRQLQueryBuilder}
+        />
+
+        <figcaption>
+          Use the `filter()` function to limit the results for one of the aggregator functions in your `SELECT` statement.
+        </figcaption>
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="func-funnel"
+    title={<InlineCode>funnel(attribute, steps)</InlineCode>}
+  >
+    Use the `funnel()` function to generate a funnel chart. It takes an attribute as its first argument. You then specify steps as [`WHERE`](#sel-where) clauses (with optional [`AS`](#sel-as) clauses for labels) separated by commas.
+
+    For details and examples, see the [funnels documentation](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/funnels-evaluate-data-series-events).
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="func-histogram"
+    title={<InlineCode>histogram(attribute, ceiling [,number of buckets])</InlineCode>}
+  >
+    Use the `histogram()` function to generate histograms. It takes three arguments:
+
+    * Attribute name
+    * Maximum value of the sample range
+    * Total number of buckets (between 1 and 500, inclusive)
+
+      <CollapserGroup>
+        <Collapser
+          id="histogram-response-times"
+          title="Histogram of response times from PageView events"
+        >
+          This query results in a histogram of response times ranging up to 10 seconds over 20 buckets.
+
+          ```sql
+          SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
+          ```
+        </Collapser>
+
+        <Collapser
+          id="histogram-prometheus"
+          title="Prometheus histogram buckets"
+        >
+          `histogram()` accepts Prometheus histogram buckets:
+
+          ```sql
+          SELECT histogram(duration_bucket, 10, 20) FROM Metric SINCE 1 week ago
+          ```
+        </Collapser>
+
+        <Collapser
+          id="distribution-metric"
+          title="New Relic distribution metric"
+        >
+          `histogram()` accepts [Distribution metric](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics#limits-rules) as an input:
+
+          ```sql
+          SELECT histogram(myDistributionMetric, 10, 20) FROM Metric SINCE 1 week ago
+          ```
+        </Collapser>
+
+        <Collapser
+          id="histogram-facet-heatmap"
+          title="Histogram with a FACET clause"
+        >
+          Use `histogram()` with a `FACET` clause to generate a heatmap chart:
+
+          ```sql
+          SELECT histogram(duration) FROM PageView FACET appName SINCE 1 week ago
+          ```
+        </Collapser>
+      </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="keyset"
+    title={<InlineCode>keyset()</InlineCode>}
+  >
+    Using `keyset()` will allow you to see all of the attributes for a given data type over a given time range. It takes no arguments. It returns a JSON structure containing groups of string-typed keys, numeric-typed keys, boolean-typed keys, and all keys.
+
+    <CollapserGroup>
+      <Collapser title="See all attributes for a data type">
+        This query returns the attributes found for `PageView` events from the last day:
+
+        ```sql
+        SELECT keyset() FROM PageView SINCE 1 day ago
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="latest"
+    title={<InlineCode>latest(attribute)</InlineCode>}
+  >
+    Use the `latest()` function to return the most recent value for an attribute over a specified time range.
+
+    It takes a single argument.
+
+    If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
+
+    <CollapserGroup>
+      <Collapser title="Get most recent country per user agent from PageView">
+        This query returns the most recent country code per each user agent from the `PageView` event.
+
+        ```sql
+        SELECT latest(countryCode) FROM PageView FACET userAgentName
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
     id="latestrate"
     title={<InlineCode>latestrate(attribute, time interval)</InlineCode>}
   >
@@ -2005,14 +2163,6 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     title={<InlineCode>min(attribute)</InlineCode>}
   >
     Use the `min()` function to return the minimum recorded value of a numeric attribute over the time range specified. It takes a single attribute name as an argument. If a value of the attribute is not numeric, it will be ignored when aggregating. If data matching the query's conditions is not found, or there are no numeric values returned by the query, it will return a value of null.
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="func-minOf"
-    title={<InlineCode>minuteOf(attribute)</InlineCode>}
-  >
-    Use the `minuteOf()` function to extract only the minute portion (that is, minutes 0 to 59) of an attribute holding a valid timestamp value.
   </Collapser>
 
   <Collapser
@@ -2465,28 +2615,6 @@ Note: `aparse()` is case-insensitive.
 
   <Collapser
     className="freq-link"
-    id="earliest-func"
-    title={<InlineCode>earliest(attribute)</InlineCode>}
-  >
-    Use the `earliest()` function to return the earliest value for an attribute over the specified time range.
-
-    It takes a single argument.
-
-    If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
-
-    <CollapserGroup>
-      <Collapser title="Get earliest country per user agent from PageView">
-        This query returns the earliest country code per each user agent from the `PageView` event.
-
-        ```sql
-        SELECT earliest(countryCode) FROM PageView FACET userAgentName
-        ```
-      </Collapser>
-    </CollapserGroup>
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
     id="event-type"
     title={<InlineCode>eventType()</InlineCode>}
   >
@@ -2524,44 +2652,6 @@ Note: `aparse()` is case-insensitive.
         ```
       </Collapser>
     </CollapserGroup>
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="func-filter"
-    title={<InlineCode>filter(function(attribute), WHERE condition)</InlineCode>}
-  >
-    Use the `filter()` function to limit the results for one of the aggregator functions in your SELECT statement. You can use `filter()` in conjunction with `FACET` or `TIMESERIES`. Filter is only useful when selecting multiple different aggregations such as:
-    ```sql
-    SELECT filter(sum(x), WHERE attribute='a') AS 'A', filter(sum(x), WHERE attribute='b') AS 'B' ...
-    ```
-    Otherwise, it's better to just use the standard `WHERE` clause.
-
-    <CollapserGroup>
-      <Collapser title="Analyze purchases that used offer codes">
-        You could use `filter()` to compare the items bought in a set of transactions for those using an offer code versus those who aren't:
-
-        <img
-          title="screenshot insights filter"
-          alt="screenshot insights filter"
-          src={queriesnrqlFilterNRQLQueryBuilder}
-        />
-
-        <figcaption>
-          Use the `filter()` function to limit the results for one of the aggregator functions in your `SELECT` statement.
-        </figcaption>
-      </Collapser>
-    </CollapserGroup>
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="func-funnel"
-    title={<InlineCode>funnel(attribute, steps)</InlineCode>}
-  >
-    Use the `funnel()` function to generate a funnel chart. It takes an attribute as its first argument. You then specify steps as [`WHERE`](#sel-where) clauses (with optional [`AS`](#sel-as) clauses for labels) separated by commas.
-
-    For details and examples, see the [funnels documentation](/docs/insights/nrql-new-relic-query-language/nrql-query-examples/funnels-evaluate-data-series-events).
   </Collapser>
 
   <Collapser
@@ -2684,64 +2774,6 @@ Note: `aparse()` is case-insensitive.
 
   <Collapser
     className="freq-link"
-    id="func-histogram"
-    title={<InlineCode>histogram(attribute, ceiling [,number of buckets])</InlineCode>}
-  >
-    Use the `histogram()` function to generate histograms. It takes three arguments:
-
-    * Attribute name
-    * Maximum value of the sample range
-    * Total number of buckets (between 1 and 500, inclusive)
-
-      <CollapserGroup>
-        <Collapser
-          id="histogram-response-times"
-          title="Histogram of response times from PageView events"
-        >
-          This query results in a histogram of response times ranging up to 10 seconds over 20 buckets.
-
-          ```sql
-          SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
-          ```
-        </Collapser>
-
-        <Collapser
-          id="histogram-prometheus"
-          title="Prometheus histogram buckets"
-        >
-          `histogram()` accepts Prometheus histogram buckets:
-
-          ```sql
-          SELECT histogram(duration_bucket, 10, 20) FROM Metric SINCE 1 week ago
-          ```
-        </Collapser>
-
-        <Collapser
-          id="distribution-metric"
-          title="New Relic distribution metric"
-        >
-          `histogram()` accepts [Distribution metric](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics#limits-rules) as an input:
-
-          ```sql
-          SELECT histogram(myDistributionMetric, 10, 20) FROM Metric SINCE 1 week ago
-          ```
-        </Collapser>
-
-        <Collapser
-          id="histogram-facet-heatmap"
-          title="Histogram with a FACET clause"
-        >
-          Use `histogram()` with a `FACET` clause to generate a heatmap chart:
-
-          ```sql
-          SELECT histogram(duration) FROM PageView FACET appName SINCE 1 week ago
-          ```
-        </Collapser>
-      </CollapserGroup>
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
     id="func-if"
     title={<><InlineCode>if(condition, trueValue [, falseValue])</InlineCode></>}
   >
@@ -2784,46 +2816,6 @@ Note: `aparse()` is case-insensitive.
 
   <Collapser
     className="freq-link"
-    id="keyset"
-    title={<InlineCode>keyset()</InlineCode>}
-  >
-    Using `keyset()` will allow you to see all of the attributes for a given data type over a given time range. It takes no arguments. It returns a JSON structure containing groups of string-typed keys, numeric-typed keys, boolean-typed keys, and all keys.
-
-    <CollapserGroup>
-      <Collapser title="See all attributes for a data type">
-        This query returns the attributes found for `PageView` events from the last day:
-
-        ```sql
-        SELECT keyset() FROM PageView SINCE 1 day ago
-        ```
-      </Collapser>
-    </CollapserGroup>
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="latest"
-    title={<InlineCode>latest(attribute)</InlineCode>}
-  >
-    Use the `latest()` function to return the most recent value for an attribute over a specified time range.
-
-    It takes a single argument.
-
-    If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
-
-    <CollapserGroup>
-      <Collapser title="Get most recent country per user agent from PageView">
-        This query returns the most recent country code per each user agent from the `PageView` event.
-
-        ```sql
-        SELECT latest(countryCode) FROM PageView FACET userAgentName
-        ```
-      </Collapser>
-    </CollapserGroup>
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
     id="func-length"
     title={<InlineCode>length(attribute)</InlineCode>}
   >
@@ -2858,7 +2850,6 @@ Note: `aparse()` is case-insensitive.
   For more information, see [How to query lookup table data](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/lookups).
 
   </Collapser>
-
 
   <Collapser
     className="freq-link"
@@ -2895,6 +2886,14 @@ Note: `aparse()` is case-insensitive.
       </Collapser>
     </CollapserGroup>
     _Related function: [<InlineCode>upper()</InlineCode>](#func-upper)_
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="func-minOf"
+    title={<InlineCode>minuteOf(attribute)</InlineCode>}
+  >
+    Use the `minuteOf()` function to extract only the minute portion (that is, minutes 0 to 59) of an attribute holding a valid timestamp value.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

A bunch of aggregator NRQL functions are in the non-aggregators section of the NRQL Reference page, and there's one non-aggregator in the aggregators section.  I've moved them to the appropriate sections.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.