### PR TITLE
fix: replace # with ;

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -120,9 +120,9 @@ Assuming you don't specifiy a custom installation path when using the MSI instal
 ```ini
 COR_ENABLE_PROFILING=1
 COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
-COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll" # may not be necessary due to profiler being registered with the system
+COR_PROFILER_PATH="C:\Program Files\New Relic\.NET Agent\netframework\NewRelic.Profiler.dll" ; may not be necessary due to profiler being registered with the system
 NEWRELIC_INSTALL_PATH="C:\Program Files\New Relic\.NET Agent"
-NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" # may not be necessary due to registry key being set
+NEWRELIC_HOME="C:\ProgramData\New Relic\.NET Agent" ; may not be necessary due to registry key being set
 ```
 
 ##### For .NET Core applications:


### PR DESCRIPTION
`;` seems to be a more universal comment char in ini file than `#`, so I'm checking if this will format the comment more correctly than our site does with `#`. Right now the docs site doesn't color them like a comment:
<img width="1169" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/1f14b714-ab98-4746-9431-e6234f5d9fc1">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.