### PR TITLE
fix: Node agent compatibility typo

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -31,7 +31,7 @@ The Node.js agent is compatible with the following operating systems:
 * SmartOS
 * macOS 10.7 and higher
 * Windows Server 2008 and higher
-The following are proposed time ranges. The actual release date may vary.
+
 </Collapser>
 <Collapser
     id="host"


### PR DESCRIPTION
## Give us some context

Line 34, "The following are proposed time ranges. The actual release date may vary.", didn't belong there. It looked like a copy/paste error. The line is repeated further down on line 61 and looks to make sense in that location.
