### PR TITLE
nvidia gpu integration added to on-host integrations nav

### DIFF
--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -216,6 +216,8 @@ pages:
                 path: /docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-integration
               - title: NGINX configuration settings
                 path: /docs/infrastructure/host-integrations/host-integrations-list/nginx/nginx-config
+          - title: NVIDIA GPU integration
+            path: /docs/infrastructure/host-integrations/host-integrations-list/nvidia-gpu-integration
           - title: Openstack Controller integration
             path: /docs/infrastructure/host-integrations/host-integrations-list/openstack-controller-integration
           - title: Oracle Database integration


### PR DESCRIPTION
## Give us some context

* We recently added https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/nvidia-gpu-integration/ but it's not listed in the on-host integrations list. 