### PR TITLE
Nr 101608: break apart AWS metrics tables

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -81,9 +81,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
  <tbody>
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ActiveConnectionCount`
@@ -95,9 +93,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ClientTLSNegotiationErrorCount`
@@ -109,9 +105,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ConsumedLCUs`
@@ -123,9 +117,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ELBAuthError`
@@ -137,9 +129,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ELBAuthFailure`
@@ -151,9 +141,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ELBAuthLatency`
@@ -165,9 +153,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ELBAuthRefreshTokenSuccess`
@@ -179,9 +165,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ELBAuthSuccess`
@@ -193,9 +177,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ELBAuthUserClaimsSizeExceeded`
@@ -207,9 +189,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTP_Fixed_Response_Count`
@@ -221,9 +201,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTP_Redirect_Count`
@@ -235,9 +213,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTP_Redirect_Url_Limit_Exceeded_Count`
@@ -249,9 +225,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_2XX_Count`
@@ -263,9 +237,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_3XX_Count`
@@ -277,9 +249,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_4XX_Count`
@@ -291,9 +261,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_500_Count`
@@ -305,9 +273,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_502_Count`
@@ -319,9 +285,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_503_Count`
@@ -333,9 +297,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_504_Count`
@@ -347,9 +309,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_ELB_5XX_Count`
@@ -361,9 +321,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.IPv6ProcessedBytes`
@@ -375,9 +333,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.IPv6RequestCount`
@@ -389,9 +345,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.LambdaTargetProcessedBytes`
@@ -403,9 +357,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.NewConnectionCount`
@@ -417,9 +369,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.ProcessedBytes`
@@ -431,9 +381,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.RejectedConnectionCount`
@@ -445,9 +393,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.RequestCount.byAlb`
@@ -459,9 +405,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.RuleEvaluations`
@@ -473,9 +417,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.RulesEvaluated`
@@ -487,9 +429,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HealthyHostCount`
@@ -501,9 +441,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_Target_2XX_Count`
@@ -515,9 +453,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_Target_3XX_Count`
@@ -529,9 +465,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_Target_4XX_Count`
@@ -543,9 +477,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.HTTPCode_Target_5XX_Count`
@@ -557,9 +489,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.LambdaInternalError`
@@ -571,9 +501,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.LambdaUserError`
@@ -585,9 +513,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.NonStickyRequestCount`
@@ -599,9 +525,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.RequestCount.byTargetGroup`
@@ -613,9 +537,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.RequestCountPerTarget`
@@ -627,9 +549,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.TargetConnectionErrorCount`
@@ -641,9 +561,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.TargetResponseTime`
@@ -655,9 +573,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.TargetTLSNegotiationErrorCount`
@@ -669,9 +585,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ALB
-      </td>
+
 
       <td>
         `aws.applicationelb.UnHealthyHostCount`
@@ -692,9 +606,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
  <tbody>
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.4XXError.byApi`
@@ -706,9 +618,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.5XXError.byApi`
@@ -720,9 +630,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.CacheHitCount.byApi`
@@ -734,9 +642,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.CacheMissCount.byApi`
@@ -748,9 +654,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.Count.byApi`
@@ -762,9 +666,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.IntegrationLatency.byApi`
@@ -776,9 +678,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.Latency.byApi`
@@ -790,9 +690,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.4XXError.byResourceWithMetrics`
@@ -804,9 +702,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.5XXError.byResourceWithMetrics`
@@ -818,9 +714,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.CacheHitCount.byResourceWithMetrics`
@@ -832,9 +726,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.CacheMissCount.byResourceWithMetrics`
@@ -846,9 +738,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.Count.byResourceWithMetrics`
@@ -860,9 +750,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.IntegrationLatency.byResourceWithMetrics`
@@ -874,9 +762,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.Latency.byResourceWithMetrics`
@@ -888,9 +774,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.4XXError.byStage`
@@ -902,9 +786,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.5XXError.byStage`
@@ -916,9 +798,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.CacheHitCount.byStage`
@@ -930,9 +810,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.CacheMissCount.byStage`
@@ -944,9 +822,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.Count.byStage`
@@ -958,9 +834,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.IntegrationLatency.byStage`
@@ -972,9 +846,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS API Gateway
-      </td>
+
 
       <td>
         `aws.apigateway.Latency.byStage`
@@ -994,9 +866,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS AppSync
-      </td>
+
 
       <td>
         `aws.appsync.4XXError`
@@ -1008,9 +878,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS AppSync
-      </td>
+
 
       <td>
         `aws.appsync.5XXError`
@@ -1022,9 +890,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS AppSync
-      </td>
+
 
       <td>
         `aws.appsync.Latency`
@@ -1044,9 +910,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Athena
-      </td>
+
 
       <td>
         `aws.athena.ProcessedBytes`
@@ -1058,9 +922,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Athena
-      </td>
+
 
       <td>
         `aws.athena.TotalExecutionTime`
@@ -1081,9 +943,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupDesiredCapacity`
@@ -1095,9 +955,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupInServiceInstances`
@@ -1109,9 +967,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupMaxSize`
@@ -1123,9 +979,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupMinSize`
@@ -1137,9 +991,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupPendingInstances`
@@ -1151,9 +1003,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupStandbyInstances`
@@ -1165,9 +1015,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupTerminatingInstances`
@@ -1179,9 +1027,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.GroupTotalInstances`
@@ -1193,9 +1039,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Auto Scaling
-      </td>
+
 
       <td>
         `aws.autoscaling.healthStatus`
@@ -1229,9 +1073,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Billing
-      </td>
+
 
       <td>
         `aws.billing.EstimatedCharges.byAccountServiceCost`
@@ -1243,9 +1085,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Billing
-      </td>
+
 
       <td>
         `aws.billing.actualAmount.byBudget`
@@ -1257,9 +1097,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Billing
-      </td>
+
 
       <td>
         `aws.billing.forecastedAmount.byBudget`
@@ -1271,9 +1109,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Billing
-      </td>
+
 
       <td>
         `aws.billing.limitAmount.byBudget`
@@ -1285,9 +1121,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Billing
-      </td>
+
 
       <td>
         `aws.billing.EstimatedCharges.byServiceCost`
@@ -1307,9 +1141,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
 <tbody>
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.cloudfront.4xxErrorRate`
@@ -1321,9 +1153,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.cloudfront.5xxErrorRate`
@@ -1335,9 +1165,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.cloudfront.BytesDownloaded`
@@ -1349,9 +1177,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.cloudfront.BytesUploaded`
@@ -1363,9 +1189,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.cloudfront.Requests`
@@ -1377,9 +1201,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.cloudfront.TotalErrorRate`
@@ -1391,9 +1213,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.lambda.Duration.byEdgeFunction`
@@ -1405,9 +1225,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.lambda.Errors.byEdgeFunction`
@@ -1419,9 +1237,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.lambda.Invocations.byEdgeFunction`
@@ -1433,9 +1249,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS CloudFront
-      </td>
+
 
       <td>
         `aws.lambda.Throttles.byEdgeFunction`
@@ -1455,9 +1269,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.FederationSuccesses`
@@ -1469,9 +1281,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.FederationThrottles`
@@ -1483,9 +1293,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.SignInSuccesses`
@@ -1497,9 +1305,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.SignInThrottles`
@@ -1511,9 +1317,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.SignUpSuccesses`
@@ -1525,9 +1329,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.SignUpThrottles`
@@ -1539,9 +1341,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.TokenRefreshSuccesses`
@@ -1553,9 +1353,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Cognito
-      </td>
+
 
       <td>
         `aws.cognito.TokenRefreshThrottles`
@@ -1576,9 +1374,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
   <tbody>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.CallRecordingUploadError`
@@ -1590,9 +1386,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.ContactFlowErrors`
@@ -1604,9 +1398,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.ContactFlowFatalErrors`
@@ -1618,9 +1410,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.MisconfiguredPhoneNumbers`
@@ -1632,9 +1422,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.PublicSigningKeyUsage`
@@ -1646,9 +1434,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.CallsBreachingConcurrencyQuota`
@@ -1660,9 +1446,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.CallsPerInterval`
@@ -1674,9 +1458,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.ConcurrentCalls`
@@ -1688,9 +1470,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.ConcurrentCallsPercentage`
@@ -1702,9 +1482,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.MissedCalls`
@@ -1716,9 +1494,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.ThrottledCalls`
@@ -1730,9 +1506,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.CallBackNotDialableNumber`
@@ -1744,9 +1518,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.LongestQueueWaitTime`
@@ -1758,9 +1530,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.QueueCapacityExceededError`
@@ -1772,9 +1542,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Connect
-      </td>
+
 
       <td>
         `aws.connect.QueueSize`
