### PR TITLE
Document EU PrivateLink Endpoints

### DIFF
--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -71,12 +71,17 @@ These are the New Relic endpoint services available via AWS PrivateLink:
 
 <Tabs>
   <TabsBar>
-    <TabsBarItem id="1">US</TabsBarItem>
-    <TabsBarItem id="2">EU</TabsBarItem>
+    <TabsBarItem id="1">
+    US
+    </TabsBarItem>
+    <TabsBarItem id="2">  
+    EU
+    </TabsBarItem>
   </TabsBar>
 
   <TabsPages>
     <TabsPageItem id="1">
+
       <table>
         <thead>
           <tr>
@@ -193,8 +198,10 @@ These are the New Relic endpoint services available via AWS PrivateLink:
           </tr>
         </tbody>
       </table>
+
     </TabsPageItem>
     <TabsPageItem id="2">
+
       <table>
         <thead>
           <tr>
@@ -309,12 +316,10 @@ These are the New Relic endpoint services available via AWS PrivateLink:
           </tr>
         </tbody>
       </table>
+
     </TabsPageItem>
   </TabsPages>
-</Tabs>;
-
-
-
+</Tabs>
 
 <Callout variant="tip">
   Endpoints are **not** yet available for:

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -69,122 +69,252 @@ This means that if your VPC is in `us-east-2`, the only thing you need to do is 
 
 These are the New Relic endpoint services available via AWS PrivateLink:
 
-    <table>
-      <thead>
-        <tr>
-          <th>
-            Data source
-          </th>
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="1">US</TabsBarItem>
+    <TabsBarItem id="2">EU</TabsBarItem>
+  </TabsBar>
 
-          <th>
-            Hostname(s)
-          </th>
-          <th>
-            Endpoint service name
-          </th>
-        </tr>
-      </thead>
+  <TabsPages>
+    <TabsPageItem id="1">
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Data source
+            </th>
+  
+            <th>
+              Hostname(s)
+            </th>
+            <th>
+              Endpoint service name
+            </th>
+          </tr>
+        </thead>
+  
+        <tbody>
+          <tr>
+            <td>
+            APM
+            </td>
+            <td>
+            `collector.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-00e75af63239fbdc8`
+            </td>
+  
+          </tr>
+          <tr>
+            <td>
+            Event API
+            </td>
+            <td>
+            `insights-collector.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-030074dde03e5f7f1`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Metric API (including Prometheus and other integrations)
+            </td>
+            <td>
+            `metric-api.newrelic.com`
+            </td>
+  
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-0b48963952181a468`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Logging
+            </td>
+            <td>
+            `log-api.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-070f8190492d268ec`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Distributed tracing
+            </td>
+            <td>
+            `trace-api.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-0cc5a5c85730683db`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            AWS Lambda and Cloudwatch Logs monitoring 
+            </td>
+            <td>
+            `cloud-collector.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-0c4032e13941b3e9d`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Infrastructure monitoring and on-host integrations
+            </td>
+            <td>
+            `infra-api.newrelic.com`
+            </td>
+  
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-0df10112dc8c0f0b0`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            OpenTelemetry
+            </td>
+            <td>
+            `otlp.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-0bf91fb637cf37b4f`
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </TabsPageItem>
+    <TabsPageItem id="2">
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Data source
+            </th>
+  
+            <th>
+              Hostname(s)
+            </th>
+            <th>
+              Endpoint service name
+            </th>
+          </tr>
+        </thead>
+  
+        <tbody>
+          <tr>
+            <td>
+            APM
+            </td>
+            <td>
+            `collector.eu.newrelic.com` and `collector.eu01.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-080da8c256534bc15` and `com.amazonaws.vpce.eu-central-1.vpce-svc-09677bc6c976d9d9e`, respectively
+            </td>
+  
+          </tr>
+          <tr>
+            <td>
+            Event API
+            </td>
+            <td>
+            `insights-collector.eu01.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-02a22c14c11af33eb`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Metric API (including Prometheus and other integrations)
+            </td>
+            <td>
+            `metric-api.eu.newrelic.com`
+            </td>  
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-046613de75b465eb5`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Logging
+            </td>
+            <td>
+            `log-api.eu.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-042ba37fec695fcde`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Distributed tracing
+            </td>
+            <td>
+            `trace-api.eu.newrelic.com`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-07ae0a14716c59a2d`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            AWS Lambda and Cloudwatch Logs monitoring 
+            </td>
+            <td>
+            `cloud-collector.eu01.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-0cf7eae9d784a86a8`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            Infrastructure monitoring and on-host integrations
+            </td>
+            <td>
+            `infra-api.eu01.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-06d5b2d7e79ddd78e`
+            </td>
+          </tr>
+  
+          <tr>
+            <td>
+            OpenTelemetry
+            </td>
+            <td>
+            `otlp.eu01.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.eu-central-1.vpce-svc-04308d96cf1012913`
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>;
 
-      <tbody>
-        <tr>
-          <td>
-          APM
-          </td>
-          <td>
-          `collector.newrelic.com`
-          </td>
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-00e75af63239fbdc8`
-          </td>
 
-        </tr>
-        <tr>
-          <td>
-          Event API
-          </td>
-          <td>
-          `insights-collector.newrelic.com`
-          </td>
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-030074dde03e5f7f1`
-          </td>
-        </tr>
 
-        <tr>
-          <td>
-          Metric API (including Prometheus and other integrations)
-          </td>
-          <td>
-          `metric-api.newrelic.com`
-          </td>
-
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-0b48963952181a468`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-          Logging
-          </td>
-          <td>
-          `log-api.newrelic.com`
-          </td>
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-070f8190492d268ec`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-          Distributed tracing
-          </td>
-          <td>
-          `trace-api.newrelic.com`
-          </td>
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-0cc5a5c85730683db`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-          AWS Lambda and Cloudwatch Logs monitoring 
-          </td>
-          <td>
-          `cloud-collector.newrelic.com`
-          </td>
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-0c4032e13941b3e9d`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-          Infrastructure monitoring and on-host integrations
-          </td>
-          <td>
-          `infra-api.newrelic.com`
-          </td>
-
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-0df10112dc8c0f0b0`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-          OpenTelemetry
-          </td>
-          <td>
-          `otlp.nr-data.net`
-          </td>
-          <td>
-          `com.amazonaws.vpce.us-east-2.vpce-svc-0bf91fb637cf37b4f`
-          </td>
-        </tr>
-      </tbody>
-    </table>
 
 <Callout variant="tip">
   Endpoints are **not** yet available for:


### PR DESCRIPTION
This change introduces a `<Tabs>` component and adds the EU endpoints to the documentation on configuring New Relic to use AWS PrivateLink.