### PR TITLE
update: explain what labels do, remove more `<var>`s

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -171,7 +171,7 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     ```ini
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
-    CORECLR_NEWRELIC_HOME=<var>path/to/agent/directory</var>
+    CORECLR_NEWRELIC_HOME=PATH/TO/AGENT/DIRECTORY
     CORECLR_PROFILER_PATH="${CORECLR_NEWRELIC_HOME}/libNewRelicProfiler.so"
     ```
 
@@ -180,8 +180,8 @@ Our .NET agent relies on environment variables to tell the .NET Common Language 
     ```ini
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
-    NEWRELIC_INSTALL_PATH=<var>C:\Program Files\New Relic\.NET Agent\</var>
-    CORECLR_NEWRELIC_HOME=<var>C:\ProgramData\New Relic\.NET Agent\</var>
+    NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\
+    CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\
     ```
     
     The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications. See [Compatibility and requirements for .NET Framework](/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework) for .NET Framework applications.
@@ -229,8 +229,8 @@ NEW_RELIC_PROXY_DOMAIN=mydomain.com
 NEW_RELIC_PROXY_PASS_OBFUSCATED=XXXXXXXX
 NEW_RELIC_CONFIG_OBSCURING_KEY=XXXXXXXX
 NEW_RELIC_DISABLE_SAMPLERS=true
