### PR TITLE
upgrade `@newrelic/gatsby-theme-newrelic` to 7.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@github-docs/frontmatter": "^1.3.1",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "7.1.2",
+    "@newrelic/gatsby-theme-newrelic": "7.1.3",
     "@splitsoftware/splitio-react": "^1.2.4",
     "cockatiel": "^3.0.0-beta.0",
     "common-tags": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,10 +3572,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@7.1.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-7.1.2.tgz#d22de0dc505f45b8b0ecacf537a231a1f618c73e"
-  integrity sha512-Q4zIhldVmC5TwD9vgwvCDR+LN/xED8UoX6Xg6t36uMVfq6zRIsW9lXmrzdCsAVDXKWY0KzZKv6wUpCtsJ8sOfQ==
+"@newrelic/gatsby-theme-newrelic@7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-7.1.3.tgz#eb1d5584ac1c6c7fb5a838065a39eb6820fdd117"
+  integrity sha512-GwhEQEx/aPIWO8nYIdDE6AxNMpCI9UyalsRnIvmss6Kb7r6JnF7Pt9bHOGTULEcwRUVqwA345gzVFq6jqjHkAw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
fixes issue with images overflowing body

https://github.com/newrelic/gatsby-theme-newrelic/pull/944