### PR TITLE
feat: update AJAX docs to describe new GQL properties

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls.mdx
@@ -50,6 +50,7 @@ Here are some troubleshooting tips for identifying performance problems with you
         Total [time percentages](#time-percentage-example), throughput requests per minute (rpm), and average data transfer rates per request can help identify timing problems.
 
         * Look for large spikes in the **AJAX** summary page's **Average data transfer per request** chart.
+        * Analyze the trends of your data using the **Group By** drop down to evaluate your AJAX performance by **Request URL**, **GraphQL Operation Names** and many other fields.
         * From the individual call's **AJAX performance** tab, look for correlations between high callback time values and data transfer rates.
       </td>
     </tr>

--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/ajax-page-identify-time-consuming-calls.mdx
@@ -50,7 +50,7 @@ Here are some troubleshooting tips for identifying performance problems with you
         Total [time percentages](#time-percentage-example), throughput requests per minute (rpm), and average data transfer rates per request can help identify timing problems.
 
         * Look for large spikes in the **AJAX** summary page's **Average data transfer per request** chart.
-        * Analyze the trends of your data using the **Group By** drop down to evaluate your AJAX performance by **Request URL**, **GraphQL Operation Names** and many other fields.
+        * Analyze the trends of your data using the **Group By** drop-down to evaluate your AJAX performance by request URL, GraphQL operation names, and many other fields.
         * From the individual call's **AJAX performance** tab, look for correlations between high callback time values and data transfer rates.
       </td>
     </tr>

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection.mdx
@@ -1,0 +1,85 @@
+---
+title: GraphQL metadata is not found on AjaxRequests
+type: troubleshooting
+tags:
+  - Browser
+  - Browser monitoring
+  - Troubleshooting
+metaDescription: Troubleshooting for not seeing GraphQL metadata on AjaxRequest events for your browser app.
+redirects:
+  - /docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection
+---
+
+## Problem
+
+You are seeing AjaxRequest events, but they do not contain the following GraphQL metadata properties for your browser app.
+* [Operation Framework](https://docs.newrelic.com/attribute-dictionary/?event=AjaxRequest&attribute=operationFramework)
+* [Operation Name](https://docs.newrelic.com/attribute-dictionary/?event=AjaxRequest&attribute=operationName)
+* [Operation Type](https://docs.newrelic.com/attribute-dictionary/?event=AjaxRequest&attribute=operationType)
+
+## Cause
+
+The Browser Agent analyzes each AJAX request body and query and attempts to identify common GraphQL patterns. When detecting these patterns, it will append extra metadata properties to the outgoing AjaxRequest event being harvested. If the agent fails to detect these patterns, it will not add the extra event properties.
+
+## Solution
+
+If your application is [instrumented with the latest version of browser monitoring](/docs/browser/new-relic-browser/installation-configuration/troubleshooting-browser-monitoring-installation) and is collecting data for all [Pro features](/docs/browser/new-relic-browser/browser-pro-features), please ensure the following:
+
+
+### Verify the AJAX requests are being sent using standard GraphQL formatting
+Use your browser's dev console to verify your page's GraphQL requests are sending with standard formatting. Please see [GraphQL's Official Documentation](https://graphql.org/learn/serving-over-http/#post-request) for a thorough description of these standards.
+
+<CollapserGroup>
+  <Collapser
+      id="post"
+      title="GraphQL POST Requests"
+    >
+    For POST GraphQL queries, mutations and subscriptions, the Browser Agent parses the request body for data formatted as such:
+    ```js
+      {
+        "query": ...,
+        "operationName": ...,
+        "variables": ... 
+      }
+    ```
+  </Collapser>
+  <Collapser
+        id="get"
+        title="GraphQL GET Requests"
+    >
+    For GET GraphQL queries, the Browser Agent parses the request query parameters for data formatted as such:
+    ```js
+      ?query=...&operationName=...&variables=...
+    ```
+  </Collapser>
+  <Collapser
+        id="batch"
+        title="GraphQL Batched POST Requests"
+    >
+    For batched GraphQL operations, the Browser Agent parses the request body for data data formatted as such:
+    ```js
+      [
+        {
+          "query": ...,
+          "operationName": ...,
+          "variables": ... 
+        },
+        {
+          "query": ...,
+          "operationName": ...,
+          "variables": ... 
+        },
+        ...etc
+      ]
+    ```
+  </Collapser>
+</CollapserGroup>
+
+The agent uses the contents of this payload to detect GraphQL patterns and build the metadata properties. Any body or query missing the `query` section will not be processed as GraphQL data at all.
+
+If you see your GraphQL payloads not following this pattern, the agent will not be able to reliably detect the GraphQL metadata.
+  
+
+If any of these troubleshooting steps fails or you are still having issues with missing AJAX data properties, get support at [support.newrelic.com](https://support.newrelic.com).
+
+

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection.mdx
@@ -19,7 +19,7 @@ You are seeing AjaxRequest events, but they do not contain the following GraphQL
 
 ## Cause
 
-The Browser Agent analyzes each AJAX request body and query and attempts to identify common GraphQL patterns. When detecting these patterns, it will append extra metadata properties to the outgoing AjaxRequest event being harvested. If the agent fails to detect these patterns, it will not add the extra event properties.
+The browser agent analyzes each AJAX request body and query and attempts to identify common GraphQL patterns. When detecting these patterns, it will append extra metadata properties to the outgoing AjaxRequest event being harvested. If the agent fails to detect these patterns, it will not add the extra event properties.
 
 ## Solution
 
@@ -32,7 +32,7 @@ To verify the format of your AJAX request, use your browser's dev console to vie
       id="post"
       title="GraphQL POST Requests"
     >
-    For POST GraphQL queries, mutations and subscriptions, the Browser Agent parses the request body for data formatted as such:
+    For POST GraphQL queries, mutations, and subscriptions, the browser agent parses the request body for data formatted as such:
     ```js
       {
         "query": ...,
@@ -45,7 +45,7 @@ To verify the format of your AJAX request, use your browser's dev console to vie
         id="get"
         title="GraphQL GET Requests"
     >
-    For GET GraphQL queries, the Browser Agent parses the request query parameters for data formatted as such:
+    For GET GraphQL queries, the browser agent parses the request query parameters for data formatted as such:
     ```js
       ?query=...&operationName=...&variables=...
     ```
@@ -54,7 +54,7 @@ To verify the format of your AJAX request, use your browser's dev console to vie
         id="batch"
         title="GraphQL Batched POST Requests"
     >
-    For batched GraphQL operations, the Browser Agent parses the request body for data data formatted as such:
+    For batched GraphQL operations, the browser agent parses the request body for data formatted as such:
     ```js
       [
         {
@@ -75,9 +75,8 @@ To verify the format of your AJAX request, use your browser's dev console to vie
 
 See [GraphQL's documentation](https://graphql.org/learn/serving-over-http/#post-request) for a thorough description of these standards.
 
-The agent uses the contents of this payload to detect GraphQL patterns and build the metadata properties. Any body or query missing the `query` section will not be processed as GraphQL data at all.
+The agent uses the contents of this payload to detect GraphQL patterns and build the metadata properties. Any request body or query missing the `query` section will not be processed as GraphQL data at all.
 
 If you see your GraphQL payloads not following this pattern, the agent will not be able to reliably detect the GraphQL metadata.
-  
 
-If any of these troubleshooting steps fails or you are still having issues with missing AJAX data properties, get support at [support.newrelic.com](https://support.newrelic.com).
+If any of these troubleshooting steps fail or you are still having issues with missing AJAX data properties, get support at [support.newrelic.com](https://support.newrelic.com).

--- a/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection.mdx
+++ b/src/content/docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection.mdx
@@ -23,11 +23,9 @@ The Browser Agent analyzes each AJAX request body and query and attempts to iden
 
 ## Solution
 
-If your application is [instrumented with the latest version of browser monitoring](/docs/browser/new-relic-browser/installation-configuration/troubleshooting-browser-monitoring-installation) and is collecting data for all [Pro features](/docs/browser/new-relic-browser/browser-pro-features), please ensure the following:
+If your application is [instrumented with the latest version of browser monitoring](/docs/browser/new-relic-browser/installation-configuration/troubleshooting-browser-monitoring-installation) and is collecting data for all [Pro features](/docs/browser/new-relic-browser/browser-pro-features), make sure your AJAX requests are being sent using standard GraphQL formatting.
 
-
-### Verify the AJAX requests are being sent using standard GraphQL formatting
-Use your browser's dev console to verify your page's GraphQL requests are sending with standard formatting. Please see [GraphQL's Official Documentation](https://graphql.org/learn/serving-over-http/#post-request) for a thorough description of these standards.
+To verify the format of your AJAX request, use your browser's dev console to view the requests and compare them to the syntax below.
 
 <CollapserGroup>
   <Collapser
@@ -75,11 +73,11 @@ Use your browser's dev console to verify your page's GraphQL requests are sendin
   </Collapser>
 </CollapserGroup>
 
+See [GraphQL's documentation](https://graphql.org/learn/serving-over-http/#post-request) for a thorough description of these standards.
+
 The agent uses the contents of this payload to detect GraphQL patterns and build the metadata properties. Any body or query missing the `query` section will not be processed as GraphQL data at all.
 
 If you see your GraphQL payloads not following this pattern, the agent will not be able to reliably detect the GraphQL metadata.
   
 
 If any of these troubleshooting steps fails or you are still having issues with missing AJAX data properties, get support at [support.newrelic.com](https://support.newrelic.com).
-
-

--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -252,6 +252,30 @@
         }
       },
       {
+        "definition": "<p>The AJAX processing framework used to compile the request. This attribute is currently only seen in <code>AjaxRequest</code> data that detected standard <a href=\"https://graphql.org\">GraphQL</code> payloads. Example: <code>GraphQL</code>.</p>\n",
+        "events": [
+          "AjaxRequest"
+        ],
+        "name": "operationFramework",
+        "units": null
+      },
+      {
+        "definition": "<p>The operation name detected while processing AJAX requests compiled by processing framework. This attribute is currently only seen in <code>AjaxRequest</code> data that detected standard <a href=\"https://graphql.org\">GraphQL</code> payloads. Example: <code>MyGqlQuery</code>.</p>\n",
+        "events": [
+          "AjaxRequest"
+        ],
+        "name": "operationName",
+        "units": null
+      },
+      {
+        "definition": "<p>The operation type detected while processing AJAX requests compiled by processing framework. This attribute is currently only seen in <code>AjaxRequest</code> data that detected standard <a href=\"https://graphql.org\">GraphQL</code> payloads. Example: <code>query</code>.</p>\n",
+        "events": [
+          "AjaxRequest"
+        ],
+        "name": "operationType",
+        "units": null
+      },
+      {
         "definition": "<p>The URL of the page that was loaded for the PageView, for example: <a href=\"http://www.newrelic.com\">http://www.newrelic.com</a>. This URL does not include query parameters.</p>\n",
         "events": [
           "AjaxRequest",

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -170,6 +170,8 @@ pages:
         path: /docs/browser/new-relic-browser/troubleshooting/browser-data-doesnt-match-other-analytics-tools
       - title: Google Indexing 404 Paths
         path: /docs/browser/new-relic-browser/troubleshooting/google-indexing-unknown-paths
+      - title: GraphQL metadata is not found on AjaxRequests
+        path: /docs/browser/new-relic-browser/troubleshooting/troubleshoot-graphql-collection
       - title: HAR data collection
         path: /docs/browser/new-relic-browser/troubleshooting/get-browser-side-troubleshooting-details-har-file
       - title: Installation


### PR DESCRIPTION

## Give us some context
This PR updates a few AjaxRequest related docs to describe GraphQL metadata that has recently been introduced by the Browser Agent in [v1.245.0](https://github.com/newrelic/newrelic-browser-agent/releases/tag/v1.245.0)