### PR TITLE
Fixed broken replication slave link

### DIFF
--- a/src/install/mysql/whatsNext.mdx
+++ b/src/install/mysql/whatsNext.mdx
@@ -42,7 +42,7 @@ The MySQL integration collects the following metrics:
           </td>
     
           <td>
-            Boolean. `1` if this server is a replication slave that is connected to a replication master, and both the I/O and SQL threads are running; otherwise, it is `0`. For metrics reported if enabled, see [replication slave metrics](#slave).
+            Boolean. `1` if this server is a replication slave that is connected to a replication master, and both the I/O and SQL threads are running; otherwise, it is `0`. For metrics reported if enabled, see [replication slave metrics](#extended-slave-cluster-metrics).
           </td>
         </tr>
     


### PR DESCRIPTION
Fixed broken link in the description for cluster.slaveRunning.