### PR TITLE
Update opentelemetry-tutorial-java.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -99,7 +99,7 @@ This is a great option if you want us to do the instrumentation so you can quick
 
       * `OTEL_EXPORTER_OTLP_HEADERS=api-key=INSERT_YOUR_NEW_RELIC_LICENSE_KEY`
       * `OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net:4317`
-3. Set these environment variables to name the service, set the service instance ID (which will help light up certain platform features), and enable logs (logging is off by default):
+3. Set the first environment variable below to name the service, then set the second for the service instance ID, which activates certain platform features. Finally, enable logs since logging is off by default:
       * `OTEL_SERVICE_NAME=getting-started-java`
       * `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=INSERT_YOUR_ID_HERE`
         * Replace `INSERT_YOUR_OWN_ID_HERE` with a unique instance id. For example, you could use 1234.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -99,8 +99,10 @@ This is a great option if you want us to do the instrumentation so you can quick
 
       * `OTEL_EXPORTER_OTLP_HEADERS=api-key=INSERT_YOUR_NEW_RELIC_LICENSE_KEY`
       * `OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net:4317`
-3. Set these two environment variables to name the service and enable logs (logging is off by default):
+3. Set these environment variables to name the service, set the service instance ID (which will help light up certain platform features), and enable logs (logging is off by default):
       * `OTEL_SERVICE_NAME=getting-started-java`
+      * `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=INSERT_YOUR_ID_HERE`
+        * Replace `INSERT_YOUR_OWN_ID_HERE` with a unique instance id. For example, you could use 1234.
       * `OTEL_LOGS_EXPORTER=otlp`
 4. In the same `getting-started-guides/java` directory, build and run the application:
       * macOS:
@@ -1005,7 +1007,7 @@ This is a list of the environment variables you should export if you're doing tu
           <td>
             `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=INSERT_YOUR_OWN_ID_HERE`
 
-            * Replace `INSERT_YOUR_OWN_ID_HERE` with a unique instance id. For example, you could use `1234`. For more details, see OpenTelemetry's [Resource Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service).
+            * Replace `INSERT_YOUR_OWN_ID_HERE` with a unique instance id. For example, you could use `1234`. For more details, see OpenTelemetry's [Resource Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#service-experimental).
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
This PR:

1. Adds a step in Tutorial 1 to set the env var for `service.instance.id`
2. Updates a broken external link 