### PR TITLE
Add minimum value info as well as default one

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5283,7 +5283,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
     >
      `ntp_metrics` is a key-value map used to configure the time offset metric. When enabled and an NTP Hosts list is provided,
      the agent will provide the host's `ntp offset` metric (in seconds). This value is checked against the provided NTP
-     hosts pool every `interval` minutes (default: 15). Between intervals, the last known offset is reported.
+     hosts pool every `interval` minutes (the default and the minumum value is 15 minutes). Between intervals, the last known offset is reported.
      If the reported offset is greater than few seconds it can cause issues with alert conditions, NRQL queries and data gaps in dashboards.
 
       Example as a YAML attribute:


### PR DESCRIPTION
The documentation currently states that the default value for the interval of NTP requests is 15 minutes but it does not contain the fact that the minimum value is 15 minutes as well (see the [source code](https://github.com/newrelic/infrastructure-agent/blob/master/pkg/metrics/ntp.go#L19)).

Moreover, the following behaviour
```
Between intervals, the last known offset is reported.
```
causes a misunderstanding from the customer perspective especially if they set the interval below 15 minutes.

What they see in New Relic is that every minute an `NTP offset value` is being sent from the infra agent where all the values are exactly the same for 15 minutes long and they suddenly change in the next 15 minute interval.

With this PR, that misunderstanding can be clarified.