### PR TITLE
Add PHP support info to Vulnerability Management docs

### DIFF
--- a/src/content/docs/vulnerability-management/integrations/apm-agents/php-support.mdx
+++ b/src/content/docs/vulnerability-management/integrations/apm-agents/php-support.mdx
@@ -1,0 +1,50 @@
+---
+title: Vulnerability Management PHP Support
+metaDescription: 'Limitations in detecting vulnerabilities from PHP packages.'
+freshnessValidatedDate: never
+---
+
+Our New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) currently provides support for detecting CVEs related to packages from the following frameworks:
+
+<table>
+  <thead>
+    <tr>
+      <th>Packages</th>
+      <th>Minimum Version</th>
+    </tr>
+  </thead>
+    <tbody>
+    <tr>
+      <td>Drupal</td>
+      <td>8.X</td>
+    </tr>
+    <tr>
+      <td>Guzzle</td>
+      <td>6.X</td>
+    </tr>
+    <tr>
+      <td>Laravel</td>
+      <td>6.X</td>
+    </tr>
+    <tr>
+      <td>PHPUnit</td>   
+      <td>9.X</td>
+    </tr>
+    <tr>
+      <td>Predis</td>
+      <td>2.X</td>
+    </tr>
+    <tr>
+      <td>Slim</td>    
+      <td>2.X</td>
+    </tr>
+    <tr>
+      <td>Wordpress</td>    
+      <td>5.9.X</td>
+    </tr>
+    </tbody>
+</table>
+
+It's recommended to use [officially supported versions](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) of PHP. Note, the PHP agent differs from other language agents as it is not aware of packages until they are used. If the version is not specified in the package's source code in an accessible way, the PHP agent is unable to provide version detection information for that package, and vulnerabilities will not be shown.
+
+To disable package detection for Vulnerability Management, you can find more information on the [configuration page](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-package-detection).

--- a/src/content/docs/vulnerability-management/integrations/intro.mdx
+++ b/src/content/docs/vulnerability-management/integrations/intro.mdx
@@ -43,6 +43,11 @@ There are three ways to import common vulnerabilitie and exposure (CVE) data:
     icon="logo-ruby"
     to="https://one.newrelic.com/nr1-core?state=d69143ab-605c-579b-25bf-cc6e5fee5b80"
   />
+  <TechTile
+    name="PHP agent"
+    icon="logo-php"
+    to="https://one.newrelic.com/nr1-core?state=aa633b41-72d4-009c-3abf-55dcf64894fe"
+  />
 </TechTileGrid>
 
 CVE detection coverage differs between agents:
@@ -83,8 +88,8 @@ CVE detection coverage differs between agents:
     </tr>
     <tr>
       <td>PHP</td>    
-      <td>Not supported</td>
-      <td>N/A</td>
+      <td>10.17 or higher</td>
+      <td>[Some Packages](/docs/vulnerability-management/integrations/apm-agents/php-support/)</td>
     </tr>
     <tr>
       <td>.NET</td>    

--- a/src/nav/vuln-management.yml
+++ b/src/nav/vuln-management.yml
@@ -11,6 +11,10 @@ pages:
     pages:
       - title: Vulnerability integrations overview
         path: /docs/vulnerability-management/integrations/intro
+      - title: APM agent notes
+        pages:
+          - title: PHP Support
+            path: /docs/vulnerability-management/integrations/apm-agents/php-support
       - title: AWS Security
         path: /docs/vulnerability-management/integrations/aws
       - title: Dependabot


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
PHP support for Vulnerability Management is now live and will be GA'd to customers at the end of the quarter. This updates the overview page for vulnerability integrations to indicate PHP support, as well as adds a sub-page to describe the limitations of PHP support.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
<img width="1681" alt="Screenshot 2024-03-05 at 1 05 18 PM" src="https://github.com/newrelic/docs-website/assets/1945929/f7c88fdf-7053-4e3e-91ae-eb60705e85a8">
<img width="1683" alt="Screenshot 2024-03-05 at 1 05 29 PM" src="https://github.com/newrelic/docs-website/assets/1945929/61840fe9-c2de-4d8d-be10-d858409b7d6d">