### PR TITLE
chore: Add release notes for ping-runtime:1.38.0

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.30.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.30.0.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Ping Runtime
-releaseDate: '2023-06-27'
-version: 1.30.0
+releaseDate: '2024-02-07'
+version: 1.38.0
 ---
 
 ### Fixes

--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
@@ -1,0 +1,13 @@
+---
+subject: Ping Runtime
+releaseDate: '2023-10-19'
+version: 1.38.0
+---
+
+### Improvements
+* Upgrades JDK to Java 21
+* Upgrades to Dropwizard 4
+
+### Security Patches
+* CVE-2023-6481
+* CVE-2024-21634

--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Ping Runtime
+subject: Ping runtime
 releaseDate: '2023-10-19'
 version: 1.38.0
 ---


### PR DESCRIPTION
Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? Adds release notes for ping-runtime 1.38.0
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.