### PR TITLE
[MERGE 9/20] feat(php-agent): Errors Inbox Improvement API Documentation

### DIFF
--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -35,6 +35,8 @@ Using the provided context information, the callback must return a non-empty str
   - When there are multiple calls to this function in a single transaction, the PHP agent retains the callback from the last call only.
 
   - Callbacks are registered on a per-request basis. This API should be called in a code path that is guaranteed to be executed for each request, or the callback will not be invoked.
+
+  - It is highly recommended to keep your callback function as minimal as possible. Cpu-intensive callbacks (such as database calls) or other complex logic will result in performance impacts to your application.
 </Callout>
 
 ## Parameters
@@ -214,12 +216,23 @@ API returns `true` if the callback is registered successfully, otherwise `false`
 ## Examples
 
 ```php
-$callback = function(array $txndata, array $errdata) 
-{
-    // custom code to parse array data
-    $fingerprint = "YOUR CUSTOM ERROR GROUP NAME";
-    return $fingerprint;    // non-empty string error group name
-};
+if (extension_loaded('newrelic')) { // Ensure PHP agent is available
+  $callback = function(array $txndata, array $errdata) 
+  {
+      $fingerprint = "";
+      
+      //
+      // Add custom code to parse array data
+      //
 
-newrelic_set_error_group_callback($callback);
+      // Example code
+      if ($errdata["klass"] == "E_USER_ERROR") {
+        $fingerprint = "USER ERROR";
+      };
+
+      return $fingerprint;    // Non-empty string error group name
+  };
+
+  newrelic_set_error_group_callback($callback);
+};
 ```

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -209,7 +209,7 @@ This API accepts a single function-type callback as an argument. The provided ca
 
 ## Return values
 
-Must return a non-empty string or the error group name will not be set.
+API returns `true` if the callback is registered successfully, otherwise `false`.
 
 ## Examples
 

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -34,7 +34,7 @@ Using the provided context information, the callback must return a non-empty str
 <Callout variant="important">
   - When there are multiple calls to this function in a single transaction, the PHP agent retains the callback from the last call only.
 
-  - Callbacks are registered on a per-request basis. A callback should be registered in a code path that is guaranteed to be executed for each request, or it will not be registered/invoked.
+  - Callbacks are registered on a per-request basis. A callback should be registered in a code path that is guaranteed to be executed for each request, or it will not be invoked.
 </Callout>
 
 ## Parameters
@@ -217,6 +217,7 @@ Must return a non-empty string or the error group name will not be set.
 $callback = function(array $txndata, array $errdata) 
 {
     // custom code to parse array data
+    $fingerprint = "YOUR CUSTOM ERROR GROUP NAME";
     return $fingerprint;    // non-empty string error group name
 };
 

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -34,12 +34,12 @@ Using the provided context information, the callback must return a non-empty str
 <Callout variant="important">
   - When there are multiple calls to this function in a single transaction, the PHP agent retains the callback from the last call only.
 
-  - Callbacks are registered on a per-request basis. A callback should be registered in a code path that is guaranteed to be executed for each request, or it will not be invoked.
+  - Callbacks are registered on a per-request basis. This API should be called in a code path that is guaranteed to be executed for each request, or the callback will not be invoked.
 </Callout>
 
 ## Parameters
 
-This function accepts only a single parameter. You must pass in a function-type argument that accepts 2 parameters.
+This API accepts a single function-type callback as an argument. The provided callback must accept 2 parameters.
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -85,7 +85,7 @@ This API accepts a single function-type callback as an argument. The provided ca
   <tbody>
     <tr>
       <td>
-        `$txndata` (_array_)
+        `$transaction_data` (_array_)
       </td>
 
       <td>
@@ -94,7 +94,7 @@ This API accepts a single function-type callback as an argument. The provided ca
     </tr>
     <tr>
      <td>
-       `$errdata` (_array_)
+       `$error_data` (_array_)
      </td>
      <td>
        Required. An array of error data provided to your callback by the PHP Agent.
@@ -105,7 +105,7 @@ This API accepts a single function-type callback as an argument. The provided ca
 
 ### Array Key/Value pairs
 
-#### `$txndata` - PHP Agent transaction data provided to your callback
+#### `$transaction_data` - PHP Agent transaction data provided to your callback
 
 <table>
   <thead>
@@ -154,7 +154,7 @@ This API accepts a single function-type callback as an argument. The provided ca
   </tbody>
 </table>
 
