### PR TITLE
fix: note about yaml parsing

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent.mdx
@@ -43,7 +43,8 @@ A configuration file template is available in [Infrastructure config file templa
 To configure on-host integrations that work with the infrastructure agent, see a [specific integration's documentation](/docs/integrations/host-integrations/get-started/introduction-host-integrations).
 
 <Callout variant="important">
-  Always [restart the agent](/docs/infrastructure-start-stop-restart-check-agent-status) or your web server after changing settings.
+  Always [restart the agent](/docs/infrastructure-start-stop-restart-check-agent-status) after changing settings.
+  Integration config updates do not require an agent restart (hot-reload is supported).
 </Callout>
 
 ## Configuration methods and precedence [#precedence]
@@ -72,7 +73,7 @@ Here are detailed descriptions of each configuration method:
     * Linux: `/etc/newrelic-infra.yml`
     * Windows: `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`
     * MacOS Intel: `/usr/local/etc/newrelic-infra/newrelic-infra.yml`
-    * MacOS Silicon: `/opt/homebrew/etc/newrelic-infra/newrelic-infra.yml`
+    * MacOS Apple Silicon: `/opt/homebrew/etc/newrelic-infra/newrelic-infra.yml`
     
       For a sample config file, see our [infrastructure config file template](https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example).
   </Collapser>
@@ -142,11 +143,12 @@ For a list of all settings you can configure, including definitions, defaults, a
 
 ## Configuration file structure [#config_structure]
 
-When editing `newrelic-infra.yml`:
+When editing agent or integration YAML config files:
 
 * Follow [YAML formatting conventions](https://en.wikipedia.org/wiki/YAML).
 * Do not modify the casing of the configuration options: YAML keys are case sensitive.
 * Respect the indentation levels. All indentations are in similar increments, typically of two space characters. Data in the same stanza of the file must use the same level of indentation. Indent any sub-stanzas by an additional two spaces (see examples in [Custom attributes](/docs/infrastructure/install-configure-infrastructure/configuration/infrastructure-configuration-settings#custom-attributes) and [Network interface filters](/docs/infrastructure/install-configure-infrastructure/configuration/infrastructure-configuration-settings#network-interface-filters)).
+* YAML format distinguish between numbers and strings. Use quotes to parse configuration values as string.
 
 A template of `newrelic-infra.yml` is available in the [infrastructure agent repository](https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example). Use a [validator](http://www.yamllint.com/) to ensure the syntax is accurate before using the file with the infrastructure agent.
 


### PR DESCRIPTION
## Give us some context

* Adding a note to explain config values must be quoted to treat them as strings (and not numbers).