### PR TITLE
Add release note for ping runtime

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.35.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.35.0.mdx
@@ -1,0 +1,8 @@
+---
+subject: Ping Runtime
+releaseDate: '2023-12-02'
+version: 1.35.0
+---
+
+### Fixes
+* Upgrades httpclient version to remediate CVE-2020-13956


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Adds release note for ping-runtime release on 12/02/2023.