### PR TITLE
Remove outdated section from transactions UI docs

### DIFF
--- a/src/content/docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page.mdx
@@ -269,13 +269,3 @@ The trace details page will display slightly different information when looking 
 * All attributes are grouped into a single `Attributes` section rather than being split out into the three default attribute types
 * Segment metric names may differ slightly between distributed traces and transaction traces
 * Stack traces are not displayed in segment attributes
-
-## Examine logs for trace details [#logs-context]
-
-You can bring your logs and application's data together to make troubleshooting easier and faster. With [logs in context](/docs/logs/logs-context/configure-logs-context-apm-agents/), you can see log messages related to your errors and traces directly in your app's UI.
-
-1. From the **Transactions** page, click on a trace to go to the [**Trace details** page](/docs/apm/transactions/transaction-traces/transaction-traces-trace-details-page).
-2. From the trace details page, click **See logs**.
-3. To view details related to an individual log message, click directly on the message.
-
-You can also see logs in context of your [infrastructure data](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/), such as Kubernetes clusters. No need to switch to another UI page.


### PR DESCRIPTION
This section is not currently true - used to exist in the old Seldon UI but has been gone for some time. We intend to add the logs link *back*, but it won't be until early 2024 so we should remove this in the meantime.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.