### PR TITLE
fix: validate `freshnessValidatedDate` with regex

### DIFF
--- a/scripts/utils/__tests__/frontmatter.js
+++ b/scripts/utils/__tests__/frontmatter.js
@@ -57,7 +57,7 @@ howdy: cowboy 🤠
 list:
   - item 1
   - item 2
-freshnessValidatedDate: 2023-12-02
+freshnessValidatedDate: '2023-12-02'
 ---
 some content!
 `;
@@ -67,7 +67,7 @@ howdy: cowboy 🤠
 list:
   - item 1
   - item 2
-freshnessValidatedDate: 23-12-02
+freshnessValidatedDate: '23-12-02'
 ---
 some content!
 `;

--- a/scripts/utils/frontmatter.js
+++ b/scripts/utils/frontmatter.js
@@ -116,8 +116,10 @@ const validateFreshnessDate = (mdString) => {
 
   const { data } = grayMatter(mdString);
 
-  const isValidDate = (date) => {
-    return !isNaN(new Date(date));
+  const isValidDate = (dateString) => {
+    const regex = /^\d{4}-\d{2}-\d{2}$/;
+
+    return regex.test(dateString);
   };
 
   // freshnessValidatedDate is a required field and must be a date or `never`


### PR DESCRIPTION
### ✨ Summary

Use regex to validate `freshnessValidatedDate` frontmatter field. Currently, partial dates like `2023` are considered valid. Probably also helpful to enforce the `YYYY-MM-DD` format for consistency over time. 

This means that field should always be entered as a string like so:

```
freshnessValidatedDate: '2023-09-03'
```

### 🖼️ Screenshots

![2023-11-28_15-59-31](https://github.com/newrelic/docs-website/assets/2952843/da011c0f-76a4-4e63-a423-750f5ce6edac)

### 🔮 Engineering checklist

- [ ] Relevant documentation including README's or Confluence are updated to reflect these changes
- [ ] Code changes are self-documenting or clearly commented/documented
- [ ] Changes that effect tech writers have been communicated to tech docs team
