### PR TITLE
fix: re-group ntp

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5276,11 +5276,8 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
     </table>
   </Collapser>
 
-  <Collapser
-      className="freq-link"
-      id="ntp-metrics"
-      title="ntp_metrics"
-    >
+## NTP Offset variables
+
      `ntp_metrics` is a key-value map used to configure the time offset metric. When enabled and an NTP Hosts list is provided,
      the agent will provide the host's `ntp offset` metric (in seconds). This value is checked against the provided NTP
      hosts pool every `interval` minutes (the default and the minumum value is 15 minutes). Between intervals, the last known offset is reported.
@@ -5306,11 +5303,11 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
       NRIA_NTP_METRICS_INTERVAL='15'
       NRIA_NTP_METRICS_TIMEOUT='10'
       ```
-    </Collapser>
+
       <Collapser
         className="freq-link"
         id="ntp-enabled"
-        title="enabled"
+        title="ntp_metrics.enabled"
       >
         Flag to enable/disable the NTP Offset metric.
 
@@ -5367,7 +5364,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
       <Collapser
         className="freq-link"
         id="ntp-pool"
-        title="pool"
+        title="ntp_metrics.pool"
       >
         Defines list of NTP Hosts to query. When multiple hosts are defined, all of them will be queried and the reported
         metrics will be the average value between them.
@@ -5428,7 +5425,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
       <Collapser
         className="freq-link"
         id="ntp-interval"
-        title="interval"
+        title="ntp_metrics.interval"
       >
        Defines the interval in minutes to request NTP Offset from the provided pool.
 
@@ -5486,7 +5483,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
       <Collapser
           className="freq-link"
           id="ntp-timeout"
-          title="timeout"
+          title="ntp_metrics.timeout"
         >
          Defines the timeout in seconds for the requests made to the NTP hosts.
 


### PR DESCRIPTION
## Give us some context

* Based on customer feedback, re-grouping NTP metrics together in a specific section so that's easier to understand.