### PR TITLE
Small typo correction: "vale"->"value"

### DIFF
--- a/src/content/docs/logs/ui-data/timestamp-support.mdx
+++ b/src/content/docs/logs/ui-data/timestamp-support.mdx
@@ -178,7 +178,7 @@ The attribute name extracted by the expression must be `timestamp` and its data 
 
 If the timestamp in your log is a Unix epoch or ISO8601 formatted timestamp you can use the default Grok patterns to match them. For example:
 
-* To extract a Unix epoch timestamp you can use any expression that matches the vale, like `NUMBER`, `NOTSPACE`, `DATA`, or `GREEDYDATA`.
+* To extract a Unix epoch timestamp you can use any expression that matches the value, like `NUMBER`, `NOTSPACE`, `DATA`, or `GREEDYDATA`.
 * To extract an ISO8601 formatted timestamp you should use the `TIMESTAMP_ISO8601` Grok expression.
 
 You can use the `datetime` Grok type to parse timestamps in non-supported formats.  To do this you must include the `datetime` Grok type with the `pattern` matching your logs timestamp format.  The `pattern` must use the Java Simple Date and Time Patterns found [here](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). Take these examples that show how Grok expressions transform unsupported timestamp formats into supported formats: 


### PR DESCRIPTION
Small typo correction: "vale" -> "value"