### PR TITLE
chore(java): updating security vulnerability with security agent

### DIFF
--- a/src/content/docs/apm/agents/java-agent/troubleshooting/java-agent-identified-with-security-vulnerabilities.mdx
+++ b/src/content/docs/apm/agents/java-agent/troubleshooting/java-agent-identified-with-security-vulnerabilities.mdx
@@ -17,9 +17,9 @@ When a security scan is performed, it reports back vulnerabilities for the New R
 
 ## Cause
 
-While any software product has the potential to have security vulnerabilities, the New Relic Java agent may be erroneously identified by security products. Those that scan for certain string patterns in files due to instrumentation modules that are a part of the agent.
+While any software product can potentially have security vulnerabilities, the New Relic Java agent may be erroneously identified by security products. Security products that scan for certain string patterns in files may mistakenly flag instrumentation modules that are a part of the agent as vulnerable libraries. 
 
-These instrumentation modules are JAR files that named after the software frameworks they're designed to instrument and their versions. They don't contain code from the frameworks, but may contain classes with the same name. Some security scanning tools detect these names/versions and interpret them as being the actual software framework itself, when it's just an instrumentation module.
+These instrumentation modules are JAR files named after the software frameworks designed to instrument and their versions. They don't contain code from the frameworks but may contain classes with the same name. Some security scanning tools detect these names/versions and interpret them as being the actual software framework itself, when it's just an instrumentation module.
 
 They're found inside `newrelic.jar` under the `instrumentation` package, or inside `newrelic-security-agent.jar` under the `instrumentation-security` package.
 


### PR DESCRIPTION
## Give us some context

This PR updates Java agent's security vulnerability troubleshooting to add info about the New Relic Security Agent for Java and its instrumentation modules.

The text was reorganized to mention the location of the instrumentation modules in the last paragraph, mentioning both the Security agent and Java agent's locations.