### PR TITLE
The output is named `newrelic`

### DIFF
--- a/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
@@ -103,7 +103,7 @@ Fluent Bit needs to know the location of the New Relic plugin and the New Relic 
        Record hostname ${HOSTNAME}
 
    [OUTPUT]
-       Name nrlogs
+       Name newrelic
        Match *
        licenseKey YOUR_LICENSE_KEY
    ```


### PR DESCRIPTION
I am not sure why [this change](https://github.com/newrelic/docs-website/commit/7bd25c0996076b0517b2448cd19087a55f72de49) made it, but the plugin is actually named `newrelic`.