### PR TITLE
Update java-agent-configuration-config-file.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -382,47 +382,6 @@ Set these options in the `common` stanza. To [override](#System_Properties) any 
   </Collapser>
 
   <Collapser
-    id="use_private_ssl"
-    title="use_private_ssl"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `false`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    The following SSL certificates are bundled into the agent jar:
-
-    ```
-    META-INF/certs/eu-newrelic-com.pem
-    META-INF/certs/eu01-nr-data-net.pem
-    META-INF/certs/newrelic-com.pem
-    ```
-
-    By default (`use_private_ssl: false`) the agent will use the SSL certificates bundled into the JDK to establish a secure connection to New Relic or the custom SSL certificates bundle specified by `ca_bundle_path`. If you want to use the SSL certificates bundled with the agent, set `use_private_ssl: true`.
-
-    Note: `use_private_ssl` will be ignored if `ca_bundle_path` is set.
-  </Collapser>
-
-  <Collapser
     id="cfg-enable_auto_app_naming"
     title="enable_auto_app_naming"
   >


### PR DESCRIPTION
Remove use_private_ssl config option as it no longer exists in the Java agent.