### PR TITLE
fix: inp shows as seconds in NR1 not ms

### DIFF
--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -13443,7 +13443,7 @@
         ],
         "name": "interactionToNextPaint",
         "units": {
-          "label": "milliseconds (ms)"
+          "label": "seconds (s)"
         }
       },
       {


### PR DESCRIPTION
This PR updates the data dictionary to note that INP shows as "seconds (s)" instead of "milliseconds (ms)" 