### PR TITLE
Update kubernetes-components.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: New Relic Kubernetes components
+title: Kubernetes integration components
 tags:
   - Integrations
   - Kubernetes integration
@@ -9,9 +9,13 @@ metaDescription: "Learn what components are deployed after installing the Kubern
 
 The New Relic Kubernetes integration gives you full observability into the health and performance of your cluster, whether you're running Kubernetes on-premises or in the cloud. It gives you visibility into Kubernetes namespaces, deployments, replicasets, nodes, pods, and containers.
 
+The [`newrelic-infrastructure` chart](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure) is the main component of the integration. Learn about its architecture [here](#architecture). 
+
+The [`nri-bundle` chart](https://github.com/newrelic/helm-charts/tree/master/charts/nri-bundle) groups together individual charts for the integration, including `newrelic-infrastructure`, which allows you to easily install and upgrade the integration using only one chart. Learn about the default and optional components you can install with this chart [here](#components). 
+
 ## Architecture [#architecture]
 
-The `newrelic-infrastructure` chart is the main component of the integration. It's divided into three different components: `nrk8s-ksm`, `nrk8s-kubelet`, and `nrk8s-controlplane`. The first is a deployment and the next two are DaemonSets.
+The `newrelic-infrastructure` chart is divided into three different components: `nrk8s-ksm`, `nrk8s-kubelet`, and `nrk8s-controlplane`. The first is a deployment and the next two are DaemonSets.
 
 Each of the components has two containers:
 
@@ -93,3 +97,137 @@ Some of the new features that our new Helm chart exposes are these:
 * Better alignment with Helm idioms and standards
 
 You can check full details on all the switches that can be flipped in the [Chart's `README.md`](https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/README.md).
+
+## Components [#components]
+
+When you install the Kubernetes integration using `nri-bundle`, these two components are installed by default:
+
+<table class="alternate">
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Component 
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+    <tbody>
+    <tr>
+      <td>
+        <a href="https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure">newrelic-infrastructure
+      </td>
+      <td>
+        Sends metrics about nodes, cluster objects (e.g. Deployments, Pods), and the control plane to New Relic.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection">nri-metadata-injection
+      </td>
+      <td>
+        Enriches New Relic-instrumented applications (APM) with Kubernetes information.
+      </td>
+    </tr>
+    </tbody>
+</table>
+
+These are optional components you can either install using `nri-bundle` or separately:
+
+<table class="alternate">
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Component 
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+    <tbody>
+    <tr>
+      <td>
+        <a href="https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics">kube-state-metrics
+      </td>
+      <td>
+        Required for newrelic-infrastructure to gather cluster-level metrics.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events">nri-kube-events
+      </td>
+      <td>
+        Reports Kubernetes events to New Relic.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator">newrelic-infra-operator
+      </td>
+      <td>
+        (Beta) Used with Fargate or serverless environments to inject newrelic-infrastructure as a sidecar instead of the usual DaemonSet.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter">newrelic-k8s-metrics-adapter
+      </td>
+      <td>
+        (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics">kube-state-metrics
+      </td>
+      <td>
+        Required for newrelic-infrastructure to gather cluster-level metrics.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging">newrelic-logging
+      </td>
+      <td>
+        Sends logs for Kubernetes components and workloads running on the cluster to New Relic.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus">nri-prometheus
+      </td>
+      <td>
+        Sends metrics from applications exposing Prometheus metrics to New Relic.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/newrelic/newrelic-prometheus-configurator/tree/master/charts/newrelic-prometheus-agent">newrelic-prometheus-configurator
+      </td>
+      <td>
+        Configures instances of Prometheus in Agent mode to send metrics to the New Relic Prometheus endpoint.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie">newrelic-pixie
+      </td>
+      <td>
+        Connects to the Pixie API and enables the New Relic plugin in Pixie. The plugin allows you to export data from Pixie to New Relic for long-term data retention.
+      </td>
+    </tr>
+        <tr>
+      <td>
+        <a href="https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy">Pixie
+      </td>
+      <td>
+        An open source observability tool for Kubernetes applications that uses eBPF to automatically capture telemetry data without the need for manual instrumentation.
+      </td>
+    </tr>
+    </tbody>
+</table>

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
@@ -119,7 +119,7 @@ When you install the Kubernetes integration using `nri-bundle`, these two compon
         [newrelic-infrastructure](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
       </td>
       <td>
-        Sends metrics about nodes, cluster objects (e.g. Deployments, Pods), and the control plane to New Relic.
+        Sends metrics about nodes, cluster objects (for exmaample, deployments, pods), and the control plane to New Relic.
       </td>
     </tr>
     <tr>

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
@@ -102,13 +102,12 @@ You can check full details on all the switches that can be flipped in the [Chart
 
 When you install the Kubernetes integration using `nri-bundle`, these two components are installed by default:
 
-<table class="alternate">
+<table>
   <thead>
     <tr>
       <th style={{ width: "200px" }}>
         Component 
       </th>
-
       <th>
         Description
       </th>
@@ -117,7 +116,7 @@ When you install the Kubernetes integration using `nri-bundle`, these two compon
     <tbody>
     <tr>
       <td>
-        <a href="https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure">newrelic-infrastructure
+        [newrelic-infrastructure](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
       </td>
       <td>
         Sends metrics about nodes, cluster objects (e.g. Deployments, Pods), and the control plane to New Relic.
@@ -125,7 +124,7 @@ When you install the Kubernetes integration using `nri-bundle`, these two compon
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection">nri-metadata-injection
+        [nri-metadata-injection](https://github.com/newrelic/k8s-metadata-injection/tree/main/charts/nri-metadata-injection)
       </td>
       <td>
         Enriches New Relic-instrumented applications (APM) with Kubernetes information.
@@ -136,13 +135,12 @@ When you install the Kubernetes integration using `nri-bundle`, these two compon
 
 These are optional components you can either install using `nri-bundle` or separately:
 
-<table class="alternate">
+<table>
   <thead>
     <tr>
       <th style={{ width: "200px" }}>
         Component 
       </th>
-
       <th>
         Description
       </th>
@@ -151,7 +149,7 @@ These are optional components you can either install using `nri-bundle` or separ
     <tbody>
     <tr>
       <td>
-        <a href="https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics">kube-state-metrics
+        [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics)
       </td>
       <td>
         Required for newrelic-infrastructure to gather cluster-level metrics.
@@ -159,71 +157,71 @@ These are optional components you can either install using `nri-bundle` or separ
     </tr>
     <tr>
       <td>
-        <a href="https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events">nri-kube-events
+        [nri-kube-events](https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events)
       </td>
       <td>
         Reports Kubernetes events to New Relic.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator">newrelic-infra-operator
+        [newrelic-infra-operator](https://github.com/newrelic/newrelic-infra-operator/tree/main/charts/newrelic-infra-operator)
       </td>
       <td>
         (Beta) Used with Fargate or serverless environments to inject newrelic-infrastructure as a sidecar instead of the usual DaemonSet.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter">newrelic-k8s-metrics-adapter
+        [newrelic-k8s-metrics-adapter](https://github.com/newrelic/newrelic-k8s-metrics-adapter/tree/main/charts/newrelic-k8s-metrics-adapter)
       </td>
       <td>
         (Beta) Provides a source of data for Horizontal Pod Autoscalers (HPA) based on a NRQL query from New Relic.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics">kube-state-metrics
+        [kube-state-metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics)
       </td>
       <td>
         Required for newrelic-infrastructure to gather cluster-level metrics.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging">newrelic-logging
+        [newrelic-logging](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging)
       </td>
       <td>
         Sends logs for Kubernetes components and workloads running on the cluster to New Relic.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus">nri-prometheus
+        [nri-prometheus](https://github.com/newrelic/nri-prometheus/tree/main/charts/nri-prometheus)
       </td>
       <td>
         Sends metrics from applications exposing Prometheus metrics to New Relic.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/newrelic/newrelic-prometheus-configurator/tree/master/charts/newrelic-prometheus-agent">newrelic-prometheus-configurator
+        [newrelic-prometheus-configurator](https://github.com/newrelic/newrelic-prometheus-configurator/tree/master/charts/newrelic-prometheus-agent)
       </td>
       <td>
         Configures instances of Prometheus in Agent mode to send metrics to the New Relic Prometheus endpoint.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie">newrelic-pixie
+        [newrelic-pixie](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-pixie)
       </td>
       <td>
         Connects to the Pixie API and enables the New Relic plugin in Pixie. The plugin allows you to export data from Pixie to New Relic for long-term data retention.
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        <a href="https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy">Pixie
+        [Pixie](https://docs.pixielabs.ai/installing-pixie/install-schemes/helm/#3.-deploy)
       </td>
       <td>
         An open source observability tool for Kubernetes applications that uses eBPF to automatically capture telemetry data without the need for manual instrumentation.

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-components.mdx
@@ -119,7 +119,7 @@ When you install the Kubernetes integration using `nri-bundle`, these two compon
         [newrelic-infrastructure](https://github.com/newrelic/nri-kubernetes/tree/main/charts/newrelic-infrastructure)
       </td>
       <td>
-        Sends metrics about nodes, cluster objects (for exmaample, deployments, pods), and the control plane to New Relic.
+        Sends metrics about nodes, cluster objects (for example, deployments, pods), and the control plane to New Relic.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Adds:
* link to `newrelic-infrastructure` chart
* blurb about `nri-bundle`
* table of the components that come by default when you install the integration using `nri-bundle`
* table of optional components you can install using `nri-bundle`

Renames page title to more accurately reflect its contents. 