### PR TITLE
Update instructions for monitoring .NET Lambda functions with OpenTelemetry

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
@@ -194,18 +194,24 @@ For SAM and CloudFormation templates, add this to your function's properties:
 
 ## Step 5: Instrument Your Function [#instrument]
 
-First add the [OpenTelemetry SDK for AWS Lambda](https://www.nuget.org/packages/OpenTelemetry.Contrib.Instrumentation.AWSLambda/).
+First add the [OpenTelemetry SDK for AWS Lambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda/), as well as the [OTLP exporter package](https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol).
 
 ```bash
-dotnet add package OpenTelemetry.Contrib.Instrumentation.AWSLambda
+dotnet add package OpenTelemetry.Instrumentation.AWSLambda
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
 ```
 
-Add a call to `AddAWSLambdaConfigurations()` from `TracerProvider`.
+Add calls to `AddAWSLambdaConfigurations()` and `AddOtlpExporter()` from `TracerProvider` in your function's static constructor.
+
+<Callout variant="important">
+  Your function's constructor should be static, because the `TracerProvider` should only be initialized once per Lambda cold start.
+</Callout>
 
 ```csharp
 TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
     // add other instrumentations here
     .AddAWSLambdaConfigurations()
+    .AddOtlpExporter()
     .Build();
 ```
 
@@ -234,8 +240,8 @@ namespace Example
         {
             tracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddAWSInstrumentation()
-                .AddOtlpExporter()
                 .AddAWSLambdaConfigurations()
+                .AddOtlpExporter()
                 .Build();
         }
 


### PR DESCRIPTION
I recently followed this document to instrument a .NET Lambda with OpenTelemetry, and I ran into a few hiccups, which I've attempted to correct with these changes.

First, the previously referenced `OpenTelemetry.Contrib.Instrumentation.AWSLambda` package has been deprecated in favor of `OpenTelemetry.Instrumentation.AWSLambda`.  

Secondly, I made the need to add the OTLP exporter package and configuration more explicit (it's shown in the full example function, but was not called out during the step-by-step instructions).

Thirdly, I made more clear that the configuration steps need to happen in the function's constructor, and that the constructor needs to be static (and why).  Thanks to @nrcventura for helping me understand that one.  Again, this was in the sample code but not the step-by-step instructions.