### PR TITLE
infra-agent macos version support

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -185,7 +185,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        10.15 (Catalina), 11 (Big Sur), 12 (Monterey) and 13 (Ventura).
+        3 most recent major versions of macOS. Currently: 12 (Monterey), 13 (Ventura), 14 (Sonoma).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -185,7 +185,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        3 most recent major versions of macOS. Currently: 12 (Monterey), 13 (Ventura), 14 (Sonoma).
+        3 most recent major versions. Currently: 12 (Monterey), 13 (Ventura), 14 (Sonoma).
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Give us some context

* Updated supported version of the infrastructure agent on macOS, which is aligned with Apple & Brew support on the most recent 3 major versions.