### PR TITLE
chore: format output lines in bash codeblock

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
@@ -111,10 +111,10 @@ Here are some examples of using the npm module via the command line.
 
     ```bash
     list-sourcemaps --applicationId=YOUR_APP_ID --apiKey=YOUR_NEW_RELIC_USER_KEY
-
-    Options:
-      --applicationId  Browser application id
-      --apiKey         New Relic user API key
+    [output]
+    [output] Options:
+    [output]   --applicationId  Browser application id
+    [output]   --apiKey         New Relic user API key
     ```
   </Collapser>
 
@@ -126,11 +126,11 @@ Here are some examples of using the npm module via the command line.
 
     ```bash
     delete-sourcemap --applicationId=YOUR_APP_ID --apiKey=YOUR_NEW_RELIC_USER_API_KEY --sourcemapId=YOUR_SOURCE_MAP_ID
-
-    Options:
-      --applicationId  Browser application id
-      --apiKey         New Relic user API key
-      --sourcemapId    Unique id generated for a source map
+    [output] 
+    [output] Options:
+    [output]   --applicationId  Browser application id
+    [output]   --apiKey         New Relic user API key
+    [output]   --sourcemapId    Unique id generated for a source map
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
The `[output]` in the bash codeblock should format those lines as output, without the `$` which indicates input
How it looks now:
<img width="844" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/0a3ae9be-247b-48d5-8b40-cdf1fcb77b76">

what my change will do:
<img width="669" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/fedd70f4-264b-4dd0-8fec-8d92eedfc4a6">
