### PR TITLE
chore: Update aws-elastic-beanstalk-installation-java.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java.mdx
@@ -58,9 +58,9 @@ Your Elastic Beanstalk will then update your environment.
 
 For applications deployed with the AWS Elastic Beanstalk Java SE Platform:
 
-1. Add the `newrelic.jar` and `newrelic.yml` files to your project, for example in a subdirectory named `opt/newrelic`.
+1. Add the `newrelic.jar` and `newrelic.yml` files to your project, such in a subdirectory named `opt/newrelic`.
 
-2. To use custom JVM arguments with your Java SE application, it is recommended to include a `Procfile` at the root of the source bundle of your application. See [Java SE documentation](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-se-platform.html) for details.    
+2. To use custom JVM arguments with your Java SE application, we recommend that you include a `Procfile` at the root of the source bundle of your application. See [Java SE documentation](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-se-platform.html) for details.    
 
    Pass the `-javaagent` flag as a JVM argument in the `Procfile`:
 

--- a/src/content/docs/apm/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/additional-installation/aws-elastic-beanstalk-installation-java.mdx
@@ -24,7 +24,11 @@ Before completing the configuration, you must first:
 * Create a [New Relic account](http://newrelic.com/signup).
 * [Download and install the Java agent](/docs/agents/java-agent/installation/java-agent-manual-installation).
 
-To complete Java agent installation on AWS Elastic Beanstalk:
+To complete Java agent installation on AWS Elastic Beanstalk, follow the steps for your platform:
+
+## Tomcat Platform
+
+For applications deployed with the AWS Elastic Beanstalk Tomcat Platform:
 
 1. In your WAR file, add the `newrelic.jar` and `newrelic.yml` files to `WEB-INF/lib/`.
 2. Repackage and deploy your new WAR file as a new application or an update to a previous application.
@@ -34,16 +38,14 @@ To complete Java agent installation on AWS Elastic Beanstalk:
 sudo find </var | /usr> -name "newrelic.jar"
 ```
 
-## Pass -javaagent flag to JVM [#javaagent-flag]
+To pass the `-javaagent` flag to the JVM:
 
-To pass the `-javaagent` flag to JVM in AWS Elastic Beanstalk
-
-1. In the AWS console, open the Elastic Beanstalk.
-2. Select the relevant region.
-3. Select your application.
-4. In the left pane, select **Configurations**.
-5. Open **Software Configuration**.
-6. Under **Container Options**, add the following in the **JVM options** field:
+4. In the AWS console, open the Elastic Beanstalk.
+5. Select the relevant region.
+6. Select your environment.
+7. In the left pane, select **Configurations**.
+8. Scroll to **Updates, monitoring, and logging** and select **Edit** in the upper right corner.
+9. Scroll to **Platform Software** and add the following line to the **JVM Options** field:
 
    ```
    -javaagent:/full/path/to/newrelic.jar
@@ -51,3 +53,18 @@ To pass the `-javaagent` flag to JVM in AWS Elastic Beanstalk
 7. Select **Apply** to save.
 
 Your Elastic Beanstalk will then update your environment.
+
+## Java SE Platform
+
+For applications deployed with the AWS Elastic Beanstalk Java SE Platform:
+
+1. Add the `newrelic.jar` and `newrelic.yml` files to your project, for example in a subdirectory named `opt/newrelic`.
+
+2. To use custom JVM arguments with your Java SE application, it is recommended to include a `Procfile` at the root of the source bundle of your application. See [Java SE documentation](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/java-se-platform.html) for details.    
+
+   Pass the `-javaagent` flag as a JVM argument in the `Procfile`:
+
+   ```
+   web:java -javaagent:path/from/bundle/root/to/newrelic.jar -jar <your-application>.jar
+   ```
+3. Repackage and deploy the source bundle to your Elastic Beanstalk.


### PR DESCRIPTION
This PR addresses [java agent issue 1580 ](https://github.com/newrelic/newrelic-java-agent/issues/1508)

The previous installation instructions for the Java Agent on AWS Elastic Beanstalk were incorrect. This PR provides up-to-date instructions for AWS Elastic Beanstalk users on two different Java platforms. 

The changes were tested and verified locally for both platforms. 