### PR TITLE
Adding a known limitation for the shimming, keyset cannot be used with timeseries

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
@@ -370,4 +370,7 @@ Here are some notable differences when querying dimensional metrics:
   ```sql
   SELECT max(host.cpuPercent) FROM Metric TIMESERIES 1 MINUTE SINCE 60 MINUTES AGO RAW
   ```
-  
+* Using `keyset` with `TIMESERIES`is not supported and will return an error. See an exampler below:
+  ```sql
+  FROM Metric SELECT keyset() WHERE instrumentation.provider = 'infrastructure' TIMESERIES
+  ```

--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/query-infrastructure-dimensional-metrics-nrql.mdx
@@ -370,7 +370,7 @@ Here are some notable differences when querying dimensional metrics:
   ```sql
   SELECT max(host.cpuPercent) FROM Metric TIMESERIES 1 MINUTE SINCE 60 MINUTES AGO RAW
   ```
-* Using `keyset` with `TIMESERIES`is not supported and will return an error. See an exampler below:
+* We don't support using `keyset` with `TIMESERIES` and doing so will return an error. See the example below:
   ```sql
   FROM Metric SELECT keyset() WHERE instrumentation.provider = 'infrastructure' TIMESERIES
   ```


### PR DESCRIPTION
Adding a known limitation for the shimming, keyset cannot be used with timeseries

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? Document a known limitation for the shimming, keyset cannot be used with timeseries.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.: https://new-relic.atlassian.net/browse/NR-129404
* If your issue relates to an existing GitHub issue, please link to it.