### PR TITLE
chore: Update Android Gradle plugin installation

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-android-gradle-android-studio.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-android-gradle-android-studio.mdx
@@ -23,8 +23,8 @@ These procedures to configure your Android app with Gradle and Android Studio al
 
     <CollapserGroup>
         <Collapser
-        id="project-level"
-        title="Project-level build.gradle file:"
+          id="project-level"
+          title="Project-level build.gradle(.kts) file:"
         >
         Project-level configuration is used to configure the agent for all apps in a project. This includes setting the project token, enabling or disabling features, and setting thresholds for alerts. In this example, AGENT_VERSION represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -42,8 +42,8 @@ These procedures to configure your Android app with Gradle and Android Studio al
         </Collapser>
 
         <Collapser
-        id="app-level"
-        title="App-level build.gradle file:"
+          id="app-level"
+          title="App-level build.gradle(.kts) file:"
         >
         Use app-level configuration if you want to configure the settings for one specific app. In this example, AGENT_VERSION represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -60,16 +60,73 @@ These procedures to configure your Android app with Gradle and Android Studio al
         }
         ```
         </Collapser>
+
+       <Collapser
+          id="app-level"
+          title="Using the Gradle DSL with Gradle Plugin Portal"
+        >
+
+        <Callout variant="important">
+          By default, the plugins {} DSL resolves plugins from the public <a href="https://plugins.gradle.org/">Gradle Plugin Portal</a>Gradle Plugin Portal</a>.
+          The Android agent is not yet available as a community plugin, but you can provide the classpath to a href="https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin">MavenCentral</a> and still use the Plugins DSL.
+
+          Resolution of the agent plugin is configured in your project's "settings.gradle(.kts)" file, through the <a href="https://docs.gradle.org/current/dsl/org.gradle.plugin.management.PluginManagementSpec.html">pluginManagement { ... }</a> block.
+
+          In this example, AGENT_VERSION represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+
+          ```
+          pluginManagement {
+            repositories {
+              mavenCentral()  // adds repo for NewRelic artifacts
+            }
+            resolutionStrategy {
+              eachPlugin {
+                if (requested.id.id.startsWith("newrelic")) {
+                  useModule("com.newrelic.agent.android:agent-gradle-plugin:${AGENT_VERSION}")
+                }
+              }
+            }
+
+            // optional: define as a community plugin here or in root level build file
+
+            // for core Gradle plugins or plugins already available to the build script
+            plugins {
+              id("newrelic") version "${<AGENT_VERSION>}"
+            }
+          }
+          ```
+
+          The New Relic plugin can be declared in either pluginManagement{} (as above), or the project-level gradle build file:
+
+          ```
+          plugins {
+            // for binary Gradle plugins that need to be resolved
+            id("newrelic") version "<AGENT_VERSION>" apply false
+          }
+
+          ```
+
+          The plugin is then applied in the app-level build file(s) with:
+          ```
+          plugins {
+              id("com.android.application")
+              id("org.jetbrains.kotlin.android")
+              id("newrelic")
+          }
+          ```
+        </Callout">
+      </Collapser>
     </CollapserGroup>
 
-2. **(Optional)** For ProGuard or DexGuard: 
+
+2. **(Optional)** For ProGuard or DexGuard:
 
     a. In your project’s root directory (`/projectname/app`), add a `newrelic.properties` file with the following line:
 
         ```
         com.newrelic.application_token=GENERATED_TOKEN
         ```
-    b. Complete the configuration steps on [Configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps). Then come back to this page and move on to the next step. 
+    b. Complete the configuration steps on [Configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps). Then come back to this page and move on to the next step.
 
 
 3. Set app permissions. Ensure that your Android app requests `INTERNET` and `ACCESS_NETWORK_STATE` permissions by adding these lines to your `AndroidManifest.xml` file:
@@ -124,7 +181,7 @@ If you see the `java.lang.NoClassDefFoundError` error, then you must [manually s
 2. Merge the following code into your app-level `build.gradle` file:
 
     ```
