### PR TITLE
feat(PHP): Adds log context data documentation

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1547,6 +1547,8 @@ The value `newrelic.application_logging.enabled` controls if the logs in context
   </Collapser>
 </CollapserGroup>
 
+### Log fowarding [#log-forwarding]
+
 If you're using a [supported logging framework](/docs/logs/logs-context/configure-logs-context-php) and want to use the agent to send your application logs to New Relic, you can control that through the `newrelic.config.application_logging.forwarding` prefixed INI settings. Options available are:
 
 <CollapserGroup>
@@ -1747,6 +1749,118 @@ newrelic.application_logging.forwarding.log_level = "INFO"
   </Collapser>
 </CollapserGroup>
 
+#### Log context data [#log-context-data]
+
+The PHP agent can capture context data for the Monolog library and add its contents as attributes in the logs forwarded to New Relic. You can control that through settings under the `context_data` stanza, which is nested under the `forwarding` stanza.  Options available are:
+
+<CollapserGroup>
+  <Collapser
+    id="cfg-application_logging_forwarding_context_data-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+              <td>
+                Boolean
+              </td>
+            </tr>
+
+            <tr>
+              <th>
+                Default
+              </th>
+
+              <td>
+                `false`
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        Set this to `true` sending of context data as log attributes to New Relic.
+
+        Set this to `false` if you do not want context data in the logs sent to New Relic.
+  </Collapser>
+
+    <Collapser
+    id="cfg-application_logging_forwarding_context_data-include"
+    title="include"
+    >
+    <table>
+        <tbody>
+        <tr>
+            <th>
+            Type
+            </th>
+
+            <td>
+            List of strings
+            </td>
+        </tr>
+
+        <tr>
+            <th>
+            Default
+            </th>
+
+            <td>
+            (none)
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    If `context_data` is enabled for log forwarding, all attribute keys found in this list will be sent to New Relic in log records. If this list is empty, then all attributes will be sent.
+
+    <Callout variant="important">
+        When attribute rules are applied to log context attributes the "include" rules only include attributes which match and drop attributes not covered by the "include" rules.  This is different than other types of agent attributes.  If log context attributes do not appear to be showing up as inspected be sure to check the "newrelic.attributes.include" ruleset to make sure it is not excluding the log context attribute.  If all "include" lists are empty then all log context attributes are forwarded.
+    </Callout>
+
+    </Collapser>
+
+    <Collapser
+    id="cfg-application_logging_forwarding_context_data-exclude"
+    title="exclude"
+    >
+    <table>
+        <tbody>
+        <tr>
+            <th>
+            Type
+            </th>
+
+            <td>
+            List of strings
+            </td>
+        </tr>
+
+        <tr>
+            <th>
+            Default
+            </th>
+
+            <td>
+            (none)
+            </td>
+        </tr>
+        </tbody>
+    </table>
+        If `context_data` is enabled for log forwarding, all attribute keys found in this list will NOT be sent to New Relic in log records.
+
+        The include and exclude list follow the rules `Exclude overrides include`, `More specific rules take priority`, `Keys are case-sensitive` and `Use an asterisk for wildcards` defined in [Enabling and disabling attributes](/docs/php/php-agent-enabling-and-disabling-attributes#cfg-attributes-enabled).
+    </Collapser>
+</CollapserGroup>
+
+<Callout variant="important">
+  The PHP agent will only forward log context data which has a string key and a value which is a string or a scalar (int, double, boolean).
+</Callout>
+
+### Log decoration [#log-decoration]
+
 The PHP agent can collect also add linking metadata to Monolog log records to allow logs in context to work with log data forwarded by a 3rd party log forwarder. To enable this feature use the the `newrelic.application_logging.local_decorating.enable` option:
 
 <CollapserGroup>
@@ -1802,6 +1916,8 @@ The PHP agent can collect also add linking metadata to Monolog log records to al
 
   </Collapser>
 </CollapserGroup>  
+
+### Log metrics [#log-metrics]
 
 The PHP agent can collect metrics related to log events for [supported logging frameworks](/docs/logs/logs-context/configure-logs-context-php). The creation of these metrics is controlled by the `newrelic.application_logging.metrics.enable` option:
 

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1756,7 +1756,7 @@ The PHP agent can capture context data for the Monolog library and add its conte
 <CollapserGroup>
   <Collapser
     id="cfg-application_logging_forwarding_context_data-enabled"
-    title="enabled"
+    title="newrelic.application_logging.forwarding.context_data.enable"
   >
     <table>
       <tbody>
@@ -1789,7 +1789,7 @@ The PHP agent can capture context data for the Monolog library and add its conte
 
     <Collapser
     id="cfg-application_logging_forwarding_context_data-include"
-    title="include"
+    title="newrelic.application_logging.forwarding.context_data.include"
     >
     <table>
         <tbody>
@@ -1824,7 +1824,7 @@ The PHP agent can capture context data for the Monolog library and add its conte
 
     <Collapser
     id="cfg-application_logging_forwarding_context_data-exclude"
-    title="exclude"
+    title="newrelic.application_logging.forwarding.context_data.exclude"
     >
     <table>
         <tbody>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1549,7 +1549,7 @@ The value `newrelic.application_logging.enabled` controls if the logs in context
 
 ### Log fowarding [#log-forwarding]
 
-If you're using a [supported logging framework](/docs/logs/logs-context/configure-logs-context-php) and want to use the agent to send your application logs to New Relic, you can control that through the `newrelic.config.application_logging.forwarding` prefixed INI settings. Options available are:
+If you're using a [supported logging framework](/docs/logs/logs-context/configure-logs-context-php) and want to use the agent to send your application logs to New Relic, you can control that through the `newrelic.application_logging.forwarding` prefixed INI settings. Options available are:
 
 <CollapserGroup>
   <Collapser
@@ -1817,7 +1817,7 @@ The PHP agent can capture context data for the Monolog library and add its conte
     If `context_data` is enabled for log forwarding, all attribute keys found in this list will be sent to New Relic in log records. If this list is empty, then all attributes will be sent.
 
     <Callout variant="important">
-        When attribute rules are applied to log context attributes the "include" rules only include attributes which match and drop attributes not covered by the "include" rules.  This is different than other types of agent attributes.  If log context attributes do not appear to be showing up as inspected be sure to check the "newrelic.attributes.include" ruleset to make sure it is not excluding the log context attribute.  If all "include" lists are empty then all log context attributes are forwarded.
+        When attribute rules are applied to log context attributes the "include" rules only include attributes which match, and drop attributes not covered by the "include" rules.  This is different than other types of agent attributes.  If log context attributes do not appear to be showing up as expected, be sure to check the "newrelic.attributes.include" ruleset to make sure it is not excluding the log context attribute.  If all "include" lists are empty then all log context attributes are forwarded.
     </Callout>
 
     </Collapser>
@@ -1849,7 +1849,9 @@ The PHP agent can capture context data for the Monolog library and add its conte
         </tr>
         </tbody>
     </table>
-        If `context_data` is enabled for log forwarding, all attribute keys found in this list will NOT be sent to New Relic in log records.
+        If `context_data` is enabled for log forwarding, all attribute keys found in this list will NOT be sent to New Relic in log records.  If this field is empty then no attributes are explicitely excluded.  Attributes may still be excluded if 
+        include rules exists and an attribute name is not included
+        in those rules.
 
         The include and exclude list follow the rules `Exclude overrides include`, `More specific rules take priority`, `Keys are case-sensitive` and `Use an asterisk for wildcards` defined in [Enabling and disabling attributes](/docs/php/php-agent-enabling-and-disabling-attributes#cfg-attributes-enabled).
     </Collapser>

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -75,6 +75,14 @@ If you're using a supported logging framework and want to use the agent to send 
 * [`max_samples_stored`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding-max_samples_stored)
 * [`log_level`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding-log-level)
 
+If you are using the Monolog logging library (version 2 or 3) then you may also enable log context attributes.  This converts logging context data
+passed to Monolog into New Relic attributes.  You can control this feature through settings `newrelic.config.application_logging.forwarding.context_data`
+prefixed INI settings. Options available are:
+
+* [`enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/cfg-application_logging_forwarding_context_data-enabled)
+* [`include`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding_context_data-include)
+* [`exclude`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding_context_data-exclude)
+
 <Callout variant="important">
   If you have an existing log forwarding solution and are updating your agent to use automatic logs in context, be sure to **disable your manual log forwarder**. Otherwise, your app will be sending double the log data. Depending on your account, this could result in double billing. For more information, learn how to [disable your specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
 </Callout>

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -66,17 +66,17 @@ There is a single option to control if the core logging feature is active:
 
 * [`newrelic.application_logging.enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding-enabled)
 
-If you're using a supported logging framework the agent can send metrics which measure the number of severity of log messages your application is generating. You can enable this features using the  [`newrelic.config.application_logging.metrics.enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_metrics-enabled) config. 
+If you're using a supported logging framework the agent can send metrics which measure the number of severity of log messages your application is generating. You can enable this features using the  [`newrelic.application_logging.metrics.enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_metrics-enabled) config. 
 
 
-If you're using a supported logging framework and want to use the agent to send your application logs to New Relic, you can control that through settings `newrelic.config.application_logging.forwarding` prefixed INI settings. Options available are:
+If you're using a supported logging framework and want to use the agent to send your application logs to New Relic, you can control that through settings `newrelic.application_logging.forwarding` prefixed INI settings. Options available are:
 
 * [`enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding-enabled)
 * [`max_samples_stored`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding-max_samples_stored)
 * [`log_level`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding-log-level)
 
 If you are using the Monolog logging library (version 2 or 3) then you may also enable log context attributes.  This converts logging context data
-passed to Monolog into New Relic attributes.  You can control this feature through settings `newrelic.config.application_logging.forwarding.context_data`
+passed to Monolog into New Relic attributes.  You can control this feature through settings `newrelic.application_logging.forwarding.context_data`
 prefixed INI settings. Options available are:
 
 * [`enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/cfg-application_logging_forwarding_context_data-enabled)


### PR DESCRIPTION
This PR contains updates documentation for the PHP agent for the added support of log context attributes for the Monolog library.

I would like this PR reviewed but please do not merge until I let you know.