-#### `$errdata` - PHP Agent error data provided to your callback
+#### `$error_data` - PHP Agent error data provided to your callback
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -1,0 +1,224 @@
+---
+title: newrelic_set_error_group_callback (PHP agent API)
+type: apiDoc
+shortDescription: This method allows a user to define a custom callback function to generate error group names.
+tags:
+  - Agents
+  - PHP agent
+  - PHP agent API
+metaDescription: 'Use this API to register a callback which returns a custom error group name.'
+redirects:
+  - /docs/agents/php-agent/php-agent-api/newrelic_set_error_group_callback
+---
+
+Group errors with your own custom-defined fingerprinting callback function.
+
+## Syntax
+
+```php
+newrelic_set_error_group_callback($callback)
+```
+
+## Requirements
+
+Agent version 10.12 or higher.
+
+## Description
+
+This API allows a user to register a custom callback function with the PHP Agent that will be called when the application encounters an error.
+
+The callback will provided two PHP arrays from the Agent- one containing transaction data, another containing error data.
+
+Using the provided context information, the callback must return a non-empty string based on user-defined logic that will serve as the error group name displayed in the Errors Inbox UI.
+
+<Callout variant="important">
+  - When there are multiple calls to this function in a single transaction, the PHP agent retains the callback from the last call only.
+
+  - Callbacks are registered on a per-request basis. A callback should be registered in a code path that is guaranteed to be executed for each request, or it will not be registered/invoked.
+</Callout>
+
+## Parameters
+
+This function accepts only a single parameter. You must pass in a function-type argument that accepts 2 parameters.
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        API Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `$callback` (_function_)
+      </td>
+
+      <td>
+        Required. Provide a callback function that will be registered with the PHP Agent.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Callback Parameters
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `$txndata` (_array_)
+      </td>
+
+      <td>
+        Required. An array of transaction data provided to your callback by the PHP Agent.
+      </td>
+    </tr>
+    <tr>
+     <td>
+       `$errdata` (_array_)
+     </td>
+     <td>
+       Required. An array of error data provided to your callback by the PHP Agent.
+     </td>
+    </tr>
+  </tbody>
+</table>
+
+### Array Key/Value pairs
+
+#### `$txndata` - PHP Agent transaction data provided to your callback
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Key
+      </th>
+      <th>
+        Value
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        "request_uri"
+      </td>
+      <td>
+        (_string_) Request URI
+      </td>
+    </tr>
+    <tr>
+      <td>
+        "path"
+      </td>
+      <td>
+        (_string_) Filepath
+      </td>
+    </tr>
+    <tr>
+      <td>
+        "method"
+      </td>
+      <td>
+        (_string_) HTTP method (`GET`, `POST`, etc.)
+      </td>
+    </tr>
+    <tr>
+      <td>
+        "status_code"
+      </td>
+      <td>
+        (_int_) HTTP status code (`200`, `404`, etc.)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+#### `$errdata` - PHP Agent error data provided to your callback
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Key
+      </th>
+      <th>
+        Value
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        "klass"
+      </td>
+      <td>
+        (_string_) Class name
+      </td>
+    </tr>
+    <tr>
+      <td>
+        "message"
+      </td>
+      <td>
+        (_string_) Error message
+      </td>
+    </tr>
+    <tr>
+      <td>
+        "file"
+      </td>
+      <td>
+        (_string_) Filepath
+      </td>
+    </tr>
+    <tr>
+      <td>
+        "stack"
+      </td>
+      <td>
+        (_string_) JSON error strack trace
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="important">
+  - Not all keys are guaranteed to contain values. This is highly dependent on the user application and the nature of the error.
+  
+  - Array keys will always be set regardless of whether or not they contain empty values.
+</Callout>
+
+## Return values
+
+Must return a non-empty string or the error group name will not be set.
+
+## Examples
+
+```php
+$callback = function(array $txndata, array $errdata) 
+{
+    // custom code to parse array data
+    return $fingerprint;    // non-empty string error group name
+};
+
+newrelic_set_error_group_callback($callback);
+```

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -11,13 +11,13 @@ redirects:
   - /docs/agents/php-agent/php-agent-api/newrelic_set_error_group_callback
 ---
 
-Group errors with your own custom-defined fingerprinting callback function.
-
 ## Syntax
 
 ```php
 newrelic_set_error_group_callback($callback)
 ```
+
+Group errors with your own custom-defined fingerprinting callback function.
 
 ## Requirements
 
