### PR TITLE
chore: additional .NET agent support for .NET 8.0/ASP.NET Core 8.0

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -168,7 +168,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, and 7.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, please refer to the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, 7.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, please refer to the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
 
     Supported:
 
@@ -202,6 +202,10 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
 
     ```xml
     <TargetFramework>net7.0</TargetFramework>
+    ```
+
+    ```xml
+    <TargetFramework>net8.0</TargetFramework>
     ```
 
     <Callout variant="important">

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -410,8 +410,8 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
   >
     The .NET agent automatically instruments these application frameworks:
 
-    * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, and 7.0 (includes Web API)
-    * ASP.NET Core Razor Pages 6.0 and 7.0 (starting with .NET agent version 10.19.0)
+    * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, 7.0, and 8.0 (includes Web API)
+    * ASP.NET Core Razor Pages 6.0, 7.0, and 8.0 (starting with .NET agent version 10.19.0)
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -168,7 +168,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, 7.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, please refer to the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
+    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, 7.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, see the above section of our documentation, **[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**.
 
     Supported:
 


### PR DESCRIPTION
Resolves https://github.com/newrelic/newrelic-dotnet-agent/issues/2141 by adding .NET 8.0/ASP.NET 8.0 support statements in a few places missed previously.