### PR TITLE
chore: add language identifiers

### DIFF
--- a/src/content/docs/apm/agents/python-agent/installation/python-agent-admin-script-advanced-usage.mdx
+++ b/src/content/docs/apm/agents/python-agent/installation/python-agent-admin-script-advanced-usage.mdx
@@ -36,8 +36,19 @@ When executed with no further arguments, this provides a listing of all accepted
 ```shell
 newrelic-admin help
 [output]  Usage: newrelic-admin command [options]
-
-[output]  Type 'newrelic-admin help <command>' for help on any of the commands listed in this document.
+[output]  
+[output]  Type 'newrelic-admin help <command>'for help on a specific command.
+[output]  
+[output]  Available commands are:
+[output]    generate-config
+[output]    license-key
+[output]    local-config
+[output]    network-config
+[output]    record-deploy
+[output]    run-program
+[output]    run-python
+[output]    server-config
+[output]    validate-config
 ```
 
 To view additional details about a subcommand, run the help command with the subcommand and any of its options. For example:
@@ -45,8 +56,8 @@ To view additional details about a subcommand, run the help command with the sub
 ```shell
 newrelic-admin help generate-config
 [output]  Usage: newrelic-admin generate-config license_key [output_file]
-
-[output]  Generates a sample agent configuration file for <license_key>
+[output]  
+[output]  Generates a sample agent configuration file for <license_key>.
 ```
 
 ## generate-config license_key \[output_file] [#generate-config]

--- a/src/content/docs/apm/agents/python-agent/installation/python-agent-admin-script-advanced-usage.mdx
+++ b/src/content/docs/apm/agents/python-agent/installation/python-agent-admin-script-advanced-usage.mdx
@@ -25,7 +25,7 @@ This document gives more in-depth detail about these uses of the admin script:
 
 To execute subcommands, provide the name of the subcommand as the first argument to the `newrelic-admin` script. Then add any options after the name of the subcommand. For example:
 
-```
+```shell
 newrelic-admin help
 ```
 
@@ -33,18 +33,20 @@ newrelic-admin help
 
 When executed with no further arguments, this provides a listing of all accepted subcommands:
 
-```
-$ newrelic-admin help
-    Usage: newrelic-admin command [options]
+```shell
+newrelic-admin help
+[output]  Usage: newrelic-admin command [options]
 
-    Type 'newrelic-admin help <command>' for help on any of the commands listed in this document.
+[output]  Type 'newrelic-admin help <command>' for help on any of the commands listed in this document.
+```
 
 To view additional details about a subcommand, run the help command with the subcommand and any of its options. For example:
 
-    $ newrelic-admin help generate-config
-    Usage: newrelic-admin generate-config license_key [output_file]
+```shell
+newrelic-admin help generate-config
+[output]  Usage: newrelic-admin generate-config license_key [output_file]
 
-    Generates a sample agent configuration file for <license_key>
+[output]  Generates a sample agent configuration file for <license_key>
 ```
 
 ## generate-config license_key \[output_file] [#generate-config]
@@ -81,7 +83,7 @@ When using a hosting service such as Heroku where an agent configuration file wo
 
 In this case where an environment variable is used to define the license key, to run the connectivity test, pass the value `-` for the `config_file` option in place of the path to the agent configuration file. So, to run the command on your Heroku instance you would use:
 
-```
+```shell
 heroku run newrelic-admin validate-config - stdout
 ```
 
@@ -99,13 +101,13 @@ Agent configuration when using this method can be provided in two different ways
 
 If you were using gunicorn for example, you could say:
 
-```
+```ini
 NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn wsgi:application
 ```
 
 OR
 
-```
+```shell
 NEW_RELIC_CONFIG_FILE=newrelic.ini
 export NEW_RELIC_CONFIG_FILE
 
@@ -139,13 +141,13 @@ This is a shortcut method for starting up a Python web application without needi
 
 As for `run-program` subcommand above, environment variables are used to configure the Python agent. If you were using `python` executable directly for example, you could say:
 
-```
+```ini
 NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-python wsgi.py
 ```
 
 OR
 
-```
+```shell
 NEW_RELIC_CONFIG_FILE=newrelic.ini 
 export NEW_RELIC_CONFIG_FILE 
 
@@ -158,7 +160,7 @@ Outputs the license key which will be used. This can be used in any startup scri
 
 It may be used with the agent configuration file:
 
-```
+```shell
 newrelic-admin license-key newrelic.ini
 ```
 
@@ -166,22 +168,22 @@ OR
 
 If setting the license key using environment variables, use `-` as the name of the configuration file:
 
-```
+```shell
 NEW_RELIC_LICENSE_KEY='YOUR-LICENSE-KEY'
-    export NEW_RELIC_LICENSE_KEY 
-    
-    newrelic-admin license-key -
+export NEW_RELIC_LICENSE_KEY 
+
+newrelic-admin license-key -
 ```
 
 Output will be in the form:
 
-```
+```ini
 license_key = 'YOUR-LICENSE-KEY'
 ```
 
 If no license key was found in the agent configuration file or picked up from user environment variables, the output will be:
 
-```
+```ini
 license_key = None
 ```
 
@@ -191,7 +193,7 @@ Outputs the network configuration which will be used. This can be used in any st
 
 It may be used with the agent configuration file:
 
-```
+```shell
 newrelic-admin network-config newrelic.ini
 ```
 
@@ -199,35 +201,35 @@ OR
 
 If setting any proxy information using environment variables, use `-` as the name of the configuration file:
 
-```
+```shell
 NEW_RELIC_PROXY_HOST=proxy.example.com
