### PR TITLE
Capabiility doc code formatting

### DIFF
--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -39,9 +39,11 @@ It’s not necessary to use trademark characters after product names in headings
 
 In general, it’s not necessary or recommended to use trademark characters after third-party product names on newrelic.com webpages or documents (including PDFs). New Relic is typically not in the position to know if a particular mark is registered. Assuming a third-party product name or other third-party mark is registered can lead to unintended and undesired consequences for New Relic. Thus, avoid using the `®` or `™` symbol unless a third party that New Relic partners or works with specifically requires the use of the symbol as a part of its trademark policy.
 
-In some instances, a third party requires the use of the `®` or `™` symbol by contract or through its trademark policy. For example, `LEGO`. A recent FutureStack event promoted an activity in which a LEGO master would create a LEGO model. In this case, LEGO required that the first occurrence of LEGO in New Relic copy should be followed by ®. For example, "You can win a one-of-a-kind LEGO® model of the New Relic Data Nerd Knuckles."
+In some instances, a third party requires the use of the `®` or `™` symbol by contract or through its trademark policy. For example, `LEGO`. A recent FutureStack event promoted an activity in which a LEGO master would create a LEGO model. In this case, LEGO required that the first occurrence of LEGO in New Relic copy should be followed by ®. For example, "You can win a one-of-a-kind LEGO<sup>®</sup> model of the New Relic Data Nerd Knuckles."
 
 If a company we're working with has its trademark policy publicly available or has privately provided the policy to New Relic, please consult that policy and follow the company’s policy for use of the `®` or `™` symbol.  If you're unsure of whether you need to acknowledge a third-party trademark in your copy, contact Legal in the #suplegal channel in Slack.
+
+The `®` and `™` symbols should be superscript wherever technically possible. For example: FutureStack<sup>®</sup>.
 
 ## When to use title case
 
@@ -414,7 +416,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
 
 ## What not to capitalize
 
-Do not capitalize our capability and feature names (what you get with our platform) unless they begin a sentence (and then only capitalize the first word) or are included in the table above. If a capability or feature name includes the name of a trademarked product, then only capitalize the trademarked name (for example, Pixie or Kubernetes).
+Do not capitalize our capability and feature names (what you get with our platform) unless they begin a sentence (and then only capitalize the first word) or are included in the table above. If a capability or feature name includes the name of a trademarked product, then only capitalize the trademarked name (for example, `Pixie` or `Kubernetes`).
 
 Feature and capability defined:
 
@@ -424,7 +426,7 @@ Feature and capability defined:
 Notes about features and capabilities:
 
 * These are largely internal terms used so that we can discuss New Relic and its structure more clearly. For public resources, we should attempt to avoid these terms and their distinctions and simply talk about how something works.
