### PR TITLE
Update java-agent-881.mdx

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-881.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-881.mdx
@@ -21,6 +21,17 @@ security: []
 
 - Fixed a `NullPointerException` when working with Synthetics headers [1690](https://github.com/newrelic/newrelic-java-agent/pull/1690)
 
+## Deprecations
+
+The following instrumentation modules are deprecated and will be removed in the next major release:
+
+- `aws-wrap-0.7.0`
+- `java.completable-future-jdk8`
+- `play-2.3`
+- `spring-3.0.0`
+- `netty-3.4`
+- `Struts v1`
+
 ## Update to latest version [#procedures]
 
 To identify which version of the Java agent you're currently using, run `java -jar newrelic.jar -v`. Your Java agent version will be printed to your console.


### PR DESCRIPTION
Adds deprecation notices to Java Agent 8.8.1 release doc. 