### PR TITLE
Update errors-inbox.mdx

### DIFF
--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -89,7 +89,7 @@ Supported APM agents:
 * [Browser](/docs/browser/new-relic-browser/browser-apis/seterrorhandler/#fingerprinting-errors-in-handler-function)
 * [Go](/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api/#error-fingerprinting)
 * [Java](/docs/apm/agents/java-agent/api-guides/java-agent-api-register-error-group-callback-to-set-fingerprint)
-* [Node.js](/docs/apm/agents/java-agent/api-guides/java-agent-api-register-error-group-callback-to-set-fingerprint)
+* [Node.js](docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#setErrorGroupCallback)
 * [.Net](/docs/apm/agents/net-agent/net-agent-api/seterrorgroupcallback-net-agent-api)
 * [Python](/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api)
 * [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)


### PR DESCRIPTION
The link for the Node Agent incorrectly linked to the Java Agent's docs for setting error group callbacks. There's no specific page for this in the Node space so I changed the link to route to our docs around the API method that is used, which gives details and links to an example app further showing how to use it.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.