### PR TITLE
(Publish 8/23) chore(Horde): Update target date for IP range changes

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -618,7 +618,7 @@ To configure your firewall to allow synthetic monitors to access your monitored 
 ### Private locations [#synthetics-private]
 
 <Callout variant="important">
-  IP addresses used by synthetics private locations [are changing on August 22, 2023.](/whats-new/2023/06/whats-new-06-23-synthetics-horde-ip-changes/)
+  IP addresses used by synthetics private locations [are changing on August 23, 2023.](/whats-new/2023/06/whats-new-06-23-synthetics-horde-ip-changes/)
 </Callout>
 
 Synthetic private minions report to a specific endpoint based on region. To allow the private minion to access the endpoint or the static IP addresses associated with the endpoint, follow the specific procedures for the operating system and the firewall you use. These IP addresses may change in the future.

--- a/src/content/whats-new/2023/06/whats-new-06-23-synthetics-horde-ip-changes.md
+++ b/src/content/whats-new/2023/06/whats-new-06-23-synthetics-horde-ip-changes.md
@@ -5,7 +5,7 @@ releaseDate: '2023-06-23'
 learnMoreLink: 'https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#synthetics' 
 ---
 
-Starting **August 22, 2023**, the IP address range associated with the New Relic service used by [synthetics private locations](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#synthetics) will be updated.
+Starting **August 23, 2023**, the IP address range associated with the New Relic service used by [synthetics private locations](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#synthetics) will be updated.
 
 **What’s changing?**
 We’ll be migrating the IP address range for the New Relic service used by synthetics private locations to align with our [standard IP ranges](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#ingest-blocks) used across other data ingest.


### PR DESCRIPTION
The IP range change for the Synthetics Horde endpoints has been moved from today (Aug 22) to tomorrow (Aug 23). This updates the date references in the networks doc and in the original what's new post.