### PR TITLE
fix(Mobile monitoring): Fixed a wrong query

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-app-launch-time-android-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-app-launch-time-android-apps.mdx
@@ -17,6 +17,7 @@ This feature is available for agent versions 6.9.0 and higher.
 </Callout>
 
 To enable the Android agent to report app launch time: Add the following to your application's `AndroidManifest.xml`:
+
    ```xml
    <application>
 
@@ -35,7 +36,7 @@ Your app launch time is reported with the `AppLaunch/Cold` and `AppLaunch/Hot` [
 Here's a sample query for capturing cold and hot launch times: 
 
 ```sql
-  SELECT average(newrelic.timeslice.value ) AS `AppLaunch/Cold` FROM Metric WHERE metricTimesliceName = ‘AppLaunch/Cold’ AND `entity.guid` = ‘your app token here’ SINCE 1664218800000 UNTIL 1664220600000 TIMESERIES
+  SELECT average(newrelic.timeslice.value ) AS 'AppLaunch/Cold' FROM Metric WHERE metricTimesliceName = 'AppLaunch/Cold' AND entity.guid = 'your app token here' SINCE 1664218800000 UNTIL 1664220600000 TIMESERIES
   ```
 
 If no data appears, review your `logcat` output for errors.


### PR DESCRIPTION
Fixed the query on this page: [Configure app launch times](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-app-launch-time-android-apps/)

This is the ticket: NR-217916