### PR TITLE
Chore: Update .NET Agent installation and configuration docs to improve install experience.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -210,7 +210,7 @@ For specific install instructions, see the [.NET agent install documentation](/d
 
 Some configuration options in New Relic's .NET agent can be set via environment variables as an alternative to setting them in a config file. Below is a list of environment variables recognized by the .NET agent with example values.
 
-```
+```ini
 NEW_RELIC_LICENSE_KEY=XXXXXXXX
 NEW_RELIC_LOG=MyApp.log
 NEW_RELIC_APP_NAME=Descriptive Name
@@ -253,6 +253,21 @@ NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
 NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
 NEW_RELIC_HIGH_SECURITY=<var>true|false</var>
 ```
+
+<CollapserGroup>
+  <Collapser
+    id="net-framework-32on64-env-variables"
+    title="Supporting 32-bit applications on 64-bit systems."
+  >
+    The 64-bit MSI installer for New Relic's .NET agent automatically installs the 32-bit profiler assembly along with the 64-bit assembly and as of v10.16.0, enables 32-bit support for IIS automatically.  For non-IIS hosted applications, you can set the required environment variable manually.
+
+    ```ini
+    COR_PROFILER_PATH_32="C:\Program Files (x86)\New Relic\.NET Agent\NewRelic.Profiler.dll"
+    ```
+
+  </Collapser>
+</CollapserGroup>
+
 
 If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/how-use-codestream/performance-monitoring#repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/how-use-codestream/performance-monitoring#buildsha).
 

--- a/src/install/dotnet/installation/dockerWindows.mdx
+++ b/src/install/dotnet/installation/dockerWindows.mdx
@@ -16,7 +16,7 @@ Some notes about how to implement your Docker file:
   Note that Windows Nano Server images are not supported.
 </Callout>
 
-### Example Windows Dockerfile for .NET Framework application using IIS [#example-windows-dockerfile-framework]
+### Example Windows dockerfile for .NET framework application using IIS [#example-windows-dockerfile-framework]
 
 <Callout variant="important">
   For non-IIS hosted applications:

--- a/src/install/dotnet/installation/dockerWindows.mdx
+++ b/src/install/dotnet/installation/dockerWindows.mdx
@@ -16,7 +16,13 @@ Some notes about how to implement your Docker file:
   Note that Windows Nano Server images are not supported.
 </Callout>
 
-### Example Windows Dockerfile for .NET Framework application [#example-windows-dockerfile-framework]
+### Example Windows Dockerfile for .NET Framework application using IIS [#example-windows-dockerfile-framework]
+
+<Callout variant="important">
+  For non-IIS hosted applications:
+  * The `INSTALLLEVEL=50` switch must be used to set the [required environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables).
+  * Enable the agent for your application using: [application config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#app-config), [app name in newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config), or [a local newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config-local).
+</Callout>
 
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/framework/aspnet

--- a/src/install/dotnet/installation/windowsNonIisInstall-2.mdx
+++ b/src/install/dotnet/installation/windowsNonIisInstall-2.mdx
@@ -6,6 +6,7 @@ descriptionText: ""
 ---
 
 1. Run the install wizard. Some tips for using the install wizard:
+   * For .NET Framework only: You'll need to select **Instrument all .NET Framework Applications** or implement the [required environment](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables) variables manually.
    * You'll need your [New Relic license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
    * If you're updating an existing installation using the install wizard, select the **Change** option.
    * **Optional**: you can also run the installer via the command line or from a script. For how to do that, see the advanced install details below.
@@ -23,7 +24,7 @@ Instead of using the MSI install wizard, described above, you can run the MSI fr
 
 Here's an example command for performing a new agent install using the MSI installer. (For changes to an existing installation, use the `ADDLOCAL` command, explained below.) Replace the values with values relevant to your install.
 
-```bash
+```powershell
 msiexec.exe /i C:\PATH_TO\newrelic-agent-win-x86-VERSION.msi /qb NR_LICENSE_KEY=YOUR_LICENSE_KEY INSTALLLEVEL=1
 ```
 
@@ -34,7 +35,7 @@ The `INSTALLLEVEL` can be either `1` or `50`:
 
 Instead of using the `INSTALLLEVEL` presets, you can customize which features to install with the `ADDLOCAL` command shown below. This is also the command you'd use to update an existing installation. Here's an example command:
 
-```bash
+```powershell
 msiexec.exe /i C:\PATH_TO\newrelic-agent-win-x86-VERSION.msi /qb NR_LICENSE_KEY=YOUR_LICENSE_KEY ADDLOCAL=OPTION_1, OPTION_2
 ```
 

--- a/src/install/dotnet/installation/windowsNonIisInstall-2.mdx
+++ b/src/install/dotnet/installation/windowsNonIisInstall-2.mdx
@@ -6,7 +6,7 @@ descriptionText: ""
 ---
 
 1. Run the install wizard. Some tips for using the install wizard:
-   * For .NET Framework only: You'll need to select **Instrument all .NET Framework Applications** or implement the [required environment](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables) variables manually.
+   * For .NET Framework only: You'll need to select **Instrument all .NET Framework Applications** or implement the [required environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables) manually.
    * You'll need your [New Relic license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
    * If you're updating an existing installation using the install wizard, select the **Change** option.
    * **Optional**: you can also run the installer via the command line or from a script. For how to do that, see the advanced install details below.


### PR DESCRIPTION
## Give us some context

- Config: Add 32-bit profiler env vars since we set them up for 64-bit installs on IIS and the DLL is already there.  Added as a collapser under option env vars. 
- Monitor your .NET app: For Windows non-iis no Docker call out needing INSTALLLEVEL=50 for Framework apps.
- Monitor your .NET app: For Windows non-iis Docker add missing INSTALLLEVEL=50 and mention required config changes for Framework.