### PR TITLE
fix: mislabeled table

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -267,11 +267,9 @@ All calls to Amazon Web Services(AWS) with the [aws-sdk](https://www.npmjs.com/p
 
 <Collapser
     id="instance"
-    title="Instance details"
+    title="Database Instance details"
 >
 We collect [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM depends on your agent version.
-
-New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-1310) or higher supports the following:
 
 <table>
   <thead>
@@ -360,6 +358,24 @@ New Relic's Node.js agent [version 1.31.0](/docs/release-notes/agent-release-not
 
       <td>
         2.4.1
+      </td>
+
+      <td>
+        1.32.0
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [MySQL](http://www.mysql.com/)
+      </td>
+
+      <td>
+        [mysql2](https://www.npmjs.com/package/mysql2)
+      </td>
+
+      <td>
+        1.3.1
       </td>
 
       <td>
@@ -561,7 +577,7 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
     <thead>
       <tr>
         <th>
-          Logging library
+          Framework
         </th>
   
         <th>

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -267,7 +267,7 @@ All calls to Amazon Web Services(AWS) with the [aws-sdk](https://www.npmjs.com/p
 
 <Collapser
     id="instance"
-    title="Database Instance details"
+    title="Database instance details"
 >
 We collect [instance details for a variety of databases and database drivers](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues). The ability to view specific instances and the types of database information in APM depends on your agent version.
 


### PR DESCRIPTION
Frameworks table was labeled Logging Libraries. 

I also removed an old note which was no longer relevant because the table was more up to date

and added a new row in the database instance table for `mysql2`

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.