### PR TITLE
chore: Add eolDate override for .NET Agent v6.27.0.0 release notes.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -28,7 +28,7 @@ Any versions not listed in the following table are no longer supported. Please [
   <EolPage agent='dotnet' />
   </table>
 
-* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only the latest 6.x agent version is supported.  The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
+* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only versions 6.26 and 6.27 are supported.   The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
 
 ## Microsoft .NET runtimes [#microsoft-runtimes]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -28,7 +28,7 @@ Any versions not listed in the following table are no longer supported. Please [
   <EolPage agent='dotnet' />
   </table>
 
-* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only versions 6.26 and 6.27 are supported. The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
+* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only receives critical security patches.  Only versions 6.26 and 6.27 are supported. The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
 
 ## Microsoft .NET runtimes [#microsoft-runtimes]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
@@ -28,7 +28,7 @@ Any versions not listed in the following table are no longer supported. Please [
   <EolPage agent='dotnet' />
   </table>
 
-* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only versions 6.26 and 6.27 are supported.   The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
+* The 6.x agent line is maintained to support customers with applications running on .NET Framework versions earlier than 4.5, and only recieves critical security patches.  Only versions 6.26 and 6.27 are supported. The EOL date for 6.x agents is the same as Microsoft's support end date for .NET Framework 3.5 Service Pack 1.
 
 ## Microsoft .NET runtimes [#microsoft-runtimes]
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-62700.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-62700.mdx
@@ -1,6 +1,7 @@
 ---
 subject: .NET agent
 releaseDate: '2021-01-28'
+eolDate: '2029-01-09'
 version: 6.27.0.0
 downloadLink: 'https://download.newrelic.com/dot_net_agent/6.x_release/'
 features: ['Continue to support .NET Framework 4.5 and below']


### PR DESCRIPTION
To clear up some confusion about which 6.x version of the .NET Agent is still supported, we're adding an `eolDate` override to the frontmatter for 6.27 as we've previously done for 6.26 -- essentially, either of those two versions will have long-term support until January of 2029.