### PR TITLE
Update view-system-limits.mdx - Removed unused limit

### DIFF
--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -261,7 +261,6 @@ This table includes general max limits that apply across all New Relic accounts.
       </td>
 
       <td>
-        * Number of infrastructure agents and/or integrations: 5K per account
         * Gross number of new monitored containers: 5K per hour per account
         * Gross number of new monitored entities from Cloud integrations (AWS, Azure, GCP): 30K per hour, per account
         * AWS Metric Streams - Kinesis Data Firehose requests per minute: 50


### PR DESCRIPTION
The 5000 infra agent account limit is not being enforced. Having it documented creates unnecessary concerns.