### PR TITLE
Errors inbox: Add workload tip

### DIFF
--- a/src/content/docs/errors-inbox/error-external-services.mdx
+++ b/src/content/docs/errors-inbox/error-external-services.mdx
@@ -19,14 +19,12 @@ To connect an inbox to Slack either follow the steps below or follow along with 
 <Video id="HEbX0dgeGGw" type="youtube" />
 
 1. If your Slack workspace does not have the [New Relic app](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info) installed, do that first.
-2. Open one of your New Relic error inboxes, select the **Notification Settings** icon (looks like a bell) in the top right corner.
-    <Callout variant="tip">
-      You won't see the bell icon for notifications unless you've set up a workload.
-    </Callout>
-3. Toggle the Slack button to **on** if it is **off**.
-4. If no workspaces are available, click the <Icon name="fe-plus" /> plus button to enable Slack with a one click Slack authentication.
-5. Once authenticated, you will be able to select a Workspace and specific Channel to send notifications to.
-6. Click **Test** to ensure messages are being sent to the right channel.
+2. If you haven't already, set up a [workload](https://docs.newrelic.com/docs/errors-inbox/getting-started/#global-workload).
+3. Open one of your New Relic error inboxes, and select the **Notification Settings** icon (looks like a bell) in the top right corner.
+4. Toggle the Slack button to **on** if it is **off**.
+5. If no workspaces are available, click the <Icon name="fe-plus" /> plus button to enable Slack with a one click Slack authentication.
+6. Once authenticated, you will be able to select a Workspace and specific Channel to send notifications to.
+7. Click **Test** to ensure messages are being sent to the right channel.
 
 ## Connect errors inbox to CodeStream
 

--- a/src/content/docs/errors-inbox/error-external-services.mdx
+++ b/src/content/docs/errors-inbox/error-external-services.mdx
@@ -20,6 +20,9 @@ To connect an inbox to Slack either follow the steps below or follow along with 
 
 1. If your Slack workspace does not have the [New Relic app](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info) installed, do that first.
 2. Open one of your New Relic error inboxes, select the **Notification Settings** icon (looks like a bell) in the top right corner.
+    <Callout variant="tip">
+      You won't see the bell icon for notifications unless you've set up a workload.
+    </Callout>
 3. Toggle the Slack button to **on** if it is **off**.
 4. If no workspaces are available, click the <Icon name="fe-plus" /> plus button to enable Slack with a one click Slack authentication.
 5. Once authenticated, you will be able to select a Workspace and specific Channel to send notifications to.


### PR DESCRIPTION
This is from customer feedback. You need to have a workload set up in order to see the bell icon.