### PR TITLE
Update kubernetes-integration-troubleshooting-not-seeing-data.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/kubernetes-integration-troubleshooting-not-seeing-data.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Kubernetes integration troubleshooting: Not seeing data'
+title: 'Not seeing data'
 type: troubleshooting
 tags:
   - Integrations
@@ -14,13 +14,11 @@ redirects:
 
 ## Problem
 
-You have completed the [installation procedure](/docs/kubernetes-monitoring-integration#install) for New Relic's Kubernetes integration but are not seeing Kubernetes data in your New Relic account.
+You have [installed the New Relic Kubernetes integration](/docs/kubernetes-monitoring-integration#install), but are not seeing Kubernetes data in your New Relic account.
 
 ## Solution
 
-If you have [deployed the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent/#install) and completed the [Kubernetes installation procedure](/docs/kubernetes-monitoring-integration#install) but are not seeing any information in the Kubernetes dashboard, follow these steps:
-
-1. Confirm you have configured `CLUSTER_NAME` and `NRI_LICENSE_KEY` correctly. See the [installation procedures](/docs/integrations/host-integrations/host-integrations-list/kubernetes-monitoring-integration#install) for more information.
+1. Confirm you have configured `CLUSTER_NAME` and `NRI_LICENSE_KEY` correctly. See the [installation instructions](/docs/integrations/host-integrations/host-integrations-list/kubernetes-monitoring-integration#install) for more information.
 2. Confirm the deployment of the integration was successful by running:
    ```
    kubectl get pods -o wide -n <NEWRELIC_NAMESPACE>


### PR DESCRIPTION
Retitles page to align with other pages in this section (removes "Kubernetes integration:" prefix), and cleans up some of the wording.
