### PR TITLE
Update manage-pixie-memory.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/advanced-configuration/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/advanced-configuration/manage-pixie-memory.mdx
@@ -20,10 +20,10 @@ You can configure the amount of memory Pixie uses. During the installation, use 
 
 The primary focus of the [open source Pixie project](https://github.com/pixie-io/pixie) is to build a real-time debugging platform. Pixie [isn't intended to be a long-term durable storage solution](https://docs.px.dev/about-pixie/faq/#data-collection-how-much-data-does-pixie-store) and is best used in conjunction with New Relic. The New Relic integration queries Pixie every few minutes and persists a subset of Pixie's telemetry data in New Relic.
 
-When you install the New Relic Pixie integration, a `vizier-pem` agent is deployed to each node in your cluster via a DaemonSet. The `vizier-pem` agents use memory for two main purposes:
+When you install the New Relic Pixie integration, a [`vizier-pem` agent](https://docs.px.dev/reference/architecture/#vizier) is deployed to each node in your cluster via a DaemonSet. The `vizier-pem` agents use memory for two main purposes:
 
-* **Collecting telemetry data**: tracing application traffic or CPU profiles, amongst other. Those values must be stored in memory somewhere, as they're processed.
-* **Short-term storage of telemetry data**: to power troubleshooting via the [Live debugging with Pixie tab](/docs/kubernetes-pixie/auto-telemetry-pixie/understand-use-data/live-debugging-with-pixie); and as a temporary storage location for a subset of the telemetry data before it's stored in New Relic.
+* **Collecting telemetry data**: tracing application traffic or CPU profiles, amongst others. Those values must be stored in memory somewhere, as they're processed.
+* **Short-term storage of telemetry data**: to power troubleshooting via the [Live debugging with Pixie tab](/docs/kubernetes-pixie/auto-telemetry-pixie/understand-use-data/live-debugging-with-pixie), and as a temporary storage location for a subset of the telemetry data before it's stored in New Relic.
 
 By default, `vizier-pem` pods have a `2Gi` memory limit, and a `2Gi` memory request. They set aside 60% of their allocated memory for short-term data storage, leaving the other 40% for the data collection.
 

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/advanced-configuration/manage-pixie-memory.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/advanced-configuration/manage-pixie-memory.mdx
@@ -23,7 +23,7 @@ The primary focus of the [open source Pixie project](https://github.com/pixie-io
 When you install the New Relic Pixie integration, a [`vizier-pem` agent](https://docs.px.dev/reference/architecture/#vizier) is deployed to each node in your cluster via a DaemonSet. The `vizier-pem` agents use memory for two main purposes:
 
 * **Collecting telemetry data**: tracing application traffic or CPU profiles, amongst others. Those values must be stored in memory somewhere, as they're processed.
-* **Short-term storage of telemetry data**: to power troubleshooting via the [Live debugging with Pixie tab](/docs/kubernetes-pixie/auto-telemetry-pixie/understand-use-data/live-debugging-with-pixie), and as a temporary storage location for a subset of the telemetry data before it's stored in New Relic.
+* **Short-term storage of telemetry data**: to power troubleshooting via the [Live debugging with Pixie tab](/docs/kubernetes-pixie/auto-telemetry-pixie/understand-use-data/live-debugging-with-pixie) and as a temporary storage location for a subset of the telemetry data before it's stored in New Relic.
 
 By default, `vizier-pem` pods have a `2Gi` memory limit, and a `2Gi` memory request. They set aside 60% of their allocated memory for short-term data storage, leaving the other 40% for the data collection.
 


### PR DESCRIPTION
Adds hyperlink to Pixie documentation about `vizier-pem`, which is referenced but not linked.
