### PR TITLE
Fix vale linter checks

### DIFF
--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-      - tabatha/fix-vale-checks
 
 jobs:
   vale-linter:

--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - develop
+      - tabatha/fix-vale-checks
 
 jobs:
   vale-linter:
@@ -13,9 +14,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run vale
-        uses: errata-ai/vale-action@v1
+        uses: errata-ai/vale-action@reviewdog
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
-          files: __onlyModified
-          onlyAnnotateModifiedLines: true
+          reporter: github-check
+          fail_on_error: true
+          filter_mode: added
+          token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Its possible the version of Vale we were using has been deprecated. All the docs point to the `reviewdog` version vs `v1`. The docs for `v2` are using the reviewdog configs anyways, so I am just running with that one. 

I got the `reviewdog` configurations to run successfully in [this PR](https://github.com/newrelic/docs-website/pull/14989)

TODO:
- [x] get approval from docs
- [x] remove test branch from ln 7