### PR TITLE
fix(SynthListPrice): Fixed link to list price collapser

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/monitor-limits.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/monitor-limits.mdx
@@ -29,7 +29,7 @@ The following are the synthetic checks included for free on each pricing edition
 
 ## Exceeding free amount [#exceeding-free]
 
-For information on the cost of exceeding the free number of monitor checks, see the [list price table](/docs/licenses/license-information/usage-plans/new-relic-usage-plan/#list-price). Scroll down to view Add-ons pricing which includes Synthetic Checks. 
+For information on the cost of exceeding the free number of monitor checks, see the [list price table](/docs/licenses/license-information/usage-plans/new-relic-usage-plan/#list-price). Scroll down to view add-on pricing, which includes synthetic checks. 
 
 ## Usage timestamps [#usage-timestamps]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/getting-started/monitor-limits.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/getting-started/monitor-limits.mdx
@@ -29,7 +29,7 @@ The following are the synthetic checks included for free on each pricing edition
 
 ## Exceeding free amount [#exceeding-free]
 
-For information on the cost of exceeding the free number of monitor checks, see the [list price table](/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions#list-price).
+For information on the cost of exceeding the free number of monitor checks, see the [list price table](/docs/licenses/license-information/usage-plans/new-relic-usage-plan/#list-price). Scroll down to view Add-ons pricing which includes Synthetic Checks. 
 
 ## Usage timestamps [#usage-timestamps]
 


### PR DESCRIPTION
The existing link pointed to the Usage Plan correctly, but was not expanding the list prices section. I also added a clarification that you will need to scroll down to view Add-On pricing for Synthetics since we cannot link directly to this content inside of a collapser. 