### PR TITLE
NR-150571: fix haproxy integration metrics description

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration.mdx
@@ -458,7 +458,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average connect time over the 1024 last requests, in milliseconds.
+        Average connect time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -468,7 +468,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average queue time over the 1024 last requests, in milliseconds.
+        Average queue time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -478,7 +478,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average response time over the 1024 last requests, in milliseconds.
+        Average response time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -488,7 +488,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average total session time over the 1024 last requests, in milliseconds.
+        Average total session time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1218,7 +1218,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Time taken to finish last check, in milliseconds.
+        Time taken to finish last check, in seconds.
       </td>
     </tr>
 
@@ -1248,7 +1248,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average connect time over the 1024 last requests, in milliseconds.
+        Average connect time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1258,7 +1258,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average queue time over the 1024 last requests, in milliseconds.
+        Average queue time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1268,7 +1268,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average response time over the 1024 last requests, in milliseconds.
+        Average response time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1278,7 +1278,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average total session time over the 1024 last requests, in milliseconds.
+        Average total session time over the 1024 last requests, in seconds.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This PR fixes some inconsistencies in metrics units for haproxy integration. It should not be merged until [newrelic/nri-haproxy#116](https://github.com/newrelic/nri-haproxy/pull/116) is released (It will be kept as 'Draft PR' until them).
