### PR TITLE
infrastructure metrics: RAW keyword limitation

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
@@ -362,6 +362,11 @@ Here are some notable differences when querying dimensional metrics:
   SELECT average(host.swap%Bytes) FROM Metric
   ```
 * [Functions](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#functions) used on multiple metrics may fail or return incorrect results, for example:
-  ```
+  ```sql
   FROM Metric SELECT latest(metricNameA + metricNameB)
   ```
+* Using the `RAW` keyword has no effect on queries on infrastructure metrics. For example:
+  ```sql
+  SELECT max(host.cpuPercent) FROM Metric TIMESERIES 1 MINUTE SINCE 60 MINUTES AGO RAW
+  ```
+  does not actually show raw data, as the query is transformed internally to an equivalent query on event data, which is aggregated.


### PR DESCRIPTION
Added a known limitation about the usage of the RAW keyword when querying infrastructure metrics.

* What problems does this PR solve?
There is a known limitation when querying infrastructure metrics with the RAW keyword that is not documented explicitly.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  Ticket: https://new-relic.atlassian.net/browse/NR-183231