### PR TITLE
Update install-infrastructure-monitoring-agent-linux.mdx

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -205,6 +205,12 @@ To install infrastructure in Linux, follow these instructions:
        ```bash
        echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt bullseye main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
        ```
+
+       **Debian 12 ("Bookworm")**
+
+       ```bash
+       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt bookworm main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
+       ```
      </Collapser>
 
      <Collapser


### PR DESCRIPTION
Added "adding repo" command for Debian 12 (Bookworm) distro which is newly supported.

