### PR TITLE
Dotnet custom attributes pr

### DIFF
--- a/src/content/docs/apm/agents/net-agent/attributes/custom-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/attributes/custom-attributes-net.mdx
@@ -12,7 +12,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-[Attributes](/docs/features/agent-attributes) are key-value pairs containing information that determines the properties of an event or transaction. You can create custom attributes using the [AddCustomAttribute API](/docs/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
+[Attributes](/docs/features/agent-attributes) are key-value pairs containing information that determines the properties of an event or transaction. You can create custom attributes using the [`AddCustomAttribute` API](/docs/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
 
 When adding custom attribute values to transactions, custom events, spans, and errors, the API accepts an `object`. This describes how these values are processed and how they will appear in APM. In all cases, `NULL` values are not recorded.
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3345,7 +3345,7 @@ There are three main sub-features:
 
 1. Metrics: Collect metrics on the total number of log lines written per harvest cycle (`Logging/lines`), as well as the number of log lines written at particular logging levels (for example, `Logging/lines/ERROR`).
 2. Log forwarding: When enabled, the agent will capture log data and send it to New Relic.
-    * Context data (custom attributes): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
+    * Context data ([custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
     * Log-level filtering:  When configured with one or more log levels in a comma-separated list, the agent will prevent messages at those levels from being captured and forwarded.
 3. Local log decoration: When enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 
@@ -3439,7 +3439,7 @@ The `applicationLogging` element supports the following attributes and sub-eleme
     id="contextData"
     title="Context data (custom attributes)"
   >
-    Use this sub-element, which is a child of the `forwarding` element, to configure the capture and fowarding of logging context data (custom attributes), in agent versions 10.4.0 and higher.
+    Use this sub-element, which is a child of the `forwarding` element, to configure the capture and fowarding of logging context data ([custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)), in agent versions 10.4.0 and higher.
 
     Set the `enabled` attribute to `true` to enable capture and forwarding of logging context data to New Relic. The default value is `false`.
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3345,7 +3345,7 @@ There are three main sub-features:
 
 1. Metrics: Collect metrics on the total number of log lines written per harvest cycle (`Logging/lines`), as well as the number of log lines written at particular logging levels (for example, `Logging/lines/ERROR`).
 2. Log forwarding: When enabled, the agent will capture log data and send it to New Relic.
-    * Context data ([custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
+    * Context data (via [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
     * Log-level filtering:  When configured with one or more log levels in a comma-separated list, the agent will prevent messages at those levels from being captured and forwarded.
 3. Local log decoration: When enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/introduction-new-relic-net.mdx
@@ -131,7 +131,7 @@ After installing the .NET agent, extend the agent's instrumentation with one or 
 
     <tr>
       <td>
-        [Custom attributes](/docs/agents/net-agent/attributes/net-agent-attributes)
+        [Custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api.mdx
@@ -95,7 +95,7 @@ When you want to instrument a method within an existing transaction, see [Custom
 Sometimes the code you are targeting is visible in the New Relic UI, but some details of the method are not useful. For example:
 
 * The default name might not be helpful. (Perhaps it is causing a [metric grouping issue](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues#video).)
-* You want to add [custom attributes](/docs/agents/manage-apm-agents/agent-data/collect-custom-attributes) to your transactions so you can filter them in dashboards.
+* You want to add [custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) to your transactions so you can filter them in dashboards.
 
 Use these methods when you want to change how New Relic instruments a transaction that's already visible in the New Relic UI:
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/set-user-parameters.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/set-user-parameters.mdx
@@ -33,7 +33,7 @@ Must be called inside a [transaction](/docs/accounts-partnerships/education/gett
   This call only allows you to assign values to pre-existing keys. For a more flexible method to create key/value pairs, use [`AddCustomAttribute()`](/docs/agents/net-agent/net-agent-api/itransaction).
 </Callout>
 
-Define user-related [custom attributes](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes) to associate with a browser page view (user name, account name, and product name). The values are automatically associated with pre-existing keys (`user`, `account`, and `product`), then attached to the parent APM transaction. You can also [attach (or "forward") these attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#forwarding-attributes) to browser [PageView](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes#destinations) events.
+Define user-related [custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)to associate with a browser page view (user name, account name, and product name). The values are automatically associated with pre-existing keys (`user`, `account`, and `product`), then attached to the parent APM transaction. You can also [attach (or "forward") these attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#forwarding-attributes) to browser [PageView](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes#destinations) events.
 
 ## Parameters
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/set-user-parameters.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/set-user-parameters.mdx
@@ -19,7 +19,7 @@ freshnessValidatedDate: never
 NewRelic.Api.Agent.NewRelic.SetUserParameters(string $user_value, string $account_value, string $product_value)
 ```
 
-Create user-related custom attributes. `AddCustomAttribute()` is more flexible.
+Create user-related custom attributes. [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) is more flexible.
 
 ## Requirements
 

--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -183,7 +183,7 @@ To enable and use custom attributes for APM, follow the procedure for your <Inli
   >
     Custom attribute collection is enabled by default in .NET. To collect custom attributes, call the relevant API methods:
 
-    1. For each method for which you want to record an attribute, call `AddCustomAttribute`.
+    1. For each method for which you want to record an attribute, call [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
     2. Optional: Include or exclude attributes with the [`include`](/docs/agents/net-agent/installation-configuration/net-agent-configuration#agent-attributes-include) and [`exclude`](/docs/agents/net-agent/installation-configuration/net-agent-configuration#agent-attributes-exclude) configuration options.
 
        For example, to record attributes for a coupon code (string) and an item ID code (number), you could include this code in the parent method:


### PR DESCRIPTION
Updating custom attribute links related to .NET to link to the doc that explains how to add them, rather than the links to conceptual docs that explain custom attributes in general. I chose the docs by:

- Sweeping for the top 10 docs in Google Analytics for .NET
- Addressing the specific docs in the jira
- Doing a ctrl+f for all mentions of "custom attributes", then finding the relevant spots for .NET. 

I believe this captures everything