### PR TITLE
fix: Remove duplicated section for logging_retry_limit in Infrastructure Agent Configuration Docs

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -560,7 +560,7 @@ For an example of how all these variables can be used, see our [sample configura
           </td>
 
           <td>
-            5
+            `5`
           </td>
 
           <td>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -512,69 +512,13 @@ For an example of how all these variables can be used, see our [sample configura
       </tbody>
     </table>
   </Collapser>
-  <Collapser
-    className="freq-link"
-    id="logging-retry-limit"
-    title="logging_retry_limit"
-  >
-    Enables [Agent Retry for Log Transmission](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-behavior/#retry).
 
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "200px" }}>
-            YML option name
-          </th>
-
-          <th style={{ width: "200px" }}>
-            Environment variable
-          </th>
-
-          <th>
-            Type
-          </th>
-
-          <th>
-            Default
-          </th>
-
-          <th>
-            Version
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            `logging_retry_limit`
-          </td>
-
-          <td>
-            `NRIA_LOGGING_RETRY_LIMIT`
-          </td>
-
-          <td>
-            integer
-          </td>
-
-          <td>
-            `5`
-          </td>
-
-          <td>
-            [1.29.1](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1291)
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
   <Collapser
     className="freq-link"
     id="logging_retry-limit"
     title="logging_retry_limit"
   >
-    Enables the retry limit for the embedded fluentbit logging forwarder. Integer values are for the number of intended retries. Other possible values include `False` to set the number of retries to infinite and `no_retries` to turn off the retry functionality entirely.
+    Enables [Agent Retry for Log Transmission](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/infrastructure-agent-behavior/#retry) via the embedded fluentbit logging forwarder. Integer values are for the number of intended retries. Other possible values include `False` to set the number of retries to infinite and `no_retries` to turn off the retry functionality entirely.
 
     <table>
       <thead>


### PR DESCRIPTION
## Give us some context

* This PR remove the duplicated `Collapser` element in the Infrastructure [Agent Configuration documentation](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/) on the `logging_retry_limit`. All other information in both collapsers is identical except of the description.
* I merged the description of both collapsers into one.