### PR TITLE
feat: meraki api polling installation instructions for netmon

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp/meraki-api-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp/meraki-api-monitoring.mdx
@@ -1,0 +1,302 @@
+---
+title: Set up Meraki Dashboard API monitoring
+tags:
+  - Integrations
+  - Network monitoring
+  - Meraki
+  - Installation
+  - Setup
+metaDescription: "Set up New Relic's Meraki Dashboard API monitoring."
+---
+
+Use New Relic's network monitoring agent to monitor your Meraki environment.
+
+## Prerequisites [#prerequisites]
+
+### New Relic prerequisites [#prerequisites-NR]
+
+* A New Relic account. If you haven't already, sign up for free! No credit card required.
+  <InlineSignup/>
+* A New Relic [account ID](/docs/accounts/accounts-billing/account-setup/account-id).
+* A New Relic <InlinePopover type="licenseKey" />.
+
+### Docker prerequisites [#prerequisites-docker]
+
+* [Docker](https://docs.docker.com/engine/install) installed in a Linux host
+  * Ability to launch new containers via command line
+
+### Meraki prerequisites [#prerequisites-meraki]
+
+* [Meraki Dashboard API key](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#Enable_API_Access) for authentication
+
+### Network security prerequisites [#prerequisites-network]
+
+<Collapser
+  id="prerequisites-network-collapser"
+  title="Network firewall rules"
+>
+  <table>
+      <thead>
+      <tr>
+          <th style={{ width: '200px' }}>
+          Direction
+          </th>
+          <th>
+          Source
+          </th>
+          <th>
+          Destination
+          </th>
+          <th>
+          Ports
+          </th>
+          <th>
+          Protocol
+          </th>
+          <th>
+          Required
+          </th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+          <td>
+          Outbound
+          </td>
+          <td>
+          Docker host
+          </td>
+          <td>
+          `ktranslate` image on [Docker Hub](https://hub.docker.com/r/kentik/ktranslate), [Quay.io](https://quay.io/repository/kentik/ktranslate), or your company's internal repository.
+          </td>
+          <td>
+          443
+          </td>
+          <td>
+          TCP
+          </td>
+          <td>
+              ✓
+          </td>
+      </tr>
+      <tr>
+          <td>
+          Outbound
+          </td>
+          <td>
+          Docker host
+          </td>
+          <td>
+          [New Relic Metric API](/docs/data-apis/ingest-apis/metric-api/introduction-metric-api/#requirements)
+          Endpoint:
+          `https://metric-api.newrelic.com`
+          </td>
+          <td>
+          443
+          </td>
+          <td>
+          TCP
+          </td>
+          <td>
+          ✓
+          </td>
+      </tr>
+      <tr>
+          <td>
+              Outbound
+          </td>
+          <td>
+              Docker host
+          </td>
+          <td>
+              [New Relic Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api#requirements)
+              Endpoint:
+              `https://insights-collector.newrelic.com`
+          </td>
+          <td>
+              443
+          </td>
+          <td>
+              TCP
+          </td>
+          <td>
+              ✓
+          </td>
+      </tr>
+      <tr>
+          <td>
+          Outbound
+          </td>
+          <td>
+          Docker host
+          </td>
+          <td>
+          [New Relic Log API](/docs/logs/log-management/log-api/introduction-log-api/#endpoint)
+          Endpoint:
+          `https://log-api.newrelic.com`
+          </td>
+          <td>
+          443
+          </td>
+          <td>
+          TCP
+          </td>
+          <td>
+          
+          </td>
+      </tr>
+      <tr>
+          <td>
+          Outbound
+          </td>
+          <td>
+          Docker host
+          </td>
+          <td>
+          [Meraki Dashboard API](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#API_Requests) endpoint: `https://api.meraki.com/api/v1/`
+          </td>
+          <td>
+          443 (default)
+          </td>
+          <td>
+          TCP
+          </td>
+          <td>
+          ✓
+          </td>
+      </tr>
+      </tbody>
+  </table>
+</Collapser>
+
+## Installation [#installation]
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="1">
+      Add Meraki monitoring to existing SNMP container
+    </TabsBarItem>
+    <TabsBarItem id="2">
+      Run a dedicated container for Meraki monitoring
+    </TabsBarItem>
+  </TabsBar>
+
+  <TabsPages>
+    <TabsPageItem id="1">
+      <Steps>
+        <Step>
+          In your existing configuration file for the SNMP agent, manually add the Meraki device object, replacing `$DASHBOARD_API_KEY` with your [Meraki Dashboard API key](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#Enable_API_Access):
+
+          ```yaml
+          devices:
+            meraki_cloud_controller:
+              device_name: meraki_cloud_controller
+              device_ip: snmp.meraki.com
+              provider: meraki-cloud-controller
+              ext:
+                ext_only: true
+                meraki_config:
+                  api_key: "$DASHBOARD_API_KEY"
+          ```
+
+          <Callout variant="tip">
+            This is a minimal example. Additional configuration options are available on the [Advanced Configuration page](/docs/network-performance-monitoring/advanced/advanced-config/).
+          </Callout>
+        </Step>
+        <Step>
+          Stop and remove the existing container:
+
+          ```shell
+            # find your current container
+            docker ps -a
+
+            # forcibly stop and delete the target container (you may also use the container ID here in place of the name)
+            docker rm -f $CONTAINER_NAME
+          ```
+        </Step>
+        <Step>
+          Start a fresh container with the updated configuration file, replacing `$CONTAINER_SERVICE` with a unique name for the container and `$NR_LICENSE_KEY` and `$NR_ACCOUNT_ID` with your values:
+
+          ```shell
+          # In this example, we are assuming the default configuration file name of 'snmp-base.yaml'
+          docker run -d --name ktranslate-$CONTAINER_SERVICE --restart unless-stopped --pull=always -p 162:1620/udp \
+          -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
+          -e NEW_RELIC_API_KEY=$NR_LICENSE_KEY \
+          kentik/ktranslate:v2 \
+            -snmp /snmp-base.yaml \
+            -nr_account_id=$NR_ACCOUNT_ID \
+            -metrics=jchf \
+            -tee_logs=true \
+            -service_name=$CONTAINER_SERVICE \
+            nr1.snmp
+          ```
+        </Step>
+      </Steps>
+    </TabsPageItem>
+    <TabsPageItem id="2">
+      <Steps>
+        <Step>
+          On a Linux host with Docker installed, use the text editor of your choice to create the configuration file you'll use to run the container, replacing `$DASHBOARD_API_KEY` with your [Meraki Dashboard API key](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#Enable_API_Access):
+
+          Example using [vim](https://www.vim.org/):
+
+          ```shell
+          sudo vim meraki-base.yaml
+          ```
+
+          File contents:
+
+          ```yaml
+          devices:
+            meraki_cloud_controller:
+              device_name: meraki_cloud_controller
+              device_ip: snmp.meraki.com
+              provider: meraki-cloud-controller
+              ext:
+                ext_only: true
+                meraki_config:
+                  api_key: "$DASHBOARD_API_KEY"
+          trap: {}
+          discovery: {}
+          global:
+            poll_time_sec: 300
+            timeout_ms: 30000
+          ```
+
+          <Callout variant="tip">
+            This is a minimal example. Additional configuration options are available on the [Advanced Configuration page](/docs/network-performance-monitoring/advanced/advanced-config/).
+          </Callout>
+        </Step>
+        <Step>
+          Start the network monitoring agent to poll the Meraki Dashboard API, replacing `$NR_LICENSE_KEY` and `$NR_ACCOUNT_ID` with your values:
+
+          ```shell
+          # In this example, we have saved our configuration file as 'meraki-base.yaml'
+          docker run -d --name ktranslate-meraki --restart unless-stopped --pull=always -p 162:1620/udp \
+          -v `pwd`/meraki-base.yaml:/snmp-base.yaml \
+          -e NEW_RELIC_API_KEY=$NR_LICENSE_KEY \
+          kentik/ktranslate:v2 \
+            -snmp /snmp-base.yaml \
+            -nr_account_id=$NR_ACCOUNT_ID \
+            -metrics=jchf \
+            -tee_logs=true \
+            -service_name=meraki \
+            nr1.snmp
+          ```
+        </Step>
+      </Steps>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>
+
+## What's next? 
+
+You can set up some additional agents to complement your Meraki environment data:
+
+* To get better visibility into how your network is being used, [set up network flow data monitoring](/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring).
+
+* To get insights into system messages from your devices, [setup network syslog collection](/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring).
+
+<br />
+
+<InstallFeedback />

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp/snmp-performance-monitoring.mdx
@@ -14,6 +14,7 @@ redirects:
   - /docs/snmp-integration-new-relic-infrastructure
   - /docs/snmp-monitoring-integration
   - /docs/infrastructure/host-integrations/host-integrations-list/snmp-monitoring-integration/
+  - /docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring/
 ---
 
 import networkSnmpGuidedInstall from 'images/network_screenshot-full_snmp-guided-install.webp'

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp/snmp-performance-monitoring.mdx
@@ -3,6 +3,7 @@ title: Set up SNMP data monitoring
 tags:
   - Integrations
   - Network monitoring
+  - SNMP
   - Installation
   - Setup
 metaDescription: "Set up New Relic's SNMP data monitoring."

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -9,6 +9,12 @@ pages:
         path: /install/npm
       - title: Best practices guide
         path: /docs/network-performance-monitoring/get-started/network-monitoring-best-practices
+      - title: Set up SNMP data monitoring
+        pages:
+          - title: Set up SNMP polling and trap collection
+            path: /docs/network-performance-monitoring/setup-performance-monitoring/snmp/snmp-performance-monitoring
+          - title: Set up Meraki API monitoring
+            path: /docs/network-performance-monitoring/setup-performance-monitoring/snmp/meraki-api-monitoring
       - title: Set up cloud flow log monitoring
         pages:
           - title: Set up AWS VPC flow log monitoring
@@ -19,8 +25,6 @@ pages:
         path: /docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring
       - title: Set up network syslog monitoring
         path: /docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring
-      - title: Set up SNMP data monitoring
-        path: /docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring
   - title: Visualize your network data in New Relic
     path: /docs/network-performance-monitoring/monitoring-network-data/visualize-network-data
   - title: Monitor your network devices


### PR DESCRIPTION
adding a new installation document for the updated meraki api polling in netmon. this has become a common customer request as it's a unique situation within the more traditional SNMP polling configuration.