-NEWRELIC_PROFILER_LOG_DIRECTORY=<var>path\to\a\directory</var> (not configurable via config file)
-NEWRELIC_LOG_DIRECTORY=<var>path\to\a\directory</var> (Insert a directory where you want to put the agent and profiler logs. You can't set this directory for both agent and profiler logs in the configuration file.)
+NEWRELIC_PROFILER_LOG_DIRECTORY=PATH\TO\LOG\DIRECTORY (not configurable via config file)
+NEWRELIC_LOG_DIRECTORY=PATH\TO\LOG\DIRECTORY (Insert a directory where you want to put the agent and profiler logs. You can't set this directory for both agent and profiler logs in the configuration file.)
 NEWRELIC_LOG_LEVEL=<var>off|error|warn|info|debug|finest|all</var>
 NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
 NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED=true
@@ -250,7 +250,7 @@ NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=<var>true|false</var>
 NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=<var>true|false</var>
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=<var>true|false</var>
 NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
-NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
+NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=2000
 ```
 
 If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
@@ -349,7 +349,7 @@ The `configuration` element supports the following attributes:
 The first child of the `configuration` element is a `service` element. The service element configures the agent's connection to the New Relic service.
 
 ```xml
-<service licenseKey="<var>YOUR_LICENSE_KEY</var>"
+<service licenseKey="YOUR_LICENSE_KEY"
   sendEnvironmentInfo="true"
   syncStartup="false"
   sendDataOnExit="false"
@@ -393,7 +393,7 @@ The `service` element supports the following attributes:
     Alternatively, set the `NEW_RELIC_LICENSE_KEY` environment variable in the application's environment.
 
     ```ini
-    NEW_RELIC_LICENSE_KEY=<var>XXXXXXXX</var>
+    NEW_RELIC_LICENSE_KEY=YOUR_LICENSE_KEY
     ```
   </Collapser>
 
@@ -492,7 +492,7 @@ The `service` element supports the following attributes:
     Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT` environment variable in the application's environment.
 
     ```ini
-    NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
+    NEW_RELIC_SEND_DATA_ON_EXIT=true
     ```
   </Collapser>
 
@@ -539,7 +539,7 @@ The `service` element supports the following attributes:
     Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS` environment variable in the application's environment.
 
     ```ini
-    NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
+    NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=2000
     ```
   </Collapser>
 
@@ -611,7 +611,7 @@ The `service` element supports the following attributes:
     Alternatively, the `NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD` environment variable may be used to control this behavior.
 
     ```ini
-    NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=<var>true|false</var>
+    NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=true
     ```
   </Collapser>
 
@@ -737,8 +737,8 @@ The `service` element supports the following attributes:
 The `obscuringKey` element is an optional child of the `service` element. The .NET Agent uses this value to deobfuscate supported configuration values. For example, when an [obfuscated proxy password](#proxy-password) is supplied, it will be deobfuscated using this key.
 
 ```xml
-<service licenseKey="<var>YOUR_LICENSE_KEY</var>">
-  <obscuringKey><var>OBSCURING_KEY</var></obscuringKey>
+<service licenseKey="YOUR_LICENSE_KEY">
+  <obscuringKey>OBSCURING_KEY</obscuringKey>
 </service>
 ```
 
@@ -753,15 +753,15 @@ The obscuring key may also be configured by setting the `NEW_RELIC_CONFIG_OBSCUR
 The `proxy` element is an optional child of the `service` element. The `proxy` element is used when the agent communicates to the New Relic backend service via a proxy.
 
 ```xml
-<service licenseKey="<var>YOUR_LICENSE_KEY</var>">
+<service licenseKey="YOUR_LICENSE_KEY">
   <proxy
-    host="<var>hostname</var>"
-    port="<var>PROXY_PORT</var>"
-    uriPath="<var>path/to/something.aspx</var>"
-    domain="<var>mydomain.com</var>"
-    user="<var>PROXY_USERNAME</var>"
-    password="<var>PROXY_PASSWORD</var>"
-    passwordObfuscated="<var>OBFUSCATED_PROXY_PASSWORD</var>"/>
+    host="HOSTNAME"
+    port="PROXY_PORT"
+    uriPath="FILEPATH\FILENAME.aspx"
+    domain="mydomain.com"
+    user="PROXY_USERNAME"
+    password="PROXY_PASSWORD"
+    passwordObfuscated="OBFUSCATED_PROXY_PASSWORD"/>
 </service>
 ```
 
@@ -1016,8 +1016,8 @@ The `log` element is a child of the `configuration` element. The `log` element c
 <log level="info"
   auditLog="false"
   console="false"
-  directory="<var>PATH\TO\LOG\DIRECTORY</var>"
-  fileName="<var>FILENAME.log</var>" />
+  directory="PATH\TO\LOG\DIRECTORY"
+  fileName="FILENAME.log" />
 ```
 
 The `log` element supports the following attributes:
@@ -1240,9 +1240,9 @@ The `application` element is a child of the `configuration` element. This requir
 
     ```xml
     <application>
-      <name><var>MY APPLICATION PRIMARY</var></name>
-      <name><var>SECOND APP NAME</var></name>
-      <name><var>THIRD APP NAME</var></name>
+      <name>MY APPLICATION PRIMARY</name>
+      <name>SECOND APP NAME</name>
+      <name>THIRD APP NAME</name>
     </application>
     ```
 
@@ -1351,7 +1351,7 @@ To set a display name, choose one of the following options. The environment vari
 
     ```xml
     <configuration . . . >
-      <processHost displayName="<var>CUSTOM_NAME</var>" />
+      <processHost displayName="CUSTOM_NAME" />
     </configuration>
     ```
   </Collapser>
@@ -1363,7 +1363,7 @@ To set a display name, choose one of the following options. The environment vari
     Set the `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME` environment variable:
 
     ```ini
-    NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="<var>CUSTOM_NAME</var>"
+    NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="CUSTOM_NAME"
     ```
   </Collapser>
 </CollapserGroup>
@@ -1414,7 +1414,7 @@ The `utilization` element supports the following attributes:
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_AWS` environment variable:
 
     ```ini
-    NEW_RELIC_UTILIZATION_DETECT_AWS=<var>true|false</var>
+    NEW_RELIC_UTILIZATION_DETECT_AWS=false
     ```
   </Collapser>
 
@@ -1451,7 +1451,7 @@ The `utilization` element supports the following attributes:
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_AZURE` environment variable:
 
     ```ini
-    NEW_RELIC_UTILIZATION_DETECT_AZURE=<var>true|false</var>
+    NEW_RELIC_UTILIZATION_DETECT_AZURE=false
     ```
   </Collapser>
 
@@ -1488,7 +1488,7 @@ The `utilization` element supports the following attributes:
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_GCP` environment variable:
 
     ```ini
-    NEW_RELIC_UTILIZATION_DETECT_GCP=<var>true|false</var>
+    NEW_RELIC_UTILIZATION_DETECT_GCP=false
     ```
   </Collapser>
 
@@ -1525,7 +1525,7 @@ The `utilization` element supports the following attributes:
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_PCF` environment variable:
 
     ```ini
-    NEW_RELIC_UTILIZATION_DETECT_PCF=<var>true|false</var>
+    NEW_RELIC_UTILIZATION_DETECT_PCF=false
     ```
   </Collapser>
 
@@ -1562,7 +1562,7 @@ The `utilization` element supports the following attributes:
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_DOCKER` environment variable:
 
     ```ini
-    NEW_RELIC_UTILIZATION_DETECT_DOCKER=<var>true|false</var>
+    NEW_RELIC_UTILIZATION_DETECT_DOCKER=false
     ```
   </Collapser>
 
@@ -1599,7 +1599,7 @@ The `utilization` element supports the following attributes:
     Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES` environment variable:
 
     ```ini
-    NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=<var>true|false</var>
+    NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=false
     ```
   </Collapser>
 </CollapserGroup>
@@ -1627,9 +1627,9 @@ The `applications` element is a child of the `instrumentation` element. The `app
 ```xml
 <instrumentation>
   <applications>
-    <application name="<var>MyService1.exe</var>" />
-    <application name="<var>MyService2.exe</var>" />
-    <application name="<var>MyService3.exe</var>" />
+    <application name="MyService1.exe" />
+    <application name="MyService2.exe" />
+    <application name="MyService3.exe" />
   </applications>
 </instrumentation>
 ```
@@ -1642,8 +1642,8 @@ In this example, the agent excludes all attributes whose key begins with **myApi
 
 ```xml
 <attributes enabled="true">
-  <exclude><var>myApiKey.*</var></exclude>
-  <include><var>myApiKey.foo</var></include>
+  <exclude>myApiKey.*</exclude>
+  <include>myApiKey.foo</include>
 </attributes>
 ```
 
@@ -1798,8 +1798,8 @@ Here is an example of disabling instrumentation for specific application pools:
 
 ```xml
 <applicationPools>
-  <applicationPool name="<var>Foo</var>" instrument="false"/>
-  <applicationPool name="<var>Bar</var>" instrument="false"/>
+  <applicationPool name="Foo" instrument="false"/>
+  <applicationPool name="Bar" instrument="false"/>
 </applicationPools>
 ```
 
@@ -1808,8 +1808,8 @@ Here is an example of disabling instrumentation for all application pools curren
 ```xml
 <applicationPools>
   <defaultBehavior instrument="false"/>
-  <applicationPool name="<var>Foo</var>" instrument="true"/>
-  <applicationPool name="<var>Bar</var>" instrument="true"/>
+  <applicationPool name="Foo" instrument="true"/>
+  <applicationPool name="Bar" instrument="true"/>
 </applicationPools>
 ```
 
@@ -1864,33 +1864,33 @@ The `errorCollector` element is a child of the `configuration` element. `errorCo
 ```xml
 <errorCollector enabled="true" captureEvents="true" maxEventSamplesStored="100">
   <ignoreClasses>
-    <errorClass><var>System.IO.FileNotFoundException</var></errorClass>
-    <errorClass><var>System.Threading.ThreadAbortException</var></errorClass>
+    <errorClass>System.IO.FileNotFoundException</errorClass>
+    <errorClass>System.Threading.ThreadAbortException</errorClass>
   </ignoreClasses>
   <ignoreMessages>
-    <errorClass name="<var>System.Exception</var>">
-       <message><var>Ignore message</var></message>
-       <message><var>Ignore too</var></message>
+    <errorClass name="System.Exception">
+       <message>Ignore message</message>
+       <message>Ignore too</message>
     </errorClass>
   </ignoreMessages>
   <ignoreStatusCodes>
-    <code><var>401</var></code>
-    <code><var>404</var></code>
+    <code>401</code>
+    <code>404</code>
   </ignoreStatusCodes>
   <expectedClasses>
-    <errorClass><var>System.ArgumentNullException</var></errorClass>
-    <errorClass><var>System.ArgumentOutOfRangeException</var></errorClass>
+    <errorClass>System.ArgumentNullException</errorClass>
+    <errorClass>System.ArgumentOutOfRangeException</errorClass>
   </expectedClasses>
   <expectedMessages>
-    <errorClass name="<var>System.Exception</var>">
-       <message><var>Expected message</var></message>
-       <message><var>Expected too</var></message>
+    <errorClass name="System.Exception">
+       <message>Expected message</message>
+       <message>Expected too</message>
     </errorClass>
   </expectedMessages>
   <expectedStatusCodes>403,500-505</expectedStatusCodes>
   <attributes enabled="true">
-    <exclude><var>myApiKey.*</var></exclude>
-    <include><var>myApiKey.foo</var></include>
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
   </attributes>
 </errorCollector>
 ```
@@ -2197,8 +2197,8 @@ The `transactionEvents` element is a child of the `configuration` element. Use `
 ```xml
 <transactionEvents enabled="true" maximumSamplesStored="10000">
   <attributes enabled="true">
-    <exclude><var>myApiKey.*</var></exclude>
-    <include><var>myApiKey.foo</var></include>
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
   </attributes>
 </transactionEvents>
 ```
@@ -2415,12 +2415,12 @@ The `customParameters` element supports the following attributes:
 
 ### Labels (tags)
 
-The `labels` element is a child of the `configuration` element.
+The `labels` element is a child of the `configuration` element. Labels are key value pairs associated with an application, they will not be applied to [MELT data](/docs/data-apis/understand-data/new-relic-data-types/). 
 
 This sets [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) names and values. The list is a semicolon delimited list of colon-separated name and value pairs. You can also use with the `NEW_RELIC_LABELS` environment variable. Example:
 
 ```xml
-<labels><var>foo</var>:<var>bar</var>;<var>zip</var>:<var>zap</var></labels>
+<labels>foo:bar;zip:zap</labels>
 ```
 
 ### Browser instrumentation [#browser_monitoring]
@@ -2438,8 +2438,8 @@ The `browserMonitoring` element is a child of the `configuration` element. `brow
     <path regex="url-regex-n"/>
   </requestPathsExcluded>
   <attributes enabled="true">
-    <exclude><var>myApiKey.*</var></exclude>
-    <include><var>myApiKey.foo</var></include>
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
   </attributes>
 </browserMonitoring>
 ```
@@ -2568,8 +2568,8 @@ The `transactionTracer` element is a child of the `configuration` element. `tran
     maxSegments="3000"
     maxExplainPlans="20">
   <attributes enabled="true">
-    <exclude><var>myApiKey.*</var></exclude>
-    <include><var>myApiKey.foo</var></include>
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
   </attributes>
  </transactionTracer>
 ```
@@ -3020,7 +3020,7 @@ To turn on [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introdu
 <configuration . . . >
   <distributedTracing enabled="true" />
   <infiniteTracing>
-    <trace_observer host="<var>YOUR_TRACE_OBSERVER_HOST</var>" />
+    <trace_observer host="YOUR_TRACE_OBSERVER_HOST" />
   </infiniteTracing>
 </configuration>
 ```
@@ -3100,8 +3100,8 @@ The `spanEvents` element is a child of the `configuration` element. Use `spanEve
 ```xml
 <spanEvents enabled="true">
   <attributes enabled="true">
-    <exclude><var>myApiKey.*</var></exclude>
-    <include><var>myApiKey.foo</var></include>
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
   </attributes>
 </spanEvents>
 ```
@@ -3303,10 +3303,10 @@ NEW_RELIC_APPLICATION_LOGGING_ENABLED=<var>true|false</var>
 NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED=<var>true|false</var>
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=<var>true|false</var>
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED=<var>true|false</var>
-NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE=<var>"myCustomAttribute1, myOtherCustomAttribute*"</var>
-NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE=<var>"myCustomAttribute2, myOtherCustomAttributeMoreSpecificName"</var>
-NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=<var>10000</var>
-NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST=<var>"log_level_1, log_level_2"</var>
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE="myCustomAttribute1, myOtherCustomAttribute*"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE="myCustomAttribute2, myOtherCustomAttributeMoreSpecificName"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST="log_level_1, log_level_2"
 NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=<var>true|false</var>
 ```
 
@@ -3406,7 +3406,7 @@ For more details, see our documentation for [New Relic CodeStream integration](/
 This can also be configured via environment variable:
 
 ```ini
-NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=<var>true|false</var>
+NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
 ```
 
 ## Settings in app.config or web.config [#app-config-settings]

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -491,8 +491,9 @@ This section defines the Node.js agent variables in the order they typically app
     id="labels"
     title="labels"
   >
-    Adds [tags](/docs/apm/new-relic-apm/maintenance/labels-categories-organize-your-apps-servers). Specify your tags as objects or a semicolon-delimited string of colon-separated pairs (for example, `Server:One;Data Center:Primary`).
+    Adds [tags](/docs/apm/new-relic-apm/maintenance/labels-categories-organize-your-apps-servers) to your application, tags/labels are key value pairs associated with an application, they will not be applied to [MELT data](/docs/data-apis/understand-data/new-relic-data-types/). Specify your tags as objects or a semicolon-delimited string of colon-separated pairs (for example, `Server:One;Data Center:Primary`).
 
+    
     <table>
       <tbody>
         <tr>


### PR DESCRIPTION
Labels were not clearly explained, so added some info about what they do and don't do. Internal source: https://source.datanerd.us/agents/agent-specs/blob/b657613819369c60be766556ea4a62cb82fd8597/Labels.md

I also removed more `<var>`s which we don't use anymore. I left them in code samples that shows multiple values, like `true|false` or a series of possible options

For examples that did show `true|false` before I kept the non-default value. So if the default of `X=true`, in the example of configuring `X` I made it 
```ini
X=false
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.