### PR TITLE
fix: correct endpoint address

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -105,7 +105,7 @@ For more detail on specific agents and integrations, and about ports, keep readi
        `cloud-collector.newrelic.com`
       </td>
       <td>
-       `cloud-collector.eu01.newrelic.com`
+       `cloud-collector.eu.newrelic.com`
       </td>
      
     </tr>
@@ -377,7 +377,7 @@ Here's a list of the [EU data center region](/docs/accounts/accounts-billing/acc
 * `collector*.eu01.nr-data.net`
 * `aws-api.eu.newrelic.com`
 * `aws-api.eu01.nr-data.net`
-* `cloud-collector.eu01.newrelic.com`
+* `cloud-collector.eu.newrelic.com`
 * `bam.eu01.nr-data.net`
 * `insights-collector.eu01.nr-data.net`
 * `log-api.eu.newrelic.com`


### PR DESCRIPTION

* What problems does this PR solve?

It corrects an endpoint address for the EU `cloud-collector`.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

`cloud-collector.eu01.newrelic.com` does not exist or match the pattern of other domains, which are either in `eu01.nr-data.net` or `eu.newrelic.com`.  `cloud-collector.eu.newrelic.com` does resolve/respond.

* If your issue relates to an existing GitHub issue, please link to it.