@@ -1794,9 +1562,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionBpsEgress`
@@ -1808,9 +1574,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionBpsIngress`
@@ -1822,9 +1586,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionCRCErrorCount`
@@ -1836,9 +1598,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionLightLevelRx`
@@ -1850,9 +1610,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionLightLevelTx`
@@ -1864,9 +1622,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionPpsEgress`
@@ -1878,9 +1634,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionPpsIngress`
@@ -1892,9 +1646,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.ConnectionState`
@@ -1906,9 +1658,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.VirtualInterfaceBpsEgress`
@@ -1920,9 +1670,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.VirtualInterfaceBpsIngress`
@@ -1934,9 +1682,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.VirtualInterfacePpsEgress`
@@ -1948,9 +1694,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Direct Connect
-      </td>
+
 
       <td>
         `aws.dx.VirtualInterfacePpsIngress`
@@ -1984,9 +1728,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.BufferCacheHitRatio.byCluster`
@@ -1998,9 +1740,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.CPUUtilization.byCluster`
@@ -2012,9 +1752,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DatabaseConnections.byCluster`
@@ -2026,9 +1764,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBClusterReplicaLagMaximum.byCluster`
@@ -2040,9 +1776,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBClusterReplicaLagMinimum.byCluster`
@@ -2054,9 +1788,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBInstanceReplicaLag.byCluster`
@@ -2068,9 +1800,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DiskQueueDepth.byCluster`
@@ -2082,9 +1812,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.EngineUptime.byCluster`
@@ -2096,9 +1824,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.FreeableMemory.byCluster`
@@ -2110,9 +1836,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.FreeLocalStorage.byCluster`
@@ -2124,9 +1848,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkReceiveThroughput.byCluster`
@@ -2138,9 +1860,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkThroughput.byCluster`
@@ -2152,9 +1872,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkTransmitThroughput.byCluster`
@@ -2166,9 +1884,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadIOPS.byCluster`
@@ -2180,9 +1896,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadLatency.byCluster`
@@ -2194,9 +1908,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadThroughput.byCluster`
@@ -2208,9 +1920,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.SnapshotStorageUsed.byCluster`
@@ -2222,9 +1932,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.SwapUsage.byCluster`
@@ -2236,9 +1944,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.TotalBackupStorageBilled.byCluster`
@@ -2250,9 +1956,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeBytesUsed.byCluster`
@@ -2264,9 +1968,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeReadIOPs.byCluster`
@@ -2278,9 +1980,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeWriteIOPs.byCluster`
@@ -2292,9 +1992,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteIOPS.byCluster`
@@ -2306,9 +2004,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteLatency.byCluster`
@@ -2320,9 +2016,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteThroughput.byCluster`
@@ -2334,9 +2028,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.BackupRetentionPeriodStorageUsed.byClusterByRole`
@@ -2348,9 +2040,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.BufferCacheHitRatio.byClusterByRole`
@@ -2362,9 +2052,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.CPUUtilization.byClusterByRole`
@@ -2376,9 +2064,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DatabaseConnections.byClusterByRole`
@@ -2390,9 +2076,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBClusterReplicaLagMaximum.byClusterByRole`
@@ -2404,9 +2088,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBClusterReplicaLagMinimum.byClusterByRole`
@@ -2418,9 +2100,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBInstanceReplicaLag.byClusterByRole`
@@ -2432,9 +2112,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DiskQueueDepth.byClusterByRole`
@@ -2446,9 +2124,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.EngineUptime.byClusterByRole`
@@ -2460,9 +2136,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.FreeableMemory.byClusterByRole`
@@ -2474,9 +2148,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.FreeLocalStorage.byClusterByRole`
@@ -2488,9 +2160,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkReceiveThroughput.byClusterByRole`
@@ -2502,9 +2172,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkThroughput.byClusterByRole`
@@ -2516,9 +2184,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkTransmitThroughput.byClusterByRole`
@@ -2530,9 +2196,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadIOPS.byClusterByRole`
@@ -2544,9 +2208,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadLatency.byClusterByRole`
@@ -2558,9 +2220,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadThroughput.byClusterByRole`
@@ -2572,9 +2232,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.SnapshotStorageUsed.byClusterByRole`
@@ -2586,9 +2244,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.SwapUsage.byClusterByRole`
@@ -2600,9 +2256,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.TotalBackupStorageBilled.byClusterByRole`
@@ -2614,9 +2268,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeBytesUsed.byClusterByRole`
@@ -2628,9 +2280,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeReadIOPs.byClusterByRole`
@@ -2642,9 +2292,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeWriteIOPs.byClusterByRole`
@@ -2656,9 +2304,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteIOPS.byClusterByRole`
@@ -2670,9 +2316,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteLatency.byClusterByRole`
@@ -2684,9 +2328,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteThroughput.byClusterByRole`
@@ -2698,9 +2340,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.BackupRetentionPeriodStorageUsed.byInstance`
@@ -2712,9 +2352,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.BufferCacheHitRatio.byInstance`
@@ -2726,9 +2364,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.CPUUtilization.byInstance`
@@ -2740,9 +2376,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DatabaseConnections.byInstance`
@@ -2754,9 +2388,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBClusterReplicaLagMaximum.byInstance`
@@ -2768,9 +2400,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBClusterReplicaLagMinimum.byInstance`
@@ -2782,9 +2412,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DBInstanceReplicaLag.byInstance`
@@ -2796,9 +2424,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.DiskQueueDepth.byInstance`
@@ -2810,9 +2436,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.EngineUptime.byInstance`
@@ -2824,9 +2448,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.FreeableMemory.byInstance`
@@ -2838,9 +2460,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.FreeLocalStorage.byInstance`
@@ -2852,9 +2472,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkReceiveThroughput.byInstance`
@@ -2866,9 +2484,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkThroughput.byInstance`
@@ -2880,9 +2496,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.NetworkTransmitThroughput.byInstance`
@@ -2894,9 +2508,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadIOPS.byInstance`
@@ -2908,9 +2520,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadLatency.byInstance`
@@ -2922,9 +2532,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.ReadThroughput.byInstance`
@@ -2936,9 +2544,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.SnapshotStorageUsed.byInstance`
@@ -2950,9 +2556,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.SwapUsage.byInstance`
@@ -2964,9 +2568,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.TotalBackupStorageBilled.byInstance`
@@ -2978,9 +2580,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeBytesUsed.byInstance`
@@ -2992,9 +2592,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeReadIOPs.byInstance`
@@ -3006,9 +2604,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.VolumeWriteIOPs.byInstance`
@@ -3020,9 +2616,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteIOPS.byInstance`
@@ -3034,9 +2628,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteLatency.byInstance`
@@ -3048,9 +2640,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DocumentDB
-      </td>
+
 
       <td>
         `aws.docdb.WriteThroughput.byInstance`
@@ -3070,9 +2660,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ConsumedReadCapacityUnits.byGlobalSecondaryIndex`
@@ -3084,9 +2672,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ConsumedWriteCapacityUnits.byGlobalSecondaryIndex`
@@ -3098,9 +2684,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.OnlineIndexConsumedWriteCapacity`
@@ -3112,9 +2696,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.OnlineIndexPercentageProgress`
@@ -3126,9 +2708,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.OnlineIndexThrottleEvents`
@@ -3140,9 +2720,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ProvisionedReadCapacityUnits.byGlobalSecondaryIndex`
@@ -3154,9 +2732,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ProvisionedWriteCapacityUnits.byGlobalSecondaryIndex`
@@ -3168,9 +2744,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ReadThrottleEvents.byGlobalSecondaryIndex`
@@ -3182,9 +2756,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.WriteThrottleEvents.byGlobalSecondaryIndex`
@@ -3196,9 +2768,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.byRegion`
@@ -3210,9 +2780,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.UserErrors.byRegion`
@@ -3224,9 +2792,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ConditionalCheckFailedRequests`
@@ -3238,9 +2804,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ConsumedReadCapacityUnits.byTable`
@@ -3252,9 +2816,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ConsumedWriteCapacityUnits.byTable`
@@ -3266,9 +2828,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamoDb.ItemCount`
@@ -3280,9 +2840,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.PendingReplicationCount`
@@ -3294,9 +2852,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ProvisionedReadCapacityUnits.byTable`
@@ -3308,9 +2864,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ProvisionedWriteCapacityUnits.byTable`
@@ -3322,9 +2876,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ReadThrottleEvents.byTable`
@@ -3336,9 +2888,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ReplicationLatency`
@@ -3350,9 +2900,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ReturnedItemCount`
@@ -3364,9 +2912,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ReturnedItemCount.scan`
@@ -3378,9 +2924,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.batchGet`
@@ -3392,9 +2936,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.batchWrite`
@@ -3406,9 +2948,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.delete`
@@ -3420,9 +2960,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.get`
@@ -3434,9 +2972,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.put`
@@ -3448,9 +2984,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.query`
@@ -3462,9 +2996,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.scan`
@@ -3476,9 +3008,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SuccessfulRequestLatency.update`
@@ -3490,9 +3020,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.batchGet`
@@ -3504,9 +3032,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.batchWrite`
@@ -3518,9 +3044,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.byTable`
@@ -3532,9 +3056,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.delete`
@@ -3546,9 +3068,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.get`
@@ -3560,9 +3080,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.put`
@@ -3574,9 +3092,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.query`
@@ -3588,9 +3104,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.scan`
@@ -3602,9 +3116,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.SystemErrors.update`
@@ -3616,9 +3128,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamoDb.TableSizeBytes`
@@ -3630,9 +3140,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.batchGet`
@@ -3644,9 +3152,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.batchWrite`
@@ -3658,9 +3164,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.delete`
@@ -3672,9 +3176,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.get`
@@ -3686,9 +3188,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.put`
@@ -3700,9 +3200,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.query`
@@ -3714,9 +3212,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.scan`
@@ -3728,9 +3224,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.ThrottledRequests.update`
@@ -3742,9 +3236,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.UserErrors.byTable`
@@ -3756,9 +3248,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS DynamoDB
-      </td>
+
 
       <td>
         `aws.dynamodb.WriteThrottleEvents.byTable`
@@ -3778,9 +3268,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.BurstBalance`
@@ -3792,9 +3280,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeConsumedReadWriteOps`
@@ -3806,9 +3292,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeIdleTime`
@@ -3820,9 +3304,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeQueueLength`
@@ -3834,9 +3316,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeReadBytes`
@@ -3848,9 +3328,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeReadOps`
@@ -3862,9 +3340,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeThroughputPercentage`
@@ -3876,9 +3352,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeTotalReadTime`
@@ -3890,9 +3364,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeTotalWriteTime`
@@ -3904,9 +3376,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeWriteBytes`
@@ -3918,9 +3388,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EBS
-      </td>
+
 
       <td>
         `aws.ebs.VolumeWriteOps`
@@ -3940,9 +3408,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.CPUCreditBalance`
@@ -3954,9 +3420,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.CPUCreditUsage`
@@ -3968,9 +3432,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.CPUSurplusCreditBalance`
@@ -3982,9 +3444,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.CPUSurplusCreditsCharged`
@@ -3996,9 +3456,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.CPUUtilization`
@@ -4010,9 +3468,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.DiskReadBytes`
@@ -4024,9 +3480,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.DiskReadOps`
@@ -4038,9 +3492,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.DiskWriteBytes`
@@ -4052,9 +3504,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.DiskWriteOps`
@@ -4066,9 +3516,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.NetworkIn`
@@ -4080,9 +3528,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.NetworkOut`
@@ -4094,9 +3540,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.NetworkPacketsIn`
@@ -4108,9 +3552,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.NetworkPacketsOut`
@@ -4122,9 +3564,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.StatusCheckFailed`
@@ -4136,9 +3576,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.StatusCheckFailed_Instance`
@@ -4150,9 +3588,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EC2
-      </td>
+
 
       <td>
         `aws.ec2.StatusCheckFailed_System`
@@ -4172,9 +3608,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.activeServicesCount.byCluster`
@@ -4186,9 +3620,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.CPUReservation`
@@ -4200,9 +3632,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.CPUUtilization.byCluster`
@@ -4214,9 +3644,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.MemoryReservation`
@@ -4228,9 +3656,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.MemoryUtilization.byCluster`
@@ -4242,9 +3668,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.pendingTasksCount.byCluster`
@@ -4256,9 +3680,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.registeredContainerInstancesCount.byCluster`
@@ -4270,9 +3692,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.runningTasksCount.byCluster`
@@ -4284,9 +3704,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.CPUUtilization.byService`
@@ -4298,9 +3716,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.desiredCount.byService`
@@ -4312,9 +3728,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.MemoryUtilization.byService`
@@ -4326,9 +3740,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.pendingCount.byService`
@@ -4340,9 +3752,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ECS
-      </td>
+
 
       <td>
         `aws.ecs.runningCount.byService`
@@ -4362,9 +3772,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.BurstCreditBalance`
@@ -4376,9 +3784,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.ClientConnections`
@@ -4390,9 +3796,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.DataReadIOBytes`
@@ -4404,9 +3808,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.DataWriteIOBytes`
@@ -4418,9 +3820,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.lastKnownSizeInBytes`
@@ -4432,9 +3832,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.MetadataIOBytes`
@@ -4446,9 +3844,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.PercentIOLimit`
@@ -4460,9 +3856,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.PermittedThroughput`
@@ -4474,9 +3868,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EFS
-      </td>
+
 
       <td>
         `aws.efs.TotalIOBytes`
@@ -4496,9 +3888,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.2xx`
@@ -4510,9 +3900,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.3xx`
@@ -4524,9 +3912,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.4xx`
@@ -4538,9 +3924,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.5xx`
@@ -4552,9 +3936,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.AutomatedSnapshotFailure`
@@ -4566,9 +3948,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ClusterIndexWritesBlocked`
@@ -4580,9 +3960,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ClusterStatus.green`
@@ -4594,9 +3972,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ClusterStatus.red`
@@ -4608,9 +3984,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ClusterStatus.yellow`
@@ -4622,9 +3996,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ClusterUsedSpace`
@@ -4636,9 +4008,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.CPUCreditBalance`
@@ -4650,9 +4020,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.CPUUtilization.byCluster`
@@ -4664,9 +4032,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.DeletedDocuments`
@@ -4678,9 +4044,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.DiskQueueDepth`
@@ -4692,9 +4056,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ElasticsearchRequests`
@@ -4706,9 +4068,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.FreeStorageSpace.byCluster`
@@ -4720,9 +4080,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.IndexingLatency.byCluster`
@@ -4734,9 +4092,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.IndexingRate.byCluster`
@@ -4748,9 +4104,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.InvalidHostHeaderRequests`
@@ -4762,9 +4116,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCOldCollectionCount.byCluster`
@@ -4776,9 +4128,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCOldCollectionTime.byCluster`
@@ -4790,9 +4140,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCYoungCollectionCount.byCluster`
@@ -4804,9 +4152,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCYoungCollectionTime.byCluster`
@@ -4818,9 +4164,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMMemoryPressure.byCluster`
@@ -4832,9 +4176,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.KibanaHealthyNodes`
@@ -4846,9 +4188,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.KMSKeyError`
@@ -4860,9 +4200,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.KMSKeyInaccessible`
@@ -4874,9 +4212,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.MasterCPUCreditBalance`
@@ -4888,9 +4224,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.MasterCPUUtilization`
@@ -4902,9 +4236,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.MasterJVMMemoryPressure`
@@ -4916,9 +4248,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.MasterReachableFromNode`
@@ -4930,9 +4260,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.Nodes`
@@ -4944,9 +4272,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ReadIOPS`
@@ -4958,9 +4284,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ReadLatency`
@@ -4972,9 +4296,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ReadThroughput`
@@ -4986,9 +4308,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SearchableDocuments`
@@ -5000,9 +4320,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SearchLatency.byCluster`
@@ -5014,9 +4332,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SearchRate.byCluster`
@@ -5028,9 +4344,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SysMemoryUtilization.byCluster`
@@ -5042,9 +4356,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolBulkQueue.byCluster`
@@ -5056,9 +4368,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolBulkRejected.byCluster`
@@ -5070,9 +4380,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolBulkThreads.byCluster`
@@ -5084,9 +4392,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolForce_mergeQueue.byCluster`
@@ -5098,9 +4404,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolForce_mergeRejected.byCluster`
@@ -5112,9 +4416,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolForce_mergeThreads.byCluster`
@@ -5126,9 +4428,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolIndexQueue.byCluster`
@@ -5140,9 +4440,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolIndexRejected.byCluster`
@@ -5154,9 +4452,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolIndexThreads.byCluster`
@@ -5168,9 +4464,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolSearchQueue.byCluster`
@@ -5182,9 +4476,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolSearchRejected.byCluster`
@@ -5196,9 +4488,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolSearchThreads.byCluster`
@@ -5210,9 +4500,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.WriteIOPS`
@@ -5224,9 +4512,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.WriteLatency`
@@ -5238,9 +4524,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.WriteThroughput`
@@ -5252,9 +4536,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.CPUUtilization.byNode`
@@ -5266,9 +4548,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.FreeStorageSpace.byNode`
@@ -5280,9 +4560,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.IndexingLatency.byNode`
@@ -5294,9 +4572,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.IndexingRate.byNode`
@@ -5308,9 +4584,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCOldCollectionCount.byNode`
@@ -5322,9 +4596,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCOldCollectionTime.byNode`
@@ -5336,9 +4608,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCYoungCollectionCount.byNode`
@@ -5350,9 +4620,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMGCYoungCollectionTime.byNode`
@@ -5364,9 +4632,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.JVMMemoryPressure.byNode`
@@ -5378,9 +4644,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SearchLatency.byNode`
@@ -5392,9 +4656,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SearchRate.byNode`
@@ -5406,9 +4668,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.SysMemoryUtilization.byNode`
@@ -5420,9 +4680,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolBulkQueue.byNode`
@@ -5434,9 +4692,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolBulkRejected.byNode`
@@ -5448,9 +4704,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolBulkThreads.byNode`
@@ -5462,9 +4716,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolForce_mergeQueue.byNode`
@@ -5476,9 +4728,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolForce_mergeRejected.byNode`
@@ -5490,9 +4740,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolForce_mergeThreads.byNode`
@@ -5504,9 +4752,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolIndexQueue.byNode`
@@ -5518,9 +4764,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolIndexRejected.byNode`
@@ -5532,9 +4776,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolIndexThreads.byNode`
@@ -5546,9 +4788,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolSearchQueue.byNode`
@@ -5560,9 +4800,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolSearchRejected.byNode`
@@ -5574,9 +4812,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElasticSearch
-      </td>
+
 
       <td>
         `aws.es.ThreadpoolSearchThreads.byNode`
