### PR TITLE
Update header anchor position and add collapser header copy button

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.1.1",
+    "@newrelic/gatsby-theme-newrelic": "9.1.2",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/plugins/gatsby-remark-autolink-headers-custom/index.js
+++ b/plugins/gatsby-remark-autolink-headers-custom/index.js
@@ -20,8 +20,7 @@ module.exports = (
     className = `anchor`,
     maintainCase = false,
     removeAccents = false,
-    enableCustomId = false,
-    isIconAfterHeader = false,
+    enableCustomId = true,
     elements = null,
   }
 ) => {
@@ -36,9 +35,9 @@ module.exports = (
     let id;
     if (enableCustomId && node.children.length > 0) {
       const last = node.children[node.children.length - 1];
-      // This regex matches to preceding spaces and {#custom-id} at the end of a string.
+      // This regex matches to preceding spaces and #custom-id at the end of a string.
       // Also, checks the text of node won't be empty after the removal of {#custom-id}.
-      const match = /^(.*?)\s*\{#([\w-]+)\}$/.exec(toString(last));
+      const match = /^(.*?)\s*#([\w-]+)$/.exec(toString(last));
       if (match && (match[1] || node.children.length > 1)) {
         id = match[2];
         // Remove the custom ID from the original text.
@@ -64,10 +63,15 @@ module.exports = (
     if (icon !== false) {
       patch(data.hProperties, `style`, `position:relative;`);
       const label = id.split(`-`).join(` `);
-      const method = isIconAfterHeader ? `push` : `unshift`;
+      const method = `push`;
       node.children[method]({
         type: 'mdxBlockElement',
         name: 'HeaderLink',
+        data: {
+          hProperties: {
+            class: `${className} after`,
+          },
+        },
         children: [
           {
             type: `link`,
@@ -77,7 +81,7 @@ module.exports = (
             data: {
               hProperties: {
                 'aria-label': `${label} permalink`,
-                class: `${className} ${isIconAfterHeader ? `after` : `before`}`,
+                class: `${className} after`,
               },
               hChildren: [
                 {

--- a/plugins/gatsby-remark-autolink-headers-custom/index.js
+++ b/plugins/gatsby-remark-autolink-headers-custom/index.js
@@ -63,8 +63,7 @@ module.exports = (
     if (icon !== false) {
       patch(data.hProperties, `style`, `position:relative;`);
       const label = id.split(`-`).join(` `);
-      const method = `push`;
-      node.children[method]({
+      node.children.push({
         type: 'mdxBlockElement',
         name: 'HeaderLink',
         data: {

--- a/src/components/HeaderLink.js
+++ b/src/components/HeaderLink.js
@@ -36,8 +36,8 @@ from {
   opacity: 0;
 }
 
-20%, to {
-  transform: translate3d(0, -5px, 0);
+40%, to {
+  transform: translate3d(5px, 0, 0);
   opacity: 1;
 }
 `;

--- a/src/components/HeaderLink.js
+++ b/src/components/HeaderLink.js
@@ -50,8 +50,8 @@ const CopiedMessage = styled.p`
   min-width: 70px;
   padding: 0 0.25rem;
   position: absolute;
-  bottom: 90%;
-  left: -10px;
+  bottom: 0;
+
   animation: ${copyAnimation} 1s ease;
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3547,10 +3547,11 @@
     eslint-plugin-prettier "^3.1.1"
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
-"@newrelic/gatsby-theme-newrelic@9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.1.1.tgz#9f7f65a58fede5daa72ce04c8abc99fe17fec404"
-  integrity sha512-3+A0flwLHS7QtHac8BsM7xiiS/UkgNifgOryVpwUnpRSewF95WfDK2ZL2BIgQ6yAgl+r/Yei0c1sxl/Ws4RDJw==
+
+"@newrelic/gatsby-theme-newrelic@9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.1.2.tgz#8408eb0806143f9b83e8560e3b58ff5817e8e51b"
+  integrity sha512-FqmEJrGcI7dqkLXBjneKQj/wsi086uX9t+V/BGiDagJe2WfU/0m5I4Z0MBAtaskBKcI/IZx4AkqUfTQ54BQbkw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
This moves the header anchor link to the right of headers (to match the positioning in collapser headers) and also adds copy functionality to collapser headers via the theme update