### PR TITLE
Whats new 01 24 javaagent8

### DIFF
--- a/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
+++ b/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
@@ -6,15 +6,15 @@ learnMoreLink: 'https://docs.newrelic.com/docs/apm/agents/java-agent/getting-sta
 getStartedLink: 'https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/'
 ---
 
-Starting with Java agent version 7.6.0, we introduced new standard attributes for HTTP status code: **http.statusCode** and **http.statusText**. The old attributes **httpResponseCode**, **response.status**, and **response.statusMessage**, were marked as deprecated and have been completely removed in versions 8.0.0 through 8.7.0. This means any alerts or dashboards relying on these old attributes will stop functioning, potentially leading to missed alerts and inaccurate data.
+Starting with Java agent version 7.6.0, we introduced new standard attributes for HTTP status code: `http.statusCode` and `http.statusText` The old attributes `httpResponseCode` `response.status` and `response.statusMessage` were marked as deprecated and have been completely removed in versions 8.0.0 through 8.7.0. This means any alerts or dashboards relying on these old attributes will stop functioning, potentially leading to missed alerts and inaccurate data.
 
 In version 8.8.0, the deprecated attributes were re-introduced with a compatibility flag so if you are still relying on those attributes you can continue to use them.
 
-**What You Need to Do:**
+**What you need to do:**
 
-* **Option 1: Update Your Agent to [v8.8.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/):** 
+* **Option one: update your agent to [v8.8.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/):** 
 The simplest solution is to update your agent for the impacted entities to the latest version, v8.8.0, which reintroduces the older attributes for backward compatibility. 
-* **Option 2: Update Your Alerts/Dashboards:**
+* **Option two: update your alerts/dashboards:**
 Alternatively, you can update your existing alerts and dashboards to use the new standard attributes. Our [migration guide](https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/migration-8x-guide/) provides clear instructions
 
 Please reach out to [New Relic Support](https://support.newrelic.com/s/) or your account team if you have any questions. 

--- a/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
+++ b/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
@@ -1,7 +1,7 @@
 ---
 title: 'Upgrade your Java agent to v8.8.0 to avoid impacts to your alerts/dashboards.'
 summary: 'Java agent v8.0.0-8.7.0 introduced new standard attributes for HTTP status code that might impact alerts/dashboards'
-releaseDate: '2023-01-24'
+releaseDate: '2024-01-24'
 learnMoreLink: 'https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/migration-8x-guide/'
 getStartedLink: 'https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/'
 ---

--- a/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
+++ b/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
@@ -1,0 +1,22 @@
+---
+title: 'Upgrade your Java agent to v8.8.0 to avoid impacts to your alerts/dashboards.'
+summary: 'Java agent v8.0.0-8.7.0 introduced new standard attributes for HTTP status code that might impact alerts/dashboards'
+releaseDate: '2023-01-24'
+learnMoreLink: 'https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/migration-8x-guide/'
+getStartedLink: 'https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/'
+---
+
+Starting with Java agent version 7.6.0, we introduced new standard attributes for HTTP status code: http.statusCode and http.statusText. The old attributes httpResponseCode, response.status, and response.statusMessage, were marked as deprecated and have been completely removed in versions 8.0.0 through 8.7.0. This means any alerts or dashboards relying on these old attributes will stop functioning, potentially leading to missed alerts and inaccurate data.
+
+In version 8.8.0, the deprecated attributes were re-introduced with a compatibility flag so if you are still relying on those attributes you can continue to use them.
+
+* **What You Need to Do:**
+
+* **Option 1: Update Your Agent to [v8.8.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/)**
+The simplest solution is to update your agent for the impacted entities to the latest version, v8.8.0, which reintroduces the older attributes for backward compatibility. 
+* **Option 2: Update Your Alerts/Dashboards**
+Alternatively, you can update your existing alerts and dashboards to use the new standard attributes. Our [migration guide](https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/migration-8x-guide/) provides clear instructions
+
+Please reach out to [New Relic Support](https://support.newrelic.com/s/) or your account team if you have any questions. 
+
+

--- a/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
+++ b/src/content/whats-new/2024/01/whats-new-01-24-javaagent8.md
@@ -6,15 +6,15 @@ learnMoreLink: 'https://docs.newrelic.com/docs/apm/agents/java-agent/getting-sta
 getStartedLink: 'https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/'
 ---
 
-Starting with Java agent version 7.6.0, we introduced new standard attributes for HTTP status code: http.statusCode and http.statusText. The old attributes httpResponseCode, response.status, and response.statusMessage, were marked as deprecated and have been completely removed in versions 8.0.0 through 8.7.0. This means any alerts or dashboards relying on these old attributes will stop functioning, potentially leading to missed alerts and inaccurate data.
+Starting with Java agent version 7.6.0, we introduced new standard attributes for HTTP status code: **http.statusCode** and **http.statusText**. The old attributes **httpResponseCode**, **response.status**, and **response.statusMessage**, were marked as deprecated and have been completely removed in versions 8.0.0 through 8.7.0. This means any alerts or dashboards relying on these old attributes will stop functioning, potentially leading to missed alerts and inaccurate data.
 
 In version 8.8.0, the deprecated attributes were re-introduced with a compatibility flag so if you are still relying on those attributes you can continue to use them.
 
-* **What You Need to Do:**
+**What You Need to Do:**
 
-* **Option 1: Update Your Agent to [v8.8.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/)**
+* **Option 1: Update Your Agent to [v8.8.0](https://docs.newrelic.com/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880/):** 
 The simplest solution is to update your agent for the impacted entities to the latest version, v8.8.0, which reintroduces the older attributes for backward compatibility. 
-* **Option 2: Update Your Alerts/Dashboards**
+* **Option 2: Update Your Alerts/Dashboards:**
 Alternatively, you can update your existing alerts and dashboards to use the new standard attributes. Our [migration guide](https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/migration-8x-guide/) provides clear instructions
 
 Please reach out to [New Relic Support](https://support.newrelic.com/s/) or your account team if you have any questions. 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

This post talks about the impact of upgrading to Java agent version v8.0.0-v8.7.0. Java agent v8.0.0-v8.7.0 introduced new standard attributes that impacts alerts/dashboards for customers. This is re-introduced in Java agent v8.8.0 for compatibility purpose. 