### PR TITLE
APIs: Remove link to outdated video.

### DIFF
--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -34,8 +34,6 @@ NerdGraph is one of several New Relic [APIs](/docs/apis/get-started/intro-apis/i
 
 NerdGraph is built using [GraphQL](https://graphql.org), which is an open source API format that allows you to request exactly the data needed, with no over-fetching or under-fetching.
 
-Want to watch video tutorials about NerdGraph? Go to the New Relic University's [Intro to NerdGraph](https://newrelic.wistia.com/medias/h9qfum9nh0), or see the [online course on New Relic APIs](https://learn.newrelic.com/new-relic-apis).
-
 ## Requirements [#requirements]
 
 Before you get started:


### PR DESCRIPTION
Now that the NerdGraph experience has moved into the New Relic UI and has some other minor internal layout changes, I'm removing the link to the outdated video.