### PR TITLE
fix: varnish configuration description typo

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration.mdx
@@ -178,7 +178,7 @@ The Varnish Cache integration collects both metrics(<strong>M</strong>) and inve
         * `/etc/sysconfig/varnish/varnish.params`
 
           Note: The location and name of the Varnish configuration file may vary. For details, see [Different locations of the Varnish configuration file](https://book.varnish-software.com/4.0/chapters/Getting_Started.html#different-locations-of-the-varnish-configuration-file).
-          For Varnish versions lower than 6, this parameter is not required and the integration should be set up for metrics collection only. See [the example for Varnish 6](#example6).
+          For Varnish 6 and above, this parameter is not required and the integration should be set up for metrics collection only. See [the example for Varnish 6](#example6).
       </td>
 
       <td>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

It fixes a typo in varnish configuration description

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

The `params` file was deprecated in varnish 6 and versions above. Check [upgrading to varnish 6 docs](https://varnish-cache.org/docs/6.0/whats-new/upgrading-6.0.html#services) for details.

* If your issue relates to an existing GitHub issue, please link to it.