### PR TITLE
fix: theme bump for content width

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.2.4",
+    "@newrelic/gatsby-theme-newrelic": "9.2.5",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,10 +3548,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.2.4.tgz#3aaf9f01ade5871ccab08047525ff15a98653241"
-  integrity sha512-OP+2Flpwpjc954p2vLaETovH9y1WP5TY4L93pDL7RLpVeuxE6ayiVMMl7QvpFYIORT9sW3CAB84pckRElkGqMg==
+"@newrelic/gatsby-theme-newrelic@9.2.5":
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.2.5.tgz#8c9938bdb0d5da3774e89f0b8fb90504b7c67c79"
+  integrity sha512-MUYILRwcVLU3+qmC7gG2YJ3OkXfTNjMfv0T6xISQim14/FimXI/jK3BLmDiuIKXQV66YD6V1aW/wEpEDIGv70g==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
Before:
<img width="1536" alt="Screenshot 2024-01-23 at 12 00 47 PM" src="https://github.com/newrelic/docs-website/assets/26727669/2b1ba190-16b7-41e6-98e7-f43ae9fc00a3">
<img width="1534" alt="Screenshot 2024-01-23 at 12 00 40 PM" src="https://github.com/newrelic/docs-website/assets/26727669/e1c8e64f-c884-4e13-99fb-d340242b41f8">


After:
<img width="1536" alt="Screenshot 2024-01-23 at 12 16 03 PM" src="https://github.com/newrelic/docs-website/assets/26727669/56e6e8c6-2b0f-444a-ab38-579cf618b52e">
<img width="1536" alt="Screenshot 2024-01-23 at 12 15 55 PM" src="https://github.com/newrelic/docs-website/assets/26727669/eedcd955-24cd-42fd-aade-f1170e2989c3">

