### PR TITLE
chore: Documents new configuration options for the .NET agent

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1288,7 +1288,7 @@ The `log` element supports the following attributes:
     </table>
 
     Defines the log file rolling strategy. Possible values are: 
-    * `size` (default): The log file rolls over when it reaches the size specified in `maxLogFileSizeBytes`.
+    * `size` (default): The log file rolls over when it reaches the size specified in `maxLogFileSizeMB`.
     * `day`: The log file rolls over at midnight.
 
     Alternatively, set the `NEW_RELIC_LOG_ROLLING_STRATEGY` environment variable in the application's environment.
@@ -1339,8 +1339,8 @@ The `log` element supports the following attributes:
   </Collapser>
 
   <Collapser
-      id="log-maxLogFileSizeBytes"
-      title="maxLogFileSizeBytes"
+      id="log-maxLogFileSizeMB"
+      title="maxLogFileSizeMB"
   >
     <table>
       <tbody>
@@ -1360,18 +1360,18 @@ The `log` element supports the following attributes:
           </th>
 
           <td>
-            52428800 (50 MB)
+            50
           </td>
         </tr>
       </tbody>
     </table>
 
-    Defines the maximum size of the log file before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
+    Defines the maximum size of the log file in megabytes before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
 
-    Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_BYTES` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_MB` environment variable in the application's environment.
 
     ```ini
-    NEW_RELIC_LOG_MAX_FILE_SIZE_BYTES=20971520
+    NEW_RELIC_LOG_MAX_FILE_SIZE_MB=100
     ```
 
     Supported in .NET agent v10.21.0 and higher.

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1258,6 +1258,124 @@ The `log` element supports the following attributes:
     NEW_RELIC_LOG=MyApp.log
     ```
   </Collapser>
+
+  <Collapser
+    id="log-logRollingStrategy"
+    title="logRollingStrategy"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            size
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the log file rolling strategy. Possible values are: 
+    * `size` (default): The log file rolls over when it reaches the size specified in `maxLogFileSizeBytes`.
+    * `day`: The log file rolls over at midnight.
+
+    Alternatively, set the `NEW_RELIC_LOG_ROLLING_STRATEGY` environment variable in the application's environment.
+
+    ```ini
+    NEW_RELIC_LOG_ROLLING_STRATEGY=day
+    ```
+
+    Supported in .NET agent v10.21.0 and higher.
+  </Collapser>
+  <Collapser
+    id="log-logMaxFiles"
+    title="logMaxFiles"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            4
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the number of log files to retain. When the maximum number of log files is reached, the oldest log file is deleted. A value of `0` specifies that there is no maximum number of log files.
+
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILES` environment variable in the application's environment.
+
+    ```ini
+    NEW_RELIC_LOG_MAX_FILES=31
+    ```
+
+    Supported in .NET agent v10.21.0 and higher.
+  </Collapser>
+
+  <Collapser
+      id="log-maxLogFileSizeBytes"
+      title="maxLogFileSizeBytes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            52428800 (50 MB)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the maximum size of the log file before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
+
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_BYTES` environment variable in the application's environment.
+
+    ```ini
+    NEW_RELIC_LOG_MAX_FILE_SIZE_BYTES=20971520
+    ```
+
+    Supported in .NET agent v10.21.0 and higher.
+  </Collapser>
 </CollapserGroup>
 
 ### Application element (required) [#application-configuration]

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1287,7 +1287,7 @@ The `log` element supports the following attributes:
       </tbody>
     </table>
 
-    Defines the log file rolling strategy. Possible values are: 
+    Defines the agent log file rolling strategy. Possible values are: 
     * `size` (default): The log file rolls over when it reaches the size specified in `maxLogFileSizeMB`.
     * `day`: The log file rolls over at midnight.
 
@@ -1327,7 +1327,7 @@ The `log` element supports the following attributes:
       </tbody>
     </table>
 
-    Defines the number of log files to retain. When the maximum number of log files is reached, the oldest log file is deleted. A value of `0` specifies that there is no maximum number of log files.
+    Defines the number of agent log files to retain. When the maximum number of log files is reached, the oldest log file is deleted. A value of `0` specifies that there is no maximum number of log files.
 
     Alternatively, set the `NEW_RELIC_LOG_MAX_FILES` environment variable in the application's environment.
 
@@ -1366,7 +1366,7 @@ The `log` element supports the following attributes:
       </tbody>
     </table>
 
-    Defines the maximum size of the log file in megabytes before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
+    Defines the maximum size of the agent log file in megabytes before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
 
     Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_MB` environment variable in the application's environment.
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1291,7 +1291,7 @@ The `log` element supports the following attributes:
     * `size` (default): The log file rolls over when it reaches the size specified in `maxLogFileSizeMB`.
     * `day`: The log file rolls over at midnight.
 
