### PR TITLE
workflows for manual Netlify builds & notifications

### DIFF
--- a/.github/workflows/build-notification.yml
+++ b/.github/workflows/build-notification.yml
@@ -1,0 +1,126 @@
+name: update PR comment after Netlify notification
+env:
+  repo: ${{ github.repository }}
+on:
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: PR to update with build status
+        required: true
+        type: number
+      buildStatus:
+        description: current build status from Netlify
+        required: true
+        type: choice
+        options:
+          - building
+          - succeeded
+          - failed
+      deployUrl:
+        description: URL of live branch deploy
+        required: false
+      deployLogUrl:
+        description: URL of logs
+        required: true
+      sha:
+        description: SHA hash of the commit built
+        required: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      # set body of the PR comment
+      - name: construct message
+        id: construct-message
+        run: |
+          case '${{ inputs.buildStatus }}' in
+            "building")
+              comment_body=$(cat <<-END
+          ### <span aria-hidden="true">⏳</span> Deploy Preview building!
+
+          |  Name | Link |
+          |:-:|------------------------|
+          |<span aria-hidden="true">🔨</span> Latest commit | ${{ inputs.sha }} |
+          |<span aria-hidden="true">🔍</span> Latest deploy log | ${{ inputs.deployLogUrl }} |
+          ---
+          END
+              )
+              ;;
+            "succeeded")
+              comment_body=$(cat <<-END
+          ### <span aria-hidden="true">✅</span> Deploy Preview ready!
+
+          |  Name | Link |
+          |:-:|------------------------|
+          |<span aria-hidden="true">🔨</span> Latest commit | ${{ inputs.sha }} |
+          |<span aria-hidden="true">🔍</span> Latest deploy log | ${{ inputs.deployLogUrl }} |
+          |<span aria-hidden="true">😎</span> Deploy Preview | [${{ inputs.deployUrl }}](${{ inputs.deployUrl }}) |
+          ---
+          END
+              )
+              ;;
+            "failed")
+              comment_body=$(cat <<-END
+          ### <span aria-hidden="true">❌</span> Deploy Preview failed!
+
+          |  Name | Link |
+          |:-:|------------------------|
+          |<span aria-hidden="true">🔨</span> Latest commit | ${{ inputs.sha }} |
+          |<span aria-hidden="true">🔍</span> Latest deploy log | ${{ inputs.deployLogUrl }} |
+          ---
+          END
+              )
+              ;;
+          esac
+          {
+          echo 'comment_body<<EOF'
+          echo "$comment_body"
+          echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: update PR check - pending
+        if: ${{ inputs.buildStatus == 'building' }}
+        env: 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -f state='pending' \
+            -f target_url='${{ inputs.deployLogUrl }}' \
+            -f description='The build has started' \
+            -f context='netlify/build' \
+            /repos/${{ env.repo }}/statuses/${{ inputs.sha }}
+
+      - name: update PR check - failed
+        if: ${{ inputs.buildStatus == 'failed' }}
+        env: 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -f state='failure' \
+            -f target_url='${{ inputs.deployLogUrl }}' \
+            -f description='The build has failed' \
+            -f context='netlify/build' \
+            /repos/${{ env.repo }}/statuses/${{ inputs.sha }}
+
+      - name: update PR check - succeeded
+        if: ${{ inputs.buildStatus == 'succeeded' }}
+        env: 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -f state='success' \
+            -f target_url='${{ inputs.deployLogUrl }}' \
+            -f description='The build has finished successfully' \
+            -f context='netlify/build' \
+            /repos/${{ env.repo }}/statuses/${{ inputs.sha }}
+
+      - name: update PR comment with Netlify status
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: ${{ steps.construct-message.outputs.comment_body }}
+          pr_number: ${{ inputs.prNumber }}
+          comment_tag: manual-build-comment

--- a/.github/workflows/manual-deploy-comment.yml
+++ b/.github/workflows/manual-deploy-comment.yml
@@ -1,0 +1,40 @@
+name: Netlify build manual deploy comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      # we use `jq` to parse the GH API response
+      - name: setup jq
+        uses: dcarbone/install-jq-action@v2
+
+      - name: send request to Netlify build hook
+        env: 
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # when a contributor comments 'netlify build',
+        # but only on pull requests, not issues
+        if: |
+          contains(github.event.comment.body, 'netlify build')
+          && ${{ github.event.issue.pull_request }}
+        run: |
+          gh_api_url=$(echo ${{ github.event.issue.pull_request.url }} | sed 's/https:\/\/api.github.com//')
+          gh_api_response=$(gh api $gh_api_url)
+          branch_name=$(echo $gh_api_response | jq -r .head.ref)
+          sha=$(echo $gh_api_response | jq -r .head.sha)
+          pr_number=$(echo $gh_api_response | jq -r .number)
+
+          curl -X POST \
+          "https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK_ID }}?trigger_branch=$branch_name"'&trigger_title=Manual+deploy+preview+for+PR+%23'"$pr_number"'+-+'"$sha"
+
+      - name: comment for Netlify to update with preview URL
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ### <span aria-hidden="true">⏳</span> Netlify Preview Deployment Information
+
+            This comment will auto update when your preview build is ready
+          comment_tag: manual-build-comment


### PR DESCRIPTION
the manual deploy workflow consists of three parts:

## 1) triggering the build

a build can be triggered by commenting 'netlify build' on a PR. this will send a request to Netlify to build the most recent commit and leave a comment on the PR. the workflow defined in `manual-deploy-comment.yml` handles this

## 2) deploy notification service

after Netlify receives a build request, it will POST to a URL we define with the status of that build. not included in this PR is a AWS Lambda that receives this request, parses some information out of it, then POSTs a request to Github to kick off step 3

## 3) updating when a notification is recieved

the workflow defined in `build-notification.yml` is only manually triggered and requires several inputs. the Lambda from step 2 will POST to Github with the required fields, triggering this workflow to run. this workflow will update the comment on the PR left by step 1 and set the commit check status