@@ -5596,9 +4832,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditBalance.byMemcachedCluster`
@@ -5610,9 +4844,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditUsage.byMemcachedCluster`
@@ -5624,9 +4856,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUUtilization.byMemcachedCluster`
@@ -5638,9 +4868,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DatabaseMemoryUsagePercentage.byMemcachedCluster`
@@ -5652,9 +4880,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.FreeableMemory.byMemcachedCluster`
@@ -5666,9 +4892,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesIn.byMemcachedCluster`
@@ -5680,9 +4904,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesOut.byMemcachedCluster`
@@ -5694,9 +4916,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SwapUsage.byMemcachedCluster`
@@ -5708,9 +4928,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.BytesReadIntoMemcached`
@@ -5722,9 +4940,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.BytesUsedForCacheItems`
@@ -5736,9 +4952,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.BytesUsedForHash`
@@ -5750,9 +4964,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.BytesWrittenOutFromMemcached`
@@ -5764,9 +4976,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CasBadval`
@@ -5778,9 +4988,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CasHits`
@@ -5792,9 +5000,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CasMisses`
@@ -5806,9 +5012,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CmdConfigGet`
@@ -5820,9 +5024,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CmdConfigSet`
@@ -5834,9 +5036,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CmdFlush`
@@ -5848,9 +5048,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CmdGet`
@@ -5862,9 +5060,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CmdSet`
@@ -5876,9 +5072,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CmdTouch`
@@ -5890,9 +5084,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditBalance.byMemcachedNode`
@@ -5904,9 +5096,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditUsage.byMemcachedNode`
@@ -5918,9 +5108,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUUtilization.byMemcachedNode`
@@ -5932,9 +5120,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CurrConfig`
@@ -5946,9 +5132,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CurrConnections.byMemcachedNode`
@@ -5960,9 +5144,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CurrItems.byMemcachedNode`
@@ -5974,9 +5156,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DatabaseMemoryUsagePercentage.byMemcachedNode`
@@ -5988,9 +5168,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DecrHits`
@@ -6002,9 +5180,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DecrMisses`
@@ -6016,9 +5192,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DeleteHits`
@@ -6030,9 +5204,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DeleteMisses`
@@ -6044,9 +5216,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.EvictedUnfetched`
@@ -6058,9 +5228,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.Evictions.byMemcachedNode`
@@ -6072,9 +5240,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ExpiredUnfetched`
@@ -6086,9 +5252,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.FreeableMemory.byMemcachedNode`
@@ -6100,9 +5264,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.GetHits`
@@ -6114,9 +5276,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.GetMisses`
@@ -6128,9 +5288,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.IncrHits`
@@ -6142,9 +5300,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.IncrMisses`
@@ -6156,9 +5312,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesIn.byMemcachedNode`
@@ -6170,9 +5324,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesOut.byMemcachedNode`
@@ -6184,9 +5336,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NewConnections.byMemcachedNode`
@@ -6198,9 +5348,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NewItems`
@@ -6212,9 +5360,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.Reclaimed.byMemcachedNode`
@@ -6226,9 +5372,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SlabsMoved`
@@ -6240,9 +5384,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SwapUsage.byMemcachedNode`
@@ -6254,9 +5396,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.TouchHits`
@@ -6268,9 +5408,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.TouchMisses`
@@ -6282,9 +5420,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.UnusedMemory`
@@ -6296,9 +5432,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ActiveDefragHits.byRedisCluster`
@@ -6310,9 +5444,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditBalance.byRedisCluster`
@@ -6324,9 +5456,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditUsage.byRedisCluster`
@@ -6338,9 +5468,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUUtilization.byRedisCluster`
@@ -6352,9 +5480,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DatabaseMemoryUsagePercentage.byRedisCluster`
@@ -6366,9 +5492,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.EngineCPUUtilization.byRedisCluster`
@@ -6380,9 +5504,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.FreeableMemory.byRedisCluster`
@@ -6394,9 +5516,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesIn.byRedisCluster`
@@ -6408,9 +5528,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesOut.byRedisCluster`
@@ -6422,9 +5540,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.StreamBasedCmds.byRedisCluster`
@@ -6436,9 +5552,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SwapUsage.byRedisCluster`
@@ -6450,9 +5564,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ActiveDefragHits.byRedisNode`
@@ -6464,9 +5576,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.BytesUsedForCache`
@@ -6478,9 +5588,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CacheHitRate`
@@ -6492,9 +5600,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CacheHits`
@@ -6506,9 +5612,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CacheMisses`
@@ -6520,9 +5624,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditBalance.byRedisNode`
@@ -6534,9 +5636,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUCreditUsage.byRedisNode`
@@ -6548,9 +5648,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CPUUtilization.byRedisNode`
@@ -6562,9 +5660,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CurrConnections.byRedisNode`
@@ -6576,9 +5672,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.CurrItems.byRedisNode`
@@ -6590,9 +5684,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DatabaseMemoryUsagePercentage.byRedisNode`
@@ -6604,9 +5696,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.DB0AverageTTL`
@@ -6618,9 +5708,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.EngineCPUUtilization.byRedisNode`
@@ -6632,9 +5720,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.EvalBasedCmds`
@@ -6646,9 +5732,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.EvalBasedCmdsLatency`
@@ -6660,9 +5744,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.Evictions.byRedisNode`
@@ -6674,9 +5756,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.FreeableMemory.byRedisNode`
@@ -6688,9 +5768,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.GeoSpatialBasedCmds`
@@ -6702,9 +5780,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.GeoSpatialBasedCmdsLatency`
@@ -6716,9 +5792,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.GetTypeCmds`
@@ -6730,9 +5804,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.GetTypeCmdsLatency`
@@ -6744,9 +5816,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.HashBasedCmds`
@@ -6758,9 +5828,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.HashBasedCmdsLatency`
@@ -6772,9 +5840,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.HyperLogLogBasedCmds`
@@ -6786,9 +5852,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.HyperLogLogBasedCmdsLatency`
@@ -6800,9 +5864,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.KeyBasedCmds`
@@ -6814,9 +5876,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.KeyBasedCmdsLatency`
@@ -6828,9 +5888,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ListBasedCmds`
@@ -6842,9 +5900,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ListBasedCmdsLatency`
@@ -6856,9 +5912,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.MasterLinkHealthStatus`
@@ -6870,9 +5924,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.MemoryFragmentationRatio`
@@ -6884,9 +5936,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesIn.byRedisNode`
@@ -6898,9 +5948,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NetworkBytesOut.byRedisNode`
@@ -6912,9 +5960,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.NewConnections.byRedisNode`
@@ -6926,9 +5972,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.PubSubBasedCmds`
@@ -6940,9 +5984,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.PubSubBasedCmdsLatency`
@@ -6954,9 +5996,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.Reclaimed.byRedisNode`
@@ -6968,9 +6008,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ReplicationBytes`
@@ -6982,9 +6020,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.ReplicationLag`
@@ -6996,9 +6032,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SaveInProgress`
@@ -7010,9 +6044,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SetBasedCmds`
@@ -7024,9 +6056,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SetBasedCmdsLatency`
@@ -7038,9 +6068,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SetTypeCmds`
@@ -7052,9 +6080,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SetTypeCmdsLatency`
@@ -7066,9 +6092,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SortedBasedCmdsLatency`
@@ -7080,9 +6104,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SortedSetBasedCmds`
@@ -7094,9 +6116,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.StreamBasedCmds.byRedisNode`
@@ -7108,9 +6128,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.StreamBasedCmdsLatency`
@@ -7122,9 +6140,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.StringBasedCmds`
@@ -7136,9 +6152,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.StringBasedCmdsLatency`
@@ -7150,9 +6164,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ElastiCache
-      </td>
+
 
       <td>
         `aws.elasticache.SwapUsage.byRedisNode`
@@ -7173,9 +6185,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP10.byEnvironment`
@@ -7187,9 +6197,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP50.byEnvironment`
@@ -7201,9 +6209,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP75.byEnvironment`
@@ -7215,9 +6221,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP85.byEnvironment`
@@ -7229,9 +6233,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP90.byEnvironment`
@@ -7243,9 +6245,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP95.byEnvironment`
@@ -7257,9 +6257,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP99.9.byEnvironment`
@@ -7271,9 +6269,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP99.byEnvironment`
@@ -7285,9 +6281,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests2xx.byEnvironment`
@@ -7299,9 +6293,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests3xx.byEnvironment`
@@ -7313,9 +6305,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests4xx.byEnvironment`
@@ -7327,9 +6317,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests5xx.byEnvironment`
@@ -7341,9 +6329,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequestsTotal.byEnvironment`
@@ -7355,9 +6341,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.EnvironmentHealth`
@@ -7369,9 +6353,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesDegraded`
@@ -7383,9 +6365,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesInfo`
@@ -7397,9 +6377,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesNoData`
@@ -7411,9 +6389,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesOk`
@@ -7425,9 +6401,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesPending`
@@ -7439,9 +6413,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesSevere`
@@ -7453,9 +6425,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesUnknown`
@@ -7467,9 +6437,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstancesWarning`
@@ -7481,9 +6449,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP10.byInstance`
@@ -7495,9 +6461,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP50.byInstance`
@@ -7509,9 +6473,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP75.byInstance`
@@ -7523,9 +6485,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP85.byInstance`
@@ -7537,9 +6497,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP90.byInstance`
@@ -7551,9 +6509,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP95.byInstance`
@@ -7565,9 +6521,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP99.9.byInstance`
@@ -7579,9 +6533,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationLatencyP99.byInstance`
@@ -7593,9 +6545,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests2xx.byInstance`
@@ -7607,9 +6557,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests3xx.byInstance`
@@ -7621,9 +6569,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests4xx.byInstance`
@@ -7635,9 +6581,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequests5xx.byInstance`
@@ -7649,9 +6593,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.ApplicationRequestsTotal.byInstance`
@@ -7663,9 +6605,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUIdle`
@@ -7677,9 +6617,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUIowait`
@@ -7691,9 +6629,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUIrq`
@@ -7705,9 +6641,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUNice`
@@ -7719,9 +6653,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUSoftirq`
@@ -7733,9 +6665,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUSystem`
@@ -7747,9 +6677,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.CPUUser`
@@ -7761,9 +6689,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.InstanceHealth`
@@ -7775,9 +6701,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.LoadAverage1min`
@@ -7789,9 +6713,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elastic Beanstalk
-      </td>
+
 
       <td>
         `aws.elasticbeanstalk.RootFilesystemUtil`
@@ -7811,9 +6733,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.BackendConnectionErrors`
@@ -7825,9 +6745,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.EstimatedALBActiveConnectionCount`
@@ -7839,9 +6757,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.EstimatedALBConsumedLCUs`
@@ -7853,9 +6769,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.EstimatedALBNewConnectionCount`
@@ -7867,9 +6781,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.EstimatedProcessedBytes`
@@ -7881,9 +6793,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HealthyHostCount`
@@ -7895,9 +6805,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HTTPCode_Backend_2XX`
@@ -7909,9 +6817,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HTTPCode_Backend_3XX`
@@ -7923,9 +6829,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HTTPCode_Backend_4XX`
@@ -7937,9 +6841,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HTTPCode_Backend_5XX`
@@ -7951,9 +6853,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HTTPCode_ELB_4XX`
@@ -7965,9 +6865,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.HTTPCode_ELB_5XX`
@@ -7979,9 +6877,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.Latency`
@@ -7993,9 +6889,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.RequestCount`
@@ -8007,9 +6901,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.SpilloverCount`
@@ -8021,9 +6913,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.SurgeQueueLength`
@@ -8035,9 +6925,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS ELB
-      </td>
+
 
       <td>
         `aws.elb.UnhealthyHostCount`
@@ -8057,9 +6945,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.AppsCompleted`
@@ -8071,9 +6957,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.AppsFailed`
@@ -8085,9 +6969,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.AppsKilled`
@@ -8099,9 +6981,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.AppsPending`
@@ -8113,9 +6993,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.AppsRunning`
@@ -8127,9 +7005,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.AppsSubmitted`
@@ -8141,9 +7017,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.CapacityRemainingGB`
@@ -8155,9 +7029,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.ContainerAllocated`
@@ -8169,9 +7041,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.ContainerPending`
@@ -8183,9 +7053,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.ContainerPendingRatio`
@@ -8197,9 +7065,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.ContainerReserved`
@@ -8211,9 +7077,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.CoreNodesPending`
@@ -8225,9 +7089,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.CoreNodesRunning`
@@ -8239,9 +7101,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.CorruptBlocks`
@@ -8253,9 +7113,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.HDFSBytesRead`
@@ -8267,9 +7125,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.HDFSBytesWritten`
@@ -8281,9 +7137,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.HDFSUtilization`
@@ -8295,9 +7149,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.IsIdle`
@@ -8309,9 +7161,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.JobsFailed`
@@ -8323,9 +7173,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.JobsRunning`
@@ -8337,9 +7185,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.LiveDataNodes`
@@ -8351,9 +7197,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.LiveTaskTrackers`
@@ -8365,9 +7209,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MapSlotsOpen`
@@ -8379,9 +7221,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MemoryAllocatedMB`
@@ -8393,9 +7233,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MemoryAvailableMB`
@@ -8407,9 +7245,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MemoryReservedMB`
@@ -8421,9 +7257,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MemoryTotalMB`
@@ -8435,9 +7269,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MissingBlocks`
@@ -8449,9 +7281,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MRActiveNodes`
@@ -8463,9 +7293,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MRDecommissionedNodes`
@@ -8477,9 +7305,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MRLostNodes`
@@ -8491,9 +7317,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MRRebootedNodes`
@@ -8505,9 +7329,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MRTotalNodes`
@@ -8519,9 +7341,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.MRUnhealthyNodes`
@@ -8533,9 +7353,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.PendingDeletionBlocks`
@@ -8547,9 +7365,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.ReduceSlotsOpen`
@@ -8561,9 +7377,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.RemainingMapTasksPerSlot`
@@ -8575,9 +7389,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.S3BytesRead`
@@ -8589,9 +7401,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.S3BytesWritten`
@@ -8603,9 +7413,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.TaskNodesPending`
@@ -8617,9 +7425,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.TaskNodesRunning`
@@ -8631,9 +7437,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.TotalLoad`
@@ -8645,9 +7449,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.UnderReplicatedBlocks`
@@ -8659,9 +7461,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS EMR
-      </td>
+
 
       <td>
         `aws.elasticmapreduce.YARNMemoryAvailablePercentage`