-    Alternatively, set the `NEW_RELIC_LOG_ROLLING_STRATEGY` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_LOG_ROLLING_STRATEGY` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_LOG_ROLLING_STRATEGY=day
@@ -1329,7 +1329,7 @@ The `log` element supports the following attributes:
 
     Defines the number of agent log files to retain. When the maximum number of log files is reached, the oldest log file is deleted. A value of `0` specifies that there is no maximum number of log files.
 
-    Alternatively, set the `NEW_RELIC_LOG_MAX_FILES` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILES` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_LOG_MAX_FILES=31
@@ -1368,7 +1368,7 @@ The `log` element supports the following attributes:
 
     Defines the maximum size of the agent log file in megabytes before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
 
-    Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_MB` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_MB` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_LOG_MAX_FILE_SIZE_MB=100

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -417,7 +417,7 @@ The `service` element supports the following attributes:
 
     Your New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). New Relic uses the license key to match your app's data to the correct account in the UI. Set the license key via environment variable.
 
-    Alternatively, set the `NEW_RELIC_LICENSE_KEY` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_LICENSE_KEY` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_LICENSE_KEY=<var>XXXXXXXX</var>
@@ -516,7 +516,7 @@ The `service` element supports the following attributes:
 
     Block application shutdown while the agent initiates a final harvest cycle and sends all data to New Relic.
   
-    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_SEND_DATA_ON_EXIT=<var>true|false</var>
@@ -563,7 +563,7 @@ The `service` element supports the following attributes:
 
     The minimum amount of time the process must run before the agent blocks it from shutting down. This setting only applies when [`sendDataOnExit`](#service-sendDataOnExit) is `true`.
   
-    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=<var>2000</var>
@@ -1252,7 +1252,7 @@ The `log` element supports the following attributes:
 
     Defines a name for the log file. If you do not define a `fileName`, the name is derived from the name of the monitored process.
 
-    Alternatively, set the `NEW_RELIC_LOG` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_LOG` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_LOG=MyApp.log
@@ -1423,7 +1423,7 @@ The `application` element is a child of the `configuration` element. This requir
     </application>
     ```
 
-    Alternatively, set the `NEW_RELIC_APP_NAME` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_APP_NAME` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_APP_NAME=Descriptive Name
@@ -1460,7 +1460,7 @@ The `application` element is a child of the `configuration` element. This requir
 
     Samplers collect information about memory and CPU consumption. Set this to `true` to disable sampling.
 
-    Alternatively, set the `NEW_RELIC_DISABLE_SAMPLERS` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_DISABLE_SAMPLERS` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_DISABLE_SAMPLERS=true
@@ -2324,7 +2324,7 @@ The `highSecurity` element is a child of the `configuration` element. To enable 
     <highSecurity enabled="true"/>
     ```
 
-    Alternatively, set the `NEW_RELIC_HIGH_SECURITY` environment variable in the application's environment.    
+    Alternatively, set the `NEW_RELIC_HIGH_SECURITY` environment variable in the application's environment:    
 
     ```ini
     NEW_RELIC_HIGH_SECURITY=true
@@ -2450,7 +2450,7 @@ The `transactionEvents` element supports the following attributes:
 
     The maximum number of sampled transaction events the agent can store in memory at once. This will be the maximum number of transaction events the agent can send per minute.
 
-    Alternatively, set the `MAX_TRANSACTION_SAMPLES_STORED` environment variable in the application's environment.
+    Alternatively, set the `MAX_TRANSACTION_SAMPLES_STORED` environment variable in the application's environment:
 
     ```ini
     MAX_TRANSACTION_SAMPLES_STORED=500
@@ -2545,7 +2545,7 @@ The `customEvents` element supports the following attributes:
 
     The maximum number of sampled custom events the agent can store in memory at once. This will be the maximum number of custom events the agent can send per minute.
 
-    Alternatively, set the `MAX_EVENT_SAMPLES_STORED` environment variable in the application's environment.
+    Alternatively, set the `MAX_EVENT_SAMPLES_STORED` environment variable in the application's environment:
 
     ```ini
     MAX_EVENT_SAMPLES_STORED=500
@@ -3124,7 +3124,7 @@ The `distributedTracing` element supports the following attributes:
       </tbody>
     </table>
 
-    Alternatively, enable distributed tracing via the `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED` environment variable in the application's environment.
+    Alternatively, enable distributed tracing via the `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
@@ -3185,7 +3185,7 @@ Distributed tracing reports span events. Span event reporting is enabled by defa
     id="span-events-disable-env_variable"
     title="Disable span events via environment variable"
   >
-    Set the `NEW_RELIC_SPAN_EVENTS_ENABLED` environment variable in the application's environment.
+    Set the `NEW_RELIC_SPAN_EVENTS_ENABLED` environment variable in the application's environment:
 
     ```ini
     NEW_RELIC_SPAN_EVENTS_ENABLED=false
@@ -3417,7 +3417,7 @@ request.headers.user-agent
 
     Enable or disable HTTP request headers capture. Example:
 
-    Alternatively, set the `NEW_RELIC_ALLOW_ALL_HEADERS` environment variable in the application's environment.
+    Alternatively, set the `NEW_RELIC_ALLOW_ALL_HEADERS` environment variable in the application's environment:
 
     ```xml
     <allowAllHeaders enabled="true" />


### PR DESCRIPTION
Updates the configuration documentation for the .NET agent to include 3 new configuration options introduced in v10.21.0. 