### PR TITLE
feat: add obfuscation documentation

### DIFF
--- a/src/content/docs/browser/new-relic-browser/configuration/browser-app-settings-page.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/browser-app-settings-page.mdx
@@ -12,6 +12,7 @@ On the **Application settings** page, you can make these configurations to your 
 * [Filter domains and sub-domains](/docs/browser/new-relic-browser/configuration/monitor-or-block-specific-domains-subdomains/)
 * [Filter AJAX requests](/docs/browser/new-relic-browser/configuration/filter-ajax-request-events/)
 * [Group data by URL patterns](/docs/browser/new-relic-browser/configuration/group-browser-metrics-urls/)
+* [Obfuscate Data](/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data/)
 * [Rename browser apps](/docs/browser/new-relic-browser/configuration/rename-browser-apps/)
 * [Disable browser monitoring](/docs/browser/new-relic-browser/installation/disable-browser-monitoring/)
 * [Delete a browser app](/docs/apm/new-relic-apm/maintenance/remove-applications-new-relic/#remove)

--- a/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
@@ -3,7 +3,7 @@ title: Obfuscate Browser Agent Data
 tags:
   - Browser monitoring
   - Obfuscation
-metaDescription: "The agent can be configured to obfuscate the data it sends."
+metaDescription: "You can configure the browser agent to obfuscate the data it sends."
 ---
 
 <Callout variant="important">

--- a/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
@@ -10,7 +10,7 @@ metaDescription: "You can configure the browser agent to obfuscate the data it s
 This feature is currently available for those using the copy/paste or NPM browser installation methods. There is currently no UI or NerdGraph configuration options available. We are continuing to work on improving access to these and other configuration options.
 </Callout>
 
-While New Relic's recommendation is to abstain from utilizing sensitive information in the public structure of your application, we also understand that it is not always feasible to remove all traces of said information. The browser agent can be configured to selectively obfuscate data in every payload it sends.  This can be useful if your application uses sentitive data in places that the agent captures, such as navigation paths, error messages, and more.
+While New Relic's recommendation is to avoid using sensitive information in the public structure of your application, we also understand that this is not always possible. You can configure the browser agent to selectively obfuscate data in every payload it sends.  This can be useful if your application uses sensitive data in places that the agent captures, such as navigation paths, error messages, and more.
 
 ## How it works [#how-it-works]
 

--- a/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
@@ -16,13 +16,13 @@ While New Relic's recommendation is to avoid using sensitive information in the 
 
 As of browser agent [version 1216](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes) and higher, obfuscation rules can be applied to outgoing harvest payloads. 
 
-To set up these rules, you'll need to configure the following browser agent properties: 
-* `init.obfuscate` contains an array of selectors and replacements which will be utilized to modify each harvest before sending.
-  * If you’re using the copy/paste installation method, you’ll need to manually edit your JavaScript snippet and set the `obfuscate` array to contain your obfuscation conditions.
+To set up these rules, you'll need to configure the following browser agent property: 
+* The property `init.obfuscate` contains an array of selectors and replacements which will be used to modify each harvest before sending.
+  * Since obfuscation currently requires you to use the copy/paste or NPM installation methods, you’ll need to manually edit your JavaScript configuration section and set the `obfuscate` array to contain your obfuscation conditions.
 
 ### Recommendations
 
-When configuring these properties, we recommend the following:
+When configuring this property, we recommend the following:
 
 * Use intentional regex patterns to obfuscate only what needs obfuscation.
   - Needlessly obfuscating can have side-effects such as less granularity when grouping data and less ability to digest what the agent captured.

--- a/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
@@ -25,7 +25,7 @@ To set up these rules, you'll need to configure the following browser agent prop
 When configuring these properties, we recommend the following:
 
 * Use intentional regex patterns to obfuscate only what needs obfuscation.
-  - Needlessly obfuscating can have side-effects such as less granularity when grouping data and less ability to digest what the agent captured
+  - Needlessly obfuscating can have side-effects such as less granularity when grouping data and less ability to digest what the agent captured.
 * Replace your sensitive data with neutral and generic terms that also indicate what data has been redacted.
   - Example: `/account-id/g` --> `ACCOUNT_ID`
 

--- a/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data.mdx
@@ -1,0 +1,95 @@
+---
+title: Obfuscate Browser Agent Data
+tags:
+  - Browser monitoring
+  - Obfuscation
+metaDescription: "The agent can be configured to obfuscate the data it sends."
+---
+
+<Callout variant="important">
+This feature is currently available for those using the copy/paste or NPM browser installation methods. There is currently no UI or NerdGraph configuration options available. We are continuing to work on improving access to these and other configuration options.
+</Callout>
+
+While New Relic's recommendation is to abstain from utilizing sensitive information in the public structure of your application, we also understand that it is not always feasible to remove all traces of said information. The browser agent can be configured to selectively obfuscate data in every payload it sends.  This can be useful if your application uses sentitive data in places that the agent captures, such as navigation paths, error messages, and more.
+
+## How it works [#how-it-works]
+
+As of browser agent [version 1216](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes) and higher, obfuscation rules can be applied to outgoing harvest payloads. 
+
+To set up these rules, you'll need to configure the following browser agent properties: 
+* `init.obfuscate` contains an array of selectors and replacements which will be utilized to modify each harvest before sending.
+  * If you’re using the copy/paste installation method, you’ll need to manually edit your JavaScript snippet and set the `obfuscate` array to contain your obfuscation conditions.
+
+### Recommendations
+
+When configuring these properties, we recommend the following:
+
+* Use intentional regex patterns to obfuscate only what needs obfuscation.
+  - Needlessly obfuscating can have side-effects such as less granularity when grouping data and less ability to digest what the agent captured
+* Replace your sensitive data with neutral and generic terms that also indicate what data has been redacted.
+  - Example: `/account-id/g` --> `ACCOUNT_ID`
+
+### Copy/paste installation [#copy-paste]
+
+If you're using the copy/paste installation method, add the following configuration to your browser JavaScript configurations before the agent loader:
+
+```js
+window.NREUM.init = {
+    ...<other init properties>...,
+    obfuscate: [
+      {
+        regex: <RegExp | string>
+        replacement: <string>
+      },
+      ...<other obfuscation rules>...
+    ]
+}
+```
+
+
+### NPM installation [#npm]
+
+If you’re using the NPM browser installation method, add the following configuration when initializing the browser agent:
+
+```js
+new BrowserAgent({ 
+  init: {
+    ...<other init properties>...,
+    obfuscate: [
+      {
+        regex: <RegExp | string>
+        replacement: <string>
+      },
+      ...<other obfuscation rules>...
+    ]
+  }
+})
+```
+
+### Examples
+
+```js
+window.NREUM.init = {
+    ...<other init properties>...,
+    obfuscate: [
+      {
+        regex: /user-id/g,
+        replacement: 'USER_ID'
+      },
+    ]
+}
+```
+
+```js
+new BrowserAgent({ 
+  init: {
+    ...<other init properties>...,
+    obfuscate: [
+      {
+        regex: /account-id/g,
+        replacement: 'ACCOUNT_ID'
+      },
+    ]
+  }
+})
+```

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -40,6 +40,8 @@ pages:
         path: /docs/browser/new-relic-browser/configuration/filter-ajax-request-events
       - title: Group data by URL patterns
         path: /docs/browser/new-relic-browser/configuration/group-browser-metrics-urls
+      - title: Obfuscate Browser Agent Data
+        path: /docs/browser/new-relic-browser/configuration/obfuscate-browser-agent-data
       - title: Change your browser agent type
         path: /docs/browser/new-relic-browser/configuration/change-browser-agent-type
       - title: Disable browser monitoring


### PR DESCRIPTION
This PR adds documentation about the Browser Agent's obfuscation configurations.  This was first introduced [over a year ago](https://github.com/newrelic/newrelic-browser-agent/releases?q=obfuscate&expanded=true) but has gone undocumented up until now.  