### PR TITLE
Doc updates: correct misleading description for mobile android agent

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -361,7 +361,7 @@ To change settings, you have two options (if the setting supports it):
                 Specifies the log level. Options include:
 
                     * `ERROR` (least verbose)
-                    * `WARNING`
+                    * `WARN`
                     * `INFO`
                     * `VERBOSE`
                     * `DEBUG`
@@ -372,7 +372,7 @@ To change settings, you have two options (if the setting supports it):
             </td>
             <td> 
               ```java
-              withLogLevel("ERROR")
+              withLogLevel(AgentLog.ERROR)
               ```
             </td>
         </tr>


### PR DESCRIPTION
* What problems does this PR solve?

- We got feedback that the docs are misleading to setLoglevel for android agent [here](https://newrelic.slack.com/archives/C01FKANDWJU/p1705663571167449)
- I have updated our docs to match with the code.