### PR TITLE
Update .NET logging framework compatability info

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -767,12 +767,13 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </th>
 
           <th>
-            Minimum supported version
+            Minimium framework version
           </th>
 
           <th>
-            Verified compatible versions
+            Minimium agent version
           </th>
+
         </tr>
       </thead>
 
@@ -782,47 +783,51 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             Log4Net
           </td>
           <td>
-            2.0.6
+            v2.0.10
           </td>
           <td>
-            2.0.10, 2.0.12, 2.0.13, 2.0.14
+            v9.7.0
           </td>
         </tr>
+
         <tr>
           <td>
             Serilog
           </td>
           <td>
-            2.0.0
+            v2.5
           </td>
           <td>
-            2.8.0, 2.10.0, 2.11.0, 3.0.1, 3.1.1
+            v9.7.0
           </td>
         </tr>
-        <tr>
-          <td>
-            Microsoft.Extensions.Logging
-          </td>
-          <td>
-            2.0.0
-          </td>
-          <td>
-            3.0.0, 3.1.22, 6.0.0, 7.0.0, 8.0.0
-          </td>
-        </tr>
+
         <tr>
           <td>
             NLog
           </td>
           <td>
-            4.0.0
+            v4.5
           </td>
           <td>
-            4.5.9, 4.7.15, 5.0.4, 5.2.0, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7
+            v9.7.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Microsoft.Extensions.Logging
+          </td>
+          <td>
+            v3.0
+          </td>
+          <td>
+            v10.0.0
           </td>
         </tr>
       </tbody>
     </table>
+
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -837,12 +837,13 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </th>
 
           <th>
-            Minimium supported version
+            Minimium framework version
           </th>
 
           <th>
-            Verified compatible versions
+            Minimium agent version
           </th>
+
         </tr>
       </thead>
 
@@ -852,32 +853,54 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             Log4Net
           </td>
           <td>
-            1.2.10
+            For .NET Framework: v1.2.10
+
+            For .NET Core: v2.0.10
           </td>
           <td>
-            1.2.10, 2.0.5, 2.0.14
+            v9.7.0
           </td>
         </tr>
+
         <tr>
           <td>
             Serilog
           </td>
           <td>
-            1.0.0
+            For .NET Framework: v2.0
+
+            For .NET Core: v2.5
           </td>
           <td>
-            1.5.14, 2.5.0, 2.10.0, 3.0.1, 3.1.1
+            v9.7.0
           </td>
         </tr>
+
         <tr>
           <td>
             NLog
           </td>
           <td>
-            4.0.0
+            For .NET Framework: v4.1
+
+            For .NET Core: v4.5
           </td>
           <td>
-            4.1.2, 4.3.11, 4.5.11, 5.2.0, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7
+            v9.7.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Microsoft.Extensions.Logging
+          </td>
+          <td>
+            v3.0
+          </td>
+          <td>
+            For .NET Framework: Agent v9.7.0
+
+            For .NET Core: Agent v10.0.0
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -853,9 +853,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             Log4Net
           </td>
           <td>
-            For .NET Framework: v1.2.10
-
-            For .NET Core: v2.0.10
+            v1.2.10
           </td>
           <td>
             v9.7.0
@@ -867,9 +865,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             Serilog
           </td>
           <td>
-            For .NET Framework: v2.0
-
-            For .NET Core: v2.5
+            v2.0
           </td>
           <td>
             v9.7.0
@@ -881,9 +877,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             NLog
           </td>
           <td>
-            For .NET Framework: v4.1
-
-            For .NET Core: v4.5
+            v4.1
           </td>
           <td>
             v9.7.0
@@ -898,9 +892,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             v3.0
           </td>
           <td>
-            For .NET Framework: Agent v9.7.0
-
-            For .NET Core: Agent v10.0.0
+            v9.7.0
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -30,22 +30,93 @@ import logsDotnetLogsinContextSerilog from 'images/logs_diagram_dotnet-logs-in-c
 With our .NET <InlinePopover type="apm" /> agent, you can get **logs in context**, which lets you see your app logs in the context of your other New Relic data. For general information on this feature, see [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context).
 
 <Callout variant="tip">
-Got lots of .Net logs? Check out our [tutorial on how to optimize and manage them](/docs/tutorial-large-logs/get-started-managing-large-logs/). 
+  Got lots of .Net logs? Check out our [tutorial on how to optimize and manage them](/docs/tutorial-large-logs/get-started-managing-large-logs/). 
 </Callout>
 
 ## Automatic logs in context options [#automatic]
 
 You have three options to configure <InlinePopover type="apm" /> logs in context to send your app's logs and linking metadata automatically to New Relic. Supported frameworks for automatic logs in context using in agent forwarding include:
 
-- log4net: 1.2.10+ (.NET Framework), 2.0.10+ (.NET Core). Requires .NET Agent v9.7.0+.
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Frameworks
+          </th>
+
+          <th>
+            Minimium framework version
+          </th>
+
+          <th>
+            Minimium agent version
+          </th>
+
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Log4Net
+          </td>
+          <td>
+            For .NET Framework: v1.2.10
+
+            For .NET Core: v2.0.10
+          </td>
+          <td>
+            v9.7.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Serilog
+          </td>
+          <td>
+            For .NET Framework: v2.0
+
+            For .NET Core: v2.5
+          </td>
+          <td>
+            v9.7.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            NLog
+          </td>
+          <td>
+            For .NET Framework: v4.1
+
+            For .NET Core: v4.5
+          </td>
+          <td>
+            v9.7.0
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Microsoft.Extensions.Logging
+          </td>
+          <td>
+            v3.0
+          </td>
+          <td>
+            For .NET Framework: Agent v9.7.0
+
+            For .NET Core: Agent v10.0.0
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
 <Callout variant="tip">
   Many versions of Sitecore use Sitecore.Logging, which is based off a fork of log4net, but independent. Support for this library was added in version 10.14.0 of the .NET Agent.
 </Callout>
-
-- NLog: 4.1+ (.NET Framework), 4.5+ (.NET Core). Requires .NET Agent v9.7.0+.
-- Serilog: 2.0+ (.NET Framework), 2.5+ (.NET Core). Requires .NET Agent v9.7.0+.
-- Microsoft.Extensions.Logging: 3.0+. Requires .NET Agent v9.7.0+ (.NET Core), Agent v10.0.0+ (.NET Framework).
 
 <CollapserGroup>
 


### PR DESCRIPTION
Updated the individual compatibility docs for Core and Framework. I replaced the known compatible versions with minimum versions and agent versions. Known compatible version lists are really tough to keep up to date and I'm not sure they are as valuable as a list of minimums or versions with known issues.

I also replaced the confusing bullet point list of compatibility info in the LIC doc with a table that is easier to read.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.