### PR TITLE
docs: Updates .NET Agent documentation to include support  for automatic browser injection in ASP.NET Core 6+ web applications

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -399,6 +399,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
     The .NET agent automatically instruments these application frameworks:
 
     * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, and 7.0 (includes Web API)
+    * ASP.NET Core Razor Pages 6.0 and 7.0 (starting with .NET Agent version 10.19.0)
   </Collapser>
 
   <Collapser
@@ -786,7 +787,6 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 The following features are not available for the .NET agent:
 
-* Automatic brower monitoring script injection ([API](/docs/agents/net-agent/net-agent-api/get-browser-timing-header) or [manual instrumentation](/docs/agents/net-agent/additional-installation/new-relic-browser-net-agent#manual_instrumentation) is required)
 * The .NET agent does not support [trim self-contained deployments and executables](https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-self-contained), because the compiler can potentially trim assemblies that the agent depends on.
 * [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing) is not supported on Alpine Linux due to a [GRPC compatibility issue](https://github.com/grpc/grpc/issues/21446). See [this agent issue](https://github.com/newrelic/newrelic-dotnet-agent/issues/289) for more information.
 
@@ -814,9 +814,11 @@ In addition to [APM](/docs/apm/new-relic-apm/getting-started/introduction-new-re
       </td>
 
       <td>
-        The browser monitoring JavaScript agent will not be injected by the .NET agent for **ASP.NET core** applications. However, you can inject the browser agent by using the [.NET agent API](/docs/agents/net-agent/net-agent-api/get-browser-timing-header) or the [browser agent's copy/paste method](/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent#copy-paste-app).
+        For ASP.NET Core v6.0 and later web applications (MVC, Razor and Blazor), the .NET agent (starting with version 10.19.0) automatically injects the browser JavaScript agent when you [enable auto-instrumentation](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#select-apm-app). 
 
-        After enabling browser injection, you can view browser data in the [APM Summary page](/docs/apm/applications-menu/monitoring/apm-overview-page) and quickly switch between the APM and browser data for a particular app. For configuration options and manual instrumentation, see [browser monitoring and the .NET agent](/docs/agents/net-agent/instrumentation-features/new-relic-browser-net-agent).
+        For other types of web applications, you can inject the browser agent by using the [.NET agent API](/docs/agents/net-agent/net-agent-api/get-browser-timing-header) or the [browser agent's copy/paste method](/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent#copy-paste-app).
+        
+        After enabling browser injection, you can view browser data in the [APM Summary page](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data/) and quickly switch between the APM and browser data for a particular app. For configuration options and manual instrumentation, see [Browser monitoring and the .NET agent](/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent/).
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -399,7 +399,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
     The .NET agent automatically instruments these application frameworks:
 
     * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, and 7.0 (includes Web API)
-    * ASP.NET Core Razor Pages 6.0 and 7.0 (starting with .NET Agent version 10.19.0)
+    * ASP.NET Core Razor Pages 6.0 and 7.0 (starting with .NET agent version 10.19.0)
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -1040,9 +1040,9 @@ In addition to [APM](/docs/apm/new-relic-apm/getting-started/introduction-apm/),
       </td>
 
       <td>
-        For ASP.NET applications, the .NET agent automatically injects the browser JavaScript agent when you [enable auto-instrumentation](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#select-apm-app). After enabling browser injection, you can view browser data in the [APM Summary page](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data/) and quickly switch between the APM and browser data for a particular app. For configuration options and manual instrumentation, see [Browser monitoring and the .NET agent](/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent/).
-
-        Automatic browser injection is not supported for ASP.NET core applications.
+        For ASP.NET web applications, the .NET agent automatically injects the browser JavaScript agent when you [enable auto-instrumentation](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#select-apm-app). 
+        
+        After enabling browser injection, you can view browser data in the [APM Summary page](/docs/apm/apm-ui-pages/monitoring/apm-summary-page-view-transaction-apdex-usage-data/) and quickly switch between the APM and browser data for a particular app. For configuration options and manual instrumentation, see [Browser monitoring and the .NET agent](/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent/).
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
@@ -22,7 +22,7 @@ Follow the [.NET agent requirements](/docs/agents/net-agent/getting-started/intr
 ## Auto-instrumentation [#auto_instrumentation]
 
 <Callout variant="important">
-  Auto-instrumentation is only available for .NET Framework apps and .NET Core v6.0 and later web apps. Auto-instrumentation is unavailable for ASP.NET Core v5.0 and earlier applications whether they're monitored by the .NET Framework or Core agent.
+  Auto-instrumentation is only available for .NET Framework apps and .NET Core v6.0 and later web apps. Auto-instrumentation is unavailable for ASP.NET Core v5.0 and earlier applications even if they're monitored by the .NET agent.
 </Callout>
 
 [Browser auto-instrumentation](/docs/agents/net-agent/configuration/net-agent-configuration#browsermon-autoInstrument) is enabled by default. With browser auto-instrumentation, the .NET Framework agent automatically injects the browser JavaScript header into any page that has a `content-type` of `text/html` and also has `<head>` tag within the page.

--- a/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
@@ -22,7 +22,7 @@ Follow the [.NET agent requirements](/docs/agents/net-agent/getting-started/intr
 ## Auto-instrumentation [#auto_instrumentation]
 
 <Callout variant="important">
-  Auto-instrumentation is only available for .NET Framework apps, .NET Core apps need to use [manual instrumentation](#manual_instrumentation). Auto-instrumentation is unavailable for ASP.NET Core applications whether they're monitored by the .NET Framework or Core agent.
+  Auto-instrumentation is only available for .NET Framework apps and .NET Core v6.0 and later web apps. Auto-instrumentation is unavailable for ASP.NET Core v5.0 and earlier applications whether they're monitored by the .NET Framework or Core agent.
 </Callout>
 
 [Browser auto-instrumentation](/docs/agents/net-agent/configuration/net-agent-configuration#browsermon-autoInstrument) is enabled by default. With browser auto-instrumentation, the .NET Framework agent automatically injects the browser JavaScript header into any page that has a `content-type` of `text/html` and also has `<head>` tag within the page.


### PR DESCRIPTION
## Give us some context

Updates the .NET Agent compatibility docs to add support for automatic browser injection in ASP.NET Core 6+ web applications. Also adds support for automatic instrumentation of ASP.NET Core 6+ Razor Pages.