### PR TITLE
chore: update docs on using cloud secrets

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1081,7 +1081,7 @@ global:
   </Collapser>
 </CollapserGroup>
 
-## Cloud Provider Secrets [#cloud-provider-secrets]
+## Cloud provider secrets [#cloud-provider-secrets]
 
 The network monitoring agent has built-in support for retrieving keys from [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/), [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/), and [GCP Secret Manager](https://cloud.google.com/secret-manager/docs).
 
@@ -1100,7 +1100,7 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
     <TabsPages>
       <TabsPageItem id="aws-secrets-manager">
 
-      To use AWS Secrets Manager, you will need to set the following 3 [environmental variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list) and provide them to Docker at runtime:
+      To use AWS Secrets Manager, you will need to set the following three [environmental variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list) and provide them to Docker at runtime:
 
       <table>
         <thead>
@@ -1162,7 +1162,7 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
       </TabsPageItem>
       <TabsPageItem id="azure-key-vault">
 
-      To use Azure Key Vault, you will need to set the following 5 environmental variables and provide them to Docker at runtime:
+      To use Azure Key Vault, you will need to set the following five environmental variables and provide them to Docker at runtime:
 
       <Callout variant="tip">
         You need to set `KT_AZURE_KEY_VAULT_NAME` or `KT_AZURE_KEY_VAULT_URL`, not both. The default is to use `KT_AZURE_KEY_VAULT_NAME` and the agent will use a common URL pattern: `https://$KT_AZURE_KEY_VAULT_NAME.vault.azure.net/`
@@ -1255,7 +1255,7 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
       </TabsPageItem>
       <TabsPageItem id="gcp-secret-manager">
 
-      To use GCP Secret Manager, you will need to set the following volume mount for a credential JSON file along with 2 environmental variables and provide them to Docker at runtime:
+      To use GCP Secret Manager, you will need to set the following volume mount for a credential JSON file along with two environmental variables and provide them to Docker at runtime:
 
       <table>
         <thead>

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -1081,6 +1081,244 @@ global:
   </Collapser>
 </CollapserGroup>
 
+## Cloud Provider Secrets [#cloud-provider-secrets]
+
+The network monitoring agent has built-in support for retrieving keys from [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/), [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/), and [GCP Secret Manager](https://cloud.google.com/secret-manager/docs).
+
+<Collapser
+  id="cloud-secrets"
+  title="Cloud secrets configuration"
+>
+
+  <Tabs>
+    <TabsBar>
+      <TabsBarItem id="aws-secrets-manager">AWS Secrets Manager</TabsBarItem>
+      <TabsBarItem id="azure-key-vault">Azure Key Vault</TabsBarItem>
+      <TabsBarItem id="gcp-secret-manager">GCP Secret Manager</TabsBarItem>
+    </TabsBar>
+
+    <TabsPages>
+      <TabsPageItem id="aws-secrets-manager">
+
+      To use AWS Secrets Manager, you will need to set the following 3 [environmental variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list) and provide them to Docker at runtime:
+
+      <table>
+        <thead>
+          <tr>
+            <th style={{ width: "200px" }}>
+              Name
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              `AWS_ACCESS_KEY_ID`
+            </td>
+            <td>
+              Specifies the AWS access key used as part of the credentials to authenticate the user.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              `AWS_SECRET_ACCESS_KEY`
+            </td>
+            <td>
+              Specifies the AWS secret key used as part of the credentials to authenticate the user.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              `AWS_REGION`
+            </td>
+            <td>
+              Specifies the AWS Region to send requests to.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      ```
+      docker run -d --name ktranslate-$CONTAINER_SERVICE --restart unless-stopped --pull=always -p 162:1620/udp \
+      -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
+      -e NEW_RELIC_API_KEY=$YOUR_NR_LICENSE_KEY \
+      -e AWS_ACCESS_KEY_ID=$YOUR_AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY=$YOUR_AWS_SECRET_ACCESS_KEY \
+      -e AWS_REGION=$YOUR_AWS_REGION \
+      kentik/ktranslate:v2 \
+        -snmp /snmp-base.yaml \
+        -nr_account_id=$YOUR_NR_ACCOUNT_ID \
+        -metrics=jchf \
+        -tee_logs=true \
+        -service_name=$CONTAINER_SERVICE \
+        -snmp_discovery_on_start=true \
+        -snmp_discovery_min=180 \
+        nr1.snmp
+      ```
+
+      </TabsPageItem>
+      <TabsPageItem id="azure-key-vault">
+
+      To use Azure Key Vault, you will need to set the following 5 environmental variables and provide them to Docker at runtime:
+
+      <Callout variant="tip">
+        You need to set `KT_AZURE_KEY_VAULT_NAME` or `KT_AZURE_KEY_VAULT_URL`, not both. The default is to use `KT_AZURE_KEY_VAULT_NAME` and the agent will use a common URL pattern: `https://$KT_AZURE_KEY_VAULT_NAME.vault.azure.net/`
+      </Callout>
+
+      <table>
+        <thead>
+          <tr>
+            <th style={{ width: "200px" }}>
+              Name
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              `KT_AZURE_KEY_VAULT_NAME`
+            </td>
+            <td>
+              The vault name where the secret is stored. 
+            </td>
+          </tr>
+          <tr>
+            <td>
+              `KT_AZURE_KEY_VAULT_URL`
+            </td>
+            <td>
+              Optional full URL for the API call to target.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [AZURE_CLIENT_ID](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#sign-in-to-the-application)
+            </td>
+            <td>
+              Sometimes called the `Application ID`, this is the identifier for your service principal used to access the secret.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [AZURE_CLIENT_SECRET](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal#option-3-create-a-new-client-secret)
+            </td>
+            <td>
+              This is the client secret (password) that is used for the service principal during authentication. Note this ID is for the client secret's **value**, not the ID of the secret itself.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [AZURE_SUBSCRIPTION_ID](https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id#find-your-azure-subscription)
+            </td>
+            <td>
+              This is the 32-digit GUID associated with the subscription where your secret is managed.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [AZURE_TENANT_ID](https://learn.microsoft.com/en-us/azure/azure-portal/get-subscription-tenant-id#find-your-microsoft-entra-tenant)
+            </td>
+            <td>
+              Sometimes called the `Directory ID`, this is the identifier for the tenant in Microsoft Entra where your service principle is stored.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      ```
+      docker run -d --name ktranslate-$CONTAINER_SERVICE --restart unless-stopped --pull=always -p 162:1620/udp \
+      -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
+      -e KT_AZURE_KEY_VAULT_NAME=$YOUR_KEY_VAULT_NAME \
+      #### Optional: Provide the full URL to target
+      # -e KT_AZURE_KEY_VAULT_URL=$YOUR_KEY_VAULT_URL \
+      -e AZURE_CLIENT_ID=$YOUR_CLIENT_ID \
+      -e AZURE_CLIENT_SECRET=$YOUR_CLIENT_SECRET \
+      -e AZURE_TENANT_ID=$YOUR_TENANT_ID \
+      -e AZURE_SUBSCRIPTION_ID=$YOUR_SUBSCRIPTION_ID \
+      kentik/ktranslate:v2 \
+        -snmp /snmp-base.yaml \
+        -nr_account_id=$YOUR_NR_ACCOUNT_ID \
+        -metrics=jchf \
+        -tee_logs=true \
+        -service_name=$CONTAINER_SERVICE \
+        -snmp_discovery_on_start=true \
+        -snmp_discovery_min=180 \
+        nr1.snmp
+      ```
+
+      </TabsPageItem>
+      <TabsPageItem id="gcp-secret-manager">
+
+      To use GCP Secret Manager, you will need to set the following volume mount for a credential JSON file along with 2 environmental variables and provide them to Docker at runtime:
+
+      <table>
+        <thead>
+          <tr>
+            <th style={{ width: "200px" }}>
+              Name
+            </th>
+            <th>
+              Description
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              [Service account key](https://cloud.google.com/iam/docs/keys-create-delete#creating)
+            </td>
+            <td>
+              Specifies the local file path for the service account key used to authenticate the user. This file is volume mounted into the Docker container and then referenced in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [GOOGLE_APPLICATION_CREDENTIALS](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key)
+            </td>
+            <td>
+              Specifies the file path in the container where you've mapped your service account key file.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [GOOGLE_CLOUD_PROJECT](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects)
+            </td>
+            <td>
+              Specifies the unique project ID where the secret is stored.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      ```
+      docker run -d --name ktranslate-$CONTAINER_SERVICE --restart unless-stopped --pull=always -p 162:1620/udp \
+      -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
+      -v $YOUR_LOCAL_SERVICE_ACCOUNT_KEY_FILE_PATH:/gcp_snmp_sa_key.json \
+      -e GOOGLE_APPLICATION_CREDENTIALS='./gcp_snmp_sa_key.json' \
+      -e GOOGLE_CLOUD_PROJECT=$YOUR_PROJECT_ID \
+      kentik/ktranslate:v2 \
+        -snmp /snmp-base.yaml \
+        -nr_account_id=$YOUR_NR_ACCOUNT_ID \
+        -metrics=jchf \
+        -tee_logs=true \
+        -service_name=$CONTAINER_SERVICE \
+        -snmp_discovery_on_start=true \
+        -snmp_discovery_min=180 \
+        nr1.snmp
+      ```
+
+      </TabsPageItem>
+    </TabsPages>
+  </Tabs>
+
+</Collapser>
+
 ## SNMPv3 options [#snmpv3-options]
 
 <CollapserGroup>
@@ -1198,43 +1436,93 @@ global:
       </tbody>
     </table>
 
-    Example:
+    ### Examples:
 
-    ```yaml
-    discovery:
-      default_v3:
-        user_name: test1
-        authentication_protocol: MD5
-        authentication_passphrase: authPass1
-        privacy_protocol: AES256
-        privacy_passphrase: privacyPass1
-        context_engine_id: ""
-        context_name: ""
-    ```
-  </Collapser>
+    <Callout variant="tip">
+      Using secrets from AWS, Azure, of GCP will also require that you [provide the proper environment variables](/docs/network-performance-monitoring/advanced/advanced-config/#cloud-secrets) and any other authentication information needed for the agent to query the target API.
+    </Callout>
 
-  <Collapser
-    id="snmpv3-aws-secrets"
-    title="SNMPv3 - AWS Secrets"
-  >
+    <Tabs>
+      <TabsBar>
+        <TabsBarItem id="v3-plain-text">Plain Text</TabsBarItem>
+        <TabsBarItem id="v3-aws-secret">AWS Secret</TabsBarItem>
+        <TabsBarItem id="v3-azure-secret">Azure Secret</TabsBarItem>
+        <TabsBarItem id="v3-gcp-secret">GCP Secret</TabsBarItem>
+      </TabsBar>
 
-    To use [AWS Secrets](/docs/network-performance-monitoring/advanced/advanced-config/#aws-secrets) to pass your credentials; you would update your SNMPv3 config snippet as follows, prefixing the `$SECRET_NAME` with `aws.sm.`:
+      <TabsPages>
+        <TabsPageItem id="v3-plain-text">
 
-    ```yaml
-      default_v3: aws.sm.$SECRET_NAME
-    ```
+          ```yaml
+          discovery:
+            default_v3:
+              user_name: $YOUR_SNMPV3_USER
+              authentication_protocol: $YOUR_AUTHENTICATION_PROTOCOL
+              authentication_passphrase: $YOUR_AUTHENTICATION_PASSPHRASE
+              privacy_protocol: $YOUR_PRIVACY_PROTOCOL
+              privacy_passphrase: $YOUR_PRIVACY_PASSPHRASE
+          ```
 
-    In AWS, you need to store your secrets in JSON format with all the relevant `key:value` pairs. This is an example:
+        </TabsPageItem>
+        <TabsPageItem id="v3-aws-secret">
 
-    ```json
-    {
-    "user_name": "$YOUR_USER_NAME",
-    "authentication_protocol": "$YOUR_AUTHENTICATION_PROTOCOL",
-    "authentication_passphrase": "$YOUR_AUTHENTICATION_PASSPHRASE",
-    "privacy_protocol": "$YOUR_PRIVACY_PROTOCOL",
-    "privacy_passphrase": "$YOUR_PRIVACY_PASSPHRASE"
-    }
-    ```
+          ```yaml
+          discovery:
+            default_v3: aws.sm.$YOUR_SECRET_NAME
+          ```
+
+          In AWS, you need to [store your secrets in a JSON structure](https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_secret_json_structure.html) with all the relevant `key:value` pairs. This is an example:
+          
+          ```json
+          {
+          "user_name": "$YOUR_SNMPV3_USER",
+          "authentication_protocol": "$YOUR_AUTHENTICATION_PROTOCOL",
+          "authentication_passphrase": "$YOUR_AUTHENTICATION_PASSPHRASE",
+          "privacy_protocol": "$YOUR_PRIVACY_PROTOCOL",
+          "privacy_passphrase": "$YOUR_PRIVACY_PASSPHRASE"
+          }
+          ```
+
+        </TabsPageItem>
+        <TabsPageItem id="v3-azure-secret">
+
+          ```yaml
+          discovery:
+            default_v3: azure.kv.$YOUR_SECRET_NAME
+          ```
+
+          In Azure, you need to [store your secrets in a multi-line structure](https://learn.microsoft.com/en-us/azure/key-vault/secrets/multiline-secrets) with all the relevant `key:value` pairs. This is an example:
+
+          ```
+          user_name: $YOUR_SNMPV3_USER
+          authentication_protocol: $YOUR_AUTHENTICATION_PROTOCOL
+          authentication_passphrase: $YOUR_AUTHENTICATION_PASSPHRASE
+          privacy_protocol: $YOUR_PRIVACY_PROTOCOL
+          privacy_passphrase: $YOUR_PRIVACY_PASSPHRASE
+          ```
+
+        </TabsPageItem>
+        <TabsPageItem id="v3-gcp-secret">
+
+          ```yaml
+          discovery:
+            default_v3: gcp.sm.$YOUR_SECRET_NAME
+          ```
+
+          In GCP, you need to [store your secrets in a multi-line structure](https://cloud.google.com/secret-manager/docs/create-secret-quickstart) with all the relevant `key:value` pairs. This is an example:
+
+          ```
+          user_name: $YOUR_SNMPV3_USER
+          authentication_protocol: $YOUR_AUTHENTICATION_PROTOCOL
+          authentication_passphrase: $YOUR_AUTHENTICATION_PASSPHRASE
+          privacy_protocol: $YOUR_PRIVACY_PROTOCOL
+          privacy_passphrase: $YOUR_PRIVACY_PASSPHRASE
+          ```
+
+        </TabsPageItem>
+      </TabsPages>
+    </Tabs>
+
   </Collapser>
 
   <Collapser
@@ -1262,13 +1550,22 @@ global:
         context_engine_id: ""
         context_name: ""
     ```
+
+    This can also work using a cloud provider secrets manager. An example for AWS:
+
+    ```yaml
+    discovery:
+      other_v3s:
+      - aws.sm.$YOUR_SECRET_NAME_1
+      - aws.sm.$YOUR_SECRET_NAME_2
+    ```
   </Collapser>
 </CollapserGroup>
 
 ## API polling configurations [#api-polling-configurations]
 
 <Callout variant="tip">
-  You can use [AWS Secrets Manager](/docs/network-performance-monitoring/advanced/advanced-config/#aws-secrets) natively in your API config using the `aws.sm.$SECRET_NAME` syntax, replacing `$SECRET_NAME` as necessary to have `ktranslate` pull in your credentials during Docker runtime.
+  You can also use cloud provider secrets in your API authentication configuration.
 </Callout>
 
 <CollapserGroup>
@@ -1741,78 +2038,6 @@ global:
 
   </Collapser>
 </CollapserGroup>
-
-## AWS Secrets [#aws-secrets]
-
-`ktranslate` has built-in support for retrieving keys from [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
-
-<Collapser
-  id="aws-secrets-configuration"
-  title="AWS Secrets Configuration"
->
-
-  To use this feature, you will need to set the following 3 environmental variables and provide them to Docker at runtime:
-
-  <table>
-    <thead>
-      <tr>
-        <th style={{ width: "200px" }}>
-          Name
-        </th>
-        <th>
-          Description
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          [AWS_ACCESS_KEY_ID](https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-aws_access_key_id.html)
-        </td>
-        <td>
-          Specifies the AWS access key used as part of the credentials to authenticate the user.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          [AWS_SECRET_ACCESS_KEY](https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-aws_secret_access_key.html)
-        </td>
-        <td>
-          Specifies the AWS secret key used as part of the credentials to authenticate the user.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          [AWS_REGION](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-the-region)
-        </td>
-        <td>
-          Specifies the AWS Region to send requests to for commands requested using this profile.
-        </td>
-      </tr>
-    </tbody>
-  </table>
-
-  Example for Docker runtime:
-
-  ```shell
-  docker run -d --name ktranslate-$UNIQUE_NAME --restart unless-stopped --pull=always -p 162:1620/udp \
-    -v `pwd`/snmp-base.yaml:/snmp-base.yaml \
-    -e NEW_RELIC_API_KEY=$YOUR_NR_LICENSE_KEY \
-    -e AWS_ACCESS_KEY_ID=$YOUR_AWS_ACCESS_KEY_ID \
-    -e AWS_SECRET_ACCESS_KEY=$YOUR_AWS_SECRET_ACCESS_KEY \
-    -e AWS_REGION=$YOUR_AWS_REGION \
-    kentik/ktranslate:v2 \
-      -snmp /snmp-base.yaml \
-      -nr_account_id=$YOUR_NR_ACCOUNT_ID \
-      -log_level=info \
-      -metrics=jchf \
-      -tee_logs=true \
-      -service_name=$UNIQUE_NAME \
-      -snmp_discovery_on_start=true \
-      -snmp_discovery_min=180 \
-      nr1.snmp
-  ```
-</Collapser>
 
 ## External config files [#external-config-files]
 

--- a/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-management.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-management.mdx
@@ -79,15 +79,15 @@ Below are the various options available during Docker runtime for the **ktransla
 <table>
   <thead>
     <tr>
-      <th style={{ width: "200px" }}>
+      <th style={{ width: "300px" }}>
         Option name
       </th>
 
-      <th>
+      <th style={{ width: "50px" }}>
         Type
       </th>
 
-      <th>
+      <th style={{ width: "50px" }}>
         Required
       </th>
 
@@ -481,54 +481,6 @@ Below are the various options available during Docker runtime for the **ktransla
 
     <tr>
       <td>
-        `AWS_ACCESS_KEY_ID`
-      </td>
-
-      <td>
-        Environment Variable
-      </td>
-
-      <td/>
-
-      <td>
-        Environment variable that can be used during Docker runtime to setup **ktranslate's** SNMPv3 configuration to use AWS Secrets Manager. Specifies the AWS access key used as part of the credentials to authenticate the user.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `AWS_SECRET_ACCESS_KEY`
-      </td>
-
-      <td>
-        Environment Variable
-      </td>
-
-      <td/>
-
-      <td>
-        Environment variable that can be used during Docker runtime to setup **ktranslate's** SNMPv3 configuration to use AWS Secrets Manager. Specifies the AWS secret key used as part of the credentials to authenticate the user.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `AWS_DEFAULT_REGION`
-      </td>
-
-      <td>
-        Environment Variable
-      </td>
-
-      <td/>
-
-      <td>
-        Environment variable that can be used during Docker runtime to setup **ktranslate's** SNMPv3 configuration to use AWS Secrets Manager. Specifies the AWS Region to send requests to for commands requested using this profile.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         `KENTIK_PING_PRIV`
       </td>
 
@@ -556,6 +508,22 @@ Below are the various options available during Docker runtime for the **ktransla
 
       <td>
         Environment variable that can be used during Docker runtime to pass the [Meraki Dashboard API key](https://documentation.meraki.com/General_Administration/Other_Topics/Cisco_Meraki_Dashboard_API#Enable_API_Access) into **ktranslate**. Ex: `-e KENTIK_MERAKI_API_KEY=$DASHBOARD_API_KEY`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Various Cloud Provider Environment Variables](/docs/network-performance-monitoring/advanced/advanced-config/#cloud-secrets)
+      </td>
+
+      <td>
+        Environment Variable
+      </td>
+
+      <td/>
+
+      <td>
+        Environment variables that can be used during Docker runtime to retrieve secrets from AWS, Azure, or GCP.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
updating netmon docs to include examples of using cloud provider secret managers to retrieve secrets