### PR TITLE
feat: add release date to security RSS feed

### DIFF
--- a/plugins/gatsby-plugin-security-bulletins-rss/gatsby-node.js
+++ b/plugins/gatsby-plugin-security-bulletins-rss/gatsby-node.js
@@ -32,6 +32,7 @@ const securityBulletinsQuery = async (graphql) => {
           frontmatter {
             title
             metaDescription
+            releaseDate
           }
           slug
           mdxAST
@@ -59,7 +60,7 @@ const securityBulletinsQuery = async (graphql) => {
 
 const getFeedItem = (node, siteMetadata, imageHashMap) => {
   const { frontmatter, slug, mdxAST } = node;
-  const { title, metaDescription } = frontmatter;
+  const { title, metaDescription, releaseDate } = frontmatter;
 
   const transformedAST = htmlGenerator.runSync(mdxAST);
   const html = htmlGenerator.stringify(
@@ -72,7 +73,7 @@ const getFeedItem = (node, siteMetadata, imageHashMap) => {
   );
 
   // time is necessary for RSS validity
-  const date = new Date();
+  const date = new Date(releaseDate);
   const pubDate = `${format(date, 'EE, dd LLL yyyy')} 00:00:00 +0000`;
   const link = new URL(slug, siteMetadata.siteUrl).href;
   const id = Buffer.from(`${title}`).toString('base64');

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,7 @@ Otherwise, it will read all files under `/src/content/` and `src/i18n/content`.
 - markdown and JSX syntax
 - valid yaml frontmatter
   - We also check for the required field `freshnessValidatedDate` which must be a date (`YYYY-MM-DD`) or `never`
+  - `release-notes`, `security-bulletins` and `whats-new` posts will also be scanned for a required `releaseDate` field in the frontmatter.
 - `<img />` sources and imports which utilizes the [image-import-utils script](#image-import-utils.js)
   - this util has its own progress bar and error output section in the terminal
 

--- a/scripts/utils/__tests__/frontmatter.js
+++ b/scripts/utils/__tests__/frontmatter.js
@@ -1,4 +1,8 @@
-const { frontmatter, validateFreshnessDate } = require('../frontmatter');
+const {
+  frontmatter,
+  validateFreshnessDate,
+  validateReleaseDate,
+} = require('../frontmatter');
 
 const mdxString = `---
 howdy: cowboy 🤠
@@ -126,6 +130,78 @@ describe('freshness frontmatter field', () => {
 
     const expectedError =
       'freshnessValidatedDate field missing from frontmatter';
+
+    expect(error.message).toEqual(expectedError);
+  });
+});
+
+const happyReleaseDateMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+releaseDate: '2021-12-02'
+---
+some content!
+`;
+
+const invalidReleaseDateMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+releaseDate: '23-12-02'
+---
+some content!
+`;
+const badFormatReleaseDateMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+releaseDate: 2023
+---
+some content!
+`;
+
+const missingReleaseDateMdxString = `---
+howdy: cowboy 🤠
+list:
+  - item 1
+  - item 2
+---
+some content!
+`;
+
+describe('releaseDate frontmatter field', () => {
+  it('should pass the check with valid "never" value', () => {
+    const error = validateReleaseDate(happyReleaseDateMdxString);
+
+    expect(error).toBeFalsy;
+  });
+
+  it('should throw error for invalid date value', () => {
+    const error = validateReleaseDate(invalidReleaseDateMdxString);
+
+    const expectedError =
+      "releaseDate is not a valid value. Must be date string formatted like 'YYYY-MM-DD' wrapped in single quotes";
+
+    expect(error.message).toEqual(expectedError);
+  });
+
+  it('should throw error for valid date but wrong format', () => {
+    const error = validateReleaseDate(badFormatReleaseDateMdxString);
+
+    const expectedError =
+      "releaseDate is not a valid value. Must be date string formatted like 'YYYY-MM-DD' wrapped in single quotes";
+
+    expect(error.message).toEqual(expectedError);
+  });
+
+  it('should throw error missing releaseDate field', () => {
+    const error = validateReleaseDate(missingReleaseDateMdxString);
+
+    const expectedError = 'releaseDate field missing from frontmatter';
 
     expect(error.message).toEqual(expectedError);
   });

--- a/scripts/utils/frontmatter.js
+++ b/scripts/utils/frontmatter.js
@@ -142,7 +142,71 @@ const validateFreshnessDate = (mdString) => {
   return error;
 };
 
+/**
+ * Parse the frontmatter and check for required releaseDate field on whats-new, security-bulletins, and release-notes. 
+ * Valid format is `YYYY-MM-DD`
+ *
+ * @example
+ * ```yaml
+ * ---
+ * title: This is a security bulletin
+ * releaseDate: '2021-03-15'
+ * ---
+ * ```
+ * 
+ *```js
+ * // error.message = undefined
+ * ``` 
+ * 
+ * ```yaml
+ * ---
+ * title: This is a security bulletin with an invalid date
+ * releaseDate: 21-03-15
+ * ---
+ * ```
+ * 
+ *```js
+ * // error.message = releaseDate is not a valid value. Must be date string formatted like 'YYYY-MM-DD' wrapped in single quotes
+ * ```
+
+ *
+ *
+ *
+ * @param {string} mdString - Full content of the MD(X) file to parse.
+ * @returns error | undefined
+ */
+
+const validateReleaseDate = (mdString) => {
+  let error;
+
+  const { data } = grayMatter(mdString, {
+    engines: {
+      yaml: {
+        parse: (string) => yaml.safeLoad(string, { schema: yaml.JSON_SCHEMA }),
+      },
+    },
+  });
+
+  const isValidDate = (date) => {
+    const regex = /\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])/;
+    return regex.test(date);
+  };
+  // releaseDate is a required field and must be a date wrapped in single quotes
+  if (data.releaseDate) {
+    if (!isValidDate(data.releaseDate)) {
+      error = new Error(
+        "releaseDate is not a valid value. Must be date string formatted like 'YYYY-MM-DD' wrapped in single quotes"
+      );
+    }
+  } else {
+    error = new Error('releaseDate field missing from frontmatter');
+  }
+
+  return error;
+};
+
 module.exports = {
   frontmatter,
   validateFreshnessDate,
+  validateReleaseDate,
 };

--- a/scripts/verify_mdx.js
+++ b/scripts/verify_mdx.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
-const { frontmatter, validateFreshnessDate } = require('./utils/frontmatter');
+const {
+  frontmatter,
+  validateFreshnessDate,
+  validateReleaseDate,
+} = require('./utils/frontmatter');
 const { verifyImageImports } = require('./utils/image-import-utils.js');
 const mdx = require('@mdx-js/mdx');
 const fs = require('fs');
@@ -92,6 +96,10 @@ const readFile = async (filePath) => {
     (excludedPath) => filePath.includes(excludedPath)
   );
 
+  const includeInReleaseDateRegex = /src\/(?!i18n).*(\/security-bulletins\/|\/release-notes\/|\/whats-new\/).*(?<!index)(.mdx|.md)/;
+
+  const shouldValidateReleaseDate = includeInReleaseDateRegex.test(filePath);
+
   const { error } = frontmatter(mdxText);
 
   if (error != null) {
@@ -101,6 +109,13 @@ const readFile = async (filePath) => {
     failed = true;
   } else if (shouldValidateFreshnessDate) {
     const error = validateFreshnessDate(mdxText);
+    if (error) {
+      mdxErrors.push(`\x1b[35m Frontmatter field error:\x1b[0m ${filePath} \n
+        \x1b[31m${error.message}\x1b[0m`);
+      failed = true;
+    }
+  } else if (shouldValidateReleaseDate) {
+    const error = validateReleaseDate(mdxText);
     if (error) {
       mdxErrors.push(`\x1b[35m Frontmatter field error:\x1b[0m ${filePath} \n
         \x1b[31m${error.message}\x1b[0m`);

--- a/src/content/docs/security/new-relic-security/security-bulletins/covid-19.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/covid-19.mdx
@@ -8,6 +8,7 @@ metaDescription: Information from New Relic's Crisis Management Team about COVID
 redirects:
   - /docs/security/new-relic-security/security-bulletins/covid-19-bulletin
   - /docs/security/security-privacy/security-bulletins/covid-19
+releaseDate: '2021-01-14'
 ---
 
 This document describes New Relic’s current operating plan and our commitment to keeping our products and services running for our customers.

--- a/src/content/docs/security/new-relic-security/security-bulletins/notification-apolloio-security-incident.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/notification-apolloio-security-incident.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: A summary of the 2018 security breach of the systems of Apollo.io and New Relic's response.
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/notification-apolloio-security-incident
+releaseDate: '2020-12-10'
 ---
 
 **October 9, 2018**

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-01.mdx
@@ -11,6 +11,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr17-01
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr17-01
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr17-01
+releaseDate: '2020-12-09'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-02.mdx
@@ -11,6 +11,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr17-02
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr17-02
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr17-02
+releaseDate: '2020-12-09'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-03.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr17-03
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr17-03
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr17-03
+releaseDate: '2020-12-09'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-04.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr17-04
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr17-04
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr17-04
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-05.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-05.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/nr17-05
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr17-05
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr17-05
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-06.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr17-06.mdx
@@ -8,6 +8,7 @@ metaDescription: Security vulnerability update for New Relic .NET agent.
 redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr17-06
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr17-06
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-01.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr18-01
   - /docs/accounts-partnerships/welcome-new-relic/security-bulletins/security-bulletin-nr18-01
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-01
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-02.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security-bulletins/security-bulletin-nr18-02
   - /docs/accounts-partnerships/welcome-new-relic/security-bulletins/security-bulletin-nr18-02
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-02
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-03.mdx
@@ -10,6 +10,7 @@ redirects:
   - /docs/accounts-partnerships/welcome-new-relic/security-bulletins/security-bulletin-nr18-03
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr18-03
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-03
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-04.mdx
@@ -8,6 +8,7 @@ metaDescription: Security vulnerability update for New Relic .NET agent.
 redirects:
   - /docs/accounts-partnerships/welcome-new-relic/security-bulletins/security-bulletin-nr18-04
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-04
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-05.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-05.mdx
@@ -8,6 +8,7 @@ metaDescription: Security vulnerability update for New Relic Infrastructure agen
 redirects:
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr18-05
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-05
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-06.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-06.mdx
@@ -7,6 +7,7 @@ tags:
 redirects:
   - /docs/accounts-partnerships/new-relic-security/security-bulletins/security-bulletin-nr18-06
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-06
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-07.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-07.mdx
@@ -8,6 +8,7 @@ metaDescription: 'Security vulnerability update for New Relic Java, Python, and 
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-08
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-07
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-08.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-08.mdx
@@ -4,6 +4,7 @@ tags:
   - Security
   - Security and Privacy
   - Security bulletins
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-09.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-09.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for New Relic Java, Python, and .NET agents.'
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-09
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-10.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-10.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for New Relic Java, Python, and .NET agents.'
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-10
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-11.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-11.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for New Relic Java, Python, and .NET agents.'
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-11
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-12.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr18-12.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: Security vulnerability update for New Relic Infrastructure agent for Windows
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr18-12
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-01.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: Security vulnerability update for New Relic .NET agent.
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr19-01
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-02.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: Security vulnerability update for New Relic .NET agent.
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr19-02
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-03.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: Security vulnerability update for New Relic .NET agent.
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr19-03
+releaseDate: '2020-12-10'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-04.mdx
@@ -6,6 +6,7 @@ tags:
   - Security bulletins
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr19-04
+releaseDate: '2021-01-14'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-05.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr19-05.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: Security vulnerability update for New Relic .NET agent.
 redirects:
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-bulletin-nr19-05
+releaseDate: '2021-01-14'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr20-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr20-01.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for New Relic .NET agent,  January 16, 2020'
 redirects:
   - /docs/security/security-privacy/security-bulletins/security-bulletin-nr20-01
+releaseDate: '2021-01-14'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr20-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr20-02.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for New Relic Node.js agent, August 20, 2020'
 redirects:
   - /docs/security/security-privacy/security-bulletins/security-bulletin-nr20-02
+releaseDate: '2021-01-14'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-01.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for browser monitoring agent, March 09, 2021'
 redirects:
   - /docs/security/security-privacy/security-bulletins/security-bulletin-nr21-01
+releaseDate: '2021-03-22'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-02.mdx
@@ -7,6 +7,7 @@ tags:
 metaDescription: 'Security vulnerability update for New Relic Java agent, April 26, 2021'
 redirects:
   - /docs/security/security-privacy/security-bulletins/security-bulletin-nr21-01
+releaseDate: '2021-04-26'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-03.mdx
@@ -6,6 +6,7 @@ tags:
   - Security bulletin
   - Log4j
 metaDescription: 'Apache Log4j CVE-2021-44228, Security Bulletin NR21-03 (Java)'
+releaseDate: '2021-12-10'
 ---
 
 **Versions affected:** All agent versions between (a) 4.12.0 and 6.5.1; and (b) 7.0.0 and 7.4.1

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-04.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr21-04.mdx
@@ -6,6 +6,7 @@ tags:
   - Security bulletin
   - Log4j
 metaDescription: 'Apache Log4j CVE 2021-44228, Security Bulletin NR21-04 (Containerized Private Minions)'
+releaseDate: '2021-12-14'
 ---
 
 ## Summary

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr22-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr22-01.mdx
@@ -6,6 +6,7 @@ tags:
   - Security bulletin
   - Log4j
 metaDescription: 'Containerized Private Minion Removes Log4j Version 1.2.17 subdependency, Security Bulletin NR22-01'
+releaseDate: '2022-01-14'
 ---
 
 **Versions Affected:** 3.0.59 and earlier

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr23-01-security-advisory.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr23-01-security-advisory.mdx
@@ -1,6 +1,7 @@
 ---
 title: Security Bulletin NR23-01 — Security Advisory
 metaDescription: Advisory related to ongoing security investigation
+releaseDate: '2023-11-22'
 ---
 
 ## Incident report update: December 1, 2023 [#dec-1-2023-update]

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nrsg2202-01.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nrsg2202-01.mdx
@@ -5,6 +5,7 @@ tags:
   - Security and Privacy
   - Security bulletin
 metaDescription: "New Relic advises updating .NET agent for customers employing Microsoft Extensions Logging with log forwarding enabled"
+releaseDate: '2022-12-03'
 ---
 
 ## Summary [#summary]

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-heartbleed-vulnerability.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-heartbleed-vulnerability.mdx
@@ -9,6 +9,7 @@ redirects:
   - /docs/accounts-partnerships/accounts/security/security-heartbleed-vulnerability
   - /docs/accounts-partnerships/welcome-new-relic/security-bulletins/security-heartbleed-vulnerability
   - /docs/using-new-relic/new-relic-security/security-bulletins/security-heartbleed-vulnerability
+releaseDate: '2020-10-08'
 ---
 
 import accountsUserPreferences from 'images/accounts_screenshot-full_user-preferences.webp'

--- a/src/content/docs/security/new-relic-security/security-bulletins/solarwinds-orion.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/solarwinds-orion.mdx
@@ -8,6 +8,7 @@ metaDescription: A summary of the 2020 security breach of the systems of SolarWi
 redirects:
   - /docs/security/security-privacy/security-bulletins/new-relic-solarwinds-orion
   - /docs/security/security-privacy/security-bulletins/solarwinds-orion
+releaseDate: '2021-02-05'
 ---
 
 We understand that our customers are evaluating the impact of the [SolarWinds Security Advisory](https://www.solarwinds.com/securityadvisory) to their business. To address the immediate concern: New Relic is not a customer of the SolarWinds Orion product and therefore New Relic and customers using New Relic are not impacted by the compromised SolarWinds product.


### PR DESCRIPTION
### ✨ Summary

`pubDate` is now accurate and not the same as `lastBuildDate`

[build preview security rss](https://docswebsitedevelop-tabatharssfeeddates.gatsbyjs.io/docs/security/new-relic-security/security-bulletins/feed.xml)

The RSS feed validator did find some warnings, but they match up exactly to our current page:

- [build preview](https://www.rssboard.org/rss-validator/check.cgi?url=https%3A%2F%2Fdocswebsitedevelop-tabatharssfeeddates.gatsbyjs.io%2Fdocs%2Fsecurity%2Fnew-relic-security%2Fsecurity-bulletins%2Ffeed.xml)
- [docs.newrelic.com](https://www.rssboard.org/rss-validator/check.cgi?url=https%3A%2F%2Fdocs.newrelic.com%2Fdocs%2Fsecurity%2Fnew-relic-security%2Fsecurity-bulletins%2Ffeed.xml)

### 🔮 Engineering checklist

<!-- Remove any items that do not apply -->

- [x] Relevant documentation including README's or Confluence are updated to reflect these changes
- [x] Code changes are self-documenting or clearly commented/documented
- [x] New tests are added where applicable and total coverage remains >70%
- [x] No new warnings or errors where added to the browser or build console
- All downstream dependencies for DaaS have been considered for negative impacts
  - [x] security-bulletin rss feed
