### PR TITLE
fix: default for browser monitoring

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -2721,7 +2721,7 @@ This section defines the Node.js agent variables in the order they typically app
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
 
@@ -2747,7 +2747,7 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    Generate JavaScript headers for browser instrumentation. If set to `true` the agent doesn't inject the browser JS code unless you have [enabled browser monitoring](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser). Even if you have enabled it and [added the browser timing header](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs#procedures), you can [disable browser monitoring for your app](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs#disabling) by setting this to `false`.
+    Generate JavaScript headers for browser instrumentation. If set to `true` the agent does not automatically inject the browser JS code unless you have [manually enabled browser monitoring](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser). Even if you have enabled it and [added the browser timing header](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs#procedures), you can [disable browser monitoring for your app](/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs#disabling) by setting this to `false`.
 
   </Collapser>
 


### PR DESCRIPTION
This default value was wrong, you can check the default value here: 
- https://github.com/newrelic/node-newrelic/blob/3f494f8ad8dd1350fbe034e9c4a582a40228bc45/lib/config/default.js#L696

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.