### PR TITLE
Update install-net-agent-azure-web-apps.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -51,6 +51,7 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
 2. Add the site extension: Navigate to `http://[yoursitename].scm.azurewebsites.net`, then select **Site extensions > Gallery**.
 3. Select the plus <Icon name="fe-plus"/> icon next to the New Relic site extension.
 4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service. This installs the latest .NET agent version. With version 10.x, we dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower (see [the migration guide](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide)). If you need a lower agent version, use the `NEWRELIC_AGENT_VERSION_OVERRIDE` environment variable. For example: `NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0`.
+>**NOTE**: If you've already installed the site extension and set the version override but your application is not reporting, you may need to remove and re-install the site extension for the environment variable to be recognized and for the correct version to be installed.
 5. Restart your web app.
 
 A couple notes related to this install process:

--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -51,8 +51,11 @@ To install the .NET agent for an Azure Web App using the New Relic Azure Site Ex
 2. Add the site extension: Navigate to `http://[yoursitename].scm.azurewebsites.net`, then select **Site extensions > Gallery**.
 3. Select the plus <Icon name="fe-plus"/> icon next to the New Relic site extension.
 4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service. This installs the latest .NET agent version. With version 10.x, we dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower (see [the migration guide](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide)). If you need a lower agent version, use the `NEWRELIC_AGENT_VERSION_OVERRIDE` environment variable. For example: `NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0`.
->**NOTE**: If you've already installed the site extension and set the version override but your application is not reporting, you may need to remove and re-install the site extension for the environment variable to be recognized and for the correct version to be installed.
 5. Restart your web app.
+
+<Callout variant="tip">
+If you've already installed the site extension and set the version override but your application is not reporting, you may need to remove and re-install the site extension for the environment variable to be recognized and for the correct version to be installed.
+</Callout>
 
 A couple notes related to this install process:
 


### PR DESCRIPTION
customers noticed that this wasn't working and after working on their case, it was found that the env might need to be in place before the site extension is installed for this override to work.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.