### PR TITLE
fix(Java): removing compatibility list from JVM section

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -262,36 +262,6 @@ Before you install the Java agent, ensure your system meets these requirements:
         </tr>
       </tbody>
     </table>
-
-    Compatible:
-
-    * IBM JVM versions 8 for Linux
-    * Eclipse OpenJ9 versions 8 to 19 for Linux, Windows, and macOS
-    * OpenJDK versions 8 to 20 for Linux, Windows, and macOS
-    * AdoptOpenJDK versions 8 to 16 for Linux, Windows, and macOS
-    * Temurin version 17 to 20 for Linux, Windows, and macOS
-    * Oracle Hotspot JVM versions 8 to 20 for Linux, Solaris, Windows, and macOS
-    * Azul Zing JVM versions 8 and 11 for Linux, Windows, and macOS
-    * Azul Zulu JVM versions 8 to 20 for Linux, Windows, and macOS
-    * Amazon Corretto JVM versions 8, 11, and 17 to 20 for Linux, Windows, and macOS
-    * Alibaba Dragonwell JVM versions 8 and 11 for Linux, Windows, and macOS
-
-    (Java 1.7) Compatible only with [Java agent 6.5.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/6.5.3/newrelic-java-6.5.3.zip) \[ZIP | 16.8 MB] legacy agent:
-
-    * OpenJDK and AdoptOpenJDK JVM versions 7
-    * IBM JVM version 7
-    * Oracle Hotspot JVM version 7 for Linux, Solaris, Windows, macOS
-
-    (Java 1.6) Compatible only with [Java agent 4.3.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/4.3.0/newrelic-java-4.3.0.zip) \[ZIP | 9.9 MB] legacy agent:
-
-    * Apple Hotspot JVM version 6 for macOS
-    * IBM JVM version 6
-    * Oracle Hotspot JVM version 6.0 for Linux, Solaris, Windows, macOS
-
-    (Java 1.5) Compatible only with [Java agent 2.21.x](https://download.newrelic.com/newrelic/java-agent/newrelic-agent/2.21.7/newrelic-java-2.21.7.zip) \[ZIP | 2.8 MB] legacy agent:
-
-    * Oracle Hotspot JVM version 5.0 for Linux, Solaris, Windows, macOS ([Java SE 5.0](/docs/java/java-se-5))
-    * Oracle JRockit up to and including 1.6.0_50
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Removing compatibility list from JVM section to prevent customer confusion on supported Java versions.