### PR TITLE
feat: add eolDate frontmatter type

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -354,6 +354,7 @@ exports.createSchemaCustomization = (
     translationType: String
     dataSource: String
     hideNavs: Boolean
+    eolDate: String
     downloadLink: String
     signupBanner: SignupBanner
     features: [String]
@@ -463,6 +464,10 @@ exports.createResolvers = ({ createResolvers }) => {
       hideNavs: {
         resolve: (source) =>
           hasOwnProperty(source, 'hideNavs') ? source.hideNavs : null,
+      },
+      eolDate: {
+        resolve: (source) =>
+          hasOwnProperty(source, 'eolDate') ? source.eolDate : null,
       },
       downloadLink: {
         resolve: (source) =>

--- a/scripts/releaseNotes.mjs
+++ b/scripts/releaseNotes.mjs
@@ -86,13 +86,14 @@ const generateReleaseNoteObject = async (filePath) => {
     slug,
   };
 
-  if (attributes.releaseDate) {
+  if (attributes.eolDate) {
+    output.eolDate = attributes.eolDate;
+  } else if (attributes.releaseDate) {
     output.eolDate = getEOLDate(attributes.releaseDate);
   }
 
   return output;
 };
-
 const releaseNoteMdxs = await glob('src/content/docs/release-notes/**/*.mdx', {
   ignore: '**/index.mdx',
 });

--- a/src/components/EolPage.js
+++ b/src/components/EolPage.js
@@ -19,6 +19,7 @@ const releaseNotesQuery = graphql`
         fileAbsolutePath
         frontmatter {
           releaseDate
+          eolDate
           version
         }
       }
@@ -32,7 +33,9 @@ const EolPage = ({ agent, locale = 'en' }) => {
     .filter((note) => getAgentName(note.fileAbsolutePath) === agent)
     .map((note) => ({
       date: parseISO(note.frontmatter.releaseDate),
-      eolDate: parseISO(getEOLDate(note.frontmatter.releaseDate)),
+      eolDate:
+        parseISO(note.frontmatter.eolDate) ||
+        parseISO(getEOLDate(note.frontmatter.releaseDate)),
       version: note.frontmatter.version,
     }));
 
@@ -69,6 +72,8 @@ const EolPage = ({ agent, locale = 'en' }) => {
   return (
     <tbody>
       {table.map((note) => {
+        console.log('eolDate', note.eolDate);
+
         return (
           // Some release notes have the same date but diff versions
           <tr key={note.date + note.version}>

--- a/src/components/EolPage.js
+++ b/src/components/EolPage.js
@@ -33,9 +33,9 @@ const EolPage = ({ agent, locale = 'en' }) => {
     .filter((note) => getAgentName(note.fileAbsolutePath) === agent)
     .map((note) => ({
       date: parseISO(note.frontmatter.releaseDate),
-      eolDate:
-        parseISO(note.frontmatter.eolDate) ||
-        parseISO(getEOLDate(note.frontmatter.releaseDate)),
+      eolDate: parseISO(
+        note.frontmatter.eolDate ?? getEOLDate(note.frontmatter.releaseDate)
+      ),
       version: note.frontmatter.version,
     }));
 
@@ -72,8 +72,6 @@ const EolPage = ({ agent, locale = 'en' }) => {
   return (
     <tbody>
       {table.map((note) => {
-        console.log('eolDate', note.eolDate);
-
         return (
           // Some release notes have the same date but diff versions
           <tr key={note.date + note.version}>


### PR DESCRIPTION
- gives release note authors the option to specify an eolDate in frontmatter that overrides the default generated one
- these changes apply to eolPage.js as well as the generated release-notes.json

v6.26.0 shows the January eol date instead of September
<img width="895" alt="Screenshot 2023-08-22 at 11 41 58 AM" src="https://github.com/newrelic/docs-website/assets/47728020/53f9996d-b647-4d3f-bfc9-bb740b3a63a3">

I modified the releaseNotes.mjs script to write to a file locally and got these results:

generated json for the release note with specified eolDate:
```json
  {
    "agent": "dotnet",
    "date": "2020-09-15",
    "downloadLink": "https://download.newrelic.com/dot_net_agent/6.x_release/",
    "version": "6.26.0.0",
    "features": null,
    "bugs": null,
    "security": null,
    "description": "Notes The 6.x agent supports legacy frameworks...",
    "eolDate": "2029-01-09"
  },
```
generated json for another release note with the default generated eolDate that adds 3 years is still working as expected
```json
  {
    "agent": "dotnet",
    "date": "2020-01-15",
    "downloadLink": null,
    "version": "6.25.0.0",
    "features": null,
    "bugs": null,
    "security": null,
    "description": "This is a security-only release for the 6.x agents that support...",
    "slug": "docs/release-notes/agent-release-notes/net-release-notes/net-agent-62500",
    "eolDate": "2023-01-15"
  },
```