### PR TITLE
feat: Add support for Docker API metrics fetch (NR-221195)

### DIFF
--- a/src/content/docs/infrastructure/elastic-container-service-integration/introduction-amazon-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/introduction-amazon-ecs-integration.mdx
@@ -57,7 +57,6 @@ Requirements:
 * Amazon ECS container agent 1.21.0 or higher.
 * Windows is not supported.
 * This integration uses our [infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure) and our [Docker instrumentation](/docs/infrastructure/install-configure-manage-infrastructure/docker-installation/docker-instrumentation-infrastructure): applicable requirements and restrictions of those systems apply.
-* EC2 hosts running cgroup v2 is not supported.
 
 ## Install [#install]
 

--- a/src/content/docs/infrastructure/elastic-container-service-integration/understand-use-ecs-data.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/understand-use-ecs-data.mdx
@@ -49,7 +49,7 @@ SELECT uniqueCount(containerId)
 ```
 
 <Callout variant="important">
-On EC2 nodes with Cgroup V2 version the `nri-docker` integration collects all container metrics from the Docker API. Variations in collected metrics are detailed in the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
+On EC2 nodes with Cgroup version V2, the `nri-docker` integration collects all container metrics from the Docker API. For a list of variations in the collected metrics, see the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
 </Callout>
 
 To learn more about creating custom queries and charts:

--- a/src/content/docs/infrastructure/elastic-container-service-integration/understand-use-ecs-data.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/understand-use-ecs-data.mdx
@@ -48,6 +48,10 @@ SELECT uniqueCount(containerId)
   FACET imageName SINCE 1 HOUR AGO
 ```
 
+<Callout variant="important">
+On EC2 nodes with Cgroup V2 version the `nri-docker` integration collects all container metrics from the Docker API. Variations in collected metrics are elaborated in the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
+</Callout>
+
 To learn more about creating custom queries and charts:
 
 * [How to query New Relic data](/docs/using-new-relic/data/understand-data/query-new-relic-data)

--- a/src/content/docs/infrastructure/elastic-container-service-integration/understand-use-ecs-data.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/understand-use-ecs-data.mdx
@@ -49,7 +49,7 @@ SELECT uniqueCount(containerId)
 ```
 
 <Callout variant="important">
-On EC2 nodes with Cgroup V2 version the `nri-docker` integration collects all container metrics from the Docker API. Variations in collected metrics are elaborated in the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
+On EC2 nodes with Cgroup V2 version the `nri-docker` integration collects all container metrics from the Docker API. Variations in collected metrics are detailed in the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
 </Callout>
 
 To learn more about creating custom queries and charts:

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
@@ -31,7 +31,7 @@ Requirement details for automatic container monitoring for New Relic's infrastru
 * A New Relic account. Don't have one? [Sign up for free!](https://newrelic.com/signup). No credit card required.
 * Infrastructure agent [1.8.32](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1832) or higher running on Linux
 * If using CentOS, you must have CentOS version 6.0 or higher
-* Docker with engine from [v1.12](https://docs.docker.com/engine/release-notes/prior-releases/#1120-2016-07-28) or other [`containerd`-based container runtimes](https://kubernetes.io/docs/setup/production-environment/container-runtimes). 
+* Docker with engine from [v1.12](https://docs.docker.com/engine/release-notes/prior-releases/#1120-2016-07-28) or other [`containerd`-based container runtimes](https://kubernetes.io/docs/setup/production-environment/container-runtimes).
 
 <Callout variant="important">
 Support for Operating systems using Control Group v2 is included from infrastructure agent v.1.26.0 and nri-docker v1.7.0.
@@ -88,7 +88,7 @@ To create container-related alert conditions, use either of these options:
 3. For the condition type, select **Container metrics**.
 
 ## Enable container metrics collection from Docker API
-The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics. As of version <INSERT RELEASE VERSION HERE> of the agent, you can reconfigure the integration to solely source metrics from the Docker API.
+The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics. As of version v1.51.0 of the Infrastructure Agent, you can reconfigure the integration to solely source metrics from the Docker API.
 
 This Docker API-only collection strategy is applicable only when the Docker Engine Cgroup operates under version V2. To enforce the Docker API-only collection, adapt the docker-config.yml configuration file located in the integrations.d directory to resemble the following:
 
@@ -108,5 +108,5 @@ Metrics variations between metrics sources are detailed in the [`ContainerSample
 </Callout>
 
 ## Disabling container monitoring
-To disable this capability simply delete the `docker-config.yml` configuration file from the `integrations.d` folder. 
+To disable this capability simply delete the `docker-config.yml` configuration file from the `integrations.d` folder.
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
@@ -88,9 +88,9 @@ To create container-related alert conditions, use either of these options:
 3. For the condition type, select **Container metrics**.
 
 ## Enable container metrics collection from Docker API
-The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics. As of version v1.51.0 of the Infrastructure Agent, you can reconfigure the integration to solely source metrics from the Docker API.
+The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics. As of version v1.51.0 of the infrastructure agent, you can reconfigure the integration to solely source metrics from the Docker API.
 
