### PR TITLE
chore: Updated Node Agent supported-version for ElasticSearch

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -411,11 +411,11 @@ We collect [instance details for a variety of databases and database drivers](/d
       </td>
 
       <td>
-        7.13.0
+        7.16.0
       </td>
 
       <td>
-        11.3.0
+        11.9.0
       </td>
     </tr>
 
@@ -579,133 +579,133 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
         <th>
           Framework
         </th>
-  
+
         <th>
           Supported versions
         </th>
-  
+
         <th>
           Minimum agent version
         </th>
-  
+
         <th>
           Notes
         </th>
       </tr>
     </thead>
-  
+
     <tbody>
       <tr>
         <td>
           [Express](https://www.npmjs.com/package/express)
         </td>
-  
+
         <td>
           4.6.0+
         </td>
-  
+
         <td>
         </td>
-  
+
         <td>
         </td>
       </tr>
-  
+
       <tr>
         <td>
           [Restify](https://www.npmjs.com/package/restify)
         </td>
-  
+
         <td>
         </td>
-  
+
         <td>
         </td>
-  
+
         <td>
         </td>
       </tr>
-  
+
       <tr>
         <td>
           [Connect](https://www.npmjs.com/package/connect)
         </td>
-  
+
         <td>
         </td>
-  
+
         <td>
         </td>
-  
+
         <td>
         </td>
       </tr>
-  
+
       <tr>
         <td>
           [Hapi](https://www.npmjs.com/package/hapi)
         </td>
-  
+
         <td>
           20.0.0+
         </td>
-  
+
         <td>
           9.0.0
         </td>
-  
+
         <td>
           With v9.0.0 of the agent we updated the minimum supported version of Hapi to be >= v20.0.0. All versions under v20.0.0 are deprecated by Hapi for security reasons, see their [support policy](https://hapi.dev/policies/support/).
         </td>
       </tr>
-  
+
       <tr>
         <td>
           [Koa](https://www.npmjs.com/package/koa)
         </td>
-  
+
         <td>
           2.0.0+
         </td>
-  
+
         <td>
         </td>
-  
+
         <td>
             [External module](https://github.com/newrelic/node-newrelic-koa) loaded with the agent
         </td>
       </tr>
-  
+
       <tr>
         <td>
           [Fastify](https://www.npmjs.com/package/fastify)
         </td>
-  
+
         <td>
           2+
         </td>
-  
+
         <td>
           8.5.0
         </td>
-  
+
         <td>
         </td>
       </tr>
-  
+
       <tr>
         <td>
           [Nest.js](https://nestjs.com/)
         </td>
-  
+
         <td>
           8.0.0+
         </td>
-  
+
         <td>
           10.1.0
         </td>
-  
+
         <td>
           If using the `nest start` command to start the application, modify its startup binary to load the New Relic agent: `nest start --exec 'node -r newrelic'`
         </td>
@@ -713,22 +713,22 @@ For other message queue libraries, use [custom instrumentation](/docs/agents/nod
 
       <tr>
         <td>
-          [Next.js](https://www.npmjs.com/package/next)  
+          [Next.js](https://www.npmjs.com/package/next)
         </td>
-  
+
         <td>
           12.0.9 - 13.3.0
         </td>
-  
+
         <td>
           10.1.0
         </td>
-  
+
         <td>
           v12.2.0 or higher required for middleware instrumentation
         </td>
       </tr>
-    
+
     </tbody>
   </table>
 

--- a/src/i18n/content/jp/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -449,11 +449,11 @@ Node.js用エージェントは、[Node Package Manager（npm）リポジトリ]
           </td>
 
           <td>
-            7.13.0
+            7.16.0
           </td>
 
           <td>
-            11.3.0
+            11.9.0
           </td>
         </tr>
 
@@ -739,7 +739,7 @@ Node.js用エージェントは、[Node Package Manager（npm）リポジトリ]
 
         <tr>
           <td>
-            [Next.js](https://www.npmjs.com/package/next)  
+            [Next.js](https://www.npmjs.com/package/next)
 
           </td>
 


### PR DESCRIPTION
## Give us some context

The Node Agent dropped instrumentation for ElasticSearch prior to v716.0. This updates the supported version information.  Previously, New Relic's Node Agent instrumented ElasticSearch as early as v7.13.0, which was susceptible to crashing when using ElasticSearch's `.helper` API. ElasticSearch [fixed this bug in v7.16.0](https://github.com/elastic/elasticsearch-js/pull/1594), so we now support instrumentation from that version onward, and previous versions are noops.  