### PR TITLE
update top 404s with redirects to proper docs

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -28,6 +28,7 @@ redirects:
   - /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/alerts-concepts-workflow
   - /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence/
   - /docs/introduction-new-relic-ai
+  - /docs/alerts/new-relic-alerts/getting-started/alerting-new-relic
 signupBanner:
   text: Monitor and improve your entire stack. 100GB free. Forever.
 ---

--- a/src/content/docs/browser/new-relic-browser/browser-apis/noticeerror.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/noticeerror.mdx
@@ -14,6 +14,7 @@ redirects:
   - /docs/browser/new-relic-browser/browser-agent-apis/noticing-or-logging-frontend-errors
   - /docs/browser/new-relic-browser/browser-agent-spa-api/newrelicnoticeerror-browser-agent-api
   - /docs/browser/new-relic-browser/browser-agent-spa-api/notice-error
+  - /docs/browser/new-relic-browser/browser-agent-spa-api/noticeerror-browser-agent-api
 ---
 <Callout variant="important">
 To use this API, you need either a Browser Pro or Pro+SPA edition of the browser agent.

--- a/src/content/docs/browser/new-relic-browser/installation/update-browser-agent.mdx
+++ b/src/content/docs/browser/new-relic-browser/installation/update-browser-agent.mdx
@@ -10,6 +10,7 @@ redirects:
   - /docs/browser/new-relic-browser/installation-configuration/upgrading-browser-agent
   - /docs/browser/new-relic-browser/installation-configuration/upgrade-browser-agent
   - /docs/browser/new-relic-browser/installation/upgrade-browser-agent
