### PR TITLE
[Publish 10/03/2023] chore(PHP agent): Adds log decoration docs

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1788,19 +1788,16 @@ The PHP agent can collect also add linking metadata to Monolog log records to al
       </tbody>
     </table>
 
-    Enables the addition of linking metadata to Monolog log records.  
+    This enables the addition of linking metadata to Monolog log records. Set this to `true` to enable this feature. Leave this set to `false` if using the APM log forwarding feature to forward your logs to New Relic.
 
-    Leave this set to false if using the APM log forwarding feature to forward your logs to New Relic.
-
-    Set this to `true` to enable this feature.
 
     <Callout variant="important">
       The log decoration feature first appears in PHP agent release 10.13.0.1.
 
-      The log decoration feature requires additional steps to ensure the linking metadata is contained in the log messages.  See the 
+      The log decoration feature requires additional steps to ensure the linking metadata is contained in the log messages. See the 
       (PHP logs in context)[/docs/logs/logs-context/configure-logs-context-php] page for more information on using this feature.
 
-      If you enable log forwarding and log decorating then your logs will very likely be sent to New Relic in duplicate.
+      If you enable both log forwarding and log decorating then it will very likely cause your logs to be sent to New Relic in duplicate.
     </Callout>
 
   </Collapser>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1747,6 +1747,65 @@ newrelic.application_logging.forwarding.log_level = "INFO"
   </Collapser>
 </CollapserGroup>
 
