### PR TITLE
Remove <dd> and </dd> tags across site

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2683,11 +2683,8 @@ To enable Infinite Tracing, enable distributed tracing (set `config.DistributedT
         </tr>
       </tbody>
     </table>
-  </Collapser>
-
-  <dd>
     For help getting a valid Infinite Tracing trace observer host entry, see [Find or create a trace observer endpoint](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer).
-  </dd>
+  </Collapser>
 </CollapserGroup>
 
 ## Application logging settings [#application-logging]

--- a/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-attributes.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/go-agent-attributes.mdx
@@ -60,14 +60,12 @@ The Go agent receives the following [default attributes](/docs/agents/manage-apm
       ```go
       config.Attributes.Exclude = append(config.Attributes.Exclude, newrelic.AttributeResponseCodeDeprecated)
       ```
-  </Collapser>
 
-  <dd>
     <Callout variant="important">
       As of Go agent v3.0.0, this attribute has been marked deprecated and been renamed to `http.statusCode`. The v3.x agent will continue to produce this attribute, but it will be removed in v4.0.0.
     </Callout>
-  </dd>
-
+  
+  </Collapser>
   <Collapser
     id="requestHeadersAccept"
     title="request.headers.accept"

--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -1131,13 +1131,13 @@ Set these options in the `common` section. To [override](#System_Properties) any
     The agent communicates with New Relic via HTTPS by default, and New Relic [requires HTTPS](/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls) for all traffic to <InlinePopover type="apm" /> and the New Relic REST API.
 
     This work is done asynchronously to the threads that process your application code, so response times will not be directly affected by this change.
-  </Collapser>
 
-  <dd>
     <Callout variant="important">
       As of [Java agent 3.48.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-3480), SSL is enabled by default and the config option to disable it has been deprecated. As of [Java agent 4.0.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-400), the ability to disable SSL has been removed.
     </Callout>
-  </dd>
+  </Collapser>
+
+
 
   <Collapser
     id="cfg-sync_startup"
@@ -1662,14 +1662,12 @@ Attributes are key-value pairs related to transaction traces, traced errors, <In
     * `legacy` : Reporting will be done by the reintroduced HTTP Attributes, this configuration may impact current or future functionality.
     * `both` : This is the default configuration, reporting will be done by the reintroduced HTTP Attributes and the OTEL Attributes. This configuration will also increase your data ingest.
 
-  </Collapser>
-  <dd>
     <Callout variant="important">
 
       Available since [Java agent version 8.8.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-880). The default configuration, `both`, will increase data ingest. To avoid an increase in data ingest, you must override the default by setting `http_attribute_mode` to `legacy` or `standard`.
-
     </Callout>
-  </dd>
+  </Collapser>
+
 </CollapserGroup>
 
 ## Async instrumentation [#async_config]

--- a/src/content/docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/instrument-browser-monitoring-java-agent-api.mdx
@@ -62,13 +62,11 @@ If your framework does not allow you to enable browser monitoring from our UI, w
 3. [Access the Java agent API class](/docs/agents/java-agent/api-guides/guide-using-java-agent-api#api) by adding `newrelic-api.jar` to your application class path.
 4. Add the `com.newrelic.api.agent.NewRelic.getBrowserTimingHeader()` method to enable time tracking. See below for procedures for specific frameworks.
 
-   <dd>
     <Callout variant="important">
       As of [Java agent 8.9.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-890), the [getBrowserTimingFooter() API](https://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html) method call is deprecated. The entire browser script is now included when calling `getBrowserTimingHeader()`.
     </Callout>
-   </dd>
 
-   Find the appropriate methods based on the framework you are using:
+    Find the appropriate methods based on the framework you are using:
 
    <CollapserGroup>
      <Collapser

--- a/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -102,84 +102,80 @@ This API call sends a browser [`PageAction` event](/docs/insights/explore-data/c
 
 ### Record link clicks (JavaScript) [#example-link-click-js]
 
-<dd>
-  This example records a PageAction event whenever a user selects the **Try Me** link. The event is recorded with an `actionName` of `clickedTryMe`:
 
-  ```html
-  <a href="/demo" id="try-me">Try Me!</a>
-  <script>
-      document.getElementById('try-me').addEventListener('click', function(e) {
-          newrelic.addPageAction('clickedTryMe');
-      })
-  </script>
-  ```
+This example records a PageAction event whenever a user selects the **Try Me** link. The event is recorded with an `actionName` of `clickedTryMe`:
 
-  You can then query the number of times the **Try Me** button was clicked with the following NRQL query:
+```html
+<a href="/demo" id="try-me">Try Me!</a>
+<script>
+    document.getElementById('try-me').addEventListener('click', function(e) {
+        newrelic.addPageAction('clickedTryMe');
+    })
+</script>
+```
 
-  ```sql
-  SELECT count(*) FROM PageAction WHERE actionName = 'clickedTryMe' SINCE 1 hour ago
-  ```
+You can then query the number of times the **Try Me** button was clicked with the following NRQL query:
 
-  ### Record link clicks (jQuery) [#example-link-click-jquery]
-</dd>
+```sql
+SELECT count(*) FROM PageAction WHERE actionName = 'clickedTryMe' SINCE 1 hour ago
+```
 
-<dd>
-  This example sends a PageAction event when a user clicks on an element with the class `copy-text`. The `actionName` is `copy-text-button` and the value is reported as another attribute called `Result` that corresponds to methods named `success` and `error` that handle the outcome.
+### Record link clicks (jQuery) [#example-link-click-jquery]
 
-  ```js
-  $('.copy-text').click(function() {
-      var clipboard = new Clipboard('.copy-text');
-      clipboard.on('success', function(event) {
-          // Do stuff
-          // Report data to New Relic
-          if (typeof newrelic == 'object') {
-              newrelic.addPageAction('copy-text-button', { result: 'success' });
-          }
-      });
-      clipboard.on('error', function(event) {
-          // Do stuff
-          // Report data to New Relic
-          if (typeof newrelic == 'object') {
-              newrelic.addPageAction('copy-text-button', { result: 'error' });
-          }
-      });
-  });
-  ```
+This example sends a PageAction event when a user clicks on an element with the class `copy-text`. The `actionName` is `copy-text-button` and the value is reported as another attribute called `Result` that corresponds to methods named `success` and `error` that handle the outcome.
 
-  Then in the query builder, you can create a pie chart to see the breakdown of how many button clicks resulted in success versus error over the past 30 days:
+```js
+$('.copy-text').click(function() {
+    var clipboard = new Clipboard('.copy-text');
+    clipboard.on('success', function(event) {
+        // Do stuff
+        // Report data to New Relic
+        if (typeof newrelic == 'object') {
+            newrelic.addPageAction('copy-text-button', { result: 'success' });
+        }
+    });
+    clipboard.on('error', function(event) {
+        // Do stuff
+        // Report data to New Relic
+        if (typeof newrelic == 'object') {
+            newrelic.addPageAction('copy-text-button', { result: 'error' });
+        }
+    });
+});
+```
 
-  ```sql
-  SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET result SINCE 30 days ago
-  ```
+Then in the query builder, you can create a pie chart to see the breakdown of how many button clicks resulted in success versus error over the past 30 days:
 
-  Or you can create a query to see what pages have the most copy button clicks in the last 30 days:
+```sql
+SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET result SINCE 30 days ago
+```
 
-  ```sql
-  SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET currentUrl SINCE 30 days ago
-  ```
+Or you can create a query to see what pages have the most copy button clicks in the last 30 days:
 
-  ### Capture form input [#example-form-input]
-</dd>
+```sql
+SELECT count(*) AS 'Clicks' FROM PageAction WHERE actionName = 'copy-text-button' FACET currentUrl SINCE 30 days ago
+```
 
-<dd>
-  This example captures user input (email addresses) from a form called **Signup**. The event is recorded with an `actionName` of `userSignup`:
+### Capture form input [#example-form-input]
 
-  ```html
-  <form action="/signup" id="myform">
-      <input id="email" name="email">
-      <input type="submit" value="Signup">
-  </form>
-  <script type="text/javascript">
-      document.getElementById('myform').addEventListener('submit', function(e) {
-          var email = e.target.elements['email'].value;
-          newrelic.addPageAction('userSignup', { email: email });
-      })
-  </script>
-  ```
+This example captures user input (email addresses) from a form called **Signup**. The event is recorded with an `actionName` of `userSignup`:
 
-  You can then see the emails that you gathered with the following NRQL query:
+```html
+<form action="/signup" id="myform">
+    <input id="email" name="email">
+    <input type="submit" value="Signup">
+</form>
+<script type="text/javascript">
+    document.getElementById('myform').addEventListener('submit', function(e) {
+        var email = e.target.elements['email'].value;
+        newrelic.addPageAction('userSignup', { email: email });
+    })
+</script>
+```
 
-  ```sql
-  SELECT uniques(email) FROM PageAction WHERE actionName = 'userSignup' SINCE 1 hour ago
-  ```
-</dd>
+You can then see the emails that you gathered with the following NRQL query:
+
+```sql
+SELECT uniques(email) FROM PageAction WHERE actionName = 'userSignup' SINCE 1 hour ago
+```
+

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration.mdx
@@ -82,273 +82,271 @@ To view [metric data](/docs/telemetry-data-platform/understand-data/new-relic-da
 
 ### GcpAppEngineServiceSample [#gcp-app-engine-service-sample]
 
-<dd>
-  Query `GcpAppEngineServiceSample` events in New Relic to view data for the following attributes:
+Query `GcpAppEngineServiceSample` events in New Relic to view data for the following attributes:
 
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `flex.Cpu.ReservedCores`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `flex.Cpu.ReservedCores`
+      </td>
 
-        <td>
-          Total number of CPU cores allocated to an App Engine flexible environment version.
-        </td>
-      </tr>
+      <td>
+        Total number of CPU cores allocated to an App Engine flexible environment version.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `flex.Cpu.Utilization`
-        </td>
+    <tr>
+      <td>
+        `flex.Cpu.Utilization`
+      </td>
 
-        <td>
-          The fraction of allocated CPU in use across an App Engine flexible environment version.
-        </td>
-      </tr>
+      <td>
+        The fraction of allocated CPU in use across an App Engine flexible environment version.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `flex.Disk.ReadBytes`
-        </td>
+    <tr>
+      <td>
+        `flex.Disk.ReadBytes`
+      </td>
 
-        <td>
-          Delta count of bytes read from disk across an App Engine flexible environment version.
-        </td>
-      </tr>
+      <td>
+        Delta count of bytes read from disk across an App Engine flexible environment version.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `flex.Disk.WriteBytes`
-        </td>
+    <tr>
+      <td>
+        `flex.Disk.WriteBytes`
+      </td>
 
-        <td>
-          Delta count of bytes written from disk across an App Engine flexible environment version.
-        </td>
-      </tr>
+      <td>
+        Delta count of bytes written from disk across an App Engine flexible environment version.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `flex.Disk.ReceivedBytes`
-        </td>
+    <tr>
+      <td>
+        `flex.Disk.ReceivedBytes`
+      </td>
 
-        <td>
-          Delta count of incoming network bytes across all VMs in an App Engine flexible environment version.
-        </td>
-      </tr>
+      <td>
+        Delta count of incoming network bytes across all VMs in an App Engine flexible environment version.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `flex.Disk.SentBytes`
-        </td>
+    <tr>
+      <td>
+        `flex.Disk.SentBytes`
+      </td>
 
-        <td>
-          Delta count of outgoing network bytes across all VMs in an App Engine flexible environment version.
-        </td>
-      </tr>
+      <td>
+        Delta count of outgoing network bytes across all VMs in an App Engine flexible environment version.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `server.DosIntercepts`
-        </td>
+    <tr>
+      <td>
+        `server.DosIntercepts`
+      </td>
 
-        <td>
-          Delta count of interceptions performed to prevent DoS attacks.
-        </td>
-      </tr>
+      <td>
+        Delta count of interceptions performed to prevent DoS attacks.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `server.QuotaDenials`
-        </td>
+    <tr>
+      <td>
+        `server.QuotaDenials`
+      </td>
 
-        <td>
-          Delta count of requests that failed due to the app being over quota.
-        </td>
-      </tr>
+      <td>
+        Delta count of requests that failed due to the app being over quota.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `server.Responses`
-        </td>
+    <tr>
+      <td>
+        `server.Responses`
+      </td>
 
-        <td>
-          Delta HTTP response count.
-        </td>
-      </tr>
+      <td>
+        Delta HTTP response count.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `server.ResponseLatenciesMilliseconds`
-        </td>
+    <tr>
+      <td>
+        `server.ResponseLatenciesMilliseconds`
+      </td>
 
-        <td>
-          HTTP response latency, in milliseconds.
-        </td>
-      </tr>
+      <td>
+        HTTP response latency, in milliseconds.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `server.ResponseStyle`
-        </td>
+    <tr>
+      <td>
+        `server.ResponseStyle`
+      </td>
 
-        <td>
-          Delta counts on the HTTP serve style.
-        </td>
-      </tr>
+      <td>
+        Delta counts on the HTTP serve style.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `memcache.CentiMcu`
-        </td>
+    <tr>
+      <td>
+        `memcache.CentiMcu`
+      </td>
 
-        <td>
-          Memcache utilization, in 1/100th of a Memcache Compute Unit.
-        </td>
-      </tr>
+      <td>
+        Memcache utilization, in 1/100th of a Memcache Compute Unit.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `memcache.Operations`
-        </td>
+    <tr>
+      <td>
+        `memcache.Operations`
+      </td>
 
-        <td>
-          Count of memcache key operations.
-        </td>
-      </tr>
+      <td>
+        Count of memcache key operations.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `memcache.ReceivedBytes`
-        </td>
+    <tr>
+      <td>
+        `memcache.ReceivedBytes`
+      </td>
 
-        <td>
-          Number of bytes received by app from the memcache API.
-        </td>
-      </tr>
+      <td>
+        Number of bytes received by app from the memcache API.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `memcache.SentBytes`
-        </td>
+    <tr>
+      <td>
+        `memcache.SentBytes`
+      </td>
 
-        <td>
-          Number of bytes sent by app through the memcache API.
-        </td>
-      </tr>
+      <td>
+        Number of bytes sent by app through the memcache API.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `system.cpu.Usage`
-        </td>
+    <tr>
+      <td>
+        `system.cpu.Usage`
+      </td>
 
-        <td>
-          CPU usage in megacycles.
-        </td>
-      </tr>
+      <td>
+        CPU usage in megacycles.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `system.Instances`
-        </td>
+    <tr>
+      <td>
+        `system.Instances`
+      </td>
 
-        <td>
-          Number of instances that exist.
-        </td>
-      </tr>
+      <td>
+        Number of instances that exist.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `system.Memory.UsageBytes`
-        </td>
+    <tr>
+      <td>
+        `system.Memory.UsageBytes`
+      </td>
 
-        <td>
-          Total memory used by running instances.
-        </td>
-      </tr>
+      <td>
+        Total memory used by running instances.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `system.Network.ReceivedBytes`
-        </td>
+    <tr>
+      <td>
+        `system.Network.ReceivedBytes`
+      </td>
 
-        <td>
-          Delta count of incoming network bandwidth.
-        </td>
-      </tr>
+      <td>
+        Delta count of incoming network bandwidth.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `system.Network.SentBytes`
-        </td>
+    <tr>
+      <td>
+        `system.Network.SentBytes`
+      </td>
 
-        <td>
-          Delta count of outgoing network bandwidth.
-        </td>
-      </tr>
-    </tbody>
-  </table>
+      <td>
+        Delta count of outgoing network bandwidth.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-  ### GcpCloudTasksQueueSample [#gcp-cloud-tasks-queue-sample]
+### GcpCloudTasksQueueSample [#gcp-cloud-tasks-queue-sample]
 
-  Query `GcpCloudTasksQueueSample` events in New Relic to view data for the following attributes:
+Query `GcpCloudTasksQueueSample` events in New Relic to view data for the following attributes:
 
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `api.Requests`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `api.Requests`
+      </td>
 
-        <td>
-          Count of Cloud Tasks API calls.
-        </td>
-      </tr>
+      <td>
+        Count of Cloud Tasks API calls.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `queue.TaskAttempts`
-        </td>
+    <tr>
+      <td>
+        `queue.TaskAttempts`
+      </td>
 
-        <td>
-          Count of task attempts broken down by response code.
-        </td>
-      </tr>
+      <td>
+        Count of task attempts broken down by response code.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `queue.taskAttemptDelaysMilliseconds`
-        </td>
+    <tr>
+      <td>
+        `queue.taskAttemptDelaysMilliseconds`
+      </td>
 
-        <td>
-          Delay between each scheduled attempt time and actual attempt time.
-        </td>
-      </tr>
-    </tbody>
-  </table>
+      <td>
+        Delay between each scheduled attempt time and actual attempt time.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-</dd>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
@@ -43,194 +43,188 @@ To view [metric data](/docs/telemetry-data-platform/understand-data/new-relic-da
 
 Query `GcpBigQueryProjectSample` events in New Relic to view data for the following metrics. Resolution is one data point per minute with an 8-minute delay.
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `query.Count`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `query.Count`
+      </td>
 
-        <td>
-          In-flight queries.
-        </td>
-      </tr>
+      <td>
+        In-flight queries.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `query.ExecutionTimes`
-        </td>
+    <tr>
+      <td>
+        `query.ExecutionTimes`
+      </td>
 
-        <td>
-          Distribution of query execution times.
-        </td>
-      </tr>
+      <td>
+        Distribution of query execution times.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `slots.Allocated`
-        </td>
+    <tr>
+      <td>
+        `slots.Allocated`
+      </td>
 
-        <td>
-          Number of slots currently allocated for project.
-        </td>
-      </tr>
+      <td>
+        Number of slots currently allocated for project.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `slots.AllocatedForProject`
-        </td>
+    <tr>
+      <td>
+        `slots.AllocatedForProject`
+      </td>
 
-        <td>
-          Number of slots currently allocated for query jobs in the project.
-        </td>
-      </tr>
+      <td>
+        Number of slots currently allocated for query jobs in the project.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `slots.AllocatedForProjectAndJobType`
-        </td>
+    <tr>
+      <td>
+        `slots.AllocatedForProjectAndJobType`
+      </td>
 
-        <td>
-          Number of slots currently allocated for the project and job type.
-        </td>
-      </tr>
+      <td>
+        Number of slots currently allocated for the project and job type.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `slots.AllocatedForReservation`
-        </td>
+    <tr>
+      <td>
+        `slots.AllocatedForReservation`
+      </td>
 
-        <td>
-          Number of slots currently allocated for project in the reservation.
-        </td>
-      </tr>
+      <td>
+        Number of slots currently allocated for project in the reservation.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `slots.TotalAllocatedForReservation`
-        </td>
+    <tr>
+      <td>
+        `slots.TotalAllocatedForReservation`
+      </td>
 
-        <td>
-          Number of slots currently allocated across projects in the reservation.
-        </td>
-      </tr>
+      <td>
+        Number of slots currently allocated across projects in the reservation.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `slots.TotalAvailable`
-        </td>
+    <tr>
+      <td>
+        `slots.TotalAvailable`
+      </td>
 
-        <td>
-          Total number of slots available for the project.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Total number of slots available for the project.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### GcpBigQueryDatasetSample [#dataset-sample]
 
 Query `GcpBigQueryDatasetSample` events in New Relic to view data for the following metrics. Resolution is one data point every 30 minutes with a 3-hour delay.
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `storage.StoredBytes`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `storage.StoredBytes`
+      </td>
 
-        <td>
-          Amount of stored bytes.
-        </td>
-      </tr>
+      <td>
+        Amount of stored bytes.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `storage.Tables`
-        </td>
+    <tr>
+      <td>
+        `storage.Tables`
+      </td>
 
-        <td>
-          Number of tables.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Number of tables.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### GcpBigQueryTableSample [#table-sample]
 
 Query `GcpBigQueryTableSample` events to view data for the following metrics. Resolution is one data point per minute with a 6-hour delay.
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `storage.UploadedBytes`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `storage.UploadedBytes`
+      </td>
 
-        <td>
-          Uploaded bytes.
-        </td>
-      </tr>
+      <td>
+        Uploaded bytes.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `storage.UploadedBytesBilled`
-        </td>
+    <tr>
+      <td>
+        `storage.UploadedBytesBilled`
+      </td>
 
-        <td>
-          Uploaded bytes billed. Currently only streaming API is billed.
-        </td>
-      </tr>
+      <td>
+        Uploaded bytes billed. Currently only streaming API is billed.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `storage.UploadedRowCount`
-        </td>
+    <tr>
+      <td>
+        `storage.UploadedRowCount`
+      </td>
 
-        <td>
-          Uploaded rows.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Uploaded rows.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-load-balancing-monitoring-integration.mdx
@@ -38,264 +38,258 @@ To view [metric data](/docs/telemetry-data-platform/understand-data/new-relic-da
 
 Query `GcpHttpLoadBalancerSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `https.BackendLatencies`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `https.BackendLatencies`
+      </td>
 
-        <td>
-          Mean latency (in milliseconds) calculated from when the request was sent by the proxy to the backend until the proxy received from the backend the last byte of response.
-        </td>
-      </tr>
+      <td>
+        Mean latency (in milliseconds) calculated from when the request was sent by the proxy to the backend until the proxy received from the backend the last byte of response.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.BackendRequestBytes`
-        </td>
+    <tr>
+      <td>
+        `https.BackendRequestBytes`
+      </td>
 
-        <td>
-          The number of bytes sent as requests from HTTP/S load balancer to backends.
-        </td>
-      </tr>
+      <td>
+        The number of bytes sent as requests from HTTP/S load balancer to backends.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.BackendRequests`
-        </td>
+    <tr>
+      <td>
+        `https.BackendRequests`
+      </td>
 
-        <td>
-          The number of requests served by backends of HTTP/S load balancer.
-        </td>
-      </tr>
+      <td>
+        The number of requests served by backends of HTTP/S load balancer.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.BackendResponseBytes`
-        </td>
+    <tr>
+      <td>
+        `https.BackendResponseBytes`
+      </td>
 
-        <td>
-          The number of bytes sent as responses from backends (or cache) to HTTP/S load balancer.
-        </td>
-      </tr>
+      <td>
+        The number of bytes sent as responses from backends (or cache) to HTTP/S load balancer.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.FrontendTcpRtt`
-        </td>
+    <tr>
+      <td>
+        `https.FrontendTcpRtt`
+      </td>
 
-        <td>
-          Mean of the Round-Trip Time (RTT) measured for each connection between client and proxy.
-        </td>
-      </tr>
+      <td>
+        Mean of the Round-Trip Time (RTT) measured for each connection between client and proxy.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.RequestBytes`
-        </td>
+    <tr>
+      <td>
+        `https.RequestBytes`
+      </td>
 
-        <td>
-          The number of bytes sent as requests from clients to HTTP/S load balancer.
-        </td>
-      </tr>
+      <td>
+        The number of bytes sent as requests from clients to HTTP/S load balancer.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.Requests`
-        </td>
+    <tr>
+      <td>
+        `https.Requests`
+      </td>
 
-        <td>
-          The number of requests served by HTTP/S load balancer.
-        </td>
-      </tr>
+      <td>
+        The number of requests served by HTTP/S load balancer.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.ResponseBytes`
-        </td>
+    <tr>
+      <td>
+        `https.ResponseBytes`
+      </td>
 
-        <td>
-          The number of bytes sent as responses from HTTP/S load balancer to clients.
-        </td>
-      </tr>
+      <td>
+        The number of bytes sent as responses from HTTP/S load balancer to clients.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `https.TotalLatencies`
-        </td>
+    <tr>
+      <td>
+        `https.TotalLatencies`
+      </td>
 
-        <td>
-          Mean of the latency (in milliseconds) calculated from when the request was received by the proxy until the proxy got ACK from client on last response byte.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Mean of the latency (in milliseconds) calculated from when the request was received by the proxy until the proxy got ACK from client on last response byte.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### GcpTcpSslProxyLoadBalancerSample [#gcp-tcp-ssl-proxy-load-balancer-sample]
 
 Query `GcpTcpSslProxyLoadBalancerSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `tcpSslProxy.ClosedConnections`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `tcpSslProxy.ClosedConnections`
+      </td>
 
-        <td>
-          Number of connections that were terminated over TCP/SSL proxy.
-        </td>
-      </tr>
+      <td>
+        Number of connections that were terminated over TCP/SSL proxy.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `tcpSslProxy.EgressBytes`
-        </td>
+    <tr>
+      <td>
+        `tcpSslProxy.EgressBytes`
+      </td>
 
-        <td>
-          Number of bytes sent from VM to client using proxy.
-        </td>
-      </tr>
+      <td>
+        Number of bytes sent from VM to client using proxy.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `tcpSslProxy.FrontendTcpRtt`
-        </td>
+    <tr>
+      <td>
+        `tcpSslProxy.FrontendTcpRtt`
+      </td>
 
-        <td>
-          Mean of the smoothed RTT (in milliseconds) measured by the proxy's TCP stack, each minute application layer bytes pass from proxy to client.
-        </td>
-      </tr>
+      <td>
+        Mean of the smoothed RTT (in milliseconds) measured by the proxy's TCP stack, each minute application layer bytes pass from proxy to client.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `tcpSslProxy.IngressBytes`
-        </td>
+    <tr>
+      <td>
+        `tcpSslProxy.IngressBytes`
+      </td>
 
-        <td>
-          Number of bytes sent from client to VM using proxy.
-        </td>
-      </tr>
+      <td>
+        Number of bytes sent from client to VM using proxy.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `tcpSslProxy.NewConnections`
-        </td>
+    <tr>
+      <td>
+        `tcpSslProxy.NewConnections`
+      </td>
 
-        <td>
-          Number of connections that were created over TCP/SSL proxy.
-        </td>
-      </tr>
+      <td>
+        Number of connections that were created over TCP/SSL proxy.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `tcpSslProxy.OpenConnections`
-        </td>
+    <tr>
+      <td>
+        `tcpSslProxy.OpenConnections`
+      </td>
 
-        <td>
-          Current number of outstanding connections through the TCP/SSL proxy.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Current number of outstanding connections through the TCP/SSL proxy.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### GcpInternalLoadBalancerSample [#gcp-tcp-ssl-proxy-load-balancer-sample]
 
 Query `GcpInternalLoadBalancerSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `l3.internal.EgressBytes`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `l3.internal.EgressBytes`
+      </td>
 
-        <td>
-          The number of bytes sent from Internal Load Balancing (ILB) backend to client (for TCP flows it only counts bytes on the application stream).
-        </td>
-      </tr>
+      <td>
+        The number of bytes sent from Internal Load Balancing (ILB) backend to client (for TCP flows it only counts bytes on the application stream).
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `l3.internal.EgressPackets`
-        </td>
+    <tr>
+      <td>
+        `l3.internal.EgressPackets`
+      </td>
 
-        <td>
-          The number of packets sent from ILB backend to client.
-        </td>
-      </tr>
+      <td>
+        The number of packets sent from ILB backend to client.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `l3.internal.IngressBytes`
-        </td>
+    <tr>
+      <td>
+        `l3.internal.IngressBytes`
+      </td>
 
-        <td>
-          The number of bytes sent from client to ILB backend (for TCP flows it only counts bytes on the application stream).
-        </td>
-      </tr>
+      <td>
+        The number of bytes sent from client to ILB backend (for TCP flows it only counts bytes on the application stream).
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `l3.internal.IngressPackets`
-        </td>
+    <tr>
+      <td>
+        `l3.internal.IngressPackets`
+      </td>
 
-        <td>
-          The number of packets sent from client to ILB backend.
-        </td>
-      </tr>
+      <td>
+        The number of packets sent from client to ILB backend.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `l3.internal.RttLatencies`
-        </td>
+    <tr>
+      <td>
+        `l3.internal.RttLatencies`
+      </td>
 
-        <td>
-          Mean of the RTT (in milliseconds) measured over TCP connections for ILB flows.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Mean of the RTT (in milliseconds) measured over TCP connections for ILB flows.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
@@ -39,442 +39,438 @@ To view [metric data](/docs/telemetry-data-platform/understand-data/new-relic-da
 
 Query `GcpPubSubTopicSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "400px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `topic.ByteCost`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `topic.ByteCost`
+      </td>
 
-        <td>
-          Cost of operations, measured in bytes. This is used to measure utilization for quotas.
-        </td>
-      </tr>
+      <td>
+        Cost of operations, measured in bytes. This is used to measure utilization for quotas.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.ConfigUpdates`
-        </td>
+    <tr>
+      <td>
+        `topic.ConfigUpdates`
+      </td>
 
-        <td>
-          Cumulative count of configuration changes, grouped by operation type and result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of configuration changes, grouped by operation type and result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.MessageSizes`
-        </td>
+    <tr>
+      <td>
+        `topic.MessageSizes`
+      </td>
 
-        <td>
-          Distribution of publish message sizes (in bytes).
-        </td>
-      </tr>
+      <td>
+        Distribution of publish message sizes (in bytes).
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.NumRetainedAckedMessagesByRegion`
-        </td>
+    <tr>
+      <td>
+        `topic.NumRetainedAckedMessagesByRegion`
+      </td>
 
-        <td>
-          Number of acknowledged messages retained in a topic, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Number of acknowledged messages retained in a topic, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.NumUnackedMessagesByRegion`
-        </td>
+    <tr>
+      <td>
+        `topic.NumUnackedMessagesByRegion`
+      </td>
 
-        <td>
-          Number of unacknowledged messages in a topic, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Number of unacknowledged messages in a topic, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.OldestRetainedAckedMessageAgeByRegion`
-        </td>
+    <tr>
+      <td>
+        `topic.OldestRetainedAckedMessageAgeByRegion`
+      </td>
 
-        <td>
-          Age (in seconds) of the oldest acknowledged message retained in a topic, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Age (in seconds) of the oldest acknowledged message retained in a topic, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.OldestUnackedMessageAgeByRegion`
-        </td>
+    <tr>
+      <td>
+        `topic.OldestUnackedMessageAgeByRegion`
+      </td>
 
-        <td>
-          Age (in seconds) of the oldest unacknowledged message in a topic, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Age (in seconds) of the oldest unacknowledged message in a topic, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.RetainedAckedBytesByRegion`
-        </td>
+    <tr>
+      <td>
+        `topic.RetainedAckedBytesByRegion`
+      </td>
 
-        <td>
-          Total byte size of the acknowledged messages retained in a topic, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Total byte size of the acknowledged messages retained in a topic, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.SendMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `topic.SendMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of publish message operations.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of publish message operations.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.SendRequest`
-        </td>
+    <tr>
+      <td>
+        `topic.SendRequest`
+      </td>
 
-        <td>
-          Cumulative count of publish requests.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of publish requests.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `topic.UnackedBytesByRegion`
-        </td>
+    <tr>
+      <td>
+        `topic.UnackedBytesByRegion`
+      </td>
 
-        <td>
-          Total byte size of the unacknowledged messages in a topic, broken down by Cloud region.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Total byte size of the unacknowledged messages in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### GcpPubSubSubscriptionSample [#gcp-app-engine-service-sample]
 
 Query `GcpPubSubSubscriptionSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "400px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `subscription.BacklogBytes`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `subscription.BacklogBytes`
+      </td>
 
-        <td>
-          Total byte size of the unacknowledged messages (a.k.a. backlog messages) in a subscription.
-        </td>
-      </tr>
+      <td>
+        Total byte size of the unacknowledged messages (a.k.a. backlog messages) in a subscription.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.ByteCost`
-        </td>
+    <tr>
+      <td>
+        `subscription.ByteCost`
+      </td>
 
-        <td>
-          Cumulative cost of operations, measured in bytes. This is used to measure quota utilization.
-        </td>
-      </tr>
+      <td>
+        Cumulative cost of operations, measured in bytes. This is used to measure quota utilization.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.ConfigUpdates`
-        </td>
+    <tr>
+      <td>
+        `subscription.ConfigUpdates`
+      </td>
 
-        <td>
-          Cumulative count of configuration changes for each subscription, grouped by operation type and result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of configuration changes for each subscription, grouped by operation type and result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.ModAckDeadlineMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `subscription.ModAckDeadlineMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of ModifyAckDeadline message operations, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of ModifyAckDeadline message operations, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.ModAckDeadlineRequest`
-        </td>
+    <tr>
+      <td>
+        `subscription.ModAckDeadlineRequest`
+      </td>
 
-        <td>
-          Cumulative count of ModifyAckDeadline requests, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of ModifyAckDeadline requests, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.NumOutstandingMessages`
-        </td>
+    <tr>
+      <td>
+        `subscription.NumOutstandingMessages`
+      </td>
 
-        <td>
-          Number of messages delivered to a subscription's push endpoint, but not yet acknowledged.
-        </td>
-      </tr>
+      <td>
+        Number of messages delivered to a subscription's push endpoint, but not yet acknowledged.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.NumRetainedAckedMessages`
-        </td>
+    <tr>
+      <td>
+        `subscription.NumRetainedAckedMessages`
+      </td>
 
-        <td>
-          Number of acknowledged messages retained in a subscription.
-        </td>
-      </tr>
+      <td>
+        Number of acknowledged messages retained in a subscription.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.NumRetainedAckedMessagesByRegion`
-        </td>
+    <tr>
+      <td>
+        `subscription.NumRetainedAckedMessagesByRegion`
+      </td>
 
-        <td>
-          Number of acknowledged messages retained in a subscription, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Number of acknowledged messages retained in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.NumUnackedMessagesByRegion`
-        </td>
+    <tr>
+      <td>
+        `subscription.NumUnackedMessagesByRegion`
+      </td>
 
-        <td>
-          Number of unacknowledged messages in a subscription, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Number of unacknowledged messages in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.NumUndeliveredMessages`
-        </td>
+    <tr>
+      <td>
+        `subscription.NumUndeliveredMessages`
+      </td>
 
-        <td>
-          Number of unacknowledged messages (a.k.a. backlog messages) in a subscription.
-        </td>
-      </tr>
+      <td>
+        Number of unacknowledged messages (a.k.a. backlog messages) in a subscription.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.OldestRetainedAckedMessageAge`
-        </td>
+    <tr>
+      <td>
+        `subscription.OldestRetainedAckedMessageAge`
+      </td>
 
-        <td>
-          Age (in seconds) of the oldest acknowledged message retained in a subscription.
-        </td>
-      </tr>
+      <td>
+        Age (in seconds) of the oldest acknowledged message retained in a subscription.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.OldestRetainedAckedMessageAgeByRegion`
-        </td>
+    <tr>
+      <td>
+        `subscription.OldestRetainedAckedMessageAgeByRegion`
+      </td>
 
-        <td>
-          Age (in seconds) of the oldest acknowledged message retained in a subscription, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Age (in seconds) of the oldest acknowledged message retained in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.OldestUnackedMessageAge`
-        </td>
+    <tr>
+      <td>
+        `subscription.OldestUnackedMessageAge`
+      </td>
 
-        <td>
-          Age (in seconds) of the oldest unacknowledged message (a.k.a. backlog message) in a subscription.
-        </td>
-      </tr>
+      <td>
+        Age (in seconds) of the oldest unacknowledged message (a.k.a. backlog message) in a subscription.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.OldestUnackedMessageAgeByRegion`
-        </td>
+    <tr>
+      <td>
+        `subscription.OldestUnackedMessageAgeByRegion`
+      </td>
 
-        <td>
-          Age (in seconds) of the oldest unacknowledged message in a subscription, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Age (in seconds) of the oldest unacknowledged message in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.PullAckMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `subscription.PullAckMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of acknowledge message operations, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of acknowledge message operations, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.PullAckRequest`
-        </td>
+    <tr>
+      <td>
+        `subscription.PullAckRequest`
+      </td>
 
-        <td>
-          Cumulative count of acknowledge requests, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of acknowledge requests, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.PullMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `subscription.PullMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of pull message operations, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of pull message operations, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.PullRequest`
-        </td>
+    <tr>
+      <td>
+        `subscription.PullRequest`
+      </td>
 
-        <td>
-          Cumulative count of pull requests, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of pull requests, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.PushRequest`
-        </td>
+    <tr>
+      <td>
+        `subscription.PushRequest`
+      </td>
 
-        <td>
-          Cumulative count of push attempts, grouped by result. Unlike pulls, the push server implementation does not batch user messages, so each request only contains one user message. The push server retries on errors, so a given user message can appear multiple times.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of push attempts, grouped by result. Unlike pulls, the push server implementation does not batch user messages, so each request only contains one user message. The push server retries on errors, so a given user message can appear multiple times.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.PushRequestLatencies`
-        </td>
+    <tr>
+      <td>
+        `subscription.PushRequestLatencies`
+      </td>
 
-        <td>
-          Distribution of push request latencies (in microseconds), grouped by result.
-        </td>
-      </tr>
+      <td>
+        Distribution of push request latencies (in microseconds), grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.RetainedAckedBytes`
-        </td>
+    <tr>
+      <td>
+        `subscription.RetainedAckedBytes`
+      </td>
 
-        <td>
-          Total byte size of the acknowledged messages retained in a subscription.
-        </td>
-      </tr>
+      <td>
+        Total byte size of the acknowledged messages retained in a subscription.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.RetainedAckedBytesByRegion`
-        </td>
+    <tr>
+      <td>
+        `subscription.RetainedAckedBytesByRegion`
+      </td>
 
-        <td>
-          Total byte size of the acknowledged messages retained in a subscription, broken down by Cloud region.
-        </td>
-      </tr>
+      <td>
+        Total byte size of the acknowledged messages retained in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.StreamingPullAckMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `subscription.StreamingPullAckMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of StreamingPull acknowledge message operations, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of StreamingPull acknowledge message operations, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.StreamingPullAckRequest`
-        </td>
+    <tr>
+      <td>
+        `subscription.StreamingPullAckRequest`
+      </td>
 
-        <td>
-          Cumulative count of streaming pull requests with non-empty acknowledge ids, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of streaming pull requests with non-empty acknowledge ids, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.StreamingPullMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `subscription.StreamingPullMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of streaming pull message operations, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of streaming pull message operations, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.StreamingPullModAckDeadlineMessageOperation`
-        </td>
+    <tr>
+      <td>
+        `subscription.StreamingPullModAckDeadlineMessageOperation`
+      </td>
 
-        <td>
-          Cumulative count of StreamingPull ModifyAckDeadline operations, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of StreamingPull ModifyAckDeadline operations, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.StreamingPullModAckDeadlineRequest`
-        </td>
+    <tr>
+      <td>
+        `subscription.StreamingPullModAckDeadlineRequest`
+      </td>
 
-        <td>
-          Cumulative count of streaming pull requests with non-empty ModifyAckDeadline fields, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of streaming pull requests with non-empty ModifyAckDeadline fields, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.StreamingPullResponse`
-        </td>
+    <tr>
+      <td>
+        `subscription.StreamingPullResponse`
+      </td>
 
-        <td>
-          Cumulative count of streaming pull responses, grouped by result.
-        </td>
-      </tr>
+      <td>
+        Cumulative count of streaming pull responses, grouped by result.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `subscription.UnackedBytesByRegion`
-        </td>
+    <tr>
+      <td>
+        `subscription.UnackedBytesByRegion`
+      </td>
 
-        <td>
-          Total byte size of the unacknowledged messages in a subscription, broken down by Cloud region.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Total byte size of the unacknowledged messages in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration.mdx
@@ -37,142 +37,138 @@ To view [metric data](/docs/integrations/new-relic-integrations/getting-started/
 
 Query `GcpSpannerInstanceSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `instance.cpu.Utilization`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `instance.cpu.Utilization`
+      </td>
 
-        <td>
-          Utilization of the provisioned CPU, between 0 and 1.
-        </td>
-      </tr>
+      <td>
+        Utilization of the provisioned CPU, between 0 and 1.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `instance.cpu.utilization_by_priority`
-        </td>
+    <tr>
+      <td>
+        `instance.cpu.utilization_by_priority`
+      </td>
 
-        <td>
-          Utilization of the provisioned CPU by priority, between 0 and 1.
-        </td>
-      </tr>
+      <td>
+        Utilization of the provisioned CPU by priority, between 0 and 1.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `instance.cpu.smoothed_utilization`
-        </td>
+    <tr>
+      <td>
+        `instance.cpu.smoothed_utilization`
+      </td>
 
-        <td>
-          24-hour smoothed utilization of the provisioned CPU , between 0 and 1.
-        </td>
-      </tr>
+      <td>
+        24-hour smoothed utilization of the provisioned CPU , between 0 and 1.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `instance.nodes`
-        </td>
+    <tr>
+      <td>
+        `instance.nodes`
+      </td>
 
-        <td>
-          Total number of nodes.
-        </td>
-      </tr>
+      <td>
+        Total number of nodes.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `instance.sessions`
-        </td>
+    <tr>
+      <td>
+        `instance.sessions`
+      </td>
 
-        <td>
-          Number of sessions in use.
-        </td>
-      </tr>
+      <td>
+        Number of sessions in use.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `instance.storage.UsedBytes`
-        </td>
+    <tr>
+      <td>
+        `instance.storage.UsedBytes`
+      </td>
 
-        <td>
-          Storage used in bytes.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Storage used in bytes.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### GcpSpannerDatabaseSample [#gcp-spanner-database-sample]
 
 Query `GcpSpannerDatabaseSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
 
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <tr>
-        <td>
-          `api.ReceivedBytes`
-        </td>
+  <tbody>
+    <tr>
+      <td>
+        `api.ReceivedBytes`
+      </td>
 
-        <td>
-          Uncompressed request bytes received by Cloud Spanner.
-        </td>
-      </tr>
+      <td>
+        Uncompressed request bytes received by Cloud Spanner.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `api.Requests`
-        </td>
+    <tr>
+      <td>
+        `api.Requests`
+      </td>
 
-        <td>
-          Rate of Cloud Spanner API requests.
-        </td>
-      </tr>
+      <td>
+        Rate of Cloud Spanner API requests.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `api.RequestLatencies`
-        </td>
+    <tr>
+      <td>
+        `api.RequestLatencies`
+      </td>
 
-        <td>
-          Distribution of server request latencies for a database. This includes latency of request processing in Cloud Spanner backends and API layer. It does not include network or reverse-proxy overhead between clients and servers.
-        </td>
-      </tr>
+      <td>
+        Distribution of server request latencies for a database. This includes latency of request processing in Cloud Spanner backends and API layer. It does not include network or reverse-proxy overhead between clients and servers.
+      </td>
+    </tr>
 
-      <tr>
-        <td>
-          `api.SentBytes`
-        </td>
+    <tr>
+      <td>
+        `api.SentBytes`
+      </td>
 
-        <td>
-          Uncompressed response bytes sent by Cloud Spanner.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+      <td>
+        Uncompressed response bytes sent by Cloud Spanner.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-sql-monitoring-integration.mdx
@@ -38,386 +38,384 @@ To view [metric data](/docs/telemetry-data-platform/understand-data/new-relic-da
 
 Query `GcpCloudSqlSample` events in New Relic to view data for the following attributes:
 
-<dd>
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "300px" }}>
-          Attribute
-        </th>
-
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
-
-    <tbody>
-      <tr>
-        <td>
-          `database.AutoFailoverRequestCount`
-        </td>
-
-        <td>
-          Delta of number of instance auto-failover requests.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.AvailableForFailover`
-        </td>
-
-        <td>
-          This is over `0` if the failover operation is available on the instance.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.cpu.ReservedCores`
-        </td>
-
-        <td>
-          Number of cores reserved for the database.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.cpu.UsageTime`
-        </td>
-
-        <td>
-          Cumulative CPU usage time in seconds.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.cpu.Utilization`
-        </td>
-
-        <td>
-          The fraction of the reserved CPU that is currently in use.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.disk.BytesUsed`
-        </td>
-
-        <td>
-          Data utilization in bytes.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.disk.Quota`
-        </td>
-
-        <td>
-          Maximum data disk size in bytes.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.disk.ReadOps`
-        </td>
-
-        <td>
-          Delta count of data disk read IO operations.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.disk.Utilization`
-        </td>
-
-        <td>
-          The fraction of the disk quota that is currently in use.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.disk.WriteOps`
-        </td>
-
-        <td>
-          Delta count of disk write IO operations.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.memory.Quota`
-        </td>
-
-        <td>
-          Maximum RAM size in bytes.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.memory.Usage`
-        </td>
-
-        <td>
-          RAM usage in bytes.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.memory.Utilization`
-        </td>
-
-        <td>
-          The fraction of the memory quota that is currently in use.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbBufferPoolPagesDirty`
-        </td>
-
-        <td>
-          The fraction of the memory quota that is currently in use.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbBufferPoolPagesFree`
-        </td>
-
-        <td>
-          Number of unused pages in the InnoDB buffer pool.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbBufferPoolPagesTotal`
-        </td>
-
-        <td>
-          Total number of pages in the InnoDB buffer pool.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbDataFsyncs`
-        </td>
-
-        <td>
-          Delta count of InnoDB fsync() calls.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbOsLogFsyncs`
-        </td>
-
-        <td>
-          Delta count of InnoDB fsync() calls to the log file.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbPagesRead`
-        </td>
-
-        <td>
-          Delta count of InnoDB pages read.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.InnodbPagesWritten`
-        </td>
-
-        <td>
-          Delta count of InnoDB pages written.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.Queries`
-        </td>
-
-        <td>
-          Delta count of statements executed by the server.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.Questions`
-        </td>
-
-        <td>
-          Delta count of statements executed by the server sent by the client.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.ReceivedBytesCount`
-        </td>
-
-        <td>
-          Delta count of bytes received by MySQL process.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.replication.SecondsBehindMaster`
-        </td>
-
-        <td>
-          Number of seconds the read replica is behind its master (approximation).
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.replication.SlaveIoRunning`
-        </td>
-
-        <td>
-          Indicates whether the I/O thread for reading the master's binary log is running. Possible values are `Yes`, `No`, and `Connecting`.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.replication.SlaveSqlRunning`
-        </td>
-
-        <td>
-          Indicates whether the I/O thread for reading the master's binary log is running. Possible values are `Yes`, `No`, and `Connecting`.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.mysql.SentBytesCount`
-        </td>
-
-        <td>
-          Indicates whether the I/O thread for reading the master's binary log is running. Possible values are `Yes`, `No`, and `Connecting`.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.network.Connections`
-        </td>
-
-        <td>
-          Number of connections to the Cloud SQL MySQL instance.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.network.ReceivedBytesCount`
-        </td>
-
-        <td>
-          Delta count of bytes received through the network.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.network.SentBytesCount`
-        </td>
-
-        <td>
-          Delta count of bytes sent through the network.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.postgresql.NumBackends`
-        </td>
-
-        <td>
-          Number of connections to the Cloud SQL PostgreSQL instance.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.postgresql.replication.ReplicaByteLag`
-        </td>
-
-        <td>
-          Replication lag in bytes. Reported from the master per replica.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.postgresql.TransactionCount`
-        </td>
-
-        <td>
-          Delta count of number of transactions.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.State`
-        </td>
-
-        <td>
-          The current serving state of the Cloud SQL instance. This can be one of the following:
-
-          * `RUNNABLE`: The instance is running, or is ready to run when accessed.
-          * `SUSPENDED`: The instance is not available, for example due to problems with billing.
-          * `PENDING_CREATE`: The instance is being created.
-          * `MAINTENANCE`: The instance is down for maintenance.
-          * `UNKNOWN_STATE`: The state of the instance is unknown.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.Up`
-        </td>
-
-        <td>
-          Indicates if the server is up or not. On-demand instances are spun down if no connections are made for a sufficient amount of time.
-        </td>
-      </tr>
-
-      <tr>
-        <td>
-          `database.Uptime`
-        </td>
-
-        <td>
-          Delta count of the time in seconds the instance has been running.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</dd>
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "300px" }}>
+        Attribute
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `database.AutoFailoverRequestCount`
+      </td>
+
+      <td>
+        Delta of number of instance auto-failover requests.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.AvailableForFailover`
+      </td>
+
+      <td>
+        This is over `0` if the failover operation is available on the instance.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.cpu.ReservedCores`
+      </td>
+
+      <td>
+        Number of cores reserved for the database.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.cpu.UsageTime`
+      </td>
+
+      <td>
+        Cumulative CPU usage time in seconds.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.cpu.Utilization`
+      </td>
+
+      <td>
+        The fraction of the reserved CPU that is currently in use.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.disk.BytesUsed`
+      </td>
+
+      <td>
+        Data utilization in bytes.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.disk.Quota`
+      </td>
+
+      <td>
+        Maximum data disk size in bytes.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.disk.ReadOps`
+      </td>
+
+      <td>
+        Delta count of data disk read IO operations.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.disk.Utilization`
+      </td>
+
+      <td>
+        The fraction of the disk quota that is currently in use.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.disk.WriteOps`
+      </td>
+
+      <td>
+        Delta count of disk write IO operations.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.memory.Quota`
+      </td>
+
+      <td>
+        Maximum RAM size in bytes.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.memory.Usage`
+      </td>
+
+      <td>
+        RAM usage in bytes.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.memory.Utilization`
+      </td>
+
+      <td>
+        The fraction of the memory quota that is currently in use.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbBufferPoolPagesDirty`
+      </td>
+
+      <td>
+        The fraction of the memory quota that is currently in use.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbBufferPoolPagesFree`
+      </td>
+
+      <td>
+        Number of unused pages in the InnoDB buffer pool.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbBufferPoolPagesTotal`
+      </td>
+
+      <td>
+        Total number of pages in the InnoDB buffer pool.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbDataFsyncs`
+      </td>
+
+      <td>
+        Delta count of InnoDB fsync() calls.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbOsLogFsyncs`
+      </td>
+
+      <td>
+        Delta count of InnoDB fsync() calls to the log file.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbPagesRead`
+      </td>
+
+      <td>
+        Delta count of InnoDB pages read.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.InnodbPagesWritten`
+      </td>
+
+      <td>
+        Delta count of InnoDB pages written.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.Queries`
+      </td>
+
+      <td>
+        Delta count of statements executed by the server.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.Questions`
+      </td>
+
+      <td>
+        Delta count of statements executed by the server sent by the client.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.ReceivedBytesCount`
+      </td>
+
+      <td>
+        Delta count of bytes received by MySQL process.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.replication.SecondsBehindMaster`
+      </td>
+
+      <td>
+        Number of seconds the read replica is behind its master (approximation).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.replication.SlaveIoRunning`
+      </td>
+
+      <td>
+        Indicates whether the I/O thread for reading the master's binary log is running. Possible values are `Yes`, `No`, and `Connecting`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.replication.SlaveSqlRunning`
+      </td>
+
+      <td>
+        Indicates whether the I/O thread for reading the master's binary log is running. Possible values are `Yes`, `No`, and `Connecting`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.mysql.SentBytesCount`
+      </td>
+
+      <td>
+        Indicates whether the I/O thread for reading the master's binary log is running. Possible values are `Yes`, `No`, and `Connecting`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.network.Connections`
+      </td>
+
+      <td>
+        Number of connections to the Cloud SQL MySQL instance.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.network.ReceivedBytesCount`
+      </td>
+
+      <td>
+        Delta count of bytes received through the network.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.network.SentBytesCount`
+      </td>
+
+      <td>
+        Delta count of bytes sent through the network.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.postgresql.NumBackends`
+      </td>
+
+      <td>
+        Number of connections to the Cloud SQL PostgreSQL instance.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.postgresql.replication.ReplicaByteLag`
+      </td>
+
+      <td>
+        Replication lag in bytes. Reported from the master per replica.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.postgresql.TransactionCount`
+      </td>
+
+      <td>
+        Delta count of number of transactions.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.State`
+      </td>
+
+      <td>
+        The current serving state of the Cloud SQL instance. This can be one of the following:
+
+        * `RUNNABLE`: The instance is running, or is ready to run when accessed.
+        * `SUSPENDED`: The instance is not available, for example due to problems with billing.
+        * `PENDING_CREATE`: The instance is being created.
+        * `MAINTENANCE`: The instance is down for maintenance.
+        * `UNKNOWN_STATE`: The state of the instance is unknown.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.Up`
+      </td>
+
+      <td>
+        Indicates if the server is up or not. On-demand instances are spun down if no connections are made for a sufficient amount of time.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database.Uptime`
+      </td>
+
+      <td>
+        Delta count of the time in seconds the instance has been running.
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/mobile-crash-rest-api-v1.mdx
+++ b/src/content/docs/mobile-crash-rest-api-v1.mdx
@@ -1069,11 +1069,9 @@ https://rpm.newrelic.com/accounts/{account_ID}/mobile/{mobile_application_ID}
   </Collapser>
 </CollapserGroup>
 
-<dd>
-  ## GET thread-data/:crash_fingerprint [#get-thread-data-fingerprints]
+## GET thread-data/:crash_fingerprint [#get-thread-data-fingerprints]
 
-  **Purpose:** Returns symbolicated (iOS) or deobfuscated (Android) thread data for a given crash fingerprint.
-</dd>
+**Purpose:** Returns symbolicated (iOS) or deobfuscated (Android) thread data for a given crash fingerprint.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/style-guide/formatting/ui-paths.mdx
+++ b/src/content/docs/style-guide/formatting/ui-paths.mdx
@@ -67,12 +67,9 @@ Our goal for UI paths is to make them easy to understand and follow, preferably 
 
         Here's one that links to an earlier section:
 
-        <dd>
-          To find details about the entity associated with a span:
-
-          1. From a span’s [details pane](http://details-pane-empty-link) \[link to doc section above], select **Attributes**.
-          2. Look for entity-related attributes, like _entityId_ and _entity.name_.
-        </dd>
+        ...
+            1. From a span’s [details pane](http://details-pane-empty-link) \[link to doc section above], select **Attributes**.
+            2. Look for entity-related attributes, like _entityId_ and _entity.name_.
       </td>
     </tr>
 


### PR DESCRIPTION
We have a number of docs that have `<dd>` tags to indent content. This isn't the convention we're following on the site, and we can't guarantee how the translation engine will handle these (per development). So, I'm removing these.

This is for NR-220635.