### PR TITLE
Clarify instrumentation steps in Tutorial 3

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
@@ -396,7 +396,7 @@ In `app.py`, insert the highlighted lines below to start a new span called `/fib
 
 You may want to record exceptions as they happen. We recommend you do this in conjunction with setting the span status.
 
-1. To set the span's status code to `ERROR` when an exception occurs, we also need to import the `Status` and `StatusCode` modules from the `opentelemetry.trace.status package`. Add the highlighted line below to the `Traces` section with the other traces libraries:
+1. To set the span's status code to `ERROR` when an exception occurs, you will use the `Status` and `StatusCode` modules from the `opentelemetry.trace.status package` that you added in step [D](#library-traces):
 
 ```python lineHighlight=8
 ##########
@@ -446,7 +446,7 @@ The OpenTelemetry metrics API defines a number of instruments, which record meas
 * Synchronous: These instruments record measurements as they occur
 * Asynchronous: These instruments register a callback, which is invoked only once per collection and do not have associated context
 
-1. In `app.py`, add the highlighted line below in the `Metrics` section to create a counter:
+1. In step [E](#library-metrics), you added the highlighted line below, which will create a counter:
 
 ```python lineHighlight=13
 ###########


### PR DESCRIPTION
This PR changes some wording for two steps in Tutorial 3 to eliminate confusion (the lines readers were told to add were already added in a previous step). 