### PR TITLE
fix(workloads): replace queries marked as deprecated

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-workloads-api-tutorials.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-workloads-api-tutorials.mdx
@@ -43,9 +43,9 @@ To get all workloads of an account, use the following [GraphQL query](https://ap
 ```
 {
   actor {
-    account(id: YOUR_ACCOUNT_ID) {
-      workload {
-        collections {
+    entitySearch(query: "accountId = YOUR_ACCOUNT_ID and type = 'WORKLOAD'") {
+      results {
+        entities {
           guid
           name
           permalink
@@ -62,10 +62,9 @@ The response includes this type of data for each workload:
 {
   "data": {
     "actor": {
-      "account": {
-        "workload": {
-          "collections": [
-            ...,
+      "entitySearch": {
+        "results": {
+          "entities": [
             {
               "guid": "MTY...NTY",
               "name": "Acme Telco - Fulfillment Chain",
@@ -163,7 +162,7 @@ The query returns a list of entities that looks like this:
                   "guid": "MTYwNjg2MnxJTkZSQXxOQXw1MjMyNzM2ODgzNjAwNjYyMjE1",
                   "name": "TelcoDT-purchase-log-lambda"
                 },
-                ...   
+                ...
               ]
             }
           }
@@ -181,13 +180,11 @@ If you want to force the calculation of the status of a workload, you can use th
 ```
 {
   actor {
-    account(id: YOUR_ACCOUNT_ID) {
-      workload {
-        collection(guid: "YOUR_WORKLOAD_GUID") {
-          guid
-          status {
-            value
-          }
+    entity(guid: "YOUR_WORKLOAD_GUID") {
+      ... on WorkloadEntity {
+        guid
+        workloadStatus {
+          statusValue
         }
       }
     }
@@ -201,14 +198,10 @@ And this is what you'll get in the response:
 {
   "data": {
     "actor": {
-      "account": {
-        "workload": {
-          "collection": {
-            "guid": "MTYwNjg2MnxOUjF8V09SS0xPQUR8MTIyMzQ",
-            "status": {
-              "value": "OPERATIONAL"
-            }
-          }
+      "entity": {
+        "guid": "MTYwNjg2MnxOUjF8V09SS0xPQUR8MTIyMzQ",
+        "workloadStatus": {
+          "statusValue": "OPERATIONAL"
         }
       }
     }
@@ -225,21 +218,21 @@ The following is an example NerdGraph call that creates a workload using the `wo
 ```
 mutation {
   workloadCreate(
-    accountId: NEW_WORKLOAD_ACCOUNT_ID, 
+    accountId: NEW_WORKLOAD_ACCOUNT_ID,
     workload: {
-      name: "NAME_OF_WORKLOAD", 
-      entityGuids: ["ENTITY_GUID_1", "ENTITY_GUID_2", ...], 
+      name: "NAME_OF_WORKLOAD",
+      entityGuids: ["ENTITY_GUID_1", "ENTITY_GUID_2", ...],
       entitySearchQueries: [
-        {      
+        {
           query: "(type = 'SERVICE') and tags.label.environment = 'production'"
-        },    
+        },
         ...
-      ], 
+      ],
       scopeAccounts: {
         accountIds: [NEW_RELIC_ACCOUNT_ID_1, NEW_RELIC_ACCOUNT_ID_2, ...]
       }
     }
-  ) 
+  )
   {
     guid
   }
@@ -276,25 +269,25 @@ Here's an example of the `workloadUpdate` query:
 ```
 mutation {
   workloadUpdate(
-    guid: "YOUR_WORKLOAD_GUID", 
+    guid: "YOUR_WORKLOAD_GUID",
     workload: {
-      name: "A new name for the workload", 
-      entityGuids: ["ENTITY_GUID_1", "ENTITY_GUID_2", ...], 
-      entitySearchQueries: [  
-        {      
+      name: "A new name for the workload",
+      entityGuids: ["ENTITY_GUID_1", "ENTITY_GUID_2", ...],
+      entitySearchQueries: [
+        {
           query: "(domain = 'INFRA' and type = 'HOST') and tags.label.environment = 'staging'"
-        },  
-        { 
-          id: AN_EXISTING_QUERY_ID,      
+        },
+        {
+          id: AN_EXISTING_QUERY_ID,
           query: "(type = 'SERVICE') and tags.label.environment = 'staging'"
-        }, 
+        },
         ...
-      ], 
+      ],
       scopeAccounts: {
         accountIds: [NEW_RELIC_ACCOUNT_ID_1, NEW_RELIC_ACCOUNT_ID_2, ...]
       }
     }
-  ) 
+  )
   {
     guid
   }
@@ -314,7 +307,7 @@ To set a static status, you must know the workload's `guid` and use the followin
 ```
 mutation {
   workloadUpdate(
-    guid: "YOUR_WORKLOAD_GUID", 
+    guid: "YOUR_WORKLOAD_GUID",
     workload: {
       statusConfig: {
         static: {
@@ -324,10 +317,10 @@ mutation {
         }
       }
     }
-  ) 
+  )
   {
     guid
-    updatedAt 
+    updatedAt
     status {
       value
     }
@@ -345,7 +338,7 @@ However, if you just don't use the `statusConfig` object when you create a workl
 "statusConfig": {
   "automatic": {
     "enabled": true,
-    "rules": [ 
+    "rules": [
       {
         "entitySearchQueries": [{"query": "(domain = 'APM' and type = 'APPLICATION')"}],
         "rollup": {
@@ -379,13 +372,13 @@ However, if you just don't use the `statusConfig` object when you create a workl
         }
       }
     ],
-    "remainingEntitiesRule": { 
-      "rollup": { 
-        "groupBy": "ENTITY_TYPE", 
-        "strategy": "BEST_STATUS_WINS", 
-        "thresholdType": null, 
-        "thresholdValue": null 
-      } 
+    "remainingEntitiesRule": {
+      "rollup": {
+        "groupBy": "ENTITY_TYPE",
+        "strategy": "BEST_STATUS_WINS",
+        "thresholdType": null,
+        "thresholdValue": null
+      }
     }
   }
 }
@@ -416,8 +409,8 @@ After duplicating a workload, you can [modify it](#modify).
 ```
 mutation {
   workloadDuplicate(
-    accountId: NEW_WORKLOAD_ACCOUNT_ID, 
-    sourceGuid: "ORIGINAL_WORKLOAD_GUID", 
+    accountId: NEW_WORKLOAD_ACCOUNT_ID,
+    sourceGuid: "ORIGINAL_WORKLOAD_GUID",
     workload: {
       name: "New workload"
     }


### PR DESCRIPTION
## Give us some context

We were recommending queries that are marked as deprecated in NerdGraph. There is no current date for the deprecation, but we consider it is better to recommend non-deprecated queries.
