### PR TITLE
chore: Update ruby-agent-attributes.mdx

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/attributes/ruby-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/attributes/ruby-agent-attributes.mdx
@@ -50,14 +50,12 @@ The following table lists the attributes that can be automatically captured by t
     id="requestParameters"
     title="request.parameters.*"
   >
-    The HTTP request parameters, associated with the transaction. Available for Rails, Sinatra, and Grape applications only. Defaults:
+    The HTTP request parameters are associated with the transaction. Available for Rails, Sinatra, Roda and Grape applications only. Defaults:
 
     * Transaction traces: Disabled
     * Error collector (traced errors): Disabled
     * Transaction events: Disabled
     * Page views (browser monitoring): Disabled
-
-      **Note:** The `capture_params` property is deprecated. However, if set to `true`, it will enable request parameters for transaction traces and traced errors.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
* The `capture_params` configuration option is not deprecated
* Roda instrumentation will capture params

cc @fallwith, @hannahramadan, @tannalynn 