### PR TITLE
NR-180031 - docs freshness utils

### DIFF
--- a/.github/workflows/verify-mdx.yml
+++ b/.github/workflows/verify-mdx.yml
@@ -1,0 +1,40 @@
+name: verify mdx files
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - tabatha/docs-freshness
+
+env:
+  NODE_OPTIONS: '--max-old-space-size=4096'
+  CHOKIDAR_USEPOLLING: 1
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  verify-mdx:
+    name: run verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Cache dependencies
+        id: yarn-cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Run Eslint
+        run: yarn verify-mdx

--- a/scripts/addFreshnessFrontmatter.mjs
+++ b/scripts/addFreshnessFrontmatter.mjs
@@ -12,6 +12,7 @@ const allDocs = await glob('src/content/docs/**/*.mdx', {
   ignore: [
     '**/index.mdx',
     'src/content/docs/release-notes/**/*.mdx',
+    'src/content/docs/style-guide/**/*.mdx',
     'src/content/whats-new/**/*.mdx',
     'src/content/docs/security/new-relic-security/security-bulletins/**/*.mdx',
   ],
@@ -51,7 +52,7 @@ const addFreshnessFrontmatter = (allDocs) => {
     const content = fileData.split('---');
 
     // modify the frontmatter adding the freshness field if it does not have it already
-    if (!content[1].includes(freshnessFrontmatterKey)) {
+    if (!content[1]?.includes(freshnessFrontmatterKey)) {
       content[1] = `${content[1]}${freshnessFrontmatterKey}${
         isDocStale(created) ? 'never' : created.toISOString().slice(0, 10)
       }\n`;

--- a/scripts/addFreshnessFrontmatter.mjs
+++ b/scripts/addFreshnessFrontmatter.mjs
@@ -1,0 +1,82 @@
+#! /usr/bin/env node
+
+import { execSync } from 'child_process';
+import { glob } from 'glob10';
+import { writeFile, readFileSync } from 'fs';
+import cliProgress from 'cli-progress';
+
+console.log('Reading git history...');
+console.time('Freshness field added');
+
+const allDocs = await glob('src/content/docs/**/*.mdx', {
+  ignore: [
+    '**/index.mdx',
+    'src/content/docs/release-notes/**/*.mdx',
+    'src/content/whats-new/**/*.mdx',
+    'src/content/docs/security/new-relic-security/security-bulletins/**/*.mdx',
+  ],
+});
+
+/**
+ * Helper function that checks if a date is outside the freshness threshold of 180 days.
+ * @param {Date} date
+ * @returns {boolean} if date is stale
+ */
+const isDocStale = (date) => {
+  const days = 180;
+  const today = Date.now();
+  const staleDate = new Date(today - days * 24 * 60 * 60 * 1000);
+  return staleDate > date;
+};
+
+const freshnessFrontmatterKey = 'freshnessValidatedDate: ';
+
+/**
+ * Reads an array of docs and writes a new freshnessValidatedDate field to frontmatter.
+ * Uses the last git rename date on that file to set the value.
+ * @param {Array} docs - Array of docs file paths
+ */
+const addFreshnessFrontmatter = (allDocs) => {
+  allDocs.map(async (doc, i) => {
+    // get rename date of file to get a 'created' date
+    const gitLogCreatedDate = execSync(
+      `git log --follow --pretty=format:%aI ${doc}  | tail -1`
+    ).toString();
+
+    const created = new Date(gitLogCreatedDate);
+
+    const fileData = readFileSync(doc, 'utf-8');
+
+    // split doc into sections using the frontmatter delimiter
+    const content = fileData.split('---');
+
+    // modify the frontmatter adding the freshness field if it does not have it already
+    if (!content[1].includes(freshnessFrontmatterKey)) {
+      content[1] = `${content[1]}${freshnessFrontmatterKey}${
+        isDocStale(created) ? 'never' : created.toISOString().slice(0, 10)
+      }\n`;
+    }
+    // put the doc back together
+    const newContent = content.join('---');
+
+    writeFile(doc, newContent, 'utf-8', function (err) {
+      if (err) {
+        console.log(
+          '\n',
+          'Some error occurred - file either not saved or corrupted file saved.'
+        );
+      }
+    });
+    progressBar.update(i + 1);
+  });
+  progressBar.stop();
+  console.timeEnd('Freshness field added');
+};
+
+const progressBar = new cliProgress.SingleBar(
+  {},
+  cliProgress.Presets.shades_classic
+);
+progressBar.start(allDocs.length, 0);
+
+addFreshnessFrontmatter(allDocs);

--- a/scripts/docsAndLastDateEdited.mjs
+++ b/scripts/docsAndLastDateEdited.mjs
@@ -72,8 +72,8 @@ const allDocsAndDates = allDocs.map((doc, i) => {
 
   // shorten date to YYYY-MM-DD and return author data formatted for readability
   const authorsAndDates = authorData.map((author) => {
-    const split = author.split(',');
-    return `[${split[0]} - ${split[1]?.slice(0, 10)}]`;
+    const [name, date] = author.split(',');
+    return `[${name} - ${date?.slice(0, 10)}]`;
   });
 
   progressBar.update(i + 1);

--- a/scripts/docsAndLastDateEdited.mjs
+++ b/scripts/docsAndLastDateEdited.mjs
@@ -12,6 +12,7 @@ const allDocs = await glob('src/content/docs/**/*.mdx', {
   ignore: [
     '**/index.mdx',
     'src/content/docs/release-notes/**/*.mdx',
+    'src/content/docs/style-guide/**/*.mdx',
     'src/content/whats-new/**/*.mdx',
     'src/content/docs/security/new-relic-security/security-bulletins/**/*.mdx',
   ],
@@ -29,7 +30,7 @@ const getFreshnessFrontmatter = (doc) => {
   const frontmatter = readFileSync(doc, 'utf-8').split('---')[1];
   let freshnessDate;
 
-  if (frontmatter.includes(freshnessFrontmatterKey)) {
+  if (frontmatter?.includes(freshnessFrontmatterKey)) {
     freshnessDate = frontmatter
       .split('\n')
       // find the line with the freshnessDate, there should always be one, and remove the key

--- a/scripts/docsAndLastDateEdited.mjs
+++ b/scripts/docsAndLastDateEdited.mjs
@@ -2,7 +2,7 @@
 
 import { execSync } from 'child_process';
 import { glob } from 'glob10';
-import { writeFile } from 'fs';
+import { writeFileSync, writeFile, readFileSync } from 'fs';
 import { stringify } from 'csv-stringify';
 import cliProgress from 'cli-progress';
 
@@ -10,8 +10,40 @@ console.log('Building CSV file...');
 console.time('csvCreation');
 
 const allDocs = await glob('src/content/docs/**/*.mdx', {
-  ignore: '**/index.mdx',
+  ignore: [
+    '**/index.mdx',
+    'src/content/docs/release-notes/**/*.mdx',
+    'src/content/whats-new/**/*.mdx',
+    'src/content/docs/security/new-relic-security/security-bulletins/**/*.mdx',
+  ],
 });
+
+const freshnessFrontmatterKey = 'freshnessValidatedDate: ';
+
+/**
+ * Reads a doc file and extracts the `freshnessValidatedDate` value from frontmatter
+ * @param {String} doc - doc file path
+ * @returns {String} freshnessDate - date string | `never` | null
+ **/
+const getFreshnessFrontmatter = (doc) => {
+  // split the doc using the frontmatter delimiter and keep the frontmatter data
+  const frontmatter = readFileSync(doc, 'utf-8').split('---')[1];
+  let freshnessDate;
+
+  if (frontmatter.includes(freshnessFrontmatterKey)) {
+    freshnessDate = frontmatter
+      .split('\n')
+      // find the line with the freshnessDate, there should always be one, and remove the key
+      .filter((string) => string.includes(freshnessFrontmatterKey))[0]
+      .replace(freshnessFrontmatterKey, '');
+  } else {
+    freshnessDate = null;
+  }
+
+  return freshnessDate?.includes('never') | (freshnessDate === null)
+    ? freshnessDate
+    : new Date(freshnessDate).toDateString();
+};
 
 const progressBar = new cliProgress.SingleBar(
   {},
@@ -24,20 +56,26 @@ const allDocsAndDates = allDocs.map((doc, i) => {
     `git log -1 --pretty=format:%aI ${doc}`
   ).toString();
 
-  const dateModified = new Date(gitLogModifiedDate);
+  const dateModified = new Date(gitLogModifiedDate).toDateString();
+  const freshnessDate = getFreshnessFrontmatter(doc);
 
-  progressBar.update(i);
+  progressBar.update(i + 1);
 
-  return [doc, dateModified.toDateString()];
+  return [doc, freshnessDate, dateModified];
 });
+
+const headers = ['Doc', 'Freshness Date', 'Last Modified Date'];
+
+allDocsAndDates.unshift(headers);
 
 stringify(allDocsAndDates, function (err, output) {
   writeFile('docsLastModifiedDate.csv', output, 'utf8', function (err) {
     if (err) {
       console.log(
-        'Some error occured - file either not saved or corrupted file saved.'
+        'Some error occurred - file either not saved or corrupted file saved.'
       );
     } else {
+      console.log('\n');
       console.timeEnd('csvCreation');
       console.log('CSV Created!');
       progressBar.stop();

--- a/scripts/utils/__tests__/frontmatter.js
+++ b/scripts/utils/__tests__/frontmatter.js
@@ -1,4 +1,4 @@
-const { frontmatter } = require('../frontmatter');
+const { frontmatter, validateFreshnessDate } = require('../frontmatter');
 
 const mdxString = `---
 howdy: cowboy 🤠
@@ -39,5 +39,76 @@ describe('frontmatter', () => {
 
     expect(error).not.toBe(null);
     expect(attributes).toEqual({});
+  });
+});
+
+const happyFreshnessMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+freshnessValidatedDate: never
+---
+some content!
+`;
+
+const happierFreshnessMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+freshnessValidatedDate: 2023-12-02
+---
+some content!
+`;
+
+const badDateFreshnessMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+freshnessValidatedDate: 23-12-02
+---
+some content!
+`;
+
+const missingFreshnessMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+---
+some content!
+`;
+
+describe('freshness frontmatter field', () => {
+  it('should pass the check with valid "never" value', () => {
+    const error = validateFreshnessDate(happyFreshnessMdxString);
+
+    expect(error).toBeFalsy;
+  });
+
+  it('should pass the check with valid YYYY-MM-DD date value', () => {
+    const error = validateFreshnessDate(happierFreshnessMdxString);
+
+    expect(error).toBeFalsy;
+  });
+
+  it('should throw error for invalid date value', () => {
+    const error = validateFreshnessDate(badDateFreshnessMdxString);
+
+    const expectedError =
+      'freshnessValidatedDate is not a valid value. Must be date format YYYY-MM-DD or `never`';
+
+    expect(error.message).toEqual(expectedError);
+  });
+
+  it('should throw error missing freshnessValidatedDate field', () => {
+    const error = validateFreshnessDate(missingFreshnessMdxString);
+
+    const expectedError =
+      'freshnessValidatedDate field missing from frontmatter';
+
+    expect(error.message).toEqual(expectedError);
   });
 });

--- a/scripts/utils/frontmatter.js
+++ b/scripts/utils/frontmatter.js
@@ -54,7 +54,6 @@ const DEFAULT_REASON = 'Invalid frontmatter entry';
  */
 const frontmatter = (mdString) => {
   let result;
-
   try {
     const { content, data } = grayMatter(mdString);
 
@@ -78,6 +77,67 @@ const frontmatter = (mdString) => {
   return result;
 };
 
+/**
+ * Parse the frontmatter and check for required freshnessValidatedDate field on most content doc pages. 
+ * Valid options are `never` or `YYYY-MM-DD`
+ *
+ * @example
+ * ```yaml
+ * ---
+ * title: This is a doc page
+ * freshnessValidatedDate: 2021-03-15
+ * ---
+ * ```
+ * 
+ *```js
+ * // error.message = undefined
+ * ``` 
+ * 
+ * ```yaml
+ * ---
+ * title: This is a doc page with an invalid date
+ * freshnessValidatedDate: 21-03-15
+ * ---
+ * ```
+ * 
+ *```js
+ * // error.message = freshnessValidatedDate is not a valid value. Must be date format YYYY-MM-DD or `never`
+ * ```
+
+ *
+ *
+ *
+ * @param {string} mdString - Full content of the MD(X) file to parse.
+ * @returns error | undefined
+ */
+
+const validateFreshnessDate = (mdString) => {
+  let error;
+
+  const { data } = grayMatter(mdString);
+
+  const isValidDate = (date) => {
+    return !isNaN(new Date(date));
+  };
+
+  // freshnessValidatedDate is a required field and must be a date or `never`
+  if (data.freshnessValidatedDate) {
+    if (
+      !isValidDate(data.freshnessValidatedDate) &&
+      !data.freshnessValidatedDate.includes('never')
+    ) {
+      error = new Error(
+        'freshnessValidatedDate is not a valid value. Must be date format YYYY-MM-DD or `never`'
+      );
+    }
+  } else {
+    error = new Error('freshnessValidatedDate field missing from frontmatter');
+  }
+
+  return error;
+};
+
 module.exports = {
   frontmatter,
+  validateFreshnessDate,
 };

--- a/scripts/verify_mdx.js
+++ b/scripts/verify_mdx.js
@@ -38,6 +38,7 @@ const readFile = async (filePath) => {
   const excludeFromFreshnessRegex = [
     'src/content/docs/release-notes/',
     'src/content/whats-new/',
+    'src/content/docs/style-guide/',
     'src/content/docs/security/new-relic-security/security-bulletins/',
     'src/i18n/content/',
   ];

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-log-parsing-rules-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-log-parsing-rules-tutorial.mdx
@@ -64,7 +64,7 @@ Available parsing rule fields include:
       </td>
 
       <td>
-        The [Grok](https://grokdebug.herokuapp.com/patterns#) pattern for this parsing rule. For example, you can include the `logtype` for the Grok pattern you are using with a [built-in parsing rule](/docs/logs/log-management/ui-data/built-log-parsing-rulesets/), such as `logtype = 'alb'`. However, you are not limited to using `logtype`; any attribute can be used as matching criteria.
+        The Grok pattern for this parsing rule. For example, you can include the `logtype` for the Grok pattern you are using with a [built-in parsing rule](/docs/logs/log-management/ui-data/built-log-parsing-rulesets/), such as `logtype = 'alb'`. However, you are not limited to using `logtype`; any attribute can be used as matching criteria.
       </td>
     </tr>
 


### PR DESCRIPTION
### ✨ Summary

* creates script that adds `freshnessValidatedDate` field to frontmatter. Equals a date if document has been created/renamed in the last 180 days. Otherwise sets the field to `never`
* update csv script
  * now includes headers
  * new column that grabs value from `freshnessValidateDate`
  * new column of authors and dates of all commits on that file in the last 180 days
 * both scripts ignore `release-notes`, `whats-new`, and `security-bulletin` dirs
* add verify-mdx as github action
  * modify mdx frontmatter verification to also check for newly required `freshnessValidatedDate` field and validate its value.
  * frontmatter script tests were updated to add coverage for new function

#### example terminal errors:
```bash
Error:  Frontmatter field error: /home/runner/work/docs-website/docs-website/src/content/docs/...mdx 

        freshnessValidatedDate field missing from frontmatter

Error:  Frontmatter field error: /home/runner/work/docs-website/docs-website/src/content/docs/...mdx 

        freshnessValidatedDate is not a valid value. Must be date format YYYY-MM-DD or `never`
```
  
### 🧪 To reproduce:
* run `node scripts/addFreshnessFrontmatter` to see the script run
  * You can can modify the `glob` path to a sub directory if you don't want to run on the whole repo
  * it can be hard to find a dir with changes in the last 180 days. I used `/browser/` [here](https://github.com/newrelic/docs-website/pull/15217/files)
* once `freshnessValidatedDate` is added, you can run `yarn docs-freshness` to output a csv file
  * if you changed the `glob` before, you should change it here too


### Example csv output
|Doc                                                                    |Freshness Date |Last Modified Date|Recent Authors                                     |
|-----------------------------------------------------------------------|---------------|------------------|---------------------------------------------------|
|src/content/docs/mlops/integrations/truera-mlops-integration.mdx       |never          |Tue Jul 25 2023   |[Natasha White - 2023-07-25]                       |
|src/content/docs/mlops/integrations/superwise-mlops-integration.mdx    |never          |Tue Jul 25 2023   |[Natasha White - 2023-07-25]                       |
|src/content/docs/mlops/integrations/openai-integration.mdx             |Tue Mar 14 2023|Thu Jun 22 2023   |[Bradley Camacho - 2023-06-22]                     |
|src/content/docs/mlops/integrations/mona-mlops-integration.mdx         |never          |Tue Jul 25 2023   |[Natasha White - 2023-07-25]                       |
|src/content/docs/mlops/integrations/datarobot-mlops-integration.mdx    |never          |Mon Oct 02 2023   |[Clinton - 2023-10-02],[Natasha White - 2023-07-25]|
|src/content/docs/mlops/integrations/dagshub-mlops-integration.mdx      |never          |Tue Jul 25 2023   |[Natasha White - 2023-07-25]                       |
|src/content/docs/mlops/integrations/comet-mlops-integration.mdx        |never          |Tue Jul 25 2023   |[Natasha White - 2023-07-25]                       |
|src/content/docs/mlops/integrations/aws-sagemaker-mlops-integration.mdx|never          |Mon Oct 02 2023   |[Clinton - 2023-10-02],[Natasha White - 2023-07-25]|
|src/content/docs/mlops/integrations/aporia-mlops-integration.mdx       |never          |Tue Jul 25 2023   |[Natasha White - 2023-07-25]                       |
|src/content/docs/mlops/get-started/intro-mlops.mdx                     |never          |Fri Mar 24 2023   |                                                   |
|src/content/docs/mlops/bring-your-own/mlops-byo.mdx                    |never          |Thu Apr 27 2023   |                                                   |
|src/content/docs/mlops/bring-your-own/getting-started-byo.mdx          |Mon Jan 09 2023|Tue Mar 07 2023   |                                                   |


### 🔮 Engineering checklist

<!-- Remove any items that do not apply -->

- [ ] Relevant documentation including README's or Confluence are updated to reflect these changes
  -  TODO: update verify-mdx documentation for writers or let them decide where this should go after we chat about it
  - TODO: update confluence
- [x] Code changes are self-documenting or clearly commented/documented
- [ ] Changes that effect tech writers have been communicated to tech docs team
- [x] New tests are added where applicable and total coverage remains >70%



