### PR TITLE
added: infra-agent winpkg integration note

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure.mdx
+++ b/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure.mdx
@@ -422,7 +422,8 @@ Inventory is collected from the infrastructure agent's built-in data collectors,
     id="windows"
     title="Windows built-in agent data"
   >
-    The infrastructure agent collects this data for Windows systems.
+    The infrastructure agent uses a combination of built-in instrumentation and the `com.newrelic.winpkg` integration to collect system information on Windows hosts. 
+    The following table shows the data that is collected on Windows systems.
 
     <table>
       <thead>


### PR DESCRIPTION
## Give us some context

* Added a note explaining that "com.newrelic.winpkg" is an infrastructure agent built-in integration that's available on Windows to collect inventory data. 