+The PHP agent can collect also add linking metadata to Monolog log records to allow logs in context to work with log data forwarded by a 3rd party log forwarder. To enable this feature use the the `newrelic.application_logging.local_decorating.enable` option:
+
+<CollapserGroup>
+  <Collapser
+    id="cfg-application_logging_local_decorating-enabled"
+    title="newrelic.application_logging.local_decorating.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            PERDIR
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables the addition of linking metadata to Monolog log records.  
+
+    Leave this set to false if using the APM log forwarding feature to forward your logs to New Relic.
+
+    Set this to `true` to enable this feature.
+
+    <Callout variant="important">
+      The log decoration feature first appears in PHP agent release 10.13.0.1.
+
+      The log decoration feature requires additional steps to ensure the linking metadata is contained in the log messages.  See the 
+      (PHP logs in context)[/docs/logs/logs-context/configure-logs-context-php] page for more information on using this feature.
+
+      If you enable log forwarding and log decorating then your logs will very likely be sent to New Relic in duplicate.
+    </Callout>
+
+  </Collapser>
+</CollapserGroup>  
+
 The PHP agent can collect metrics related to log events for [supported logging frameworks](/docs/logs/logs-context/configure-logs-context-php). The creation of these metrics is controlled by the `newrelic.application_logging.metrics.enable` option:
 
 <CollapserGroup>

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -22,6 +22,21 @@ Got lots of PHP logs? Check out our [tutorial on how to optimize and manage them
 
 ## Automatic logs in context options [#automatic-logs-in-context]
 
+You have two options to configure <InlinePopover type="apm" /> logs in context to send your app's logs and linking metadata automatically to New Relic. Supported frameworks for automatic logs in context using in agent forwarding include:
+
+- Monolog 2 or 3. Requires PHP Agent v10.1.0+.
+
+The other option is to have the agent decorate log records with a token containing linking metadata and use an external log forwarder to send logs to New Relic.  Supported frameworks for log decoration include:
+
+- Monolog 2 or 3. Requires PHP Agent v10.13.0+.
+
+<CollapserGroup>
+
+  <Collapser
+    id="1-agent"
+    title="Option 1 (simplest): Let the agent forward your log's messages."
+  >
+
 If you're using a supported framework, you can configure the APM agent to send your app's logs and linking metadata automatically to New Relic. Supported frameworks for automatic logs in context include:
 
 * Monolog (version 2 or 3)
@@ -64,52 +79,19 @@ If you're using a supported logging framework and want to use the agent to send 
   If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your manual log forwarder**. Otherwise, your app will be sending double the log data. Depending on your account, this could result in double billing. For more information, learn how to [disable your specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
 </Callout>
 
-<InstallFeedback />
 
-## Secure your data [#obfuscation]
+ </Collapser>
 
-Your logs may include sensitive information protected by HIPAA or other compliance protocols. By default we obfuscate number patterns that appear to be for items such as credit cards or Social Security numbers, but you may need to hash or mask additional information.
-
-For more information, see our documentation about [obfuscation expressions and rules](/docs/logs/ui-data/obfuscation-ui/). You can hash or mask your log data by using the New Relic UI or by using NerdGraph, our GraphQL API.
-
-## Explore your data [#view-ui]
-
-To make the most of your logging data:
-
-* On the [APM **Summary** page](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data), click your **Web transaction time** chart to view logs associated with a specific point in time.
-* Check your app's [**Errors inbox**](/docs/errors-inbox/errors-inbox) to view the logs associated with your errors.
-* Use [distributed tracing](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) to see the logs associated with individual traces.
-* Explore more logging data across your platform with our [logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
-* Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/) based on log output and severity.
-* [Query your data](/docs/logs/ui-data/query-syntax-logs/) using our specialized UI for logs data, and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) with the results.
-
-## Troubleshooting tips [#troubleshooting]
-
-Typically your logs will start to appear less than a minute after you enable <InlinePopover type="apm" /> logs in context. Check your app's **Triage > Logs** section. You will also start seeing [log patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns) related to the error there.
-
-If you don't see any logs for errors or traces, there may not be any for your app. Try refreshing the UI page, or change the [selected time period](/docs/new-relic-one/ui-data/basic-ui-features/#data-analysis).
-
-## Disable automatic logging [#disable-automatic]
-
-APM logs in context automatically forwards <InlinePopover type="apm" /> agent log data when enabled.  As of agent release 10.3.0, this feature is enabled by default for the PHP agent. This can have a negative impact on your security, compliance, billing, or system performance. For more information, or if you need to adjust the default setting, follow the procedures to [disable automatic logging](/docs/logs/logs-context/disable-automatic-logging).
-
-
-## Manual logs in context option using local log decoration[#enable-logs-decoration-php]
+  <Collapser
+    id="2-decorate"
+    title="Option 2: Let the agent decorate your logs."
+  >
 
 Already have a log forwarder you like? We've got you covered! Language agents can decorate your logs with the linking metadata needed to provide access to automatic logs-in-context features.
 
 This method requires that you install an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) before enabling logs in context. If you do not have a log forwarder, the New Relic UI will prompt you to use our [infrastructure agent](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/).
 
 If you decide to use your existing log forwarding solution and later decide to update your agent to use automatic logs in context, be sure to **disable your manual log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
-
-Update your agent's configuration to disable log forwarding, then restart the agent.
-
-    Configuration file (`newrelic.ini`):
-
-    ```
-    newrelic.application_logging.forwarding.enabled = false
-
-    ```
 
  <Callout variant="important">
     Local log decoration for the PHP agent does not directly alter log messages. Your logging framework configuration will need to be updated to write out the `NR-LINKING` token in messages. 