@@ -220,7 +220,7 @@ if (extension_loaded('newrelic')) { // Ensure PHP agent is available
   $callback = function(array $txndata, array $errdata) 
   {
       $fingerprint = "";
-      
+
       //
       // Add custom code to parse array data
       //

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -217,7 +217,7 @@ API returns `true` if the callback is registered successfully, otherwise `false`
 
 ```php
 if (extension_loaded('newrelic')) { // Ensure PHP agent is available
-  $callback = function(array $txndata, array $errdata) 
+  $callback = function(array $transaction_data, array $error_data)
   {
       $fingerprint = "";
 
@@ -226,7 +226,7 @@ if (extension_loaded('newrelic')) { // Ensure PHP agent is available
       //
 
       // Example code
-      if ($errdata["klass"] == "E_USER_ERROR") {
+      if ($error_data["klass"] == "E_USER_ERROR") {
         $fingerprint = "USER ERROR";
       };
 

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback.mdx
@@ -25,9 +25,9 @@ Agent version 10.12 or higher.
 
 ## Description
 
-This API allows a user to register a custom callback function with the PHP Agent that will be called when the application encounters an error.
+This API allows a user to register a custom callback function with the PHP agent that will be called when the application encounters an error.
 
-The callback will provided two PHP arrays from the Agent- one containing transaction data, another containing error data.
+The callback will provide two PHP arrays from the agent - one containing transaction data, and another containing error data.
 
 Using the provided context information, the callback must return a non-empty string based on user-defined logic that will serve as the error group name displayed in the Errors Inbox UI.
 
@@ -36,7 +36,7 @@ Using the provided context information, the callback must return a non-empty str
 
   - Callbacks are registered on a per-request basis. This API should be called in a code path that is guaranteed to be executed for each request, or the callback will not be invoked.
 
-  - It is highly recommended to keep your callback function as minimal as possible. Cpu-intensive callbacks (such as database calls) or other complex logic will result in performance impacts to your application.
+  - It is highly recommended to keep your callback function as minimal as possible. CPU-intensive callbacks (such as database calls) or other complex logic will result in performance impacts on your application.
 </Callout>
 
 ## Parameters
@@ -63,7 +63,7 @@ This API accepts a single function-type callback as an argument. The provided ca
       </td>
 
       <td>
-        Required. Provide a callback function that will be registered with the PHP Agent.
+        Required. Provide a callback function that will be registered with the PHP agent.
       </td>
     </tr>
   </tbody>
@@ -89,7 +89,7 @@ This API accepts a single function-type callback as an argument. The provided ca
       </td>
 
       <td>
-        Required. An array of transaction data provided to your callback by the PHP Agent.
+        Required. An array of transaction data provided to your callback by the PHP agent.
       </td>
     </tr>
     <tr>
@@ -97,15 +97,15 @@ This API accepts a single function-type callback as an argument. The provided ca
        `$error_data` (_array_)
      </td>
      <td>
-       Required. An array of error data provided to your callback by the PHP Agent.
+       Required. An array of error data provided to your callback by the PHP agent.
      </td>
     </tr>
   </tbody>
 </table>
 
-### Array Key/Value pairs
+### Array key/value pairs
 
-#### `$transaction_data` - PHP Agent transaction data provided to your callback
+#### `$transaction_data` - PHP agent transaction data provided to your callback
 
 <table>
   <thead>
@@ -154,7 +154,7 @@ This API accepts a single function-type callback as an argument. The provided ca
   </tbody>
 </table>
 
-#### `$error_data` - PHP Agent error data provided to your callback
+#### `$error_data` - PHP agent error data provided to your callback
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id.mdx
@@ -1,0 +1,75 @@
+---
+title: newrelic_set_user_id (PHP agent API)
+type: apiDoc
+shortDescription: Associate a unique user ID with the current transaction
+tags:
+  - Agents
+  - PHP agent
+  - PHP agent API
+metaDescription: New Relic PHP agent API associate a unique user ID with the current transaction.
+redirects:
+  - /docs/agents/php-agent/php-agent-api/newrelic_set_user_id
+---
+
+Associate a unique user ID with the current transaction.
+
+## Syntax
+
+```php
+newrelic_set_user_id(string $user_id)
+```
+
+## Requirements
+
+Agent version 10.12 or higher.
+
+## Description
+
+This API allows an application to assign a unique User ID to the current transaction. 
+
+This will allow a user to gain insight about individual end users, such as the impact of an error event.
+
+## Parameters
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `$user_id` (_string_)
+      </td>
+
+      <td>
+        Required. 
+        
+        Should be a unique value (such as a UUID) that will be assigned to the current transaction.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Return values
+
+This function will return `true` if the user ID was added successfully, otherwise `false`.
+
+## Examples
+
+```php
+function example() {
+    if (extension_loaded('newrelic')) { // Ensure PHP agent is available
+        $user_id = "YOUR UNIQUE USER ID";
+        newrelic_set_user_id($user_id);
+    }
+}
+```

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id.mdx
@@ -11,13 +11,13 @@ redirects:
   - /docs/agents/php-agent/php-agent-api/newrelic_set_user_id
 ---
 
-Associate a unique user ID with the current transaction.
-
 ## Syntax
 
 ```php
 newrelic_set_user_id(string $user_id)
 ```
+
+Associate a unique user ID with the current transaction.
 
 ## Requirements
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -705,6 +705,8 @@ pages:
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback
               - title: newrelic_set_user_attributes
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_attributes
+              - title: newrelic_set_user_id
+                path: /docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id
               - title: newrelic_start_transaction
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelic_start_transaction
           - title: Attributes

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -701,6 +701,8 @@ pages:
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelic_record_datastore_segment
               - title: newrelic_set_appname
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelic_set_appname
+              - title: newrelic_set_error_group_callback
+                path: /docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback
               - title: newrelic_set_user_attributes
                 path: /docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_attributes
               - title: newrelic_start_transaction


### PR DESCRIPTION
Addition of API documentation for the new API calls implemented as part of the Errors Inbox Improvement effort. 

The new APIs are:
- `newrelic_set_error_group_callback`, allowing a user to register a callback with the PHP Agent that will return a custom error group name when invoked by the agent during the handling of an error.
- `newrelic_set_user_id`, allowing an application to set a unique user ID string that associates an individual user with the current transaction.

Depends on https://github.com/newrelic/docs-website/pull/14640