### PR TITLE
fix(kafka): clarifying docs

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -838,7 +838,7 @@ The Kafka integration collects the following metrics. Each metric name is prefix
           </td>
 
           <td>
-            In disk Topic size. Only present if COLLECT_TOPIC_SIZE is enabled.
+            In disk Topic size per broker and per topic. Only present if COLLECT_TOPIC_SIZE is enabled.
           </td>
         </tr>
 
@@ -848,7 +848,7 @@ The Kafka integration collects the following metrics. Each metric name is prefix
           </td>
 
           <td>
-            Topic offset. Only present if COLLECT_TOPIC_OFFSET is enabled.
+            Topic offset per broker and per topic. Only present if COLLECT_TOPIC_OFFSET is enabled.
           </td>
         </tr>
       </tbody>
@@ -1265,16 +1265,7 @@ The Kafka integration collects the following metrics. Each metric name is prefix
       </thead>
 
       <tbody>
-        <tr>
-          <td>
-            `topic.diskSize`
-          </td>
-
-          <td>
-            Current topic disk size per broker in bytes.
-          </td>
-        </tr>
-
+        
         <tr>
           <td>
             `topic.partitionsWithNonPreferredLeader`

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -848,7 +848,7 @@ The Kafka integration collects the following metrics. Each metric name is prefix
           </td>
 
           <td>
-            Topic offset per broker and per topic. Only present if COLLECT_TOPIC_OFFSET is enabled.
+            Topic offset per broker and per topic. Only present if `COLLECT_TOPIC_OFFSET` is enabled.
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -838,7 +838,7 @@ The Kafka integration collects the following metrics. Each metric name is prefix
           </td>
 
           <td>
-            In disk Topic size per broker and per topic. Only present if COLLECT_TOPIC_SIZE is enabled.
+            Topic disk size per broker and per topic. Only present if `COLLECT_TOPIC_SIZE` is enabled.
           </td>
         </tr>
 


### PR DESCRIPTION
## Give us some context

Considering a single broker and two topics scraped, we get two samples attached to the same entity:
```
      "entity": {
        "name": "kafka-0.kafka-headless.can-kafka.svc.cluster.local:9092",
        "type": "ka-broker",
[...]
      "metrics": [
        {
          "broker.bytesWrittenToTopicPerSecond": 0,
          "clusterName": "kafka-canary",
          "displayName": "kafka-0.kafka-headless.can-kafka.svc.cluster.local:9092",
          "entityName": "broker:kafka-0.kafka-headless.can-kafka.svc.cluster.local:9092",
          "event_type": "KafkaBrokerSample",
          "topic": "topicA",
          "topic.diskSize": 197053793,
          "topic.offset": 2403128
        },
        {
          "broker.bytesWrittenToTopicPerSecond": 0,
          "clusterName": "kafka-canary",
          "displayName": "kafka-0.kafka-headless.can-kafka.svc.cluster.local:9092",
          "entityName": "broker:kafka-0.kafka-headless.can-kafka.svc.cluster.local:9092",
          "event_type": "KafkaBrokerSample",
          "topic": "__consumer_offsets",
          "topic.diskSize": 23889855,
          "topic.offset": 4808573
        }
```


Moreover, topic.diskSize is not included in the KafkaTopicSample:
```
       {
          "clusterName": "kafka-canary",
          "displayName": "topicA",
          "entityName": "topic:topicA",
          "event_type": "KafkaTopicSample",
          "topic.partitionsWithNonPreferredLeader": 0,
          "topic.respondsToMetadataRequests": 1,
          "topic.underReplicatedPartitions": 0
        }
```