### PR TITLE
fix(actions): checkout main branch to generate release notes

### DIFF
--- a/.github/workflows/agent-release-notes.yml
+++ b/.github/workflows/agent-release-notes.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: main
 
       - name: Setup node.js
         uses: actions/setup-node@v3

--- a/scripts/releaseNotes.mjs
+++ b/scripts/releaseNotes.mjs
@@ -12,8 +12,6 @@ import { Command } from 'commander';
 
 import getAgentName from '../src/utils/getAgentName.js';
 import getEOLDate from '../src/utils/getEOLDate.js';
-import fs from 'fs';
-import path from 'path';
 
 const program = new Command();
 program
@@ -126,10 +124,5 @@ if (uploadToS3) {
       console.error(err);
     });
 } else {
-  console.log('Writing JSON to file');
-  fs.writeFileSync(
-    path.join(process.cwd(), 'release-note.json'),
-    JSON.stringify(releaseNotes, null, 2),
-    'utf-8'
-  );
+  console.log(JSON.stringify(releaseNotes));
 }

--- a/scripts/releaseNotes.mjs
+++ b/scripts/releaseNotes.mjs
@@ -12,6 +12,8 @@ import { Command } from 'commander';
 
 import getAgentName from '../src/utils/getAgentName.js';
 import getEOLDate from '../src/utils/getEOLDate.js';
+import fs from 'fs';
+import path from 'path';
 
 const program = new Command();
 program
@@ -124,5 +126,10 @@ if (uploadToS3) {
       console.error(err);
     });
 } else {
-  console.log(JSON.stringify(releaseNotes));
+  console.log('Writing JSON to file');
+  fs.writeFileSync(
+    path.join(process.cwd(), 'release-note.json'),
+    JSON.stringify(releaseNotes, null, 2),
+    'utf-8'
+  );
 }


### PR DESCRIPTION
## Description

Changes the ref to `main` that the workflow checks out when generating release note JSON.

When using `develop` there's a chance that any new release notes in `develop` are not yet deployed to prod, but downstream deps (agent upgrade nerdlet) will use data in JSON and display release note info that isn't yet live. for example, links to site will 404 for relevant release note until it's live.

Also changed `releaseNotes.mjs` to write to a file instead of log to console. the JSON logged overflows viewable/searchable console and needed to analyze full JSON. I suppose I also could have just written output to file. Defer to y'all if we want that to be default or not.

## Related
Mitigates  https://issues.newrelic.com/browse/NR-155603
