### PR TITLE
fix: improve documentation around Metric API double precision limits

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -167,7 +167,7 @@ The following default limits apply for all Metric data:
 
     <tr>
       <td>
-        Numerical double values that require rounding to convert to a double-precision floating-point number
+        Numerical double values that require rounding to convert to a double-precision floating-point number.
       </td>
 
       <td>

--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -167,6 +167,22 @@ The following default limits apply for all Metric data:
 
     <tr>
       <td>
+        Numerical double values that require rounding to convert to a double-precision floating-point number
+      </td>
+
+      <td>
+        Numeric double values that require rounding to convert to a double-precision floating-point number will be rejected.
+
+        An example of this is `1.12345678901234567E18`. A double can contain a value this large but it does not have enough precision to represent it accurately (it would have to be rounded to `1.12345678901234573E18`).
+
+        * If the number is in the common block, then the entire block will be dropped.
+        * If the number is in a metric data point, then the metric data point it resides in will be dropped.
+      </td>
+    </tr>
+
+
+    <tr>
+      <td>
         Payload size
       </td>
 
@@ -438,7 +454,7 @@ Additional restrictions include:
       </td>
 
       <td>
-        Avoid using [reserved words](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-words), such as `accountId`, `appId`, and `eventType`. You should also avoid using NRQL syntax terms unless you backtick (``` `` ```) them. 
+        Avoid using [reserved words](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits#reserved-words), such as `accountId`, `appId`, and `eventType`. You should also avoid using NRQL syntax terms unless you backtick (``` `` ```) them.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

This PR adds more clarity around why the Metric API might drop a large numeric value where we provided no details before. 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
I had considered adding a link to the Wiki page on double precision floats but decided against it. 
https://en.wikipedia.org/wiki/Double-precision_floating-point_format
* If your issue relates to an existing GitHub issue, please link to it.