### PR TITLE
chore(PHP): Fix link

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -79,7 +79,7 @@ If you are using the Monolog logging library (version 2 or 3) then you may also 
 passed to Monolog into New Relic attributes.  You can control this feature through settings `newrelic.application_logging.forwarding.context_data`
 prefixed INI settings. Options available are:
 
-* [`enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/cfg-application_logging_forwarding_context_data-enabled)
+* [`enabled`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding_context_data-enabled)
 * [`include`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding_context_data-include)
 * [`exclude`](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#cfg-application_logging_forwarding_context_data-exclude)
 


### PR DESCRIPTION
This fixes a link for the log context attributes configuration option.
