### PR TITLE
Set max width of left-justified images

### DIFF
--- a/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
+++ b/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
@@ -108,7 +108,7 @@ Here are some helpful insights you can get by recording changes and leveraging o
 * Faceted findings from a variety of New Relic products including errors inbox, log monitoring, AIOps (issues, incidents, and anomalies), and more show how this change has affected or relates to crucial troubleshooting and analysis records. The insights featured here and how data is filtered will vary by entity type. Hover over titles of page sections to learn more about how we surface meaningful insights here.
 
     <img
-      style={{align: "left"}}
+      style={{ align: 'left';maxWidth: '100%' }}
       title="A screenshot showing some faceted findings since your change"
       alt="A screenshot showing some faceted findings since your change"
       src={trackingFacetedFindings}

--- a/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
+++ b/src/content/docs/change-tracking/change-tracking-view-analyze.mdx
@@ -47,7 +47,7 @@ Before you jump into the details here about how to view and analyze the impact o
 * **Charts in APM and dashboards:** A vertical line with a pinhead appears on time series charts. This marker represents the recorded change, and if you click on the pinhead, you can start drilling into the impact the change had on entity health and quality.
 
     <img
-      style={{align: "left"}}
+      style={{ align: 'left',maxWidth: '100%' }}
       title="A screenshot showing a change in a time series chart"
       alt="A screenshot showing a change in a time series chart"
       src={trackingDeploymentinTimeseriesChart}
@@ -62,7 +62,7 @@ Before you jump into the details here about how to view and analyze the impact o
 * **New Relic Alerts & Detection:** If your change is related to an issue, you'll see it listed in the **Root Cause Analysis** section of the **Issues** page.
 
     <img
-      style={{align: "left"}}
+      style={{ align: 'left',maxWidth: '100%' }}
       title="A screenshot showing the root cause analysis page in the UI"
       alt="A screenshot showing the root cause analysis page in the user interface"
       src={trackingRootCauseAnalysis}
@@ -70,7 +70,7 @@ Before you jump into the details here about how to view and analyze the impact o
 * **Activity stream component:** You can see recorded changes in the activity feed on the right collapsible panel on various pages across the New Relic UI.
 
     <img
-      style={{align: "left"}}
+      style={{ align: 'left',maxWidth: '100%' }}
       title="A screenshot showing the activity stream in the right pane of the UI"
       alt="A screenshot showing the activity stream in the right pane of the UI"
       src={trackingActivityStreamExample}
@@ -108,7 +108,7 @@ Here are some helpful insights you can get by recording changes and leveraging o
 * Faceted findings from a variety of New Relic products including errors inbox, log monitoring, AIOps (issues, incidents, and anomalies), and more show how this change has affected or relates to crucial troubleshooting and analysis records. The insights featured here and how data is filtered will vary by entity type. Hover over titles of page sections to learn more about how we surface meaningful insights here.
 
     <img
-      style={{ align: 'left';maxWidth: '100%' }}
+      style={{ align: 'left',maxWidth: '100%' }}
       title="A screenshot showing some faceted findings since your change"
       alt="A screenshot showing some faceted findings since your change"
       src={trackingFacetedFindings}
@@ -128,7 +128,7 @@ Here are some helpful insights you can get by recording changes and leveraging o
 The **Change details** page hinges on the idea that records and signals generated over a period of time leading up to this change are being compared with a period of equal length following this change. You can change the length of that period using a time picker in the top-right corner. Note that this will affect both time series charts and other UI elements featuring data-driven insights.
 
 <img
-  style={{align: "left"}} 
+  style={{ align: 'left',maxWidth: '100%' }}
   title="A screenshot showing how to change the time window for the comparison"
   alt="A screenshot showing how to change the time window for the comparison"
   src={trackingComparisonWindow}
@@ -143,7 +143,7 @@ The **Change details** page hinges on the idea that records and signals generate
 Next to the timepicker in the top-right corner of the **Change details** page, you will see **compared with** next to a dropdown menu. Using that dropdown menu, you can select another recorded change. This will toggle the page to a comparative mode.
 
 <img
-  style={{align: "left"}}
+  style={{ align: 'left',maxWidth: '100%' }}
   title="A screenshot showing how to compare with another change"
   alt="A screenshot showing how to compare with another change"
   src={trackingCompareDeployments}


### PR DESCRIPTION
This PR adds a maxWidth attribute to left-justified images that are not shrinking when the viewport is decreased.

@homelessbirds the way to test this is to make the browser narrow and just scroll up and down to make sure no images run into the right gutter.