### PR TITLE
Update fluent-bit-plugin-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding.mdx
@@ -186,6 +186,16 @@ Once you have [installed](#fluentbit-plugin) and [configured](#configure-plugin)
         **Deprecated.** Takes a New Relic [Insights insert key](/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api#register), but using the `licenseKey` attribute is preferred. Use either `licenseKey` or `apiKey`, not both.
       </td>
     </tr>
+
+    <tr>
+      <td>
+        `endpoint`
+      </td>
+
+      <td>
+        Defaults to https://log-api.newrelic.com/log/v1 - If using an EU key needs to be set to https://log-api.eu.newrelic.com/log/v1
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
adding optional config value that is described in github docs but not reflected here - https://github.com/newrelic/newrelic-fluent-bit-output?tab=readme-ov-file#configuration-parameters

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This value is needed when a user is using an EU license key. Otherwise the plugin will default to the US endpoint and the user will get a 403 response.
