### PR TITLE
Fix wording in Azure log forwarding integrations docs

### DIFF
--- a/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
@@ -50,13 +50,13 @@ To send the logs from your Event Hub:
 Follow these steps:
 
 1. Make sure you have a <InlinePopover type="licenseKey" />.
-2. Log into **[the Logs UI](https://one.newrelic.com/launcher/logger.log-launcher)** and click on  **Add data** on the left sidebar.
+2. Go to **[the logs UI](https://one.newrelic.com/launcher/logger.log-launcher)** and, on the left, click **Add data**.
 3. Under **Logging**, click the `Microsoft Azure Event Hub` tile:
-4. Select the account you want to send the logs, and click **Continue**.
-5. Click **Generate API Key** and copy the generated API key.
+4. Select the account where you want to send the logs, and click **Continue**.
+5. Click **Generate API key** and copy the generated API key.
 6. Click **Deploy to Azure** and a new tab will be open with the ARM template loaded in Azure.
-7. Select the **Resource Group** where you want to create the necessary resources, and a **Region**. Despite not being mandatory, we recommend installing the template in a new resource group, to avoid deleting any of the components it creates accidentally.
-8. In the **New Relic License Key** field, paste the previously copied API key.
+7. Select the **Resource group** where you want to create the necessary resources, and a **Region**. Despite not being mandatory, we recommend installing the template in a new resource group, to avoid deleting any of the components it creates accidentally.
+8. In the **New Relic license key** field, paste the previously copied API key.
 9. Ensure the [New Relic endpoint](/docs/logs/log-api/introduction-log-api/#endpoint) is set to the one corresponding to your account.
 10. Optional: Set to `true` the [Azure subscription activity logs](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log) you want to forward. See [the subscription information](#subscription-activity-logs) in this document for more details.
 11. Click **Review + create**, review the data you've inserted, and click **Create**.
@@ -145,7 +145,7 @@ To send the blobs from a container in your Storage Account, follow these steps:
 Follow these steps:
 
 1. Make sure you have a <InlinePopover type="licenseKey" />.
-2. Log into **[the Logs UI](https://one.newrelic.com/launcher/logger.log-launcher)** and click on  **Add data** on the left sidebar.
+2. Go to **[the logs UI](https://one.newrelic.com/launcher/logger.log-launcher)** and, on the left, click **Add data**.
 3. Under **Logging**, click the `Microsoft Azure Blob Storage` tile.
 4. Select the account you want to send the logs, and click **Continue**.
 5. Click **Generate API key** and copy the generated **API key**.

--- a/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
@@ -50,8 +50,8 @@ To send the logs from your Event Hub:
 Follow these steps:
 
 1. Make sure you have a <InlinePopover type="licenseKey" />.
-2. Log in to **[one.newrelic.com > Logs](https://one.newrelic.com/launcher/logger.log-launcher) > Add more data sources** on the top right of the page.
-3. Under **Log ingestion**, click the `Microsoft Azure Event Hub` tile:
+2. Log into **[the Logs UI](https://one.newrelic.com/launcher/logger.log-launcher)** and click on  **Add data** on the left sidebar.
+3. Under **Logging**, click the `Microsoft Azure Event Hub` tile:
 4. Select the account you want to send the logs, and click **Continue**.
 5. Click **Generate API Key** and copy the generated API key.
 6. Click **Deploy to Azure** and a new tab will be open with the ARM template loaded in Azure.
@@ -145,8 +145,8 @@ To send the blobs from a container in your Storage Account, follow these steps:
 Follow these steps:
 
 1. Make sure you have a <InlinePopover type="licenseKey" />.
-2. Go to our [logs UI](https://one.newrelic.com/launcher/logger.log-launcher) and click **Add more data sources** on the top right of the page.
-3. Under **Log ingestion**, click the `Microsoft Azure Blob Storage` tile.
+2. Log into **[the Logs UI](https://one.newrelic.com/launcher/logger.log-launcher)** and click on  **Add data** on the left sidebar.
+3. Under **Logging**, click the `Microsoft Azure Blob Storage` tile.
 4. Select the account you want to send the logs, and click **Continue**.
 5. Click **Generate API key** and copy the generated **API key**.
 6. Click **Deploy to Azure** and a new tab will be open with the ARM template loaded in Azure.
@@ -193,19 +193,19 @@ If you have any questions regarding this notice, contact [our support team](http
     id="disabling-public-network-access-storage-account"
     title="Disabling public network access to your storage account"
   >
-    Modifying this setting is quite complex, as it involves: 
-    - Creating another private-access storage account. 
+    Modifying this setting is quite complex, as it involves:
+    - Creating another private-access storage account.
     - Moving all the file shares and blobs to this new private-access storage account.
-    - Creating private endpoints for the new private-access storage account. 
-    - Creating DNS records for the new private endpoints. 
-    - Modifying the network configuration of the Function App accordingly. 
+    - Creating private endpoints for the new private-access storage account.
+    - Creating DNS records for the new private endpoints.
+    - Modifying the network configuration of the Function App accordingly.
 
     Due to this complexity, we recommend you to redeploy our ARM template from scratch instead of attempting to manually modify this setting.
 
     <Callout variant="tip">
     If you can't complete a full redeployment, read how to perform a redeployment of an existing storage account in [Microsoft's documentation](https://learn.microsoft.com/en-us/azure/azure-functions/configure-networking-how-to?tabs=portal#existing-function-app), or in this [blog post](https://techcommunity.microsoft.com/t5/apps-on-azure-blog/secure-storage-account-linked-to-function-app-with-private/ba-p/2644772). When following the instructions, avoid adding the `WEBSITE_VNET_ROUTE_ALL` option.
     </Callout>
-  
+
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
* What problems does this PR solve?
It fixes the wording for the Microsoft Azure log forwarding integrations. These integrations were referring to an old UI component that has changed its naming from "Add more data sources" to "Add data". Also, the instructions were pointing to the "top right of the page", and this has now been physically moved to the left sidebar.