### PR TITLE
feat(StepMonitors): Supported in Chrome 100+ runtime

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -68,7 +68,7 @@ Decided to upgrade to the new runtime? Check out our [NerdGraph APIs](/docs/apis
 
 ## Version requirements [#requirements]
 
-Some capabilities require a minimum version of Job Manager and runtime container images. 
+Some capabilities require a minimum version of job manager and runtime container images. 
 
 <table id="min-versions">
   <thead>

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -66,7 +66,7 @@ If you want to upgrade your monitors:
 
 Decided to upgrade to the new runtime? Check out our [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#update-monitors) to programmatically update monitors.
 
-## Version requirements
+## Version requirements [#requirements]
 
 Some capabilities require a minimum version of Job Manager and runtime container images. 
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -55,7 +55,7 @@ If you want to upgrade your monitors:
 
 1. Go to **[one.newrelic.com > Synthetic monitoring](https://one.newrelic.com/synthetics-nerdlets)**, then select the monitor you want to edit.
 2. From the **Settings** tab, click **General**. 
-3. Switch to the newest runtime view via the dropdown menu. For scripted API monitors, choose Node.js 16. For scripted browser monitors, choose Chrome 100.
+3. Switch to the newest runtime view via the dropdown menu. For scripted API monitors, choose Node.js 16. For scripted browser monitors, choose Chrome 100+.
 4. If using separate private locations for containerized private minions and synthetics job managers, update the location selection.
 5. Click **Validate** to check that your monitors function in the new runtime. Make any script modifications if needed. 
 6. Save.
@@ -66,11 +66,49 @@ If you want to upgrade your monitors:
 
 Decided to upgrade to the new runtime? Check out our [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/#update-monitors) to programmatically update monitors.
 
+## Version requirements
+
+Some capabilities require a minimum version of Job Manager and runtime container images. 
+
+<table id="min-versions">
+  <thead>
+    <tr>
+      <th>
+        Capability
+      </th>
+
+      <th>
+        Job Manager Version
+      </th>
+
+      <th>
+        Runtime Version(s)
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Step Monitor
+      </td>
+
+      <td>
+        release-332
+      </td>
+
+      <td>
+        Browser runtime v2.2.22
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Limitations [#limitations]
 
 A few capabilities available to CPMs aren't supported by synthetics job manager. We'll include these features in the upcoming months and update this page as they become available. They include: 
 
-* Support for SSL certificate expiration, broken link, and step monitors
+* Support for SSL certificate expiration and broken link monitors
 * Verified script execution (VSE)
 * User defined environment variables
-* Adjusting JVM configuration options
+* Custom node modules

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -78,11 +78,11 @@ Some capabilities require a minimum version of job manager and runtime container
       </th>
 
       <th>
-        Job Manager Version
+        Job manager version
       </th>
 
       <th>
-        Runtime Version(s)
+        Runtime version(s)
       </th>
     </tr>
   </thead>
@@ -90,11 +90,11 @@ Some capabilities require a minimum version of job manager and runtime container
   <tbody>
     <tr>
       <td>
-        Step Monitor
+        Step monitor
       </td>
 
       <td>
-        release-332
+        Release-332
       </td>
 
       <td>

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
@@ -33,7 +33,7 @@ To convert:
 
 1. Go to **[one.newrelic.com > Synthetic monitoring](https://one.newrelic.com/synthetics-nerdlets)**, then select the monitor you want to edit.
 2. Click **General**. 
-3. Use the dropdown menu to switch the current runtime view (use Node.js 16 for scripted API monitors and Chrome 100 for scripted browser monitors). 
+3. Use the dropdown menu to switch the current runtime view (use Node.js 16 for scripted API monitors and Chrome 100+ for scripted browser monitors). 
 4. Click **Validate** to check that your monitors function in the new runtime. Make any script modifications if needed. 
 5. Save.
 


### PR DESCRIPTION
- Removed step monitors from limitations of new Synthetics runtime
- Added minimum version section
- Updated Chrome 100 references to Chrome 100+