### PR TITLE
fix: remove whats new image links feature

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -125,7 +125,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 850,
-              linkImagesToOriginal: true,
+              linkImagesToOriginal: false,
               backgroundColor: 'transparent',
               disableBgImageOnAlpha: true,
             },


### PR DESCRIPTION
Removes the ability for images in What's New posts to be opened in new tabs, as it was causing issues in the NR UI.