### PR TITLE
docs: Added missing `docker run` mount arguments to External Config Files section

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -2043,6 +2043,8 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
 
 To support a wide variety of configuration and automation needs, you can use external files that you volume mount into your Docker container to decouple certain elements of the standard configuration file. You will need to include the mount argument below in your `docker run` command, with one argument per external configuration file.
 
+
+``
 -v `pwd`/fileName.yaml:/fileName.yaml \
 ```
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -2041,9 +2041,12 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
 
 ## External config files [#external-config-files]
 
-To support a wide variety of configuration and automation needs, you can use external files that you volume mount into your Docker container to decouple certain elements of the standard configuration file.
+To support a wide variety of configuration and automation needs, you can use external files that you volume mount into your Docker container to decouple certain elements of the standard configuration file. You will need to include the mount argument below in your `docker run` command, with one argument per external configuration file.
+```
+-v `pwd`/fileName.yaml:/fileName.yaml \
+```
 
-The syntax for these files is `"@fileName.extension"`, including the double quotes.
+The syntax for these files is `"@fileName.yaml"`, including the double quotes.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -2042,7 +2042,7 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
 ## External config files [#external-config-files]
 
 To support a wide variety of configuration and automation needs, you can use external files that you volume mount into your Docker container to decouple certain elements of the standard configuration file. You will need to include the mount argument below in your `docker run` command, with one argument per external configuration file.
-```
+
 -v `pwd`/fileName.yaml:/fileName.yaml \
 ```
 

--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -2043,8 +2043,7 @@ The network monitoring agent has built-in support for retrieving keys from [AWS 
 
 To support a wide variety of configuration and automation needs, you can use external files that you volume mount into your Docker container to decouple certain elements of the standard configuration file. You will need to include the mount argument below in your `docker run` command, with one argument per external configuration file.
 
-
-``
+```
 -v `pwd`/fileName.yaml:/fileName.yaml \
 ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Documentation was missing Docker mount arguments required for external config files to be copied to container and read correctly.