### PR TITLE
fix(user-permission): Update to include security capability

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -297,5 +297,11 @@ These permissions pertain to [synthetics monitoring](/docs/synthetics/synthetic-
 * **Secure credentials**: relates to [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests).
 
 </Collapser>
+  <Collapser
+    id="security"
+    title="Security"
+  >
+* **Vulnerabilities**: refers to the ability to view and manage vulnerabilities detected in entities.
+</Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
## Give us some context

* A new capability has been added to manage access to new relic security products. We want to update the docs to include the 'vulnerabilities' capability that is already added.

Capability mentioned
<img width="827" alt="Screenshot 2024-01-19 at 2 07 31 PM" src="https://github.com/newrelic/docs-website/assets/156934130/70491337-4079-4c2d-ba64-d6febe623ced">
