### PR TITLE
docs: .NET Agent multiple app names via environment variable

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/name-your-net-application.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/name-your-net-application.mdx
@@ -269,4 +269,14 @@ For the .NET agent, you can set up to three application names. The first name is
     </appSettings>
     ```
   </Collapser>
-</CollapserGroup>
+
+  <Collapser
+    id="example-app"
+    title={<><InlineCode>NEW_RELIC_APP_NAME</InlineCode> environment variable</>}
+  >
+    Here's an example of setting multiple names in the `NEW_RELIC_APP_NAME` environment variable:
+
+    ```
+    NEW_RELIC_APP_NAME="App Name, App Name 2, App Name 3"
+    ```
+  </Collapser></CollapserGroup>


### PR DESCRIPTION
## Give us some context

Updates the .NET Agent docs to include an example of setting multiple app names via an environment variable.