### PR TITLE
Update nerdgraph-synthetics-tutorial.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -877,9 +877,10 @@ Use these scripts to delete your monitors:
     syntheticsDeleteMonitor (
       guid: "ENTITY_GUID"
       ) {
-      errors {
-        description
-      }
+      deletedEntities
+        failures {
+          message
+        }
     }
   }
   ```


### PR DESCRIPTION
Problem with delete example fields, example throws an error because errors does not seem to exist. 

Looking into the Nerdgraph explorer, it looks like the properties are:

entity
entityDelete
forceDelete!: 
guids!: 
deletedEntities
failures
guid
message
type


So i added the guid that was deleted to be returned in the query and any failures / message.


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.