### PR TITLE
docs: DESIRED_RUNTIMES

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
@@ -198,7 +198,7 @@ Environmental variables allow you to fine-tune the synthetics job manager config
             `DESIRED_RUNTIMES`
           </td>
           <td>
-            An array that may be used to run specific runtime images. Format: ['newrelic/synthetics-node-api-runtime:latest', 'newrelic/synthetics-node-browser-runtime:latest']
+            An array that may be used to run specific runtime images. Format: ['newrelic/synthetics-ping-runtime:latest','newrelic/synthetics-node-api-runtime:latest','newrelic/synthetics-node-browser-runtime:latest']
 
             Default: all latest runtimes.
           </td>


### PR DESCRIPTION
## fix spacing for `DESIRED_RUNTIMES` environment variable value

If extra spaces exist, the following error will occur:

```sh
docker: invalid reference format.
See 'docker run --help'.
```

## add `newrelic/synthetics-ping-runtime:latest` example

- list all available options
- can remove runtimes as needed
- can utilize `DESIRED_RUNTIMES` to run specific tags of runtime images like `newrelic/synthetics-ping-runtime:1.39.0`