### PR TITLE
feat: Added infra agent status endpoint settings

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5677,9 +5677,9 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
     title="status_server_enabled"
   >
     Enables the status server on the agent providing local health information.
-    Available endpoints:
+    The available endpoints are:
     
-    Main status endpoint example (no errors):
+    Main status endpoint example (with no errors):
     ```
       curl http://localhost:8003/v1/status
 
@@ -5760,7 +5760,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
         }
       }
     ```
-    Similar as the main status endpoint but filtering those with errors only.
+    This is similar to the main status endpoint but filtering those with errors only.
 
     Entity endpoint example:
     ```

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5667,6 +5667,178 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
   </Collapser>
 </CollapserGroup>
 
+## Status endpoint variables
+
+<CollapserGroup>
+
+  <Collapser
+    className="freq-link"
+    id="status-server-enabled"
+    title="status_server_enabled"
+  >
+    Enables the status server on the agent providing local health information.
+    Available endpoints:
+    - Main status:
+    ```
+      curl http://localhost:8003/v1/status
+
+      {
+        "checks": {
+          "endpoints": [
+            {
+              "url": "https://infrastructure-command-api.newrelic.com/agent_commands/v1/commands",
+              "reachable": true
+            },
+            {
+              "url": "https://infra-api.newrelic.com/infra/v2/metrics",
+              "reachable": true
+            },
+            {
+              "url": "https://identity-api.newrelic.com/identity/v1",
+              "reachable": true
+            },
+            {
+              "url": "https://infra-api.newrelic.com/inventory",
+              "reachable": true
+            }
+          ]
+        },
+        "config": {
+          "reachability_timeout": "10s"
+        }
+      }
+    ```
+
+    - Errors
+    ```
+      curl http://localhost:18003/v1/status/errors
+
+      {
+
+      }
+    ```
+
+    - Entity 
+    ```
+      {
+        "guid":"MMMMNjI0NjR8SU5GUkF8TkF8ODIwMDg3MDc0ODE0MTUwNTMy",
+        "key":"your-host-name"
+      }
+    ```
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `status_server_enabled`
+          </td>
+
+          <td>
+            `NRIA_STATUS_SERVER_ENABLED`
+          </td>
+
+          <td>
+            boolean
+          </td>
+
+          <td>
+            `false`
+          </td>
+
+          <td>
+            1.19.0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="status-server-port"
+    title="status_server_port"
+  >
+
+  Defines the port for the status server endpoint.
+
+  <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `status_server_port`
+          </td>
+
+          <td>
+            `NRIA_STATUS_SERVER_PORT`
+          </td>
+
+          <td>
+            integer
+          </td>
+
+          <td>
+            8003
+          </td>
+
+          <td>
+            1.19.0
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </Collapser>
+
+</CollapserGroup>
+
 ## Windows variables
 
 <CollapserGroup>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5678,7 +5678,8 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
   >
     Enables the status server on the agent providing local health information.
     Available endpoints:
-    - Main status:
+    
+    Main status endpoint example (no errors):
     ```
       curl http://localhost:8003/v1/status
 
@@ -5709,22 +5710,68 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
       }
     ```
 
-    - Errors
+    Main status endpoint (with errors):
+
+    ```
+    {
+      "checks": {
+        "endpoints": [
+          {
+            "url": "https://staging-infra-api.newrelic.com/infra/v2/metrics",
+            "reachable": false,
+            "error": "endpoint check timeout exceeded"
+          },
+          {
+            "url": "https://infra-api.newrelic.com/infra/v2/metrics",
+            "reachable": true
+          },
+          {
+            "url": "https://identity-api.newrelic.com/identity/v1",
+            "reachable": true
+          },
+          {
+            "url": "https://infra-api.newrelic.com/inventory",
+            "reachable": true
+          }
+        ]
+      },
+      "config": {
+        "reachability_timeout": "10s"
+      }
+    }
+    ```
+
+    Errors endpoint example:
     ```
       curl http://localhost:18003/v1/status/errors
 
       {
-
+        "checks": {
+          "endpoints": [
+            {
+              "url": "https://staging-infra-api.newrelic.com/infra/v2/metrics",
+              "reachable": false,
+              "error": "endpoint check timeout exceeded"
+            }
+          ]
+        },
+        "config": {
+          "reachability_timeout": "10s"
+        }
       }
     ```
+    Similar as the main status endpoint but filtering those with errors only.
 
-    - Entity 
+    Entity endpoint example:
     ```
       {
         "guid":"MMMMNjI0NjR8SU5GUkF8TkF8ODIwMDg3MDc0ODE0MTUwNTMy",
         "key":"your-host-name"
       }
     ```
+    Returns information about the agent/host entity. A response status code *204* ("No Content") will be returned when the agent still has no information
+about the agent/host entity. Therefore, it may take several requests to until the agent provides entity data. 
+
     <table>
       <thead>
         <tr>


### PR DESCRIPTION
## Give us some context

* The infrastructure agent provides an optional setting to enable a status / health check point. 