@@ -122,11 +104,6 @@ If you choose to use log decoration to activate logs in context for PHP, first s
 3. Install [Monolog](https://github.com/Seldaek/monolog) version 2 or 3.
 4. Configure logs decoration for PHP using the Monolog extension.
 
-<CollapserGroup>
-  <Collapser
-    id="php-monolog"
-    title="PHP configuration with Monolog"
-  >
     To enable local log decoration:
 
     1. Disable automatic log forwarding:
@@ -160,20 +137,43 @@ If you choose to use log decoration to activate logs in context for PHP, first s
       Our decorator adds five attributes to every log `message` (plain text): `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
 
       ```
-      This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}
+      This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
       ```
-
-  </Collapser>
-
-</CollapserGroup>
 
 5. To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
 
 If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).
 
-If the logs from your application do not include fields like `trace.id` and `span.id`, there may be a problem with the configuration of the Monolog log enricher. In this situation:
+ </Collapser>
 
-* Check that the PHP agent for your app has been installed and is configured to enable distributed tracing.
-* Check that your application is using the Monolog logger object when sending log records, not `syslog()`.
+</CollapserGroup>
 
+<InstallFeedback />
+
+## Secure your data [#obfuscation]
+
+Your logs may include sensitive information protected by HIPAA or other compliance protocols. By default we obfuscate number patterns that appear to be for items such as credit cards or Social Security numbers, but you may need to hash or mask additional information.
+
+For more information, see our documentation about [obfuscation expressions and rules](/docs/logs/ui-data/obfuscation-ui/). You can hash or mask your log data by using the New Relic UI or by using NerdGraph, our GraphQL API.
+
+## Explore your data [#view-ui]
+
+To make the most of your logging data:
+
+* On the [APM **Summary** page](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data), click your **Web transaction time** chart to view logs associated with a specific point in time.
+* Check your app's [**Errors inbox**](/docs/errors-inbox/errors-inbox) to view the logs associated with your errors.
+* Use [distributed tracing](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui) to see the logs associated with individual traces.
+* Explore more logging data across your platform with our [logs UI](/docs/logs/log-management/ui-data/use-logs-ui/).
+* Set up [alerts](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/) based on log output and severity.
+* [Query your data](/docs/logs/ui-data/query-syntax-logs/) using our specialized UI for logs data, and [create dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) with the results.
+
+## Troubleshooting tips [#troubleshooting]
+
+Typically your logs will start to appear less than a minute after you enable <InlinePopover type="apm" /> logs in context. Check your app's **Triage > Logs** section. You will also start seeing [log patterns](/docs/logs/ui-data/find-unusual-logs-log-patterns) related to the error there.
+
+If you don't see any logs for errors or traces, there may not be any for your app. Try refreshing the UI page, or change the [selected time period](/docs/new-relic-one/ui-data/basic-ui-features/#data-analysis).
+
+## Disable automatic logging [#disable-automatic]
+
+APM logs in context automatically forwards <InlinePopover type="apm" /> agent log data when enabled.  As of agent release 10.3.0, this feature is enabled by default for the PHP agent. This can have a negative impact on your security, compliance, billing, or system performance. For more information, or if you need to adjust the default setting, follow the procedures to [disable automatic logging](/docs/logs/logs-context/disable-automatic-logging).
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -94,18 +94,13 @@ If you don't see any logs for errors or traces, there may not be any for your ap
 APM logs in context automatically forwards <InlinePopover type="apm" /> agent log data when enabled.  As of agent release 10.3.0, this feature is enabled by default for the PHP agent. This can have a negative impact on your security, compliance, billing, or system performance. For more information, or if you need to adjust the default setting, follow the procedures to [disable automatic logging](/docs/logs/logs-context/disable-automatic-logging).
 
 
-## Manual logs in context option [#enable-logs-php]
+## Manual logs in context option using local log decoration[#enable-logs-decoration-php]
 
-Before language agents had the ability to forward and decorate logs, you could use our manual solutions to send linking metadata.
+Already have a log forwarder you like? We've got you covered! Language agents can decorate your logs with the linking metadata needed to provide access to automatic logs-in-context features.
 
-This option is still supported, but is no longer encouraged. Also, this method requires that you install a log forwarder before enabling logs in context. If you do not have a log forwarder, the New Relic UI will prompt you to use our [infrastructure agent](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/).
+This method requires that you install an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) before enabling logs in context. If you do not have a log forwarder, the New Relic UI will prompt you to use our [infrastructure agent](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/).
 
 If you decide to use your existing log forwarding solution and later decide to update your agent to use automatic logs in context, be sure to **disable your manual log forwarder**. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
-
-
-<Callout variant="important">
-  This option should not be used with in-agent forwarding. Using an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) to send logs to New Relic while in-agent forwarding is enabled will cause your logs to be sent up twice to New Relic. Depending on your account, this may result in double billing.
-</Callout>
 
 Update your agent's configuration to disable log forwarding, then restart the agent.
 
@@ -116,70 +111,60 @@ Update your agent's configuration to disable log forwarding, then restart the ag
 
     ```
 
