### PR TITLE
docs: new flags in newrelic-infrastructure-agent troubleshooting

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/troubleshoot-running-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/troubleshoot-running-infrastructure-agent.mdx
@@ -74,6 +74,28 @@ To change the default settings of `newrelic-infra-ctl`:
         `newrelic-infra-ctl -docker-api-version 1.24`
       </td>
     </tr>
+
+
+    <tr>
+      <td>
+        [`container-runtime`] Container runtime ('docker' -default- or 'containerd')(when using a containerized version of the agent)
+      </td>
+
+      <td>
+        `newrelic-infra-ctl -container-runtime containerd`
+      </td>
+    </tr>
+
+
+    <tr>
+      <td>
+        [`containerd-namespace`] Namespace in containerd where the agent container is runing (when using a containerized version of the agent)
+      </td>
+
+      <td>
+        `newrelic-infra-ctl -containerd-namespace default`
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/troubleshoot-running-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/troubleshoot-running-infrastructure-agent.mdx
@@ -78,7 +78,7 @@ To change the default settings of `newrelic-infra-ctl`:
 
     <tr>
       <td>
-        `container-runtime` ('docker' -default- or 'containerd')
+        `container-runtime` (`docker` (default) or `containerd`)
       </td>
 
       <td>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/troubleshoot-running-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/manage-your-agent/troubleshoot-running-infrastructure-agent.mdx
@@ -78,7 +78,7 @@ To change the default settings of `newrelic-infra-ctl`:
 
     <tr>
       <td>
-        [`container-runtime`] Container runtime ('docker' -default- or 'containerd')(when using a containerized version of the agent)
+        `container-runtime` ('docker' -default- or 'containerd')
       </td>
 
       <td>
@@ -89,7 +89,7 @@ To change the default settings of `newrelic-infra-ctl`:
 
     <tr>
       <td>
-        [`containerd-namespace`] Namespace in containerd where the agent container is runing (when using a containerized version of the agent)
+        `containerd-namespace` (Namespace where the agent container is running)
       </td>
 
       <td>


### PR DESCRIPTION
New flags in newrelic-infrastructure-agent troubleshooting to allow signaling an agent running in containerd.