### PR TITLE
fix(azureintegrations): Add redirect for MySQL flexible server page

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-flexible-server-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-database-mysql-flexible-server-monitoring-integration.mdx
@@ -5,6 +5,8 @@ tags:
   - Microsoft Azure integrations
   - Azure integrations list
 metaDescription: 'Azure Database for MySQL flexible server data integration: how to install it, configure it, and understand the data it reports.'
+redirects:
+  - /docs/azure-azure_mysqlflexible-integration
 ---
 
 We offer a cloud integration for reporting your Azure MySQL flexible server data to our platform. Here we explain how to activate the integration and what data it collects.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->



Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
- Some docs linked to in meatballs-ui cloud integrations pages have been moved. Add the old path to the redirects
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
<img width="838" alt="image" src="https://github.com/newrelic/docs-website/assets/13279967/95010e09-d9e2-4916-9a74-9c412c76424a">

## Testing
Go to the old link at [/docs/azure-azure_mysqlflexible-integration](https://docswebsitedevelop-leetoscdocswebsitepatch182274.gatsbyjs.io/docs/azure-azure_mysqlflexible-integration)
- should get redirected to the correct page

* If your issue relates to an existing GitHub issue, please link to it.