### PR TITLE
Remove not supported fluent-bit config options

### DIFF
--- a/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
@@ -105,10 +105,6 @@ Fluent Bit needs to know the location of the New Relic plugin and the New Relic 
        Name newrelic
        Match *
        licenseKey YOUR_LICENSE_KEY
-
-   # Optional
-   maxBufferSize 256000
-   maxRecords 1024
    ```
 5. Restart your Fluent Bit instance with the following command:
 


### PR DESCRIPTION
## What problems does this PR solve?

This PR removes some configurations from the fluent-bit examples that:
1. [Are not supported since 1.3](https://github.com/newrelic/newrelic-fluent-bit-output#configuration-parameters) ([deprecated on 2020](https://github.com/newrelic/newrelic-fluent-bit-output/releases/tag/1.3.0))
2. Are not properly set (they should go inside the OUTPUT section)