### PR TITLE
Update agent links to Code-level Metrics

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config.mdx
@@ -8,7 +8,7 @@ metaDescription: For the New Relic Go language agent, you can add source code co
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see <InlinePopover type="apm" /> data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see <InlinePopover type="apm" /> data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 When you enable code-level metrics, the Go agent will attach attributes to trace data. These attributes show the location in your application source code responsible for the actions instrumented by those traces. The data you can see includes:
  * Source file name

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2164,7 +2164,7 @@ The code-level metrics options are set in the `code_level_metrics` stanza and ca
       </tbody>
     </table>
 
-    [Code-level metrics](/docs/codestream/how-use-codestream/performance-monitoring/#code-level) is disabled by default in agent version 7.10.0. Set this to true to turn it on. Beginning in agent version 7.11.0 the default is, as noted above, `true`.
+    [Code-level metrics](/docs/codestream/observability/code-level-metrics) is disabled by default in agent version 7.10.0. Set this to true to turn it on. Beginning in agent version 7.11.0 the default is, as noted above, `true`.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/java-agent/features/java-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/java-agent/features/java-codestream-integration.mdx
@@ -8,7 +8,7 @@ metaDescription: Code-level metrics for Java can be displayed in your IDE using 
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 ## Getting started
 

--- a/src/content/docs/apm/agents/net-agent/other-features/net-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-features/net-codestream-integration.mdx
@@ -8,7 +8,7 @@ metaDescription: Code-level metrics for .NET can be displayed in your IDE using 
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 ## Get started [#get-started]
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/codestream-integration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/codestream-integration.mdx
@@ -8,7 +8,7 @@ metaDescription: Code-level metrics for Node.js can be displayed in your IDE usi
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 ## Get started [#get-started]
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -4161,7 +4161,7 @@ For more details, see [our code-level metrics docs](/docs/apm/agents/nodejs-agen
       </tbody>
     </table>
 
-    Toggles whether to capture additional attributes on middleware spans for all Node.js web frameworks that help drive [Code level metrics](/docs/codestream/how-use-codestream/performance-monitoring/#code-level). The additional attributes are: `code.filepath`, `code.function`, `code.lineno`, and `code.column`.
+    Toggles whether to capture additional attributes on middleware spans for all Node.js web frameworks that help drive [Code level metrics](/docs/codestream/observability/code-level-metrics). The additional attributes are: `code.filepath`, `code.function`, `code.lineno`, and `code.column`.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/php-agent/features/php-code-level-metrics.mdx
+++ b/src/content/docs/apm/agents/php-agent/features/php-code-level-metrics.mdx
@@ -8,7 +8,7 @@ metaDescription: Code-level metrics for PHP can be displayed in your IDE using t
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 ## Getting started
 

--- a/src/content/docs/apm/agents/python-agent/supported-features/python-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/python-codestream-integration.mdx
@@ -11,7 +11,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 ## Getting started
 

--- a/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/ruby-codestream-integration.mdx
@@ -8,7 +8,7 @@ metaDescription: Code-level metrics for Ruby can be displayed in your IDE using 
 freshnessValidatedDate: never
 ---
 
-Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/how-use-codestream/performance-monitoring#code-level) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
+Code-level metrics allow developers using the [New Relic CodeStream extension](/docs/codestream/observability/code-level-metrics) to see APM data displayed contextually in their IDE, alongside individual methods in the code. This allows developers to be more proactive about addressing performance issues as they write and review code.
 
 ## Getting started
 


### PR DESCRIPTION
Update the links to Code-level Metrics from all the APM agent docs.