+  - /docs/browser/new-relic-browser/installation/update-browser-agent/embed
 ---
 
 Running the latest version of our browser agent ensures you can access all browser features and enhancements. To update to the latest version, [check your version number](#checking), then follow the steps for either [updating an APM-managed installation](#upgrading-apm) or [upgrading a copy/paste installation](#upgrading-copy-paste).

--- a/src/content/docs/data-apis/convert-to-metrics/analyze-monitor-data-trends-metrics.mdx
+++ b/src/content/docs/data-apis/convert-to-metrics/analyze-monitor-data-trends-metrics.mdx
@@ -12,6 +12,7 @@ redirects:
   - /docs/accounts/accounts/data-management/introduction-events-metrics-service
   - /docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/introduction-events-metrics-service
   - /docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics/analyze-monitor-data-trends-metrics
+  - /docs/telemetry-data-platform/ingest-manage-data/convert-data-metrics
 ---
 
 You can generate [metric-type data](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types#dimensional-metrics) from other types of data in New Relic, including [events, logs, and spans](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types#events-new-relic). Metrics are aggregates of your data and are optimal for analyzing and monitoring trends over long time periods.

--- a/src/content/docs/data-apis/custom-data/get-custom-data-from-any-source.mdx
+++ b/src/content/docs/data-apis/custom-data/get-custom-data-from-any-source.mdx
@@ -4,6 +4,7 @@ metaDescription: "An introduction to reporting custom data to New Relic: why you
 redirects:
   - /docs/telemetry-data-platform/custom-data/intro-custom-data
   - /docs/data-apis/custom-data/intro-custom-data
+  - /docs/insights/explore-add-data
 ---
 
 To get the most out of New Relic, you may need or want to report custom data. We give you the tools you need to get any types of data into New Relic.

--- a/src/content/docs/distributed-tracing/concepts/quick-start.mdx
+++ b/src/content/docs/distributed-tracing/concepts/quick-start.mdx
@@ -12,6 +12,7 @@ redirects:
   - /docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing
   - /docs/distributed-tracing/enable-configure/integrations-enable-distributed-tracing
   - /docs/distributed-tracing/enable-configure/overview-enable-distributed-tracing
+  - /docs/understand-dependencies/distributed-tracing/enable-configure/overview-enable-distributed-tracing
 ---
 
 import distributedtracingHighLevelDistTr from 'images/distributed-tracing_diagram_high-level-dist-tr.webp'

--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -18,6 +18,7 @@ redirects:
   - /docs/using-new-relic/user-interface-functions/share-your-data/ticketing-integrations-lighthouse-pivotal-tracker
   - /docs/using-new-relic/user-interface-functions/share-your-data/ticketing-integrations
   - /docs/errors-inbox
+  - /docs/apm/applications-menu/error-analytics/error-analytics-manage-error-traces
 ---
 
 import errorsinboxScoptedOtel from 'images/errors-inbox_screenshot-full_scopted-otel.webp'

--- a/src/content/docs/infrastructure/infrastructure-ui-pages/infra-hosts-ui-page.mdx
+++ b/src/content/docs/infrastructure/infrastructure-ui-pages/infra-hosts-ui-page.mdx
@@ -1,5 +1,5 @@
 ---
-title: The infrastructure hosts UI
+title: Infrastructure hosts UI
 tags:
   - Infrastructure
   - Infrastructure monitoring UI
@@ -21,6 +21,7 @@ redirects:
   - /docs/infrastructure/new-relic-infrastructure/scope-filter/organize-infrastructure-hosts-scopes
   - /docs/infrastructure/new-relic-infrastructure/filter-group/organize-infrastructure-hosts-filter-sets
   - /docs/infrastructure/infrastructure-ui-pages/infrastructure-ui-entities
+  - /docs/infrastructure/infrastructure-ui-pages/infrastructure-hosts-page
 ---
 
 import infrastructureHostsUiDiagram from 'images/infrastructure_screenshot-crop_infrastructure-hosts-ui-diagram.webp'

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
@@ -13,6 +13,7 @@ redirects:
   - /docs/infrastructure/install-configure-manage-infrastructure/docker-installation/docker-instrumentation-infrastructure
   - /docs/infrastructure/install-configure-manage-infrastructure-agent/linux-installation/docker-instrumentation-infrastructure
   - /docs/infrastructure/install-infrastructure-agent/linux-installation/docker-instrumentation-infrastructure-monitoring
+  - /docs/infrastructure/install-infrastructure-agent/linux-installation/docker-instrumentation-infrastructure
 ---
 
 Our [infrastructure agent](/docs/welcome-new-relic-infrastructure) automatically monitors your containers. With container monitoring you can:

--- a/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
+++ b/src/content/docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-data.mdx
@@ -26,6 +26,7 @@ redirects:
   - /docs/infrastructure/manage-your-data/data-instrumentation/default-infrastructure-monitoring-events
   - /docs/insights/event-data-sources/default-events/infrastructure-events
   - /docs/infrastructure/manage-your-data
+  - /docs/infrastructure-metrics
 ---
 
 New Relic's infrastructure monitoring agent collects and displays data using six primary [events](/docs/using-new-relic/data/understand-data/new-relic-data-types#event-data), each with associated [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) that represent assorted metrics and metadata.

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/get-started/introduction-azure-monitoring-integrations.mdx
@@ -12,6 +12,7 @@ redirects:
   - /docs/infrastructure/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
   - /docs/integrations/microsoft-azure-integrations/getting-started/introduction-azure-monitoring-integrations
   - /docs/infrastructure/microsoft-azure-integrations
+  - /docs/integrations/microsoft-azure-integrations/getting-started
 ---
 
 We have several ways for you to monitor your [Microsoft Azure](https://azure.microsoft.com) applications and services. Here's an overview of these offerings and why you'd use one versus the other. 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/get-started/introduction-new-relic-mobile-android.mdx
@@ -33,6 +33,8 @@ redirects:
   - /docs/mobile-monitoring/new-relic-mobile-android/legacy/installing-android-apps-eclipse
   - /docs/mobile-monitoring/new-relic-mobile-android/install-configure/installing-android-apps-maven
   - /docs/mobile-monitoring/new-relic-mobile-android/install-configure
+  - /docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api
+  - /docs/mobile-monitoring/new-relic-mobile-android/android-sdk-api
 ---
 
 [Mobile monitoring](/docs/mobile-monitoring/new-relic-mobile/getting-started/introduction-new-relic-mobile) for Android monitors your mobile app, giving you a comprehensive view of your app's performance. It works for Android apps written using Java or Kotlin.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/cocoapods-installation.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/cocoapods-installation.mdx
@@ -1,15 +1,16 @@
 ---
 title: CocoaPods manual installation
 tags:
-  - Mobile monitoring
-  - New Relic Mobile iOS
-  - Installation
+   - Mobile monitoring
+   - New Relic Mobile iOS
+   - Installation
 metaDescription: How to add New Relic to your iOS applications using Cocoapods.
 redirects:
-  - /docs/mobile-monitoring-installation/cocoapods-installation-and-configuration
-  - /docs/mobile-monitoring/mobile-monitoring-installation/ios/cocoapods-installation-and-configuration
-  - /docs/mobile-monitoring/mobile-monitoring-installation/ios/cocoapods-installation-configuration
-  - /docs/mobile-monitoring/new-relic-mobile-ios/install-configure/cocoapods-installation-configuration
+   - /docs/mobile-monitoring-installation/cocoapods-installation-and-configuration
+   - /docs/mobile-monitoring/mobile-monitoring-installation/ios/cocoapods-installation-and-configuration
+   - /docs/mobile-monitoring/mobile-monitoring-installation/ios/cocoapods-installation-configuration
+   - /docs/mobile-monitoring/new-relic-mobile-ios/install-configure/cocoapods-installation-configuration
+   - /docs/mobile-monitoring/new-relic-mobile-ios/tvos/cocoapods-tvos-installation-configuration
 ---
 
 We recommend that you use our [guided install](https://onenr.io/0qwLv87gkj5) to set up iOS monitoring. However, if you need to install the agent manually, follow the steps below to install the New Relic iOS agent with Cocoapods.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide.mdx
@@ -8,6 +8,7 @@ redirects:
   - /docs/mobile-monitoring/new-relic-mobile-android/api-guides/add-custom-data
   - /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/add-custom-data
   - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-sdk-api-guide
+  - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api
 ---
 
 Use the New Relic mobile SDK API calls to customize and extend the data your mobile app reports to New Relic. 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide.mdx
@@ -7,6 +7,7 @@ metaDescription: 'Customize your mobile agent instrumentation to send custom dat
 redirects:
   - /docs/mobile-monitoring/new-relic-mobile-android/api-guides/add-custom-data
   - /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/add-custom-data
+  - /docs/mobile-monitoring/new-relic-mobile-ios/ios-sdk-api/ios-sdk-api-guide
 ---
 
 Use the New Relic mobile SDK API calls to customize and extend the data your mobile app reports to New Relic. 

--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -26,6 +26,8 @@ redirects:
   - /docs/using-new-relic/welcome-new-relic/get-started/get-started-full-stack-observability
   - /docs/agents/manage-apm-agents/installation/install-agent
   - /docs/new-relic-one/use-new-relic-one/cross-product-functions/install-configure/install-new-relic
+  - /docs
+  - /docs/using-new-relic/cross-product-functions/install-configure/install-new-relic
 signupBanner:
   text: Monitor and improve your entire stack. 100GB free. Forever.
 ---

--- a/src/content/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent.mdx
@@ -15,6 +15,7 @@ redirects:
   - /docs/using-new-relic/cross-product-functions/install-configure/update-new-relic-agent
   - /docs/new-relic-one/use-new-relic-one/cross-product-functions/install-configure/update-new-relic-agent
   - /docs/new-relic-one/install-configure/update-new-relic-agent
+  - /new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent
 ---
 
 import apmGroundskeeperApp from 'images/apm_screenshot-full_groundskeeper-app.webp'

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
@@ -11,6 +11,7 @@ redirects:
   - /docs/customize-your-charts
   - /docs/use-your-charts
   - /docs/chart-builder/use-chart-builder/use-charts/use-your-charts
+  - /docs/insights/use-insights-ui/export-data/embed-insights-widgets-external-webpages
 ---
 
 import queriesnrqlChartType from 'images/queries-nrql_screenshot-full_chart-type.webp'

--- a/src/content/docs/style-guide/writing-strategies/introduction-style-guide.mdx
+++ b/src/content/docs/style-guide/writing-strategies/introduction-style-guide.mdx
@@ -25,6 +25,7 @@ redirects:
   - /docs/style-guide/get-started/introduction-style-guide
   - /docs/style-guide
   - /docs/basic-style-guide/style-guide-quick-reference
+  - /docs/new-relic-only/style-guide
 ---
 
 Welcome to New Relic's style guide. We've written these guidelines for content creators across New Relic, and for contributors to our open source content projects, like the Docs or our other New Relic GitHub repositories. 

--- a/src/content/docs/tutorial-create-alerts/create-new-relic-alerts.mdx
+++ b/src/content/docs/tutorial-create-alerts/create-new-relic-alerts.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Getting started with New Relic alerts"
 metaDescription: "How to create alerts and alert ecosystems with New Relic"
+redirects:
+  - /docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-alerts
 ---
 
 import alertsFlow from 'images/journey_diagram_alerts-flow.webp'

--- a/src/content/docs/tutorial-innovation-and-growth/development-quality-mgmt.mdx
+++ b/src/content/docs/tutorial-innovation-and-growth/development-quality-mgmt.mdx
@@ -3,6 +3,7 @@ title: "Improve your code base"
 metaDescription: "Our development quality guide helps increase stability by using New Relic to ensure that fewer defects are introduced into the code base."
 redirects: 
   - /docs/new-relic-solutions/observability-maturity/innovation-growth/development-quality-implementation-guide
+  - /docs/new-relic-solutions/new-relic-solutions/measure-devops-success
 ---
 
 Overall, a business's digital operations are only as stable as its code. Without a stable code base, engineering will never have time to meet even basic demand for new features, let alone move at the pace required to innovate new and exciting features for their customers. Engineers will spend their time troubleshooting and fixing poor quality code to prevent negative customer experience. Implementing high quality code is key to an organization's ability to innovate and grow.


### PR DESCRIPTION
This updates the top 404 pages with proper redirects. Some of the top 50 seem to have redirects and therefore would not be reflected here. 