### PR TITLE
feat(php-agent): add php to list of agents supporting error fingerprinting

### DIFF
--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -93,6 +93,7 @@ Supported APM agents:
 * [.Net](/docs/apm/agents/net-agent/net-agent-api/seterrorgroupcallback-net-agent-api)
 * [Python](/docs/apm/agents/python-agent/python-agent-api/seterrrorgroupcallback-python-agent-api)
 * [Ruby](/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/#error-fingerprinting)
+* [PHP](/docs/apm/agents/php-agent/php-agent-api/newrelic_set_error_group_callback)
 
 Even if we don't support your language, you can still set `error.group.name` as a custom attribute. This signals to us that the event belongs to a custom group, but the events captured won't have other agent attributes.
 


### PR DESCRIPTION
Adds the PHP Agent to the list of APM agents that support error fingerprinting (error grouping).