### PR TITLE
chore: Update get-started-kubecost.mdx to not preview status

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubecost/get-started-kubecost.mdx
+++ b/src/content/docs/kubernetes-pixie/kubecost/get-started-kubecost.mdx
@@ -9,6 +9,10 @@ tags:
 metaDescription: "Understand the costs associated with your Kubernetes resources"
 ---
 
+<Callout title="Preview">
+  This feature is currently in preview.
+</Callout>
+
 With New Relic and [Kubecost](https://kubecost.github.io/cost-analyzer/), you can understand the costs associated with each of your Kubernetes resources.
 
 Actionable insights:


### PR DESCRIPTION
Notes that kubecost integration with NR is currently in preview.

## Give us some context
Kubecost integration for NR is not thoroughly tested; this makes that clear to readers.