### PR TITLE
fix(Java agent): Removed Java 5 and Java 6

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -53,34 +53,6 @@ Before you install the Java agent, ensure your system meets these requirements:
       <tbody>
         <tr>
           <td>
-            Java 5
-          </td>
-
-          <td>
-            v1.3.0 to v2.21.7
-          </td>
-
-          <td>
-            v2.21.7 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 6
-          </td>
-
-          <td>
-            v3.0.0 to v4.3.0
-          </td>
-
-          <td>
-            v4.3.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
             Java 7
           </td>
 


### PR DESCRIPTION
Updated the [Compatibility and requirements for the Java agent](https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent/#jvm) page. Removed Java 5 and Java 6 from the table.

This has been requested in the `help-documentation` channel.