### PR TITLE
Chore: Update mongodb-monitoring-integration-new.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -183,7 +183,7 @@ For example, the following Prometheus agent configuration adds to all the Promet
 
 ```
 # (...)
-new_relic_remote_write:
+newrelic_remote_write:
   extra_write_relabel_configs:
     - source_labels: [__name__]
       regex: 'mongodb_.*'
@@ -191,8 +191,23 @@ new_relic_remote_write:
       replacement: 'cluster-name-example'
 ```
 
-On the other hand, in a Prometheus server, you can add custom attributes to all metrics with `external_labels`, or per job with `static_configs`, or for more complex scenarios `metric_relabel_config`.
+If you are using multiple `percona/mongodb_exporter` pods to serve metrics from multiple MongoDB clusters, you can label each with a separate `mongodb_cluster_name` using a configuration like this:
 
+```
+# (...)
+newrelic_remote_write:
+  extra_write_relabel_configs:
+    - source_labels: [pod]
+      regex: 'mongodb-exporter-clst-1.*'
+      target_label: mongodb_cluster_name
+      replacement: 'cluster-name-example-1'
+    - source_labels: [pod]
+      regex: 'mongodb-exporter-clst-2.*'
+      target_label: mongodb_cluster_name
+      replacement: 'cluster-name-example-2'
+```
+
+On the other hand, in a Prometheus server, you can add custom attributes to all metrics with `external_labels`, or per job with `static_configs`, or for more complex scenarios `metric_relabel_config`.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
Add example for multiple clusters/exporters in k8s. This is to set different `mongodb_cluster_name` values based on the name of the `percona/mongodb_exporter` pod that is being scraped.

Fix reference to newrelic_remote_write (see https://github.com/newrelic/newrelic-prometheus-configurator/blob/main/charts/newrelic-prometheus-agent/values.yaml#L141)