### PR TITLE
fix(HordeIPRanges): Removed old callout

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -618,10 +618,6 @@ To configure your firewall to allow synthetic monitors to access your monitored 
 
 ### Private locations [#synthetics-private]
 
-<Callout variant="important">
-  IP addresses used by synthetics private locations [changed on August 23, 2023.](/whats-new/2023/06/whats-new-06-23-synthetics-horde-ip-changes/)
-</Callout>
-
 Synthetic private minions report to a specific endpoint based on region. To allow the private minion to access the endpoint or the static IP addresses associated with the endpoint, follow the specific procedures for the operating system and the firewall you use. These IP addresses may change in the future.
 
 [TLS](#tls) is required for all domains. Use the IP connections for your [data center region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center) (US or EU):


### PR DESCRIPTION
Removed a callout about previous changes to Horde IP ranges that occurred in August 2023. This notice is no longer necessary. 