### PR TITLE
Updating content to reflect customer confusion around metrics postfix

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -11,18 +11,18 @@ redirects:
 
 We recommend using the [AWS CloudWatch Metric Streams integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/) to ingest AWS services' metrics. For a complete list of available metrics, check the CloudWatch metrics listing documentation for each AWS service.
 
-## ## Dimensional metric naming convention [#metric-naming-convention]
+## Dimensional metric naming convention [#metric-naming-convention]
 
-Metrics received from AWS CloudWatch are stored in New Relic as [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) following this convention:
+Metrics received from AWS CloudWatch are stored in New Relic as [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) following these conventions:
 
-* Metrics are prefixed by the AWS namespace, all lowercase, where / is replaced with . :
-  * `AWS/EC2 -> aws.ec2`
-  * `AWS/ApplicationELB -> aws.applicationelb`
-* The original AWS metric name with its original case:
+* Metrics are prefixed by the AWS namespace in all lowercase, where `/` is replaced with a `.`. For example: 
+  * `AWS/EC2` becomes `aws.ec2`
+  * `AWS/ApplicationELB` becomes `aws.applicationelb`
+* The original AWS metric name with its original case. For example: 
   * `aws.ec2.CPUUtilization`
   * `aws.s3.5xxErrors`
   * `aws.sns.NumberOfMessagesPublished`
-* If the resource the metric belongs to has a specific namespace prefix, it is used. If the resource the metric belongs to doesn't have a specific namespace prefix, metrics use the `aws.` prefix.
+* If the resource the metric belongs to has a specific namespace prefix, that prefix is used. If the resource the metric belongs to doesn't have a specific namespace prefix, metrics use the `aws.` prefix. For example: 
   * `aws.Region`
   * `aws.s3.BucketName`
 
@@ -33,6 +33,10 @@ For more information about namespaces supported by AWS, see the [CloudWatch docu
 For a reference on available metrics from each one of the polling integrations and their names, [check out our doc on the individual integrations](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/).
 
 The following table is a noncomprehensive list of the metrics collected by the AWS polling integrations and their [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) translations. 
+
+<Callout variant="tip">
+Some attributes use a postfix `.by` in their naming conventions, such as `aws.lambda.Invocations.byFunction`. Without the postfix `.byFunction` in a NRQL query, you may receive a `NULL` result. When querying for Lambda invocations, errors, duration, or throttles, be sure to add a `.byXYZ` postfix, where `XYZ` represents variations of the `Function` postfix. This will return relevant data. 
+</Callout>
 
 <table>
   <tbody>


### PR DESCRIPTION
Refers to this issue filed here: https://github.com/newrelic/docs-website/issues/15311 

as of 11/27, 'BANANA' acts as stand in as I dig a bit deeper into the `.byXYZ` functionality