### PR TITLE
 Fix Amazon CloudWatch Metric Streams integration pathing instructions

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -97,7 +97,8 @@ We recommend sending the data to a non-production New Relic account where you ca
 Alternatively, you can use filtering on queries to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
 
 ### Migration to Metric Streams [#migration-steps]
-We recommend that existing customers migrate from API polling to Metric Streams first in a dev or staging environment. For typical deployments, we recommend using a CloudFormation template by following the instructions below. If you prefer to not use a CloudFormation template, select the second tab:
+
+We recommend that existing customers migrate from API polling to Metric Streams using a CloudFormation template by following the instructions below.
 
 
 <Tabs>

--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -97,19 +97,39 @@ We recommend sending the data to a non-production New Relic account where you ca
 Alternatively, you can use filtering on queries to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
 
 ### Migration to Metric Streams [#migration-steps]
+We recommend that existing customers migrate from API polling to Metric Streams first in a dev or staging environment. For typical deployments, we recommend using a CloudFormation template by following the instructions below. If you prefer to not use a CloudFormation template, select the second tab:
 
-We recommend that existing customers migrate from API polling to Metric Streams first in a dev or staging environment. For typical deployments, follow these steps to migrate to AWS Cloudwatch Metric Streams:  
 
-1. Replicate the namespaces from polling to metric streams by going to <DoNotTranslate>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS**</DoNotTranslate>. Click on the <DoNotTranslate>**Migrate to AWS Cloudwatch metric streams**</DoNotTranslate> button, then configure your AWS Metric Streams account. 
-2. Download the customized CloudFormation template. This template contains the preconfigured namespaces that are based on your existing polling configuration.
-3. Add your account details. 
+<Tabs>
+	<TabsBar>
+        <TabsBarItem id="1">
+            CloudFormation template (recommended)
+        </TabsBarItem>
+        <TabsBarItem id="2">
+            Non-template option
+        </TabsBarItem>
+    </TabsBar>
 
+    <TabsPages>
+        <TabsPageItem id="1">
+To migrate from API polling to Metric Streams using a CloudFormation template, follow these instructions:
+        
+1. Replicate the namespaces from polling into metric streams by going to <DoNotTranslate>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS > Migrate to AWS Cloudwatch metric streams**</DoNotTranslate>, and then configuring your AWS Metric Streams account. 
+2. Download the customized CloudFormation template under the **Configure metric streams** step. This template contains the preconfigured namespaces that are based on your existing polling configuration.
+3. Add your account details to the downloaded template. 
+4. In the AWS Console, upload your CloudFormation template by going to **Cloud Formation > Create Stack > Upload a template file**. 
+        </TabsPageItem>
+        <TabsPageItem id="2">
 If you prefer not to use the CloudFormation template, here's an alternative option:
 
-1. Go to <DoNotTranslate>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS**</DoNotTranslate>. Click on <DoNotTranslate>**Add an AWS account**</DoNotTranslate>, then add your AWS account. This step is required even if you've already linked your AWS account with polling integrations.
-2. During the last onboarding step, ensure you've enabled AWS CloudWatch Metric Stream and the AWS Kinesis Data Firehose. This pushes metrics to New Relic. AWS CloudWatch requires one stream per region, so repeat this step for any additional AWS regions you want to monitor.
+1. Go to <DoNotTranslate>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS > Add an AWS account**</DoNotTranslate>, then add your AWS account. This step is required even if you've already linked your AWS account with polling integrations.
+2. Enable AWS CloudWatch Metric Stream and the AWS Kinesis Data Firehose in the final step of the **Add an AWS account** process. This pushes metrics to New Relic. AWS CloudWatch requires one stream per region, so repeat this step for any additional AWS regions you want to monitor.
 3. Ensure metrics are received from all connected regions and namespaces. This may take several minutes.
 4. Disable all unnecessary polling integrations in the previous AWS provider account. Remember that [some integrations still need to be enabled](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream#integrations-not-replaced-streams) because they aren't fully replaced by Metric Streams.
+        </TabsPageItem>
+    </TabsPages>
+</Tabs>
+
 
 ### Query, dashboard, and alert considerations [#considerations]
 


### PR DESCRIPTION
Closes NR-163604

* Clarifies the pathing needed to use CloudFormation templates while migrating metric stream.
* Clarifies that the options under the header are parallel procedures and users must choose one or the other

https://deploy-preview-16379--docs-website-netlify.netlify.app/docs/infrastructure/amazon-integrations/connect/aws-metric-stream/#migration-steps