### PR TITLE
fix: remove pull request target from check for keys workflow

### DIFF
--- a/.github/workflows/check-for-keys.yml
+++ b/.github/workflows/check-for-keys.yml
@@ -1,7 +1,7 @@
 name: Check for Keys
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
     branches:


### PR DESCRIPTION
Remove the `pull_request_target` flag in this action to ensure it cannot run for all parties