### PR TITLE
feat: point nav to mdx intro page instead of JS

### DIFF
--- a/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
+++ b/src/content/docs/apm/new-relic-apm/getting-started/introduction-apm.mdx
@@ -16,6 +16,7 @@ redirects:
   - /docs/apm
   - /docs/apm/new-relic-apm
   - /docs/apm/new-relic-apm/getting-started/introduction-new-relic-apm
+  - /introduction-apm
 freshnessValidatedDate: never
 ---
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -2,7 +2,7 @@ title: Application performance monitoring
 path: /docs/apm
 pages:
   - title: Get started with APM
-    path: /introduction-apm
+    path: /docs/apm/new-relic-apm/getting-started/introduction-apm
   - title: My app is slow
     label: Tutorial
     path: /docs/tutorial-app-slow/root-causes


### PR DESCRIPTION
Points the APM intro page to the MDX version instead of the JS version. JS version will be deprecated soon.
