### PR TITLE
chore: add language identifiers to C docs

### DIFF
--- a/src/content/docs/apm/agents/c-sdk/get-started/apm-security-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/apm-security-c-sdk.mdx
@@ -71,14 +71,14 @@ By default, this is how the C SDK handles the following potentially sensitive da
       <td>
         The audit log is a plain text logging of all data sent to New Relic by the C SDK. When [starting the C SDK daemon](/docs/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code#daemon), add `-auditlog <file>` to the daemon configuration file. For example:
 
-        ```
+        ```sh
         ./newrelic-daemon -f -logfile stdout -loglevel debug -auditlog audit.log
         ```
 
         <Callout variant="tip">
           To see all of the available options for the C daemon: At the command line, type:
 
-          ```
+          ```sh
           ./newrelic-daemon --help
           ```
         </Callout>

--- a/src/content/docs/apm/agents/c-sdk/get-started/introduction-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/get-started/introduction-c-sdk.mdx
@@ -184,7 +184,7 @@ Working together, the C SDK instrumentation and the daemon forward data on to Ne
 
 The call to [`newrelic_create_app()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a61dd90439ae3cc5060021f6ab4701132) is non-blocking. Its second parameter allows you to specify an amount of time for your instrumented application to wait so that the socket communication is adequately established. For example:
 
-```
+```c
 newrelic_app_t* app = newrelic_create_app(config, 10000);
 ```
 

--- a/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/install-c-sdk-compile-link-your-code.mdx
@@ -59,7 +59,7 @@ To install the C SDK into your application's code library, follow this procedure
     id="header-file"
     title="2. Include the provided header file."
   >
-    ```
+    ```c
     #include "libnewrelic.h"
     ```
   </Collapser>
@@ -70,11 +70,11 @@ To install the C SDK into your application's code library, follow this procedure
   >
     Follow the procedures to [configure logging](/docs/generate-logs-troubleshooting-c-sdk) for both the C SDK and the daemon. For example:
 
-    ```
+    ```c
     if (!newrelic_configure_log("./c_sdk.log", NEWRELIC_LOG_INFO)) {
-        printf("Error configuring logging.\n");
-        return -1;
-      }
+      printf("Error configuring logging.\n");
+      return -1;
+    }
     ```
   </Collapser>
 
@@ -84,7 +84,7 @@ To install the C SDK into your application's code library, follow this procedure
   >
     Be prepared to provide a [meaningful app name](/docs/agents/manage-apm-agents/app-naming/name-your-application) in your initial application configuration; for example:
 
-    ```
+    ```c
     newrelic_app_config_t* config;
     /* ... */
     config = newrelic_create_app_config("Your Application Name", "LICENSE_KEY_HERE");
@@ -92,13 +92,13 @@ To install the C SDK into your application's code library, follow this procedure
 
     You may give your application up to three different names, separated by `;`. [Giving your application multiple names](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app) allows you to aggregate metrics for multiple agents across an entire app or service; for example:
 
-    ```
+    ```c
     config = newrelic_create_app_config("YOUR_APP_NAME;APP_GROUP_1;ALL_APPS", "LICENSE_KEY_HERE");
     ```
 
     With the application configured, you can create a new application to connect to the daemon.
 
-    ```
+    ```c
     newrelic_app_t* app;
 
     /* ... */
@@ -131,7 +131,7 @@ To install the C SDK into your application's code library, follow this procedure
 
     For example:
 
-    ```
+    ```sh
     gcc -o test_app test_app.c -L. -lnewrelic -lpcre -lm -pthread -rdynamic
     ```
   </Collapser>
@@ -142,7 +142,7 @@ To install the C SDK into your application's code library, follow this procedure
   >
     1. Start the C SDK's daemon. For example:
 
-       ```
+       ```sh
        ./newrelic-daemon -f -logfile newrelic-daemon.log -loglevel debug
        ```
     2. Check the output in the `c_sdk.log` and `newrelic-daemon.log` files.
@@ -152,7 +152,7 @@ To install the C SDK into your application's code library, follow this procedure
        <Callout variant="tip">
          To see all of the available options for the C daemon: At the command line, type:
 
-         ```
+         ```sh
          ./newrelic-daemon --help
          ```
        </Callout>

--- a/src/content/docs/apm/agents/c-sdk/install-configure/uninstall-remove-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/install-configure/uninstall-remove-c-sdk.mdx
@@ -34,21 +34,21 @@ One approach is to use an `#ifdef` macro. By surrounding all your instrumentatio
     id="ifdef"
     title="Using #ifdef macros to disable C SDK instrumentation"
   >
-    ```
+    ```c
     // replace `YOURNAMESPACE` with something that's unique to
     // your company/project to ensure a unique name
     #ifdef YOURNAMESPACE_NEWRELIC_ENABLED
     int priority = 50;
     newrelic_txn_t* txn = newrelic_start_non_web_transaction(app, transaction_name);
-
+    
     ...
-
+    
     if (err) {
-    newrelic_notice_error(txn, priority, "Meaningful error message", "Error.class");
+      newrelic_notice_error(txn, priority, "Meaningful error message", "Error.class");
     }
-
+    
     ...
-
+    
     newrelic_end_transaction(&txn);
     #endif
     ```

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/distributed-tracing-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/distributed-tracing-c-sdk.mdx
@@ -51,7 +51,7 @@ We have an example of how to install the C SDK and instrument a sample app so it
 
 Before going to the sample service below, note that it will have you create a default [`newrelic_app_config_t`](https://newrelic.github.io/c-sdk/structnewrelic__app__config__t.html), but you'll also need to add `distributed_tracing.enabled` and set it to `true`:
 
-```
+```c
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/guide-using-c-sdk-api.mdx
@@ -123,7 +123,11 @@ To instrument a method within an existing transaction, create segments for any o
       </td>
 
       <td>
-        `newrelic_start_datastore_segment()newrelic_start_external_segment()newrelic_start_segment()`
+        ```c
+        newrelic_start_datastore_segment()
+        newrelic_start_external_segment()
+        newrelic_start_segment()
+        ```
       </td>
     </tr>
 
@@ -288,9 +292,9 @@ To record [custom data](/docs/data-analysis/metrics/analyze-your-metrics/data-co
 
     ```
     // txn is a newrelic_txn_t*, created via newrelic_start_web_transaction
-       newrelic_custom_event_t* custom_event=0;
-       custom_event = <a href="https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a83b5b78623bcefda6d4e1e6d207f7b7a">newrelic_create_custom_event</a>("aTypeForYourEvent");
-       <a href="https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a4af935da4651e398e3773c148e8db814">newrelic_record_custom_event</a>(txn, &custom_event);
+   newrelic_custom_event_t* custom_event=0;
+   custom_event = <a href="https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a83b5b78623bcefda6d4e1e6d207f7b7a">newrelic_create_custom_event</a>("aTypeForYourEvent");
+   <a href="https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a4af935da4651e398e3773c148e8db814">newrelic_record_custom_event</a>(txn, &custom_event);
     ```
 
     Be sure to review the [custom data requirements and limits](/docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits) for guidance on what values are and are not allowed inside your custom event. For more information, see [Custom events in APM](/docs/insights/insights-data-sources/custom-data/insert-custom-events-new-relic-apm-agents).
@@ -340,11 +344,11 @@ To record [custom data](/docs/data-analysis/metrics/analyze-your-metrics/data-co
 
       For example:
 
-      ```
+      ```c
       // txn is a newrelic_txn_t*, created via newrelic_start_web_transaction
 
       // Record a metric value of 100ms in the transaction txn
-          newrelic_record_custom_metric(txn, "Custom/MyMetric/My_label", 100);
+      newrelic_record_custom_metric(txn, "Custom/MyMetric/My_label", 100);
       ```
 
       For more information, see [Collect custom metrics](/docs/agents/manage-apm-agents/agent-data/collect-custom-metrics).

--- a/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-transactions-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/instrumentation/instrument-transactions-c-sdk.mdx
@@ -26,22 +26,22 @@ To instrument a transaction so you can monitor it in the New Relic UI, wrap the 
 
    For web transactions:
 
-   ```
+   ```c
    newrelic_txn_t *txn;
    /* ... */
-   txn = newrelic_start_web_transaction(<a href="/docs/c-agent-configuration">app</a>, "NAME_YOUR_TRANSACTION");
+   txn = newrelic_start_web_transaction(app, "NAME_YOUR_TRANSACTION");
    ```
 
    For non-web transactions:
 
-   ```
+   ```c
    newrelic_txn_t *txn;
    /* ... */
-   txn = newrelic_start_non_web_transaction(<a href="/docs/c-agent-configuration">app</a>, "NAME_YOUR_TRANSACTION");
+   txn = newrelic_start_non_web_transaction(app, "NAME_YOUR_TRANSACTION");
    ```
 2. Add the following code immediately **after** the web or non-web transaction that you want to monitor:
 
-   ```
+   ```c
    newrelic_end_transaction(&txn);
    ```
 

--- a/src/content/docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk.mdx
+++ b/src/content/docs/apm/agents/c-sdk/troubleshooting/generate-logs-troubleshooting-c-sdk.mdx
@@ -57,7 +57,7 @@ To help troubleshoot an issue, we recommend generating logs at their highest lev
 
     To set a different log level for troubleshooting purposes: Call [`newrelic_configure_log()`](https://newrelic.github.io/c-sdk/libnewrelic_8h.html#a8922f48a2b92714fb2fc05ad7bd5c003) in your application code, and set a log level. For example:
 
-    ```
+    ```c
     newrelic_configure_log("./c_sdk.log", NEWRELIC_LOG_INFO);
     ```
   </Collapser>
@@ -77,14 +77,14 @@ To help troubleshoot an issue, we recommend generating logs at their highest lev
 
     These log levels are invoked using flags from the command line:
 
-    ```
-    --logfile <DAEMON_FILE_NAME>. Sets the path to the log file.
-    --loglevel <LOG_LEVEL>. Sets the log level. Default: info.
+    ```sh
+    --logfile <DAEMON_FILE_NAME>  # Sets the path to the log file.
+    --loglevel <LOG_LEVEL>        # Sets the log level. Default: info.
     ```
 
     To set a different log level for troubleshooting purposes: From the command line, set a different log level flag. For example:
 
-    ```
+    ```sh
     ./newrelic-daemon -f -logfile stdout -loglevel debug
     ```
   </Collapser>


### PR DESCRIPTION
I know this agent is deprecated, so I just added basic code styling and didn't check most things

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.