-* Note that this use of “capability” is different from how we define “capability” in the [user management space](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions).
+* Note that this use of `capability` is different from how we define `capability` in the [user management space](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions).
 
 [View a diagram](#relationships-between-products-features-and-capabilities) of the relationship between our product, features, and capabilities.
 
@@ -452,7 +454,7 @@ Notes about features and capabilities:
   <tbody>
     <tr>
       <td>
-        alerts
+        `alerts`
       </td>
 
       <td>
@@ -460,17 +462,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        alerts
+        `alerts`
       </td>
 
       <td>
-        Do not use: Alerts
+        Do not use: `Alerts`
       </td>
     </tr>
 
     <tr>
       <td>
-        anomaly detection
+        `anomaly detection`
       </td>
 
       <td>
@@ -478,17 +480,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        anomaly detection
+        `anomaly detection1`
       </td>
 
       <td>
-        Do not use: Anomaly Detection, Anomaly detection
+        Do not use: `Anomaly Detection`, `Anomaly detection`
       </td>
     </tr>
 
     <tr>
       <td>
-        application performance monitoring
+        `application performance monitoring`
       </td>
 
       <td>
@@ -496,19 +498,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: application performance monitoring (APM)
+        First use: `application performance monitoring (APM)`
 
-        Subsequent uses: application performance monitoring, APM, or application monitoring
+        Subsequent uses: `application performance monitoring`, `APM`, or `application monitoring`
       </td>
 
       <td>
-        Do not use: Application Performance Management, Application Performance Monitoring, Application Monitoring
+        Do not use: `Application Performance Management`, `Application Performance Monitoring`, `Application Monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        applied intelligence
+        `applied intelligence`
       </td>
 
       <td>
@@ -516,17 +518,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        applied intelligence
+        `applied intelligence`
       </td>
 
       <td>
-        Do not use: Applied Intelligence, Applied intelligence, AI, AIOps
+        Do not use: `Applied Intelligence`, `Applied intelligence`, `AI`, `AIOps`
       </td>
     </tr>
 
     <tr>
       <td>
-        automap
+        `automap`
       </td>
 
       <td>
@@ -534,17 +536,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        automap
+        `automap`
       </td>
 
       <td>
-        Do not use: auto map, Auto Map, Auto map
+        Do not use: `auto map`, `Auto Map`, `Auto map`
       </td>
     </tr>
 
     <tr>
       <td>
-        auto-telemetry with Pixie
+        `auto-telemetry with Pixie`
       </td>
 
       <td>
@@ -552,19 +554,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: auto-telemetry with Pixie
+        First use: `auto-telemetry with Pixie`
 
-        Subsequent uses: auto-telemetry with Pixie, the Pixie integration with New Relic, our Pixie integration, or the integration with Pixie
+        Subsequent uses: `auto-telemetry with Pixie`, `the Pixie integration with New Relic`, `our Pixie integration`, or `the integration with Pixie`
       </td>
 
       <td>
-        Do not use: Pixie (okay if referring to px.dev and the open-source Pixie project), Pixie's, Auto-telemetry with Pixie
+        Do not use: `Pixie` (okay if referring to px.dev and the open-source Pixie project), `Pixie's`, `Auto-telemetry with Pixie`
       </td>
     </tr>
 
     <tr>
       <td>
-        browser monitoring
+        `browser monitoring`
       </td>
 
       <td>
@@ -572,30 +574,30 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        browser monitoring
+        `browser monitoring`
       </td>
 
       <td>
-        Do not use: Browser Monitoring, Browser monitoring
+        Do not use: `Browser Monitoring`, `Browser monitoring`
       </td>
     </tr>
     <tr>
       <td>
-        code-level metric(s)
+        `code-level metric(s)`
       </td>
       <td>
         feature of the New Relic CodeStream capability that allows you to see the golden signals (throughput, error rate, response rate) at the method level within your code.
       </td>
       <td>
-        code-level metric or code-level metrics
+        `code-level metric` or `code-level metrics`
       </td>
       <td>
-        Do not use: code level metric(s), Code-Level Metric(s), Code-level Metric(s), Code-level metric(s) (unless at the beginning of a sentence), CLM
+        Do not use: `code level metric(s)`, `Code-Level Metric(s)`, `Code-level Metric(s)`, `Code-level metric(s)` (unless at the beginning of a sentence), `CLM`
       </td>
     </tr>
     <tr>
       <td>
-        containers
+        `containers`
       </td>
 
       <td>
@@ -603,17 +605,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        containers
+        `containers`
       </td>
 
       <td>
-        Do not use: Containers
+        Do not use: `Containers`
       </td>
     </tr>
 
     <tr>
       <td>
-        dashboards
+        `dashboards`
       </td>
 
       <td>
@@ -621,17 +623,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        dashboards
+        `dashboards`
       </td>
 
       <td>
-        Do not use: Dashboards
+        Do not use: `Dashboards`
       </td>
     </tr>
 
     <tr>
       <td>
-        data ingest
+        `data ingest`
       </td>
 
       <td>
@@ -639,17 +641,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        data ingest
+        `data ingest`
       </td>
 
       <td>
-        Do not use: Data Ingest, Data ingest
+        Do not use: `Data Ingest`, `Data ingest`
       </td>
     </tr>
 
     <tr>
       <td>
-        digital experience monitoring
+        `digital experience monitoring`
       </td>
 
       <td>
@@ -657,19 +659,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: digital experience monitoring (DEM)
+        First use: `digital experience monitoring (DEM)`
 
-        Subsequent uses: digital experience monitoring or DEM
+        Subsequent uses: `digital experience monitoring` or `DEM`
       </td>
 
       <td>
-        Do not use: Digital Experience Monitoring, Digital experience monitoring, digital monitoring
+        Do not use: `Digital Experience Monitoring`, `Digital experience monitoring`, `digital monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        distributed tracing
+        `distributed tracing`
       </td>
 
       <td>
@@ -677,11 +679,11 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        distributed tracing
+        `distributed tracing`
       </td>
 
       <td>
-        Do not use: Distributed Tracing, Distributed tracing
+        Do not use: `Distributed Tracing`, `Distributed tracing`
       </td>
     </tr>
 
@@ -695,17 +697,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        errors inbox
+        `errors inbox`
       </td>
 
       <td>
-        Do not use: Errors Inbox, Errors inbox
+        Do not use: `Errors Inbox`, `Errors inbox`
       </td>
     </tr>
 
     <tr>
       <td>
-        event correlation
+        `event correlation`
       </td>
 
       <td>
@@ -713,17 +715,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        event correlation
+        `event correlation`
       </td>
 
       <td>
-        Do not use: Event Correlation, Event correlation
+        Do not use: `Event Correlation`, `Event correlation`
       </td>
     </tr>
 
     <tr>
       <td>
-        incident intelligence
+        `incident intelligence`
       </td>
 
       <td>
@@ -731,17 +733,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        incident intelligence
+        `incident intelligence`
       </td>
 
       <td>
-        Do not use: Incident Intelligence, Incident intelligence
+        Do not use: `Incident Intelligence`, `Incident intelligence`
       </td>
     </tr>
 
     <tr>
       <td>
-        infrastructure monitoring
+        `infrastructure monitoring`
       </td>
 
       <td>
@@ -749,19 +751,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: infrastructure monitoring
+        First use: `infrastructure monitoring`
 
-        Subsequent uses: infrastructure monitoring, infra monitoring, or infra (for space-constrained areas only)
+        Subsequent uses: `infrastructure monitoring`, and in space-constrained areas only `infra monitoring` or `infra`
       </td>
 
       <td>
-        Do not use: Infrastructure Monitoring, Infrastructure monitoring
+        Do not use: `Infrastructure Monitoring`, `Infrastructure monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        integrations
+        `integrations`
       </td>
 
       <td>
@@ -769,17 +771,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        integrations
+        `integrations`
       </td>
 
       <td>
-        Do not use: Integrations
+        Do not use: `Integrations`
       </td>
     </tr>
 
     <tr>
       <td>
-        interactive application security testing
+        `interactive application security testing`
       </td>
 
       <td>
@@ -787,19 +789,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: New Relic interactive application security testing (IAST)
-
-        Subsequent uses: interactive application security testing or IAST
+        First use: `New Relic interactive application security testing (IAST)
+`
+        Subsequent uses: `interactive application security testing` or `IAST`
       </td>
 
       <td>
-        Do not use: New Relic Interactive Application Security Testing or Interactive Application Security Testing
+        Do not use: `New Relic Interactive Application Security Testing` or `Interactive Application Security Testing`
       </td>
     </tr>
 
     <tr>
       <td>
-        Kubernetes cluster explorer
+        `Kubernetes cluster explorer`
       </td>
 
       <td>
@@ -807,17 +809,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        Kubernetes cluster explorer
+        `Kubernetes cluster explorer`
       </td>
 
       <td>
-        Do not use: Kubernetes Cluster Explorer, kubernetes cluster explorer
+        Do not use: `Kubernetes Cluster Explorer`, `kubernetes cluster explorer`
       </td>
     </tr>
 
     <tr>
       <td>
-        Kubernetes monitoring
+        `Kubernetes monitoring`
       </td>
 
       <td>
@@ -825,17 +827,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        Kubernetes monitoring
+        `Kubernetes monitoring`
       </td>
 
       <td>
-        Do not use: Kubernetes Monitoring, kubernetes monitoring
+        Do not use: `Kubernetes Monitoring`, `kubernetes monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        log management
+        `log management`
       </td>
 
       <td>
@@ -843,19 +845,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: log management
+        First use: `log management`
 
-        Subsequent uses: log management or logs
+        Subsequent uses: `log management` or `logs`
       </td>
 
       <td>
-        Do not use: Log Management, Log management, Logs
+        Do not use: `Log Management`, `Log management`, `Logs`
       </td>
     </tr>
 
     <tr>
       <td>
-        logs in context
+        `logs in context`
       </td>
 
       <td>
@@ -863,17 +865,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        logs in context
+        `logs in context`
       </td>
 
       <td>
-        Do not use: Logs in Context, Logs in context
+        Do not use: `Logs in Context`, `Logs in context`
       </td>
     </tr>
 
     <tr>
       <td>
-        metrics and events
+        `metrics and events`
       </td>
 
       <td>
@@ -881,17 +883,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        metrics and events
+        `metrics and events`
       </td>
 
       <td>
-        Do not use: Metrics and events
+        Do not use: `Metrics and events`
       </td>
     </tr>
 
     <tr>
       <td>
-        metrics, events, logs, and traces
+        `metrics, events, logs, and traces` (`MELT`)
       </td>
 
       <td>
@@ -899,19 +901,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: metrics, events, logs, and traces or metrics, events, logs, and traces (MELT)
+        First use: `metrics, events, logs, and traces` or `metrics, events, logs, and traces (MELT)`
 
-        Subsequent uses: metrics, events, logs, and traces or MELT
+        Subsequent uses: `metrics, events, logs, and traces` or `MELT`
       </td>
 
       <td>
-        Do not use: Metrics, Events, Logs, and Traces
+        Do not use: `Metrics, Events, Logs, and Traces`
       </td>
     </tr>
 
     <tr>
       <td>
-        microservices
+        `microservices`
       </td>
 
       <td>
@@ -919,17 +921,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        microservices
+        `microservices`
       </td>
 
       <td>
-        Do not use: micro services, Micro Services, Microservices
+        Do not use: `micro services`, `Micro Services`, `Microservices`
       </td>
     </tr>
 
     <tr>
       <td>
-        mobile monitoring
+        `mobile monitoring`
       </td>
 
       <td>
@@ -937,17 +939,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        mobile monitoring
+        `mobile monitoring`
       </td>
 
       <td>
-        Do not use: Mobile Monitoring, Mobile monitoring
+        Do not use: `Mobile Monitoring`, `Mobile monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        model performance monitoring
+        `model performance monitoring`
       </td>
 
       <td>
@@ -955,17 +957,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        model performance monitoring
+        `model performance monitoring`
       </td>
 
       <td>
-        Do not use: Model Performance Monitoring, Model performance monitoring, ML model monitoring, ML model performance monitoring, MPM
+        Do not use: `Model Performance Monitoring`, `Model performance monitoring`, `ML model monitoring`, `ML model performance monitoring`, `MPM`
       </td>
     </tr>
 
     <tr>
       <td>
-        network performance monitoring
+        `network performance monitoring`
       </td>
 
       <td>
@@ -973,17 +975,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First and subsequent uses: network monitoring
+        First and subsequent uses: `network monitoring`
       </td>
 
       <td>
-        Do not use: Network Performance Monitoring, Network performance monitoring, Network Monitoring, Network monitoring
+        Do not use: `Network Performance Monitoring`, `Network performance monitoring`, `Network Monitoring`, `Network monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        observability
+        `observability`
       </td>
 
       <td>
@@ -991,19 +993,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: observability or observability (o11y)
+        First use: `observability` or `observability (o11y)`
 
-        Subsequent uses: observability, o11y, full-stack observability, or end-to-end observability
+        Subsequent uses: `observability`, `o11y`, `full-stack observability`, or `end-to-end observability`
       </td>
 
       <td>
-        Do not use: Observability, O11y, Full-Stack Observability, Full-stack Observability, Full-stack observability
+        Do not use: `Observability`, `O11y`, `Full-Stack Observability`, `Full-stack Observability`, `Full-stack observability`
       </td>
     </tr>
 
     <tr>
       <td>
-        query, queries, querying
+        `query`, `queries`, `querying`
       </td>
 
       <td>
@@ -1011,35 +1013,35 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        query, queries, or querying
+        `query`, `queries`, or `querying`
       </td>
 
       <td>
-        Do not use: Query, Queries, Querying
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        query builder
-      </td>
-
-      <td>
-        feature of New Relic; previously known as chart builder
-      </td>
-
-      <td>
-        query builder
-      </td>
-
-      <td>
-        Do not use: Query Builder, Query builder
+        Do not use: `Query`, `Queries`, `Querying`
       </td>
     </tr>
 
     <tr>
       <td>
-        quickstarts
+        `query builder`
+      </td>
+
+      <td>
+        feature of New Relic; previously known as `chart builder`
+      </td>
+
+      <td>
+        `query builder`
+      </td>
+
+      <td>
+        Do not use: `Query Builder`, `Query builder`, or any variation of `chart builder`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `quickstarts`
       </td>
 
       <td>
@@ -1047,17 +1049,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        quickstarts
+        `quickstarts`
       </td>
 
       <td>
-        Do not use: quick starts, Quick Starts, QuickStarts, Quickstarts
+        Do not use: `quick starts`, `Quick Starts`, `QuickStarts`, `Quickstarts`
       </td>
     </tr>
 
     <tr>
       <td>
-        real user monitoring
+        `real user monitoring`
       </td>
 
       <td>
@@ -1065,19 +1067,19 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: real user monitoring (RUM)
+        First use: `real user monitoring (RUM)`
         
-        Subsequent use: RUM
+        Subsequent use: `real user monitoring` or `RUM`
       </td>
 
       <td>
-        Do not use: real-user-monitoring, real-user monitoring, Real User Monitoring, Real-User-Monitoring, Real-User Monitoring
+        Do not use: `real-user-monitoring`, `real-user monitoring`, `Real User Monitoring`, `Real-User-Monitoring`, `Real-User Monitoring`
       </td>
     </tr>
     
     <tr>
       <td>
-        serverless monitoring
+        `serverless monitoring`
       </td>
 
       <td>
@@ -1085,17 +1087,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        serverless monitoring
+        `serverless monitoring`
       </td>
 
       <td>
-        Do not use: Serverless Monitoring, Serverless monitoring
+        Do not use: `Serverless Monitoring`, `Serverless monitoring`
       </td>
     </tr>
 
     <tr>
       <td>
-        service levels
+        `service levels`
       </td>
 
       <td>
@@ -1103,17 +1105,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        service level or service levels
+        `service level` or `service levels`
       </td>
 
       <td>
-        Do not use: Service Levels, Service levels, SL, services levels, Services Levels
+        Do not use: `Service Levels`, `Service levels`, `SL`, `services levels`, `Services Levels`
       </td>
     </tr>
 
     <tr>
       <td>
-        service maps
+        `service maps`
       </td>
 
       <td>
@@ -1121,17 +1123,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        service maps
+        `service maps`
       </td>
 
       <td>
-        Do not use: Service Maps, Service maps
+        Do not use: `Service Maps`, `Service maps`
       </td>
     </tr>
 
     <tr>
       <td>
-        synthetic monitoring
+        ``synthetic monitoring`
       </td>
 
       <td>
@@ -1139,18 +1141,18 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        First use: synthetic monitoring
+        First use: `synthetic monitoring`
 
-        Subsequent uses: synthetic monitoring or synthetics or synthetic monitors
+        Subsequent uses: `synthetic monitoring` or `synthetics` or s`ynthetic monitors`
       </td>
 
       <td>
-        Do not use: synthetics monitoring, Synthetic Monitoring, Synthetic monitoring
+        Do not use: `synthetics monitoring`, `Synthetic Monitoring`, `Synthetic monitoring`
       </td>
     </tr>
     <tr>
       <td>
-        workloads
+        `workloads`
       </td>
 
       <td>
@@ -1158,17 +1160,17 @@ Notes about features and capabilities:
       </td>
 
       <td>
-        workload or workloads
+        `workload` or `workloads`
       </td>
 
       <td>
-        Do not use: Workloads, work loads, Work Loads, Work loads
+        Do not use: `Workloads`, `work loads`, `Work Loads`, `Work loads`
       </td>
     </tr>
   </tbody>
 </table>
 
-If you don't see a feature or capability in one of the above tables, assume that it is not capitalized.
+If you don't see a feature or capability in one of the above tables, assume that it's not capitalized.
 
 ### Examples
 
@@ -1206,55 +1208,55 @@ We used to capitalize our platform components (below). However, we no longer pos
   <tbody>
     <tr>
       <td>
-        Applied Intelligence
+        `Applied Intelligence`
       </td>
 
       <td>
-        formerly a separate product—now a capability of New Relic
+        formerly a separate product, now a capability of New Relic
       </td>
 
       <td>
-        applied intelligence
+        `applied intelligence`
       </td>
 
       <td>
-        Do not use: Applied Intelligence, AI, AIOps
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Full-Stack Observability
-      </td>
-
-      <td>
-        formerly a separate product—now in lowercase, it describes an outcome of using New Relic
-      </td>
-
-      <td>
-        full-stack observability
-      </td>
-
-      <td>
-        Do not use: Full-Stack Observability, Full-stack Observability, Full Stack Observability, full stack observability, FSO
+        Do not use: `Applied Intelligence`, `AI`, `AIOps`
       </td>
     </tr>
 
     <tr>
       <td>
-        Telemetry Data Platform
+        `Full-Stack Observability`
       </td>
 
       <td>
-        formerly a separate product—now part of New Relic
+        formerly a separate product; now, in lowercase, it describes an outcome of using New Relic
       </td>
 
       <td>
-        telemetry data platform (avoid this term altogether when possible)
+        `full-stack observability`
       </td>
 
       <td>
-        Do not use: Telemetry Data Platform, Telemetry data platform, TDP
+        Do not use: `Full-Stack Observability`, `Full-stack Observability`, `Full Stack Observability`, `full stack observability`, `FSO`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `Telemetry Data Platform`
+      </td>
+
+      <td>
+        formerly a separate product, now part of New Relic
+      </td>
+
+      <td>
+        `telemetry data platform` (avoid this term altogether when possible)
+      </td>
+
+      <td>
+        Do not use: `Telemetry Data Platform`, `Telemetry data platform`, `TDP`
       </td>
     </tr>
   </tbody>
@@ -1277,7 +1279,7 @@ For purely internal documents, neither the copyright or the trademark notices ar
 
 > New Relic confidential; for internal use only
 
-You should also add the word “internal” to the file name.
+You should also add the word `internal` to the file name.
 
 ## Relationships between products, features, and capabilities
 

--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -83,7 +83,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `New Relic, Inc.` (corporation/entity), `New Relic<sup>®</sup>` (printed assets), or `New Relic` (digital assets)
+        First use: `New Relic, Inc.` (corporation/entity), `New Relic®` (printed assets), or `New Relic` (digital assets)
 
         Subsequent uses: `New Relic`, `our company`, `we`, or `it`
       </td>
@@ -127,7 +127,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `FutureStack<sup>®</sup>` or `{Future}Stack<sup>®</sup>` (printed assets), or `FutureStack` or `{Future}Stack` (digital assets)
+        First use: `FutureStack®` or `{Future}Stack®` (printed assets), or `FutureStack` or `{Future}Stack` (digital assets)
 
         Subsequent uses: `FutureStack`
       </td>
@@ -147,7 +147,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `NerdGraph<sup>®</sup>` (printed assets) or `NerdGraph` (digital assets)
+        First use: `NerdGraph®` (printed assets) or `NerdGraph` (digital assets)
 
         Subsequent uses: `NerdGraph`
       </td>
@@ -167,7 +167,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `Nerdlet<sup>®</sup>` (printed assets) or `Nerdlet` (digital assets)
+        First use: `Nerdlet®` (printed assets) or `Nerdlet` (digital assets)
 
         Subsequent uses: `Nerdlet`
       </td>
@@ -187,7 +187,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `Nerdpack<sup>®</sup>` (printed assets) or `Nerdpack` (digital assets)
+        First use: `Nerdpack®` (printed assets) or `Nerdpack` (digital assets)
 
         Subsequent uses: `Nerdpack`
       </td>
@@ -207,7 +207,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `NerdStorage<sup>®</sup>` (printed assets) or `NerdStorage` (digital assets)
+        First use: `NerdStorage®` (printed assets) or `NerdStorage` (digital assets)
 
         Subsequent uses: `NerdStorage`
       </td>
@@ -288,7 +288,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: `New Relic Infinite Tracing<sup>®</sup>` (printed assets) or `New Relic Infinite Tracing` (digital assets)
+        First use: `New Relic Infinite Tracing®` (printed assets) or `New Relic Infinite Tracing` (digital assets)
 
         Subsequent uses: `Infinite Tracing`
       </td>

--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -9,7 +9,7 @@ This page is the definitive resource for capitalizing products, features, and ca
 
 In general, we use [title case](https://en.wikipedia.org/wiki/Title_case) for our company name, product/platform name, and a few capabilities and integrations that require it for legal reasons. The following sections also call out first and subsequent uses of terms. First use refers to the first mention in the body copy. It's okay to use the subsequent versions in space-constrained areas such as titles, headers, tables, web navigation, the UI, social media posts, and so on.
 
-Do not use acronyms specific to or coined by New Relic externally; only use industry-recognized acronyms such as APM externally.
+Do not use acronyms specific to or coined by New Relic externally; only use industry-recognized acronyms such as `APM` externally.
 
 <Callout variant="important">
   Find capitalization guidelines for [user types](/docs/style-guide/word-choice/user-related-language-guidelines#styles) and [product editions](/docs/style-guide/word-choice/pricing-language-guidelines#style-format).
@@ -19,13 +19,13 @@ Do not use acronyms specific to or coined by New Relic externally; only use indu
 
 A trademark is a word, name, symbol, or a combination of the three that identifies a particular product or service. A [trademark](https://www.uspto.gov/trademarks/basics/what-trademark#:~:text=A%20trademark%20can%20be%20any,both%20trademarks%20and%20service%20marks) is how customers recognize you in the marketplace and distinguish you from your competitors for those goods and services.
 
-A trademark name is the name of a company conducting business. The New Relic trademark name is New Relic, Inc.
+A trademark name is the name of a company conducting business. The New Relic trademark name is `New Relic, Inc.`.
 
 ## Trademark guidelines
 
 Here are the general trademark guidelines when using the New Relic brand name:
 
-* Do not make New Relic or its platform, capabilities, and so on possessive using apostrophes. For example, use the “functionality of the New Relic platform” or “the New Relic platform functionality” instead of “New Relic's platform functionality” or “New Relic's functionality.”
+* Do not make New Relic or its platform, capabilities, and so on possessive using apostrophes. For example, use the "functionality of the New Relic platform" or "the New Relic platform functionality" instead of "New Relic's platform functionality" or "New Relic's functionality."
 * Do not pluralize New Relic or its platform, capabilities, and so on.
 * Do not abbreviate or combine New Relic or its platform, capabilities, and so on.
 * Do not hyphenate New Relic or its platform, capabilities, and so on, and do not allow them to break across a page line when used in text.
@@ -37,11 +37,11 @@ It’s not necessary to use trademark characters after product names in headings
 
 ## Third-party trademarks
 
-In general, it’s not necessary or recommended to use trademark characters after third-party product names on newrelic.com webpages or documents (including PDFs). New Relic is typically not in the position to know if a particular mark is registered. Assuming a third-party product name or other third-party mark is registered can lead to unintended and undesired consequences for New Relic. Thus, avoid using the ® or ™ symbol unless a third party that New Relic partners or works with specifically requires the use of the symbol as a part of its trademark policy.
+In general, it’s not necessary or recommended to use trademark characters after third-party product names on newrelic.com webpages or documents (including PDFs). New Relic is typically not in the position to know if a particular mark is registered. Assuming a third-party product name or other third-party mark is registered can lead to unintended and undesired consequences for New Relic. Thus, avoid using the `®` or `™` symbol unless a third party that New Relic partners or works with specifically requires the use of the symbol as a part of its trademark policy.
 
-In some instances, a third party requires the use of the ® or ™ symbol by contract or through its trademark policy. For example, LEGO. A recent FutureStack event promoted an activity in which a LEGO master would create a LEGO model. In this case, LEGO required that the first occurrence of LEGO in New Relic copy should be followed by ®. For example, "You can win a one-of-a-kind LEGO® model of the New Relic Data Nerd Knuckles."
+In some instances, a third party requires the use of the `®` or `™` symbol by contract or through its trademark policy. For example, `LEGO`. A recent FutureStack event promoted an activity in which a LEGO master would create a LEGO model. In this case, LEGO required that the first occurrence of LEGO in New Relic copy should be followed by ®. For example, "You can win a one-of-a-kind LEGO® model of the New Relic Data Nerd Knuckles."
 
-If a company we're working with has its trademark policy publicly available or has privately provided the policy to New Relic, please consult that policy and follow the company’s policy for use of the ® or ™ symbol.  If you're unsure of whether you need to acknowledge a third-party trademark in your copy, contact Legal in the #suplegal channel in Slack.
+If a company we're working with has its trademark policy publicly available or has privately provided the policy to New Relic, please consult that policy and follow the company’s policy for use of the `®` or `™` symbol.  If you're unsure of whether you need to acknowledge a third-party trademark in your copy, contact Legal in the #suplegal channel in Slack.
 
 ## When to use title case
 
@@ -73,7 +73,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
   <tbody>
     <tr>
       <td>
-        New Relic\*
+        `New Relic`\*
       </td>
 
       <td>
@@ -81,19 +81,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic, Inc. (corporation/entity), New Relic<sup>®</sup> (printed assets), or New Relic (digital assets)
+        First use: `New Relic, Inc.` (corporation/entity), `New Relic<sup>®</sup>` (printed assets), or `New Relic` (digital assets)
 
-        Subsequent uses: New Relic, our company, we, or it
+        Subsequent uses: `New Relic`, `our company`, `we`, or `it`
       </td>
 
       <td>
-        Do not use: New Relic's, new relic, New relic, NR, their
+        Do not use: `New Relic's`, `new relic`, `New relic`, `NR`, `their`
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic platform
+        `New Relic platform`
       </td>
 
       <td>
@@ -101,23 +101,23 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic (docs, UI, titles) or New Relic observability platform (marketing content)
+        First use: `New Relic` (docs, UI, titles) or `New Relic observability platform` (marketing content)
 
-        Subsequent uses: New Relic or New Relic platform
+        Subsequent uses: `New Relic` or `New Relic platform`
 
-        Note: New Relic observability platform is recommended for marketing content where users might not be familiar with our product.
+        Note: `New Relic observability platform` is recommended for marketing content where users might not be familiar with our product.
       </td>
 
       <td>
-        Do not use: New Relic's, New Relic One, NR1
+        Do not use: `New Relic's`, `New Relic One`, `NR1`
       </td>
     </tr>
 
     <tr>
       <td>
-        FutureStack\*
+        `FutureStack`\*
 
-        &#x7B;Future}Stack\*
+        `{Future}Stack`\*
       </td>
 
       <td>
@@ -125,19 +125,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: FutureStack<sup>®</sup> or &#x7B;Future}Stack<sup>®</sup> (printed assets), or FutureStack or &#x7B;Future}Stack (digital assets)
+        First use: `FutureStack<sup>®</sup>` or `{Future}Stack<sup>®</sup>` (printed assets), or `FutureStack` or `{Future}Stack` (digital assets)
 
-        Subsequent uses: FutureStack
+        Subsequent uses: `FutureStack`
       </td>
 
       <td>
-        Do not use: Future Stack, Futurestack, Future stack
+        Do not use: `Future Stack`, `Futurestack`, `Future stack`
       </td>
     </tr>
 
     <tr>
       <td>
-        NerdGraph\*
+        `NerdGraph`\*
       </td>
 
       <td>
@@ -145,19 +145,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: NerdGraph<sup>®</sup> (printed assets) or NerdGraph (digital assets)
+        First use: `NerdGraph<sup>®</sup>` (printed assets) or `NerdGraph` (digital assets)
 
-        Subsequent uses: NerdGraph
+        Subsequent uses: `NerdGraph`
       </td>
 
       <td>
-        Do not use: Nerd Graph, Nerdgraph, nerdgraph, nerd graph
+        Do not use: `Nerd Graph`, `Nerdgraph`, `nerdgraph`, `nerd graph`
       </td>
     </tr>
 
     <tr>
       <td>
-        Nerdlet\*
+        `Nerdlet`\*
       </td>
 
       <td>
@@ -165,19 +165,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: Nerdlet<sup>®</sup> (printed assets) or Nerdlet (digital assets)
+        First use: `Nerdlet<sup>®</sup>` (printed assets) or `Nerdlet` (digital assets)
 
-        Subsequent uses: Nerdlet
+        Subsequent uses: `Nerdlet`
       </td>
 
       <td>
-        Do not use: nerdlet, NerdLet
+        Do not use: `nerdlet`, `NerdLet`
       </td>
     </tr>
 
     <tr>
       <td>
-        Nerdpack\*
+        `Nerdpack`\*
       </td>
 
       <td>
@@ -185,19 +185,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: Nerdpack<sup>®</sup> (printed assets) or Nerdpack (digital assets)
+        First use: `Nerdpack<sup>®</sup>` (printed assets) or `Nerdpack` (digital assets)
 
-        Subsequent uses: Nerdpack
+        Subsequent uses: `Nerdpack`
       </td>
 
       <td>
-        Do not use: nerdpack, NerdPack, Nerd Pack, nerd pack
+        Do not use: `nerdpack`, `NerdPack`, `Nerd Pack`, `nerd pack`
       </td>
     </tr>
 
     <tr>
       <td>
-        NerdStorage\*
+        `NerdStorage`\*
       </td>
 
       <td>
@@ -205,19 +205,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: NerdStorage<sup>®</sup> (printed assets) or NerdStorage (digital assets)
+        First use: `NerdStorage<sup>®</sup>` (printed assets) or `NerdStorage` (digital assets)
 
-        Subsequent uses: NerdStorage
+        Subsequent uses: `NerdStorage`
       </td>
 
       <td>
-        Do not use: Nerdstorage, nerdstorage, Nerd Storage, Nerd storage, nerd storage
+        Do not use: `Nerdstorage`, `nerdstorage`, `Nerd Storage`, `Nerd storage`, `nerd storage`
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic CodeStream
+        `New Relic CodeStream`
       </td>
 
       <td>
@@ -225,17 +225,17 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        New Relic CodeStream (for the New Relic integration with CodeStream) or CodeStream (for just the CodeStream app)
+        `New Relic CodeStream` (for the New Relic integration with CodeStream) or `CodeStream` (for just the CodeStream app)
       </td>
 
       <td>
-        Do not use: New Relic CodeStream's, New Relic Code Stream, Code Stream
+        Do not use: `New Relic CodeStream's`, `New Relic Code Stream`, `Code Stream`
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic Explorer
+        `New Relic Explorer`
       </td>
 
       <td>
@@ -248,13 +248,13 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        Do not use: New Relic Explorer or Explorer. This is an end-of-life name and should no longer be used in New Relic docs or marketing materials.
+        Do not use: `New Relic Explorer` or `Explorer`. This is an end-of-life name and should no longer be used in New Relic docs or marketing materials.
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic Grok
+        `New Relic Grok`
       </td>
 
       <td>
@@ -263,22 +263,22 @@ This table is kept up to date and is the source of truth for capitalization. **M
 
       <td>
         The product is New Relic Grok, and that's how we want to present it.
-        * First use: New Relic Grok
-        * Subsequent uses: New Relic Grok
+        * First use: `New Relic Grok`
+        * Subsequent uses: `New Relic Grok`
       
         Be aware that there are other tools (not associated to New Relic) called grok. For example, grok is software that allows you to parse logs and other files. Always specify the name of those tools to ensure readers understand that we're not referring to New Relic Grok.
       </td>
 
       <td>
-        Do not use: New Relic grok, Grok (unless preceded by "New Relic"), GROK 
+        Do not use: `New Relic grok`, `Grok` (unless preceded by `New Relic`), `GROK`
         
-        Note that there are other tools (not associated with New Relic) called "Grok." For these, always specify the company name to ensure readers understand that we're not referring to New Relic Grok.
+        Note that there are other tools (not associated with New Relic) called grok. For these, always specify the company name to ensure readers understand that we're not referring to New Relic Grok.
       </td>
     </tr>  
     
     <tr>
       <td>
-        New Relic Infinite Tracing\*
+        `New Relic Infinite Tracing`\*
       </td>
 
       <td>
@@ -286,19 +286,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic Infinite Tracing<sup>®</sup> (printed assets) or New Relic Infinite Tracing (digital assets)
+        First use: `New Relic Infinite Tracing<sup>®</sup>` (printed assets) or `New Relic Infinite Tracing` (digital assets)
 
-        Subsequent uses: Infinite Tracing
+        Subsequent uses: `Infinite Tracing`
       </td>
 
       <td>
-        Do not use: Infinite tracing, infinite tracing, New Relic Edge with Infinite Tracing
+        Do not use: `Infinite tracing`, `infinite tracing`, `New Relic Edge with Infinite Tracing`
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic Instant Observability
+        `New Relic Instant Observability`
       </td>
 
       <td>
@@ -306,19 +306,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic Instant Observability or New Relic Instant Observability (I/O)
+        First use: `New Relic Instant Observability` or `New Relic Instant Observability (I/O)`
 
-        Subsequent uses: Instant Observability or New Relic I/O (avoid using the acronym externally, if possible)
+        Subsequent uses: `Instant Observability` or `New Relic I/O` (avoid using the `I/O` acronym externally, if possible)
       </td>
 
       <td>
-        Do not use: New Relic instant observability, instant observability, NRIO, IO, I/O
+        Do not use: `New Relic instant observability`, `instant observability`, `NRIO`, `IO`, `I/O`
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic Lookout
+        `New Relic Lookout`
       </td>
 
       <td>
@@ -326,21 +326,21 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic Lookout
+        First use: `New Relic Lookout`
 
-        Subsequent uses: New Relic Lookout
+        Subsequent uses: `New Relic Lookout`
 
         Describing actions in the UI: **Lookout**
       </td>
 
       <td>
-        Do not use: New Relic Lookout's, Lookout (okay when directing what to select in the UI), lookout
+        Do not use: `New Relic Lookout's`, `Lookout` (okay when directing what to select in the UI), `lookout`
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic Navigator
+        `New Relic Navigator`
       </td>
 
       <td>
@@ -348,21 +348,21 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic Navigator
+        First use: `New Relic Navigator`
 
-        Subsequent uses: New Relic Navigator
+        Subsequent uses: `New Relic Navigator`
 
         Describing actions in the UI: **Navigator**
       </td>
 
       <td>
-        Do not use: New Relic Navigator's, Navigator (okay when directing what to select in the UI), navigator
+        Do not use: `New Relic Navigator's`, `Navigator` (okay when directing what to select in the UI), `navigator`
       </td>
     </tr>
 
  <tr>
       <td>
-        New Relic Query Language
+        `New Relic Query Language`
       </td>
 
       <td>
@@ -370,19 +370,19 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        First use: New Relic Query Language (NRQL)
+        First use: `New Relic Query Language (NRQL)`
 
-        Subsequent uses: NRQL or New Relic Query Language
+        Subsequent uses: `NRQL` or `New Relic Query Language`
       </td>
 
       <td>
-        Do not use: New Relic query language, or NRQL on first occurrence
+        Do not use: `New Relic query language`, or `NRQL` on first occurrence
       </td>
     </tr>
 
     <tr>
       <td>
-        New Relic Vulnerability Management
+        `New Relic Vulnerability Management`
       </td>
 
       <td>
@@ -390,14 +390,13 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        - When writing about the activity of managing vulnerabilities: vulnerability management
-        - When referring to the capability on first mention in body copy: New Relic Vulnerability Management
-        - When referring to the capability in headings or on subsequent mentions in body copy: 
-         Vulnerability Management
+        - When writing about the activity of managing vulnerabilities: `vulnerability management`
+        - When referring to the capability on first mention in body copy: `New Relic Vulnerability Management`
+        - When referring to the capability in headings or on subsequent mentions in body copy: `Vulnerability Management`
       </td>
 
       <td>
-        Do not use: vulnerability management monitoring, vulnerability monitoring
+        Do not use: `vulnerability management monitoring`, `vulnerability monitoring`
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -1133,7 +1133,7 @@ Notes about features and capabilities:
 
     <tr>
       <td>
-        ``synthetic monitoring`
+        `synthetic monitoring`
       </td>
 
       <td>


### PR DESCRIPTION
* Consistently use code formatting throughout the doc, ala how the usage dictionary is formatting
* Note that we should use superscript on trademark symbols
* Ironically, remove superscript from table b/c it's messing up the code formatting