### PR TITLE
chore(java): removing unimportant item from release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-860.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-860.mdx
@@ -3,7 +3,7 @@ subject:  Java agent
 releaseDate:  '2023-09-07'
 version:  8.6.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.6.0/'
-features: ["Support latest Wildfly", "Support JBoss EAP 7.4", "Support Spring Cache", "Support GraphQL 19.7+", "Support Spring Cache", "Kafka client node metrics", "Kafka client config events", "Improved Struts 2 instrumentation", "Improved code-level metrics for Servlets"]
+features: ["Support latest Wildfly", "Support JBoss EAP 7.4", "Support Spring Cache", "Support Spring Cache", "Kafka client node metrics", "Kafka client config events", "Improved Struts 2 instrumentation", "Improved code-level metrics for Servlets"]
 bugs: ["Fixed a bug in the Spring instrumentation when OpenFeign was used.", "Fixed a bug where utility classes were not weaved.",
 "Fixed a bug where the agent would not properly send its dependencies."]
 security: []
@@ -22,8 +22,6 @@ security: []
 - Support latest Wildfly [#1373](https://github.com/newrelic/newrelic-java-agent/issues/1373)
 
 - Support latest JBoss EAP [#1336](https://github.com/newrelic/newrelic-java-agent/issues/1336)
-
-- Support GraphQL 19.7+ [#1469](https://github.com/newrelic/newrelic-java-agent/pull/1469)
 
 - Spring Cache instrumentation [#1458](https://github.com/newrelic/newrelic-java-agent/issues/1458)
 


### PR DESCRIPTION
## Give us some context

This specific item relates to a bad release of a library. Since older versions of the agent are compatible with the same versions, this item should be removed to avoid confusion.