### PR TITLE
fix: Aggregation window maximum is 6 hours

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names.mdx
@@ -437,7 +437,7 @@ Not every field listed in this glossary is required for every condition type. Th
 
     In the UI, under **Advanced signal settings**, this is the **Aggregation window** field.
 
-    Default is **60 seconds**. Maximum is 120 minutes.
+    Default is **60 seconds**. Maximum is 6 hours.
 
     Used for:
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
@@ -257,7 +257,7 @@ In order to make loss of signal detection more effective and to reduce unnecessa
 
 An [aggregation window](/docs/using-new-relic/welcome-new-relic/get-started/glossary#aggregation-window) is a specific block of time. We gather data points together in an aggregation window, before evaluating the data. A longer aggregation window can smooth out the data, since an outlier data point will have more data points to be aggregated with, giving it less of an influence on the aggregated data point that is sent for evaluation. When a data point arrives, its timestamp is used to put it in the proper aggregation window.
 
-You can set your aggregation window to anything between **30 seconds** and **2 hours**. The default is **1 minute**.
+You can set your aggregation window to anything between **30 seconds** and **6 hours**. The default is **1 minute**.
 
 ### Delay/timer [#delay-timer]
 


### PR DESCRIPTION
## Give us some context

The maximum aggregation window for New Relic NRQL Alert conditions is now 6 hours. These changes update the maximum aggregation window in our docs. 

https://new-relic.atlassian.net/browse/NR-113485
