### PR TITLE
docs: Add Confluent.Kafka to the .NET Agent compatibility list.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -672,7 +672,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </td>
 
           <td>
-            * Produce and Consume on Topics.
+            * Produce and consume on topics.
 
             * The following methods are instrumented:
               * `IProducer.Produce`

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -668,6 +668,25 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
       <tbody>
         <tr>
           <td>
+            Confluent.Kafka
+          </td>
+
+          <td>
+            * Produce and Consume on Topics.
+
+            * The following methods are instrumented:
+              * `IProducer.Produce`
+              * `IProducer.ProduceAsync`
+              * `IConsumer.Consume`
+
+            * Minimum supported version: 1.4.0
+
+            * Verified compatible versions: 1.4.0, 2.2.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             NServiceBus
           </td>
 
@@ -693,7 +712,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 * The following methods are instrumented:
 	* `IModel.BasicGet`
 	* `IModel.BasicPublish`
-	* `IModel.BasicComsume`
+	* `IModel.BasicConsume`
 	* `IModel.QueuePurge`
 	* `EventingBasicConsumer.HandleBasicDeliver`
 	

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -905,6 +905,25 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
       <tbody>
         <tr>
           <td>
+            Confluent.Kafka
+          </td>
+
+          <td>
+            * Produce and Consume on Topics.
+
+            * The following methods are instrumented:
+              * `IProducer.Produce`
+              * `IProducer.ProduceAsync`
+              * `IConsumer.Consume`
+
+            * Minimum supported version: 1.4.0
+
+            * Verified compatible versions: 1.4.0, 2.2.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             MSMQ
           </td>
 
@@ -940,7 +959,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 * The following methods are instrumented:
 	* `IModel.BasicGet`
 	* `IModel.BasicPublish`
-	* `IModel.BasicComsume`
+	* `IModel.BasicConsume`
 	* `IModel.QueuePurge`
 	* `EventingBasicConsumer.HandleBasicDeliver`
 	

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -909,7 +909,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </td>
 
           <td>
-            * Produce and Consume on Topics.
+            * Produce and consume on topics.
 
             * The following methods are instrumented:
               * `IProducer.Produce`


### PR DESCRIPTION
## Give us some context

Adds `Confluent.Kafka` to the list of messaging systems supported by the .NET Agent. 
