### PR TITLE
fix: repairing broken meraki links

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1530,6 +1530,12 @@ global:
           <td> [Meraki Dashboard API key](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#Enable_API_Access) for authentication. </td>
         </tr>
         <tr>
+          <td> meraki_config.max_http_retry </td>
+          <td />
+          <td> Integer between 1-10 (Default: 2) </td>
+          <td> Optional setting that controls how often a retry is attempted on API requests that return a `HTTP 429` error. The interval between retries is 5 seconds. </td>
+        </tr>
+        <tr>
           <td> meraki_config.monitor_devices </td>
           <td />
           <td> true | false (Default: false) </td>
@@ -1663,6 +1669,7 @@ global:
           ext_only: true
           meraki_config:
             api_key: "$YOUR_API_KEY_1"
+            max_http_retry: 8
             monitor_devices: true
             monitor_org_changes: true
             monitor_uplinks: true

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1379,9 +1379,9 @@ global:
     title="Meraki Dashboard API"
   >
 
-    The [Meraki Dashboard API](https://developer.cisco.com/meraki/api-latest/) integration pulls various metrics related to the health of your Meraki environment. The combination of various configuration options allows you to set up different monitoring scenarios for your needs.
+    The [Meraki Dashboard API](https://developer.cisco.com/meraki/api/) integration pulls various metrics related to the health of your Meraki environment. The combination of various configuration options allows you to set up different monitoring scenarios for your needs.
 
-    * `meraki_config.monitor_devices: true && meraki_config.preferences.device_status_only: true`: Uses the [Get Organization Device Statuses](https://developer.cisco.com/meraki/api-latest/get-organization-devices-statuses/) endpoint to list the status of every Meraki device in the organization.
+    * `meraki_config.monitor_devices: true && meraki_config.preferences.device_status_only: true`: Uses the [Get Organization Device Statuses](https://developer.cisco.com/meraki/api/get-organization-devices-statuses/) endpoint to list the status of every Meraki device in the organization.
 
     NRQL to find device status telemetry:
 
@@ -1407,7 +1407,7 @@ global:
 
     <br />
 
-    * `meraki_config.monitor_org_changes: true`: Uses the [Get Organization Configuration Changes](https://developer.cisco.com/meraki/api-latest/get-organization-configuration-changes/) endpoint to view the change log for the organization.
+    * `meraki_config.monitor_org_changes: true`: Uses the [Get Organization Configuration Changes](https://developer.cisco.com/meraki/api/get-organization-configuration-changes/) endpoint to view the change log for the organization.
 
     NRQL to find organization configuration change telemetry:
 
@@ -1417,7 +1417,7 @@ global:
 
     <br />
 
-    * `meraki_config.monitor_uplinks: true && meraki_config.preferences.hide_uplink_usage: false`: Uses the [Get Organization Uplinks Statuses](https://developer.cisco.com/meraki/api-latest/get-organization-uplinks-statuses/) endpoint to list the uplink status and performance of every Meraki MX, MG and Z series device in the organization.
+    * `meraki_config.monitor_uplinks: true && meraki_config.preferences.hide_uplink_usage: false`: Uses both the [Get Organization Uplinks Statuses](https://developer.cisco.com/meraki/api/get-organization-uplinks-statuses/) and [Get Organization Appliance Uplinks Usage by Network](https://developer.cisco.com/meraki/api/get-organization-appliance-uplinks-usage-by-network/) endpoints to list the uplink status and performance of every Meraki MX, MG and Z series device in the organization.
 
     NRQL to find device uplink telemetry:
 
@@ -1442,7 +1442,7 @@ global:
 
     <br />
 
-    * `meraki_config.monitor_uplinks: true && meraki_config.preferences.hide_uplink_usage: true`: Uses the [Get Organization Uplinks Statuses](https://developer.cisco.com/meraki/api-latest/get-organization-uplinks-statuses/) endpoint to list only the uplink status of every Meraki MX, MG and Z series device in the organization.
+    * `meraki_config.monitor_uplinks: true && meraki_config.preferences.hide_uplink_usage: true`: Uses the [Get Organization Uplinks Statuses](https://developer.cisco.com/meraki/api/get-organization-uplinks-statuses/) endpoint to list only the uplink status of every Meraki MX, MG and Z series device in the organization.
 
     NRQL to find device uplink status telemetry:
 
@@ -1463,7 +1463,7 @@ global:
 
     <br />
 
-    * `meraki_config.monitor_vpn_status: true && meraki_config.preferences.show_vpn_peers: false`: Uses the [Get Organization Appliance VPN Statuses](https://developer.cisco.com/meraki/api-latest/get-organization-appliance-vpn-statuses/) endpoint the show VPN statuses across the networks in the organization.
+    * `meraki_config.monitor_vpn_status: true && meraki_config.preferences.show_vpn_peers: false`: Uses the [Get Organization Appliance VPN Statuses](https://developer.cisco.com/meraki/api/get-organization-appliance-vpn-statuses/) endpoint the show VPN statuses across the networks in the organization.
 
     NRQL to find VPN status telemetry:
 
@@ -1485,7 +1485,7 @@ global:
 
     <br />
 
-    * `meraki_config.monitor_vpn_status: true && meraki_config.preferences.show_vpn_peers: true`: Uses the [Get Organization Appliance VPN Statuses](https://developer.cisco.com/meraki/api-latest/get-organization-appliance-vpn-statuses/) endpoint to add information about VPN peers across the networks in the organization.
+    * `meraki_config.monitor_vpn_status: true && meraki_config.preferences.show_vpn_peers: true`: Uses the [Get Organization Appliance VPN Statuses](https://developer.cisco.com/meraki/api/get-organization-appliance-vpn-statuses/) endpoint to add information about VPN peers across the networks in the organization.
 
     NRQL to find VPN peers telemetry:
 
@@ -1586,7 +1586,7 @@ global:
           <td> meraki_config.product_types </td>
           <td />
           <td> Valid types are wireless, appliance, switch, systemsManager, camera, cellularGateway, sensor, and cloudGateway. (Default: null) </td>
-          <td> Adds parameters to the [monitor_devices](https://developer.cisco.com/meraki/api-latest/get-organization-devices-statuses/) API request to filter on specific types of devices. </td>
+          <td> Adds parameters to the [monitor_devices](https://developer.cisco.com/meraki/api/get-organization-devices-statuses/) API request to filter on specific types of devices. </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
meraki recently updated their URL paths from `.../api-latest/...` to `.../api/...`; this PR fixes referenced links in our docs.

also adding one new setting introduced today via kentik/ktranslate#642