### PR TITLE
Accounts: Correct anchor link and fix add-on wording

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing.mdx
@@ -10,13 +10,13 @@ freshnessValidatedDate: 2024-02-21
 ---
 
 
-In addition to the primary billing factors of ingest and billable users, you can also purchase optional add-ons to enhance your experience with New Relic: 
+In addition to the primary billing factors of ingest and billable users, you can also use optional billable add-ons to enhance your experience with New Relic: 
 
 * **EU Data Center for New Relic - Data, and New Relic - Data Plus**: This add-on applies when you select the European Union as your data region, as available.
 * **Extended Retention for New Relic - Data, and New Relic - Data Plus**: This add-on applies if you exceed the default length of time your data is retained. This applies to all your data&mdash;not just logs&mdash;and is a good option if you need to make a lot of small queries or make queries on large volumes of data.
 * **New Relic Synthetic Checks**: This add-on applies if your Checks exceed the default number of synthetic monitor checks.
 * **Vulnerability Management**: This feature is included with Data Plus, but the add-on applies if you use the Vulnerability Management feature without Data Plus.
 * **Live Archives Storage**: Extend your log storage duration by at least 90 days more than standard retention. This add-on is best if you need to keep logs that you'll query infrequently. Live archives also requires Compute Add On. 
-* **Compute Add On**: This add-on applies to usage-based billing for queries you run against interactive application security testing, live archives, and other add-ons as made available. It measures your usage based on [Compute Capacity Units (CCUs)](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions#compute-capacity-units). 
+* **Compute Add On**: This add-on applies to usage-based billing for queries you run against interactive application security testing, live archives, and other add-ons as made available. It measures your usage based on [Compute Capacity Units (CCUs)](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions#compute-capacity-unit). 
 
 To get started with any of these optional add-ons, get in touch with your New Relic account team.

--- a/src/content/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions.mdx
+++ b/src/content/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions.mdx
@@ -87,7 +87,7 @@ This is a glossary of terms that appear in contracts for our [New Relic usage-ba
 
     <Collapser
     id="gb-months"
-    title="GB Months"
+    title="GB Month"
   >
     A GB Month is a measurement of the volume of data and length of time stored by the Products for the benefit of the Customer, including from the Software, the Customer Properties, or Third-Party Services. GB Months also includes telemetry data from preview or pre-release versions of software.
 


### PR DESCRIPTION
This is a small follow-up fix to the recent Compute Add On docs.