### PR TITLE
feat(apm): clarifying how long it takes for a host to disappear when …

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts.mdx
@@ -138,4 +138,4 @@ To remove a host, use either option:
 
 Occasionally, rogue application server processes will continue reporting data. In this situation your [app's health status indicator](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#health-status) will appear green, even though you shut the agent down and verified that no data is reporting. Check your web server for stray processes, or get support at [support.newrelic.com](https://support.newrelic.com "Link opens in a new window").
 
-Once all reporting applications are shut down on the old host, it may take up to ten minutes for the old host to disappear from the New Relic list and the new one to appear.
+Once you've uninstalled an APM agent from a host instance, it may take up to 75 minutes for the old host to disappear from the APM view. If you've removed a host by uninstalling the infrastructure agent, it may take up to 24 hours for it to disappear. 


### PR DESCRIPTION
This is an outstanding hero request about some ambiguity btwn hosts in the APM view. After meeting with @natecanfield822, we've determined that the time is 75 minutes for removing hosts from the APM view via the APM agent.