### PR TITLE
AWS Security Lake integration page: Fix formatting, typos, and links

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
@@ -13,9 +13,9 @@ Collect and send telemetry data to New Relic from [Security Lake](https://aws.am
 
 ## Activate integration [#activate]
 
-To enable this integration, set up an S3 log forwarder. We suggest using our application for ease and convenience, but you can also set your own.
+To enable this integration, set up an S3 log forwarder. We suggest using our serverless forwarder application for ease and convenience, but you can also set your own.
 
-<Callout variant="info">
+<Callout variant="tip">
   You have two options for Security Lake monitoring setup. You can consolidate multiple regions to avoid repeating steps, or you can set it up on a per-region basis. 
   For more details, see [managing multiple regions](https://docs.aws.amazon.com/security-lake/latest/userguide/manage-regions.html).
 </Callout>
@@ -101,8 +101,8 @@ To install the log forwarder:
    <img title="AWS Lambda - Select region" alt="AWS Lambda - Select region" src={serverlessAWSLambdaSelectRegion}/>
 2. Search for `newrelic` and check **Show apps that create custom IAM roles or resource policies** to find the `newrelic-securitylake-s3-processor-LogForwarder`.
 3. Click the `newrelic-securitylake-s3-processor-LogForwarder` details, and click **Deploy**.
-4. Copy/paste The `AWS role ID` ARN from the previous step into the `SecurityLakeSubscriberRoleArn` field.
-5. Copy/paste The `Subscription endpoint` ARN from the previous step into the `SecurityLakeSubscriberRoleArn` field.
+4. Copy/paste the `AWS role ID` ARN from the previous step into the `SecurityLakeSubscriberRoleArn` field.
+5. Copy/paste the `Subscription endpoint` ARN from the previous step into the `SecurityLakeSubscriberRoleArn` field.
 6. Input the `ExternalID` that you added in the previous step.
 7. Input your <InlinePopover type="licenseKey" /> into the `NRLicenseKey` field.
 8. Acknowledge and select **Deploy**.
@@ -120,7 +120,7 @@ The following log sources are currently supported:
 * [CLOUDTRAIL](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-getting-started.html)
 * [SECURITY HUB](https://docs.aws.amazon.com/securityhub/latest/userguide/what-is-securityhub.html)
 
-<Callout variant="info">
+<Callout variant="tip">
   Amazon Security Lake uses the [OCSF Schema](https://schema.ocsf.io/) for its logs.
 </Callout>
 
@@ -1697,10 +1697,10 @@ Here are attributes you can find in Security Lake logs:
   </Collapser>
 
     <Collapser
-    id="route53"
-    title="Route 53 Resolver Query Logs"
+    id="securityhub"
+    title="Security Hub Logs"
   >
-    Query `Route 53` logs to view data for the following attributes:
+    Query `Security Hug` logs to view data for the following attributes:
 
        <table>
         <thead>
@@ -3210,6 +3210,7 @@ Learn more about [creating alerts](/docs/alerts-applied-intelligence/new-relic-a
 
 Read more about New Relic AWS integrations:
 
-* [ROUTE 53 LOGS](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration/)
-* [VPC FLOW LOGS](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-vpc-flow-logs-monitoring-integration/)
-* [CLOUD TRAIL](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration/)
+* [Route 53 monitoring](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-route-53-monitoring-integration/)
+* [VPC Flow Logs monitoring](/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/aws-vpc-flow-log-monitoring/)
+* [CloudTrail monitoring](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-cloudtrail-monitoring-integration/)
+* [Ingest logs from S3](/docs/logs/forward-logs/aws-lambda-sending-logs-s3/)


### PR DESCRIPTION
- Callouts were not rendering. Fix those by using the "tip" type, which seems to exist.
- Fix some copy/paste errors next to the words "Copy/paste"
- Dropdown section on Security Hub was mislabeled as a second copy of the Route 53 section
- Correct capitalization in links on the bottom
- Pointed the link to VPC Flow Logs to the more updated, non-deprecated integration
- Added a link to our general S3 log import integration
