### PR TITLE
feat: Add support for boolean values in setCustomAttribute api

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/setcustomattribute.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setcustomattribute.mdx
@@ -20,7 +20,7 @@ redirects:
 ## Syntax
 
 ```js
-newrelic.setCustomAttribute(name: string, value: string|number|null[, persist: boolean])
+newrelic.setCustomAttribute(name: string, value: string|number|boolean|null[, persist: boolean])
 ```
 
 Adds a user-defined attribute name and value to subsequent events on the page.
@@ -105,11 +105,11 @@ Be aware that persisted attributes have precedence over `info.jsAttributes` keys
       <td>
         `value`
 
-        _string_ OR _integer_ OR _null_
+        _string_ OR _integer_ OR _boolean_ OR _null_
       </td>
 
       <td>
-        Required. Value of the attribute. Appears as the value in the named attribute column in the `PageView` event. It will appear as a column in the `PageAction` event if you are using it. Custom attribute values cannot be complex objects, only simple types such as Strings and Integers.
+        Required. Value of the attribute. Appears as the value in the named attribute column in the `PageView` event. It will appear as a column in the `PageAction` event if you are using it. Custom attribute values cannot be complex objects, only simple types such as Strings, Integers and Booleans.
 
         Passing a `null` value unsets any existing attribute of the same name.
 

--- a/src/content/docs/browser/new-relic-browser/browser-apis/setcustomattribute.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setcustomattribute.mdx
@@ -29,6 +29,7 @@ Adds a user-defined attribute name and value to subsequent events on the page.
 
 * Browser Lite, Pro, or Pro+SPA agent (v593 or higher)
   * For `persist` parameter or `null` value support, agent version 1.230.0 or higher is required.
+  * For `boolean` value support, agent version 1.245.0 or higher is required.
 * If you're using npm to install the browser agent, you must enable at least one feature when instantiating the `BrowserAgent` class. For example, add the following in the`features` array:
 
   ```js


### PR DESCRIPTION

## Give us some context
This PR updates the browser agent setCustomAttribute() API docs to indicate support of allowing boolean-type data as an accepted value.