### PR TITLE
Update aws-metric-stream.mdx

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -92,7 +92,7 @@ If you're a New Relic customer who currently has our older polling-based AWS int
 
 Note that if you have both forms of integration set up, there can be duplicated metrics. For example, <InlinePopover type="alerts" /> and dashboards that use `sum` or `count` will return twice the actual number. This includes alerts and dashboards that use metrics that have a `.Sum` suffix.
 
-We recommend sending the data to a non-production New Relic account where you can safely do tests. If that's not an option, then AWS CloudWatch Metric Stream filters are available to include or exclude certain namespaces that can cause trouble.
+We recommend sending the data to a non-production New Relic account where you can safely do tests. If that's not an option, then AWS CloudWatch Metric Stream filters are available to include or exclude certain namespaces or metrics that can cause trouble.
 
 Alternatively, you can use filtering on queries to distinguish between metrics that come from Metric Streams and those that come through polling. All metrics coming from Metric Streams are tagged with `collector.name='cloudwatch-metric-streams'`.
 


### PR DESCRIPTION
Added reference to include/exclude specific metrics.

In May 2023 AWS added the ability to curate metrics in addition to the existing ability to curate namespaces.

https://aws.amazon.com/about-aws/whats-new/2023/05/amazon-cloudwatch-metric-streams-filtering-name/

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Creates parity with AWS in terms of accurately reflecting current state of filtering.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
  Citation from May 2023 where AWS added this ability: https://aws.amazon.com/about-aws/whats-new/2023/05/amazon-cloudwatch-metric-streams-filtering-name/
  
* If your issue relates to an existing GitHub issue, please link to it.