### PR TITLE
[chore] Update mongodb-monitoring-integration-new.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -22967,7 +22967,7 @@ The following dimensional metrics are captured scraping the exporter and linked 
 
 This integration is open source software. This means you can [browse its source code](https://github.com/newrelic/newrelic-prometheus-exporters-packages) and send improvements, or create your own fork and build it.
 
-Moreover, this integration leverages an Prometheus exporter created by the community.
+Moreover, this integration leverages a [Prometheus exporter created by the community](https://github.com/newrelic/newrelic-prometheus-exporters-packages/tree/main/exporters/mongodb3).
 
 ## Troubleshooting [#troubleshooting]
 


### PR DESCRIPTION
Adds a link to the exporter source code as a hyperlink on existing text.

The existing "Browse your source code" link in this document leads to the root of the repository, which can make it a challenge to find the related code.

"Browse your source code" link to repo: https://github.com/newrelic/newrelic-prometheus-exporters-packages

Direct mongodb3 exporter codebase link: https://github.com/newrelic/newrelic-prometheus-exporters-packages/tree/main/exporters/mongodb3