### PR TITLE
Update .NET agent troubleshooting doc with .NET 8 diagnostics settings info

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/no-data-appears-net.mdx
@@ -212,6 +212,16 @@ To remedy more complex issues when no data appears, try these solutions as appli
 
     <tr>
       <td>
+        **.NET 8:** Make sure runtime diagnostics are enabled
+      </td>
+
+      <td>
+        Starting in .NET 8, setting the environment variable `DOTNET_EnableDiagnostics=0` (or `COMPlus_EnableDiagnostics=0`) will disable CLR profiling, making it impossible for the agent to work.  This setting is commonly recommended in read-only filesystem deployment scenarios, but only to disable the diagnostic port.  See [Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_enablediagnostics) on how to disable specific sub-components of the diagnostic system while leaving profiling enabled.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         Get additional help.
       </td>
 


### PR DESCRIPTION
A .NET agent customer had a problem using the agent with .NET 8 with runtime diagnostics disabled; this was caused by a change in how .NET 8 interprets a particular environment variable setting.  This PR adds info to the .NET agent "no data appears" troubleshooting doc about this particular pitfall.