### PR TITLE
chore: Updated the Apache flink documentation

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/install-apache-flink.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/install-apache-flink.mdx
@@ -38,10 +38,6 @@ You will need the Apache Flink prometheus jar file to expose metrics on a config
 
 File path: `FLINK-DIRECTORY/plugins/metrics-prometheus/`
 
-If the above mentioned jar file is not present in your downloaded flink directory, you can download it from other maven jar artifacts. Use the below example URL to download the `flink-metrics-prometheus-VERSION.jar` file. Below is the external URL from which you can download it.
-
-External URL: https://jar-download.com/artifacts/org.apache.flink/flink-metrics-prometheus
-
 Update the flink configuration file to expose metrics on ports 9250 to 9260
 
 Apache Flink configuration file path: `FLINK-DIRECTORY/conf/flink-conf.yaml`
@@ -83,9 +79,9 @@ Path: `/etc/newrelic-infra/integrations.d`
 
 Now, update the fields listed below:
 
-* cluster_name: “YOUR_DESIRED_CLUSTER_NAME”, for example: `cluster_name: "apache_flink"`
+* cluster_name: "YOUR_DESIRED_CLUSTER_NAME", for example: `cluster_name: "apache_flink"`
 
-* urls: ["http://YOUR_DOMAIN:9250", "http://YOUR_DOMAIN:9251"], for example: `urls: [“http://localhost:9250”, “http://localhost:9251”]`
+* urls: ["http://YOUR_DOMAIN:9250", "http://YOUR_DOMAIN:9251"], for example: `urls: ["http://localhost:9250", "http://localhost:9251"]`
 
 Your `nri-prometheus-config.yml` file should look like this:
 


### PR DESCRIPTION
**Ticket:** https://new-relic.atlassian.net/browse/NR-216087
**Description:** Removed the external link from the [Apache Flink](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/install-apache-flink/) documentation that guides users to download a harmful file