### PR TITLE
Update product-capability-feature-usage.mdx

### DIFF
--- a/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
+++ b/src/content/docs/style-guide/capitalization/product-capability-feature-usage.mdx
@@ -437,7 +437,7 @@ This table is kept up to date and is the source of truth for capitalization. **M
       </td>
 
       <td>
-        Do not use: vulnerability management monitoring, vulnerability monitoring
+        Do not use: VM, vulnerability management monitoring, vulnerability monitoring
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Added "VM" as a term not to use when referring specifically to New Relic Vulnerability Management.

<!-- Thanks for contributing to our docs! -->

