### PR TITLE
Update install-nodejs-agent-docker.mdx

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
@@ -23,25 +23,25 @@ With just a few additions your existing Dockerfile can be used with our Node.js 
    ```
 
    Install a specific version, or use any of the other options provided by the [`package.json` format](https://docs.npmjs.com/files/package.json#dependencies). Check [the Node.js agent release notes](/docs/release-notes/agent-release-notes/nodejs-release-notes) for information about past agent versions.
-2. Depending on how your container is setup, you can edit the `ENTRYPOINT` to include `newrelic` module first with Node.js `-r/--require` flag by running `node -r newrelic YOUR_PROGRAM.js`. If you can't control how your program runs, you can load the `newrelic` module before any other module in your program by adding `require('newrelic')`.
 
-<Callout variant="tip">
-  If you have an npm script to run your program such as `npm start`, you can programmatically modify this script by running `npm pkg set scripts.start="node -r newrelic your-program.js"`.
-</Callout>
+2. Depending on how your container is setup, you can edit the `ENTRYPOINT` to include `newrelic` module first with Node.js `-r`/`--require` flag by running `node -r newrelic YOUR_PROGRAM.js`. If you can't control how your program runs, you can load the `newrelic` module before any other module in your program by adding `require('newrelic')`.
 
-3. Add the environment variable `NEW_RELIC_NO_CONFIG_FILE=true` to your Dockerfile so the agent can run without a configuration file.
+  For Next.js use `@newrelic/next` instead of `newrelic`.
+   <Callout variant="tip">
+     If you have an npm script to run your program such as `npm start`, you can programmatically modify this script by running `npm pkg set scripts.start="node -r newrelic your-program.js"`.
+   </Callout>
 
-<Callout variant="important">
-  This environment variable is no longer required as of [v7.2.0 of the Node.js agent](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-2-0). More information on our configuration settings and order of precedence can be found [here](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/).
-</Callout>
+   <Callout variant="important">
+     If your Node.js agent is older than [v7.2.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-7-2-0) you will need to add the environment variable `NEW_RELIC_NO_CONFIG_FILE=true` to your Dockerfile so the agent can run without a configuration file.  More information on our configuration settings and order of precedence can be found [here](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/).
+   </Callout>
 
-4. Build your Docker image the way you normally do.
-5. To run your Docker app with the agent enabled, add your <InlinePopover type="licenseKey" /> and [app name](/docs/agents/manage-apm-agents/app-naming/name-your-application) to your `docker run` command as environment variables:
+3. Build your Docker image the way you normally do.
+4. To run your Docker app with the agent enabled, add your <InlinePopover type="licenseKey" /> and [app name](/docs/agents/manage-apm-agents/app-naming/name-your-application) to your `docker run` command as environment variables:
 
    ```bash
    docker run -e NEW_RELIC_LICENSE_KEY=YOUR_LICENSE_KEY \
-         -e NEW_RELIC_APP_NAME="YOUR_APP_NAME" \
-         YOUR_IMAGE_NAME:latest
+          -e NEW_RELIC_APP_NAME="YOUR_APP_NAME" \
+          YOUR_IMAGE_NAME:latest
    ```
 
 <InstallFeedback />


### PR DESCRIPTION
I added info about using Next.js, and removed step 4 since it is only applicable to a small amount of people using a legacy v6.13.1 of the agent which will be EOL next month anyway.

I made that a 'callout' instead of a step

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.