### PR TITLE
fix: `dataSource` check for filter

### DIFF
--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -30,15 +30,15 @@ const DataDictionaryFilter = ({ location, events }) => {
     [events]
   );
 
-  const filteredEvents = useMemo(
-    () =>
-      formState.dataSource
-        ? events.filter((event) =>
-            event.dataSources.includes(formState.dataSource)
-          )
-        : events,
-    [events, formState.dataSource]
-  );
+  const filteredEvents = useMemo(() => {
+    if (formState.dataSource == null) return events;
+
+    return events.filter((event) =>
+      event.dataSources
+        .map((dataSource) => dataSource.name)
+        .includes(formState.dataSource)
+    );
+  }, [events, formState.dataSource]);
 
   useEffect(() => {
     setFormState({


### PR DESCRIPTION
previously, the `dataSources` property on `event`s was just an array of strings, but now it's an array of objects with the property `name`, since that's what the GraphQL service returns.
this change fixes the logic to account for that