-This Docker API-only collection strategy is applicable only when the Docker Engine Cgroup operates under version V2. To enforce the Docker API-only collection, adapt the docker-config.yml configuration file located in the integrations.d directory to resemble the following:
+This Docker API-only collection strategy applies only when the Docker Engine Cgroup operates under version V2. To enforce the Docker API-only collection, adapt the docker-config.yml configuration file located in the integrations.d directory to resemble the following:
 
 ```yaml
 integrations:

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
@@ -87,6 +87,30 @@ To create container-related alert conditions, use either of these options:
 2. Create a new [alert condition](/docs/alerts/new-relic-alerts/defining-conditions/create-alert-conditions).
 3. For the condition type, select **Container metrics**.
 
+## Enable container metrics collection from Docker API
+The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics.
+
+As of version <INSERT RELEASE VERSION HERE> of the Agent, the integration can be reconfigured to solely source metrics from the Docker API.
+
+Note that this Docker API-only collection strategy is applicable strictly when the Docker Engine Cgroup operates under version V2.
+
+To enforce the Docker API-only collection, adapt the docker-config.yml configuration file located in the integrations.d directory to resemble the following:
+
+```yaml
+integrations:
+  - name: nri-docker
+    env:
+      USE_DOCKER_API: true
+    when:
+      feature: docker_enabled
+      file_exists: /var/run/docker.sock
+    interval: 15s
+```
+
+<Callout variant="important">
+Metrics variations between metrics sources are detailed in the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
+</Callout>
+
 ## Disabling container monitoring
 To disable this capability simply delete the `docker-config.yml` configuration file from the `integrations.d` folder. 
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
@@ -88,13 +88,9 @@ To create container-related alert conditions, use either of these options:
 3. For the condition type, select **Container metrics**.
 
 ## Enable container metrics collection from Docker API
-The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics.
+The nri-docker integration, by default, employs the Docker API in conjunction with the /proc filesystem to extract container metrics. As of version <INSERT RELEASE VERSION HERE> of the agent, you can reconfigure the integration to solely source metrics from the Docker API.
 
-As of version <INSERT RELEASE VERSION HERE> of the Agent, the integration can be reconfigured to solely source metrics from the Docker API.
-
-Note that this Docker API-only collection strategy is applicable strictly when the Docker Engine Cgroup operates under version V2.
-
-To enforce the Docker API-only collection, adapt the docker-config.yml configuration file located in the integrations.d directory to resemble the following:
+This Docker API-only collection strategy is applicable only when the Docker Engine Cgroup operates under version V2. To enforce the Docker API-only collection, adapt the docker-config.yml configuration file located in the integrations.d directory to resemble the following:
 
 ```yaml
 integrations:

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring.mdx
@@ -103,7 +103,7 @@ integrations:
     interval: 15s
 ```
 
-<Callout variant="important">
+<Callout variant="tip">
 Metrics variations between metrics sources are detailed in the [`ContainerSample`](/attribute-dictionary/?event=ContainerSample) attributes.
 </Callout>
 

--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -2545,7 +2545,7 @@
         }
       },
       {
-        "definition": "<p>The amount of memory swap the container is using, including swap.</p>\n",
+        "definition": "<p>The amount of memory swap the container is using, including swap. This metric is not available when collecting from only Docker API.</p>\n",
         "events": [
           "ContainerSample"
         ],
@@ -13867,7 +13867,7 @@
         }
       },
       {
-        "definition": "<p>Cumulative number of disk read operations by this process.</p>\n",
+        "definition": "<p>Cumulative number of disk read operations by this process. This metric is not available when collecting from only Docker API.</p>\n",
         "events": [
           "ProcessSample"
         ],
@@ -13887,7 +13887,7 @@
         }
       },
       {
-        "definition": "<p>Cumulative number of disk write operations by this process.</p>\n",
+        "definition": "<p>Cumulative number of disk write operations by this process. This metric is not available when collecting from only Docker API.</p>\n",
         "events": [
           "ProcessSample"
         ],

--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -2545,7 +2545,7 @@
         }
       },
       {
-        "definition": "<p>The amount of memory swap the container is using, including swap. This metric is not available when collecting from only Docker API.</p>\n",
+        "definition": "<p>The amount of memory swap the container is using, including swap.</p>\n",
         "events": [
           "ContainerSample"
         ],
@@ -13867,7 +13867,7 @@
         }
       },
       {
-        "definition": "<p>Cumulative number of disk read operations by this process. This metric is not available when collecting from only Docker API.</p>\n",
+        "definition": "<p>Cumulative number of disk read operations by this process.</p>\n",
         "events": [
           "ProcessSample"
         ],
@@ -13887,7 +13887,7 @@
         }
       },
       {
-        "definition": "<p>Cumulative number of disk write operations by this process. This metric is not available when collecting from only Docker API.</p>\n",
+        "definition": "<p>Cumulative number of disk write operations by this process.</p>\n",
         "events": [
           "ProcessSample"
         ],


### PR DESCRIPTION
## Give us some context

A new method to scrape metrics from DockerAPI has been added to nri-docker unblocking the use of the ecs integration when EC2 nodes are running on cgroups v2.

The feature is still WIP and has not been released so is not ready to publish.
