### PR TITLE
fix(Alerts): Added a redirect

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/overview.mdx
+++ b/src/content/docs/alerts-applied-intelligence/overview.mdx
@@ -30,6 +30,7 @@ redirects:
   - /docs/introduction-new-relic-ai
   - /docs/alerts/new-relic-alerts/getting-started/alerting-new-relic
   - /docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/basic-alerting-concepts/
+  - /docs/new-relic-one/use-new-relic-one/new-relic-ai/get-started-incident-intelligence
 signupBanner:
   text: Monitor and improve your entire stack. 100GB free. Forever.
 freshnessValidatedDate: never


### PR DESCRIPTION
Added a redirect to the [Introduction to alerts and applied intelligence](https://docs.newrelic.com/docs/alerts-applied-intelligence/overview/) page. [This link](https://docs.newrelic.com/docs/new-relic-one/use-new-relic-one/new-relic-ai/get-started-incident-intelligence/) included in the New Relic's incident intelligence text doesn't work on the [Choose your data center (US or EU)](https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/choose-your-data-center/#regions-availability) page.

This is a request from the #help-documentation channel, from Víctor Pérez.