### PR TITLE
Fix grey block formatting

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -114,7 +114,7 @@ Web servers supported by the Ruby agent include:
         Supported
       </th>
 
-      <th style={{ width: "150px" }}>
+      <th>
         Deprecated
       </th>
     </tr>
@@ -412,7 +412,7 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
     </tr>
 
     <tr>
-      <td rowSpan={2}>
+      <td>
         Elasticsearch
       </td>
 
@@ -444,7 +444,7 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
     </tr>
 
     <tr>
-      <td rowSpan={2}>
+      <td>
         Redis
       </td>
 
@@ -509,7 +509,7 @@ New Relic's Ruby agent [version 3.17.0 or higher](/docs/release-notes/agent-rele
 
   <tbody>
     <tr>
-      <td rowSpan={2}>
+      <td>
         Active Record 5 or higher
       </td>
 
@@ -541,7 +541,7 @@ New Relic's Ruby agent [version 3.17.0 or higher](/docs/release-notes/agent-rele
     </tr>
 
     <tr>
-      <td rowSpan={3}>
+      <td>
         Active Record 2.1 to 4
       </td>
 

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -420,6 +420,10 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
         * 7.x
         * 8.x
       </td>
+
+      <td>
+
+      </td>
     </tr>
 
     <tr>
@@ -440,7 +444,6 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
       <td>
         * 1.8.x - 2.3.x: Last supported in agent version 8.16.0
       </td>
-
     </tr>
 
     <tr>
@@ -454,6 +457,10 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
         * 4.1.x
         * 4.2.x
         * 5.0.x
+      </td>
+
+      <td>
+      
       </td>
     </tr>
 
@@ -583,6 +590,10 @@ New Relic's Ruby agent [version 3.17.0 or higher](/docs/release-notes/agent-rele
 
       <td>
         3.17.0
+      </td>
+
+      <td>
+      
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Fix grey block formatting, [example](https://docs.newrelic.com/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks/#databases). The style and rowSpans seem to be the outliers where colors are messed up, so I'm hoping the removal will fix this issue.