### PR TITLE
chore: add missing setting option

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -37,6 +37,7 @@ devices:
     - PowerNet-MIB_UPS
     - TCP-MIB
     - UDP-MIB
+    purge_after_num: 1
   # Sample of SNMP v3 device
   router_snmpv3__10.10.0.202:
     device_name: router_snmpv3
@@ -180,7 +181,7 @@ discovery:
   add_devices: true
   replace_devices: true
   no_dedup_engine_id: false
-  check_all_ips: false
+  check_all_ips: true
 global:
   poll_time_sec: 60
   drop_if_outside_poll: false
@@ -204,6 +205,7 @@ global:
     environment: production
   match_attributes:
     if_Description: ".*WAN.*"
+  purge_devices_after_num: 0
 ```
 
 <CollapserGroup>
@@ -542,6 +544,18 @@ global:
 
           <td>
             Disables all SNMP polling when `true`. By default, it's set to `false`.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            purge_after_num
+          </td>
+
+          <td/>
+
+          <td>
+            Removes device from config file after X scheduled discovery jobs have failed. **This setting overrides the global `purge_devices_after_num` setting.** Set this to `-1` to keep device forever, or any integer >= `1` to set up a purge threshold. (Default: `0`)
           </td>
         </tr>
 
@@ -1034,6 +1048,18 @@ global:
 
           <td>
             Indicates whether [response time](#response_time-attribute) polling is enabled for all devices in the configuration file. By default, it's set to `false`.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            purge_devices_after_num
+          </td>
+
+          <td/>
+
+          <td>
+            Removes devices from config file after X scheduled discovery jobs have failed. Set this to `-1` to keep devices forever, or any integer >= `1` to set up a purge threshold. (Default: `0`)
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
adding a missing setting option to the advanced config tables for network monitoring