-    android { 
+    android {
         defaultConfig{
             …
             multiDexKeepProguard file("proguard.multidex.config")

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio.mdx
@@ -60,12 +60,12 @@ OR:
 
 These procedures to configure your Android app with Gradle and Android Studio also appear on the **Get started** page in New Relic.
 
-1. Merge New Relic's mobile monitoring code in the **Gradle & Android Studio** tab to your `build.gradle` file.
+1. Merge New Relic's mobile monitoring code in the **Gradle & Android Studio** tab to your Gradle build file.
 
   <CollapserGroup>
     <Collapser
       id="project-level"
-      title="Project level build.gradle file:"
+      title="Project level build.gradle(.kts) file:"
     >
       In this example, AGENT_VERSION represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -84,7 +84,7 @@ These procedures to configure your Android app with Gradle and Android Studio al
 
     <Collapser
       id="app-level"
-      title="App level build.gradle file:"
+      title="App level build.gradle(.kts) file:"
     >
       In this example, AGENT_VERSION represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -101,17 +101,73 @@ These procedures to configure your Android app with Gradle and Android Studio al
       }
       ```
     </Collapser>
+
+    <Collapser
+      id="app-level"
+      title="Using the Gradle DSL with Gradle Plugin Portal"
+      >
+      <Callout variant="important">
+        By default, the plugins {} DSL resolves plugins from the public <a href="https://plugins.gradle.org/">Gradle Plugin Portal</a>Gradle Plugin Portal</a>.
+        The Android agent is not yet available as a community plugin, but you can provide the classpath to a href="https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin">MavenCentral</a> and still use the Plugins DSL.
+
+        Resolution of the agent plugin is configured in your project's "settings.gradle(.kts)" file, through the <a href="https://docs.gradle.org/current/dsl/org.gradle.plugin.management.PluginManagementSpec.html">pluginManagement { ... }</a> block.
+
+        In this example, AGENT_VERSION represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+
+        ```
+        pluginManagement {
+          repositories {
+            mavenCentral()  // adds repo for NewRelic artifacts
+          }
+          resolutionStrategy {
+            eachPlugin {
+              if (requested.id.id.startsWith("newrelic")) {
+                useModule("com.newrelic.agent.android:agent-gradle-plugin:${AGENT_VERSION}")
+              }
+            }
+          }
+
+          // optional: define as a community plugin here or in root level build file
+
+          // for core Gradle plugins or plugins already available to the build script
+          plugins {
+            id("newrelic") version "${<AGENT_VERSION>}"
+          }
+        }
+        ```
+
+        The New Relic plugin can be declared in either pluginManagement{} (as above), or the project-level gradle build file:
+
+        ```
+        plugins {
+          // for binary Gradle plugins that need to be resolved
+          id("newrelic") version "<AGENT_VERSION>" apply false
+        }
+
+        ```
+
+        The plugin is then applied in the app-level build file(s) with:
+
+        ```
+        plugins {
+            id("com.android.application")
+            id("org.jetbrains.kotlin.android")
+            id("newrelic")
+        }
+        ```
+      </Callout">
+    </Collapser>
   </CollapserGroup>
 
 
-2. **(Optional)** For ProGuard or DexGuard: 
+2. **(Optional)** For ProGuard or DexGuard:
 
     a. In your project’s root directory (`projectname/app`), add a `newrelic.properties` file with the following line:
 
       ```properties
       com.newrelic.application_token=GENERATED_TOKEN
       ```
-    b. Complete the configuration steps on [Configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps). Then come back to this page and move on to the next step. 
+    b. Complete the configuration steps on [Configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps). Then come back to this page and move on to the next step.
 
 
 3. Set app permissions: Ensure that your Android app requests `INTERNET` and `ACCESS_NETWORK_STATE` permissions by adding these lines to your `AndroidManifest.xml` file:
@@ -170,7 +226,7 @@ If you see the `java.lang.NoClassDefFoundError` error, then you must [manually s
 
 
   ```
-  android { 
+  android {
       defaultConfig{
           …
           multiDexKeepProguard file("proguard.multidex.config")


### PR DESCRIPTION
We don't support Gradle Plugin Portal, so this adds instructions for using the new plugin spec which assumes plugins all live in the portal.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The change provides information to workaround our missing support for a Gradle Plugin Portal community artifact.

* Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.
This addition will be temproary until we publish to GPP ( should be in the next month or two)

* If your issue relates to an existing GitHub issue, please link to it.
Mobile agents [Jira ticket](https://new-relic.atlassian.net/browse/NR-145885)
