### PR TITLE
fix(Go agent): Fixed a wrong URL

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-logging.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-logging.mdx
@@ -15,7 +15,7 @@ freshnessValidatedDate: never
 
 ## Write log files [#write-logfiles]
 
-To use the Go agent methods for writing log and audit files, see [log.go on the agent GitHub repo](https://github.com/newrelic/go-agent/blob/master/log.go).
+To use the Go agent methods for writing log and audit files, see [log.go on the agent GitHub repo](https://github.com/newrelic/go-agent/blob/20541a9393ae651949eb75b82666d4a7c2a10dec/v3/newrelic/log.go).
 
 ## Logrus integration example [#logrus]
 


### PR DESCRIPTION
Fixed a wrong URL on this page: [Go agent logging](https://docs.newrelic.com/docs/apm/agents/go-agent/configuration/go-agent-logging/).

This comes from this service docs-feedback ticket: NR-217243.