### PR TITLE
Add notranslate class to InlinePopover component

### DIFF
--- a/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
+++ b/scripts/actions/__tests__/__snapshots__/serialize-mdx.test.js.snap
@@ -168,7 +168,7 @@ exports[`serialize Icon inline with text to HTML 1`] = `
 
 exports[`serialize InlinePopover component 1`] = `
 "
-<div data-type=\\"component\\" data-component=\\"InlinePopover\\"></div>
+<div data-type=\\"component\\" data-component=\\"InlinePopover\\" class=\\"notranslate\\"></div>
 "
 `;
 

--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -140,7 +140,12 @@ module.exports = {
       node.children = [];
       return deserializeComponent(h, node, { tagName: 'InlinePopover' });
     },
-    serialize: serializeComponent,
+    // serialize: serializeComponent,
+    serialize: (h, node) =>
+      serializeComponent(h, node, {
+        classNames: 'notranslate',
+        wrapChildren: false,
+      }),
   },
   InlineSignup: {
     serialize: serializeComponent,


### PR DESCRIPTION
Adds `class="notranslate"` to `<InlinePopover />` during serialization.
```mdx
This is an example of an inline popover component for<span data-type="component" data-component="InlinePopover" data-props="W3sidHlwZSI6Im1keEF0dHJpYnV0ZSIsIm5hbWUiOiJ0eXBlIiwidmFsdWUiOiJhcG0ifV0=" class="notranslate"></span>

```
