### PR TITLE
fix: correct support of gauge types in the metric api

### DIFF
--- a/src/content/docs/data-apis/understand-data/metric-data/metric-data-type.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/metric-data-type.mdx
@@ -139,7 +139,7 @@ The metric `type` determines how the data is aggregated over longer time windows
       </td>
       
       <td>
-        ❌ [New Relic Metric API](/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api)
+        ✅ [New Relic Metric API](/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api)
    
         ❌ [New Relic Events to Metrics](/docs/data-apis/convert-to-metrics/analyze-monitor-data-trends-metrics)
   


### PR DESCRIPTION
[gauge](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api/#json-payload-keys) is the default metric type used by the Metric API and should definitely be supported.