### PR TITLE
.NET agent: update verified compatible versions of Elastic.Clients.ElasticSearch

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -594,8 +594,8 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 **Elastic.Clients.Elasticsearch**
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.10, 8.9.11, 8.9.12
-* Versions 8.9.10 and higher are supported beginning with .NET agent v10.20.1
+* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0
+* Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 
 **NEST**
 * Minimum supported version: 7.0.0

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -716,7 +716,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 **Elastic.Clients.Elasticsearch**
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.10.0, 8.11.0
+* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 
 **NEST**


### PR DESCRIPTION
The .NET agent team has successfully tested the latest version of a library the agent instruments, Elastic.Client.ElasticSearch v8.12.0.  This PR adds that version to the list of versions we support.

Additionally, I found that some incorrect versions had somehow made it into the list for one of the two compatibility docs; this fixes it.