@@ -8681,9 +7481,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS FSx
-      </td>
+
 
       <td>
         `aws.fsx.DataReadBytes`
@@ -8695,9 +7493,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS FSx
-      </td>
+
 
       <td>
         `aws.fsx.DataReadOperations`
@@ -8709,9 +7505,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS FSx
-      </td>
+
 
       <td>
         `aws.fsx.DataWriteBytes`
@@ -8723,9 +7517,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS FSx
-      </td>
+
 
       <td>
         `aws.fsx.DataWriteOperations`
@@ -8737,9 +7529,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS FSx
-      </td>
+
 
       <td>
         `aws.fsx.FreeStorageCapacity`
@@ -8751,9 +7541,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS FSx
-      </td>
+
 
       <td>
         `aws.fsx.MetadataOperations`
@@ -8773,9 +7561,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.ALL.jvm.heap.usage`
@@ -8787,9 +7573,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.ALL.jvm.heap.used`
@@ -8801,9 +7585,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.ALL.s3.filesystem.read_bytes`
@@ -8815,9 +7597,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.ALL.s3.filesystem.write_bytes`
@@ -8829,9 +7609,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.ALL.system.cpuSystemLoad`
@@ -8843,9 +7621,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.bytesRead`
@@ -8857,9 +7633,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.elapsedTime`
@@ -8871,9 +7645,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.numCompletedStages`
@@ -8885,9 +7657,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.numCompletedTasks`
@@ -8899,9 +7669,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.numFailedTasks`
@@ -8913,9 +7681,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.numKilledTasks`
@@ -8927,9 +7693,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.recordsRead`
@@ -8941,9 +7705,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.shuffleBytesWritten`
@@ -8955,9 +7717,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.aggregate.shuffleLocalBytesRead`
@@ -8969,9 +7729,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.BlockManager.disk.diskSpaceUsed_MB`
@@ -8983,9 +7741,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.ExecutorAllocationManager.executors.numberAllExecutors`
@@ -8997,9 +7753,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.ExecutorAllocationManager.executors.numberMaxNeededExecutors`
@@ -9011,9 +7765,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.jvm.heap.usage`
@@ -9025,9 +7777,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.jvm.heap.used`
@@ -9039,9 +7789,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.s3.filesystem.read_bytes`
@@ -9053,9 +7801,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.s3.filesystem.write_bytes`
@@ -9067,9 +7813,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Glue
-      </td>
+
 
       <td>
         `aws.glue.glue.driver.system.cpuSystemLoad`
@@ -9089,9 +7833,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AccessKeysPerUserQuota`
@@ -9103,9 +7845,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AccountAccessKeysPresent`
@@ -9117,9 +7857,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AccountMFAEnabled`
@@ -9131,9 +7869,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AccountSigningCertificatesPresent`
@@ -9145,9 +7881,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AssumeRolePolicySizeQuota`
@@ -9159,9 +7893,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AttachedPoliciesPerGroupQuota`
@@ -9173,9 +7905,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AttachedPoliciesPerRoleQuota`
@@ -9187,9 +7917,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.AttachedPoliciesPerUserQuota`
@@ -9201,9 +7929,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.GlobalEndpointTokenVersion`
@@ -9215,9 +7941,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.GroupPolicySizeQuota`
@@ -9229,9 +7953,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.Groups`
@@ -9243,9 +7965,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.GroupsPerUserQuota`
@@ -9257,9 +7977,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.GroupsQuota`
@@ -9271,9 +7989,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.InstanceProfiles`
@@ -9285,9 +8001,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.InstanceProfilesQuota`
@@ -9299,9 +8013,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.MFADevices`
@@ -9313,9 +8025,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.MFADevicesInUse`
@@ -9327,9 +8037,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.Policies`
@@ -9341,9 +8049,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.PoliciesQuota`
@@ -9355,9 +8061,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.PolicySizeQuota`
@@ -9369,9 +8073,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.PolicyVersionsInUse`
@@ -9383,9 +8085,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.PolicyVersionsInUseQuota`
@@ -9397,9 +8097,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.Providers`
@@ -9411,9 +8109,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.RolePolicySizeQuota`
@@ -9425,9 +8121,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.Roles`
@@ -9439,9 +8133,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.RolesQuota`
@@ -9453,9 +8145,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.ServerCertificates`
@@ -9467,9 +8157,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.ServerCertificatesQuota`
@@ -9481,9 +8169,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.SigningCertificatesPerUserQuota`
@@ -9495,9 +8181,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.UserPolicySizeQuota`
@@ -9509,9 +8193,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.Users`
@@ -9523,9 +8205,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.UsersQuota`
@@ -9537,9 +8217,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IAM
-      </td>
+
 
       <td>
         `aws.iam.VersionsPerPolicyQuota`
@@ -9559,9 +8237,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Connect.AuthError`
@@ -9573,9 +8249,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Connect.ClientError`
@@ -9587,9 +8261,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Connect.ServerError`
@@ -9601,9 +8273,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Connect.Success`
@@ -9615,9 +8285,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Connect.Throttle`
@@ -9629,9 +8297,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.DeleteThingShadow.Accepted`
@@ -9643,9 +8309,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.GetThingShadow.Accepted`
@@ -9657,9 +8321,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Ping.Success`
@@ -9671,9 +8333,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishIn.AuthError`
@@ -9685,9 +8345,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishIn.ClientError`
@@ -9699,9 +8357,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishIn.ServerError`
@@ -9713,9 +8369,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishIn.Success`
@@ -9727,9 +8381,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishIn.Throttle`
@@ -9741,9 +8393,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishOut.AuthError`
@@ -9755,9 +8405,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishOut.ClientError`
@@ -9769,9 +8417,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.PublishOut.Success`
@@ -9783,9 +8429,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Subscribe.AuthError`
@@ -9797,9 +8441,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Subscribe.ClientError`
@@ -9811,9 +8453,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Subscribe.ServerError`
@@ -9825,9 +8465,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Subscribe.Success`
@@ -9839,9 +8477,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Subscribe.Throttle`
@@ -9853,9 +8489,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Unsubscribe.ClientError`
@@ -9867,9 +8501,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Unsubscribe.ServerError`
@@ -9881,9 +8513,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Unsubscribe.Success`
@@ -9895,9 +8525,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Unsubscribe.Throttle`
@@ -9909,9 +8537,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.UpdateThingShadow.Accepted`
@@ -9923,9 +8549,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.ParseError`
@@ -9937,9 +8561,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.RuleMessageThrottled`
@@ -9951,9 +8573,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.RuleNotFound`
@@ -9965,9 +8585,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.TopicMatch`
@@ -9979,9 +8597,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Failure`
@@ -9993,9 +8609,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS IoT
-      </td>
+
 
       <td>
         `aws.iot.Success`
@@ -10015,9 +8629,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.GetRecords.Bytes`
@@ -10029,9 +8641,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.GetRecords.IteratorAgeMilliseconds`
@@ -10043,9 +8653,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.GetRecords.Latency`
@@ -10057,9 +8665,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.GetRecords.Records`
@@ -10071,9 +8677,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.GetRecords.Success`
@@ -10085,9 +8689,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.IncomingBytes.byStream`
@@ -10099,9 +8701,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.IncomingRecords.byStream`
@@ -10113,9 +8713,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecord.Bytes`
@@ -10127,9 +8725,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecord.Latency`
@@ -10141,9 +8737,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecord.Success`
@@ -10155,9 +8749,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecords.Bytes`
@@ -10169,9 +8761,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecords.Latency`
@@ -10183,9 +8773,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecords.Records`
@@ -10197,9 +8785,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.PutRecords.Success`
@@ -10211,9 +8797,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.ReadProvisionedThroughputExceeded.byStream`
@@ -10225,9 +8809,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.WriteProvisionedThroughputExceeded.byStream`
@@ -10239,9 +8821,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.IncomingBytes.byStreamShard`
@@ -10253,9 +8833,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.IncomingRecords.byStreamShard`
@@ -10267,9 +8845,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.IteratorAgeMilliseconds`
@@ -10281,9 +8857,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.OutgoingBytes`
@@ -10295,9 +8869,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.OutgoingRecords`
@@ -10309,9 +8881,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.ReadProvisionedThroughputExceeded.byStreamShard`
@@ -10323,9 +8893,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis
-      </td>
+
 
       <td>
         `aws.kinesis.WriteProvisionedThroughputExceeded.byStreamShard`
@@ -10345,9 +8913,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToElasticsearch.Bytes`
@@ -10359,9 +8925,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToElasticsearch.Records`
@@ -10373,9 +8937,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToElasticsearch.Success`
@@ -10387,9 +8949,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToRedshift.Bytes`
@@ -10401,9 +8961,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToRedshift.Records`
@@ -10415,9 +8973,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToRedshift.Success`
@@ -10429,9 +8985,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToS3.Bytes`
@@ -10443,9 +8997,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToS3.DataFreshness`
@@ -10457,9 +9009,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToS3.Records`
@@ -10471,9 +9021,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.DeliveryToS3.Success`
@@ -10485,9 +9033,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.IncomingBytes`
@@ -10499,9 +9045,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.IncomingRecords`
@@ -10513,9 +9057,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecord.Bytes`
@@ -10527,9 +9069,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecord.Latency`
@@ -10541,9 +9081,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecord.Requests`
@@ -10555,9 +9093,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecordBatch.Bytes`
@@ -10569,9 +9105,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecordBatch.Latency`
@@ -10583,9 +9117,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecordBatch.Records`
@@ -10597,9 +9129,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Kinesis Firehose
-      </td>
+
 
       <td>
         `aws.firehose.PutRecordBatch.Requests`
