### PR TITLE
Update php-agent-installation-tar-file.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file.mdx
@@ -30,12 +30,15 @@ Download the appropriate tar distribution file from **[download.newrelic.com/php
 
 With tar file installation, the steps for first time installation and for updating are the same. Replace X.X.X.X with the correct New Relic version. To install or update the agent:
 
-1. Download the appropriate tar file from the [New Relic website](https://download.newrelic.com/php_agent/release/), and save it to a local disk in a convenient location. Don't use the `/tmp` folder.
+1. Download the appropriate tar file from the [New Relic website](https://download.newrelic.com/php_agent/release/), and save it to a local disk in a convenient **location where you're going to keep it**. Don't use the `/tmp` folder.
 2. Decompress and extract the archive:
 
    ```bash
    gzip -dc newrelic-php5-X.X.X.X-OS.tar.gz | tar xf -
    ```
+
+**IMPORTANT**: choose this location wisely and **DO NOT DELETE THIS FOLDER AFTER INSTALLATOON**. Some of the files that will be installed (e.g. the PHP extension binary) **will be symlinks** to the downloaded files (yep, a pretty questionable choice).
+
 3. Change to the newly created directory:
 
    ```bash


### PR DESCRIPTION
Added a gigantic warning to the fact that the downloaded folder must not be deleted after installation. That's far from obvious (and actually a very bad idea); it's paramount that the user knows it in advance.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.