### PR TITLE
[fix] OTel host.id is disabled by default

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -125,6 +125,11 @@ processors:
   
   resourcedetection:
     detectors: [env, system]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
   
   resourcedetection/cloud:
     detectors: ["gcp", "ec2", "azure"]


### PR DESCRIPTION
## Give us some context

* The OTel community changed the host.id attribute to be disabled by default (v0.82.0 or greater). Adding it back to be enabled in the recommended config for host monitoring.