@@ -10619,9 +9149,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ConcurrentExecutions.byFunction`
@@ -10633,9 +9161,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.DeadLetterErrors.byFunction`
@@ -10647,9 +9173,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Duration.byFunction`
@@ -10661,9 +9185,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Errors.byFunction`
@@ -10675,9 +9197,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Invocations.byFunction`
@@ -10689,9 +9209,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.IteratorAge.byFunction`
@@ -10703,9 +9221,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrencyInvocations.byFunction`
@@ -10717,9 +9233,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrencySpilloverInvocations.byFunction`
@@ -10731,9 +9245,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrentExecutions.byFunction`
@@ -10745,9 +9257,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Throttles.byFunction`
@@ -10759,9 +9269,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.DeadLetterErrors.byFunctionAlias`
@@ -10773,9 +9281,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Duration.byFunctionAlias`
@@ -10787,9 +9293,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Errors.byFunctionAlias`
@@ -10801,9 +9305,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Invocations.byFunctionAlias`
@@ -10815,9 +9317,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.IteratorAge.byFunctionAlias`
@@ -10829,9 +9329,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrencyInvocations.byFunctionAlias`
@@ -10843,9 +9341,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrencySpilloverInvocations.byFunctionAlias`
@@ -10857,9 +9353,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrencyUtilization.byFunctionAlias`
@@ -10871,9 +9365,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ProvisionedConcurrentExecutions.byFunctionAlias`
@@ -10885,9 +9377,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.Throttles.byFunctionAlias`
@@ -10899,9 +9389,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.ConcurrentExecutions.byRegion`
@@ -10913,9 +9401,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Lambda
-      </td>
+
 
       <td>
         `aws.lambda.UnreservedConcurrentExecutions`
@@ -10935,9 +9421,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.8KOutputDuration`
@@ -10949,9 +9433,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.AudioOutputDuration`
@@ -10963,9 +9445,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.HDOutputDuration`
@@ -10977,9 +9457,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.JobsCompletedCount`
@@ -10991,9 +9469,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.JobsErroredCount`
@@ -11005,9 +9481,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.SDOutputDuration`
@@ -11019,9 +9493,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.StandbyTime`
@@ -11033,9 +9505,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.TranscodingTime`
@@ -11047,9 +9517,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.UHDOutputDuration`
@@ -11061,9 +9529,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Elemental MediaConvert
-      </td>
+
 
       <td>
         `aws.mediaconvert.Errors`
@@ -11083,9 +9549,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS MediaPackage VOD
-      </td>
+
 
       <td>
         `aws.mediapackage.EgressBytes`
@@ -11097,9 +9561,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MediaPackage VOD
-      </td>
+
 
       <td>
         `aws.mediapackage.EgressRequestCount`
@@ -11111,9 +9573,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MediaPackage VOD
-      </td>
+
 
       <td>
         `aws.mediapackage.EgressResponseTime`
@@ -11148,9 +9608,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.CpuUtilization`
@@ -11162,9 +9620,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.CurrentConnectionsCount`
@@ -11176,9 +9632,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.EstablishedConnectionsCount`
@@ -11190,9 +9644,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.HeapUsage`
@@ -11204,9 +9656,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.InactiveDurableTopicSubscribersCount`
@@ -11218,9 +9668,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.JournalFilesForFastRecovery`
@@ -11232,9 +9680,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.JournalFilesForFullRecovery`
@@ -11246,9 +9692,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.NetworkIn`
@@ -11260,9 +9704,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.NetworkOut`
@@ -11274,9 +9716,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.OpenTransactionsCount`
@@ -11288,9 +9728,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.StorePercentUsage`
@@ -11302,9 +9740,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.TotalConsumerCount`
@@ -11316,9 +9752,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.TotalMessageCount`
@@ -11330,9 +9764,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.TotalProducerCount`
@@ -11344,9 +9776,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ConsumerCount.byTopic`
@@ -11358,9 +9788,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.DequeueCount.byTopic`
@@ -11372,9 +9800,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.DispatchCount.byTopic`
@@ -11386,9 +9812,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.EnqueueCount.byTopic`
@@ -11400,9 +9824,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.EnqueueTime.byTopic`
@@ -11414,9 +9836,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ExpiredCount.byTopic`
@@ -11428,9 +9848,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.InFlightCount.byTopic`
@@ -11442,9 +9860,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.MemoryUsage.byTopic`
@@ -11456,9 +9872,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ProducerCount.byTopic`
@@ -11470,9 +9884,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ReceiveCount.byTopic`
@@ -11484,9 +9896,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ConsumerCount.byQueue`
@@ -11498,9 +9908,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.DequeueCount.byQueue`
@@ -11512,9 +9920,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.DispatchCount.byQueue`
@@ -11526,9 +9932,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.EnqueueCount.byQueue`
@@ -11540,9 +9944,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.EnqueueTime.byQueue`
@@ -11554,9 +9956,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ExpiredCount.byQueue`
@@ -11568,9 +9968,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.InFlightCount.byQueue`
@@ -11582,9 +9980,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.MemoryUsage.byQueue`
@@ -11596,9 +9992,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ProducerCount.byQueue`
@@ -11610,9 +10004,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.QueueSize`
@@ -11624,9 +10016,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MQ
-      </td>
+
 
       <td>
         `aws.amazonmq.ReceiveCount.byQueue`
@@ -11646,9 +10036,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ActiveControllerCount`
@@ -11660,9 +10048,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.GlobalPartitionCount`
@@ -11674,9 +10060,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.GlobalTopicCount`
@@ -11688,9 +10072,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.OfflinePartitionsCount`
@@ -11702,9 +10084,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.BytesInPerSec.byBroker`
@@ -11716,9 +10096,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.BytesOutPerSec.byBroker`
@@ -11730,9 +10108,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.CpuIdle`
@@ -11744,9 +10120,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.CpuSystem`
@@ -11758,9 +10132,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.CpuUser`
@@ -11772,9 +10144,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchConsumerLocalTimeMsMean`
@@ -11786,9 +10156,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchConsumerRequestQueueTimeMsMean`
@@ -11800,9 +10168,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchConsumerResponseQueueTimeMsMean`
@@ -11814,9 +10180,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchConsumerResponseSendTimeMsMean`
@@ -11828,9 +10192,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchConsumerTotalTimeMsMean`
@@ -11842,9 +10204,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchFollowerLocalTimeMsMean`
@@ -11856,9 +10216,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchFollowerRequestQueueTimeMsMean`
@@ -11870,9 +10228,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchFollowerResponseQueueTimeMsMean`
@@ -11884,9 +10240,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchFollowerResponseSendTimeMsMean`
@@ -11898,9 +10252,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchFollowerTotalTimeMsMean`
@@ -11912,9 +10264,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchMessageConversionsPerSec.byBroker`
@@ -11926,9 +10276,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchThrottleByteRate`
@@ -11940,9 +10288,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchThrottleQueueSize`
@@ -11954,9 +10300,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchThrottleTime`
@@ -11968,9 +10312,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.KafkaAppLogsDiskUsed`
@@ -11982,9 +10324,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.KafkaDataLogsDiskUsed`
@@ -11996,9 +10336,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.LeaderCount`
@@ -12010,9 +10348,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.MemoryBuffered`
@@ -12024,9 +10360,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.MemoryCached`
@@ -12038,9 +10372,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.MemoryFree`
@@ -12052,9 +10384,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.MemoryUsed`
@@ -12066,9 +10396,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.MessagesInPerSec.byBroker`
@@ -12080,9 +10408,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkProcessorAvgIdlePercent`
@@ -12094,9 +10420,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkRxDropped`
@@ -12108,9 +10432,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkRxErrors`
@@ -12122,9 +10444,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkRxPackets`
@@ -12136,9 +10456,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkTxDropped`
@@ -12150,9 +10468,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkTxErrors`
@@ -12164,9 +10480,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.NetworkTxPackets`
@@ -12178,9 +10492,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.PartitionCount`
@@ -12192,9 +10504,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceLocalTimeMsMean`
@@ -12206,9 +10516,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceMessageConversionsPerSec.byBroker`
@@ -12220,9 +10528,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceMessageConversionsTimeMsMean`
@@ -12234,9 +10540,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceRequestQueueTimeMsMean`
@@ -12248,9 +10552,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceResponseQueueTimeMsMean`
@@ -12262,9 +10564,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceResponseSendTimeMsMean`
@@ -12276,9 +10576,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceThrottleByteRate`
@@ -12290,9 +10588,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceThrottleQueueSize`
@@ -12304,9 +10600,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceThrottleTime`
@@ -12318,9 +10612,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceTotalTimeMsMean`
@@ -12332,9 +10624,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RequestBytesMean`
@@ -12346,9 +10636,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RequestExemptFromThrottleTime`
@@ -12360,9 +10648,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RequestHandlerAvgIdlePercent`
@@ -12374,9 +10660,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RequestThrottleQueueSize`
@@ -12388,9 +10672,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RequestThrottleTime`
@@ -12402,9 +10684,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RequestTime`
@@ -12416,9 +10696,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.RootDiskUsed`
@@ -12430,9 +10708,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.SwapFree`
@@ -12444,9 +10720,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.SwapUsed`
@@ -12458,9 +10732,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.UnderMinIsrPartitionCount`
@@ -12472,9 +10744,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.UnderReplicatedPartitions`
@@ -12486,9 +10756,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ZooKeeperRequestLatencyMsMean`
@@ -12500,9 +10768,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ZooKeeperSessionState`
@@ -12514,9 +10780,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.BytesInPerSec.byTopic`
@@ -12528,9 +10792,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.BytesOutPerSec.byTopic`
@@ -12542,9 +10804,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.FetchMessageConversionsPerSec.byTopic`
@@ -12556,9 +10816,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.MessagesInPerSec.byTopic`
@@ -12570,9 +10828,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS MSK
-      </td>
+
 
       <td>
         `aws.kafka.ProduceMessageConversionsPerSec.byTopic`
