### PR TITLE
feat: OTel zstd compression support

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
@@ -8,6 +8,20 @@ metaDescription: Here are some tips for working with OpenTelemetry compression a
 freshnessValidatedDate: never
 ---
 
-To maximize the amount of data you can send per request, we recommend enabling compression in all OTLP exporters. New Relic supports gzip compression for OTLP payloads transported via gRPC or HTTP. The maximum allowed payload size is 1MB (10^6 bytes).
+To maximize the amount of data you can send per request, we recommend enabling compression in all OTLP exporters. New Relic supports `gzip` and `zstd` compression for OTLP payloads transported via gRPC or HTTP. 
+The maximum allowed payload size is 1MB (10^6 bytes).
+
+## OTel collector configuration
+`zstd` compression is considered more efficient than `gzip` which is currently the default compression for the OTLP exporter in the OTel collector. See [compression comparison](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md#compression-comparison) for details benchmark information.
+
+To enable `zstd` in the collector adapt the collector exporter config:
+
+```
+exporters:
+  otlp:
+    ...
+    compression: zstd
+
+```
 
 If there are other compression formats you'd like to see us support, please let us know in the [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP). Note that you can [sign up for CNCF's Slack account here](https://slack.cncf.io/).

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
@@ -8,13 +8,12 @@ metaDescription: Here are some tips for working with OpenTelemetry compression a
 freshnessValidatedDate: never
 ---
 
-To maximize the amount of data you can send per request, we recommend enabling compression in all OTLP exporters. New Relic supports `gzip` and `zstd` compression for OTLP payloads transported via gRPC or HTTP. 
-The maximum allowed payload size is 1MB (10^6 bytes).
+To maximize the amount of data you can send per request, we recommend enabling compression in all OTLP exporters. New Relic supports `gzip` and `zstd` compression for OTLP payloads transported via gRPC or HTTP with a maximum allowed payload size of 1MB (10^6 bytes).
 
 ## OTel collector configuration
-The default compression for the OTLP exporter in the OTel collector is currently `gzip`, while `zstd` compression is considered more efficient. See [compression comparison](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md#compression-comparison) for details benchmark information.
+The default compression for the OTLP exporter in the OTel collector is currently `gzip`, while `zstd` compression often proves more efficient. See [compression comparison](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md#compression-comparison) for more details on benchmark information.
 
-To enable `zstd` in the collector adapt the collector exporter config:
+To enable `zstd` in the collector, adapt the collector exporter config:
 
 ```
 exporters:
@@ -24,4 +23,4 @@ exporters:
 
 ```
 
-If there are other compression formats you'd like to see us support, please let us know in the [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP). Note that you can [sign up for CNCF's Slack account here](https://slack.cncf.io/).
+If you'd like to see us support other compression formats, please let us know in the [CNCF Slack channel](https://cloud-native.slack.com/archives/C024DRQ63UP). You can [sign up for CNCF's Slack account here](https://slack.cncf.io/).

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-compression.mdx
@@ -12,7 +12,7 @@ To maximize the amount of data you can send per request, we recommend enabling c
 The maximum allowed payload size is 1MB (10^6 bytes).
 
 ## OTel collector configuration
-`zstd` compression is considered more efficient than `gzip` which is currently the default compression for the OTLP exporter in the OTel collector. See [compression comparison](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md#compression-comparison) for details benchmark information.
+The default compression for the OTLP exporter in the OTel collector is currently `gzip`, while `zstd` compression is considered more efficient. See [compression comparison](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md#compression-comparison) for details benchmark information.
 
 To enable `zstd` in the collector adapt the collector exporter config:
 


### PR DESCRIPTION
## Give us some context

* New Relic OTLP endpoint added support for `zstd` compression. Adapting the compression best practices explaining how to enable the different compression algorithms. 