### PR TITLE
fix(IAST): Fixed urls for config file

### DIFF
--- a/src/content/docs/iast/install.mdx
+++ b/src/content/docs/iast/install.mdx
@@ -50,12 +50,10 @@ To install New Relic IAST:
             title={<><InlineCode>newrelic.yml</InlineCode> config file</>}
 >
                 ```yml
-                host: staging-collector.newrelic.com
                 security:
                     enabled: true
-                agent:
-                    enabled: true
-                validator_service_url: wss://csec.nr-data.net
+                    agent:
+                        enabled: true
                 ```
         </Collapser>
         <Collapser
@@ -63,11 +61,10 @@ To install New Relic IAST:
             title={<><InlineCode>newrelic.yml</InlineCode> config file for EU</>}
 >
                 ```yml
-                host: staging-collector.newrelic.com
                 security:
                     enabled: true
-                agent:
-                    enabled: true
+                    agent:
+                        enabled: true
                 validator_service_url: wss://csec.eu01.nr-data.net
                 ```
         </Collapser>

--- a/src/content/docs/iast/install.mdx
+++ b/src/content/docs/iast/install.mdx
@@ -55,9 +55,28 @@ To install New Relic IAST:
                     enabled: true
                 agent:
                     enabled: true
-                validator_service_url: wss://csec-staging.nr-data.net
+                validator_service_url: wss://csec.nr-data.net
                 ```
         </Collapser>
+        <Collapser
+            id="config-file-example"
+            title={<><InlineCode>newrelic.yml</InlineCode> config file for EU</>}
+>
+                ```yml
+                host: staging-collector.newrelic.com
+                security:
+                    enabled: true
+                agent:
+                    enabled: true
+                validator_service_url: wss://csec.eu01.nr-data.net
+                ```
+        </Collapser>
+
+
+
+
+
+
     </CollapserGroup>
 
     </Step>

--- a/src/content/docs/iast/install.mdx
+++ b/src/content/docs/iast/install.mdx
@@ -69,10 +69,18 @@ To install New Relic IAST:
                 ```
         </Collapser>
 
-
-
-
-
+        <Collapser
+            id="config-file-example"
+            title={<><InlineCode>newrelic.yml</InlineCode> config file for Fed users</>}
+>
+                ```yml
+                security:
+                    enabled: true
+                    agent:
+                        enabled: true
+                validator_service_url: wss://csec-gov.nr-data.net
+                ```
+        </Collapser>
 
     </CollapserGroup>
 

--- a/src/content/docs/iast/install.mdx
+++ b/src/content/docs/iast/install.mdx
@@ -57,7 +57,7 @@ To install New Relic IAST:
                 ```
         </Collapser>
         <Collapser
-            id="config-file-example"
+            id="config-eu-file-example"
             title={<><InlineCode>newrelic.yml</InlineCode> config file for EU</>}
 >
                 ```yml
@@ -70,7 +70,7 @@ To install New Relic IAST:
         </Collapser>
 
         <Collapser
-            id="config-file-example"
+            id="config-file-fed-example"
             title={<><InlineCode>newrelic.yml</InlineCode> config file for Fed users</>}
 >
                 ```yml


### PR DESCRIPTION
Fixed the URLs for the config file on the [Install IAST](https://docs.newrelic.com/docs/iast/install/) page.

Requested from Jayant (02/22/2024)