### PR TITLE
[fix] Update setup-prometheus-agent.mdx

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent.mdx
@@ -103,7 +103,7 @@ If you need to scrape all the targets annotated with `prometheus.io/scrape: "tru
 
 Kubernetes jobs discover targets and scrape targets according to the `target_discovery` configuration. If inside the `target_discovery` configuration, you set `pod` and `endpoints` toggles to `true`, Prometheus will create rules to discover any pod or endpoint in the cluster having an exposed port.
 
-Use the `target_discovery.filter` configuration parameter to filter in the targets that Prometheus scrapes. Use the `label` and `annotation` labels to filter by current conditions, and the `AND` operator for all conditions.
+Use the `target_discovery.filter` configuration parameter to filter in the targets that Prometheus scrapes. Use the `label` and `annotations` labels to filter by current conditions, and the `AND` operator for all conditions.
 
 The following example only scrapes `Pods` and `Endpoints` with the `newrelic.io/scrape: "true"` annotation, and the `k8s.io/app` label with `postgres` or `mysql` as values. For the endpoints, the annotation must be present in the service related to it. The regexes are anchored, that is, if you configure `scrape: 'true'`, Prometheus evaluates `true` as `^true$`. To avoid that, use `.*true.*` so it also matches `a-true-example`.
 
@@ -117,7 +117,7 @@ kubernetes:
       pod: true
       endpoints: true
       filter:
-        annotation:
+        annotations:
           # <string>: <regex>
           newrelic.io/scrape: 'true'
         label:
@@ -190,7 +190,7 @@ kubernetes:
     target_discovery:
       pod: true
       filter:
-        annotation:
+        annotations:
           newrelic.io/scrape: 'true'
 
   - job_name_prefix: slow-targets-with-60s-interval
@@ -198,7 +198,7 @@ kubernetes:
     target_discovery:
       pod: true
       filter:
-        annotation:
+        annotations:
           newrelic.io/scrape_slow: 'true'
 ```
 
@@ -331,7 +331,7 @@ kubernetes:
     target_discovery:
       pod: true
       filter:
-        annotation:
+        annotations:
           newrelic.io/scrape: 'true'
   - job_name_prefix: bearer-token
     target_discovery:


### PR DESCRIPTION
The Prometheus Agent docs have `annotation` in many places where it should read `annotations` in the configuration.  This PR updates the examples to a working configuration.

Tested and confirmed that filtering requires the configuration `annotations` and will not work with `annotation`.

Please also see the Prometheus agent [chart values file](https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/charts/newrelic-prometheus-agent/values.yaml) which documents the `annotations` usage.