### PR TITLE
feat: point k8s nav to correct uninstall doc location

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/uninstall-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/uninstall-kubernetes.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: "Learn how to uninstall the Kubernetes integration."
 redirects:
   - /docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure#uninstall
+  - /docs/kubernetes-pixie/kubernetes-integration/uninstall-kubernetes
 ---
 
 The New Relic Kubernetes integration can be easily uninstalled from your platform. 


### PR DESCRIPTION
K8s nav was pointing to the old file location of the uninstall k8s doc. Pointed it to the right location and added a redirect from the old link
