### PR TITLE
use `span`s for `DoNotTranslate` tags

### DIFF
--- a/scripts/actions/utils/handlers.js
+++ b/scripts/actions/utils/handlers.js
@@ -117,6 +117,7 @@ module.exports = {
     serialize: (h, node) =>
       serializeComponent(h, node, {
         classNames: 'notranslate',
+        tagName: 'span',
         wrapChildren: false,
       }),
   },


### PR DESCRIPTION
### ✨ Summary

`DoNotTranslate` tags are being rendered as `p` tags, causing incorrect spacing on i18n pages. this PR changes them to serialize/deserialize as `span`s which should fix this

### 🔮 Engineering checklist

<!-- Remove any items that do not apply -->

- [x] Code changes are self-documenting or clearly commented/documented
