### PR TITLE
feat: release 3.27.0 go agent:

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-27-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-27-0.mdx
@@ -1,0 +1,30 @@
+---
+subject: Go agent
+releaseDate: '2023-10-19'
+version: 3.27.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.26.0'
+features: ["Automatic Instrumentation for RabbitMQ", "Support for Docker in cgroupv2"]
+bugs: []
+security: []
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+
+## 3.27.0
+# Added
+  * Added Support for getting Container ID's from cgroup v2 docker containers
+  * A new instrumentation package for RabbitMQ with distributed tracing support: nramqp
+
+ ### Fixed
+  * Unit tests repairs and improvements
+  * Removed deprecated V2 code from the repository. The support timeframe for this code has expired and is no longer recommended for use.
+  * Bumped github.com/graphql-go/graphql from 0.7.9 to 0.8.1
+
+### Support statement
+ We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+
+ See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-27-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-27-0.mdx
@@ -14,7 +14,7 @@ We recommend updating to the latest agent version as soon as it's available. If 
 
 
 ## 3.27.0
-# Added
+### Added
   * Added Support for getting Container ID's from cgroup v2 docker containers
   * A new instrumentation package for RabbitMQ with distributed tracing support: nramqp
 


### PR DESCRIPTION
Release change log for go agent version 3.27.0. Expected release EOD today.