### PR TITLE
[chore] Update kubernetes-plugin-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -23,7 +23,13 @@ To forward your Kubernetes logs to New Relic with our plugin:
 
 1. Install the New Relic Kubernetes integration following the steps from [this page](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/). This integration includes the Kubernetes plugin for logs.
 2. Optionally, you can further tune your installation in [Step 3 from the guided install](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/#kubernetes-install-navigation) using the numerous configuration options available in the [newrelic-logging repository](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging#configuration). However, we recommend the standard setup, as it is valid for most users.
-3. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
+3. The `newrelic-logging` chart defaults to sending logs to the US API endpoint. If your license key belongs to an EU or Fedramp account, you will need to update the endpoint setting with the appropriate value from the [API reference docs](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Minimal example for EU accounts:
+```
+newrelic-logging:
+  enabled: true
+  endpoint: https://log-api.eu.newrelic.com/log/v1
+```
+4. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
 
 <InstallFeedback />
 

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -23,7 +23,7 @@ To forward your Kubernetes logs to New Relic with our plugin:
 
 1. Install the New Relic Kubernetes integration following the steps from [this page](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/). This integration includes the Kubernetes plugin for logs.
 2. Optionally, you can further tune your installation in [Step 3 from the guided install](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/#kubernetes-install-navigation) using the numerous configuration options available in the [newrelic-logging repository](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging#configuration). However, we recommend the standard setup, as it is valid for most users.
-3. The `newrelic-logging` chart defaults to sending logs to the US API endpoint. If your license key belongs to an EU or Fedramp account, you will need to update the endpoint setting with the appropriate value from the [API reference docs](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Minimal example for EU accounts:
+3. Important note: if [using a Kubernetes secret](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging/values.yaml#L8-L25) to store the New Relic license key, the `newrelic-logging` chart defaults to sending logs to the US API endpoint. If the license key belongs to an EU or Fedramp account, and a secret is used for key storage, it is required to update the endpoint setting with the appropriate value from the [API reference docs](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#endpoint). Minimal example of how to set this for EU accounts:
 ```
 newrelic-logging:
   enabled: true


### PR DESCRIPTION
Added reference for required `endpoint` setting for EU/Fedramp accounts with license key secrets.


* What problems does this PR solve?

Deployments of newrelic-logging with license key secrets and  EU or Fedramp accounts must set `endpoint` or logs will not be sent successfully.

Reference:
https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging/values.yaml#L8-L25