### PR TITLE
Resolve image import and MDX errors

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
@@ -8,6 +8,8 @@ metaDescription: "The New Relic Amazon Security Lake integration: what data it r
 freshnessValidatedDate: never
 ---
 
+import serverlessAWSLambdaSelectRegion from 'images/serverless_screenshot-crop_AWS-Lambda-select-region.webp'
+
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for AWS Security Lake, allowing you to send your security log data to New Relic. 
 
 Collect and send telemetry data to New Relic from [Security Lake](https://aws.amazon.com/security-lake/) using our integration. You can use this integration to monitor your services, query incoming data, and build dashboards to observe everything at a glance.

--- a/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/monitor-your-react-native-application.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/monitor-your-react-native-application.mdx
@@ -55,6 +55,7 @@ To install the React Native agent, follow our [guided install](https://onenr.io/
 If you need to install the agent manually, follow these steps:
 
 <Steps>
+<Step>
 ### Add the React Native agent [#install]
 
 Run the following:
@@ -125,7 +126,8 @@ To copy/paste your app token(s):
 2. Copy the application token.
 
 
-In the code above, replace <IOS-APP-TOKEN> and/or <ANDROID-APP-TOKEN> with your app token. If you're deploying to both Android and iOS, repeat this process to get the second app token.
+In the code above, replace `<IOS-APP-TOKEN>` and/or `<ANDROID-APP-TOKEN>` with your app token. If you're deploying to both Android and iOS, repeat this process to get the second app token.
+</Step>
 <Step>
 ### (Android-native apps only) Install the Android agent [#android-install]
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/airflow/monitoring-airflow-ot.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/airflow/monitoring-airflow-ot.mdx
@@ -12,6 +12,7 @@ redirects:
 ---
 
 import opentelemetryAirflow01 from 'images/opentelemetry_screenshot_airflow_01.webp'
+
 import opentelemetryAirflow02 from 'images/opentelemetry_screenshot_airflow_02.webp'
 
 Monitor Apache Airflow data by configuring [OpenTelemetry](https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/metrics.html#setup-opentelemetry) to send data to New Relic, where you can visualize tasks, operators, and DAG executions as metrics.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/airflow/monitoring-airflow-ot.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/airflow/monitoring-airflow-ot.mdx
@@ -9,6 +9,7 @@ tags:
 metaDescription: Monitor Airflow data with New Relic using OpenTelemetry.
 redirects:
   - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/airflow/monitoring-airflow-ot
+freshnessValidatedDate: 2023-11-16
 ---
 
 import opentelemetryAirflow01 from 'images/opentelemetry_screenshot_airflow_01.webp'

--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
@@ -14,6 +14,8 @@ redirects:
 freshnessValidatedDate: never
 ---
 
+import solutionsUbuntuDiagnostics from 'images/solutions_screenshot-crop_ubuntu-diagnostics.gif'
+
 The Diagnostics CLI (`nrdiag`) is a utility that automatically detects common problems with New Relic products. If the Diagnostics CLI detects a problem, it suggests troubleshooting steps. The Diagnostics CLI can automatically upload troubleshooting data to a New Relic account.
 
 The Diagnostics CLI is open source and is located in [GitHub](https://github.com/newrelic/newrelic-diagnostics-cli).

--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag.mdx
@@ -10,8 +10,6 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-import solutionsUbuntuDiagnostics from 'images/solutions_screenshot-crop_ubuntu-diagnostics.gif'
-
 <ButtonLink
   role="button"
   to="https://one.newrelic.com/launcher/diagnostics?pane=eyJuZXJkbGV0SWQiOiJkaWFnbm9zdGljcy5jbGktb3V0cHV0IiwgInNob3dJbnN0YWxsUnVuTW9kYWwiOiB0cnVlfQ=="

--- a/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-layers.mdx
+++ b/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-layers.mdx
@@ -7,13 +7,7 @@ import k8sDiagramContext from 'images/tutorials_diagram_kubernetes-overview.webp
 
 import tutorialOverviewdashboard from 'images/tutorial_screenshot-full_overview-dashboard.webp'
 
-import tutorialOverviewDeployments from 'images/tutorial_screenshot-full_overview-deployments.webp'
-
 import tutorialOverviewFailed from 'images/tutorial_screenshot-crop_failed-pods.webp'
-
-import tutorialAPMOverview from 'images/tutorial_screenshot-full_apmK8s.webp'
-
-import tutorialAPMPerformance from 'images/tutorial_screenshot-full_apm-k8s-performance.webp'
 
 Let's review what makes up a Kubernetes system and explore how New Relic can help you understand your system at a cluster-wide level.
 

--- a/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-orchestrated.mdx
+++ b/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-orchestrated.mdx
@@ -7,6 +7,8 @@ import tutorialOverviewdashboard from 'images/tutorial_screenshot-full_overview-
 
 import tutorialOverviewFailed from 'images/tutorial_screenshot-crop_failed-pods.webp'
 
+import tutorialOverviewDeployments from 'images/tutorial_screenshot-full_overview-deployments.webp'
+
 Orchestrated components consist of entire deployments that spin pods up and down as needed. In a Kubernetes system, individual deployments have specific configurations. For example, a deployment might run four instances of an application in individual containers. The deployment will spin up pods containing that application until it meets that quota. If a pod were to fail, it would spin up a new one to continue to meet the specified number.
 
 Issues arise when deployments you have dozens or hundreds of deployments, each with configurations you might not even remember.

--- a/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-services.mdx
+++ b/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-services.mdx
@@ -3,6 +3,10 @@ title: Understand and monitor the service and application layer
 freshnessValidatedDate: 2023-08-29
 ---
 
+import tutorialAPMPerformance from 'images/tutorial_screenshot-full_apm-k8s-performance.webp'
+
+import tutorialAPMOverview from 'images/tutorial_screenshot-full_apmK8s.webp'
+
 In your kubernetes system, each pod contains services and applications that provide the actual functionality that your kubernetes system supports. The system could support computation, a web app, or anything inbetween.
 
 Your system might be healthy as a whole, but individual applications and services might fail or throw errors. The following steps guide you through a general strategy to monitor and triage your applications and services:

--- a/src/content/docs/tutorial-manage-large-log-volume/get-started-managing-large-logs.mdx
+++ b/src/content/docs/tutorial-manage-large-log-volume/get-started-managing-large-logs.mdx
@@ -10,6 +10,7 @@ import logsParsing from 'images/logs_screenshot_full-parsing.webp'
 
 import logsPartition from 'images/logs_screenshot_full-partition.webp'
 
+import journeyLogsDash from 'images/logs_screenshot-crop_journey-dash.webp'
 
 Modern systems create a large volume of log data. You might be dealing with hundreds of gigabytes to dozens of terabytes today, and the amount will continue to increase as your system scales. When you need to search through your logs, you'll encounter hours of toil trying to uncover valuable and relevant logs. Sending all your logs to a log management tool can help reduce this toil, but you'll quickly encounter organizational hurdles and rising costs as you ingest more logs. New Relic solves this problem by providing tools to ingest only valuable logs to reduce cost, a unified UI to correlate your logs to your services, and various ways to organize your logs before your drown in them. 
 

--- a/src/content/docs/tutorial-optimize-telemetry/detect-anomalies.mdx
+++ b/src/content/docs/tutorial-optimize-telemetry/detect-anomalies.mdx
@@ -9,6 +9,8 @@ import omaoedgIngestTargetLine from 'images/oma-oe-dg_screenshot-full_ingest-tar
 
 import omaoedgLookoutViewConsumingAccount from 'images/oma-oe-dg_screenshot-crop_lookout-view-consuming-account.webp'
 
+import omaoedgLookoutViewTelemType from 'images/oma-oe-dg_screenshot-crop_lookout-view-telem-type.webp'
+
 Once you've installed the [baseline dashboard](/docs/tutorial-optimize-telemetry/create-baseline-report/), you should keep an eye on it to detect any ingest anomalies as often as possible. While you have to wait until you have enough data to optimize your ingest, you can use your dashboard to find issues with your ingest much sooner. You can use the baseline dashboard as is, or download optional dashboards to give you even greater anomaly detection options.
 
 You should also set up alerts to help notify you of issues as they occur. You can use our [ingest alerts guide](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts) to create a large variety of alerts, but we recommend you set up these two alerts as a minimum:

--- a/src/i18n/content/jp/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
+++ b/src/i18n/content/jp/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
@@ -8,6 +8,8 @@ metaDescription: 'The New Relic Amazon Security Lake integration: what data it r
 translationType: machine
 ---
 
+import serverlessAWSLambdaSelectRegion from 'images/serverless_screenshot-crop_AWS-Lambda-select-region.webp'
+
 [New Relic インフラストラクチャの統合に](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) は AWS Security Lake の統合が含まれており、セキュリティ ログ データを New Relic に送信できるようになります。
 
 統合を使用して、 [Security Lake](https://aws.amazon.com/security-lake/) からテレメトリ データを収集して New Relic に送信します。この統合を使用して、サービスを監視し、受信データをクエリし、ダッシュボードを構築して、すべてを一目で確認できます。

--- a/src/i18n/content/jp/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
+++ b/src/i18n/content/jp/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
@@ -8,6 +8,8 @@ metaDescription: Use New Relic Diagnostics CLI to automatically diagnose common 
 translationType: machine
 ---
 
+import solutionsUbuntuDiagnostics from 'images/solutions_screenshot-crop_ubuntu-diagnostics.gif'
+
 Diagnostics CLI ( `nrdiag` ) は、New Relic 製品の一般的な問題を自動的に検出するユーティリティです。Diagnostics CLI で問題が検出されると、トラブルシューティングの手順が提案されます。Diagnostics CLI は、トラブルシューティング データを New Relic アカウントに自動的にアップロードできます。
 
 Diagnostics CLIはオープンソースで、 [GitHub](https://github.com/newrelic/newrelic-diagnostics-cli) に置かれています。

--- a/src/i18n/content/jp/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag.mdx
+++ b/src/i18n/content/jp/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag.mdx
@@ -8,8 +8,6 @@ metaDescription: How to run the New Relic Diagnostics CLI (nrdiag) and upload re
 translationType: machine
 ---
 
-import solutionsUbuntuDiagnostics from 'images/solutions_screenshot-crop_ubuntu-diagnostics.gif'
-
 <ButtonLink
   role="button"
   to="https://one.newrelic.com/launcher/diagnostics?pane=eyJuZXJkbGV0SWQiOiJkaWFnbm9zdGljcy5jbGktb3V0cHV0IiwgInNob3dJbnN0YWxsUnVuTW9kYWwiOiB0cnVlfQ=="

--- a/src/i18n/content/jp/docs/tutorial-kubernetes-learn/tutorial-k8s-layers.mdx
+++ b/src/i18n/content/jp/docs/tutorial-kubernetes-learn/tutorial-k8s-layers.mdx
@@ -7,13 +7,7 @@ import k8sDiagramContext from 'images/tutorials_diagram_kubernetes-overview.webp
 
 import tutorialOverviewdashboard from 'images/tutorial_screenshot-full_overview-dashboard.webp'
 
-import tutorialOverviewDeployments from 'images/tutorial_screenshot-full_overview-deployments.webp'
-
 import tutorialOverviewFailed from 'images/tutorial_screenshot-crop_failed-pods.webp'
-
-import tutorialAPMOverview from 'images/tutorial_screenshot-full_apmK8s.webp'
-
-import tutorialAPMPerformance from 'images/tutorial_screenshot-full_apm-k8s-performance.webp'
 
 Kubernetes システムの構成要素を確認し、New Relic がクラスター全体のレベルでシステムを理解するのにどのように役立つかを探ってみましょう。
 

--- a/src/i18n/content/jp/docs/tutorial-kubernetes-learn/tutorial-k8s-orchestrated.mdx
+++ b/src/i18n/content/jp/docs/tutorial-kubernetes-learn/tutorial-k8s-orchestrated.mdx
@@ -7,6 +7,8 @@ import tutorialOverviewdashboard from 'images/tutorial_screenshot-full_overview-
 
 import tutorialOverviewFailed from 'images/tutorial_screenshot-crop_failed-pods.webp'
 
+import tutorialOverviewDeployments from 'images/tutorial_screenshot-full_overview-deployments.webp'
+
 オーケストレーションされたコンポーネントは、必要に応じてポッドをスピンアップおよびスピンダウンするデプロイメント全体で構成されます。Kubernetes システムでは、個々のデプロイメントに特定の構成があります。たとえば、デプロイメントでは、アプリケーションの 4 つのインスタンスを個別のコンテナーで実行できます。デプロイメントでは、そのクォータに達するまで、そのアプリケーションを含むポッドがスピンアップされます。ポッドに障害が発生した場合、指定された数を満たし続けるために新しいポッドがスピンアップされます。
 
 数十、数百ものデプロイメントがあり、それぞれの構成が覚えていない可能性がある場合、問題が発生します。

--- a/src/i18n/content/jp/docs/tutorial-kubernetes-learn/tutorial-k8s-services.mdx
+++ b/src/i18n/content/jp/docs/tutorial-kubernetes-learn/tutorial-k8s-services.mdx
@@ -3,6 +3,10 @@ title: サービス層とアプリケーション層を理解して監視する
 translationType: machine
 ---
 
+import tutorialAPMPerformance from 'images/tutorial_screenshot-full_apm-k8s-performance.webp'
+
+import tutorialAPMOverview from 'images/tutorial_screenshot-full_apmK8s.webp'
+
 Kubernetes システムでは、各ポッドに、Kubernetes システムがサポートする実際の機能を提供するサービスとアプリケーションが含まれています。システムは、計算、Web アプリ、またはその間のものをサポートできます。
 
 システム全体としては正常であっても、個々のアプリケーションやサービスが失敗したり、エラーが発生したりする可能性があります。次の手順では、アプリケーションとサービスを監視し、優先順位を付けるための一般的な戦略を説明します。

--- a/src/i18n/content/jp/docs/tutorial-manage-large-log-volume/get-started-managing-large-logs.mdx
+++ b/src/i18n/content/jp/docs/tutorial-manage-large-log-volume/get-started-managing-large-logs.mdx
@@ -8,6 +8,8 @@ import logsParsing from 'images/logs_screenshot_full-parsing.webp'
 
 import logsPartition from 'images/logs_screenshot_full-partition.webp'
 
+import journeyLogsDash from 'images/logs_screenshot-crop_journey-dash.webp'
+
 最新のシステムでは、大量のログ データが作成されます。現在、数百ギガバイトから数十テラバイトを扱っているかもしれませんが、その量はシステムの規模が拡大するにつれて増加し続けます。ログを検索する必要がある場合、貴重で関連性のあるログを見つけ出すために何時間も苦労することになります。すべてのログをログ管理ツールに送信すると、この労力を軽減できますが、より多くのログを取り込むと、すぐに組織上のハードルが発生し、コストが上昇します。New Relic は、コストを削減するために貴重なログのみを取り込むツール、ログをサービスに関連付けるための統合 UI、ログに埋もれる前にログを整理するさまざまな方法を提供することで、この問題を解決します。
 
 初めてログ管理プラットフォームをセットアップする場合でも、New Relic に移行する場合でも、このチュートリアルでは New Relic を使用して大量のログ データを管理する方法を説明します。まず、ログを New Relic に転送します。これは、ログ データを New Relic に自動的に送信することを意味します。次に、どのログを取り込み、どのログを削除するかを特定します。最後に、パーティションと解析を通じてログを整理します。

--- a/src/i18n/content/jp/docs/tutorial-optimize-telemetry/detect-anomalies.mdx
+++ b/src/i18n/content/jp/docs/tutorial-optimize-telemetry/detect-anomalies.mdx
@@ -8,6 +8,8 @@ import omaoedgIngestTargetLine from 'images/oma-oe-dg_screenshot-full_ingest-tar
 
 import omaoedgLookoutViewConsumingAccount from 'images/oma-oe-dg_screenshot-crop_lookout-view-consuming-account.webp'
 
+import omaoedgLookoutViewTelemType from 'images/oma-oe-dg_screenshot-crop_lookout-view-telem-type.webp'
+
 [ベースライン ダッシュボード](/docs/tutorial-optimize-telemetry/create-baseline-report/)をインストールしたら、取り込み異常をできるだけ頻繁に検出するためにダッシュボードを監視する必要があります。取り込みを最適化するのに十分なデータが得られるまで待つ必要がありますが、ダッシュボードを使用すると、取り込みの問題をより早く見つけることができます。ベースライン ダッシュボードをそのまま使用することも、オプションのダッシュボードをダウンロードしてさらに優れた異常検出オプションを提供することもできます。
 
 また、問題が発生したときに通知できるようにアラートを設定する必要もあります。[取り込みアラート ガイド](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts) を使用してさまざまなアラートを作成できますが、少なくとも次の 2 つのアラートを設定することをお勧めします。

--- a/src/i18n/content/kr/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
+++ b/src/i18n/content/kr/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-security-lake-monitoring-integration.mdx
@@ -8,6 +8,8 @@ metaDescription: 'The New Relic Amazon Security Lake integration: what data it r
 translationType: machine
 ---
 
+import serverlessAWSLambdaSelectRegion from 'images/serverless_screenshot-crop_AWS-Lambda-select-region.webp'
+
 [New Relic 인프라 통합](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) 에는 AWS Security Lake 통합이 포함되어 있으므로 보안 로그 데이터를 New Relic으로 보낼 수 있습니다.
 
 통합을 사용하여 [Security Lake](https://aws.amazon.com/security-lake/) 에서 원격 측정 데이터를 수집하고 New Relic으로 보냅니다. 이 통합을 사용하여 서비스를 모니터링하고, 들어오는 데이터를 쿼리하고, 대시보드를 구축하여 모든 것을 한 눈에 관찰할 수 있습니다.

--- a/src/i18n/content/kr/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
+++ b/src/i18n/content/kr/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
@@ -8,6 +8,8 @@ metaDescription: Use New Relic Diagnostics CLI to automatically diagnose common 
 translationType: machine
 ---
 
+import solutionsUbuntuDiagnostics from 'images/solutions_screenshot-crop_ubuntu-diagnostics.gif'
+
 진단 CLI( `nrdiag` )는 New Relic 제품의 일반적인 문제를 자동으로 감지하는 유틸리티입니다. 진단 CLI가 문제를 감지하면 문제 해결 단계를 제안합니다. 진단 CLI는 문제 해결 데이터를 New Relic 계정에 자동으로 업로드할 수 있습니다.
 
 진단 CLI는 오픈 소스이며 [GitHub](https://github.com/newrelic/newrelic-diagnostics-cli) 에 있습니다.

--- a/src/i18n/content/kr/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag.mdx
+++ b/src/i18n/content/kr/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag.mdx
@@ -8,8 +8,6 @@ metaDescription: How to run the New Relic Diagnostics CLI (nrdiag) and upload re
 translationType: machine
 ---
 
-import solutionsUbuntuDiagnostics from 'images/solutions_screenshot-crop_ubuntu-diagnostics.gif'
-
 <ButtonLink
   role="button"
   to="https://one.newrelic.com/launcher/diagnostics?pane=eyJuZXJkbGV0SWQiOiJkaWFnbm9zdGljcy5jbGktb3V0cHV0IiwgInNob3dJbnN0YWxsUnVuTW9kYWwiOiB0cnVlfQ=="

--- a/src/i18n/content/kr/docs/tutorial-kubernetes-learn/tutorial-k8s-layers.mdx
+++ b/src/i18n/content/kr/docs/tutorial-kubernetes-learn/tutorial-k8s-layers.mdx
@@ -7,13 +7,7 @@ import k8sDiagramContext from 'images/tutorials_diagram_kubernetes-overview.webp
 
 import tutorialOverviewdashboard from 'images/tutorial_screenshot-full_overview-dashboard.webp'
 
-import tutorialOverviewDeployments from 'images/tutorial_screenshot-full_overview-deployments.webp'
-
 import tutorialOverviewFailed from 'images/tutorial_screenshot-crop_failed-pods.webp'
-
-import tutorialAPMOverview from 'images/tutorial_screenshot-full_apmK8s.webp'
-
-import tutorialAPMPerformance from 'images/tutorial_screenshot-full_apm-k8s-performance.webp'
 
 Kubernetes 시스템을 구성하는 요소를 검토하고 New Relic이 클러스터 전체 수준에서 시스템을 이해하는 데 어떻게 도움이 되는지 살펴보겠습니다.
 

--- a/src/i18n/content/kr/docs/tutorial-kubernetes-learn/tutorial-k8s-orchestrated.mdx
+++ b/src/i18n/content/kr/docs/tutorial-kubernetes-learn/tutorial-k8s-orchestrated.mdx
@@ -7,6 +7,8 @@ import tutorialOverviewdashboard from 'images/tutorial_screenshot-full_overview-
 
 import tutorialOverviewFailed from 'images/tutorial_screenshot-crop_failed-pods.webp'
 
+import tutorialOverviewDeployments from 'images/tutorial_screenshot-full_overview-deployments.webp'
+
 오케스트레이션된 구성 요소는 필요에 따라 포드를 위아래로 회전시키는 전체 배포로 구성됩니다. Kubernetes 시스템에서 개별 배포에는 특정 구성이 있습니다. 예를 들어 배포는 개별 컨테이너에서 애플리케이션의 4개 인스턴스를 실행할 수 있습니다. 배포는 해당 할당량을 충족할 때까지 해당 애플리케이션이 포함된 포드를 가동합니다. 포드가 실패하면 지정된 숫자를 계속 충족하기 위해 새 포드를 가동합니다.
 
 수십 또는 수백 개의 배포가 있고 각각의 구성이 기억나지 않을 수도 있는 경우 문제가 발생합니다.

--- a/src/i18n/content/kr/docs/tutorial-kubernetes-learn/tutorial-k8s-services.mdx
+++ b/src/i18n/content/kr/docs/tutorial-kubernetes-learn/tutorial-k8s-services.mdx
@@ -3,6 +3,10 @@ title: 서비스 및 애플리케이션 계층 이해 및 모니터링
 translationType: machine
 ---
 
+import tutorialAPMPerformance from 'images/tutorial_screenshot-full_apm-k8s-performance.webp'
+
+import tutorialAPMOverview from 'images/tutorial_screenshot-full_apmK8s.webp'
+
 kubernetes 시스템에서 각 포드에는 kubernetes 시스템이 지원하는 실제 기능을 제공하는 서비스와 애플리케이션이 포함되어 있습니다. 시스템은 계산, 웹 앱 또는 그 사이의 모든 것을 지원할 수 있습니다.
 
 시스템이 전체적으로 정상일 수 있지만 개별 애플리케이션 및 서비스가 실패하거나 오류가 발생할 수 있습니다. 다음 단계는 애플리케이션과 서비스를 모니터링하고 분류하는 일반적인 전략을 안내합니다.

--- a/src/i18n/content/kr/docs/tutorial-manage-large-log-volume/get-started-managing-large-logs.mdx
+++ b/src/i18n/content/kr/docs/tutorial-manage-large-log-volume/get-started-managing-large-logs.mdx
@@ -8,6 +8,8 @@ import logsParsing from 'images/logs_screenshot_full-parsing.webp'
 
 import logsPartition from 'images/logs_screenshot_full-partition.webp'
 
+import journeyLogsDash from 'images/logs_screenshot-crop_journey-dash.webp'
+
 최신 시스템은 대량의 로그 데이터를 생성합니다. 오늘날 수백 기가바이트에서 수십 테라바이트를 처리하고 있을 수 있으며 시스템이 확장됨에 따라 그 양은 계속 증가할 것입니다. 로그를 검색해야 하는 경우 가치 있고 관련성 있는 로그를 찾으려고 몇 시간 동안 수고해야 합니다. 모든 로그를 로그 관리 도구로 보내면 이러한 수고를 줄이는 데 도움이 될 수 있지만 더 많은 로그를 수집함에 따라 조직의 장애물과 비용 상승에 빠르게 직면하게 됩니다. New Relic은 가치 있는 로그만 수집하여 비용을 절감할 수 있는 도구, 로그를 서비스와 연관시키는 통합 UI, 로그에 빠지기 전에 로그를 정리할 수 있는 다양한 방법을 제공하여 이 문제를 해결합니다.
 
 처음으로 로그 관리 플랫폼을 설정하든 New Relic으로 마이그레이션하든 관계없이 이 튜토리얼은 New Relic을 사용하여 대량의 로그 데이터를 관리하는 방법을 안내합니다. 먼저 로그를 New Relic으로 전달합니다. 즉, 로그 데이터를 New Relic에 자동으로 전송합니다. 그런 다음 수집할 로그와 삭제할 로그를 식별합니다. 마지막으로 파티션 및 구문 분석을 통해 로그를 구성합니다.

--- a/src/i18n/content/kr/docs/tutorial-optimize-telemetry/detect-anomalies.mdx
+++ b/src/i18n/content/kr/docs/tutorial-optimize-telemetry/detect-anomalies.mdx
@@ -8,6 +8,8 @@ import omaoedgIngestTargetLine from 'images/oma-oe-dg_screenshot-full_ingest-tar
 
 import omaoedgLookoutViewConsumingAccount from 'images/oma-oe-dg_screenshot-crop_lookout-view-consuming-account.webp'
 
+import omaoedgLookoutViewTelemType from 'images/oma-oe-dg_screenshot-crop_lookout-view-telem-type.webp'
+
 [기본 대시보드를](/docs/tutorial-optimize-telemetry/create-baseline-report/) 설치한 후에는 수집 이상을 가능한 한 자주 감지하도록 계속 주시해야 합니다. 수집을 최적화하기에 충분한 데이터가 확보될 때까지 기다려야 하지만 대시보드를 사용하여 수집 관련 문제를 훨씬 더 빨리 찾을 수 있습니다. 기본 대시보드를 있는 그대로 사용하거나 선택적 대시보드를 다운로드하여 더 뛰어난 이상 탐지 옵션을 제공할 수 있습니다.
 
 또한 문제가 발생할 때 이를 알리는 데 도움이 되는 경고를 설정해야 합니다. [경고 수집 가이드를](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts) 사용하여 매우 다양한 경고를 생성할 수 있지만 다음 두 가지 경고를 최소한으로 설정하는 것이 좋습니다.


### PR DESCRIPTION
Clean up from a minor bug that allowed an image to be imported anywhere in the MDX content, and it will render with that const as an img src in a file without needing to be imported there. This has probably happened by cut+pasting content to a new doc and accidentally leaving the import statements behind. 

This doesn't effect functionality, but is throwing errors in our verify-mdx script, so we want to remove this noise. Now that verify-mdx is a required github check on PR's this shouldn't continue to happen as these would get flagged in the review process.