### PR TITLE
docs: Documents the NEW_RELIC_HIGH_SECURITY environment variable added in v10.18.0

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -251,6 +251,7 @@ NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=<var>true|false</var>
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=<var>true|false</var>
 NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
 NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
+NEW_RELIC_HIGH_SECURITY=<var>true|false</var>
 ```
 
 If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
@@ -2145,6 +2146,12 @@ The `highSecurity` element is a child of the `configuration` element. To enable 
 
     ```xml
     <highSecurity enabled="true"/>
+    ```
+
+    Alternatively, set the `NEW_RELIC_HIGH_SECURITY` environment variable in the application's environment.    
+
+    ```ini
+    NEW_RELIC_HIGH_SECURITY=true
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This PR documents a new environment variable added in .NET Agent v10.18.0, which is being released on 10/17/2023.