### PR TITLE
feat(kafka): added future metrics DO NOT MERGE

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -167,6 +167,127 @@ docker compose up
     </Step>
 </Steps>
 
+### Kafka instance metrics [#kafka-instance]
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Name
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+    <tbody>
+    <tr>
+      <td>
+        kafka.brokers
+      </td>
+      <td>
+        Number of brokers in the cluster
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.consumer_fetch_rate_avg
+      </td>
+      <td>
+        Average consumer fetch rate
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.incoming_byte_rate_avg
+      </td>
+      <td>
+        Average incoming byte rate in bytes/second
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.outgoing_byte_rate_avg
+      </td>
+      <td>
+        Average outgoing byte rate in bytes/second
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.request_latency_avg
+      </td>
+      <td>
+        Request latency average in ms
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.request_rate_avg
+      </td>
+      <td>
+        Average request rate per second
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.request_size_avg
+      </td>
+      <td>
+        Average request size in bytes
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.requests_in_flight
+      </td>
+      <td>
+        Requests in flight
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.response_rate_avg
+      </td>
+      <td>
+        Average response rate per second
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.brokers.response_size_avg
+      </td>
+      <td>
+        Average response size in bytes
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.consumer_group.lag
+      </td>
+      <td>
+        Current approximate lag of consumer group at partition of topic
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.consumer_group.lag_sum
+      </td>
+      <td>
+        Current approximate sum of consumer group lag across all partitions of topic
+      </td>
+    </tr>
+    <tr>
+      <td>
+        kafka.consumer_group.members
+      </td>
+      <td>
+        Count of members in the consumer group
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ### Confluent Cloud metrics [#confluent-metrics]
 
 <table>


### PR DESCRIPTION
This PR follows up this PR: #14911. Because of non-NR related blockers, these metrics are not yet available but will be at some point in the future. This PR stages these future changes, per @jcountsNR 