### PR TITLE
Update send-prometheus-metric-data-new-relic.mdx

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -58,7 +58,7 @@ Benefits:
 
 
 Recommendations:
-* The [scrape interval](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#target-scrape-interval) is the biggest factor influencing data volumes: select it based on your observability needs. For example, changing from the default value of 15s to 30s can reduce data volumes by 50%.
+* The [scrape interval](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#target-scrape-interval) is the biggest factor influencing data volumes: select it based on your observability needs. For example, changing from the default value of 30s to 1m can reduce data volumes by 50%.
 * Set your filters and configure data to target. See how to [filter Prometheus metrics](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent/#drop-keep-metrics).
 * Control the health of your Prometheus instances and shards by installing the Prometheus Agent quickstart.
   </Collapser>
@@ -98,7 +98,7 @@ Reminders:
 
 Recommendations:
 * Evaluate your observability needs to manage your data volumes better:
-    * The [scrape interval](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) is the biggest factor influencing data volumes: select it based on your observability needs. For example, changing from 15s (default value) to 30s can reduce data volumes by 50%.
+    * The [scrape interval](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) is the biggest factor influencing data volumes: select it based on your observability needs. For example, changing from 30s (default value) to 1m can reduce data volumes by 50%.
     * Set your filters and configure data to target. See [metrics or targets](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_action).
     * Balance remote writes between one or more New Relic accounts or sub-accounts to manage rate limits.
   </Collapser>


### PR DESCRIPTION
Confirmed our prometheus agent default scrape value is 30s not 15s. The global default within prometheus documentation is 1m. Updated the recommendations sections to reflect the correct values.

Per prometheus documentation, the global scrape_interval is set to 1 minute by default. https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file

Our prometheus agent is set to 30 seconds by default. I double checked with Engineering. https://github.com/newrelic/newrelic-prometheus-configurator/blob/7dcb9392349cef3d2a44aad5a0371e9719ea12ef/charts/newrelic-prometheus-agent/values.yaml#L134

https://newrelic.slack.com/archives/C04S2FT1LU9/p1698164053929219?thread_ts=1698162082.068379&cid=C04S2FT1LU9