### PR TITLE
Update windows-services-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
@@ -84,7 +84,7 @@ Here's an example of the Windows services integration configuration with both a 
     integrations:
       - name: nri-winservices
         config:
-          exporter_bind_address: 127.0.0.1  
+          exporter_bind_address: 127.0.0.1
           exporter_bind_port: 9182
           include_matching_entities:
             windowsService.name:


### PR DESCRIPTION
Removed trailing spaces which produce an error in yamllint

* What problems does this PR solve?
Incorrect syntax in example

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

```
$ yamllint test.yml 
test.yml
  4:39      error    trailing spaces  (trailing-spaces)
```