### PR TITLE
Update instrument-browser-monitoring-java-agent-api.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api.mdx
@@ -127,7 +127,6 @@ If your framework does not allow you to enable browser monitoring from our UI, w
        <cfset header=newRelic.getBrowserTimingHeader() />
        <cfoutput>#header#</cfoutput>
        ...
-       ...
        <cfoutput>#footer#</cfoutput>
        ```
      </Collapser>


### PR DESCRIPTION
Update the browser script injection steps since we're deprecating the getBrowserTimingFooter method call.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.