### PR TITLE
chore: updated 11.0.0 release notes for Node.js agent, we missed a line item during release

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-11-0-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-11-0-0.mdx
@@ -19,6 +19,8 @@ features: ["Added support for Node 20","Removed support for Node 14","Updated th
 * Updated agent to use require-in-the-middle to register CommonJS instrumentation. You can no longer use an onResolved hook to register custom instrumentation.
 * Updated the default context manager to be AsyncLocalContextManager.
 * Renamed `shim.handleCATHeaders` to `shim.handleMqTracingHeaders`.
+* Updated agent to only run in the main thread. This is because running in a worker thread does not completely function out of the box. This will reduce the overhead for customers that are naively trying to load this into worker threads.
+
 
 #### Features
 


### PR DESCRIPTION
We missed a changelog entry for 11.0.0. This updates it accordingly.
