### PR TITLE
fix(java): cleaning up JVM compatibility table

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -32,8 +32,6 @@ Before you install the Java agent, ensure your system meets these requirements:
   >
     The Java agent is compatible with any JVM-based language, including: Java, Scala, Kotlin, and Clojure. For instrumentation support for language-specific features, see the [Automatically instrumented frameworks and libraries](#auto-instrumented) section below.
 
-    In order to continue to innovate and efficiently provide new capabilities to our customers, we'll occasionally need to drop engineering support and technical support for older JVM versions. In the table below, the column titled **No New Relic support** refers to agent versions that are in this state. For the not-supported versions, you can continue using a version of the agent that is compatable with your older JVM version, but new features and fixes won't be included in those older agent versions. We recommend upgrading to a currently supported JVM version to take advantage of the latest agent releases.
-
     <table>
       <thead>
         <tr>
@@ -43,10 +41,6 @@ Before you install the Java agent, ensure your system meets these requirements:
 
           <th style={{ width: "300px" }}>
             Compatible Java agent versions
-          </th>
-
-          <th>
-            No New Relic support (see above)
           </th>
         </tr>
       </thead>
@@ -60,10 +54,6 @@ Before you install the Java agent, ensure your system meets these requirements:
           <td>
             v3.0.0 to v6.5.0, v6.5.2, v6.5.3, and v6.5.4
           </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
         </tr>
 
         <tr>
@@ -73,38 +63,6 @@ Before you install the Java agent, ensure your system meets these requirements:
 
           <td>
             v3.10.0 to current
-          </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 9
-          </td>
-
-          <td>
-            v3.43.0 to current
-          </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 10
-          </td>
-
-          <td>
-            v4.4.0 to current
-          </td>
-
-          <td>
-            v5.14.0 and lower
           </td>
         </tr>
 
@@ -116,80 +74,6 @@ Before you install the Java agent, ensure your system meets these requirements:
           <td>
             v4.7.0 to current
           </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 12
-          </td>
-
-          <td>
-            v4.12.0 to current
-          </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 13
-          </td>
-
-          <td>
-            v5.7.0 to current
-          </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 14
-          </td>
-
-          <td>
-            v5.11.0 to current
-          </td>
-
-          <td>
-            v5.14.0 and lower
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 15
-          </td>
-
-          <td>
-            v6.1.0 to current
-          </td>
-
-          <td>
-            NA
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 16
-          </td>
-
-          <td>
-            v7.3.0 to current
-          </td>
-
-          <td>
-            NA
-          </td>
         </tr>
 
         <tr>
@@ -200,53 +84,8 @@ Before you install the Java agent, ensure your system meets these requirements:
           <td>
             v7.4.0 to current
           </td>
-
-          <td>
-            NA
-          </td>
         </tr>
 
-        <tr>
-          <td>
-            Java 18
-          </td>
-
-          <td>
-            v7.7.0 to current
-          </td>
-
-          <td>
-            NA
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 19
-          </td>
-
-          <td>
-            v7.11.0 to current
-          </td>
-
-          <td>
-            NA
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            Java 20
-          </td>
-
-          <td>
-            v8.2.0 to current
-          </td>
-
-          <td>
-            NA
-          </td>
-        </tr>
         <tr>
           <td>
             Java 21
@@ -255,13 +94,12 @@ Before you install the Java agent, ensure your system meets these requirements:
           <td>
             v8.7.0 to current
           </td>
-
-          <td>
-            NA
-          </td>
         </tr>
       </tbody>
     </table>
+
+    Some Java agent versions in this table are no longer supported, but are still listed for reference. The list of supported Java agent versions is in [Java agent EOL policy](/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy/).
+
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
## Give us some context
The table was overcomplicated trying to list both the range of versions that support a given version of Java and the range that supports that version of Java but is no longer supported by NR.

So the third column was removed, and instead a note at the bottom of the table was added with a link to the list of supported versions.

Also, versions of Java that are not long term support were removed.