-If you need to use the manual process to set up logs in context for PHP, first setup your PHP app.
+ <Callout variant="important">
+    Local log decoration for the PHP agent does not directly alter log messages. Your logging framework configuration will need to be updated to write out the `NR-LINKING` token in messages. 
+  </Callout>
 
-1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and extends the metadata that is forwarded to New Relic.
-2. [Install](/docs/agents/php-agent/installation/php-agent-installation-overview/) or [update](/docs/agents/php-agent/installation/update-php-agent/) to the latest PHP agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [PHP agent version 9.13.0.270 or higher](/docs/release-notes/agent-release-notes/php-release-notes/) for logs in context.
-3. Install [Monolog](https://github.com/Seldaek/monolog) version 1 or 2, or use a [compatible log forwarding plugin](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/#log-forwarding) if you are not using the built-in Monolog Handler for New Relic.
-4. Configure logs in context for PHP using the Monolog extension, if used.
+If you choose to use log decoration to activate logs in context for PHP, first setup your PHP app.
+
+1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and forwards these to New Relic.
+2. [Install](/docs/agents/php-agent/installation/php-agent-installation-overview/) or [update](/docs/agents/php-agent/installation/update-php-agent/) to the latest PHP agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [PHP agent version 10.13.0.1 or higher](/docs/release-notes/agent-release-notes/php-release-notes/) for logs decoration support.
+3. Install [Monolog](https://github.com/Seldaek/monolog) version 2 or 3.
+4. Configure logs decoration for PHP using the Monolog extension.
 
 <CollapserGroup>
   <Collapser
     id="php-monolog"
     title="PHP configuration with Monolog"
   >
-    You must install the Monolog log enricher package before you can configure Monolog for logs in context. This is done by using Composer to install the [`newrelic/monolog-enricher` package](https://packagist.org/packages/newrelic/monolog-enricher).
+    To enable local log decoration:
 
-    In most cases, use the `Processor` and `Handler` classes provided by the log enricher package in conjunction with Monolog's built-in `BufferHandler`.
-
-    * The `Processor` adds the contextual metadata required for New Relic's logs in context capabilities to operate.
-    * The `Handler` sends the log records to New Relic.
-    * The `BufferHandler` ensures that the logs are delivered with as little overhead as possible.
-
-      At the point where you create the `Monolog\Logger` object, add the following `pushProcessor` and `pushHandler` calls to add the `Processor` and `Handler`:
+    1. Disable automatic log forwarding:
+      ```
+      newrelic.application_logging.forwarding.enabled = false
 
       ```
-      <?php
+    2. Enable local log decoration by the PHP agent:
+      ```
+      newrelic.application_logging.local_decorating.enabled = true
 
-      use Monolog\Handler\BufferHandler;
-      use Monolog\Logger;
-      use NewRelic\Monolog\Enricher\{Handler, Processor};
+      ```
+    3. The PHP agent will now add linking metadata to each Monolog log record.  For this information to appear in the actual log messages it is necessary to set a Monolog Formatter for each Monolog Handler that includes the `%extra.NR-LINKING%` format specification at the end of the message.  This is the necessary linking data for logs in context to work.
 
-      $log = new Logger('log');
-      $log->pushProcessor(new Processor);
-      $log->pushHandler(new BufferHandler(new Handler));
+       For example:
+       
+       ```
+       <?php
+       use Monolog\Logger;
+       use Monolog\Formatter\LineFormatter;
+       use Monolog\Handler\StreamHandler;
+
+       $logger = new Logger('log');
+       $handler = new StreamHandler('php://stderr');
+       $logfmt = "%channel%.%level_name%: %message% %extra.NR-LINKING%\n";
+       $formatter = new LineFormatter($logfmt);
+       $handler->setFormatter($formatter);
+       $logger->pushHandler($handler); 
+       ```
+  
+      Our decorator adds five attributes to every log `message` (plain text): `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
+
+      ```
+      This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}
       ```
 
-      <Callout variant="tip">
-        You can use the `Processor` and `Handler` in conjunction with any existing Monolog setup. You do not need to remove your existing processors and handlers.
-      </Callout>
   </Collapser>
 
-  <Collapser
-    id="php-advanced"
-    title="PHP configuration with other log forwarders"
-  >
-    If you use Monolog to send logs to a compatible log forwarder, and if you have already configured that tool to send logs to New Relic, you can use the `Processor` and `Formatter` solely for that tool. This option prevents additional overhead of sending logs directly to New Relic with the `Handler`.
-
-    You will need to be using a handler that supports the `setFormatter()` method, and your logging tool must be able to ingest JSON logs.
-
-    Here's an example of configuring Monolog to handle other log forwarders:
-
-    ```
-    <?php
-
-    use Monolog\Handler\StreamHandler;
-    use Monolog\Logger;
-    use NewRelic\Monolog\Enricher\{Formatter, Processor};
-
-    $log = new Logger('log');
-    $log->pushProcessor(new Processor);
-
-    $handler = new StreamHandler('php://stderr');
-    $handler->setFormatter(new Formatter);
-    $log->pushHandler($handler);
-    ```
-  </Collapser>
 </CollapserGroup>
 
 5. To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
@@ -190,5 +175,5 @@ If the logs from your application do not include fields like `trace.id` and `spa
 
 * Check that the PHP agent for your app has been installed and is configured to enable distributed tracing.
 * Check that your application is using the Monolog logger object when sending log records, not `syslog()`.
-* Check that another Monolog handler is not preventing the log record from [bubbling](https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#core-concepts).
+
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -116,7 +116,7 @@ If you choose to use log decoration to activate logs in context for PHP, first s
       newrelic.application_logging.local_decorating.enabled = true
 
       ```
-    3. The PHP agent will now add linking metadata to each Monolog log record.  For this information to appear in the actual log messages it is necessary to set a Monolog Formatter for each Monolog Handler that includes the `%extra.NR-LINKING%` format specification at the end of the message.  This is the necessary linking data for logs in context to work.
+    3. The PHP agent will now add linking metadata to each Monolog log record.  For this information to appear in the actual log messages it is necessary to set a Monolog Formatter for each Monolog Handler that includes the `%extra.NR-LINKING%` format specification at the end of the message. This is the necessary linking data for logs in context to work.
 
        For example:
        
@@ -175,5 +175,5 @@ If you don't see any logs for errors or traces, there may not be any for your ap
 
 ## Disable automatic logging [#disable-automatic]
 
-APM logs in context automatically forwards <InlinePopover type="apm" /> agent log data when enabled.  As of agent release 10.3.0, this feature is enabled by default for the PHP agent. This can have a negative impact on your security, compliance, billing, or system performance. For more information, or if you need to adjust the default setting, follow the procedures to [disable automatic logging](/docs/logs/logs-context/disable-automatic-logging).
+APM logs in context automatically forwards <InlinePopover type="apm" /> agent log data when enabled. As of agent release 10.3.0, this feature is enabled by default for the PHP agent. This can have a negative impact on your security, compliance, billing, or system performance. For more information, or if you need to adjust the default setting, follow the procedures to [disable automatic logging](/docs/logs/logs-context/disable-automatic-logging).
 


### PR DESCRIPTION
The PHP agent will be adding APM log decoration and this PR adds the configuration information needed to use the feature.  It is modeled after the [.Net ](https://docs.newrelic.com/docs/logs/logs-context/net-configure-logs-context-all/) documentation.

**I would appreciate a review of this PR but please to no merge these changes until I've given the go ahead.**