@@ -12592,9 +10848,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.BackupRetentionPeriodStorageUsed.byInstance`
@@ -12606,9 +10860,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLag.byInstance`
@@ -12620,9 +10872,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMaximum.byInstance`
@@ -12634,9 +10884,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMinimum.byInstance`
@@ -12648,9 +10896,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.CPUUtilization.byInstance`
@@ -12662,9 +10908,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.EngineUptime.byInstance`
@@ -12676,9 +10920,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.FreeableMemory.byInstance`
@@ -12690,9 +10932,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinRequestsPerSec.byInstance`
@@ -12704,9 +10944,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinWebSocketOpenConnections.byInstance`
@@ -12718,9 +10956,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.LoaderRequestsPerSec.byInstance`
@@ -12732,9 +10968,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.MainRequestQueuePendingRequests.byInstance`
@@ -12746,9 +10980,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkReceiveThroughput.byInstance`
@@ -12760,9 +10992,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkThroughput.byInstance`
@@ -12774,9 +11004,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkTransmitThroughput.byInstance`
@@ -12788,9 +11016,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxCommitted.byInstance`
@@ -12802,9 +11028,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxOpened.byInstance`
@@ -12816,9 +11040,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxRolledBack.byInstance`
@@ -12830,9 +11052,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SnapshotStorageUsed.byInstance`
@@ -12844,9 +11064,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SparqlRequestsPerSec.byInstance`
@@ -12858,9 +11076,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalBackupStorageBilled.byInstance`
@@ -12872,9 +11088,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalClientErrorsPerSec.byInstance`
@@ -12886,9 +11100,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalRequestsPerSec.byInstance`
@@ -12900,9 +11112,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalServerErrorsPerSec.byInstance`
@@ -12914,9 +11124,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeBytesUsed.byInstance`
@@ -12928,9 +11136,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeReadIOPs.byInstance`
@@ -12942,9 +11148,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeWriteIOPs.byInstance`
@@ -12956,9 +11160,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.BackupRetentionPeriodStorageUsed.byCluster`
@@ -12970,9 +11172,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLag.byCluster`
@@ -12984,9 +11184,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMaximum.byCluster`
@@ -12998,9 +11196,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMinimum.byCluster`
@@ -13012,9 +11208,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.CPUUtilization.byCluster`
@@ -13026,9 +11220,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.EngineUptime.byCluster`
@@ -13040,9 +11232,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.FreeableMemory.byCluster`
@@ -13054,9 +11244,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinRequestsPerSec.byCluster`
@@ -13068,9 +11256,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinWebSocketOpenConnections.byCluster`
@@ -13082,9 +11268,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.LoaderRequestsPerSec.byCluster`
@@ -13096,9 +11280,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.MainRequestQueuePendingRequests.byCluster`
@@ -13110,9 +11292,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkReceiveThroughput.byCluster`
@@ -13124,9 +11304,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkThroughput.byCluster`
@@ -13138,9 +11316,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkTransmitThroughput.byCluster`
@@ -13152,9 +11328,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxCommitted.byCluster`
@@ -13166,9 +11340,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxOpened.byCluster`
@@ -13180,9 +11352,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxRolledBack.byCluster`
@@ -13194,9 +11364,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SnapshotStorageUsed.byCluster`
@@ -13208,9 +11376,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SparqlRequestsPerSec.byCluster`
@@ -13222,9 +11388,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalBackupStorageBilled.byCluster`
@@ -13236,9 +11400,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalClientErrorsPerSec.byCluster`
@@ -13250,9 +11412,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalRequestsPerSec.byCluster`
@@ -13264,9 +11424,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalServerErrorsPerSec.byCluster`
@@ -13278,9 +11436,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeBytesUsed.byCluster`
@@ -13292,9 +11448,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeReadIOPs.byCluster`
@@ -13306,9 +11460,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeWriteIOPs.byCluster`
@@ -13320,9 +11472,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.BackupRetentionPeriodStorageUsed.byClusterByRole`
@@ -13334,9 +11484,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLag.byClusterByRole`
@@ -13348,9 +11496,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMaximum.byClusterByRole`
@@ -13362,9 +11508,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMinimum.byClusterByRole`
@@ -13376,9 +11520,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.CPUUtilization.byClusterByRole`
@@ -13390,9 +11532,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.EngineUptime.byClusterByRole`
@@ -13404,9 +11544,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.FreeableMemory.byClusterByRole`
@@ -13418,9 +11556,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinRequestsPerSec.byClusterByRole`
@@ -13432,9 +11568,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinWebSocketOpenConnections.byClusterByRole`
@@ -13446,9 +11580,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.LoaderRequestsPerSec.byClusterByRole`
@@ -13460,9 +11592,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.MainRequestQueuePendingRequests.byClusterByRole`
@@ -13474,9 +11604,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkReceiveThroughput.byClusterByRole`
@@ -13488,9 +11616,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkThroughput.byClusterByRole`
@@ -13502,9 +11628,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkTransmitThroughput.byClusterByRole`
@@ -13516,9 +11640,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxCommitted.byClusterByRole`
@@ -13530,9 +11652,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxOpened.byClusterByRole`
@@ -13544,9 +11664,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxRolledBack.byClusterByRole`
@@ -13558,9 +11676,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SnapshotStorageUsed.byClusterByRole`
@@ -13572,9 +11688,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SparqlRequestsPerSec.byClusterByRole`
@@ -13586,9 +11700,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalBackupStorageBilled.byClusterByRole`
@@ -13600,9 +11712,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalClientErrorsPerSec.byClusterByRole`
@@ -13614,9 +11724,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalRequestsPerSec.byClusterByRole`
@@ -13628,9 +11736,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalServerErrorsPerSec.byClusterByRole`
@@ -13642,9 +11748,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeBytesUsed.byClusterByRole`
@@ -13656,9 +11760,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeReadIOPs.byClusterByRole`
@@ -13670,9 +11772,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeWriteIOPs.byClusterByRole`
@@ -13684,9 +11784,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.BackupRetentionPeriodStorageUsed.byDatabaseClass`
@@ -13698,9 +11796,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLag.byDatabaseClass`
@@ -13712,9 +11808,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMaximum.byDatabaseClass`
@@ -13726,9 +11820,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.ClusterReplicaLagMinimum.byDatabaseClass`
@@ -13740,9 +11832,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.CPUUtilization.byDatabaseClass`
@@ -13754,9 +11844,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.EngineUptime.byDatabaseClass`
@@ -13768,9 +11856,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.FreeableMemory.byDatabaseClass`
@@ -13782,9 +11868,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinRequestsPerSec.byDatabaseClass`
@@ -13796,9 +11880,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.GremlinWebSocketOpenConnections.byDatabaseClass`
@@ -13810,9 +11892,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.LoaderRequestsPerSec.byDatabaseClass`
@@ -13824,9 +11904,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.MainRequestQueuePendingRequests.byDatabaseClass`
@@ -13838,9 +11916,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkReceiveThroughput.byDatabaseClass`
@@ -13852,9 +11928,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkThroughput.byDatabaseClass`
@@ -13866,9 +11940,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NetworkTransmitThroughput.byDatabaseClass`
@@ -13880,9 +11952,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxCommitted.byDatabaseClass`
@@ -13894,9 +11964,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxOpened.byDatabaseClass`
@@ -13908,9 +11976,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.NumTxRolledBack.byDatabaseClass`
@@ -13922,9 +11988,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SnapshotStorageUsed.byDatabaseClass`
@@ -13936,9 +12000,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.SparqlRequestsPerSec.byDatabaseClass`
@@ -13950,9 +12012,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalBackupStorageBilled.byDatabaseClass`
@@ -13964,9 +12024,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalClientErrorsPerSec.byDatabaseClass`
@@ -13978,9 +12036,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalRequestsPerSec.byDatabaseClass`
@@ -13992,9 +12048,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.TotalServerErrorsPerSec.byDatabaseClass`
@@ -14006,9 +12060,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeBytesUsed.byDatabaseClass`
@@ -14020,9 +12072,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeReadIOPs.byDatabaseClass`
@@ -14034,9 +12084,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Neptune
-      </td>
+
 
       <td>
         `aws.neptune.VolumeWriteIOPs.byDatabaseClass`
@@ -14056,9 +12104,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.ActiveFlowCount`
@@ -14070,9 +12116,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.ActiveFlowCount_TLS`
@@ -14084,9 +12128,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.ClientTLSNegotiationErrorCount`
@@ -14098,9 +12140,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.ConsumedLCUs`
@@ -14112,9 +12152,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.NewFlowCount`
@@ -14126,9 +12164,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.NewFlowCount_TLS`
@@ -14140,9 +12176,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.ProcessedBytes`
@@ -14154,9 +12188,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.ProcessedBytes_TLS`
@@ -14168,9 +12200,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.TargetTLSNegotiationErrorCount`
@@ -14182,9 +12212,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.TCP_Client_Reset_Count`
@@ -14196,9 +12224,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.TCP_ELB_Reset_Count`
@@ -14210,9 +12236,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.TCP_Target_Reset_Count`
@@ -14224,9 +12248,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.HealthyHostCount`
@@ -14238,9 +12260,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS NLB
-      </td>
+
 
       <td>
         `aws.networkelb.UnHealthyHostCount`
@@ -14260,9 +12280,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.CommandLatency`
@@ -14274,9 +12292,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.IndexedStorage`
@@ -14288,9 +12304,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.JournalStorage`
@@ -14302,9 +12316,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.OccConflictExceptions`
@@ -14316,9 +12328,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.ReadIOs`
@@ -14330,9 +12340,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.Session4xxExceptions`
@@ -14344,9 +12352,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.Session5xxExceptions`
@@ -14358,9 +12364,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.SessionRateExceededExceptions`
@@ -14372,9 +12376,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS QLDB
-      </td>
+
 
       <td>
         `aws.qldb.WriteIOs`
@@ -14394,9 +12396,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.VolumeBytesUsed.byDbCluster`
@@ -14408,9 +12408,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.VolumeReadIOPs.byDbCluster`
@@ -14422,9 +12420,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.VolumeWriteIOPs.byDbCluster`
@@ -14436,9 +12432,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ActiveTransactions`
@@ -14450,9 +12444,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.allocatedStorageBytes`
@@ -14464,9 +12456,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.AuroraBinlogReplicaLag`
@@ -14478,9 +12468,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.AuroraReplicaLag`
@@ -14492,9 +12480,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.AuroraReplicaLagMaximum`
@@ -14506,9 +12492,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.AuroraReplicaLagMinimum`
@@ -14520,9 +12504,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.BacktrackWindowActual`
@@ -14534,9 +12516,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.BacktrackWindowAlert`
@@ -14548,9 +12528,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.BinLogDiskUsage`
@@ -14562,9 +12540,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.BlockedTransactions`
@@ -14576,9 +12552,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.BufferCacheHitRatio`
@@ -14590,9 +12564,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.BurstBalance`
@@ -14604,9 +12576,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.CommitLatency`
@@ -14618,9 +12588,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.CommitThroughput`
@@ -14632,9 +12600,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.CPUCreditBalance`
@@ -14646,9 +12612,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.CPUCreditUsage`
@@ -14660,9 +12624,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.CPUUtilization`
@@ -14674,9 +12636,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.guest`
@@ -14688,9 +12648,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.idle`
@@ -14702,9 +12660,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.irq`
@@ -14716,9 +12672,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.nice`
@@ -14730,9 +12684,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.steal`
@@ -14744,9 +12696,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.system`
@@ -14758,9 +12708,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.total`
@@ -14772,9 +12720,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.user`
@@ -14786,9 +12732,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.cpuUtilization.wait`
@@ -14800,9 +12744,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DatabaseConnections`
@@ -14814,9 +12756,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DDLLatency`
@@ -14828,9 +12768,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DDLThroughput`
@@ -14842,9 +12780,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.Deadlocks`
@@ -14856,9 +12792,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DeleteLatency`
@@ -14870,9 +12804,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DeleteThroughput`
@@ -14884,9 +12816,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.avgQueueLen`
@@ -14898,9 +12828,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.avgReqSz`
@@ -14912,9 +12840,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.await`
@@ -14926,9 +12852,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.readIosps`
@@ -14940,9 +12864,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.readKb`
@@ -14954,9 +12876,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.readKbps`
@@ -14968,9 +12888,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.readLatency`
@@ -14982,9 +12900,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.rrqmPs`
@@ -14996,9 +12912,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.tps`
@@ -15010,9 +12924,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.util`
@@ -15024,9 +12936,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.writeIosps`
@@ -15038,9 +12948,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.writeKb`
@@ -15052,9 +12960,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.writeKbps`
@@ -15066,9 +12972,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.writeLatency`
@@ -15080,9 +12984,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.writeThroughput`
@@ -15094,9 +12996,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.diskIo.wrqmPs`
@@ -15108,9 +13008,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DiskQueueDepth`
@@ -15122,9 +13020,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.availKb`
@@ -15136,9 +13032,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.availPc`
@@ -15150,9 +13044,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.rdBytesPs`
@@ -15164,9 +13056,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.rdCountPs`
@@ -15178,9 +13068,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.totalKb`
@@ -15192,9 +13080,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.usedKb`
@@ -15206,9 +13092,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.usedPc`
@@ -15220,9 +13104,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.wrBytesPs`
@@ -15234,9 +13116,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.disks.wrCountPs`
@@ -15248,9 +13128,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DMLLatency`
@@ -15262,9 +13140,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.DMLThroughput`
@@ -15276,9 +13152,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.EngineUptime`
@@ -15290,9 +13164,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.fileSys.maxFiles`
@@ -15304,9 +13176,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.fileSys.total`
@@ -15318,9 +13188,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.fileSys.used`
@@ -15332,9 +13200,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.fileSys.usedFiles`
@@ -15346,9 +13212,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.fileSys.usedFilesPercent`
@@ -15360,9 +13224,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.fileSys.usedPercent`
@@ -15374,9 +13236,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.FreeableMemory`
@@ -15388,9 +13248,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.FreeLocalStorage`
@@ -15402,9 +13260,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.FreeStorageSpace`
@@ -15416,9 +13272,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.InsertLatency`
@@ -15430,9 +13284,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.InsertThroughput`
@@ -15444,9 +13296,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.loadAverageMinute.fifteen`
@@ -15458,9 +13308,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.loadAverageMinute.five`
@@ -15472,9 +13320,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.loadAverageMinute.one`
@@ -15486,9 +13332,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.LoginFailures`
@@ -15500,9 +13344,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.MaximumUsedTransactionIDs`
@@ -15514,9 +13356,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.active`
@@ -15528,9 +13368,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.buffers`
@@ -15542,9 +13380,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.cached`
@@ -15556,9 +13392,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.commitLimitKb`
@@ -15570,9 +13404,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.commitPeakKb`
@@ -15584,9 +13416,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.commitTotKb`
@@ -15598,9 +13428,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.dirty`
@@ -15612,9 +13440,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.free`
@@ -15626,9 +13452,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.hugePagesFree`
@@ -15640,9 +13464,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.hugePagesRsvd`
@@ -15654,9 +13476,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.hugePagesSize`
@@ -15668,9 +13488,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.hugePagesSurp`
@@ -15682,9 +13500,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.hugePagesTotal`
@@ -15696,9 +13512,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.inactive`
@@ -15710,9 +13524,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.kernNonpagedKb`
@@ -15724,9 +13536,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.kernPagedKb`
@@ -15738,9 +13548,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.kernTotKb`
@@ -15752,9 +13560,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.mapped`
@@ -15766,9 +13572,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.pageSize`
@@ -15780,9 +13584,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.pageTables`
@@ -15794,9 +13596,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.physAvailKb`
@@ -15808,9 +13608,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.physTotKb`
@@ -15822,9 +13620,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.slab`
@@ -15836,9 +13632,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.sqlServerTotKb`
@@ -15850,9 +13644,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.sysCacheKb`
@@ -15864,9 +13656,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.total`
@@ -15878,9 +13668,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.memory.writeback`
@@ -15892,9 +13680,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.network.rdBytesPs`
@@ -15906,9 +13692,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.network.rx`
@@ -15920,9 +13704,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.network.tx`
@@ -15934,9 +13716,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.network.wrBytesPs`
@@ -15948,9 +13728,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.NetworkReceiveThroughput`
@@ -15962,9 +13740,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.NetworkThroughput`
@@ -15976,9 +13752,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.NetworkTransmitThroughput`
@@ -15990,9 +13764,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.OldestReplicationSlotLag`
@@ -16004,9 +13776,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.cpuUsedPc`
@@ -16018,9 +13788,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.memoryUsedPc`
@@ -16032,9 +13800,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.memUsedPc`
@@ -16046,9 +13812,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.rss`
@@ -16060,9 +13824,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.virtKb`
@@ -16074,9 +13836,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.workingSetKb`
@@ -16088,9 +13848,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.workingSetPrivKb`
@@ -16102,9 +13860,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.process.workingSetShareableKb`
@@ -16116,9 +13872,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.Queries`
@@ -16130,9 +13884,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.RDSToAuroraPostgreSQLReplicaLag`
@@ -16144,9 +13896,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ReadIOPS`
@@ -16158,9 +13908,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ReadLatency`
@@ -16172,9 +13920,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ReadThroughput`
@@ -16186,9 +13932,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ReplicaLag`
@@ -16200,9 +13944,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ReplicationSlotDiskUsage`
@@ -16214,9 +13956,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.ResultSetCacheHitRatio`
@@ -16228,9 +13968,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.SelectLatency`
@@ -16242,9 +13980,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.SelectThroughput`
@@ -16256,9 +13992,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.swap.cached`
@@ -16270,9 +14004,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.swap.free`
@@ -16284,9 +14016,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.swap.total`
@@ -16298,9 +14028,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.SwapUsage`
@@ -16312,9 +14040,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.system.handles`
@@ -16326,9 +14052,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.system.processes`
@@ -16340,9 +14064,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.system.threads`
@@ -16354,9 +14076,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.tasks.blocked`
@@ -16368,9 +14088,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.tasks.running`
@@ -16382,9 +14100,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.tasks.sleeping`
@@ -16396,9 +14112,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.tasks.stopped`
@@ -16410,9 +14124,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.tasks.total`
@@ -16424,9 +14136,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.tasks.zombie`
@@ -16438,9 +14148,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.TransactionLogsDiskUsage`
@@ -16452,9 +14160,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.TransactionLogsGeneration`
@@ -16466,9 +14172,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.UpdateLatency`
@@ -16480,9 +14184,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.UpdateThroughput`
@@ -16494,9 +14196,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.WriteIOPS`
@@ -16508,9 +14208,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.WriteLatency`
@@ -16522,9 +14220,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS RDS
-      </td>
+
 
       <td>
         `aws.rds.WriteThroughput`
