### PR TITLE
Document UTF-16LE handling

### DIFF
--- a/src/content/docs/logs/forward-logs/fluentd-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluentd-plugin-log-forwarding.mdx
@@ -183,9 +183,11 @@ For more information, see the [Fluentd documentation about buffer configurations
 
 ## Configure UTF-16LE to UTF-8 transformation
 
-In this example for Microsoft SQL Server error logs, learn how to use Fluentd to send [UTF-16LE](https://docs.fluentd.org/input/tail#encoding-from_encoding) encoded logs to New Relic using the [required UTF-8 encoding](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general) for ingest. This example can be adapted to other encodings.
+In this example for Microsoft SQL Server error logs, use Fluentd to send [UTF-16LE](https://docs.fluentd.org/input/tail#encoding-from_encoding) encoded logs to New Relic with the [required UTF-8 encoding](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general) for ingest. You can also adopt this example to other encodings.
 
+<Callout variant="tip">
 We also add an appropriate `logtype` for these logs.
+</Callout>
 
 ```
 #Tail one or more log files


### PR DESCRIPTION
Add section to provide directions for UTF-16LE -> UTF-8 transform.

In some Windows environments, the Microsoft SQL Server error logs are written to disk in UTF-16LE encoding. Sending them directly to New Relic can result in formatting and display issues for the data stored to NRDB, since New Relic's API requires UTF-8 encoding ([reference](https://docs.newrelic.com/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#general)).

Configuration is required in order to send any UTF-16 logs as UTF-8. Fluentd supports the required transformation between encodings ([reference](https://docs.fluentd.org/input/tail#encoding-from_encoding)).