### PR TITLE
fix(IAST): Updated APM versions on the intro page

### DIFF
--- a/src/content/docs/iast/introduction.mdx
+++ b/src/content/docs/iast/introduction.mdx
@@ -22,10 +22,10 @@ New Relic IAST helps address some of the limitations of more traditional applica
 IAST helps you:
 
 - **Find and fix exploitable vulnerabilities**: no need to wait for scan results.
-- **Ship code faster**: Unmatched detection accuracy and substantially fewer false positives.
-- **See and secure every application**: Full visibility into your code, web components, and configuration data.
-- **Reduce time and cost**: When you eliminate vulnerabilities.
-- **Cut down the noise**: Use of both static application security testing (SAST) and dynamic application security testing (DAST) analysis.
+- **Ship code faster**: unmatched detection accuracy and substantially fewer false positives.
+- **See and secure every application**: full visibility into your code, web components, and configuration data.
+- **Reduce time and cost**: when you eliminate vulnerabilities.
+- **Cut down the noise**: use of both static application security testing (SAST) and dynamic application security testing (DAST) analysis.
 
 
 <img
@@ -78,13 +78,13 @@ Our <InlinePopover type="apm" /> agents delivers New Relic IAST and you can enab
     <tbody>
         <tr>
             <td>
-            APM version 3.23.0 or higher 
+            APM version 3.29.1 or higher 
             </td>
             <td>
-            APM version 8.4.0 or higher
+            APM version 8.9.1 or higher
             </td>
             <td>
-            APM version 10.3.0 or higher
+            APM version 11.10.3 or higher
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
Updated the APM agent versions to the latest GA license on the [Introduction to IAST](https://docs.newrelic.com/docs/iast/introduction/) page.

This request comes from the #help-documentation channel (02/15/2024)