### PR TITLE
fix: Remove irrelevant job timeout error drop down.

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/simple-scripted-or-scripted-api-non-ping-errors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/simple-scripted-or-scripted-api-non-ping-errors.mdx
@@ -393,29 +393,6 @@ Below are some of the most common non-ping monitor error messages.
   </Collapser>
 
   <Collapser
-    id="script-timeout-error-api"
-    title="ScriptTimeoutError"
-  >
-    ### Problem
-
-    This error indicates that the job has reached the Docker container timeout threshold, and the script was terminated.
-
-    ### Solution
-
-    If this is a frequent error, consider breaking up the scripted tasks into a separate scripted monitors.
-
-    If it appears that a specific task is causing the job to wait an unacceptable amount of time, consider changing the method by which you’re accomplishing that task. For example, changing `$browser.findElement(locator: $driver.Locator)` to `$browser.waitForAndFindElement(locator: $driver.Locator [, timeout: number)` would assigned the task its own configurable timeout.
-
-    If you have multiple steps where the `$browser.waitForAndFindElement(locator, timeout)` function is called, ensure that the the sum of the provided timeouts to these steps does not exceed 180 seconds. If you’re finding it difficult to accomplish this, then that is a sign that the monitor should probably be broken up into separate monitor scripts.
-
-    ### Cause
-
-    All synthetic scripted monitors have a non-configurable maximum global 180s timeout for running a script.
-
-    If a script has not completed after 180 seconds, the job is terminated. If this happens consistently it could be a sign of a script that is taking too long to complete, or that the job is waiting an extended period of time while attempting to perform a scripted task.
-  </Collapser>
-
-  <Collapser
     id="unexpected-token-arrow"
     title="SyntaxError: Unexpected token <"
   >

--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/simple-scripted-or-scripted-api-non-ping-errors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/simple-scripted-or-scripted-api-non-ping-errors.mdx
@@ -332,29 +332,6 @@ Below are some of the most common non-ping monitor error messages.
 
 <CollapserGroup>
   <Collapser
-    id="job-timed-out-api"
-    title="JobTimeoutError: Job timed-out after 180s"
-  >
-    ### Problem
-
-    The scripted monitor run reached the 180 second non-configurable timeout threshold, and the run was terminated.
-
-    ### Solution
-
-    If this is a frequent error, consider breaking up the scripted tasks into a separate scripted monitors.
-
-    If it appears that a specific task is causing the job to wait an unacceptable amount of time, consider changing the method by which you’re accomplishing that task. For example, changing `$browser.findElement(locator: $driver.Locator)` to `$browser.waitForAndFindElement(locator: $driver.Locator [, timeout: number)` would assign the task its own configurable timeout.
-
-    If you have multiple steps where the `$browser.waitForAndFindElement(locator, timeout)` function is called, ensure that the the sum of the provided timeouts to these steps does not exceed 180 seconds. If you’re finding it difficult to accomplish this, then that is a sign that the monitor should probably be broken up into separate monitor scripts.
-
-    ### Cause
-
-    All synthetic scripted monitors have a non-configurable maximum global 180s timeout for running a script.
-
-    If a script has not completed after 180 seconds, the job is terminated. If this happens consistently it could be a sign of a script that is taking too long to complete, or that the job is waiting an extended period of time while attempting to perform a scripted task.
-  </Collapser>
-
-  <Collapser
     id="network-error-api"
     title="NetworkError: Monitor produced no traffic"
   >


### PR DESCRIPTION
Ticket: https://issues.newrelic.com/browse/NR-103587

Context:
We got notified by our GTSE team that our documentation for this area is not correct. The reason behind this is that Script API monitors don't use the $browser tag they use the $http tag. In addition, this error isn't something that occurs when trying to run a Script API monitor. It was determined by our team within this slack thread that this section of the docs is misleading, so it is better off being removed: https://newrelic.slack.com/archives/C7HGFUXMH/p1680203101399849.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
An issue with unnecessary documentation.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Our team discussed this with this slack thread: https://newrelic.slack.com/archives/C7HGFUXMH/p1680203101399849, as well as private slack threads, that this error portion here is irrelevant to script api monitors, so it is better off if this section is removed.
* If your issue relates to an existing GitHub issue, please link to it.