### PR TITLE
fix(nri-mongodb): specify Atlas as special as of MongoDB metric attribute

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -653,7 +653,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
       Cluster Role which can have the following values:
       - mongos   - for mongos instances
       - shardsvr - arbiter or regular instances (primary or secondary)
-      - *empty*  - for standalone instances
+      - *empty*  - for standalone instances and Atlas
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Specify that the `cl_role` attribute is empty for Atlas instances. Discovered by @kang-makes  while giving support in a GTSE. 