### PR TITLE
fix: We made color changes for the flamegraph based on the call count

### DIFF
--- a/src/content/docs/apm/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics.mdx
+++ b/src/content/docs/apm/agents/java-agent/features/real-time-profiling-java-using-jfr-metrics.mdx
@@ -135,8 +135,8 @@ Use flame graphs to identify the Java classes and methods that are most frequent
 
 Here are some details about the flame graph colors:
 
-* Light color: methods from a Java SE package.
-* Dark color: methods from other libraries.
+* Gray gradient color: Gray gradient color is applied to methods from a Java SE package. The color is determined based on the call count, with lighter colors for lower call counts, gradually transitioning to darker shades as the call count increases.
+* Yellow orange gradient color: Yellow orange gradient is applied to methods from other libraries. The color is determined based on the call count, with lighter colors for lower call counts, gradually transitioning to darker shades as the call count increases.
 
 <img
   title="Screenshot of New Relic Java flame graph"


### PR DESCRIPTION
We made color changes for the flame graph based on the call count. We applied a gray gradient for Java calls and a yellow-orange gradient for other calls.

<img width="1792" alt="Screenshot 2023-12-12 at 9 21 03 AM" src="https://github.com/newrelic/docs-website/assets/153588313/ca7fa3cf-88f7-4cd7-89f6-4edf8c011eaf">



## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.