### PR TITLE
nri-jmx: fix downloader path

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
@@ -113,11 +113,11 @@ If you're not using the guided install, follow the instructions for your environ
   >
     1. Download the `nri-jmx` .MSI installer image from:
 
-       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64.msi)
+       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe)
     2. To install from the Windows command prompt, run:
 
        ```
-       msiexec.exe /qn /i PATH\TO\nri-jmx-amd64.msi
+       PATH\TO\nri-jmx-amd64-installer.exe
        ```
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 

--- a/src/i18n/content/jp/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
+++ b/src/i18n/content/jp/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
@@ -111,12 +111,12 @@ Kubernetes または ECS 環境で JMX を実行していない場合は、ガ�
   >
     1. `nri-jmx` .MSIインストーラーイメージを以下からダウンロードします。
 
-       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64.msi)
+       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe)
 
     2. Windowsコマンドプロンプトからインストールするには、次のコマンドを実行します。
 
        ```
-       msiexec.exe /qn /i PATH\TO\nri-jmx-amd64.msi
+       PATH\TO\nri-jmx-amd64-installer.exe
        ```
 
     3. Integrationsディレクトリ`C:\Program Files\New Relic\newrelic-infra\integrations.d\`で、次のコマンドを実行してサンプル構成ファイルのコピーを作成します。

--- a/src/i18n/content/kr/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
+++ b/src/i18n/content/kr/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
@@ -111,12 +111,12 @@ Kubernetes 또는 ECS 환경에서 JMX를 실행하지 않는 경우 안내 설�
   >
     1. 다음에서 `nri-jmx` .MSI 설치 프로그램 이미지를 다운로드합니다.
 
-       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64.msi)
+       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe)
 
     2. Windows 명령 프롬프트에서 설치하려면 다음을 실행하십시오.
 
        ```
-       msiexec.exe /qn /i PATH\TO\nri-jmx-amd64.msi
+       PATH\TO\nri-jmx-amd64-installer.exe
        ```
 
     3. Integrations 디렉터리 `C:\Program Files\New Relic\newrelic-infra\integrations.d\` 에서 다음을 실행하여 샘플 구성 파일의 복사본을 만듭니다.


### PR DESCRIPTION
This PR fixes the path to nri-jmx downloader (currently points to an old version)