### PR TITLE
Update debugging-agent-azure.mdx

### DIFF
--- a/src/content/docs/apm/agents/net-agent/azure-installation/debugging-agent-azure.mdx
+++ b/src/content/docs/apm/agents/net-agent/azure-installation/debugging-agent-azure.mdx
@@ -159,7 +159,7 @@ These examples all assume that your Azure Web App uses a `D:` file system root. 
   CORECLR_ENABLE_PROFILING = 1
   CORECLR_PROFILER = {36032161-FFC0-4B61-B559-F6C5D41BAE5A}
   CORECLR_PROFILER_PATH_32 = D:\Home\site\wwwroot\newrelic\x86\NewRelic.Profiler.dll
-  COR_PROFILER_PATH_64 = D:\Home\site\wwwroot\newrelic\NewRelic.Profiler.dll
+  CORECLR_PROFILER_PATH_64 = D:\Home\site\wwwroot\newrelic\NewRelic.Profiler.dll
   CORECLR_NEWRELIC_HOME = D:\Home\site\wwwroot\newrelic
   NEW_RELIC_LICENSE_KEY = YOUR_LICENSE_KEY
   NEW_RELIC_APP_NAME = YOUR_APP_NAME


### PR DESCRIPTION
Incorrect environment variable for .NET Core.

Changed COR_PROFILER_PATH to CORECLR_PROFILER_PATH

COR_ prefix is only for .NET Framework

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.