### PR TITLE
docs: added support for fetch and undici as of v11.1.0 of Node.js agent

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -252,9 +252,9 @@ The Node.js agent monitors the performance of Node.js application calls to these
     id="http"
     title="HTTP/1.1"
 >
-The Node.js agent instruments the native `http` module.
+The Node.js agent instruments the native `http` and `fetch` module.  In addition, the popular [undici](https://www.npmjs.com/package/undici) client has support.
 
-In addition, the popular [undici](https://www.npmjs.com/package/undici) client has experimental support as well. To use undici, be sure to set `feature_flag.undici_instrumentation = true` in the `newrelic.js` [configuration file](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#methods-and-precedence).
+**Note**: Both `fetch` and `undici` are supported as of [version 11.1.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-11-1-0).
 
 All calls to Amazon Web Services(AWS) with the [aws-sdk](https://www.npmjs.com/package/aws-sdk) are tracked.
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
As of v11.1.0 of newrelic Node.js agent it now supports fetch and undici by default.  I updated the docs to call this out and mention the mininum version support.

**Note**: We just released 11.1.0 so the release notes PR(#14519) has not yet been merged.  
