### PR TITLE
(Publish: 1/10/2024) Accounts: Delete inspected count references

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -147,14 +147,14 @@ Here's a table with comparisons of the two options. Prices and limits are monthl
 
     <tr>
       <td>
-        Max [query limit](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries/#inspected-count-limits)
+        Max [query limit](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries/#query-limits)
       </td>
 
       <td>
-        300B data points per 30 minutes
+        Up to 20B data points per minute 
       </td>
       <td>
-        1T data points per 30 minutes
+        Up to 60B data points per minute
       </td>
       <td>
       </td>

--- a/src/content/docs/data-apis/manage-data/query-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/query-limits.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 
 import accountsLimitsDashboard from 'images/accounts_screenshot-crop_limits-dashboard.webp'
 
-New Relic has resource limits in place to protect your experience, our systems, and our other customers. These limits range from the maximum number of characters you can have in a query, to API request rates, to how many events your queries inspect, and more.
+New Relic has resource limits in place to protect your experience, our systems, and our other customers. These limits range from the maximum number of characters you can have in a query, to API request rates, and more.
 
 This page describes the limit metrics and [`NrIntegrationError` events](/docs/telemetry-data-platform/manage-data/nrintegrationerror) that enable you to view your limits, your current data usage and overall resource consumption as compared to those limits, and the impact of experiencing a limit event. We also provide a handful of queries that, when compiled into a dashboard, can give you consistent insight into your limits status.
 

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -53,7 +53,7 @@ If you want more detail than the UI provides, see [Query your resource use](/doc
 Limits are enforced per account (not per [organization](/docs/glossary/glossary/#organization)). You might reach a limit if you start monitoring a new high-traffic application, or have a sudden data spike. When you do reach a limit, New Relic responds according to the type of data and the limit that's reached. Some examples of responses:
 
 * We place a limit on the number of ingested requests per minute (RPM) per data type. When this limit is reached, we stop accepting data and return a 429 status code for the duration of the minute.
-* For queries, we place limits on the number of queries per minute and the number of records inspected (see [query limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). When the number of queries per minute limit is reached, New Relic will begin rejecting queries until the number of queries is below the limit. When the records inspected limit is reached, New Relic will reject traffic from the source scanning the largest number of records and attempt to allow traffic from other sources.
+* For queries, we place limits on the number of queries per minute and the number of records inspected (see [query limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). 
 * For metrics, we place a limit on the number of unique timeseries (cardinality) per account and per metric. When this limit is reached, aggregated data is turned off for the rest of the UTC day.
 
 For every major limit incident, New Relic creates an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) for that account, which has these limit-related attributes:

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -53,7 +53,7 @@ If you want more detail than the UI provides, see [Query your resource use](/doc
 Limits are enforced per account (not per [organization](/docs/glossary/glossary/#organization)). You might reach a limit if you start monitoring a new high-traffic application, or have a sudden data spike. When you do reach a limit, New Relic responds according to the type of data and the limit that's reached. Some examples of responses:
 
 * We place a limit on the number of ingested requests per minute (RPM) per data type. When this limit is reached, we stop accepting data and return a 429 status code for the duration of the minute.
-* For queries, we place limits on the number of queries per minute and the number of records inspected (see [query limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). 
+* For queries, we place limits on the number of queries per minute and the number of records inspected (see [NRQL query rate limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). 
 * For metrics, we place a limit on the number of unique timeseries (cardinality) per account and per metric. When this limit is reached, aggregated data is turned off for the rest of the UTC day.
 
 For every major limit incident, New Relic creates an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) for that account, which has these limit-related attributes:

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/remote-write-errors-error-messages.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/remote-write-errors-error-messages.mdx
@@ -53,4 +53,4 @@ You can investigate error messages in New Relic by doing either or both of the f
    SELECT count(*) FROM NrIntegrationError WHERE newRelicFeature = 'Metrics' TIMESERIES
    ```
 
-If you’ve validated that you can send data successfully but are unable to query it, you may be running into [other kinds of limits](/docs/insights/use-insights-ui/manage-account-data/rate-limits-insights), like the inspected count limit. This may manifest itself as an error message during the integration process that says: `Unable to retrieve data for Prometheus data source <name>`.
+If you’ve validated that you can send data successfully but are unable to query it, you may be running into other kinds of limits. This may manifest itself as an error message during the integration process that says: `Unable to retrieve data for Prometheus data source <name>`.

--- a/src/content/docs/logs/get-started/logging-best-practices.mdx
+++ b/src/content/docs/logs/get-started/logging-best-practices.mdx
@@ -53,7 +53,7 @@ Here are some tips on log forwarding to supplement our [log forwarding docs](/do
 
 ## Data partitions [#partitions]
 
-If you're consuming 1 TB+ per day of log data, you definitely should work on an ingest governance plan for logs, including a plan to partition the data in a way that gives functional and thematic groupings. We suggest a best practice of no more than 1 TB per partition. This serves both performance and usability. If you sent all your logs to one giant "bucket" (the default log partition) in a single account, you could experience slower queries or failed queries (due to hitting inspected count limits).
+If you're consuming 1 TB+ per day of log data, you definitely should work on an ingest governance plan for logs, including a plan to partition the data in a way that gives functional and thematic groupings. We suggest a best practice of no more than 1 TB per partition. This serves both performance and usability. If you sent all your logs to one giant "bucket" (the default log partition) in a single account, you could experience slower queries or failed queries. For more details, see [NRQL query rate limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries/#query-limits).
 
 One way to improve query performance is by limiting the time range being searched. Searching for logs over long periods of time will return more results and require more time. Avoid searches longer than one week whenever possible, and use the time-range selector to narrow searches to smaller, more specific time windows.
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
@@ -118,16 +118,6 @@ When adding charts you may come across these error messages:
 
     <tr>
       <td>
-        Query rejected due to inspected count limit exceeded by this query group.
-      </td>
-
-      <td>
-        You’ve exceeded your querying limits. Check out our data [usage limits and policies per account](/docs/licenses/license-information/general-usage-licenses/new-relic-data-usage-limits-policies/).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         Something went wrong while executing your query.
       </td>
 

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries.mdx
@@ -24,66 +24,10 @@ You should rarely encounter limits on your NRQL queries. Here are some guideline
 
 We have limits on: 
 
-* The number of data points you can query in a given time range
 * How long a query can run before erroring and stopping
 * The number of queries you can make in a given time range
 
 Next, we'll go into more detail on these limits.  
-
-## Limits on inspected data points [#inspected-count-limits]
-
-When a NRQL query is run, either due to a customer-initiated query or to a UI page load, that query inspects a certain number of data points in our NRDB data base. For example, when you run a NRQL query, it displays the number of data points inspected, as shown here in the bottom left: 
-
-<img
-  title="New Relic inspected event count"
-  alt="New Relic inspected event count"
-  src={queriesnrqlEventCountinQueryBuilder}
-/>
-<figcaption> In this context, `events` refers to all [NRQL-stored data points](/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql#what-you-can-query) inspected by a query.
-  </figcaption>
-
-The inspected count limit represents how many data points you can query in a specific range of time. These limits differ depending on which [data option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-prices) you have: 
-
-<CollapserGroup>
-  <Collapser
-    id="data-plus"
-    title="Data Plus"
-  >
-
-The [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-prices) option includes these limits on inspected data points: 
-
-* 34B per minute
-* 500B per 15 minutes
-* 1T per 30 minutes
-
-</Collapser>
-
-  <Collapser
-    id="original-data"
-    title="Original data option"
-  >
-
-Limits on inspected data points for our [original data option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-prices):
-
-* 10B per minutes
-* 150B per 15 minutes
-* 300B per 30 minutes
-    
-</Collapser>
-</CollapserGroup>
-
-### What counts towards inspected count? [#what-counts-inspected-count]
-
-The following actions count towards the inspected count limit for your New Relic account:
-
-* Loads of curated views initiated by a user (for example, when you load an <InlinePopover type="apm" /> UI page, the distributed tracing UI, or any UI that returns data about your organization).
-* Custom queries run by a New Relic user, whether in the UI or via API.
-* Loading widgets that run queries on custom dashboards
-
-Alert condition evaluation and notifications do **not** count towards the limit but the links to New Relic that are included in an alert notification do.
-
-When the inspected count limit is reached, the features mentioned are affected. When the count drops below the limit in the next time period, any restrictions are removed.
-
 
 ## Query duration limit [#query-duration]
 


### PR DESCRIPTION
These are changes migrated from the private site. It needs to be included in the morning build on 01/10/2024 to coordinate with PMM.