### PR TITLE
chore: added missing infra-agent status endpoint example

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5769,6 +5769,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
     Main status endpoint (with errors):
 
     ```
+    curl http://localhost:8003/v1/status
     {
       "checks": {
         "endpoints": [
@@ -5820,6 +5821,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
 
     Entity endpoint example:
     ```
+      curl http://localhost:8003/v1/status/entity
       {
         "guid":"MMMMNjI0NjR8SU5GUkF8TkF8ODIwMDg3MDc0ODE0MTUwNTMy",
         "key":"your-host-name"


### PR DESCRIPTION
## Give us some context

* Added a missing example showing how to query the infra-agent status endpoint.