### PR TITLE
feat(apm): remove errors tutorial from apm category

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -18,9 +18,6 @@ pages:
       path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
   - title: Installation and configuration
     pages:
-      - title: Find errors in your failing app
-        label: Tutorial
-        path: /docs/tutorial-error-tracking/respond-outages
       - title: Go monitoring
         path: /docs/apm/agents/go-agent
         pages:


### PR DESCRIPTION
Removes the errors tutorial from the install section of the APM category. We noticed this in a feedback burndown session and agreed this isn't the right place for a link to live. 