### PR TITLE
Update alert-custom-incident-descriptions.mdx - documentation bug

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-incident-descriptions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-incident-descriptions.mdx
@@ -43,7 +43,7 @@ The **Custom incident description** field allows you to use a general template s
 
 ```
 This is my condition name : {{conditionName}}
-The hostname is : {{tags.fullHostname}}
+The hostname is : {{tag.fullHostname}}
 ```
 
 An incident resulting from this condition would fill in the details and you'd receive a notification like this:
@@ -73,21 +73,21 @@ Here's a custom incident description template example:
 
 ```
 this is my condition name : {{conditionName}}
-The hostname is : {{tags.fullHostname}}
-Owning Team: {{tags.label.owning_team}}
-Product: {{tags.label.product}}
-ec2VpcId: {{tags.aws.ec2VpcId}}
-Service name : {{tags.label.Name}}
-AWS Region : {{tags.aws.awsRegion}}
-AWS Availability Zone: {{tags.aws.awsAvailabilityZone}}
-Department : {{tags.label.department}}
-Environment: {{tags.label.environment}}
-Cluster: {{tags.clusterName}}
-Cluster Role: {{tags.clusterRole}}
-EC2 Instance Type: {{tags.instanceType}}
-EC2 InstanceID: {{tags.aws.ec2InstanceId}}
-EC2 AmiId: {{tags.aws.ec2AmiId}}
-EC2 Root Device Type: {{tags.aws.ec2RootDeviceType}}
+The hostname is : {{tag.fullHostname}}
+Owning Team: {{tag.label.owning_team}}
+Product: {{tag.label.product}}
+ec2VpcId: {{tag.aws.ec2VpcId}}
+Service name : {{tag.label.Name}}
+AWS Region : {{tag.aws.awsRegion}}
+AWS Availability Zone: {{tag.aws.awsAvailabilityZone}}
+Department : {{tag.label.department}}
+Environment: {{tag.label.environment}}
+Cluster: {{tag.clusterName}}
+Cluster Role: {{tag.clusterRole}}
+EC2 Instance Type: {{tag.instanceType}}
+EC2 InstanceID: {{tag.aws.ec2InstanceId}}
+EC2 AmiId: {{tag.aws.ec2AmiId}}
+EC2 Root Device Type: {{tag.aws.ec2RootDeviceType}}
 ```
 
 ## How to use attributes [#attributes-tags]

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-incident-descriptions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-incident-descriptions.mdx
@@ -99,19 +99,19 @@ The attributes you can use in a custom incident description are a subset of attr
   ```
   The target name is : {{targetName}}
   ```
-* Tag attributes: For tags, you would use the format `{{tags.TAG_NAME}}`. There are two types of tags:
+* Tag attributes: For tags, you would use the format `{{tag.TAG_NAME}}`. There are two types of tags:
 
   * Entity-related tags: **For infrastructure conditions only.** You can find available [entity-related tags](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor#) by going to the [entity explorer](/docs/new-relic-one/use-new-relic-one/ui-data/new-relic-one-entity-explorer-view-performance-across-apps-services-hosts) and looking under a service's **Metadata and tags**, or by viewing incident details. Here's an example of using tags in a custom incident description:
 
     ```
-    The AWS region is : {{tags.aws.awsRegion}}
-    Responsible team : {{tags.label.owning_team}}
+    The AWS region is : {{tag.aws.awsRegion}}
+    Responsible team : {{tag.label.owning_team}}
     ```
-  * Facet clause tags: **For NRQL conditions only.** If a NRQL condition uses a `FACET` clause, you can use `tags` formatting to use those values in your custom incident description. For example, if the NRQL query included `FACET hostName, cluster`, you could then use this:
+  * Facet clause tags: **For NRQL conditions only.** If a NRQL condition uses a `FACET` clause, you can use `tag` formatting to use those values in your custom incident description. For example, if the NRQL query included `FACET hostName, cluster`, you could then use this:
 
     ```
-    The host is : {{tags.hostName}}
-    The cluster is : {{tags.cluster}}
+    The host is : {{tag.hostName}}
+    The cluster is : {{tag.cluster}}
     ```
 
 Please note that tag names cannot include whitespace. The expanded values can include whitespace, but not the names of the tags themselves.
@@ -134,7 +134,7 @@ Here's an example mutation with a custom incident description:
 
 ```
 mutation {
-  alertsNrqlConditionStaticUpdate(accountId: 123456, id: "123456", condition: {description: "timestamp : {{timestamp}} \n accountId : {{accountId}} \n type : {{type}} \n event : {{event}} \n description : {{description}} \n policyId : {{policyId}} \n policyName: {{policyName}} \n conditionName : {{conditionName}} \n conditionId : {{conditionId}} \n product : {{product}} \n conditionType : {{conditionType}} \n RunbookUrl : {{runbookUrl}} \n nrqlQuery : {{nrqlQuery}} \n nrqlEventType : {{nrqlEventType}} \n targetID : {{targetId}} \n targetName : {{targetName}} \n commandLine : {{tags.commandLine}} \n entityGuid : {{tags.entityGuid}} \n entityName : {{tags.entityName}} \n fullHostname : {{tags.fullHostname}} \n instanceType : {{tags.instanceType}} \n processDisplayName : {{tags.processDisplayName}}"}) {
+  alertsNrqlConditionStaticUpdate(accountId: 123456, id: "123456", condition: {description: "timestamp : {{timestamp}} \n accountId : {{accountId}} \n type : {{type}} \n event : {{event}} \n description : {{description}} \n policyId : {{policyId}} \n policyName: {{policyName}} \n conditionName : {{conditionName}} \n conditionId : {{conditionId}} \n product : {{product}} \n conditionType : {{conditionType}} \n RunbookUrl : {{runbookUrl}} \n nrqlQuery : {{nrqlQuery}} \n nrqlEventType : {{nrqlEventType}} \n targetID : {{targetId}} \n targetName : {{targetName}} \n commandLine : {{tag.commandLine}} \n entityGuid : {{tag.entityGuid}} \n entityName : {{tag.entityName}} \n fullHostname : {{tag.fullHostname}} \n instanceType : {{tag.instanceType}} \n processDisplayName : {{tag.processDisplayName}}"}) {
     description
   }
 }


### PR DESCRIPTION
To use tags in a custom description, the syntax 'tags.<tagname> is incorrect. The correct syntax is 'tag.<tagname>. This update fixes that.