### PR TITLE
chore: Update logs specification stability

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction.mdx
@@ -342,7 +342,7 @@ Here are the OpenTelemetry data types we support and their associated mappings. 
 
 ### Logs [#logs-ingest]
 
-New Relic offers support for the OTLP ingest of log signals. Note that the maturity of the upstream specification is [experimental](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/versioning-and-stability.md#experimental). We intend to follow potentially breaking upstream changes.
+New Relic offers support for the OTLP ingest of log signals. The maturity of the upstream specification is [stable](https://github.com/open-telemetry/opentelemetry-specification/blob/87a5ed7f0d4c403e2b336f275ce3e7fd66a8041b/specification/versioning-and-stability.md#stable).
 
 OpenTelemetry logs are compatible with logs in New Relic. The OpenTelemetry logs optionally include attributes (name-value pairs) and resource attributes that map directly to dimensions you can use to facet or filter log data with queries. OpenTelemetry log metadata (for example, `name`, `severity_text`, and `trace_id`) also map directly to dimensions on New Relic's log management capabilities. We currently support all OpenTelemetry log message types.
 


### PR DESCRIPTION
The OTel Logs Bridge API, Logs SDK, and Log Data Model are all stable.

See: https://github.com/open-telemetry/opentelemetry-specification/pull/3376
