### PR TITLE
Fix anchors defined in query-time-range.mdx

### DIFF
--- a/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/query-time-range.mdx
+++ b/src/content/docs/query-your-data/nrql-new-relic-query-language/get-started/query-time-range.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 
 NRQL was created to query telemetry data, and every query made with NRQL only considers telemetry data that falls within a specified time range. If a query request doesn't specify a time range, it defaults to reporting the last hour of telemetry data by default. Fortunately, we have multiple ways to set time ranges for your query so that you can get exactly the data you need from precise buckets of time.
 
-## Specify a time range [#spec-time-range]:
+## Specify a time range [#spec-time-range]
 
 You can use two methods to specify the time range in your queries:
 
@@ -26,7 +26,7 @@ You can use two methods to specify the time range in your queries:
 
 See the [Specifying a time](#spec-time) section below for a list of supported time formats.
 
-## Use time range snapping [#range-snapping]:
+## Use time range snapping [#range-snapping]
 
 You can sometimes adjust the specified `SINCE` and `UNTIL` times depending on the type of query you run with either metric or `TIMESERIES` range snapping.
 
@@ -49,7 +49,7 @@ Queries with `TIMESERIES` may need to adjust the time range so the results do no
 
 Looking at the JSON response to this query, the timeseries buckets base themselves on the end of the time range, and the start time is adjusted so the first bucket in the response covers a full 5 minutes: `"beginTime": "2023-12-20T00:08:12Z", "endTime": "2023-12-21T00:03:12Z"`.
 
-## Specify a time with SINCE and UNTIL [#spec-time]:
+## Specify a time with SINCE and UNTIL [#spec-time]
 You have a few ways to specify time in the `SINCE` and until `UNTIL` clauses.
 
 <Callout variant="tip">
@@ -58,7 +58,7 @@ You have a few ways to specify time in the `SINCE` and until `UNTIL` clauses.
   If you want to specify a timezone other than UTC for the time range, you can include it in the DateTime string option, or you can use NRQL's [`WITH TIMEZONE`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions#sel-timezone) clause.
 </Callout>
 
-### Unix time (Epoch Milliseconds) [#time-n-units-ago]:
+### Unix time (Epoch Milliseconds) [#time-n-units-ago]
 The time can be referenced as Unix time in milliseconds. This is the number of milliseconds since `1970-01-01T00:00:00Z`, or midnight on the 1st of January, 1970. For example:
 
   ```sql
@@ -66,8 +66,8 @@ The time can be referenced as Unix time in milliseconds. This is the number of m
   ```
 These timestamp values resolve to a time range starting at `2023-12-18T11:34:56.789Z` and ending at `2023-12-18T12:34:56.789Z`.
 
-### Relative time: (n \[time units] ago) [#relative-time-n-units-ago]:
-Relative time can be referenced as `n [time units] ago` with the following components: 
+### Relative time (n \[time units] ago) [#relative-time-n-units-ago]
+Relative time can be referenced as `n [time units] ago` with the following components:
   * `n`: A positive integer value.
   * `[time units]`: Available time units include `seconds`, `minutes`, `hours`, `days`, `weeks`, `months` (defined as 30 days), `quarters` (defined as 91 days), or `years` (defined as 365 days). Time unit pluralization is optional, so you can leave the "s" off the end of the unit. `2 day ago` and `2 days ago` have the same meaning.
 
@@ -123,7 +123,7 @@ The time is relative to the time you run the query. For example, assume that you
     </tbody>
   </table>
 
-### Relative temporal time [#relative-temporal-time]:
+### Relative temporal time [#relative-temporal-time]
 Relative time can also be specified using temporal time references. These relative time references resolve to the beginning of the temporal time interval. A relative temporal time reference will honor a `WITH TIMEZONE` clause. Select a collapser below to see more information on specific temporal time references:
 
 <Collapser title={<>Day references - <InlineCode>today</InlineCode>, <InlineCode>yesterday</InlineCode> or a weekday</>}>
@@ -300,7 +300,7 @@ Note that `today AT [time]` in a `SINCE` clause will never reference a time in t
   </table>
 </Collapser>
 
-### Use a DateTime string:
+### Use a DateTime string
 You can specify a time range time using a DateTime string. The parser generally supports the ISO 8601 DateTime format: `'2023-12-18T12:34:56.789-06:00'`. But, the DateTime parser can also recognize variants of the ISO standard format, like `'2023-12-18 12:34'`. The parser also supports date-only (`'2023-12-18'`) and time-only (`'12:34:56'`) strings. We have the options and examples for using a DateTime string below:
 
     <table style={{width: "auto"}}>


### PR DESCRIPTION
The colon after the anchor was making it visible as part of the heading. Removing the colon properly hides the anchor definition.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.