### PR TITLE
Added clarifying instructions to macos infra install

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -62,6 +62,7 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
     Intel x86:
 
     ```bash
+      sudo mkdir -p /usr/local/etc/newrelic-infra/
       echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /usr/local/etc/newrelic-infra/newrelic-infra.yml
     ```
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -69,6 +69,7 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
     Apple Silicon:
     
     ```bash
+      sudo mkdir -p /opt/homebrew/etc/newrelic-infra/
       echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /opt/homebrew/etc/newrelic-infra/newrelic-infra.yml
 
 Wait a few minutes, then [view your server in the infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infra-ui-overview). If no data appears after waiting a few minutes, follow the [troubleshooting steps](/docs/infrastructure/new-relic-infrastructure/troubleshooting/no-data-appears-infrastructure).

--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -45,7 +45,7 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
       /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     ```
 
-3. In your terminal, run `mkdir -p` to create a new directory for the infrastructure agent, then run the following command:
+3. Then, open the terminal and run the following command::
 
     ```bash
       brew install newrelic-infra-agent -q

--- a/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos.mdx
@@ -35,25 +35,25 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
 2. Make sure [Homebrew](https://brew.sh/) is installed in the system.
     You can check your Homebrew installation with:
 
-    ```
+    ```bash
       which brew
     ```
 
     If it's not installed, you can install it with this command (or check [Homebrew](https://brew.sh/) up-to-date instructions):
 
-    ```
+    ```bash
       /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     ```
 
-3. Then, open the terminal and run the following command:
+3. In your terminal, run `mkdir -p` to create a new directory for the infrastructure agent, then run the following command:
 
-    ```
+    ```bash
       brew install newrelic-infra-agent -q
     ```
 
 4. Start the infrastructure agent service:
 
-    ```
+    ```bash
       brew services start newrelic-infra-agent
     ```
 
@@ -61,12 +61,13 @@ To install the infrastructure monitoring agent, follow the step-by-step instruct
 
     Intel x86:
 
-    ```
+    ```bash
       echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /usr/local/etc/newrelic-infra/newrelic-infra.yml
     ```
 
     Apple Silicon:
-    ```
+    
+    ```bash
       echo "license_key: YOUR_LICENSE_KEY" | sudo tee -a /opt/homebrew/etc/newrelic-infra/newrelic-infra.yml
 
 Wait a few minutes, then [view your server in the infrastructure UI](/docs/infrastructure/infrastructure-ui-pages/infra-ui-overview). If no data appears after waiting a few minutes, follow the [troubleshooting steps](/docs/infrastructure/new-relic-infrastructure/troubleshooting/no-data-appears-infrastructure).


### PR DESCRIPTION
Per customer feedback ticket, added some content to address the lack of directory when running through these steps literally
