### PR TITLE
Corrections for Otel Collector for host monitoring guide

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -62,6 +62,10 @@ extensions:
   health_check:
 
 receivers:
+  otlp:
+    protocols:
+      grpc:
+  
   hostmetrics:
     collection_interval: 20s
     scrapers:
@@ -142,6 +146,7 @@ exporters:
     endpoint: OTLP_ENDPOINT_HERE
     headers:
       api-key: YOUR_KEY_HERE
+logging:
 
 service:
   pipelines:

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -141,6 +141,13 @@ processors:
     timeout: 2s
     override: false
 
+  # fallback for running via mac or docker to ensure Infra UI will pick up data
+  resource:
+    attributes:
+      - key: host.id
+        value: localhost
+        action: insert
+
 exporters:
   otlp:
     endpoint: OTLP_ENDPOINT_HERE


### PR DESCRIPTION
I tried to use this guide to try out infra host monitoring via the otel collector locally, and ran into multiple issues. I used the dockerized collector as outlined in the linked guide on the opentelemetry website.

* This configuration will throw 2 `Error: invalid configuration` due to the missing `logging` and `otlp` sections which are referenced later in the config
* I also added a configuration to make sure that `host.id` is added to data points that don't already have it. This is important with how this guide is structure now with advising customers to check the Infra UI first to see this data ("By using the recommended configuration in the collector, you can view data through the standard features in the [Infrastructure UI](https://docs.newrelic.com/docs/infrastructure/infrastructure-ui-pages/infra-ui-overview/)". The current strategy in this config is to use the `resourcedetection` processor, although this doesn't work with [Docker](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#system-metadata) on [Mac](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#docker-metadata).

Additionally what is not fixed:
* Logs don't show up in New Relic. I tried for a bit to configure the collector to send it's own logs, but didn't get this working with a config and using the docker set up.

