### PR TITLE
Update opentelemetry-collector-kafka-confluentcloud.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -169,6 +169,9 @@ docker compose up
 
 ### Confluent Cloud metrics [#confluent-metrics]
 
+  * All the *Exportable* metrics exposed by [Confluent Cloud Metrics API](https://api.telemetry.confluent.cloud/docs/descriptors/datasets/cloud).
+  * The following is a partial list of the *Exportable* metrics.
+
 <table>
   <thead>
     <tr>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud.mdx
@@ -169,8 +169,7 @@ docker compose up
 
 ### Confluent Cloud metrics [#confluent-metrics]
 
-  * All the *Exportable* metrics exposed by [Confluent Cloud Metrics API](https://api.telemetry.confluent.cloud/docs/descriptors/datasets/cloud).
-  * The following is a partial list of the *Exportable* metrics.
+This integration covers all the *Exportable* metrics within the [Confluent Cloud Metrics API](https://api.telemetry.confluent.cloud/docs/descriptors/datasets/cloud). We have a partial list of the *Exportable* metrics below:
 
 <table>
   <thead>


### PR DESCRIPTION

## Give us some context
 
The *Confluent Cloud metrics* section documents a partial list of the metrics the collector is able to collect.  
It may give read an impression that the collector can only collect the metrics listed. 

