### PR TITLE
AWS Metric naming revamp

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -30,7 +30,7 @@ For more information about namespaces supported by AWS, see the [CloudWatch docu
 
 ## API Polling metrics [#aws-metrics-table]
 
-For a reference on what metrics are available from each one of the polling integrations and their names, [check each of the individual integrations documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/).
+For a reference on available metrics from each one of the polling integrations and their names, [check out our doc on the individual integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/).
 
 The following table is a noncomprehensive list of the metrics collected by the AWS polling integrations and their [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) translations. 
 

--- a/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -11,7 +11,7 @@ redirects:
 
 We recommend using the [AWS CloudWatch Metric Streams integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/) to ingest AWS services' metrics. For a complete list of available metrics, check the CloudWatch metrics listing documentation for each AWS service.
 
-## Metrics naming convention [#metric-naming-convention]
+## ## Dimensional metric naming convention [#metric-naming-convention]
 
 Metrics received from AWS CloudWatch are stored in New Relic as [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) following this convention:
 
@@ -28,9 +28,11 @@ Metrics received from AWS CloudWatch are stored in New Relic as [dimensional met
 
 For more information about namespaces supported by AWS, see the [CloudWatch documentation website](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html).
 
-## Amazon Web Services metrics [#aws-metrics-table]
+## API Polling metrics [#aws-metrics-table]
 
-The following table contains the metrics we collect from AWS API Polling integrations:
+For a reference on what metrics are available from each one of the polling integrations and their names, [check each of the individual integrations documentation](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/).
+
+The following table is a noncomprehensive list of the metrics collected by the AWS polling integrations and their [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) translations. 
 
 <table>
   <tbody>


### PR DESCRIPTION
This brings AWS metric naming section up to speed with its Azure counterpart. 