### PR TITLE
[chore] Update opentelemetry-collector-infra-hosts.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -43,7 +43,7 @@ The `collector-contrib` release includes:
 * The `hostmetrics` receiver that generates metrics about the system scraped from various sources. Deploy the collector as an agent when you use a `hostmetrics` receiver.
 * The `filelog` receiver that tails and parses logs from files.
 
-When using the `hostmetrics` receiver as part of the collector configuration, New Relic automatically detects host metrics as part of a `Host` entity and will synthesize its golden metrics providing the same experience as with the New Relic infrastructure agent. The following are the configuration requirements to enable the `Host` entity experience in New Relic UI:
+When using the `hostmetrics` receiver as part of the collector configuration, New Relic will detect host metrics as part of a `Host` entity. This means you will have the same experience as with the New Relic infrastructure agent. To make this work, you need to meet the following configuration requirements:
 
 * `host.id` attribute is present in host metrics.
 * `service.name` and `container.id` attributes are not present in host metrics.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -40,17 +40,17 @@ Your deployment experience might vary depending on which vendor-specific distrib
 This collector example is meant to serve as a starting point from which you can extend, customize, and validate configurations before using them in production.
 
 The `collector-contrib` release includes:
-* The `hostreceiver` that generates metrics about the system scraped from various sources. Deploy the collector as an agent when you use a `hostreceiver`.
-* The `filelogreceiver` that tails and parses logs from files.
+* The `hostmetrics` receiver that generates metrics about the system scraped from various sources. Deploy the collector as an agent when you use a `hostmetrics` receiver.
+* The `filelog` receiver that tails and parses logs from files.
 
-When using the host receiver as part of the collector configuration, New Relic automatically detects host metrics as part of a `Host` entity and will synthesize its golden metrics providing the same experience as with the New Relic infrastructure agent. The following are the configuration requirements to enable the `Host` entity experience in New Relic UI:
+When using the `hostmetrics` receiver as part of the collector configuration, New Relic automatically detects host metrics as part of a `Host` entity and will synthesize its golden metrics providing the same experience as with the New Relic infrastructure agent. The following are the configuration requirements to enable the `Host` entity experience in New Relic UI:
 
 * `host.id` attribute is present in host metrics.
 * `service.name` and `container.id` attributes are not present in host metrics.
 
 Learn more about available metrics and advanced configurations from the [OpenTelemetry documentation in GitHub](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver).
 
-Here is a sample configuration YAML file for a linux host. Be sure to do the following:
+Here is a sample configuration YAML file for a Linux host. Be sure to do the following:
 
 * Replace `OTLP_ENDPOINT_HERE` with the appropriate [endpoint](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
 * Replace `YOUR_KEY_HERE` with your <InlinePopover type="licenseKey" />.


### PR DESCRIPTION
Clarify references to hostmetrics and filelog receivers. Capitalize Linux


## Give us some context

* What problems does this PR solve?

The code block name for the receivers `hostmetrics` and `filelog` did not match the receiver name in the collector.yaml config.

Capitalized "Linux" in one place.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

The collector.yaml example in the same doc shows the receiver names.

* If your issue relates to an existing GitHub issue, please link to it.

n/a