### PR TITLE
fix: groupID to groupId

### DIFF
--- a/src/content/docs/change-tracking/change-tracking-graphql.mdx
+++ b/src/content/docs/change-tracking/change-tracking-graphql.mdx
@@ -148,13 +148,13 @@ The fields you'll use in your GraphQL queries fall into these general types:
             `deploymentType`
           </td>
           <td>
-            You can divide changes related to deployments into different types. These types align with common deployment techniques, but there is also an OTHER type. Types include:
-              * BASIC
-              * BLUE_GREEN
-              * CANARY
-              * ROLLING
-              * SHADOW
-              * OTHER
+            You can divide changes related to deployments into different types. These types align with common deployment techniques, but there is also an `OTHER` type. Types include:
+              * `BASIC`
+              * `BLUE_GREEN`
+              * `CANARY`
+              * `ROLLING`
+              * `SHADOW`
+              * `OTHER`
 
 
             Assigning a type to each deployment will help you filter results on change tracking interfaces and NerdGraph/NRQL query results.
@@ -165,9 +165,9 @@ The fields you'll use in your GraphQL queries fall into these general types:
             `groupId`
           </td>
           <td>
-            You may want to group deployments in cases where you're making a series of changes to one or more entities or releasing many changes across many entities within your system. By setting the same `groupID` attribute value for each related deployment, you can more easily see these changes together in New Relic interfaces or use the `groupID` to narrow query results. 
+            You may want to group deployments in cases where you're making a series of changes to one or more entities or releasing many changes across many entities within your system. By setting the same `groupId` attribute value for each related deployment, you can more easily see these changes together in New Relic interfaces or use the `groupId` to narrow query results. 
 
-            The `groupID` can be any string of your choosing, and you can continue to add deployments to a group after the first use of the `groupID` (in case you want to relate this deployment to one that happened weeks or even months ago).
+            The `groupId` can be any string of your choosing, and you can continue to add deployments to a group after the first use of the `groupId` (in case you want to relate this deployment to one that happened weeks or even months ago).
 
             <Callout variant="tip">
               In addition to using the `groupId` to relate many deployments, you may also use the attribute to define long-running changes. For example, two deployments with the same `groupId` could bracket a period during which alerts were suppressed or some migration was taking place.
@@ -221,7 +221,7 @@ The fields you'll use in your GraphQL queries fall into these general types:
             `deploymentId`
           </td>
           <td>
-            A unique identifier generated when the deployment is recorded. While you cannot set `deploymentId`, you can use it in your NerdGraph and NRQL queries to locate specific deployments. Here's an example: `deploymentId: “8a3a594c-e726-4bc2-8078-26dffec9a3d8”`.
+            A unique identifier generated when the deployment is recorded. While you cannot set `deploymentId`, you can use it in your NerdGraph and NRQL queries to locate specific deployments. Here's an example: `deploymentId: "8a3a594c-e726-4bc2-8078-26dffec9a3d8"`.
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
The doc went back and forth from `groupId` to `groupID`. I'm not positive if `groupID` is a problem, but I made it consistent with the way I know works.