### PR TITLE
feat(style): remove templating from scoping doc

### DIFF
--- a/src/content/docs/agile-handbook/appendices/project-scoping-cheatsheet.mdx
+++ b/src/content/docs/agile-handbook/appendices/project-scoping-cheatsheet.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Project scoping cheatsheet"
-template: basicDoc
 topics:
   - Docs agile handbook
 ---


### PR DESCRIPTION
The project scoping doc has a weird formatting issue with the column widths. I think this has to do with the front matter template so I'm removing that. 

<img width="1718" alt="Screenshot 2023-10-11 at 2 24 15 PM" src="https://github.com/newrelic/docs-website/assets/42678939/43dcc1fe-55f3-4cc7-b5c6-2b6d348fdde0">
