### PR TITLE
chore: Update browser ajax data troubleshooting

### DIFF
--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
@@ -24,7 +24,6 @@ If your application is [instrumented with browser monitoring](/docs/browser/new-
     title="1. Verify the page is instrumented."
   >
     Use your browser's dev console to verify page has been correctly instrumented. Enter `XMLHttpRequest` and/or `fetch` into the console.
-    If you are using `XMLHttpRequest`, use your browser's dev console to verify that the object has been instrumented by New Relic. Enter the object name at your console.
 
     If instrumentation has succeeded, the console should return something like:
 

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
@@ -1,18 +1,18 @@
 ---
-title: Troubleshoot AJAX data collection
+title: Troubleshoot Ajax data collection
 type: troubleshooting
 tags:
   - Browser
   - Browser monitoring
   - Troubleshooting
-metaDescription: Troubleshooting for not seeing AJAX data for your browser app.
+metaDescription: Troubleshooting for not seeing Ajax data for your browser app.
 redirects:
   - /docs/browser/new-relic-browser/troubleshooting/troubleshooting-ajax-data-collection
 ---
 
 ## Problem
 
-You are not seeing [AJAX data](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls) for your browser app.
+You are not seeing [Ajax data](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls) for your browser app.
 
 ## Solution
 
@@ -20,45 +20,62 @@ If your application is [instrumented with browser monitoring](/docs/browser/new-
 
 <CollapserGroup>
   <Collapser
-    id="verify-xmlhttp"
-    title="1. Verify you use XMLHttpRequest."
-  >
-    Check whether your application uses the [`XMLHttpRequest` object](https://xhr.spec.whatwg.org/) to make AJAX calls.
-
-    * Browser monitoring: Other methods (including the newer [Fetch API](https://fetch.spec.whatwg.org/)) currently are not supported when using browser Pro.
-    * Single-page app monitoring: Fetch is supported for AJAX requests within a [browser interaction](/docs/browser/single-page-app-monitoring/use-spa-data/understand-spa-data-collection#browser-interaction) with [SPA monitoring](/docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring).
-
-      If you are making requests using [JSONP](https://en.wikipedia.org/wiki/JSONP), see [JSONP requirements](#jsonp).
-  </Collapser>
-
-  <Collapser
     id="verify-instrumentation"
-    title="2. Verify the object is instrumented."
+    title="1. Verify the page is instrumented."
   >
+    Use your browser's dev console to verify page has been correctly instrumented. Enter `XMLHttpRequest` and/or `fetch` into the console.
     If you are using `XMLHttpRequest`, use your browser's dev console to verify that the object has been instrumented by New Relic. Enter the object name at your console.
 
     If instrumentation has succeeded, the console should return something like:
 
     ```js
-    function (t){var e=new p(t);try{u.emit("new-xhr"...
+    // XMLHttpRequest
+    ƒ (e){const t=new o(e),n=r.context...
+
+    // fetch
+    ƒ (){var t=3,n=(0,r().getTrace...
     ```
 
     If instrumentation failed, you will see something like:
 
     ```js
-    function XMLHttpRequest() { [native_code] }
+    // XMLHttpRequest
+    ƒ XMLHttpRequest() { [native code] }
+
+    // fetch
+    ƒ fetch() { [native code] }
     ```
 
-    If you see this type of failure response, see [Troubleshooting browser monitoring installation](/docs/browser/new-relic-browser/troubleshooting/troubleshooting-browser-monitoring-installation). If you see a different response, you may be using another script or library that is conflicting with New Relic instrumentation. Contact support at [support.newrelic.com](https://support.newrelic.com).
+    If you see this type of failure or you see a different response, Ajax instrumentation may be disabled or you may be using another script or library that is conflicting with New Relic instrumentation.
+  </Collapser>
+
+  <Collector
+    id="verify-ajax-enabled"
+    title="2. Verify Ajax instrumentation is enabled."
+  >
+    Ajax instrumentation is not included in the lite agent. Open your browser console dev tool and check the `newrelic.initializedAgents` object. This object contains an entry for every agent running on the page. There is typically only one agent on a page. Inspect the initialized agent object for a `runtime` object. This object contains information about the running agent like `loaderType`. If `loaderType` is `lite`, Ajax instrumentation is not included in the agent being used.
+
+    If the `loaderType` is not `lite`, you can also check the initialized agent for `config` and `features` objects. The `config` object will contain runtime configuration of the agent, including an `ajax` object with an `enabled` boolean. The `features` object should contain an entry for each feature initialized by the agent, including an `ajax` entry. Verify this ajax object contains a boolean `enabled` of `true` and `featAggregate` entry. If any of these items are not true, the Ajax instrumentation may not have initialized due to a configuration change in New Relic on the browser entity or possibly a manual change to the `NREUM.init` object that was copy/pasted into the HTML.
+  </Collapser>
+
+  <Collapser
+    id="verify-config"
+    title="2. Verify the deny list configuration."
+  >
+    The agent can be configured to ignore certain domains and paths when creating [AjaxRequest Events](/attribute-dictionary/?event=AjaxRequest).
+
+    Use your browser's dev console to check the current Ajax deny list rules by running `newrelic.init`. Look for a property `ajax` containing an array called `deny_list`.
+
+    If you see entries in the deny list that are unfamiliar or causing Ajax calls to be filtered, review the [Filter AjaxRequest Events](/docs/browser/new-relic-browser/configuration/filter-ajax-request-events/) documentation for further guidance.
   </Collapser>
 
   <Collapser
     id="verify-network-access"
     title="3. Verify network access."
   >
-    If the object is properly instrumented, try triggering an AJAX call in your application while monitoring network traffic in the browser's developer tools. Wait up to one minute, and look for a call to `bam.nr-data.net/jserrors` with an `xhr` parameter. If the call fails, check for network issues.
+    If the object is properly instrumented, try triggering an Ajax call in your application while monitoring network traffic in the browser's developer tools. Wait up to one minute, and look for a call to `bam.nr-data.net/jserrors` with an `xhr` parameter. If the call fails, check for network issues.
 
-    If you don't see this call, if it fails with an error not related to network access, or if it succeeds but you still aren't seeing data, get support at [support.newrelic.com](https://support.newrelic.com).
+    If you don't see this call, if it fails with an error not related to network access, or if it succeeds but you still aren't seeing data, continue through the troubleshooting documentation.
   </Collapser>
 </CollapserGroup>
 
@@ -69,11 +86,13 @@ If your requests use JSONP, see requirements and notes on functionality below:
     id="jsonp"
     title="JSONP requirements"
   >
-    If your requests use [JSONP](https://en.wikipedia.org/wiki/JSONP), these requests will not appear on the [AJAX UI page](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls). However, you can view them as assets within [session traces](/docs/browser/new-relic-browser/browser-pro-features/session-traces-exploring-webpages-life-cycle). If using SPA monitoring, you can view them on the **Breakdown** tab of the **Page views** page.
+    If your requests use [JSONP](https://en.wikipedia.org/wiki/JSONP), these requests will not appear on the [Ajax UI page](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls). However, you can view them as assets within [session traces](/docs/browser/new-relic-browser/browser-pro-features/session-traces-exploring-webpages-life-cycle). If using SPA monitoring, you can view them on the **Breakdown** tab of the **Page views** page.
 
     Requirements for JSONP to be recognized:
 
     * Each JSONP request must use a unique callback function. Most popular libraries (like jQuery) generate a unique callback function dynamically for each request.
-    * The query string callback must be named `"callback"` or `"cb"` in order to be recognized by New Relic. This is the default behavior in most popular libraries.
+    * The query string containing the callback function name must be named `"callback"` or `"cb"` in order to be recognized by New Relic. This is the default behavior in most popular libraries.
   </Collapser>
 </CollapserGroup>
+
+If any of these troubleshooting steps fails or you are still having issues with missing Ajax data, get support at [support.newrelic.com](https://support.newrelic.com).

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
@@ -27,7 +27,7 @@ If your application is [instrumented with browser monitoring](/docs/browser/new-
 
     If instrumentation has succeeded, the console should return something like:
 
-    ```js
+  ```js
     // XMLHttpRequest
     ƒ (e){const t=new o(e),n=r.context...
 
@@ -41,14 +41,14 @@ If your application is [instrumented with browser monitoring](/docs/browser/new-
     // XMLHttpRequest
     ƒ XMLHttpRequest() { [native code] }
 
-    // fetch
+    // fetch 
     ƒ fetch() { [native code] }
-    ```
+  ```
 
     If you see this type of failure or you see a different response, AJAX instrumentation may be disabled or you may be using another script or library that is conflicting with New Relic instrumentation.
   </Collapser>
 
-  <Collector
+  <Collapser
     id="verify-ajax-enabled"
     title="2. Verify AJAX instrumentation is enabled."
   >

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-ajax-data-collection.mdx
@@ -1,18 +1,18 @@
 ---
-title: Troubleshoot Ajax data collection
+title: Troubleshoot AJAX data collection
 type: troubleshooting
 tags:
   - Browser
   - Browser monitoring
   - Troubleshooting
-metaDescription: Troubleshooting for not seeing Ajax data for your browser app.
+metaDescription: Troubleshooting for not seeing AJAX data for your browser app.
 redirects:
   - /docs/browser/new-relic-browser/troubleshooting/troubleshooting-ajax-data-collection
 ---
 
 ## Problem
 
-You are not seeing [Ajax data](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls) for your browser app.
+You are not seeing [AJAX data](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls) for your browser app.
 
 ## Solution
 
@@ -46,16 +46,16 @@ If your application is [instrumented with browser monitoring](/docs/browser/new-
     ƒ fetch() { [native code] }
     ```
 
-    If you see this type of failure or you see a different response, Ajax instrumentation may be disabled or you may be using another script or library that is conflicting with New Relic instrumentation.
+    If you see this type of failure or you see a different response, AJAX instrumentation may be disabled or you may be using another script or library that is conflicting with New Relic instrumentation.
   </Collapser>
 
   <Collector
     id="verify-ajax-enabled"
-    title="2. Verify Ajax instrumentation is enabled."
+    title="2. Verify AJAX instrumentation is enabled."
   >
-    Ajax instrumentation is not included in the lite agent. Open your browser console dev tool and check the `newrelic.initializedAgents` object. This object contains an entry for every agent running on the page. There is typically only one agent on a page. Inspect the initialized agent object for a `runtime` object. This object contains information about the running agent like `loaderType`. If `loaderType` is `lite`, Ajax instrumentation is not included in the agent being used.
+    AJAX instrumentation is not included in the lite agent. Open your browser console dev tool and check the `newrelic.initializedAgents` object. This object contains an entry for every agent running on the page. There is typically only one agent on a page. Inspect the initialized agent object for a `runtime` object. This object contains information about the running agent like `loaderType`. If `loaderType` is `lite`, AJAX instrumentation is not included in the agent being used.
 
-    If the `loaderType` is not `lite`, you can also check the initialized agent for `config` and `features` objects. The `config` object will contain runtime configuration of the agent, including an `ajax` object with an `enabled` boolean. The `features` object should contain an entry for each feature initialized by the agent, including an `ajax` entry. Verify this ajax object contains a boolean `enabled` of `true` and `featAggregate` entry. If any of these items are not true, the Ajax instrumentation may not have initialized due to a configuration change in New Relic on the browser entity or possibly a manual change to the `NREUM.init` object that was copy/pasted into the HTML.
+    If the `loaderType` is not `lite`, you can also check the initialized agent for `config` and `features` objects. The `config` object will contain runtime configuration of the agent, including an `ajax` object with an `enabled` boolean. The `features` object should contain an entry for each feature initialized by the agent, including an `ajax` entry. Verify this ajax object contains a boolean `enabled` of `true` and `featAggregate` entry. If any of these items are not true, the AJAX instrumentation may not have initialized due to a configuration change in New Relic on the browser entity or possibly a manual change to the `NREUM.init` object that was copy/pasted into the HTML.
   </Collapser>
 
   <Collapser
@@ -64,16 +64,16 @@ If your application is [instrumented with browser monitoring](/docs/browser/new-
   >
     The agent can be configured to ignore certain domains and paths when creating [AjaxRequest Events](/attribute-dictionary/?event=AjaxRequest).
 
-    Use your browser's dev console to check the current Ajax deny list rules by running `newrelic.init`. Look for a property `ajax` containing an array called `deny_list`.
+    Use your browser's dev console to check the current AJAX deny list rules by running `newrelic.init`. Look for a property `ajax` containing an array called `deny_list`.
 
-    If you see entries in the deny list that are unfamiliar or causing Ajax calls to be filtered, review the [Filter AjaxRequest Events](/docs/browser/new-relic-browser/configuration/filter-ajax-request-events/) documentation for further guidance.
+    If you see entries in the deny list that are unfamiliar or causing AJAX calls to be filtered, review the [Filter AjaxRequest Events](/docs/browser/new-relic-browser/configuration/filter-ajax-request-events/) documentation for further guidance.
   </Collapser>
 
   <Collapser
     id="verify-network-access"
     title="3. Verify network access."
   >
-    If the object is properly instrumented, try triggering an Ajax call in your application while monitoring network traffic in the browser's developer tools. Wait up to one minute, and look for a call to `bam.nr-data.net/jserrors` with an `xhr` parameter. If the call fails, check for network issues.
+    If the object is properly instrumented, try triggering an AJAX call in your application while monitoring network traffic in the browser's developer tools. Wait up to one minute, and look for a call to `bam.nr-data.net/jserrors` with an `xhr` parameter. If the call fails, check for network issues.
 
     If you don't see this call, if it fails with an error not related to network access, or if it succeeds but you still aren't seeing data, continue through the troubleshooting documentation.
   </Collapser>
@@ -86,7 +86,7 @@ If your requests use JSONP, see requirements and notes on functionality below:
     id="jsonp"
     title="JSONP requirements"
   >
-    If your requests use [JSONP](https://en.wikipedia.org/wiki/JSONP), these requests will not appear on the [Ajax UI page](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls). However, you can view them as assets within [session traces](/docs/browser/new-relic-browser/browser-pro-features/session-traces-exploring-webpages-life-cycle). If using SPA monitoring, you can view them on the **Breakdown** tab of the **Page views** page.
+    If your requests use [JSONP](https://en.wikipedia.org/wiki/JSONP), these requests will not appear on the [AJAX UI page](/docs/browser/new-relic-browser/browser-pro-features/ajax-page-identifying-time-consuming-calls). However, you can view them as assets within [session traces](/docs/browser/new-relic-browser/browser-pro-features/session-traces-exploring-webpages-life-cycle). If using SPA monitoring, you can view them on the **Breakdown** tab of the **Page views** page.
 
     Requirements for JSONP to be recognized:
 
@@ -95,4 +95,4 @@ If your requests use JSONP, see requirements and notes on functionality below:
   </Collapser>
 </CollapserGroup>
 
-If any of these troubleshooting steps fails or you are still having issues with missing Ajax data, get support at [support.newrelic.com](https://support.newrelic.com).
+If any of these troubleshooting steps fails or you are still having issues with missing AJAX data, get support at [support.newrelic.com](https://support.newrelic.com).

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -95,7 +95,7 @@ pages:
       - title: PageViewTiming event
         path: /docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details
       - title: Instrumentation for browser monitoring
-        path: /docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring/
+        path: /docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring
       - title: Compare synthetic and browser page performance
         path: /docs/browser/new-relic-browser/page-load-timing-resources/compare-page-load-performance-browser-synthetics
       - title: Session tracking


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This PR updates the ajax missing data troubleshooting doc. The browser agent has supported capturing `fetch` for some time and has made strides in the data we expose on the window to help with troubleshooting agent initialization.

Also fixed a bug in the sidebar menu where click on the link for `page-load-timing-resources/instrumentation-browser-monitoring` would completely collapse the sidebar menu.