### PR TITLE
docs: Promethus CRD example code is incomplete

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration.mdx
@@ -28,15 +28,17 @@ If you're using the [Prometheus Operator](https://github.com/prometheus-operator
 kubectl -n YOUR_PROM_NAMESPACE create secret generic nr-license-key --from-literal=value=YOUR_LICENSE_KEY
 ```
 
-Next, add the following to your Prometheus CRD (`kind:Prometheus`):
+Next, add the following to your Prometheus CRD (`kind:Prometheus`) in the corresponding field from the [Helm chart](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml):
 
 ```
-  remoteWrite:
-      - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=YOUR_CLUSTER_NAME
-        authorization:
-          credentials:
-            key: value
-            name: nr-license-key
+  prometheus:
+    prometheusSpec:
+      remoteWrite:
+          - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=YOUR_CLUSTER_NAME
+            authorization:
+              credentials:
+                key: value
+                name: nr-license-key
 ```
 
 ## Set up the integration [#setup]


### PR DESCRIPTION
Helm chart has been moved to a new repository: https://github.com/prometheus-operator/prometheus-operator/tree/main/helm

Code blob's YAML path was incomplete and required the rest of the `remoteWrite` key's path to be added.