### PR TITLE
Fix: add response headers to ensure referrer it sent to signup page events

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,5 @@ for = "/*"
 
 [headers.values]
 Access-Control-Allow-Origin = "*"
+Referrer-Policy="no-referrer-when-downgrade"
+Content-Security-Policy="frame-ancestors *.newrelic.com"


### PR DESCRIPTION
### ✨ Summary

When we migrated to Netlify we didn't set the `Referrer-Policy` response header to expose referrer page to signup page so it can report where signup originated. This is useful in attributing new signups to docs.

Also brought over the `Content-Security-Policy` response header for keepsakes for time being in case we ever want to iframe embeds or other content in other NR domains. This was previously done to support docs library service content in NR UI.

[Relevant options for gatsby cloud in gatsby-config.js](https://github.com/newrelic/docs-website/blob/7425a0363356a56355fb92cea5ec55d7a01e9b8f/gatsby-config.js#L330-L331)

### 🖼️ Screenshots

https://github.com/newrelic/docs-website/assets/2952843/a61ae450-742f-44c9-bbb3-4ba6065bcbb4


### 🔮 Engineering checklist

No build preview necessary. Will need to test when on NR subdomain by clicking `Sign up` in global header and see if `referrer` in segment events is set to docs page user was on before clicking it.
