### PR TITLE
Update kubernetes-integration-predefined-alert-policy.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/kubernetes-integration-predefined-alert-policy.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/kubernetes-integration-predefined-alert-policy.mdx
@@ -9,9 +9,9 @@ redirects:
   - /docs/kubernetes-pixie/kubernetes-integration/kubernetes-events/kubernetes-integration-predefined-alert-policy
 ---
 
-When deploying the New Relic Kubernetes integration for the first time in an account, we deploy a default set of [alert conditions](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions) to your account. The predefined alert policy, named **Kubernetes default alert policy**, doesn't have a [notification channel](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts) by default to avoid unwanted notifications.
+When deploying the New Relic Kubernetes integration for the first time in an account, we deploy a default set of [alert conditions](/docs/alerts/new-relic-alerts/defining-conditions/define-alert-conditions) to your account. The predefined alert policy, named **Kubernetes default alert policy**, doesn't have a [notification channel](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-control-where-send-alerts) by default to prevent unwanted notifications.
 
-The alert conditions' thresholds can be customized to your environment and the alert policy updated to send notifications. For more information, see the [Infrastructure alerts documentation](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information).
+You can customize the thresholds for the alert conditions, as well as update the policy to send notifications. For more information, see the [Infrastructure alerts documentation](/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/infrastructure-alerts-add-edit-or-view-host-alert-information).
 
 ## Predefined alert conditions
 
@@ -447,4 +447,4 @@ The alert conditions' thresholds can be customized to your environment and the a
 
 ## Create new alert conditions [#create-policies]
 
-To create new alert conditions based on Kubernetes metric data, see [Understand and use data](/docs/integrations/kubernetes-integration/understand-use-data/understand-use-data).
+To create new alert conditions based on Kubernetes metric data, see [Manage alerts](/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data/#alerts).


### PR DESCRIPTION
Fixes some awkward wording and updates the link at the bottom (Manage alerts) so it takes the reader to the exact doc needed.
