### PR TITLE
[MERGE 9/20] feat(php-agent): 10.12 Release Notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-12-0-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-12-0-1.mdx
@@ -7,7 +7,7 @@ features: ['Improve Guzzle detection', 'Add API for custom error grouping', 'Add
 bugs: ['Fix Drupal message log level', 'Fix 8T Distributed Traces']
 security: []
 ---
-## New Relic PHP Agent v10.12.0.1
+## New Relic PHP agent v10.12.0.1
 
 ### New features
 
@@ -18,7 +18,7 @@ security: []
 * Verified support for Guzzle 7.
 * Verified support for Laravel 9 and 10.
 
-### Bug Fixes
+### Bug fixes
 
 * Reduces the log level for a Drupal-specific message to a more appropriate value.
 * Fixes a bug in Infinite Tracing where distributed traces were missing a `parentID` attribute that caused issues displaying a distributed application in the UI.
@@ -33,8 +33,8 @@ security: []
 * The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
 
 <Callout variant="important">
-**For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and removal of support for the required, unsupported features. This would disrupt APM data collection.
-The PHP agent packages which are affected are:
+**For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages that are affected are:
    - newrelic-php5
    - newrelic-php5-common
    - newrelic-daemon

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-12-0-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-12-0-1.mdx
@@ -1,0 +1,41 @@
+---
+subject: PHP agent
+releaseDate: '2023-09-20'
+version: 10.12.0.1
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.12.0.1'
+features: ['Improve Guzzle detection', 'Add API for custom error grouping', 'Add API to assign a unique ID to a transaction', 'Add docs link to install error message', 'Verified support for Laravel 9 and 10', 'Verified support for Guzzle 7']
+bugs: ['Fix Drupal message log level', 'Fix 8T Distributed Traces']
+security: []
+---
+## New Relic PHP Agent v10.12.0.1
+
+### New features
+
+* Improved Guzzle 5 and 6 detection.
+* Adds `newrelic_set_error_group_callback` API, allowing an application to register a callback function with the PHP Agent that will generate a custom error group name. Read more about this API [here](/docs/agents/php-agent/php-agent-api/newrelic_set_error_group_callback).
+* Adds `newrelic_set_user_id` API, allowing an application to assign a unique user ID to a transaction. Read more about this API [here](/docs/agents/php-agent/php-agent-api/newrelic_set_user_id).
+* Adds a link to documentation to the install error message when installing an unsupported version of PHP.
+* Verified support for Guzzle 7.
+* Verified support for Laravel 9 and 10.
+
+### Bug Fixes
+
+* Reduces the log level for a Drupal-specific message to a more appropriate value.
+* Fixes a bug in Infinite Tracing where distributed traces were missing a `parentID` attribute that caused issues displaying a distributed application in the UI.
+
+### Important end-of-life information
+
+* Support for PHP versions 7.0 and 7.1 will **EOL** in early 2024.
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages which are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>


### PR DESCRIPTION
Release Notes for the PHP Agent 10.12 release.

Planned Release Date: 09/20/23

Depends on https://github.com/newrelic/docs-website/pull/14460