### PR TITLE
docs: New Relic iOS 5.6.0 and license update

### DIFF
--- a/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses.mdx
@@ -60,20 +60,6 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        [analytics-swift](https://github.com/segmentio/analytics-swift.git)
-      </td>
-
-      <td>
-        [MIT](https://github.com/segmentio/analytics-swift/blob/main/LICENSE)
-      </td>
-
-      <td>
-        Copyright © 2021 Segment
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [CDMarkdownKit](https://github.com/chrisdhaan/CDMarkdownKit.git)
       </td>
 
@@ -228,34 +214,6 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        [Sovran-Swift](https://github.com/segmentio/Sovran-Swift.git)
-      </td>
-
-      <td>
-        [MIT](https://github.com/segmentio/Sovran-Swift/blob/main/LICENSE)
-      </td>
-
-      <td>
-        Copyright © 2021 Segment
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [swift-algorithms](https://github.com/apple/swift-algorithms)
-      </td>
-
-      <td>
-        [APACHE-2.0](https://github.com/apple/swift-algorithms/blob/main/LICENSE.txt)
-      </td>
-
-      <td>
-        Copyright © 2019-2023 Apple Inc. and the Swift project authors
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [Swift-Big-Integer](https://github.com/mkrd/Swift-Big-Integer.git)
       </td>
 
@@ -265,20 +223,6 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
       <td>
         Copyright © 2019 mkrd
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [swift-numerics](https://github.com/apple/swift-numerics)
-      </td>
-
-      <td>
-        [APACHE-2.0](https://github.com/apple/swift-numerics/blob/main/LICENSE.txt)
-      </td>
-
-      <td>
-        Copyright © 2019-2023 Apple Inc. and the Swift Numerics project authors
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-5060.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-5060.mdx
@@ -1,0 +1,19 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2023-09-29'
+version: 5.6.0
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+Improved support for instrumented Lambda functions
+
+### New features
+
+* Adds a CloudWatch metrics page
+* Adds a Logs page that is filtered to the Lambda function
+* Adds an Invocations page with detailed information
+* Adds an Errors page with detailed information
+
+### Improvements
+
+* Rewrote the monitor detail page to prevent some rare crashes


### PR DESCRIPTION
* Updates to latest licenses for the iOS mobile app
* Adds in release notes for the latest version