### PR TITLE
chore(php): add laravel 9 and 10 to supported frameworks

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -207,7 +207,7 @@ Supported PHP frameworks include:
 
     <tr>
       <td>
-        Laravel Lumen 6.x, 7.x, and 8.x
+        Laravel Lumen 6.x, 7.x, 8.x, 9.x, and 10.x
       </td>
 
       <td>


### PR DESCRIPTION
Update the PHP Agent Compatibility page by adding Laravel 9 and 10 as supported frameworks.