### PR TITLE
fix: update typo on snmpv3 setting

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1156,7 +1156,7 @@ global:
           </td>
 
           <td>
-            SNMPv3 privacy protocol. The possible values are `AuthNoPriv`, `DES`, `AES`, `AES192`, `AES256`, `AES192C`, or `AES256C`
+            SNMPv3 privacy protocol. The possible values are `NoPriv`, `DES`, `AES`, `AES192`, `AES256`, `AES192C`, or `AES256C`
           </td>
         </tr>
 


### PR DESCRIPTION
updating a setting option in the snmpv3 config for netmon