### PR TITLE
chore: format the terminal errors as output instead of input

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
@@ -21,7 +21,7 @@ You can enable Node's source map support in the `node` command that starts your 
 An application run without source map support might display an error stack trace like this:
 
 ```shell
-[output]Error: Failed to get all entries in model
+[output] Error: Failed to get all entries in model
 [output]    at /dist/models/entries.js:41:23
 [output]    ... (multiple functions in New Relic Node agent js files)
 [output]    at /dist/models/entries.js:39:35
@@ -34,7 +34,7 @@ An application run without source map support might display an error stack trace
 The same application with source map support enabled will instead reference the source code files:
 
 ```shell
-[output]Error: Failed to get all entries in model
+[output] Error: Failed to get all entries in model
 [output]    at <anonymous> (/src/models/entries.ts:28:13)
 [output]    ... (multiple functions in New Relic Node agent js files)
 [output]    at <anonymous> (/src/models/entries.ts:26:19)

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/enable-source-maps.mdx
@@ -13,7 +13,7 @@ If you enable source mapping in Node.js, you'll get more meaningful error traces
 
 You can enable Node's source map support in the `node` command that starts your application:
 
-  ```
+  ```shell
   node --enable-source-maps -r newrelic ./dist/server.js
   ```
 ## Example [#source-map-example]
@@ -21,11 +21,11 @@ You can enable Node's source map support in the `node` command that starts your 
 An application run without source map support might display an error stack trace like this:
 
 ```shell
-Error: Failed to get all entries in model
-    at /dist/models/entries.js:41:23
-    ... (multiple functions in New Relic Node agent js files)
-    at /dist/models/entries.js:39:35
-    at Generator.next (<anonymous>)
+[output]Error: Failed to get all entries in model
+[output]    at /dist/models/entries.js:41:23
+[output]    ... (multiple functions in New Relic Node agent js files)
+[output]    at /dist/models/entries.js:39:35
+[output]    at Generator.next (<anonymous>)
 ```
 <Callout variant="tip">
   Note that the trace refers to the built files in `/dist`.
@@ -34,11 +34,11 @@ Error: Failed to get all entries in model
 The same application with source map support enabled will instead reference the source code files:
 
 ```shell
-Error: Failed to get all entries in model
-    at <anonymous> (/src/models/entries.ts:28:13)
-    ... (multiple functions in New Relic Node agent js files)
-    at <anonymous> (/src/models/entries.ts:26:19)
-    at Generator.next (<anonymous>)
+[output]Error: Failed to get all entries in model
+[output]    at <anonymous> (/src/models/entries.ts:28:13)
+[output]    ... (multiple functions in New Relic Node agent js files)
+[output]    at <anonymous> (/src/models/entries.ts:26:19)
+[output]    at Generator.next (<anonymous>)
 ```
 This stack trace points to specific functions and line numbers within your source files, so you can find errors more easily.
 


### PR DESCRIPTION
see this PR to see what the change will do
https://github.com/newrelic/docs-website/pull/14959