### PR TITLE
Updated steps to "Copy a condition"

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/alert-policies/update-or-disable-policies-conditions.mdx
@@ -43,13 +43,14 @@ To [create a new NRQL condition](/docs/alerts-applied-intelligence/new-relic-ale
 
 To copy an existing condition, including its [targets](/docs/apm/new-relic-apm/getting-started/glossary#alert-target) and [thresholds](/docs/apm/new-relic-apm/getting-started/glossary#alert-threshold), and add it to another policy for the selected account:
 
-1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions (Policies)**, then select a policy.
-2. From the policy's list of one or more **Alert conditions**, click **Copy**.
-3. From the **Copy alert condition** list, search or scroll the list to select the policy where you want to add this condition.
+1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts & AI > Alert conditions**.
+2. From the list of alert conditions, click on the three dots icon of the alert you want to copy and select **Duplicate condition**.
+3. From the **Copy alert condition**, search or scroll the list to select the policy where you want to add this condition.
 4. Optional: Change the condition's name if necessary.
-5. Select **Save**.
+5. Optional: Click the toggle switch to **Enable on save**
+6. Select **Copy condition**.
 
-    By default, the selected alert policy will add the copied condition in the **Disabled** state. Follow standard procedures to [add](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) or copy more conditions to the alert policy, and then [**Enable** the condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#condition-on-off) as needed. Additionally, the new condition will not copy any [tags](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-via-ui-api) added to the original condition.
+    By default, the selected alert policy will add the copied condition in the **Disabled** state. Follow standard procedures to [add](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions) or copy more conditions to the alert policy, and then [**Enable** the condition](/docs/alerts/new-relic-alerts-beta/updating-alert-policies/disable-or-delete-alert-policies-conditions#disable-conditions) as needed. Additionally, the new condition will not copy any [tags](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-via-ui-api) added to the original condition.
 
 ## Configure an existing condition [#configure-condition]
 


### PR DESCRIPTION
After the changes to the Alerts UI, the steps to copy an alert condition are different. I have updated the instructions.