### PR TITLE
Add exception to vale linted words

### DIFF
--- a/.github/styles/new-relic/ComplexWords.yml
+++ b/.github/styles/new-relic/ComplexWords.yml
@@ -6,7 +6,7 @@ level: suggestion
 action:
   name: replace
 swap:
-  "approximate(?:ly)?": about
+  'approximate(?:ly)?': about
   abundance: plenty
   accelerate: speed up
   accentuate: stress
@@ -19,7 +19,7 @@ swap:
   acquiesce: agree
   acquire: get|buy
   additional: more|extra
-  address: discuss
+  '[^IP] address': discuss
   addressees: you
   adjacent to: next to
   adjustment: change


### PR DESCRIPTION
Add an exception for the use of `IP address` so vale doesn't think it is the verb form of `address`
<img width="595" alt="Screenshot 2024-01-04 at 11 30 32 AM" src="https://github.com/newrelic/docs-website/assets/47728020/04097d4a-6b9d-4d06-8ca4-b8267869c925">
