### PR TITLE
Update the python opentelemetry example to use current environment variable values

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
@@ -747,14 +747,14 @@ This is a list of the environment variables you should export if you're doing tu
         </tr>
         <tr>
           <td>
-            OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=DELTA
+            OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=Delta
 
             * New Relic supports metrics in delta temporality instead of the default of cumulative.
           </td>
         </tr>
         <tr>
           <td>
-            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=EXPONENTIAL_BUCKET_HISTOGRAM
+            OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=base2_exponential_bucket_histogram
 
             * (Recommended) Histogram aggregation: Use exponential histogram instead of default explicit bucket histogram for better data compression.
           </td>


### PR DESCRIPTION
The environment variables for the metrics exporter as defined [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md#opentelemetry-metrics-exporter---otlp) now use new values for temporality preference and histogram aggregation. This PR updates the Python OpenTelemetry tutorial to use the new values but keep the intended behaviour.