-    export NEW_RELIC_PROXY_HOST
-    
-    NEW_RELIC_PROXY_PORT=8888
-    export NEW_RELIC_PROXY_PORT
-    
-    newrelic-admin network-config -
+export NEW_RELIC_PROXY_HOST
+
+NEW_RELIC_PROXY_PORT=8888
+export NEW_RELIC_PROXY_PORT
+
+newrelic-admin network-config -
 ```
 
 Output will be in the form:
 
-```
+```ini
 host = 'collector.newrelic.com'
-    port = 0
-    proxy_host = 'proxy.example.com'
-    proxy_port = 8888
-    proxy_user = None
-    proxy_pass = None
-    ssl = True
+port = 0
+proxy_host = 'proxy.example.com'
+proxy_port = 8888
+proxy_user = None
+proxy_pass = None
+ssl = True
 ```
 
-A value of `0` for port indicates that the port number, either 80 or 443, will be automatically selected based on whether an SSL connection is being used to communicate with our data collector.
+A value of `0` for port indicates that the port number, either `80` or `443`, will be automatically selected based on whether an SSL connection is being used to communicate with our data collector.
 
 ## local-config config_file \[log_file] [#local-config]
 
 Outputs the local agent configuration based on built-in defaults, environment variables, and any agent configuration file. This information may be requested by our technical support when trying to debug any agent startup issues. It may be used with the agent configuration file:
 
-```
+```shell
 newrelic-admin local-config newrelic.ini
 ```
 
@@ -235,7 +237,7 @@ OR
 
 If setting any settings using environment variables, you can use `-` as the name of the configuration file:
 
-```
+```shell
 newrelic-admin local-config -
 ```
 
@@ -245,7 +247,7 @@ Outputs the full configuration for a specific application. This will be the loca
 
 It may be used with the agent configuration file:
 
-```
+```shell
 newrelic-admin server-config newrelic.ini
 ```
 
@@ -253,7 +255,7 @@ OR
 
 If changing any settings using environment variables, you can use `-` as the name of the configuration file:
 
-```
+```shell
 newrelic-admin server-config -
 ```
 
@@ -265,14 +267,14 @@ This is a wrapper around the New Relic REST API to record deployments for your a
 
 To use the command:
 
-1. Add your [API key](/docs/apis/rest-api-v2/requirements/api-keys) in the [agent configuration file](/docs/agents/python-agent/installation-configuration/python-agent-configuration#agent-configuration-file) (newrelic.ini) by adding a line similar to the following in the `[newrelic]` section:
+1. Add your [API key](/docs/apis/rest-api-v2/requirements/api-keys) in the [agent configuration file](/docs/agents/python-agent/installation-configuration/python-agent-configuration#agent-configuration-file) (`newrelic.ini`) by adding a line similar to the following in the `[newrelic]` section:
 
-   ```
+   ```ini
    api_key=substitute-your-api-key-here
    ```
 2. Call the `newrelic-admin` command from the command line. (Do not add it to your config file.) using the following subcommand structure:
 
-   ```
+   ```shell
    newrelic-admin record-deploy config_file description [revision changelog user]
    ```
 
@@ -298,7 +300,7 @@ Here are some advanced instructions for running the admin script:
   >
     You can separately set and export the `NEW_RELIC_CONFIG_FILE` environment variable before running the script. Ensure you substitute your existing command options for `YOUR_COMMAND_OPTIONS`:
 
-    ```
+    ```shell
     NEW_RELIC_CONFIG_FILE=newrelic.ini
     export NEW_RELIC_CONFIG_FILE
 
@@ -307,7 +309,7 @@ Here are some advanced instructions for running the admin script:
 
     If your startup command uses `exec`, separate the setting of the environment variable from the execution of the admin script. Ensure you substitute your existing command options for `YOUR_COMMAND_OPTIONS`:
 
-    ```
+    ```shell
     NEW_RELIC_CONFIG_FILE=newrelic.ini
     export NEW_RELIC_CONFIG_FILE
 
@@ -318,7 +320,7 @@ Here are some advanced instructions for running the admin script:
 
     For example, under **supervisord** you might use the following. Be sure to substitute your existing command options for `YOUR_COMMAND_OPTIONS`.
 
-    ```
+    ```ini
     [program:warpdrive]
     command = newrelic-admin run-program YOUR_COMMAND_OPTIONS
     environment = NEW_RELIC_CONFIG_FILE=newrelic.ini
@@ -331,7 +333,7 @@ Here are some advanced instructions for running the admin script:
   >
     If the command being run is the `python` executable and it is being run directly on a Python code file as `python main.py`, use either of the following:
 
-    ```
+    ```shell
     newrelic-admin run-program python main.py
 
     newrelic-admin run-python main.py
@@ -348,7 +350,7 @@ Here are some advanced instructions for running the admin script:
 
     If you use a process management system such as **supervisord** in a virtual environment, you could use this configuration:
 
-    ```
+    ```ini
     [program:warpdrive]
     command = newrelic-admin run-program  
     environment = PATH="/path/to/python/app/venv/bin",NEW_RELIC_CONFIG_FILE="newrelic.ini"
@@ -358,6 +360,6 @@ Here are some advanced instructions for running the admin script:
 
     Note the `PATH` environment variable that points to the same path that would be used by the virtual environment.
 
-    For more information on these options to **newrelic-admin** and the different configuration options based on user environment variables, see the more detailed documentation for the `run-program` and `run-python` options.
+    For more information on these options to `newrelic-admin` and the different configuration options based on user environment variables, see the more detailed documentation for the `run-program` and `run-python` options.
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
[output] in a shell block should format them as terminal output, I've seen this work in `src/content/docs/browser/new-relic-browser/lab/set-up-env.mdx` but haven't tested it out personally yet

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.