### PR TITLE
Update configure-logs-context-go.mdx

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
@@ -279,7 +279,7 @@ txnLogger := log.WithContext(newrelic.NewContext(context.Background(), txn))
   go get github.com/newrelic/go-agent/v3/integrations/logcontext-v2/nrzap
   ```
 
-  2. Import the nrlogrus package in the file where you initialize your Zap logger.
+  2. Import the nrzap package in the file where you initialize your Zap logger.
 
   ```go
   import (


### PR DESCRIPTION
It was referencing nrlogrus in nrzap section. Replaced to nrzap

