### PR TITLE
docs: Minor streaming export compression correction

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
@@ -398,7 +398,7 @@ You can also query for all existing streams. Here's an example:
 
 ## Export compression [#compression]
 
-Optionally, we can compress payloads before they are exported, though this is disabled by default. This can help avoid hitting your ingested data limit and save money on egress COGS.
+Optionally, we can compress payloads before they are exported, though this is disabled by default. This can help avoid hitting your ingested data limit and save money on ingress costs.
 
 You can enable compression using the `payloadCompression` field under `ruleParameters`. This field can be any of the following values:
 


### PR DESCRIPTION
## Give us some context

* Jira ticket: NR-164732
* Currently, the documentation for export compression says that users will save on "egress COGS" while using it. This is incorrect terminology, they will actually save on ingress costs. This PR corrects the mistake.