### PR TITLE
Update links in .NET agent documentation to be https

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/install-net-agent-azure-web-apps.mdx
@@ -48,7 +48,7 @@ Both New Relic's .NET agent and Microsoft Application Insights rely on the CLR P
 To install the .NET agent for an Azure Web App using the New Relic Azure Site Extension:
 
 1. Shut down your web application before installing the [New Relic Azure Site Extension](https://www.nuget.org/packages/NewRelic.Azure.WebSites.Extension).
-2. Add the site extension: Navigate to `http://[yoursitename].scm.azurewebsites.net`, then select **Site extensions > Gallery**.
+2. Add the site extension: Navigate to `https://[yoursitename].scm.azurewebsites.net`, then select **Site extensions > Gallery**.
 3. Select the plus <Icon name="fe-plus"/> icon next to the New Relic site extension.
 4. In the Azure portal, add New Relic [app settings](#web-app-agent-settings) to your Azure App Service. This installs the latest .NET agent version. With version 10.x, we dropped support for .NET Framework 4.6.1 and lower and .NET Core 3.0 and lower (see [the migration guide](/docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide)). If you need a lower agent version, use the `NEWRELIC_AGENT_VERSION_OVERRIDE` environment variable. For example: `NEWRELIC_AGENT_VERSION_OVERRIDE=9.9.0`.
 5. Restart your web app.
@@ -84,7 +84,7 @@ If you're upgrading the .NET Framework agent using NuGet, any changes you made i
 To install the .NET agent on an Azure Web App using NuGet:
 
 1. In the Azure portal, verify your Azure Platform (32-bit or 64-bit): From the Azure sidebar menu, select **App Services > Your Application > Settings > Configuration > General settings**.
-2. Open your application in Visual Studio, and install the New Relic NuGet package by running the appropriate command from the [**Package manager** console](http://docs.nuget.org/docs/start-here/using-the-package-manager-console):
+2. Open your application in Visual Studio, and install the New Relic NuGet package by running the appropriate command from the [**Package manager** console](https://learn.microsoft.com/en-us/nuget/consume-packages/install-use-packages-powershell):
    * **32-bit**: `Install-Package NewRelic.Azure.WebSites`
    * **64-bit**: `Install-Package NewRelic.Azure.WebSites.x64`
 3. Publish your application.

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3540,6 +3540,6 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
 
 <Callout variant="important">
 
-For [ASP.NET Core apps](http://asp.net/), the .NET Agent will read from `appsettings.{environment}.json` if you set the `ASPNETCORE_ENVIRONMENT` variable.
+For [ASP.NET Core apps](https://asp.net/), the .NET Agent will read from `appsettings.{environment}.json` if you set the `ASPNETCORE_ENVIRONMENT` variable.
   </Callout>
   

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/create-transactions-xml-net.mdx
@@ -196,7 +196,7 @@ This example presents a simple implementation of creating transactions.
             // The agent creates a transaction that includes an external service request in its transaction traces.
             public void Bar1()
             {
-                new WebClient().DownloadString("http://www.google.com/");
+                new WebClient().DownloadString("https://www.google.com/");
             }
 
             // Creates  a transaction containing one segment.

--- a/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net.mdx
@@ -84,7 +84,7 @@ To tell the agent to mark a non-web task as a web browser transaction, use eithe
 [Transaction(Web = true)]
 public void Run()
 {
-    var uri = new Uri("http://www.mydomain.com/path");
+    var uri = new Uri("https://www.mydomain.com/path");
     NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
 
     // your web task
@@ -190,7 +190,7 @@ The `Transaction` attribute supports the following properties:
             [Transaction(Web = true)]
             public void Method1()
             {
-                new WebClient().DownloadString("http://www.google.com/");
+                new WebClient().DownloadString("https://www.google.com/");
             }
 
             // Creates a Custom transaction containing one segment.

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -295,7 +295,7 @@ The .NET agent doesn't directly monitor datastore processes. Also, by default th
               * **Hosting Models**
                 * IIS Hosted (with and without ASP Compatibility)
                 * Self Hosted
-              * [**Binding Types**](http://docs.microsoft.com/en-us/dotnet/framework/wcf/system-provided-bindings) (both client and service)  
+              * [**Binding Types**](https://docs.microsoft.com/en-us/dotnet/framework/wcf/system-provided-bindings) (both client and service)  
                 WCF Instrumentation has been tested for the following common binding types. Varying levels of support are available for distributed tracing (DT) and cross application tracing (CAT):
 
                 <table>
@@ -421,7 +421,7 @@ The .NET agent doesn't directly monitor datastore processes. Also, by default th
             These frameworks are **not fully supported:**
 
             * **ASP.NET Web API v1:** See the [troubleshooting information](/docs/agents/net-agent/troubleshooting/web-api-transactions-are-missing) about using ASP.NET Web API v1 with New Relic's .NET agent 5.0 or higher for apps targeting .NET Framework 4.0. (This doesn't affect .NET Framework 4.5 or higher.)
-            * **Mono:** New Relic doesn't support [Mono](http://www.mono-project.com/Main_Page), an open-source .NET framework that runs on Linux. This is because there is no Profiler API to inject into the .NET agent as a profiler into Mono-based .NET applications. The Profiler API is a Component Object Model (COM)-based interface and is not supported on Linux.
+            * **Mono:** New Relic doesn't support [Mono](https://www.mono-project.com/), an open-source .NET framework that runs on Linux. This is because there is no Profiler API to inject into the .NET agent as a profiler into Mono-based .NET applications. The Profiler API is a Component Object Model (COM)-based interface and is not supported on Linux.
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
@@ -258,7 +258,10 @@ If you're considering updating a .NET Framework agent version that's lower than 
                <configuration>
                ```
 
-               For more information about this .NET framework bug, see [Why is HttpContext.Current null after await?](https://stackoverflow.com/questions/18383923/why-is-httpcontext-current-null-after-await) and [All about &lt;httpRuntime targetFramework>](https://devblogs.microsoft.com/dotnet/all-about-httpruntime-targetframework/).
+               For more information about this .NET framework bug, see:
+               
+               * [Why is HttpContext.Current null after await?](https://stackoverflow.com/questions/18383923/why-is-httpcontext-current-null-after-await)
+               * [All about httpRuntime targetFramework](https://devblogs.microsoft.com/dotnet/all-about-httpruntime-targetframework/).
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/installation/update-net-agent.mdx
@@ -258,7 +258,7 @@ If you're considering updating a .NET Framework agent version that's lower than 
                <configuration>
                ```
 
-               For more information about this .NET framework bug, see [Why is HttpContext.Current null after await?](http://stackoverflow.com/questions/18383923/why-is-httpcontext-current-null-after-await) and [All about &lt;httpRuntime targetFramework>](https://devblogs.microsoft.com/dotnet/all-about-httpruntime-targetframework/).
+               For more information about this .NET framework bug, see [Why is HttpContext.Current null after await?](https://stackoverflow.com/questions/18383923/why-is-httpcontext-current-null-after-await) and [All about &lt;httpRuntime targetFramework>](https://devblogs.microsoft.com/dotnet/all-about-httpruntime-targetframework/).
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/itransaction.mdx
@@ -543,7 +543,7 @@ transaction.AddCustomAttribute("customerName","Bob Smith")
 
 ## CurrentSpan
 
-Provides access to the currently executing [span](http://docs.newrelic.com/docs/agents/net-agent/net-agent-api/ispan), making [span-specific methods](http://docs.newrelic.com/docs/agents/net-agent/net-agent-api/ispan) available within the New Relic API.
+Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/ispan/), making [span-specific methods](/docs/apm/agents/net-agent/net-agent-api/ispan) available within the New Relic API.
 
 ### Example
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/set-transaction-uri.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/set-transaction-uri.mdx
@@ -71,6 +71,6 @@ If you use this call multiple times within the same transaction, each call overw
 ## Examples
 
 ```cs
-var uri = new System.Uri("http://www.mydomain.com/path");
+var uri = new System.Uri("https://www.mydomain.com/path");
 NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
 ```

--- a/src/content/docs/apm/agents/net-agent/other-features/async-support-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/async-support-net.mdx
@@ -186,7 +186,7 @@ Here is a summary of known limitations for async instrumentation with our .NET a
   >
     If your application calls instrumented async methods, use `await` rather than `Task` related methods like `Task.Result()` to wait for the results. Otherwise, instrumentation may not work properly.
 
-    In general, avoid using `Task.Result()` when calling async methods. It can lead to [deadlocks](http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html).
+    In general, avoid using `Task.Result()` when calling async methods. It can lead to [deadlocks](https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/browser-monitoring-net-agent.mdx
@@ -73,7 +73,7 @@ If you cannot enable auto-instrumentation, you can still include the browser age
     id="razor"
     title="Other view engines such as Razor"
   >
-    For other view engines such as [Razor](http://en.wikipedia.org/wiki/Microsoft_ASP.NET_Razor_view_engine), you can use the [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent) method to generate the header string. Here is a Razor-based view example:
+    For other view engines such as [Razor](https://en.wikipedia.org/wiki/ASP.NET_Razor), you can use the [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent) method to generate the header string. Here is a Razor-based view example:
 
     ```razor
     <!DOCTYPE html>

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/missing-net-async-metrics.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/missing-net-async-metrics.mdx
@@ -90,5 +90,5 @@ To enforce additional checks, add the following to `web.config`:
 
 Async instrumentation is disabled if the legacy integrated pipeline is present. Before .NET 4.5, the integrated pipeline could cause deadlocks. For more information about this .NET Framework bug, see:
 
-* [Why is `HttpContext.Current` null after await?](http://stackoverflow.com/questions/18383923/why-is-httpcontext-current-null-after-await)
-* [All about &lt;httpRuntime targetFramework>](http://blogs.msdn.com/b/webdev/archive/2012/11/19/all-about-httpruntime-targetframework.aspx)
+* [Why is `HttpContext.Current` null after await?](https://stackoverflow.com/questions/18383923/why-is-httpcontext-current-null-after-await)
+* [All about &lt;httpRuntime targetFramework>](https://devblogs.microsoft.com/dotnet/all-about-httpruntime-targetframework/)

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/net-agent-reports-handled-errors.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/net-agent-reports-handled-errors.mdx
@@ -68,7 +68,7 @@ To avoid false error reports, instrument a method that directly or indirectly co
     
             static string GetNotFound()
             {
-                string uri = "http://localhost/Test/this/is/not/a/real/page";
+                string uri = "https://localhost/Test/this/is/not/a/real/page";
                 var request = (HttpWebRequest)WebRequest.Create(uri);
                 var response = request.GetResponse();
                 var data = new StreamReader(response.GetResponseStream()).ReadToEnd();


### PR DESCRIPTION
Replace any `http://` links in the .NET agent documentation with `https://`.  Also updated some links based on redirections and 4xx errors.