### PR TITLE
Change "nrlogs" back to "newrelic" in fluent-bit-plugin-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
@@ -103,7 +103,7 @@ Fluent Bit needs to know the location of the New Relic plugin and the New Relic 
        Record hostname ${HOSTNAME}
 
    [OUTPUT]
-       Name nrlogs
+       Name newrelic
        Match *
        licenseKey YOUR_LICENSE_KEY
    ```


### PR DESCRIPTION
"nrlogs" is the name of a plugin that comes with fluent-bit. It takes an api_key instead of licenseKey. Unless something has changed with version 1.18 of this plugin, this was a mistake. 

Using version 1.17 and specifying the nrlogs output as in the current documentation: 

```
[OUTPUT]
    Name nrlogs
    Match *
    licenseKey YOUR_LICENSE_KEY
```

I see this error message: 
```
 [config] nrlogs: unknown configuration property 'licensekey'. The following properties are allowed: base_uri, api_key, license_key, and compress.
```

(Unfortunately I've been unable to test 1.18 using https://github.com/newrelic/newrelic-fluent-bit-output/releases/download/v1.18.0/out_newrelic-linux-amd64-1.18.0.so -- fluent-bit crashes and I don't have any troubleshooting information beyond that I see "fatal: morestack on g0")

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.