### PR TITLE
fix(Logs): Removed a confused text about the limit

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -560,8 +560,6 @@ In order to prevent problems, we apply two parsing limits: per-message-per-rule 
 
       <td>
         The per-account limit exists to prevent accounts from using more than their fair share of resources. The limit considers the total time spent processing **all** log messages for an account per-minute.
-
-        The limit is not a fixed value; it scales up or down proportionally to the volume of data stored daily by the account and the environment size that is subsequently allocated to support that customer.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Removed this text `The limit is not a fixed value; it scales up or down proportionally to the volume of data stored daily by the account and the environment size that is subsequently allocated to support that customer.` from the [Parsing log data](https://docs.newrelic.com/docs/logs/ui-data/parsing/#limits) page.

Requested in the #help-documentation channel by Alexander Mosher.