### PR TITLE
fix(apm): blank spaces to fill page width

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/getagent.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/getagent.mdx
@@ -20,7 +20,7 @@ NewRelic.Api.Agent.NewRelic.GetAgent()
 
 Get access to the agent via the `IAgent` interface.
 
-## Requirements
+## Requirements                                                                                         
 
 Agent version 8.9 or higher.
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/getagent.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/getagent.mdx
@@ -18,9 +18,11 @@ redirects:
 NewRelic.Api.Agent.NewRelic.GetAgent()
 ```
 
-Get access to the agent via the `IAgent` interface.
+Get access to the agent via the `IAgent` interface. 
 
-## Requirements                                                                                         
+                                                                                      <br />
+
+## Requirements                
 
 Agent version 8.9 or higher.
 


### PR DESCRIPTION
There's an issue where if a page's content does not fill the width of the page, it renders strangely. Adding spaces as a temporary fix
