### PR TITLE
Update custom-instrumentation-attributes-net.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
@@ -108,7 +108,11 @@ protected void MethodWithinTransaction()
 ```
 
 <Callout variant="important">
-  If some of your methods still don't show up in traces after adding the `[Trace]` attribute, disable method inlining for those methods with `[MethodImpl(MethodImplOptions.NoInlining)]`.
+  If some of your methods don't show up in traces after adding the `[Trace]` attribute, disable method inlining for those methods with `[MethodImpl(MethodImplOptions.NoInlining)]`.
+</Callout>
+
+<Callout variant="important">
+  Running your application from Visual Studio in **debug** mode may prevent some methods from appearing in New Relic traces. To ensure methods appear in New Relic, run the application in release mode via the command line. 
 </Callout>
 
 ## Properties for \[Transaction] [#properties]

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
@@ -23,13 +23,13 @@ New Relic's .NET agent provides several options for [custom instrumentation](/do
 Requirements include:
 
 * .NET agent version [6.16.178.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-6161780) or higher.
-* You must be willing to modify your source code. If you cannot or do not want to modify your source code, use [custom instrumentation via XML](/docs/agents/net-agent/custom-instrumentation/custom-instrumentation-xml-net).
+* You must be willing to modify your source code. If you can't or don't want to modify your source code, use [custom instrumentation via XML](/docs/agents/net-agent/custom-instrumentation/custom-instrumentation-xml-net).
 * Your project must have a reference to `NewRelic.Api.Agent.dll` (for example, installing the package and placing `using NewRelic.Api.Agent;` in your code). This package is in the [NuGet gallery](https://www.nuget.org/packages/NewRelic.Agent.Api/).
 * The `Transaction` and `Trace` attributes must be applied to concrete implementations of methods. They cannot be applied on interfaces or super class method definitions.
 
 ## Transactions called within transactions [#tx-vs-trace]
 
-Methods decorated with the `[Transaction]` attribute will only create a new transaction when one does not already exist. When a method decorated with `[Transaction]` is called from **within** a previously started transaction, it will be treated as the `[Trace]` attribute instead, and will provide more information about the existing transaction.
+Methods decorated with the `[Transaction]` attribute will only create a new transaction when one doesn' already exist. When a method decorated with `[Transaction]` is called from **within** a previously started transaction, it will be treated as the `[Trace]` attribute instead, and will provide more information about the existing transaction.
 
 <CollapserGroup>
   <Collapser
@@ -115,7 +115,7 @@ protected void MethodWithinTransaction()
   Running your application from Visual Studio in **debug** mode may prevent some methods from appearing in New Relic traces. To ensure methods appear in New Relic, run the application in release mode via the command line. 
 </Callout>
 
-## Properties for \[Transaction] [#properties]
+## Properties for `Transaction` [#properties]
 
 The `Transaction` attribute supports the following properties:
 


### PR DESCRIPTION
Some customers are reporting that methods are not appearing in New Relic as expected when their application is run in debug mode via Visual Studio. This PR aims to recommend that the application should be run in release mode from the command line for more methods to appear in New Relic APM.