### PR TITLE
chore: move framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -27,64 +27,6 @@ Before you [install New Relic's .NET agent](/docs/apm/agents/net-agent/getting-s
 
 <CollapserGroup>
 <Collapser
-    id="lifespan"
-    title="Application lifespan"
-  >
-    The .NET agent uploads data at the end of each [harvest cycle](/docs/new-relic-solutions/get-started/glossary/#harvest-cycle) (once per minute). If your .NET app doesn't run that long, you can set the `service element`'s `sendDataOnExit` attribute to `true` in the `newrelic.config` file.
-</Collapser>
-<Collapser
-    className="freq-link"
-    id="app-web-servers"
-    title="App/web servers"
->
-    You must use one of these app/web servers:
-
-    * IIS
-    * Self-hosted OWIN
-    * Self-hosted WCF
-    * Kestrel
-    * Kestrel with IIS reverse proxy via AspNetCoreModule
-    * Kestrel with IIS reverse proxy via AspNetCoreModuleV2
-
-      The agent automatically creates transactions for apps hosted in IIS. If you self-host with WCF and OWIN version 3 or higher, the agent also automatically creates transactions. For other self-hosted services, you will need to [create transactions via custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation/#new-existing).
-</Collapser>
-  <Collapser
-    id="aws-elastic-beanstalk"
-    title="AWS Elastic Beanstalk"
-  >
-  <Callout
-    variant="important"
-  >
-    AWS [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk) isn't a supported .NET environment.
-  </Callout>  
-  </Collapser>
-
-<Collapser
-    className="freq-link"
-    id="clrs"
-    title="CLRs"
-  >
-    The agent requires CLR version 4.0. Legacy applications running on CLR 2.0 can be instrumented with agent versions lower than 7.0.
-</Collapser>
-  <Collapser
-    className="freq-link"
-    id="code-access"
-    title="Code Access Security"
-  >
-    The use of [Code Access Security](https://docs.microsoft.com/en-us/dotnet/framework/misc/code-access-security) is compatible with the .NET agent only when Full Trust is provided. The agent isn't compatible with more restrictive trust levels.
-</Collapser>
-<Collapser
-    id="azure"
-    title="Microsoft Azure"
->
-    For Azure-specific installation instructions, see:
-
-    * [Install on Azure Cloud Services](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services/)
-    * [Install on Azure Service Fabric](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric/)
-    * [Install on Azure Web Apps](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps/)
-  </Collapser>
-
-<Collapser
     className="freq-link"
     id="net-version"
     title=".NET Framework version"
@@ -170,9 +112,67 @@ Before you [install New Relic's .NET agent](/docs/apm/agents/net-agent/getting-s
         </tr>
       </tbody>
     </table>
-
 </Collapser>
-  <Collapser title="Network requirements">
+
+<Collapser
+    id="lifespan"
+    title="Application lifespan"
+  >
+    The .NET agent uploads data at the end of each [harvest cycle](/docs/new-relic-solutions/get-started/glossary/#harvest-cycle) (once per minute). If your .NET app doesn't run that long, you can set the `service element`'s `sendDataOnExit` attribute to `true` in the `newrelic.config` file.
+</Collapser>
+<Collapser
+    className="freq-link"
+    id="app-web-servers"
+    title="App/web servers"
+>
+    You must use one of these app/web servers:
+
+    * IIS
+    * Self-hosted OWIN
+    * Self-hosted WCF
+    * Kestrel
+    * Kestrel with IIS reverse proxy via AspNetCoreModule
+    * Kestrel with IIS reverse proxy via AspNetCoreModuleV2
+
+      The agent automatically creates transactions for apps hosted in IIS. If you self-host with WCF and OWIN version 3 or higher, the agent also automatically creates transactions. For other self-hosted services, you will need to [create transactions via custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation/#new-existing).
+</Collapser>
+  <Collapser
+    id="aws-elastic-beanstalk"
+    title="AWS Elastic Beanstalk"
+  >
+  <Callout
+    variant="important"
+  >
+    AWS [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk) isn't a supported .NET environment.
+  </Callout>  
+  </Collapser>
+
+<Collapser
+    className="freq-link"
+    id="clrs"
+    title="CLRs"
+  >
+    The agent requires CLR version 4.0. Legacy applications running on CLR 2.0 can be instrumented with agent versions lower than 7.0.
+</Collapser>
+  <Collapser
+    className="freq-link"
+    id="code-access"
+    title="Code Access Security"
+  >
+    The use of [Code Access Security](https://docs.microsoft.com/en-us/dotnet/framework/misc/code-access-security) is compatible with the .NET agent only when Full Trust is provided. The agent isn't compatible with more restrictive trust levels.
+</Collapser>
+<Collapser
+    id="azure"
+    title="Microsoft Azure"
+>
+    For Azure-specific installation instructions, see:
+
+    * [Install on Azure Cloud Services](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-cloud-services/)
+    * [Install on Azure Service Fabric](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-service-fabric/)
+    * [Install on Azure Web Apps](/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps/)
+  </Collapser>
+
+<Collapser title="Network requirements">
     The agent requires your firewall to allow outgoing connections to specific [networks and ports](/docs/new-relic-solutions/get-started/networks/).
 </Collapser>
 <Collapser
@@ -593,13 +593,13 @@ Minimum supported version: 2.3.0
 Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
-* IMongoCollection.CountDocuments[Async]
-* IMongoCollection.EstimatedDocumentCount[Async]
-* IMongoCollection.AggregateToCollection[Async]
-* IMongoDatabase.ListCollectionNames[Async]
-* IMongoDatabase.Aggregate[Async]
-* IMongoDatabase.AggregateToCollection[Async]
-* IMongoDatabase.Watch[Async]
+* `IMongoCollection.CountDocuments[Async]`
+* `IMongoCollection.EstimatedDocumentCount[Async]`
+* `IMongoCollection.AggregateToCollection[Async]`
+* `IMongoDatabase.ListCollectionNames[Async]`
+* `IMongoDatabase.Aggregate[Async]`
+* `IMongoDatabase.AggregateToCollection[Async]`
+* `IMongoDatabase.Watch[Async]`
           </td>
         </tr>
 


### PR DESCRIPTION
There is no content changed. The .NET Framework version is the most important info in this doc, and most likely info people come here looking for, but it's buried midway down the page. So I moved it to the top, like we do in [the .NET Core doc](https://docs.newrelic.com/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/), alphabetically it should be here anyway.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.