### PR TITLE
Update account-linking.mdx

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking.mdx
@@ -271,7 +271,7 @@ The `newrelic-lambda` CLI adds your New Relic <InlinePopover type="licenseKey" /
           </td>
 
           <td>
-            Used in [legacy set-ups](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy/). `TRUE` by default for most agents.
+            Used in [legacy set-ups](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy/). `true` by default for most agents.
           </td>
         </tr>
 
@@ -291,7 +291,7 @@ The `newrelic-lambda` CLI adds your New Relic <InlinePopover type="licenseKey" /
           </td>
 
           <td>
-            `FALSE` by default. Set to `TRUE` to send function logs to New Relic directly, bypassing CloudWatch and the `newrelic-log-ingestion` Lambda.
+            `false` by default. Set to `true` to send function logs to New Relic directly, bypassing CloudWatch and the `newrelic-log-ingestion` Lambda.
           </td>
         </tr>
 
@@ -301,7 +301,7 @@ The `newrelic-lambda` CLI adds your New Relic <InlinePopover type="licenseKey" /
           </td>
 
           <td>
-            Set to `FALSE` to disable the extension, and use the CloudWatch telemetry path.
+            Set to `false` to disable the extension, and use the CloudWatch telemetry path.
           </td>
         </tr>
 


### PR DESCRIPTION
NEW_RELIC_EXTENSION_SEND_FUNCTION_LOGS value must be lowercase

Docs have it in uppercase, which doesn't work. Please refer to this part of the config code: https://github.com/newrelic/newrelic-lambda-extension/blob/88b35fe1b82de965f88d23c4ea3ace700143fd7a/config/config.go#L133

Note that some other config booleans actually get converted to lowercase in the code, but not this one.

Impact is that it's difficult to collect logs for debugging, unless already aware that Golang requires lowercase for booleans.

Resolves https://github.com/newrelic/newrelic-lambda-extension/issues/129