### PR TITLE
Add release notes for python agent v9.1.0 (PLEASE MERGE SEPT 26TH AM)

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90100.mdx
@@ -1,0 +1,31 @@
+---
+subject: Python agent
+releaseDate: '2023-09-25'
+version: 9.1.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for sklearn']
+bugs: []
+security: []
+---
+
+## Notes
+
+This release of the Python agent adds support for [sklearn](https://pypi.org/project/scikit-learn/) and `redis.asyncio` connections.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+
+## New features
+
+* **Add support for [sklearn](https://pypi.org/project/scikit-learn/)**
+The Python agent now supports monitoring for machine learning models created with sklearn. Check out [our documentation](https://docs.newrelic.com/docs/apm/agents/python-agent/supported-features/python-mlops/) for details on how to view and query for your prediction events and ML related metrics directly in the New Relic user interface. Machine learning instrumentation will be disabled by default in this release. To enable it, visit our [configuration page](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#ml-settings) for further information.
+This release also introduces two new APIs to support customization of machine learning monitoring: [wrap_mlmodel](https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/wrapmlmodel-python-agent-api/) and [record_ml_event](https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/recordmlevent-python-agent-api/).
+
+* **Add instrumentation for `redis.asyncio.Connection`**
+Add instrumentation support for connections initiated from the `redis.asyncio`module
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90100.mdx
@@ -3,7 +3,7 @@ subject: Python agent
 releaseDate: '2023-09-25'
 version: 9.1.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Add support for sklearn']
+features: ['Add support for sklearn', 'Add instrumentation for redis.asyncio.Connection']
 bugs: []
 security: []
 ---
@@ -22,7 +22,7 @@ The Python agent now supports monitoring for machine learning models created wit
 This release also introduces two new APIs to support customization of machine learning monitoring: [wrap_mlmodel](https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/wrapmlmodel-python-agent-api/) and [record_ml_event](https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/recordmlevent-python-agent-api/).
 
 * **Add instrumentation for `redis.asyncio.Connection`**
-Add instrumentation support for connections initiated from the `redis.asyncio`module
+Add instrumentation support for connections initiated from the `redis.asyncio` module
 
 ## Support statement
 


### PR DESCRIPTION
This PR adds release notes for Python Agent v9.1.0. If this could be merged on 9/26/23, that would coordinate with our release schedule. Thanks!