### PR TITLE
Infrastructure agent integration log management, including integration errors.

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
@@ -89,7 +89,7 @@ Agent handles each STDERR line as follows:
 * **when agent runs in verbose mode**: it just forwards the full STDERR line as a DEBUG agent log entry placing integration line contexts within the \`msg\` field.
 * **otherwise**: it parses the line against the expected format (see below) and only logs as agent ERROR level, entries produced by integrations with \`fatal\` or \`error\` severity levels. In this case fields are extracted and forwarded in structured manner (therefore if JSON output is enabled for the agent fields become queryable.
 
-The infrastructure agent is filtering by default all the errors of an integration that didn't cause it to exit. All the errors of an integration will only be shown if the log level is DEBUG or if the integration is explicitly included in the log configuration. In this example all the errors coming from nri-mssql will be shown even if the log level is INFO:
+By default, the infrastructure agent filters out any errors from integrations that don't prevent the integration from running. You'll only see all errors from an integration if the log level is set to DEBUG, or if the integration is specifically listed in the log configuration. For example, in this configuration, all errors coming from `nri-mssql` will be shown, even if the log level is INFO:
 
 ```YAML
 log:

--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-logs/infrastructure-agent-logging-behavior.mdx
@@ -89,11 +89,11 @@ Agent handles each STDERR line as follows:
 * **when agent runs in verbose mode**: it just forwards the full STDERR line as a DEBUG agent log entry placing integration line contexts within the \`msg\` field.
 * **otherwise**: it parses the line against the expected format (see below) and only logs as agent ERROR level, entries produced by integrations with \`fatal\` or \`error\` severity levels. In this case fields are extracted and forwarded in structured manner (therefore if JSON output is enabled for the agent fields become queryable.
 
-The infrastructure agent is also capable of filtering the errors of an integration if it's explicitly defined in the log configuration. In this example the errors coming from nri-mssql won't be shown when the agent log is in any level except debug:
+The infrastructure agent is filtering by default all the errors of an integration that didn't cause it to exit. All the errors of an integration will only be shown if the log level is DEBUG or if the integration is explicitly included in the log configuration. In this example all the errors coming from nri-mssql will be shown even if the log level is INFO:
 
 ```YAML
 log:
-  exclude_filters:
+  include_filters:
     integration_name:
       - nri-mssql
 ```

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1500.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1500.mdx
@@ -1,0 +1,13 @@
+---
+subject: Infrastructure agent
+releaseDate: '2024-02-26'
+version: 1.50.0
+---
+
+A new version of the agent has been released. Follow standard procedures to [update the infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent). We recommend you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [Infrastructure agent 1.38.0](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1380/).
+
+## Changed
+* Add sdk temp_dir environment variable propagation [#1808](https://github.com/newrelic/infrastructure-agent/pull/1808)
+* Exclude integration error logs by default  [#1816](https://github.com/newrelic/infrastructure-agent/pull/1816)
+* chore(deps): update dependency newrelic/nri-docker to v1.10.0  [#1817](https://github.com/newrelic/infrastructure-agent/pull/1817)
+* chore(deps): update dependency newrelic/nri-flex to v1.10.0  [#1818](https://github.com/newrelic/infrastructure-agent/pull/1818)


### PR DESCRIPTION
The infrastructure-agent's  integration errors' logs have been changed in the last release to be filtered by default and only show the errors that exit the integration with an exit-code different to 0.
By default all the errors are shown in debug mode, but if we want to show the all the errors on info level for a specific integration, we will need to explicitly include them.

In this PR also the release notes from the related infra-agent 1.50.0 are present.