### PR TITLE
updating caps for ping release notes

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.38.0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Ping runtime
+subject: Ping Runtime
 releaseDate: '2023-10-19'
 version: 1.38.0
 ---

--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.39.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.39.0.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Ping runtime
+subject: Ping Runtime
 releaseDate: '2024-02-13'
 version: 1.39.0
 ---


### PR DESCRIPTION
due to some cache issues in the original PR, i've gone ahead and made the fix separately here.

original PR:

https://github.com/newrelic/docs-website/pull/16227