### PR TITLE
fix(StandardUser): Clarified standard user permissions

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -153,9 +153,9 @@ Here's a table with our standard roles. To better understand these roles, go to 
       </td>
 
       <td>
-        Provides access to our platform features (for example, <InlinePopover type="apm" /> UI and browser monitoring UI), but lacks permissions to configure those features and lacks organization-level and user management permissions. 
+        Provides read-only access to platform features and provides create, update, and delete access to a subset of features (for example, <InlinePopover type="apm" /> UI, browser monitoring UI, and Synthetics). 
         
-        This role is essentially the **All product admin** role without the ability to configure platform features.
+        Use the access management UI to view the capabilities included in the standard user role across the platform. 
       </td>
 
       <td>


### PR DESCRIPTION
The documentation incorrectly indicated that the standard user role is essentially a read only role. That is not true for many products in the platform. 