### PR TITLE
chore: adding the 'tag' conversion

### DIFF
--- a/src/content/docs/network-performance-monitoring/troubleshooting/understanding-snmp-utilization-calculations.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/understanding-snmp-utilization-calculations.mdx
@@ -112,6 +112,10 @@ You have questions about various results calculated by the `ktranslate` network 
       </thead>
       <tbody>
         <tr>
+          <td> `tag` </td>
+          <td> Used to override the `name` attribute and present a friendly name that will be sent with the exported payload. </td>
+        </tr>
+        <tr>
           <td> `enum:[]` </td>
           <td> Used to handle SNMP enumerations which convert the integer value of a dimensional metric into the enumerated value in an attribute decorated on the dimensional metric (using the same metric name suffix). A common example is the conversion of [kentik.snmp.if_AdminStatus](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.2.2.1.7) to the enumerated value of [if_AdminStatus](https://github.com/kentik/snmp-profiles/blob/ccb1df47a5068a59fb3e3765746524e0286252e7/profiles/kentik_snmp/_general/if-mib.yml#L59-L66) as either `up`, `down`, or `testing`. </td>
         </tr>


### PR DESCRIPTION
adding a missing conversion option to this troubleshooting doc