### PR TITLE
fix(infra): remove invalid metric from metrics list of AWS DynamoDB Integration

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-dynamodb-monitoring-integration.mdx
@@ -407,16 +407,6 @@ The New Relic Amazon DynamoDB integration collects the following metric data:
 
     <tr>
       <td>
-        `userErrors`
-      </td>
-
-      <td>
-        Requests that generate an HTTP 400 status code.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         `writeThrottleEvents`
       </td>
 


### PR DESCRIPTION
Remove invalid one from metric list of AWS DynamoDB API Polling.

'userErrors' metric is region/account specific, it is not included dynamoDbTable provider.
The metric should be in dynamoDbRegion, which is already listed.

AWS Docs: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html#UserErrors