### PR TITLE
chore: correct typos in java-agent-identified-with-security-vulnerabilities.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/troubleshooting/java-agent-identified-with-security-vulnerabilities.mdx
+++ b/src/content/docs/apm/agents/java-agent/troubleshooting/java-agent-identified-with-security-vulnerabilities.mdx
@@ -32,8 +32,8 @@ For example, false positives discovered by the `DependencyCheck` project at [git
 ```jar
 <suppress>
     <notes><![CDATA[newrelic-agent false positives due to the instrumentation package]]></notes>
-    <filePath regex="true">.*newrelic-agent-.*\.jar[\\\/]instrumentation.*\.jar</filePath>
-    <cpe regex="true">.*
+    <filePath regex="true">.*newrelic.*\.jar[\\\/]instrumentation.*\.jar</filePath>
+    <cpe regex="true">.*</cpe>
 </suppress>
 ```
 


### PR DESCRIPTION
This PR addresses [java agent docs issue 1510](https://github.com/newrelic/newrelic-java-agent/issues/1510). In a snippet of solution code, it:
- closes an unclosed xml node
- corrects a regex string

I tested these changes locally to verify the corrected solution works. 