### PR TITLE
feat: Update api summary page to include new info and links to relevant pages

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
@@ -40,7 +40,7 @@ To monitor traces and events, use these methods:
       </td>
 
       <td>
-        Use `newrelic.addPageAction()`
+        Use [newrelic.addPageAction()](/docs/browser/new-relic-browser/browser-apis/addpageaction)
       </td>
     </tr>
 
@@ -50,7 +50,7 @@ To monitor traces and events, use these methods:
       </td>
 
       <td>
-        Use `newrelic.addToTrace()`
+        Use [newrelic.addToTrace()](/docs/browser/new-relic-browser/browser-apis/addtotrace)
       </td>
     </tr>
 
@@ -60,7 +60,7 @@ To monitor traces and events, use these methods:
       </td>
 
       <td>
-        Use `newrelic.finished()`
+        Use [newrelic.finished()](/docs/browser/new-relic-browser/browser-apis/finished)
       </td>
     </tr>
 
@@ -70,7 +70,17 @@ To monitor traces and events, use these methods:
       </td>
 
       <td>
-        Use `newrelic.setCustomAttribute()`
+        Use [newrelic.setCustomAttribute()](/docs/browser/new-relic-browser/browser-apis/setcustomattribute)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Add application version information to subsequent events on the page
+      </td>
+
+      <td>
+        Use [newrelic.setApplicationVersion()](/docs/browser/new-relic-browser/browser-apis/setApplicationVersion)
       </td>
     </tr>
 
@@ -80,7 +90,17 @@ To monitor traces and events, use these methods:
       </td>
 
       <td>
-        Use `newrelic.setPageViewName()`
+        Use [newrelic.setPageViewName()](/docs/browser/new-relic-browser/browser-apis/setpageviewname)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Add user id information to subsequent events on the page
+      </td>
+
+      <td>
+        Use [newrelic.setUserId()](/docs/browser/new-relic-browser/browser-apis/setuserid)
       </td>
     </tr>
   </tbody>
@@ -110,7 +130,7 @@ To report errors in your application, use these methods:
       </td>
 
       <td>
-        Use `newrelic.addRelease()`
+        Use [newrelic.addRelease()](/docs/browser/new-relic-browser/browser-apis/addrelease)
       </td>
     </tr>
 
@@ -120,7 +140,7 @@ To report errors in your application, use these methods:
       </td>
 
       <td>
-        Use `newrelic.noticeError()`
+        Use [newrelic.noticeError()](/docs/browser/new-relic-browser/browser-apis/noticeerror)
       </td>
     </tr>
 
@@ -130,7 +150,7 @@ To report errors in your application, use these methods:
       </td>
 
       <td>
-        Use `newrelic.setErrorHandler()`
+        Use [newrelic.setErrorHandler()](/docs/browser/new-relic-browser/browser-apis/seterrorhandler)
       </td>
     </tr>
   </tbody>
@@ -160,7 +180,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().actionText()`
+        Use [newrelic.interaction().actionText()](/docs/browser/new-relic-browser/browser-apis/actiontext)
       </td>
     </tr>
 
@@ -170,7 +190,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().createTracer()`
+        Use [newrelic.interaction().createTracer()](/docs/browser/new-relic-browser/browser-apis/createtracer)
       </td>
     </tr>
 
@@ -180,7 +200,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().end()`
+        Use [newrelic.interaction().end()](/docs/browser/new-relic-browser/browser-apis/end)
       </td>
     </tr>
 
@@ -190,7 +210,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().getContext()`
+        Use [newrelic.interaction().getContext()](/docs/browser/new-relic-browser/browser-apis/getcontext)
       </td>
     </tr>
 
@@ -200,7 +220,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().ignore()`
+        Use [newrelic.interaction().ignore()](/docs/browser/new-relic-browser/browser-apis/ignore)
       </td>
     </tr>
 
@@ -210,7 +230,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction()`
+        Use [newrelic.interaction()](/docs/browser/new-relic-browser/browser-apis/interaction)
       </td>
     </tr>
 
@@ -220,7 +240,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().onEnd()`
+        Use [newrelic.interaction().onEnd()](/docs/browser/new-relic-browser/browser-apis/onend)
       </td>
     </tr>
 
@@ -230,7 +250,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().save()`
+        Use [newrelic.interaction().save()](/docs/browser/new-relic-browser/browser-apis/save)
       </td>
     </tr>
 
@@ -240,7 +260,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().setAttribute()`
+        Use [newrelic.interaction().setAttribute()](/docs/browser/new-relic-browser/browser-apis/setattribute)
       </td>
     </tr>
 
@@ -250,7 +270,37 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        Use `newrelic.interaction().setCurrentRouteName`
+        Use [newrelic.interaction().setCurrentRouteName](/docs/browser/new-relic-browser/browser-apis/setcurrentroutename)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Control agent harvesting behaviors [#agent-control-api]
+
+To control agent harvesting behaviors, use these API methods:
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "350" }}>
+        If you want to...
+      </th>
+
+      <th>
+        Do this
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Prevent feature(s) from harvesting until manually triggered
+      </td>
+
+      <td>
+        Use [newrelic.start()](/docs/browser/new-relic-browser/browser-apis/start)
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This PR:
* Updates the browser API summary page to include descriptions for new(er) APIs that have been added to the docs site, but not accounted for here.
* Updates each item to link to the relevant api doc