### PR TITLE
fix: typo and startup instructions

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
@@ -20,29 +20,31 @@ We have a few paths to install the Node.js agent, depending on what you're monit
     id="docker"
     title="App deployed in a Docker container"
 >
-To install the agent in a Docker container, follow [these self-guided steps](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker) using the command line. 
-
-This process walks you through adding the agent to `package.json`, then requiring New Relic on the app-level. By the end, you'll add your license key and app name to `docker run` so the agent runs with your Docker app. 
+  To install the agent in a Docker container, follow [these self-guided steps](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker) using the command line. 
+  
+  This process walks you through adding the agent to `package.json`, then requiring New Relic on the app-level. By the end, you'll add your license key and app name to `docker run` so the agent runs with your Docker app. 
 </Collapser>
+
 <Collapser
     id="server"
     title="App deployed on a server"
 >
-We've got a few different options for apps hosted on a server.
-
-* Our [guided install](https://one.newrelic.com/marketplace/install-data-source?state=f535d53b-5b84-cd48-80cf-61704ad02e29) breaks down the installation into steps. It requires some interaction with the command line. 
-* Our [Install the Node.js agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent) doc uses the command line exclusively. You can view the same process in our [Node.js agent](https://github.com/newrelic/node-newrelic#installation) repo.
-* For apps that use the PM2 process manager, follow the [guided install](https://one.newrelic.com/marketplace/install-data-source?state=ba2c3ecb-defb-e99a-c4be-47d786690d2a). If you're using a process manager that isn't PM2, then choose either the guided or manual install option.
-
-When you're ready to monitor your app, add ` $ node -r newrelic your-program.js` to the first line of your app's code. This is especially important if you don't have root access to your app.
+  We've got a few different options for apps hosted on a server.
+  
+  * Our [guided install](https://one.newrelic.com/marketplace/install-data-source?state=f535d53b-5b84-cd48-80cf-61704ad02e29) breaks down the installation into steps. It requires some interaction with the command line. 
+  * Our [Install the Node.js agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent) doc uses the command line exclusively. You can view the same process in our [Node.js agent](https://github.com/newrelic/node-newrelic#installation) repo.
+  * For apps that use the PM2 process manager, follow the [guided install](https://one.newrelic.com/marketplace/install-data-source?state=ba2c3ecb-defb-e99a-c4be-47d786690d2a). If you're using a process manager that isn't PM2, then choose either the guided or manual install option.
+  
+  When you're ready to monitor your app, add `-r newrelic` to your app's startup command to require the agent before other modules, for example `node -r newrelic your-program.js`. This is especially important if you don't have root access to your app.
 </Collapser>
+
 <Collapser
     id="lambda"
     title="App deployed with AWS Lambda"
 >
-To install an agent for your AWS Lambda functions, our [self-guided steps](https://one.newrelic.com/marketplace/install-data-source?state=9aa3d004-6f13-1477-604e-b6a2d6bb992d) provide a setup script that automatically configures AWS for you.
-
-If you have a preference for manual installation via the command line, we currently have the option for [Legacy instrumentation for Lambda monitoring](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy/#node). 
+  To install an agent for your AWS Lambda functions, our [self-guided steps](https://one.newrelic.com/marketplace/install-data-source?state=9aa3d004-6f13-1477-604e-b6a2d6bb992d) provide a setup script that automatically configures AWS for you.
+  
+  If you have a preference for manual installation via the command line, we currently have the option for [Legacy instrumentation for Lambda monitoring](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy/#node). 
 </Collapser>
 </CollapserGroup>
 
@@ -55,4 +57,4 @@ So you've instrumented your app and want next steps. You might consider:
 * [Getting data from the Node.js virtual machine (V8)](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements)
 * Extending your instrumentation with [custom instrumentation API](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation)
 * Extending functionality with [custom transaction parameters, errors and metrics](/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api)
-* Adding [browser monitoring] with your Node.js agent(/docs/apm/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent)
+* Adding [browser monitoring](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/browser-monitoring-nodejs-agent) with your Node.js agent


### PR DESCRIPTION
The markdown link was in plain text:
<img width="1346" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/7fda3aaf-ce99-4ea4-8b52-4505433a7303">

also the startup instructions were mixing up the old suggested way or requiring the agent and the new way. You can't add a startup cmd you your app's code

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.