### PR TITLE
Fix broken overview link from #15700

### DIFF
--- a/src/nav/alerts-applied-intelligence.yml
+++ b/src/nav/alerts-applied-intelligence.yml
@@ -6,7 +6,7 @@ pages:
   - title: Alerting best practice guide
     path: /docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices
   - title: Alerts & AI overview page
-    path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/
+    path: docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-ai-overview-page
   - title: Create and manage your conditions
     pages:
       - title: Alert conditions

--- a/src/nav/alerts-applied-intelligence.yml
+++ b/src/nav/alerts-applied-intelligence.yml
@@ -6,7 +6,7 @@ pages:
   - title: Alerting best practice guide
     path: /docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices
   - title: Alerts & AI overview page
-    path: docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-ai-overview-page
+    path: /docs/alerts-applied-intelligence/new-relic-alerts/get-started/alerts-ai-overview-page
   - title: Create and manage your conditions
     pages:
       - title: Alert conditions


### PR DESCRIPTION
#15700 had a small mistake where the `Alerts and applied intelligent overview` link in the left nav shot to a 404. This point it to the right file. 