### PR TITLE
Mark cross application tracing as deprecated -- Merge April 1 2024 AM

### DIFF
--- a/src/content/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api.mdx
+++ b/src/content/docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api.mdx
@@ -169,6 +169,10 @@ Use these methods to collect data about your app’s connections to other apps o
 
       <td>
         [Cross application tracing](/docs/agents/go-agent/features/cross-application-tracing-go)
+
+        <Callout variant="important">
+          Cross application tracing has been deprecated in favor of [Distributed tracing](/docs/agents/go-agent/features/distributed-tracing-go) and will be removed in a future agent version.
+        </Callout>
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration.mdx
@@ -2540,6 +2540,10 @@ Here are datastore settings, including [slow query](/docs/apm/applications-menu/
 
 Here are settings for changing the [cross application tracing](/docs/agents/go-agent/features/cross-application-tracing-go) feature.
 
+<Callout variant="important">
+  Cross application tracing has been deprecated in favor of [Distributed tracing](/docs/agents/go-agent/features/distributed-tracing-go) and will be removed in a future agent version.
+</Callout>
+
 <CollapserGroup>
   <Collapser
     id="cross-tracer-enabled"

--- a/src/content/docs/apm/agents/go-agent/features/cross-application-tracing-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/features/cross-application-tracing-go.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 The Go agent supports [cross application tracing (CAT)](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces). Cross application tracing links transactions between APM-monitored app, which is vital for applications implementing a service-oriented or microservices architecture.
 
 <Callout variant="important">
-  [Distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) is now available. Distributed tracing is an improvement on cross application tracing and is recommended for large, distributed systems.
+  Cross application tracing has been deprecated in favor of [Distributed tracing](/docs/agents/go-agent/features/distributed-tracing-go) and will be removed in a future agent version.
 </Callout>
 
 ## Enable cross application tracing with Go [#enable]

--- a/src/content/docs/apm/agents/go-agent/instrumentation/instrument-go-segments.mdx
+++ b/src/content/docs/apm/agents/go-agent/instrumentation/instrument-go-segments.mdx
@@ -227,7 +227,7 @@ There are two ways to instrument external segments:
     id="start-external-segment"
     title={<>Use <InlineCode>StartExternalSegment()</InlineCode></>}
   >
-    <DoNotTranslate>**Recommendation:**</DoNotTranslate> Use the `StartExternalSegment` helper, since New Relic uses it to trace activity between your applications using [cross application tracing](/docs/agents/go-agent/features/cross-application-tracing-go).
+    <DoNotTranslate>**Recommendation:**</DoNotTranslate> Use the `StartExternalSegment` helper, since New Relic uses it to trace activity between your applications using [Distributed tracing](/docs/agents/go-agent/features/distributed-tracing-go).
 
     ```go
     func external(txn *newrelic.Transaction, req *http.Request) (*http.Response, error) {

--- a/src/content/docs/apm/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/java-agent-api-instrument-external-calls-messaging-datastore-web-frameworks.mdx
@@ -19,7 +19,7 @@ freshnessValidatedDate: never
 
 New Relic's Java agent collects and reports information on [web transactions](/docs/apm/transactions/intro-transactions/transactions-new-relic-apm) and [non-web transactions](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions), such as background tasks. The agent should instrument supported frameworks automatically, without any need to modify your application code. However, in addition to custom code and frameworks or technology not listed in the [Compatibility and requirements for the Java agent](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent) documentation, some implementations of supported frameworks may require [custom instrumentation](/docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation).
 
-This document describes how to use the [Java agent API](/docs/agents/java-agent/custom-instrumentation/java-agent-api) to instrument external calls, messaging frameworks, [cross application tracing](/docs/apm/transactions/cross-application-traces/cross-application-tracing) (CAT), datastores, and web frameworks. For best results when using the API, ensure that you have the [latest Java agent release](/docs/release-notes/agent-release-notes/java-release-notes). Several APIs used in the examples require Java agent 3.36.0 or higher.
+This document describes how to use the [Java agent API](/docs/agents/java-agent/custom-instrumentation/java-agent-api) to instrument external calls, messaging frameworks, [distributed tracing](/docs/distributed-tracing/), datastores, and web frameworks. For best results when using the API, ensure that you have the [latest Java agent release](/docs/release-notes/agent-release-notes/java-release-notes). Several APIs used in the examples require Java agent 3.36.0 or higher.
 
 ## External API [#external]
 
@@ -59,7 +59,7 @@ There are several builders to create `ExternalParameters`:
 * `MessageConsumeParameters`
 * `MessageProduceParameters`
 
-These builders create the input parameter object for [`TracedMethod`'s](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/TracedMethod.html) `reportAsExternal` API call. These parameter objects are used for things like linking HTTP external calls via cross application tracing, tracing external calls to a datastore, tracing external calls to a datastore with additional slow query processing, as well as tracing calls between message producers and consumers.
+These builders create the input parameter object for [`TracedMethod`'s](http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/api/agent/TracedMethod.html) `reportAsExternal` API call. These parameter objects are used for things like linking HTTP external calls via distributed tracing, tracing external calls to a datastore, tracing external calls to a datastore with additional slow query processing, as well as tracing calls between message producers and consumers.
 
 <Callout variant="important">
   All of the methods of this class have the potential to expose sensitive private information. Use caution when creating the arguments, paying particular attention to URIs and string values.

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3274,7 +3274,7 @@ The `infiniteTracing` element supports the following elements:
 The `crossApplicationTracer` element is a child of the `configuration` element. `crossApplicationTracer` links transaction traces across applications. When linked in a service-oriented architecture, all instrumented applications that communicate with each other via HTTP will now "link" transaction traces with the applications that they call and the applications they are called by. [Cross application tracing](/docs/traces/cross-application-traces) makes it easier to understand the performance relationship between services and applications.
     
 <Callout variant="important">
-  Cross application tracing has been deprecated as of [v9.0.0 of the agent](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9000/) and disabled by default. To use CAT with v9+ of the agent you must set both `crossApplicationTracer.enabled = true` and `distributedTracing.enabled = false`. Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) will disable [cross application tracing](#cross_application_tracer).
+  Cross application tracing has been deprecated as of [v9.0.0 of the agent](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9000/) and disabled by default. It will be removed in a future agent version. To use CAT with v9+ of the agent you must set both `crossApplicationTracer.enabled = true` and `distributedTracing.enabled = false`. Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) will disable [cross application tracing](#cross_application_tracer).
 </Callout>
 
 ```xml

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -311,7 +311,7 @@ The .NET agent doesn't directly monitor datastore processes. Also, by default th
                       </th>
 
                       <th>
-                        Cross Application Tracing (CAT) Support
+                        Cross Application Tracing (CAT) Support (Deprecated)
                       </th>
                     </tr>
                   </thead>

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/guide-using-nodejs-agent-api.mdx
@@ -320,6 +320,19 @@ Once the [request naming API](/docs/agents/nodejs-agent/supported-features/nodej
 
       <td>
         Use [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces).
+
+      <Callout variant="important">
+        Cross application tracing has been deprecated in favor of [Distributed tracing](/docs/enable-distributed-tracing) and will be removed in a future agent version.
+      </Callout>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        See the path that a request takes as it travels through a distributed system.
+      </td>
+
+      <td>
+        [Distributed tracing](/docs/agents/enable-distributed-tracing)
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3418,6 +3418,10 @@ This section defines the Node.js agent variables in the order they typically app
 
 The Node.js agent variables that control [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) typically appear in the `cross_application_tracer` section of your app's `newrelic.js` configuration file:
 
+<Callout variant="important">
+  Cross application tracing has been deprecated in favor of [Distributed tracing](/docs/enable-distributed-tracing) and will be removed in a future agent version.
+</Callout>
+
 <CollapserGroup>
   <Collapser
     id="cat-enabled"

--- a/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/cross-application-tracing.mdx
@@ -17,7 +17,7 @@ import apmClientCustomTransport from 'images/apm_diagram_client-custom-transport
 import apmPythonNonhttpTransport from 'images/apm_diagram_python-nonhttp-transport.webp'
 
 <Callout variant="important">
-For our Python agent, [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) has been deprecated since [agent version v7.0.0.166](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166). A [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is now available. Distributed tracing improves on cross application tracing and is recommended for monitoring activity in complex distributed systems.
+For our Python agent, [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) has been deprecated since [agent version v7.0.0.166](/docs/release-notes/agent-release-notes/python-release-notes/python-agent-70000166) and will be removed in a future agent release. A [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) feature is now available. Distributed tracing improves on cross application tracing and is recommended for monitoring activity in complex distributed systems.
 </Callout>
 
 The protocol used to communicate between applications involves attaching metadata to requests and responses. The metadata is processed by each application and the resulting data is reported by the agent.

--- a/src/content/docs/apm/agents/ruby-agent/features/cross-application-tracing-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/cross-application-tracing-ruby.mdx
@@ -13,9 +13,9 @@ freshnessValidatedDate: never
 
 <Callout variant="important">
   As of version 8.0.0 of the Ruby agent, [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) is on by default. Distributed tracing improves on cross application tracing and is recommended for large, distributed systems.
-</Callout>
 
-Cross application tracing is deprecated in favor of distributed tracing. If you need to continue using cross application tracing, such as for a non-standard middleware framework, see the [configuration information](#configuration) in this document.
+Cross application tracing is deprecated in favor of distributed tracing and will be removed in a future agent version. If you need to continue using cross application tracing, such as for a non-standard middleware framework, see the [configuration information](#configuration) in this document.
+</Callout>
 
 ## Requirements
 

--- a/src/content/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces.mdx
+++ b/src/content/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces.mdx
@@ -19,7 +19,7 @@ APM's cross application tracing lets you link transactions between your APM-moni
 ## What is cross application tracing? [#feature]
 
 <Callout variant="important">
-  Instead of using cross application tracing, we recommend our [distributed tracing features](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing). Distributed tracing is an improvement on the cross application tracing feature and is recommended for large, distributed systems.
+  Cross application tracing, has been deprecated in favor of [distributed tracing features](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) and will be removed in future agent versions. Distributed tracing is an improvement on the cross application tracing feature and is recommended for large, distributed systems.
 </Callout>
 
 APM's cross application traces link transactions between APM apps in your service-oriented architecture (SOA). This is useful, for example, to identify performance problems between your own application (the "calling" app) and any internal or external services (the "called" app), such as traffic to internal services.


### PR DESCRIPTION
Mark cross application tracing (CAT) as deprecated and slated for removal in all documentation.
This is part of the prep work needed to EOL CAT.