### PR TITLE
fix(MonitorUpgrade): Added JSON.parse error section

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
@@ -41,6 +41,10 @@ The [Node.js 16 and newer scripted API runtimes](/docs/synthetics/synthetic-moni
   The `request`-like experience provided by the `$http` object will also be returned for any customers attempting to use `request` directly in Node.js 16 and newer scripted API runtimes.
 </Callout>
 
+## Scripted API: Unexpected token JSON.parse errors
+
+Attempting to use the `JSON.parse` function while interacting with the response body may produce unexpected token errors in scripted API monitors using the Node.js 16 and newer runtime. If the content-type response header is `application/json`, the response body being returned by the `$http` object will be parsed JSON. Additional calls attempting to use `JSON.parse` to parse the response body will fail with this error because the response body has already been parsed.
+
 ## Scripted Browser: Deprecation warnings ($browser / $driver) [#deprecations]
 
 Deprecation warnings for `$browser` and `$driver` were removed starting with the 2.0.29 or newer version of the browser runtime. You should no longer receive these warnings when using public locations. Please update your node browser runtime image if you are receiving these warnings when using private locations. 


### PR DESCRIPTION
Added an additional error that customers may encounter when upgrading to the newest API runtime.