### PR TITLE
[chore] Update oracle-database-monitoring-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -3300,7 +3300,7 @@ These attributes can be found by querying the `OracleDatabaseSample` event type.
 
 ### Tablespace metrics [#tablespace-metric]
 
-The Oracle Database integration collects the following tablespace metrics. These attributes can be found by querying the `OracleTablespaceSample` event type.
+The Oracle Database integration collects the following tablespace metrics. These attributes can be found by querying the `OracleTablespaceSample` event type. Please note that tablespace usage metrics are not available for read-only standby databases - read more about this limitation in the Oracle Knowledgebase [here](https://support.oracle.com/knowledge/Enterprise%20Management/2972740_1.html).
 
 <table>
   <thead>


### PR DESCRIPTION
add note about tablespace usage metrics for read-only standby databases

* What problems does this PR solve?

Users of the integration may expect tablespace usage metrics for their standby metrics, however these metrics are not available from the source. We should clarify this edge case in documentation.

https://support.oracle.com/knowledge/Enterprise%20Management/2972740_1.html notes the following:

>  DBA_TABLESPACE_USAGE_METRICS is responsible for fetching metrics data for tablespace utilization and it is executed on primary database only.  By monitoring the tablespace usage on the primary database and performing corrective actions (if required), the changes will get automatically replicated onto the standby database through the shipped redo logs.
Hence no calculation on standby tablespace metrics is done and the metrics shows no data from OEM.
