### PR TITLE
fix: downgrade autolink-headers plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gatsby-plugin-meta-redirect": "^1.1.1",
     "gatsby-plugin-react-helmet": "^5.4.0",
     "gatsby-plugin-sharp": "4.25.0",
-    "gatsby-remark-autolink-headers": "^5.4.0",
+    "gatsby-remark-autolink-headers": "^4.0.0",
     "gatsby-remark-copy-linked-files": "^5.4.0",
     "gatsby-remark-images": "^6.4.0",
     "gatsby-source-filesystem": "4.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9688,10 +9688,10 @@ gatsby-react-router-scroll@^5.25.0:
     "@babel/runtime" "^7.15.4"
     prop-types "^15.8.1"
 
-gatsby-remark-autolink-headers@^5.4.0:
-  version "5.25.0"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.25.0.tgz#5e0b45c2c169436940315de859d02366ee106da9"
-  integrity sha512-umfbG6BiUhhbiC6yd6GAIZnkuPORdDasJfUueNfHbm6DNiUHAFZ8BU2PqeD7PPh6sHvjXBmUUdZKJfivVd2cNg==
+gatsby-remark-autolink-headers@^4.0.0:
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.12.0.tgz#cc2bc632ad2320483badee85959c0e8aa2294eb0"
+  integrity sha512-yqbmkB4XfB5yiDfRwnlO84HpYYHRhXmrF5R2DetbLDh/W53x2A6TpaF+V11CMpV16K2fiBxiWafcF4pgQurAwA==
   dependencies:
     "@babel/runtime" "^7.15.4"
     github-slugger "^1.3.0"
@@ -9700,9 +9700,9 @@ gatsby-remark-autolink-headers@^5.4.0:
     unist-util-visit "^2.0.3"
 
 gatsby-remark-copy-linked-files@^5.4.0:
-  version "5.20.0"
-  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-5.20.0.tgz#6ced11d7b7c24551a79ad64c84c084d6cc067f2f"
-  integrity sha512-LDVu772lmYZaNpfSnpU3QbgZ9QEOtM7p+XhZ6jFrUM+smM1zC/+A9tKG02cqYpDUOLxd1pNUzL4fXkrIFZRQ9g==
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-5.25.0.tgz#196d14e7f52afc40eecccd276634752156fb9beb"
+  integrity sha512-kF068dZ0U920xNrlKM5BIR1MvgFdVvgR281AJfvn1xOvv/ES3elPj2bqlokbcs1f72dYcNnaJhv3UhYoIdV6Fg==
   dependencies:
     "@babel/runtime" "^7.15.4"
     cheerio "^1.0.0-rc.10"


### PR DESCRIPTION
- changing gatsby-remark-autolink-headers version resolves bug
- tried upgrading to 5.25.0 and it did not resolve.
- installed latest v4 and it resolves
- there is a new major version available on node 18 we could revisit

`/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#filter-legend`
 should scroll to **Filter using the chart legend** and not **Export and share your data**