### PR TITLE
fix: haproxy integration metrics description and naming

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration.mdx
@@ -1211,7 +1211,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
 
     <tr>
       <td>
-        `server.agentDurationInSeconds`
+        `server.agentDurationSeconds`
       </td>
 
       <td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/haproxy-monitoring-integration.mdx
@@ -455,7 +455,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average connect time over the 1024 last requests, in milliseconds.
+        Average connect time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -465,7 +465,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average queue time over the 1024 last requests, in milliseconds.
+        Average queue time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -475,7 +475,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average response time over the 1024 last requests, in milliseconds.
+        Average response time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -485,7 +485,7 @@ These attributes are attached to the `HAProxyBackendSample` event type:
       </td>
 
       <td>
-        Average total session time over the 1024 last requests, in milliseconds.
+        Average total session time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1215,7 +1215,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Time taken to finish last check, in milliseconds.
+        Time taken to finish last check, in seconds.
       </td>
     </tr>
 
@@ -1245,7 +1245,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average connect time over the 1024 last requests, in milliseconds.
+        Average connect time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1255,7 +1255,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average queue time over the 1024 last requests, in milliseconds.
+        Average queue time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1265,7 +1265,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average response time over the 1024 last requests, in milliseconds.
+        Average response time over the 1024 last requests, in seconds.
       </td>
     </tr>
 
@@ -1275,7 +1275,7 @@ These attributes are attached to the `HAProxyServerSample` event type:
       </td>
 
       <td>
-        Average total session time over the 1024 last requests, in milliseconds.
+        Average total session time over the 1024 last requests, in seconds.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This PR fixes some inconsistencies in metrics units for haproxy integration. It should not be merged until [newrelic/nri-haproxy#116](https://github.com/newrelic/nri-haproxy/pull/116) is released (It will be kept as 'Draft PR' until them). We plan to release it next week.