### PR TITLE
[MERGE 9/13] Updates guzzle.mdx agent support info

### DIFF
--- a/src/content/docs/apm/agents/php-agent/frameworks-libraries/guzzle.mdx
+++ b/src/content/docs/apm/agents/php-agent/frameworks-libraries/guzzle.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - PHP agent
   - Frameworks and libraries
-metaDescription: New Relic PHP agent notes about the Guzzle library (supported as of PHP agent release 5.4).
+metaDescription: New Relic PHP agent notes about the Guzzle library (supported as of PHP agent release 7.0).
 redirects:
   - /docs/agents/php-agent/frameworks-libraries/guzzle
 ---
@@ -13,7 +13,7 @@ import apmGuzzleSequence from 'images/apm_screenshot-crop_guzzle-sequence.webp'
 
 import apmGuzzleParallel from 'images/apm_screenshot-crop_guzzle-parallel.webp'
 
-New Relic supports versions 3, 4, 5, 6 and 7 of the **Guzzle HTTP client library** with [New Relic PHP agent version 5.4](/docs/release-notes/agent-release-notes/php-release-notes) or higher.
+New Relic supports versions 3, 4, 5, 6 and 7 of the **Guzzle HTTP client library** with [New Relic PHP agent version 7.0](/docs/release-notes/agent-release-notes/php-release-notes) or higher.
 
 The Guzzle library allows both sequential and parallel requests. This page describes how each type of request will appear in the [**Summary** page](/docs/apm/applications-menu/monitoring/apm-overview-page) in the New Relic UI. To discover which call was the slowest, view the [External Services page](/docs/apm/applications-menu/monitoring/external-services-page) which displays timing for individual external calls.
 


### PR DESCRIPTION
The oldest supported agent version is now 7.0 so updating this page to reflect that.