### PR TITLE
feat: Correct ping runtime docs to be update same dropdown

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Ping runtime
+subject: Ping Runtime
 releaseDate: '2023-10-19'
 version: 1.38.0
 ---

--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.39.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.39.0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Ping runtime
+subject: Ping Runtime
 releaseDate: '2024-02-13'
 version: 1.39.0
 ---


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
Our current release notes for the ping runtime have broken up into two different sections, where instead we want them all in the same place. This PR modifies the title names of the release notes so they should collapse into the same dropdown.
![Screenshot 2024-02-20 at 2 51 24 PM](https://github.com/newrelic/docs-website/assets/90863144/3106fb7a-7fe5-4526-b937-6726a7e9eb27)