### PR TITLE
chore(synthetics): Removed EOLed feature and deprecation warnings

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics.mdx
@@ -89,15 +89,6 @@ SLA reports support the following features:
       </td>
     </tr>
 
-    <tr>
-      <td>
-        Make the report public
-      </td>
-
-      <td>
-        Change the **Public SLA** setting to **ON** to allow non-authenticated users to view the report. Select **Share Report** to get the public URL to share.
-      </td>
-    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/synthetics/new-relic-synthetics/scripting-monitors/synthetic-scipted-browser-reference-monitor-versions-chrome100
 ---
 
-To execute your scripted browser monitors using [Selenium Webdriver 4.1 APIs](https://www.selenium.dev/selenium/docs/api/javascript/index.html)), make sure your script's syntax uses the variables `$selenium` and `$webDriver`. To access [Selenium Webdriver APIs 3.6.0](http://seleniumhq.github.io/selenium/docs/api/javascript/index.html), use the variables `$driver` and `$browser`. While `$driver` and `$browser` are still available, you'll receive deprecation warnings indicating that these may be removed from future runtime releases.
+To execute your scripted browser monitors using [Selenium Webdriver 4.1 APIs](https://www.selenium.dev/selenium/docs/api/javascript/index.html)), make sure your script's syntax uses the variables `$selenium` and `$webDriver`. To access [Selenium Webdriver APIs 3.6.0](http://seleniumhq.github.io/selenium/docs/api/javascript/index.html), use the variables `$driver` and `$browser` as described in the [0.5.0+ browser reference documentation](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050/). 
 
 In particular:
 

--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
@@ -42,9 +42,7 @@ The [Node.js 16 and newer scripted API runtimes](/docs/synthetics/synthetic-moni
 
 ## Scripted Browser: Deprecation warnings ($browser / $driver) [#deprecations]
 
-The [Chrome 72 and older scripted browser runtimes](/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes/#dependencies) exposed Selenium WebDriver APIs [using `$driver` and `$browser`](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050/). These objects are still available in the Chrome 100 and newer runtimes for backward compatibility, but you will receive a deprecation warning in your script log when using these objects. This warning will not cause monitors to fail and no deprecation date has been set.
-
-The Chrome 100 and newer scripted browser runtimes [use `$selenium` and `$webDriver` instead of `$driver` and `$browser`](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100/). The `$selenium` and `$webDriver` objects provide access to Selenium WebDriver 4.1 APIs and the `$driver` and `$browser` objects provide backward compability with Selenium WebDriver 3.6 syntax.
+Deprecation warnings for `$browser` and `$driver` were removed starting with the 2.0.29 or newer version of the browser runtime. You should no longer receive these warnings when using public locations. Please update your node browser runtime image if you are receiving these warnings when using private locations. 
 
 ## Scripted Browser: waitForAndFindElement and waitForPendingRequests [#waitMethods]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
@@ -20,10 +20,6 @@ Making the switch gives you these features:
 * [Custom timing library](/docs/synthetics/synthetic-monitoring/scripting-monitors/custom-timing-details) for scripted API monitors.
 - Access to  our [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial) to automate the management of your synthetic monitors. 
 
-<Callout variant="important">
-Before switching, make sure you've updated your allow lists to accept network requests from the new runtime's [public IP ranges](/docs/synthetics/synthetic-monitoring/administration/new-synthetic-public-minion-ips).
-</Callout>
-
 ## Private location requirements [#private-locations]
 
 Using new runtimes on [private locations](/docs/synthetics/synthetic-monitoring/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations) requires the installation of [synthetics job manager](/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager).
@@ -75,6 +71,8 @@ The new synthetic monitoring runtime includes out-of-the-box timing details when
 
 The new runtime includes syntax changes and other deprecations. We're introducing new language that changes the [script syntax](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100) in your scripted browser monitors. The new runtime is backwards compatible with legacy runtime syntax in most cases. To avoid breaking monitors during the upgrade process, you may receive a deprecation warning in your script log output.
 
+As of version 2.0.29 or newer of the browser runtime, you will no longer receive deprecation warnings for using the `$browser` or `$driver` syntax in the new runtime. You can continue to use this Selenium 3.6 compatible syntax in the Selenium 4.1 runtime. You can also choose to use the `$webDriver` and `$selenium` based Selenium 4.1 syntax.
+
 <table>
   <thead>
     <tr>
@@ -91,28 +89,6 @@ The new runtime includes syntax changes and other deprecations. We're introducin
   </thead>
 
     <tbody>
-      <tr>
-        <td>
-          `$browser`
-        </td>
-        <td>
-          `$webDriver`
-        </td>
-        <td>$browser provides backwards compatibility with Selenium WebDriver 3.6, but $webDriver allows you to use Selenium WebDriver 4.1 syntax. 
-        </td>
-      </tr>
-      
-      <tr>
-        <td>
-          `$driver`
-        </td> 
-        <td>
-          `$selenium`
-        </td>
-        <td>$driver provides backwards compatibility with Selenium WebDriver 3.6, while $selenium allows you to use Selenium WebDriver 4.1 syntax.
-        </td>
-      </tr>
-
       <tr>
         <td>
           white/black list


### PR DESCRIPTION
- Removed references to the public SLA report. This was functionality was EOLed. 
- Removed deprecation warnings for $browser and $driver objects. These will continue to be supported. 
- Clarified new runtime transition guides and related docs for $browser and $driver object usage