### PR TITLE
Update Go Agent release notes for 3.26.0

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
@@ -15,7 +15,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 
 ## Golang versions [#golang-release]
 
-New Relic supports Golang 1.19 or higher.
+New Relic supports [Golang 1.19 or higher](https://go.dev/doc/devel/release).
 
 ## Operating environments [#operating-systems]
 
@@ -275,7 +275,7 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Use a supported database driver or [builtin instrumentation](https://godoc.org/github.com/newrelic/go-agent/v3/newrelic#InstrumentSQLConnector)
+        Use a supported database driver or [built-in instrumentation](https://godoc.org/github.com/newrelic/go-agent/v3/newrelic#InstrumentSQLConnector)
       </td>
 
       <td>
@@ -321,7 +321,7 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Instrument database calls to Postgres using the database/sql library and pq
+        Instrument database calls to Postgres using the `database/sql` library and `pq`
       </td>
     </tr>
 
@@ -335,7 +335,7 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Instrument database calls to Postgres using the database/sql library and jackc/pgx
+        Instrument database calls to Postgres using the `database/sql` library and `jackc/pgx`
       </td>
     </tr>
 
@@ -349,7 +349,7 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Instrument database calls to Postgres using the jackc/pgx/v5 library for direct Postgres calls without database/sql.
+        Instrument database calls to Postgres using the `jackc/pgx/v5` library for direct Postgres calls without `database/sql`.
       </td>
     </tr>
 
@@ -503,7 +503,7 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Instrument inbound requests using graph-gophers/graphql-go
+        Instrument inbound requests using `graph-gophers/graphql-go`
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
@@ -15,7 +15,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
 
 ## Golang versions [#golang-release]
 
-New Relic supports Golang 1.18 or higher.
+New Relic supports Golang 1.19 or higher.
 
 ## Operating environments [#operating-systems]
 
@@ -349,7 +349,7 @@ The following integration packages must be imported along with the [newrelic](ht
       </td>
 
       <td>
-        Instrument database calls to Postgres using the database/sql library and jackc/pgx/v5
+        Instrument database calls to Postgres using the jackc/pgx/v5 library for direct Postgres calls without database/sql.
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-0.mdx
@@ -9,11 +9,13 @@ security: []
 ---
 
 <Callout variant="important">
-This release was retracted. Use 3.25.1 instead.
+This release was retracted. Use [3.25.1](https://docs.newrelic.com/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-1/) instead.
 </Callout>
 
 ### Support statement
-We use the latest version of the Go language. At a minimum, you should be using no version of Go older than what is supported by the Go team themselves (i.e., Go versions 1.19 and later are supported).
-We recommend updating to the latest agent version as soon as it’s available. If you can’t upgrade to the latest version, update your agents to a version no more than 90 days old. Read more about keeping agents up to date. (https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/)
+We use the latest version of the Go language. At a minimum, you should be using no version of Go older than what is supported by the Go team themselves (for exmample, Go versions 1.19 and later are supported).
+
+We recommend updating to the latest agent version as soon as it's available. If you can't update to the latest version, update your agents to a version no more than 90 days old. Read more about [keeping agents up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+
 See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
 

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-0.mdx
@@ -1,0 +1,19 @@
+---
+subject: Go agent
+releaseDate: '2023-09-18'
+version: 3.25.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.25.0'
+features: []
+bugs: []
+security: []
+---
+
+<Callout variant="important">
+This release was retracted. Use 3.25.1 instead.
+</Callout>
+
+### Support statement
+We use the latest version of the Go language. At a minimum, you should be using no version of Go older than what is supported by the Go team themselves (i.e., Go versions 1.19 and later are supported).
+We recommend updating to the latest agent version as soon as it’s available. If you can’t upgrade to the latest version, update your agents to a version no more than 90 days old. Read more about keeping agents up to date. (https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/)
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-1.mdx
@@ -1,0 +1,29 @@
+---
+subject: Go agent
+releaseDate: '2023-09-18'
+version: 3.25.1
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.25.1'
+features: ["Added support for FastHTTP package"]
+bugs: ["Security agent fails to correctly parse NEW_RELIC_SECURITY_AGENT_ENABLED environment variable."]
+security: []
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+
+## 3.25.1
+### Added
+   * Added Support for FastHTTP package
+      * Added newrelic.WrapHandleFuncFastHTTP() and newrelic.StartExternalSegmentFastHTTP() functions to instrument fasthttp context and create wrapped handlers. These functions work similarly to the existing ones for net/http
+      * Added client-fasthttp and server-fasthttp examples to help get started with FastHTTP integration
+
+### Fixed
+ * Corrected a bug where the security agent failed to correctly parse the `NEW_RELIC_SECURITY_AGENT_ENABLED` environment variable.
+
+### Support statement
+ We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-25-1.mdx
@@ -9,15 +9,15 @@ security: []
 ---
 
 <Callout variant="important">
-We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
 </Callout>
 
 
 ## 3.25.1
 ### Added
-   * Added Support for FastHTTP package
-      * Added newrelic.WrapHandleFuncFastHTTP() and newrelic.StartExternalSegmentFastHTTP() functions to instrument fasthttp context and create wrapped handlers. These functions work similarly to the existing ones for net/http
-      * Added client-fasthttp and server-fasthttp examples to help get started with FastHTTP integration
+   * Added support for the `FastHTTP` package:
+      * Added `newrelic.WrapHandleFuncFastHTTP()` and `newrelic.StartExternalSegmentFastHTTP()` functions to instrument `fasthttp` context and create wrapped handlers. These functions work similarly to the existing ones for `net/http`.
+      * Added `client-fasthttp` and `server-fasthttp` examples to help get started with `FastHTTP` integration.
 
 ### Fixed
  * Corrected a bug where the security agent failed to correctly parse the `NEW_RELIC_SECURITY_AGENT_ENABLED` environment variable.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-26-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-26-0.mdx
@@ -9,13 +9,13 @@ security: []
 ---
 
 <Callout variant="important">
-We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
 </Callout>
 
 
 ## 3.26.0
 ### Added
- * Extended implementation of the `nrpgx5` integration (now v1.2.0). This instruments Postgres database operations using the `jackc/pgx/v5` library, including the direct access mode of operation as opposed to requiring code to use the library compatibly with the standard `database/sql` library.
+ * Extended implementation of the `nrpgx5` integration (now v1.2.0). This instruments Postgres database operations using the `jackc/pgx/v5` library, including the direct access mode of operation as opposed to requiring code to use the library compatible with the standard `database/sql` library.
 
 ### Support statement
  We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-26-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-26-0.mdx
@@ -1,0 +1,24 @@
+---
+subject: Go agent
+releaseDate: '2023-09-28'
+version: 3.26.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.26.0'
+features: ["Extended implementation of nrpgx5 integration to support Postgres direct operations with jackc/pgx/v5"]
+bugs: []
+security: []
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+
+## 3.26.0
+### Added
+ * Extended implementation of the `nrpgx5` integration (now v1.2.0). This instruments Postgres database operations using the `jackc/pgx/v5` library, including the direct access mode of operation as opposed to requiring code to use the library compatibly with the standard `database/sql` library.
+
+### Support statement
+ We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+
+ See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+


### PR DESCRIPTION
Updates release notes and compatibility matrix for the Go Agent 3.26.0 release.