@@ -16544,9 +14240,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.CPUUtilization.byCluster`
@@ -16558,9 +14252,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.DatabaseConnections.byCluster`
@@ -16572,9 +14264,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.HealthStatus.byCluster`
@@ -16586,9 +14276,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.MaintenanceMode.byCluster`
@@ -16600,9 +14288,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.NetworkReceiveThroughput.byCluster`
@@ -16614,9 +14300,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.NetworkTransmitThroughput.byCluster`
@@ -16628,9 +14312,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.PercentageDiskSpaceUsed.byCluster`
@@ -16642,9 +14324,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.QueriesCompletedPerSecond`
@@ -16656,9 +14336,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.QueryDuration`
@@ -16670,9 +14348,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.ReadIOPS.byCluster`
@@ -16684,9 +14360,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.ReadLatency.byCluster`
@@ -16698,9 +14372,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.ReadThroughput.byCluster`
@@ -16712,9 +14384,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.WriteIOPS.byCluster`
@@ -16726,9 +14396,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.WriteLatency.byCluster`
@@ -16740,9 +14408,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.WriteThroughput.byCluster`
@@ -16754,9 +14420,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.CPUUtilization.byNode`
@@ -16768,9 +14432,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.DatabaseConnections.byNode`
@@ -16782,9 +14444,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.HealthStatus.byNode`
@@ -16796,9 +14456,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.MaintenanceMode.byNode`
@@ -16810,9 +14468,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.NetworkReceiveThroughput.byNode`
@@ -16824,9 +14480,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.NetworkTransmitThroughput.byNode`
@@ -16838,9 +14492,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.PercentageDiskSpaceUsed.byNode`
@@ -16852,9 +14504,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.ReadIOPS.byNode`
@@ -16866,9 +14516,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.ReadLatency.byNode`
@@ -16880,9 +14528,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.ReadThroughput.byNode`
@@ -16894,9 +14540,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.WriteIOPS.byNode`
@@ -16908,9 +14552,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.WriteLatency.byNode`
@@ -16922,9 +14564,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Redshift
-      </td>
+
 
       <td>
         `aws.redshift.WriteThroughput.byNode`
@@ -16944,9 +14584,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Route53
-      </td>
+
 
       <td>
         `aws.route53.ChildHealthCheckHealthyCount`
@@ -16958,9 +14596,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53
-      </td>
+
 
       <td>
         `aws.route53.ConnectionTime`
@@ -16972,9 +14608,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53
-      </td>
+
 
       <td>
         `aws.route53.HealthCheckPercentageHealthy`
@@ -16986,9 +14620,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53
-      </td>
+
 
       <td>
         `aws.route53.HealthCheckStatus`
@@ -17000,9 +14632,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53
-      </td>
+
 
       <td>
         `aws.route53.SSLHandshakeTime`
@@ -17014,9 +14644,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53
-      </td>
+
 
       <td>
         `aws.route53.TimeToFirstByte`
@@ -17036,9 +14664,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Route53 Resolver
-      </td>
+
 
       <td>
         `aws.route53resolver.InboundQueryVolume`
@@ -17050,9 +14676,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53 Resolver
-      </td>
+
 
       <td>
         `aws.route53resolver.OutboundQueryAggregatedVolume`
@@ -17064,9 +14688,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Route53 Resolver
-      </td>
+
 
       <td>
         `aws.route53resolver.OutboundQueryVolume`
@@ -17087,9 +14709,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.BucketSizeBytes`
@@ -17101,9 +14721,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.NumberOfObjects`
@@ -17115,9 +14733,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.4xxErrors`
@@ -17129,9 +14745,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.5xxErrors`
@@ -17143,9 +14757,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.AllRequests`
@@ -17157,9 +14769,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.BytesDownloaded`
@@ -17171,9 +14781,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.BytesUploaded`
@@ -17185,9 +14793,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.DeleteRequests`
@@ -17199,9 +14805,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.FirstByteLatency`
@@ -17213,9 +14817,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.GetRequests`
@@ -17227,9 +14829,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.HeadRequests`
@@ -17241,9 +14841,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.ListRequests`
@@ -17255,9 +14853,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.PostRequests`
@@ -17269,9 +14865,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.PutRequests`
@@ -17283,9 +14877,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS S3
-      </td>
+
 
       <td>
         `aws.s3.TotalRequestLatency`
@@ -17305,9 +14897,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS SES
-      </td>
+
 
       <td>
         `aws.ses.Bounce`
@@ -17319,9 +14909,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SES
-      </td>
+
 
       <td>
         `aws.ses.Click`
@@ -17333,9 +14921,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SES
-      </td>
+
 
       <td>
         `aws.ses.Complaint`
@@ -17347,9 +14933,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SES
-      </td>
+
 
       <td>
         `aws.ses.Delivery`
@@ -17361,9 +14945,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SES
-      </td>
+
 
       <td>
         `aws.ses.Open`
@@ -17375,9 +14957,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SES
-      </td>
+
 
       <td>
         `aws.ses.Send`
@@ -17397,9 +14977,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.NumberOfMessagesPublished`
@@ -17411,9 +14989,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.NumberOfNotificationsDelivered`
@@ -17425,9 +15001,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.NumberOfNotificationsFailed`
@@ -17439,9 +15013,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.PublishSize`
@@ -17453,9 +15025,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.SubscriptionsConfirmed`
@@ -17467,9 +15037,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.SubscriptionsDeleted`
@@ -17481,9 +15049,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SNS
-      </td>
+
 
       <td>
         `aws.sns.SubscriptionsPending`
@@ -17503,9 +15069,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.ApproximateAgeOfOldestMessage`
@@ -17517,9 +15081,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.ApproximateNumberOfMessagesDelayed`
@@ -17531,9 +15093,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.ApproximateNumberOfMessagesNotVisible`
@@ -17545,9 +15105,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.ApproximateNumberOfMessagesVisible`
@@ -17559,9 +15117,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.NumberOfEmptyReceives`
@@ -17573,9 +15129,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.NumberOfMessagesDeleted`
@@ -17587,9 +15141,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.NumberOfMessagesReceived`
@@ -17601,9 +15153,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.NumberOfMessagesSent`
@@ -17615,9 +15165,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS SQS
-      </td>
+
 
       <td>
         `aws.sqs.SentMessageSize`
@@ -17637,9 +15185,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionsAborted`
@@ -17651,9 +15197,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionsFailed`
@@ -17665,9 +15209,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionsStarted`
@@ -17679,9 +15221,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionsSucceeded`
@@ -17693,9 +15233,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionsTimedOut`
@@ -17707,9 +15245,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionThrottled`
@@ -17721,9 +15257,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ExecutionTime`
@@ -17735,9 +15269,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivitiesFailed`
@@ -17749,9 +15281,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivitiesHeartbeatTimedOut`
@@ -17763,9 +15293,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivitiesScheduled`
@@ -17777,9 +15305,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivitiesStarted`
@@ -17791,9 +15317,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivitiesSucceeded`
@@ -17805,9 +15329,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivitiesTimedOut`
@@ -17819,9 +15341,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivityRunTime`
@@ -17833,9 +15353,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivityScheduleTime`
@@ -17847,9 +15365,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ActivityTime`
@@ -17861,9 +15377,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionRunTime`
@@ -17875,9 +15389,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionScheduleTime`
@@ -17889,9 +15401,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionsFailed`
@@ -17903,9 +15413,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionsScheduled`
@@ -17917,9 +15425,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionsStarted`
@@ -17931,9 +15437,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionsSucceeded`
@@ -17945,9 +15449,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionsTimedOut`
@@ -17959,9 +15461,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.LambdaFunctionTime`
@@ -17973,9 +15473,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationRunTime`
@@ -17987,9 +15485,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationScheduleTime`
@@ -18001,9 +15497,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationsFailed`
@@ -18015,9 +15509,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationsScheduled`
@@ -18029,9 +15521,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationsStarted`
@@ -18043,9 +15533,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationsSucceeded`
@@ -18057,9 +15545,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationsTimedOut`
@@ -18071,9 +15557,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ServiceIntegrationTime`
@@ -18085,9 +15569,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ConsumedCapacity.byService`
@@ -18099,9 +15581,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ProvisionedBucketSize.byService`
@@ -18113,9 +15593,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ProvisionedRefillRate.byApiUsage`
@@ -18127,9 +15605,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ThrottledEvents.byService`
@@ -18141,9 +15617,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ConsumedCapacity.byApiUsage`
@@ -18155,9 +15629,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ProvisionedBucketSize.byApiUsage`
@@ -18169,9 +15641,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ProvisionedRefillRate.byService`
@@ -18183,9 +15653,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Step Functions
-      </td>
+
 
       <td>
         `aws.states.ThrottledEvents.byApiUsage`
