### PR TITLE
chore(infrastructure): Remove uninstall instructions for CLI fleet deployment

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/uninstall-infrastructure-agent.mdx
@@ -131,41 +131,11 @@ To uninstall the infrastructure agent if you used a configuration management too
   <tbody>
     <tr>
       <td>
-        [Ansible](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-ansible)
-      </td>
-
-      <td>
-        Set the [`'agent_state'`](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-ansible#role-config) parameter to `'absent'`
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Chef](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-chef)
-      </td>
-
-      <td>
-        Set the [`'agent_action'`](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-using-chef#attributes) node to `uninstall`
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [AWS Elastic Beanstalk](/docs/infrastructure/install-infrastructure-agent/config-management-tools/install-infrastructure-agent-aws-elastic-beanstalk)
       </td>
 
       <td>
         Remove `newrelic.config` from `.ebextensions`, then deploy.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [Puppet](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-puppet)
-      </td>
-
-      <td>
-        Set the [`'ensure'`](/docs/infrastructure/new-relic-infrastructure/config-management-tools/configure-new-relic-infrastructure-puppet#reference) parameter to `'absent'`
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
With the new fleet deployment solutions for the CLI install, our docs list uninstall methods for infrastructure agents deployed with Ansible, Chef, and Puppet. However, this documentation refers to the previous packages published by the infrastructure team, not the CLI install packages published by Virtuoso.

As the CLI does not support uninstall at this time, and as the docs point to the new A/C/P solutions from Virtuoso, I'm proposing to delete the out-of-date uninstall instructions for the infrastructure agent for A/C/P to prevent confusion in the short term about the use of these products.