### PR TITLE
Removing FedRAMP restriction from VM Get Started Page

### DIFF
--- a/src/content/docs/vulnerability-management/overview.mdx
+++ b/src/content/docs/vulnerability-management/overview.mdx
@@ -80,7 +80,7 @@ To get started:
 ## Requirements 
 
 - Vulnerability Management is available to full platform users.
-- Vulnerability Management isn't available to HIPAA-enabled accounts or FedRamp-enabled accounts.
+- Vulnerability Management isn't available to HIPAA-enabled accounts.
 
 To report vulnerability data using an APM agent, [ensure it supports vulnerability reporting](/docs/vulnerability-management/integrations/intro/#apm-agents).
 

--- a/src/content/docs/vulnerability-management/overview.mdx
+++ b/src/content/docs/vulnerability-management/overview.mdx
@@ -80,7 +80,6 @@ To get started:
 ## Requirements 
 
 - Vulnerability Management is available to full platform users.
-- Vulnerability Management isn't available to HIPAA-enabled accounts.
 
 To report vulnerability data using an APM agent, [ensure it supports vulnerability reporting](/docs/vulnerability-management/integrations/intro/#apm-agents).
 


### PR DESCRIPTION
My understanding is FedRamp is now authorized  for VM as of Oct 1, 2023 so removing the FedRAMP restriction from this page now.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.