### PR TITLE
style(Alerts): Removed "Introduction to" from the nav title

### DIFF
--- a/src/nav/alerts-applied-intelligence.yml
+++ b/src/nav/alerts-applied-intelligence.yml
@@ -114,7 +114,7 @@ pages:
                     path: /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/alerts-nerdgraph/nerdgraph-api-examples
               - title: REST API
                 pages:
-                  - title: Introduction to REST API for alerts
+                  - title: REST API for alerts
                     path: /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts
                   - title: Manage alert entities
                     path: /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/manage-entities-alerts-conditions


### PR DESCRIPTION
Removed the "Introduction to" from the nav title of this page: [REST API calls for alerts](https://docs.newrelic.com/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/rest-api-calls-alerts/)