### PR TITLE
chore(style): clarify hero responsibilities

### DIFF
--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -20,9 +20,16 @@ A high-altitude view of the `What's new` process looks like this:
 
 ## Specific tech writer tasks for posts [#specific-writing-tasks]
 
-Each day, the hero is responsible for checking the status of `What’s new` posts. The daily hero takes ownership of the post (reviewing, posting, and confirming that posts make it to docs site and product UI). When the post comes in, only assign it to yourself if you're going to see it through from start to finish. Otherwise, you can just monitor it as it goes through the workflow.
+The daily hero has the following responsibilities each day:
 
+* **Merge scheduled posts:** Check the `Scheduled work` column on the Github board for any `What's new` posts that have already been approved and are scheduled to merge that day. For example, if Monday's hero reviewed and approved a post scheduled to go live on your Wednsday hero shift, you should merge that PR.
+* **Review any incoming posts:** Any `What's new` posts that come in should be reviewed and approved during your hero shift. This includes basic copy edits, ensuring correct image formatting, and confirming a successful preview build. Edit the title to the day it should be published and then move the PR to the `Scheduled work` column. 
+
+See the rest of the doc for more detailed instructions.
+
+<Callout variant="tip">
 Before you start your writing review, make sure it was reviewed by a product marketing manager if the post was from outside that department. For example, if a developer or product manager submits a post, it should be reviewed first by a product marketing manager (anyone listed in the [CODEOWNERS file](.github/CODEOWNERS)). After a product marketing manager reviews the post and passes it to the hero, make sure you complete the steps in the sections below.
+</Callout>
 
 ### Manage GitHub board [#the-board]
 

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -23,7 +23,7 @@ A high-altitude view of the `What's new` process looks like this:
 The daily hero has the following responsibilities each day:
 
 * **Merge scheduled posts:** Check the `Scheduled work` column on the Github board for any `What's new` posts that have already been approved and are scheduled to merge that day. For example, if Monday's hero reviewed and approved a post scheduled to go live on your Wednsday hero shift, you should merge that PR.
-* **Review any incoming posts:** Any `What's new` posts that come in should be reviewed and approved during your hero shift. This includes basic copy edits, ensuring correct image formatting, and confirming a successful preview build. Edit the title to the day it should be published and then move the PR to the `Scheduled work` column. 
+* **Review any incoming posts:** Any `What's new` posts that come in should be reviewed and approved during your hero shift. This includes basic copy edits, ensuring correct image formatting, and confirming a successful preview build. Edit the title to the day it should be published and then move the PR to the `Scheduled work` column. Reviewing PRs as they appear ensures a smooth release once they are ready to merge. 
 
 See the rest of the doc for more detailed instructions.
 

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -23,7 +23,7 @@ A high-altitude view of the `What's new` process looks like this:
 The daily hero has the following responsibilities each day:
 
 * **Merge scheduled posts:** Check the `Scheduled work` column on the Github board for any `What's new` posts that have already been approved and are scheduled to merge that day. For example, if Monday's hero reviewed and approved a post scheduled to go live on your Wednsday hero shift, you should merge that PR.
-* **Review any incoming posts:** Any `What's new` posts that come in should be reviewed and approved during your hero shift. This includes basic copy edits, ensuring correct image formatting, and confirming a successful preview build. Edit the title to the day it should be published and then move the PR to the `Scheduled work` column. Reviewing PRs as they appear ensures a smooth release once they are ready to merge. 
+* **Review any incoming posts:** Any `What's new` posts that come in should be reviewed and approved during your hero shift. This includes basic copy edits, ensuring correct image formatting, and confirming a successful preview build. Edit the title to the day it should be published and then move the PR to the `Scheduled work` column. By reviewing PRs as they arrive, you ensure a smooth release once they are ready to merge. 
 
 See the rest of the doc for more detailed instructions.
 

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -51,6 +51,10 @@ Before you start your writing review, make sure it was reviewed by a product mar
 
 4. Check if the post has the `isFeatured: true` in the front matter. If so, this means that the post will be pinned to the top of the product UI. You should remove the corresponding flag in the previously featured post so only one post is featured.
 
+<Callout variant="tip">
+If you can't complete a "What's new" post review during your hero shift, please alert the hero taking the next shift so that they can complete it.
+</Callout>
+
 ### Publish the post [#publish-the-post]
 
 There are two merges to `main` involved in publishing a "What's new?" post. 


### PR DESCRIPTION
Clarifies that reviewing What's New posts is the responsibility of the daily hero and not the hero of the release date. 