### PR TITLE
Update addcustomattributes-python-agent-api.mdx

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/addcustomattributes-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/addcustomattributes-python-agent-api.mdx
@@ -83,6 +83,6 @@ You can also use custom attributes to troubleshoot performance issues. For examp
 ```py
 # Set server_ip to be the current server processing the transaction
 newrelic.agent.add_custom_attributes([
-    ("memcache_query_frontend_lookup", "server_ip")
+    ("memcache_query_frontend_lookup", server_ip)
 ])
 ```


### PR DESCRIPTION
Hey, I believe the metric key shouldn't be a string, but whatever value the variable `server_ip` has.

Akin to the example [here](https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/addcustomattribute-python-agent-api)
