### PR TITLE
Update nerdgraph-entities-api-tutorial.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -640,7 +640,9 @@ mutation {
 
 ## Delete entities [#delete-entities]
 
-You can manually delete any entity in your account by using the NerdGraph API. To do so, run this query with the entity's GUID in the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql):
+You can manually delete any entity in your account by using the NerdGraph API in the [NerdGraph GraphiQL explorer](https://api.newrelic.com/graphiql). 
+
+To delete `EXT-SERVICE` and `REF-REPOSITORY` entities, run this mutation with the entity's GUID:
 
 ```graphql
 mutation {
@@ -652,11 +654,24 @@ mutation {
     }
   }
 }
-
 ```
 
 <Callout variant="important">
-  Currently, you can only remove the following [entity types](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) using the Nerdgraph API: `APM-APPLICATION`, `EXT-SERVICE`, and `REF-REPOSITORY`.
+  After running the `entityDelete` mutation, you may see a deleted entity in your UI if a New Relic agent reindexes it again.
+</Callout>
 
-  You may see a deleted entity in your UI if a New Relic agent reindexes it again.
+To delete `APM`, `BROWSER` and `MOBILE` entities, run this mutation with the entity's GUID:
+
+```graphql
+mutation {
+  agentApplicationDelete(guid: "ENTITY_GUID") {
+    success
+  }
+}
+```
+
+<Callout variant="important">
+  * The `agentApplicationDelete` mutation requires that the New Relic agent must not have reporting data for 12 hours before deletion.
+  * Currently, you can only remove the following [entity types](/docs/new-relic-one/use-new-relic-one/core-concepts/what-entity-new-relic) using the Nerdgraph API: `APM-APPLICATION`, `EXT-SERVICE`, and `REF-REPOSITORY`.
+  * You may see a deleted entity in your UI if a New Relic agent reindexes it again.
 </Callout>

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -647,6 +647,7 @@ mutation {
   entityDelete(guids: ["ENTITY_GUID_1", "ENTITY_GUID_2"]) {
     deletedEntities
     failures {
+      guid
       message
     }
   }

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial.mdx
@@ -646,7 +646,9 @@ You can manually delete any entity in your account by using the NerdGraph API. T
 mutation {
   entityDelete(guids: ["ENTITY_GUID_1", "ENTITY_GUID_2"]) {
     deletedEntities
-    failures
+    failures {
+      message
+    }
   }
 }
 


### PR DESCRIPTION
pass atleast message subfield, other wise the query fails

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Fixes the graphql query to delete an entity
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.