### PR TITLE
fix: Fix Arguments to Python error_group_callback

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api.mdx
@@ -14,7 +14,7 @@ redirects:
 ## Syntax [#syntax]
 
 ```py
-newrelic.agent.set_error_group_callback(callback_function(exc))
+newrelic.agent.set_error_group_callback(callback_function(exception, transaction_data))
 ```
 
 This method allows error groups within the errors inbox to be set to a specific identifier (or "fingerprint"). 
@@ -97,6 +97,17 @@ This endpoint takes in a single input, a callback, which is used to register err
         Required. This would be the runtime exception that triggered the agent's [`notice_error` API](/docs/agents/python-agent/python-agent-api/noticeerror-python-agent-api).
       </td>
     </tr>
+    <tr>
+      <td>
+        `transaction_data`
+
+        _dictionary_
+      </td>
+
+      <td>
+        Required. A dictionary of transaction data captured by the Python agent.
+      </td>
+    </tr>
 
   </tbody>
 </table>
@@ -114,8 +125,8 @@ When unsuccessful, the API will not add `error.group.name` as an agent attribute
 An example of using `set_error_group_callback`:
 
 ```py
-def customer_callback(exc):
-    if isinstance(exc,ValueError):
+def customer_callback(exc, data):
+    if isinstance(exc, ValueError):
         return "group1"
 
 


### PR DESCRIPTION
## Give us some context

* Fixes documentation around Python agent's error_group_callback to reflect the real arguments accepted.