### PR TITLE
PUBLISH: TBD chore(PHP): update configuration page with new package detection INI option

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -4277,4 +4277,55 @@ This section lists the remaining newrelic.ini settings.
 
     Enables the detection of frameworks and libraries when preloading is enabled. Preloading was introduced in PHP version 7.4. `newrelic.preload_framework_library_detection` will only take effect when `opcache.preload` is set in the `php.ini` file.
   </Collapser>
+
+<Collapser
+    id="inivar-autorum"
+    title="newrelic.vulnerability_management.package_detection.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            SYSTEM
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Notes:
+          </th>
+
+          <td>
+            Introduced in PHP agent version 10.17
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, the agent will send up package detection information that can be viewed on the environment page.
+  </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -4279,7 +4279,7 @@ This section lists the remaining newrelic.ini settings.
   </Collapser>
 
 <Collapser
-    id="inivar-autorum"
+    id="inivar-package-detection"
     title="newrelic.vulnerability_management.package_detection.enabled"
   >
     <table>


### PR DESCRIPTION
This PR adds information about the new INI configuration: `newrelic.vulnerability_management.package_detection.enabled`. This PR is co-dependent on PR #16223 and should be merged at the same time as PR #16223. Thanks!