### PR TITLE
Correction of name of function setUserId for the node docs

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -859,16 +859,16 @@ New Relic's Node.js agent includes additional API calls.
   </Collapser>
 
   <Collapser
-    id="setUserID"
-    title={<InlineCode>newrelic.setUserID(string)</InlineCode>}
+    id="setUserId"
+    title={<InlineCode>newrelic.setUserId(string)</InlineCode>}
   >
     ```js
-    newrelic.setUserID(string)
+    newrelic.setUserId(string)
     ```
     This method gives you a way to associate a unique identifier with a transaction event, transaction trace and errors within transaction. A new property, `enduser.id`, will be added to the error and reported to errors inbox.
     
     <Callout variant="important">
-      The `setUserID` API requires [Node.js agent version 9.13.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-13-0/) or higher. 
+      The `setUserId` API requires [Node.js agent version 9.13.0](/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-9-13-0/) or higher. 
     </Callout>
 
   </Collapser>


### PR DESCRIPTION

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* The function for setting userId is named **setUserId**, _not_ setUserID, i.e. with a large D.
* Try calling the function with a large D and see your application crash.
* I'm using version 11.2.1 of the new relic agent, together with @newrelic/next version 0.7.0.