### PR TITLE
feat: sentence case all 'Prometheus agent'

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic.mdx
@@ -37,18 +37,18 @@ This page provides an overview of the options for the Prometheus integrations of
 
 We currently offer three alternatives to send Prometheus metrics to New Relic.
 
-* [Prometheus Agent for Kubernetes](#Agent).
+* [Prometheus agent for Kubernetes](#Agent).
 * [Prometheus OpenMetrics integration for Docker](#OpenMetrics).
 * [Prometheus remote write integration](#remote-write)
 
-If you already have a Prometheus server, we recommend getting started with the remote write integration. Otherwise, depending on your needs, you may choose between the [Prometheus Agent for Kubernetes](#Agent) and [Prometheus OpenMetrics integration for Docker](#OpenMetrics).
+If you already have a Prometheus server, we recommend getting started with the remote write integration. Otherwise, depending on your needs, you may choose between the [Prometheus agent for Kubernetes](#Agent) and [Prometheus OpenMetrics integration for Docker](#OpenMetrics).
 
 Examine the benefits, reminders, and recommendations for each option below.
 
 <CollapserGroup>
   <Collapser
     id="prometheus-agent"
-    title="Prometheus Agent for Kubernetes"
+    title="Prometheus agent for Kubernetes"
   >
 Benefits:
 
@@ -61,7 +61,7 @@ Benefits:
 Recommendations:
 * The [scrape interval](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#target-scrape-interval) is the biggest factor influencing data volumes: select it based on your observability needs. For example, changing from the default value of 30s to 1m can reduce data volumes by 50%.
 * Set your filters and configure data to target. See how to [filter Prometheus metrics](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent/#drop-keep-metrics).
-* Control the health of your Prometheus instances and shards by installing the Prometheus Agent quickstart.
+* Control the health of your Prometheus instances and shards by installing the Prometheus agent quickstart.
   </Collapser>
 
   <Collapser
@@ -113,13 +113,13 @@ Regardless of the option you chose, with our Prometheus integrations:
 * The [database](/docs/telemetry-data-platform/get-started/nrdb-horsepower-under-hood) of New Relic can be the centralized long-term data store for all your Prometheus metrics, allowing you to observe all your data in one place.
 * You can execute queries to scale, supported by New Relic.
 
-## Prometheus Agent for Kubernetes [#Agent]
+## Prometheus agent for Kubernetes [#Agent]
 
-The Prometheus Agent of New Relic allows you to easily scrape Prometheus metrics from a Kubernetes cluster. By leveraging on the service discovery and the Kubernetes labels, you'll get instant access to metrics, dashboards, and alerts of the most popular workloads.
+The Prometheus agent of New Relic allows you to easily scrape Prometheus metrics from a Kubernetes cluster. By leveraging on the service discovery and the Kubernetes labels, you'll get instant access to metrics, dashboards, and alerts of the most popular workloads.
 
-You can install Prometheus Agent in two modes:
+You can install Prometheus agent in two modes:
 
-* [Alongside the Kubernetes integration](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#kubernetes-install): Prometheus agent is installed automatically together with the [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
+* [Alongside the Kubernetes integration](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#kubernetes-install): The Prometheus agent is installed automatically together with the [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
 * [Standalone](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent#prometheus-install): If you don't need to monitor your Kubernetes cluster and only want to monitor workloads running on it, you can easily deploy the Prometheus agent just by running a single Helm command. Keep in mind that if you're only using the Prometheus agent, the Prometheus metrics won't be decorated with Kubernetes tags like cluster, pod, or container name.
 
 With this integration you can:
@@ -165,7 +165,7 @@ To learn more about how to scale your data without the hassles of managing Prome
 
 ## Prometheus remote write integration [#remote-write]
 
-Unlike the [Prometheus Agent](/docs/integrations/prometheus-integrations/install-configure-prometheus-agent) and [Docker](/docs/integrations/prometheus-integrations/get-started/new-relic-prometheus-openmetrics-integration-docker) OpenMetrics integrations, which scrape data from Prometheus endpoints, the remote write integration allows you to forward [telemetry data](/docs/telemetry-data-platform/get-started/capabilities/get-know-telemetry-data-platform) from your existing Prometheus servers to New Relic. You can leverage the full range of options for setup and management, from raw data to queries, dashboards, and beyond.
+Unlike the [Prometheus agent](/docs/integrations/prometheus-integrations/install-configure-prometheus-agent) and [Docker](/docs/integrations/prometheus-integrations/get-started/new-relic-prometheus-openmetrics-integration-docker) OpenMetrics integrations, which scrape data from Prometheus endpoints, the remote write integration allows you to forward [telemetry data](/docs/telemetry-data-platform/get-started/capabilities/get-know-telemetry-data-platform) from your existing Prometheus servers to New Relic. You can leverage the full range of options for setup and management, from raw data to queries, dashboards, and beyond.
 
 ### Scale your data and get moving quickly [#remote-write-scale]
 
@@ -212,7 +212,7 @@ With the Prometheus remote write integration you can:
 
 Ready to get moving? Here are some suggested next steps:
 
-* Read the how-to for completing the [Prometheus Agent for Kubernetes](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent).
+* Read the how-to for completing the [Prometheus agent for Kubernetes](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent).
 * Read the how-to for completing the [Prometheus OpenMetrics integration for Docker](/docs/integrations/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration).
 * Read the how-to for completing the [remote write integration](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration).
 * Remote write and Prometheus OpenMetrics integration options generate dimensional metrics that are subject to the same rate limits described in the [Metric API](/docs/telemetry-data-platform/ingest-apis/introduction-metric-api).

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/install-update-or-uninstall-your-prometheus-openmetrics-integration.mdx
@@ -79,6 +79,6 @@ docker rm -f nri-prometheus
 
 ## Kubernetes [#kubernetes]
 
-Please, check the following [page](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent) to understand the benefits of the Prometheus Agent and get a full visiblity of your Prometheus workloads running in a Kubernetes cluster.
+Please, check the following [page](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent) to understand the benefits of the Prometheus agent and get a full visiblity of your Prometheus workloads running in a Kubernetes cluster.
 
 In case you need to migrate from the Prometheus Open Metrics integration to Open Metrics check the following [migration guide](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/migration-guide).

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent.mdx
@@ -46,7 +46,7 @@ You can install our [Kubernetes integration](/docs/kubernetes-pixie/kubernetes-i
 
 If you don't need the Kubernetes integration, you can install the Prometheus agent on its own.
 
-1. Install the [Prometheus Agent](https://github.com/newrelic/newrelic-prometheus-configurator#readme) by running:
+1. Install the [Prometheus agent](https://github.com/newrelic/newrelic-prometheus-configurator#readme) by running:
   ```shell
   helm repo add newrelic-prometheus https://newrelic.github.io/newrelic-prometheus-configurator
   helm upgrade --install newrelic newrelic-prometheus/newrelic-prometheus-agent -f YOUR_CUSTOM_VALUES.yaml

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/migration-guide.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/migration-guide.mdx
@@ -4,7 +4,7 @@ tags:
   - Integrations
   - Prometheus integrations
   - Install and configure OpenMetrics
-metaDescription: Migration guidelines to move from Prometheus OpenMetrics to New Relic Prometheus Agent.
+metaDescription: Migration guidelines to move from Prometheus OpenMetrics to New Relic Prometheus agent.
 freshnessValidatedDate: never
 ---
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent.mdx
@@ -12,7 +12,7 @@ freshnessValidatedDate: never
 
 import infrastructurePrometheusScrapeOnlyMetrics from 'images/infrastructure_screenshot-crop_prometheus-scrape-only-metrics.webp'
 
-## Configure the Prometheus Agent [#configure-prometheus-agent]
+## Configure the Prometheus agent [#configure-prometheus-agent]
 
 You need to place the examples below in the `config` section of the agent. Refer to the [installation method](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent) you used to known which is in your case.
 

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/argocd-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/argocd-integration.mdx
@@ -33,10 +33,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Argo CD documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/metrics/) to learn more about the metrics exposed by Argo CD.
 
-2. Set up Prometheus monitoring. Prometheus metrics need to be integrated with New Relic. You can use the Prometheus Agent for Kubernetes or the Prometheus Remote Write integration. See [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) for more details.
+2. Set up Prometheus monitoring. Prometheus metrics need to be integrated with New Relic. You can use the Prometheus agent for Kubernetes or the Prometheus Remote Write integration. See [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) for more details.
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `argocd`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/calico-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/calico-integration.mdx
@@ -34,10 +34,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Calico documentation](https://projectcalico.docs.tigera.io/maintenance/monitor/monitor-component-metrics) for Prometheus to discover the Calico metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `calico`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/cockroach-db-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/cockroach-db-integration.mdx
@@ -41,10 +41,10 @@ Follow these steps to enable the integration.
 
 1. Follow the  [CockroachDB documentation](https://www.cockroachlabs.com/docs/v22.1/monitor-cockroachdb-with-prometheus.html) for Prometheus to discover the CockroachDB metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `cockroachdb`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/core-dns-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/core-dns-integration.mdx
@@ -30,10 +30,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [CoreDNS documentation](https://coredns.io/plugins/kubernetes/#metrics) for Prometheus to discover the CoreDNS metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `coredns` or `kube-dns`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/etcd-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/etcd-integration.mdx
@@ -31,10 +31,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Etcd documentation](https://etcd.io/docs/v3.5/op-guide/monitoring/) for Prometheus to discover the metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `etcd`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/harbor-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/harbor-integration.mdx
@@ -30,10 +30,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Harbor documentation](https://goharbor.io/docs/2.2.0/administration/metrics/#scrapping-metrics-with-prometheus) for Prometheus to discover the Harbor metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration. See [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) for more details.
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration. See [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) for more details.
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `harbor`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/ingress-controller-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/ingress-controller-integration.mdx
@@ -33,10 +33,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [NGINX Ingress Controller documentation](https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/#prometheus-and-grafana-installation-using-pod-annotations) for Prometheus to discover the metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `nginx`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/redis-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/redis-integration.mdx
@@ -33,10 +33,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Redis exporter documentation](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-redis-exporter) to add the required pod annotations for Prometheus to discover the metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `redis`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/traefik-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/traefik-integration.mdx
@@ -26,10 +26,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Traefik documentation](https://doc.traefik.io/traefik/getting-started/quick-start-with-kubernetes/) to setup Traefik proxy on Kubernetes for Prometheus to discover the metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `traefik`.
   </Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/velero-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/velero-integration.mdx
@@ -32,10 +32,10 @@ Follow these steps to enable the integration.
 
 1. Follow the [Velero documentation](https://velero.io/docs/main/run-locally/#3-start-the-velero-server-locally) for Prometheus to discover the Velero metrics endpoints.
 
-2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration. See [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) for more details.
+2. Set up Prometheus monitoring. Prometheus metrics needs to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration. See [how to send Prometheus metrics](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) for more details.
 
   <Callout variant="important">
-  The [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
+  The [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent#scrape-metrics-only-from-prometheus-integrations-scrape-prometheus-integrations) only scrapes metrics by default from a [set of integrations](/docs/infrastructure/prometheus-integrations/integrations-list/integrations-list-intro).
 
   In this case, you must identify your pod or endpoint with one of the these labels `app.kubernetes.io/name`, `app.newrelic.io/name`, `k8s-app` containing the string `velero`.
   </Callout>

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure.mdx
@@ -44,7 +44,7 @@ import kubernetesFargateWorkflow from 'images/kubernetes_diagram_fargate-workflo
 
 import kubernetesFargateUi from 'images/kubernetes_screenshot-crop_fargate-ui.webp'
 
-The New Relic Kubernetes integration gives you full observability into the health and performance of your environment by leveraging the New Relic infrastructure agent. This agent collects telemetry data from your cluster using several New Relic integrations such as the [Kubernetes events integration](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration), the [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent/), and the [New Relic Logs Kubernetes plugin](/docs/logs).
+The New Relic Kubernetes integration gives you full observability into the health and performance of your environment by leveraging the New Relic infrastructure agent. This agent collects telemetry data from your cluster using several New Relic integrations such as the [Kubernetes events integration](/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration), the [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent/), and the [New Relic Logs Kubernetes plugin](/docs/logs).
 
 ## Installation options
 
@@ -1259,7 +1259,7 @@ Please notice and adjust the following flags:
 * `global.licenseKey=YOUR_NEW_RELIC_LICENSE_KEY`: Must be set to a valid <InlinePopover type="licenseKey" /> for your account.
 * `global.cluster=K8S_CLUSTER_NAME`: It's used to identify the cluster in the New Relic UI, so should be a descriptive value not used by any other Kubernetes cluster configured in your New Relic account.
 * `kube-state-metrics.enabled=true`: Setting this to `true` will automatically install Kube State Metrics (KSM) for you, which is required for our integration to run. You can set this to false if KSM is already present in your cluster, even if it's on a different namespace.
-* `newrelic-prometheus-agent.enabled=true`: Will deploy our Prometheus Agent, which automatically collects data from Prometheus endpoints present in the cluster.
+* `newrelic-prometheus-agent.enabled=true`: Will deploy our Prometheus agent, which automatically collects data from Prometheus endpoints present in the cluster.
 * `nri-metadata-injection.enabled=true`: Will install our minimal webhook, which adds environment variables that, in turn, allows [linking applications instrumented with New Relic APM to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/link-your-applications/link-your-applications-kubernetes).
 
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/reduce-ingest.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/reduce-ingest.mdx
@@ -25,7 +25,7 @@ Our charts support setting an option to reduce the amount of data ingested at th
 If `lowDataMode` is enabled, the default scrape interval changes from `15s` to `30s`.
 You can also specify a custom value for it using `config.interval`, which will take preference over `lowDataMode`.
 
-### Prometheus Agent Integration
+### Prometheus agent Integration
 
 If `lowDataMode` is enabled, the metrics that are prefixed with the following are excluded by default as they're already collected and used by the [New Relic Kubernetes Integration](/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data/#event-types).
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data.mdx
@@ -452,7 +452,7 @@ Our charts support setting an option to reduce the amount of data ingested at th
 If `lowDataMode` is enabled, the default scrape interval changes from `15s` to `30s`.
 You can also specify a custom value for it using `config.interval`, which will take preference over `lowDataMode`.
 
-### Prometheus Agent Integration
+### Prometheus agent Integration
 
 If `lowDataMode` is enabled, the metrics that are prefixed with the following are excluded by default as they're already collected and used by the [New Relic Kubernetes Integration](/docs/integrations/kubernetes-integration/understand-use-data/find-use-your-kubernetes-data/#event-types).
 

--- a/src/content/docs/more-integrations/grafana-integrations/get-started/grafana-support-prometheus-promql.mdx
+++ b/src/content/docs/more-integrations/grafana-integrations/get-started/grafana-support-prometheus-promql.mdx
@@ -18,13 +18,13 @@ In Grafana, you can configure New Relic as a Prometheus data source. Not only th
 
 ## Use existing Grafana dashboards with New Relic
 
-When you integrate Prometheus metrics with New Relic via [Remote Write](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#remote-write), [Prometheus Agent](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#agent) or the [OpenMetrics Integration](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#OpenMetric) (2.0+) and configure New Relic as a Prometheus data source in Grafana, you can use existing Grafana <InlinePopover type="dashboards" /> and seamlessly tap into the additional monitoring, reliability, and scale we provide.
+When you integrate Prometheus metrics with New Relic via [Remote Write](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#remote-write), [Prometheus agent](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#agent) or the [OpenMetrics Integration](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#OpenMetric) (2.0+) and configure New Relic as a Prometheus data source in Grafana, you can use existing Grafana <InlinePopover type="dashboards" /> and seamlessly tap into the additional monitoring, reliability, and scale we provide.
 
 ## Compatibility and requirements
 
 Before you begin, make sure you’ve finished integrating Prometheus metrics and are running a recent enough version of Grafana.
 
-* You should have either the [Remote Write](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#remote-write), [Prometheus Agent](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#agent)  or the [OpenMetrics Integration](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#OpenMetrics) ( v2.0+) set up before you can configure New Relic Prometheus data sources in Grafana.
+* You should have either the [Remote Write](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#remote-write), [Prometheus agent](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#agent)  or the [OpenMetrics Integration](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#OpenMetrics) ( v2.0+) set up before you can configure New Relic Prometheus data sources in Grafana.
 * You can only configure New Relic Prometheus data sources using this method in Grafana versions 6.7.0 or newer. You will need to configure custom headers in the UI, and this isn’t possible with earlier versions. For details, see [Configure New Relic as a Prometheus data source for Grafana](/docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana).
 
 ### Support for PromQL
@@ -44,7 +44,7 @@ To make your New Relic data available in Grafana, you can configure a new or exi
 
 Ready to configure a Grafana data source?
 
-* Read the how-to documentation for setting up the [Prometheus remote write integration](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration), [Prometheus Agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent)  or the [Prometheus OpenMetrics Integration](/docs/integrations/prometheus-integrations/install-configure/install-update-or-uninstall-your-prometheus-openmetrics-integration).
+* Read the how-to documentation for setting up the [Prometheus remote write integration](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration), [Prometheus agent](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/setup-prometheus-agent)  or the [Prometheus OpenMetrics Integration](/docs/integrations/prometheus-integrations/install-configure/install-update-or-uninstall-your-prometheus-openmetrics-integration).
 * Read the how-to documentation for [configuring Prometheus data sources in Grafana](/docs/integrations/grafana-integrations/set-configure/configure-new-relic-prometheus-data-source-grafana).
 
 <InstallFeedback />

--- a/src/content/docs/style-guide/writing-docs/article-templates/prometheus-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/prometheus-template.mdx
@@ -23,7 +23,7 @@ Add a link where it's possible to take a screenshot of the integration.
 
 ## Enable the integration
 
-Prometheus metrics need to be integrated with New Relic, you can use the Prometheus Agent or the Remote Write integration, see [how to send Prometheus metrics](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
+Prometheus metrics need to be integrated with New Relic, you can use the Prometheus agent or the Remote Write integration, see [how to send Prometheus metrics](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/).
 
 Once integrated, use the following query to confirm metrics are being ingested as expected:
 

--- a/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-intro.mdx
+++ b/src/content/docs/tutorial-kubernetes-learn/tutorial-k8s-intro.mdx
@@ -39,7 +39,7 @@ To begin, you need to set up New Relic with your Kubernetes system. The steps be
   src={tutorialInstall}
 />
 
-The New Relic Kubernetes integration gives you full observability into the health and performance of your environment. With the data it provides, you can monitor the health of your entire Kubernetes cluster, check individual pods, or drill into specific services and applications. This agent collects telemetry data from your cluster using several New Relic integrations such as the Kubernetes events integration, the Prometheus Agent, and the New Relic Logs Kubernetes plugin.
+The New Relic Kubernetes integration gives you full observability into the health and performance of your environment. With the data it provides, you can monitor the health of your entire Kubernetes cluster, check individual pods, or drill into specific services and applications. This agent collects telemetry data from your cluster using several New Relic integrations such as the Kubernetes events integration, the Prometheus agent, and the New Relic Logs Kubernetes plugin.
 
 There are various ways to integrate your Kubernetes system. For this tutorial series, we highly recommend using the guided install steps below. For other install paths, see [our Kubernetes install docs](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/).
 


### PR DESCRIPTION
Looks like we had a lot of instances of title case 'Prometheus Agent' when it should be 'Prometheus agent'
