### PR TITLE
Fix counter variable name

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -633,7 +633,7 @@ Complete the following to add a custom counter:
         private static final AttributeKey<Boolean> ATTR_VALID_N = AttributeKey.booleanKey("fibonacci.valid.n");
 
         private final Tracer tracer;
-        private final LongCounter myCounter;
+        private final LongCounter fibonacciInvocations;
 
         @Autowired
         Controller(OpenTelemetry openTelemetry) {
@@ -641,7 +641,7 @@ Complete the following to add a custom counter:
             tracer = openTelemetry.getTracer(Controller.class.getName());
             // Initialize instrument
             Meter meter = openTelemetry.getMeter(Controller.class.getName());
-            myCounter = meter
+            fibonacciInvocations = meter
                 .counterBuilder("fibonacci.invocations")
                 .setDescription("Measures the number of times the fibonacci method is invoked.")
                 .build();


### PR DESCRIPTION
The counter is referenced in the next section with a different name.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.