### PR TITLE
fix: update browser-tab.mdx - fixed typo in word "error"

### DIFF
--- a/src/content/docs/errors-inbox/browser-tab.mdx
+++ b/src/content/docs/errors-inbox/browser-tab.mdx
@@ -96,8 +96,8 @@ Stack traces can show you where in the code an error is originating from to help
 
 Here are some reasons you don't see a stack trace for an error:
     * If errors are not thrown there won't be a stack trace. 
-        - Example of a thrown errror that will NOT have a stack trace: throw `this is an error string`.
-        - Example of a thrown errror that will  have a stack trace: throw new Error `this is an error string`.
+        - Example of a thrown error that will NOT have a stack trace: throw `this is an error string`.
+        - Example of a thrown error that will  have a stack trace: throw new Error `this is an error string`.
 
     * The Javascript is hosted on a CDN or another external location, and New Relic can't see the errors originating from those scripts. This can be solved in some cases by using cross-origin resource sharing (CORS).
     * It is an AngularJS error. For more on this, see [Missing Angular errors](/docs/browser/new-relic-browser/troubleshooting/angularjs-errors-do-not-appear).


### PR DESCRIPTION
I found the typo in the docs while I was following them.

In two places word "error" is spelled as "errror".