### PR TITLE
docs: infra agent 1.48.3 release notes

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1483.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1483.mdx
@@ -11,7 +11,7 @@ of this release, the oldest supported version is [infrastructure agent
 
 ## Changed
 
-* Add the `sendMetrics` parameter to the NewRelic output plugin in the FB conf file [#1759](https://github.com/newrelic/infrastructure-agent/pull/1759)
+* Added the `sendMetrics` parameter to the NewRelic output plugin in the FB conf file [#1759](https://github.com/newrelic/infrastructure-agent/pull/1759)
 
 ## Fixed
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1483.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1483.mdx
@@ -1,0 +1,20 @@
+---
+subject: Infrastructure agent
+releaseDate: '2024-01-15'
+version: 1.48.3
+---
+
+A new version of the agent has been released. Follow standard procedures to [update the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+We recommend you upgrade the agent regularly and at a minimum every 3 months. As
+of this release, the oldest supported version is [infrastructure agent
+1.36.1](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1361).
+
+## Changed
+
+* Add `sendMetrics` param to newrelic output plugin in FB conf file [#1759](https://github.com/newrelic/infrastructure-agent/pull/1759)
+
+## Fixed
+
+* HTTP Tracer error control [#1757](https://github.com/newrelic/infrastructure-agent/pull/1757)
+* Adjust Dimensional Metrics max size [#1764](https://github.com/newrelic/infrastructure-agent/pull/1764)
+* Obfuscate wrong license key [#1767](https://github.com/newrelic/infrastructure-agent/pull/1767)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1483.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1483.mdx
@@ -11,7 +11,7 @@ of this release, the oldest supported version is [infrastructure agent
 
 ## Changed
 
-* Add `sendMetrics` param to newrelic output plugin in FB conf file [#1759](https://github.com/newrelic/infrastructure-agent/pull/1759)
+* Add the `sendMetrics` parameter to the NewRelic output plugin in the FB conf file [#1759](https://github.com/newrelic/infrastructure-agent/pull/1759)
 
 ## Fixed
 


### PR DESCRIPTION
Release notes for infrastructure agent 1.36.1: https://github.com/newrelic/infrastructure-agent/releases/tag/1.48.3