### PR TITLE
style(OHI): Fixed 2 code sections that were blank

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs.mdx
@@ -269,12 +269,12 @@ Here's a detailed example of doing the above procedure for NGINX:
 1. Ensure you have SSH access to the server or access to [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html). Log in to the host running the infrastructure agent.
 2. Via the command line, change the directory to the integrations configuration folder:
 
-  ```
+  ```shell
   cd /etc/newrelic-infra/integrations.d
   ```
 3. Create a file called `nginx-config.yml` and add the following snippet:
 
-  ```
+  ```yml
   ---
   discovery:
     docker:
@@ -292,49 +292,49 @@ Here's a detailed example of doing the above procedure for NGINX:
 4. If your NGINX status page is set to serve requests from the `STATUS_URL` on port 80, the infrastructure agent starts monitoring it. After five minutes, verify that NGINX data is appearing in our infrastructure UI (either: **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Third party services**, or **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > Third-party services**).
 5. If the configuration works, place it in the EC2 launch configuration:
 
-  1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2).
-  2. On the navigation pane, under **Auto scaling**, choose **Launch configurations**.
-  3. On the next page, select the launch configuration you want to update.
-  4. Right click and select **Copy launch configuration**.
-  5. On the **Launch configuration details** tab, click **Edit details**.
-  6. In the **User data** section, edit the `write_files` section (in the part marked `text/cloud-config`).
-  7. Add a new file/content entry:
+    1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2).
+    2. On the navigation pane, under **Auto scaling**, choose **Launch configurations**.
+    3. On the next page, select the launch configuration you want to update.
+    4. Right click and select **Copy launch configuration**.
+    5. On the **Launch configuration details** tab, click **Edit details**.
+    6. In the **User data** section, edit the `write_files` section (in the part marked `text/cloud-config`).
+    7. Add a new file/content entry:
 
-  ```
-  -   content: |
-      ---
-      discovery:
-        docker:
-          match:
-            image: /nginx/
-      integrations:
-        - name: nri-nginx
-          env:
-            STATUS_URL: http://${'${discovery.ip}'}:/status
-            REMOTE_MONITORING: true
-            METRICS: 1
-      path: /etc/newrelic-infra/integrations.d/nginx-config.yml
-  ```
-  8. Also edit the `runcmd` section to include the `yum` command to install `nri-nginx`:
+        ```yml
+        -   content: |
+            ---
+            discovery:
+              docker:
+                match:
+                  image: /nginx/
+            integrations:
+              - name: nri-nginx
+                env:
+                  STATUS_URL: http://${'${discovery.ip}'}:/status
+                  REMOTE_MONITORING: true
+                  METRICS: 1
+            path: /etc/newrelic-infra/integrations.d/nginx-config.yml
+        ```
+    8. Also edit the `runcmd` section to include the `yum` command to install `nri-nginx`:
 
-      ```
-      runcmd:
-        - [ yum, install, newrelic-infra, -y ]
-        - [ yum, install, nri-nginx, -y ]
-        - [ systemctl, daemon-reload ]
-        - [ systemctl, enable, newrelic-infra.service ]
-        - [ systemctl, start, --no-block, newrelic-infra.service ]
-      ```
+        ```yml
+        runcmd:
+          - [ yum, install, newrelic-infra, -y ]
+          - [ yum, install, nri-nginx, -y ]
+          - [ systemctl, daemon-reload ]
+          - [ systemctl, enable, newrelic-infra.service ]
+          - [ systemctl, start, --no-block, newrelic-infra.service ]
+        ```
 6. Choose **Skip to review**.
 7. Choose **Create launch configuration**.
 8. Next, update the auto scaling group:
-  1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2/).
-  2. On the navigation pane, under **Auto scaling**, choose **Auto scaling groups**.
-  3. Select the auto scaling group you want to update.
-  4. From the **Actions** menu, choose **Edit**.
-  5. In the drop down menu for **Launch configuration**, select the new launch configuration created.
-  6. Click **Save**.
+      1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2/).
+      2. On the navigation pane, under **Auto scaling**, choose **Auto scaling groups**.
+      3. Select the auto scaling group you want to update.
+      4. From the **Actions** menu, choose **Edit**.
+      5. In the drop down menu for **Launch configuration**, select the new launch configuration created.
+      6. Click **Save**.
 
-When an EC2 instance is terminated, it is replaced with a new one that automatically looks for new NGINX containers.
+When an EC2 instance is terminated, it's replaced with a new one that automatically looks for new NGINX containers.
 
 <InstallFeedback />


### PR DESCRIPTION
Updated this page: [Monitor services running on Amazon ECS](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/monitor-services-running-amazon-ecs/).

There were 2 code sections that were blank.

This is a request from the [help-documentation channel.](https://newrelic.slack.com/archives/C0DSGL3FZ/p1706086034547939)