### PR TITLE
Add new troubleshooting guide for ruby agent

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset.mdx
@@ -1,0 +1,39 @@
+---
+title: 'Generically named transactions Middleware/Rack/ActionDispatch::Routing::RouteSet#call in APM UI'
+type: troubleshooting
+tags:
+  - Agents
+  - Ruby agent
+  - Troubleshooting
+metaDescription: 'Find out what to do if you see transactions named Middleware/Rack/ActionDispatch::Routing::RouteSet#call in your APM UI.'
+---
+
+## Problem
+
+You are seeing transactions in the APM UI named `Middleware/Rack/ActionDispatch::Routing::RouteSet#call` and you are not sure what they are.
+
+
+## Cause
+
+Transactions with the name `Middleware/Rack/ActionDispatch::Routing::RouteSet#call` represent a route in your rails app that gets routed to code that is not instrumented by New Relic. Since the rails middleware is instrumented, New Relic is able to capture the time spent on the transaction, but is unable to provide any additional details about the transaction due to the lack of instrumentation.
+
+
+## Solution
+
+There are a variety of situations that can lead to transactions named `Middleware/Rack/ActionDispatch::Routing::RouteSet#call`. The most common are listed below.
+
+#### Routes to a controller that does not inherit from ActionController::Base
+ 
+The New Relic Ruby agent instruments controllers by inserting instrumentation into `ActionController::Base`. If the controller being routed to does not inherit from `ActionController::Base`, the agent will not be able to automatically instrument the controller. To resolve this issue, you can include the new relic instrumentation directly in your controller by adding the following to your controller.
+
+```ruby
+include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+```
+
+#### Routes to a gem that is not instrumented by New Relic
+
+If there is a route in your application that routes to a gem that is not instrumented by New Relic, you will only see the instrumentation for the rails middleware, which will result in a transaction with this name. To address this, you can use custom instrumentation in your application to insert New Relic instrumentation into the gem. 
+
+
+In general, adding custom instrumentation to your application is the best way to get more details about these transactions. You can find more information about custom instrumentation in our [Ruby agent documentation](https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-custom-instrumentation).
+

--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Generically named transactions Middleware/Rack/ActionDispatch::Routing::RouteSet#call in APM UI'
+title: 'Transaction labelled `Middleware/Rack/ActionDispatch::Routing::RouteSet#call`'
 type: troubleshooting
 tags:
   - Agents
@@ -8,32 +8,43 @@ tags:
 metaDescription: 'Find out what to do if you see transactions named Middleware/Rack/ActionDispatch::Routing::RouteSet#call in your APM UI.'
 ---
 
-## Problem
+## Problem [#problem]
 
-You are seeing transactions in the APM UI named `Middleware/Rack/ActionDispatch::Routing::RouteSet#call` and you are not sure what they are.
+You see transactions in the APM UI named `Middleware/Rack/ActionDispatch::Routing::RouteSet#call`, but you're unsure what they are.
 
+## Cause [#cause]
 
-## Cause
+Transactions with the name `Middleware/Rack/ActionDispatch::Routing::RouteSet#call` represent a route in your rails app that hasn't been instrumented. Since the rails middleware is instrumented, New Relic can capture the time spent on the transaction, but cannot provide any details beyond that. 
 
-Transactions with the name `Middleware/Rack/ActionDispatch::Routing::RouteSet#call` represent a route in your rails app that gets routed to code that is not instrumented by New Relic. Since the rails middleware is instrumented, New Relic is able to capture the time spent on the transaction, but is unable to provide any additional details about the transaction due to the lack of instrumentation.
+There are a variety of situations that can lead to transactions named `Middleware/Rack/ActionDispatch::Routing::RouteSet#call`. We've provided two solutions for the most common causes to this transaction type. 
 
+## Solution [#solution]
 
-## Solution
+<Tabs>
+	<TabsBar>
+        <TabsBarItem id="route-gem">
+            Add custom instrumentation to an uninstrumented gem
+        </TabsBarItem>
+        <TabsBarItem id="route-controller">
+            Instrument your controller directly
+        </TabsBarItem>
+  </TabsBar>
 
-There are a variety of situations that can lead to transactions named `Middleware/Rack/ActionDispatch::Routing::RouteSet#call`. The most common are listed below.
+    <TabsPages>
+        <TabsPageItem id="route-gem">
+        If a route in your app passes through instrumented middleware to an uninstrumented gem, then you need to add custom instrumentation to that gem to see more specific data about the transaction. To add custom instrumentation, we recommend reading our [Ruby custom instrumentation doc](https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-custom-instrumentation).
 
-#### Routes to a controller that does not inherit from ActionController::Base
- 
-The New Relic Ruby agent instruments controllers by inserting instrumentation into `ActionController::Base`. If the controller being routed to does not inherit from `ActionController::Base`, the agent will not be able to automatically instrument the controller. To resolve this issue, you can include the new relic instrumentation directly in your controller by adding the following to your controller.
+        Adding custom instrumentation to your application is the best way to get more details about these transactions.
 
-```ruby
-include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-```
+        </TabsPageItem>
+        <TabsPageItem id="route-controller">
 
-#### Routes to a gem that is not instrumented by New Relic
+        The Ruby agent instruments controllers by inserting instrumentation into `ActionController::Base`. If a route passes through a controller that does not inherit `ActionController::Base`, however, then that controller needs instrumentation. Instrument your controller directly by adding this to your app code: 
 
-If there is a route in your application that routes to a gem that is not instrumented by New Relic, you will only see the instrumentation for the rails middleware, which will result in a transaction with this name. To address this, you can use custom instrumentation in your application to insert New Relic instrumentation into the gem. 
+        ```ruby
+        include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+        ```
 
-
-In general, adding custom instrumentation to your application is the best way to get more details about these transactions. You can find more information about custom instrumentation in our [Ruby agent documentation](https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-custom-instrumentation).
-
+        </TabsPageItem>
+    </TabsPages>
+</Tabs>

--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset.mdx
@@ -39,7 +39,7 @@ There are a variety of situations that can lead to transactions named `Middlewar
         </TabsPageItem>
         <TabsPageItem id="route-controller">
 
-        The Ruby agent instruments controllers by inserting instrumentation into `ActionController::Base`. If a route passes through a controller that does not inherit `ActionController::Base`, however, then that controller needs instrumentation. Instrument your controller directly by adding this to your app code: 
+        The Ruby agent instruments controllers by inserting instrumentation into `ActionController::Base`. If a route passes through a controller that does not inherit `ActionController::Base`, however, then that controller needs instrumentation. Instrument your controller directly by adding this to your controller class: 
 
         ```ruby
         include NewRelic::Agent::Instrumentation::ControllerInstrumentation

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1193,6 +1193,8 @@ pages:
                 path: /docs/apm/agents/ruby-agent/troubleshooting/no-data-unicorn
               - title: Not installing Grape
                 path: /docs/apm/agents/ruby-agent/troubleshooting/not-installing-new-relic-supported-grape
+              - title: Transaction labelled `Middleware/Rack/ActionDispatch::Routing::RouteSet#call`
+                path: /docs/apm/agents/ruby-agent/troubleshooting/transactions-named-routeset
       - title: Advanced configuration
         path: /docs/apm/agents/manage-apm-agents
         pages:


### PR DESCRIPTION
This adds a troubleshooting guide for customers to learn more about what causes generically named transactions in their APM UI and some possible ways to solve the issue. 