### PR TITLE
Add callout to privacy settings

### DIFF
--- a/src/content/docs/apm/agents/python-agent/supported-features/python-mlops.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/python-mlops.mdx
@@ -12,13 +12,15 @@ import modelsView from 'images/python-ml-APM-models-view.png'
 import modelSummary1 from 'images/python-ml-APM-model-summary-view1.png'
 import modelSummary2 from 'images/python-ml-APM-model-summary-view2.png'
 
-New Relic now enables monitoring for Machine Learning Models.  These monitored ML models can be found in the APM in the Models section.
+Starting in the New Relic Python Agent v9.1.0, New Relic now enables monitoring for Machine Learning Models.  These monitored ML models can be found in the APM in the Models section.
 
 ## Setup
 
 <Callout variant="tip">
   ML model metrics are available for Python agent version 9.1.0 and higher but are disabled by default. To change this configuration, check out our [documentation](/docs/apm/agents/python-agent/configuration/python-agent-configuration#ml-settings).
 </Callout>
+
+ML settings can be found [here](/docs/apm/agents/python-agent/configuration/python-agent-configuration/#ml-settings)
 
 To change the default ML harvest size of 100000 every 5 seconds, either set `event_harvest_config.harvest_limits.ml_event_data` in your `newrelic.ini` file to the desired value or set the environment variable `NEW_RELIC_ML_INSIGHTS_EVENTS_MAX_SAMPLES_STORED` to the desired value:
 
@@ -62,6 +64,13 @@ Two new APIs exist to customize the ML instrumentation experience:
 - Record custom ML events: [record_ml_event](/docs/agents/python-agent/python-agent-api/recordmlevent-python-agent-api)
 - Manually instrument an ML model: [wrap_mlmodel](/docs/agents/python-agent/python-agent-api/wrapmlmodel-python-agent-api)
 
+## Ensure Data Privacy [#data-privacy]
+
+<Callout variant="caution">
+  You control what log data is sent to New Relic, so be sure to follow your organization's security guidelines to mask, obfuscate, or prevent sending personal identifiable information (PII), protected health information (PHI), or any other sensitive data.
+</Callout>
+
+You can also enable or disable raw inference values to be sent depending your desired privacy settings [here](/docs/apm/agents/python-agent/configuration/python-agent-configuration/#inference-events-value-enabled).
 
 ## Features and Functionality [#features-functionality]
 

--- a/src/content/docs/apm/agents/python-agent/supported-features/python-mlops.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/python-mlops.mdx
@@ -20,7 +20,7 @@ Starting in the New Relic Python Agent v9.1.0, New Relic now enables monitoring 
   ML model metrics are available for Python agent version 9.1.0 and higher but are disabled by default. To change this configuration, check out our [documentation](/docs/apm/agents/python-agent/configuration/python-agent-configuration#ml-settings).
 </Callout>
 
-ML settings can be found [here](/docs/apm/agents/python-agent/configuration/python-agent-configuration/#ml-settings)
+ML settings can be found [here](/docs/apm/agents/python-agent/configuration/python-agent-configuration/#ml-settings).
 
 To change the default ML harvest size of 100000 every 5 seconds, either set `event_harvest_config.harvest_limits.ml_event_data` in your `newrelic.ini` file to the desired value or set the environment variable `NEW_RELIC_ML_INSIGHTS_EVENTS_MAX_SAMPLES_STORED` to the desired value:
 
@@ -64,7 +64,7 @@ Two new APIs exist to customize the ML instrumentation experience:
 - Record custom ML events: [record_ml_event](/docs/agents/python-agent/python-agent-api/recordmlevent-python-agent-api)
 - Manually instrument an ML model: [wrap_mlmodel](/docs/agents/python-agent/python-agent-api/wrapmlmodel-python-agent-api)
 
-## Ensure Data Privacy [#data-privacy]
+## Ensure data privacy [#data-privacy]
 
 <Callout variant="caution">
   You control what log data is sent to New Relic, so be sure to follow your organization's security guidelines to mask, obfuscate, or prevent sending personal identifiable information (PII), protected health information (PHI), or any other sensitive data.


### PR DESCRIPTION
This PR adds a callout to privacy settings that exist within the new MLOps feature for Python Agent v9.1.0