### PR TITLE
Update streaming-alerts-key-terms-concepts.mdx

### DIFF
--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
@@ -266,7 +266,7 @@ The delay/timer setting controls how long the condition should wait before aggre
 
 The event flow and cadence methods use delay. Event timer uses timer.
 
-The delay default is <DoNotTranslate>**2 minutes**</DoNotTranslate>. The timer default is <DoNotTranslate>**1 minute**</DoNotTranslate> and has a minimum value of <DoNotTranslate>**5 seconds**</DoNotTranslate> and a maximum value of <DoNotTranslate>**20 minutes**</DoNotTranslate>.
+The delay default is <DoNotTranslate>**2 minutes**</DoNotTranslate>. The timer default is <DoNotTranslate>**1 minute**</DoNotTranslate>, has a minimum value of <DoNotTranslate>**5 seconds**</DoNotTranslate>, and a maximum value of <DoNotTranslate>**20 minutes**</DoNotTranslate>.
 
 ### Loss of signal detection [#signal-loss]
 

--- a/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
+++ b/src/content/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts.mdx
@@ -266,7 +266,7 @@ The delay/timer setting controls how long the condition should wait before aggre
 
 The event flow and cadence methods use delay. Event timer uses timer.
 
-The delay default is <DoNotTranslate>**2 minutes**</DoNotTranslate>. The timer default is <DoNotTranslate>**1 minute**</DoNotTranslate> and has a minimum value of <DoNotTranslate>**5 seconds**</DoNotTranslate>.
+The delay default is <DoNotTranslate>**2 minutes**</DoNotTranslate>. The timer default is <DoNotTranslate>**1 minute**</DoNotTranslate> and has a minimum value of <DoNotTranslate>**5 seconds**</DoNotTranslate> and a maximum value of <DoNotTranslate>**20 minutes**</DoNotTranslate>.
 
 ### Loss of signal detection [#signal-loss]
 


### PR DESCRIPTION
Adding maximum value for event timer value

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* This adds missing information on the maximum permitted value of the event timer delay