@@ -18205,9 +15673,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.BytesDropCountBlackhole`
@@ -18219,9 +15685,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.BytesDropCountNoRoute`
@@ -18233,9 +15697,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.BytesIn`
@@ -18247,9 +15709,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.BytesOut`
@@ -18261,9 +15721,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.PacketDropCountBlackhole`
@@ -18275,9 +15733,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.PacketDropCountNoRoute`
@@ -18289,9 +15745,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.PacketsIn`
@@ -18303,9 +15757,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Transit Gateway
-      </td>
+
 
       <td>
         `aws.transitgateway.PacketsOut`
@@ -18325,9 +15777,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS Trusted Advisor
-      </td>
+
 
       <td>
         `aws.trustedadvisor.currentUsage`
@@ -18339,9 +15789,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Trusted Advisor
-      </td>
+
 
       <td>
         `aws.trustedadvisor.limitAmount`
@@ -18353,9 +15801,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS Trusted Advisor
-      </td>
+
 
       <td>
         `aws.trustedadvisor.limitUsage`
@@ -18376,9 +15822,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.ActiveConnectionCount`
@@ -18390,9 +15834,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.BytesInFromDestination`
@@ -18404,9 +15846,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.BytesInFromSource`
@@ -18418,9 +15858,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.BytesOutToDestination`
@@ -18432,9 +15870,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.BytesOutToSource`
@@ -18446,9 +15882,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.ConnectionAttemptCount`
@@ -18460,9 +15894,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.ConnectionEstablishedCount`
@@ -18474,9 +15906,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.ErrorPortAllocation`
@@ -18488,9 +15918,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.IdleTimeoutCount`
@@ -18502,9 +15930,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.PacketsDropCount`
@@ -18516,9 +15942,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.PacketsInFromDestination`
@@ -18530,9 +15954,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.PacketsInFromSource`
@@ -18544,9 +15966,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.PacketsOutToDestination`
@@ -18558,9 +15978,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.natgateway.PacketsOutToSource`
@@ -18572,9 +15990,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.vpc.bytes`
@@ -18586,9 +16002,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.vpc.packets`
@@ -18600,9 +16014,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.vpn.TunnelDataIn`
@@ -18614,9 +16026,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.vpn.TunnelDataOut`
@@ -18628,9 +16038,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS VPC
-      </td>
+
 
       <td>
         `aws.vpn.TunnelState`
@@ -18650,9 +16058,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 <table>
   <tbody>
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.AllowedRequests.byWebACL`
@@ -18664,9 +16070,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.BlockedRequests.byWebACL`
@@ -18678,9 +16082,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.CountedRequests.byWebACL`
@@ -18692,9 +16094,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.PassedRequests.byWebACL`
@@ -18706,9 +16106,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.AllowedRequests.byRuleGroup`
@@ -18720,9 +16118,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.BlockedRequests.byRuleGroup`
@@ -18734,9 +16130,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.CountedRequests.byRuleGroup`
@@ -18748,9 +16142,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAF
-      </td>
+
 
       <td>
         `aws.waf.PassedRequests.byRuleGroup`
@@ -18769,20 +16161,8 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     >
 <table>
   <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.AllowedRequests.byWebACL`
@@ -18794,9 +16174,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.BlockedRequests.byWebACL`
@@ -18808,9 +16186,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.CountedRequests.byWebACL`
@@ -18822,9 +16198,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.PassedRequests.byWebACL`
@@ -18836,9 +16210,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.AllowedRequests.byRuleGroup`
@@ -18850,9 +16222,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.BlockedRequests.byRuleGroup`
@@ -18864,9 +16234,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.CountedRequests.byRuleGroup`
@@ -18878,9 +16246,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
 
     <tr>
-      <td>
-        AWS WAFV2
-      </td>
+
 
       <td>
         `aws.wafv2.PassedRequests.byRuleGroup`

--- a/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -73,6 +73,11 @@ For a reference on available metrics from each one of the polling integrations a
 
 The following noncomprehensive list displays the metrics collected by the AWS polling integrations and their [dimensional metrics](/docs/telemetry-data-platform/ingest-manage-data/understand-data/new-relic-data-types/#dimensional-metrics) translations. 
 
+<CollapserGroup>
+    <Collapser
+        id="AWS-ALB"
+        title="AWS ALB"
+    >
 <table>
  <tbody>
     <tr>
@@ -676,6 +681,16 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.unHealthyHostCount`
       </td>
     </tr>
+  </tbody>
+</table>
+    
+    </Collapser>
+    <Collapser
+        id="api-gateway"
+        title="AWS API Gateway"
+    >
+<table>
+ <tbody>
 
     <tr>
       <td>
@@ -970,6 +985,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.latency`
       </td>
     </tr>
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="appsync"
+        title="AWS AppSync"
+    >
+<table>
+  </tbody>
 
     <tr>
       <td>
@@ -1012,7 +1036,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.latency`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="athena"
+        title="AWS Athena"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Athena
@@ -1040,7 +1072,16 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.totalExecutionTime`
       </td>
     </tr>
+  </tbody>
+</table>
 
+    </Collapser>
+    <Collapser
+        id="auto-scaling"
+        title="AWS Auto Scaling"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Auto Scaling
@@ -1166,8 +1207,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `healthStatus`
       </td>
     </tr>
+  </tbody>
+</table>
 
-    <tr>
+    </Collapser>
+    <Collapser
+        id="billing"
+        title="AWS Billing"
+    >
+   <tr>
       <td>
         AWS Billing
       </td>
@@ -1250,7 +1298,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.estimatedCharges`
       </td>
     </tr>
-
+  </tbody>
+<table>
+    </Collapser>
+    <Collapser
+        id="cloudfront"
+        title="AWS Cloudfront"
+    >
+<table>
+<tbody>
     <tr>
       <td>
         AWS CloudFront
@@ -1389,8 +1445,16 @@ The following noncomprehensive list displays the metrics collected by the AWS po
       <td>
         `provider.throttles`
       </td>
-    </tr>
-
+  </tr> 
+</tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="cognito"
+        title="AWS Cognito"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Cognito
@@ -1502,6 +1566,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.tokenRefreshThrottles`
       </td>
     </tr>
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="conntect"
+        title="AWS Connect"
+    >
+<table>
+  <tbody>
 
     <tr>
       <td>
@@ -1712,7 +1785,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.queueSize`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="direct-connect"
+        title="AWS Direct Connect"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Direct Connect
@@ -1880,8 +1961,16 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.virtualInterfacePpsIngress`
       </td>
     </tr>
-
-    <tr>
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="documentDB"
+        title="AWS DocumentDB"
+    >
+<table>
+  <tbody>
+<tr>
       <td>
         AWS DocumentDB
       </td>
@@ -2972,7 +3061,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.writeThroughput`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="DynamoDB"
+        title="AWS DynamoDB"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS DynamoDB
@@ -3672,7 +3769,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.writeThrottleEvents`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="ebs"
+        title="AWS EBS"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS EBS
@@ -3826,7 +3931,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.volumeWriteOps`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="ec2"
+        title="AWS EC2"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS EC2
@@ -4050,7 +4163,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.statusCheckFailedSystem`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="ECS"
+        title="AWS ECS"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS ECS
@@ -4232,7 +4353,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.runningCount`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="EFS"
+        title="AWS EFS"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS EFS
@@ -4358,7 +4487,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.totalIOBytes`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="ElasticSearch"
+        title="AWS ElasticSearch"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS ElasticSearch
@@ -5450,7 +5587,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.ThreadpoolSearchThreads`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="ElastiCache"
+        title="AWS ElastiCache"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS ElastiCache
@@ -7019,6 +7164,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
       </td>
     </tr>
 
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="elastic-beanstalk"
+        title="AWS Elastic Beanstalk"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Elastic Beanstalk
@@ -7648,7 +7802,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.rootFilesystemUtil`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="elb"
+        title="AWS ELB"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS ELB
@@ -7886,7 +8048,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.unhealthyHostCount`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="emr"
+        title="AWS EMR"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS EMR
@@ -8502,7 +8672,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.yarnMemoryAvailablePercentage`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="fsx"
+        title="AWS FSx"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS FSx
@@ -8586,7 +8764,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.metadataOperations`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="glue"
+        title="AWS Glue"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Glue
@@ -8894,7 +9080,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.glue.driver.system.cpuSystemLoad`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="iam"
+        title="AWS IAM"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS IAM
@@ -9356,7 +9550,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `VersionsPerPolicyQuota`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="iot"
+        title="AWS IoT"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS IoT
@@ -9804,7 +10006,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.success`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="kinesis"
+        title="AWS Kinesis"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Kinesis
@@ -10126,7 +10336,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.writeProvisionedThroughputExceeded`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="kinesis-firehouse"
+        title="AWS Kinesis Firehose"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Kinesis Firehose
@@ -10392,7 +10610,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.putRecordBatchRequests`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="lambda"
+        title="AWS Lambda"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Lambda
@@ -10700,7 +10926,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.unreservedConcurrentExecutions`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="elemental-mediaconvert"
+        title="AWs Elemental MediaConvert"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Elemental MediaConvert
@@ -10840,6 +11074,168 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.errors`
       </td>
     </tr>
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
+
+  </tbody>
+</table>
+    </Collapser>                    
+</CollapserGroup>
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     <tr>
       <td>

--- a/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/aws-integrations-metrics.mdx
@@ -691,7 +691,6 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     >
 <table>
  <tbody>
-
     <tr>
       <td>
         AWS API Gateway
@@ -993,8 +992,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         title="AWS AppSync"
     >
 <table>
-  </tbody>
-
+  <tbody>
     <tr>
       <td>
         AWS AppSync
@@ -1209,12 +1207,13 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
   </tbody>
 </table>
-
     </Collapser>
     <Collapser
         id="billing"
         title="AWS Billing"
     >
+<table>
+  <tbody>
    <tr>
       <td>
         AWS Billing
@@ -1299,7 +1298,7 @@ The following noncomprehensive list displays the metrics collected by the AWS po
       </td>
     </tr>
   </tbody>
-<table>
+</table>
     </Collapser>
     <Collapser
         id="cloudfront"
@@ -11078,165 +11077,11 @@ The following noncomprehensive list displays the metrics collected by the AWS po
 </table>
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="mediapackage"
+        title="AWS MediaPackage VOD"
     >
 <table>
   <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-<table>
-  <tbody>
-
-  </tbody>
-</table>
-    </Collapser>                    
-</CollapserGroup>
-
-
-
-
-
-
-
-
- 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     <tr>
       <td>
         AWS MediaPackage VOD
@@ -11279,7 +11124,16 @@ The following noncomprehensive list displays the metrics collected by the AWS po
       </td>
     </tr>
 
-    <tr>
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-mq"
+        title="AWS MQ"
+    >
+<table>
+  <tbody>
+<tr>
       <td>
         AWS MQ
       </td>
@@ -11782,7 +11636,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.receiveCount`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-msk"
+        title="AWS MSK"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS MSK
@@ -12720,7 +12582,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.produceMessageConversionsPerSec`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-neptune"
+        title="AWS Neptune"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Neptune
@@ -14176,7 +14046,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.volumeWriteIOPs`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-nlb"
+        title="AWS NLB"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS NLB
@@ -14372,7 +14250,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.unHealthyHostCount`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-qldb"
+        title="AWS QLDB"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS QLDB
@@ -14498,7 +14384,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.writeIOs`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-rds"
+        title="AWS RDS"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS RDS
@@ -16640,7 +16534,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.writeThroughput`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-redshift"
+        title="AWS Redshift"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Redshift
@@ -17032,7 +16934,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.WriteThroughput`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-route53"
+        title="AWS Route53"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Route53
@@ -17116,7 +17026,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.timeToFirstByte`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-route53-resolver"
+        title="AWS Route54 Resolver"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Route53 Resolver
@@ -17159,6 +17077,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
       </td>
     </tr>
 
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-s3"
+        title="AWS S3"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS S3
@@ -17368,7 +17295,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.totalRequestLatency`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>    
+    <Collapser
+        id="aws-ses"
+        title="AWS SES"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS SES
@@ -17452,7 +17387,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.Send`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-sns"
+        title="AWS SNS"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS SNS
@@ -17550,7 +17493,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.subscriptionsPending`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>    
+    <Collapser
+        id="aws-sqs"
+        title="AWS SQS"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS SQS
@@ -17676,7 +17627,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.sentMessageSize`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-step-function"
+        title="AWS Step Functions"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Step Functions
@@ -18236,7 +18195,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.throttledEvents`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>    
+    <Collapser
+        id="aws-transit-gateway"
+        title="AWS Transit Gateway"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Transit Gateway
@@ -18348,7 +18315,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.packetsOut`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-trusted-advisor"
+        title="AWs Trusted Advisor"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS Trusted Advisor
@@ -18391,6 +18366,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
       </td>
     </tr>
 
+  </tbody>
+</table>
+    </Collapser>    
+    <Collapser
+        id="aws-vpc"
+        title="AWS VPC"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS VPC
@@ -18656,7 +18640,15 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.tunnelState`
       </td>
     </tr>
-
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="aws-waf"
+        title="AWS WAF"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS WAF
@@ -18768,7 +18760,25 @@ The following noncomprehensive list displays the metrics collected by the AWS po
         `provider.passedRequests`
       </td>
     </tr>
+  </tbody>
+</table>
+    </Collapser>    
+    <Collapser
+        id="aws-wafv2"
+        title="AWS WAFV2"
+    >
+<table>
+  <tbody>
 
+  </tbody>
+</table>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+<table>
+  <tbody>
     <tr>
       <td>
         AWS WAFV2
@@ -18882,3 +18892,5 @@ The following noncomprehensive list displays the metrics collected by the AWS po
     </tr>
   </tbody>
 </table>
+    </Collapser>        
+</CollapserGroup>


### PR DESCRIPTION
Breaks apart AWS metrics into individual collapsers per integration. 