### PR TITLE
fix: some code blocks not formatting right

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -163,7 +163,7 @@ To change settings, you have two options (if the setting supports it):
       </td>
       <td>
         ```java
-          withApplicationVersion("MY APP VERSION")
+        withApplicationVersion("MY APP VERSION")
         ```
       </td>
   </tr>
@@ -1013,7 +1013,6 @@ if(Capacitor.getPlatform() === 'ios') {
 }
 
 let agentConfig : AgentConfiguration = {
-
   analyticsEventEnabled: false,
   crashReportingEnabled: false,
   interactionTracingEnabled: false,
@@ -1203,7 +1202,7 @@ If you make any changes to the default settings, make sure to add the feature fl
 
 Here's a sample configuration:
 
-```typescript
+```shell
 # Disable Crash Reporting
 cordova plugin add https://github.com/newrelic/newrelic-cordova-plugin.git
 --variable IOS_APP_TOKEN="{ios-app-token}"
@@ -1371,37 +1370,34 @@ If you make any changes to the default settings, make sure to add the feature fl
 Here's a sample configuration:
 
 ```csharp
- using NewRelic.MAUI.Plugin;
-            ...
+using NewRelic.MAUI.Plugin;
+    ...
     public App()
+    {
+        InitializeComponent();
+
+        MainPage = new AppShell();
+
+        CrossNewRelic.Current.HandleUncaughtException();
+        CrossNewRelic.Current.TrackShellNavigatedEvents();
+
+        // Set optional agent configuration
+        // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, crashCollectorAddress, analyticsEventEnabled,
+        // networkErrorRequestEnabled, networkRequestEnabled, interactionTracingEnabled,webViewInstrumentation, fedRampEnabled
+        AgentStartConfiguration agentConfig = new AgentStartConfiguration(crashReportingEnabled:false);
+
+        if (DeviceInfo.Current.Platform == DevicePlatform.Android)
         {
-            InitializeComponent();
-
-            MainPage = new AppShell();
-
-            CrossNewRelic.Current.HandleUncaughtException();
-            CrossNewRelic.Current.TrackShellNavigatedEvents();
-
-            // Set optional agent configuration
-            // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, crashCollectorAddress,analyticsEventEnabled, networkErrorRequestEnabled, networkRequestEnabled, interactionTracingEnabled,webViewInstrumentation, fedRampEnabled
-            AgentStartConfiguration agentConfig = new AgentStartConfiguration(crashReportingEnabled:false);
-
-            if (DeviceInfo.Current.Platform == DevicePlatform.Android)
-            {
-                // CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
-                // Start with optional agent configuration
-                 CrossNewRelic.Current.Start("<APP-TOKEN-HERE", agentConfig);
-            }
-            else if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
-            {
-                // CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
-                // Start with optional agent configuration
-                 CrossNewRelic.Current.Start("<APP-TOKEN-HERE", agentConfig);
-            }
+            // CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
+            // Start with optional agent configuration
+            CrossNewRelic.Current.Start("<APP-TOKEN-HERE", agentConfig);
         }
-
-
-
+        else if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
+        {
+            // CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
+            // Start with optional agent configuration
+            CrossNewRelic.Current.Start("<APP-TOKEN-HERE", agentConfig);
+        }
     }
 ```
 
@@ -1744,31 +1740,30 @@ import NewRelic from 'newrelic-react-native-agent';
 import * as appVersion from './package.json';
 import {Platform} from 'react-native';
 
-    let appToken;
+let appToken;
 
-    if (Platform.OS === 'ios') {
-        appToken = '<IOS-APP-TOKEN>';
-    } else {
-        appToken = '<ANDROID-APP-TOKEN>';
-    }
+if (Platform.OS === 'ios') {
+    appToken = '<IOS-APP-TOKEN>';
+} else {
+    appToken = '<ANDROID-APP-TOKEN>';
+}
 
-
- const agentConfiguration = {
- Config config = Config(
-    analyticsEventEnabled: false,
-    crashReportingEnabled: false,
-    interactionTracingEnabled: false,
-    networkRequestEnabled: false,
-    networkErrorRequestEnabled: false,
-    httpResponseBodyCaptureEnabled: false,
-    loggingEnabled: false,
-    logLevel: NREnums.LogLevel.INFO,
-    webViewInstrumentation: false,
-    collectorAddress: "",
-    crashCollectorAddress: "",
-    sendConsoleEvents: false,
-    fedRampEnabled: false
-  };
+const agentConfiguration = {
+     Config config = Config(
+          analyticsEventEnabled: false,
+          crashReportingEnabled: false,
+          interactionTracingEnabled: false,
+          networkRequestEnabled: false,
+          networkErrorRequestEnabled: false,
+          httpResponseBodyCaptureEnabled: false,
+          loggingEnabled: false,
+          logLevel: NREnums.LogLevel.INFO,
+          webViewInstrumentation: false,
+          collectorAddress: "",
+          crashCollectorAddress: "",
+          sendConsoleEvents: false,
+          fedRampEnabled: false
+};
 
 
 NewRelic.startAgent(appToken,agentConfiguration);
@@ -1946,34 +1941,34 @@ Here's a sample configuration:
 
 ```csharp
 public App ()
-            {
-                InitializeComponent();
+{
+    InitializeComponent();
 
-                MainPage = new MainPage();
-                Application.Current.PageAppearing += OnPageAppearing;
-                Application.Current.PageDisappearing += PageDisappearing;
+    MainPage = new MainPage();
+    Application.Current.PageAppearing += OnPageAppearing;
+    Application.Current.PageDisappearing += PageDisappearing;
 
-                CrossNewRelicClient.Current.HandleUncaughtException();
-                CrossNewRelicClient.Current.TrackShellNavigatedEvents();
+    CrossNewRelicClient.Current.HandleUncaughtException();
+    CrossNewRelicClient.Current.TrackShellNavigatedEvents();
 
-            // Set optional agent configuration
-            // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, crashCollectorAddress,analyticsEventEnabled, networkErrorRequestEnabled, networkRequestEnabled, interactionTracingEnabled,webViewInstrumentation, fedRampEnabled
-            AgentStartConfiguration agentConfig = new AgentStartConfiguration(crashReportingEnabled:false);
-
-           if (Device.RuntimePlatform == Device.Android)
-                {
-                    //CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
-                    // Start with optional agent configuration
-                    CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
-                }
-                else if (Device.RuntimePlatform == Device.iOS)
-                {
-                    //CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
-                    // Start with optional agent configuration
-                    CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
-                }
-            }
-        }
+    // Set optional agent configuration
+    // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, crashCollectorAddress, analyticsEventEnabled, 
+    // networkErrorRequestEnabled, networkRequestEnabled, interactionTracingEnabled,webViewInstrumentation, fedRampEnabled
+    AgentStartConfiguration agentConfig = new AgentStartConfiguration(crashReportingEnabled:false);
+    
+    if (Device.RuntimePlatform == Device.Android)
+    {
+        //CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
+        // Start with optional agent configuration
+        CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
+    }
+    else if (Device.RuntimePlatform == Device.iOS)
+    {
+        //CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE>");
+        // Start with optional agent configuration
+        CrossNewRelicClient.Current.Start("<APP-TOKEN-HERE", agentConfig);
+    }
+}
 ```
 
 ## Available configurations [#configurations]

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/create-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/create-attribute.mdx
@@ -176,7 +176,7 @@ boolean attributeSet = NewRelic.setAttribute("rate", 9999.99);
 ### Kotlin [#kotlin]
 
 ```kotlin
-    val attributeSet = NewRelic.setAttribute("rate", 9999.99)
+val attributeSet = NewRelic.setAttribute("rate", 9999.99)
 ```
         </TabsPageItem>
         <TabsPageItem id="ios">
@@ -360,7 +360,7 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 ## Example [#example]
 
 ```typescript
-     NewRelicCapacitorPlugin.setAttribute({ name: "CapacitorAttribute", value: "123" });
+NewRelicCapacitorPlugin.setAttribute({ name: "CapacitorAttribute", value: "123" });
 ```
 
         </TabsPageItem>
@@ -428,7 +428,7 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 ## Example [#example]
 
   ```js
-NewRelic.setAttribute(Name: "CordovaAttribute", value: "123"): void;
+  NewRelic.setAttribute(Name: "CordovaAttribute", value: "123"): void;
   ```
 
         </TabsPageItem>
@@ -499,10 +499,10 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 
 ## Example [#example]
 
-``` C#
-    CrossNewRelic.Current.SetAttribute("MAUIBoolAttr", false);
-    CrossNewRelic.Current.SetAttribute("MAUIStrAttr", "Cat");
-    CrossNewRelic.Current.SetAttribute("MAUINumAttr", 13.5);
+```csharp
+CrossNewRelic.Current.SetAttribute("MAUIBoolAttr", false);
+CrossNewRelic.Current.SetAttribute("MAUIStrAttr", "Cat");
+CrossNewRelic.Current.SetAttribute("MAUINumAttr", 13.5);
 ```
         </TabsPageItem>
         <TabsPageItem id="flutter">
@@ -569,7 +569,7 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 ## Example [#example]
 
 ```dart
-    NewrelicMobile.instance.setAttribute('RNCustomAttrNumber', 37);
+NewrelicMobile.instance.setAttribute('RNCustomAttrNumber', 37);
 ```
         </TabsPageItem>
         <TabsPageItem id="react">
@@ -634,8 +634,8 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 
 ## Example [#example]
 
- ```js
-   NewRelic.setAttribute('RNCustomAttrNumber', 37);
+  ```js
+  NewRelic.setAttribute('RNCustomAttrNumber', 37);
   ```
 
         </TabsPageItem>
@@ -706,10 +706,10 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 
 ## Example [#example]
 
-``` csharp
-    CrossNewRelicClient.Current.SetAttribute("XamarinBoolAttr", false);
-    CrossNewRelicClient.Current.SetAttribute("XamarinStrAttr", "Cat");
-    CrossNewRelicClient.Current.SetAttribute("XamarinNumAttr", 13.5);
+```csharp
+CrossNewRelicClient.Current.SetAttribute("XamarinBoolAttr", false);
+CrossNewRelicClient.Current.SetAttribute("XamarinStrAttr", "Cat");
+CrossNewRelicClient.Current.SetAttribute("XamarinNumAttr", 13.5);
 ```
 
         </TabsPageItem>
@@ -781,10 +781,10 @@ Creates a session-level attribute shared by multiple mobile event types. Overwri
 
 ## Example [#example]
 
-``` csharp
-    NewRelicAgent.SetAttribute("UnityBoolCustomAttr", false);
-    NewRelicAgent.SetAttribute("UnityStringCustomAttr", "Cat");
-    NewRelicAgent.SetAttribute('UnityCustomAttrNumber', 37);
+```csharp
+NewRelicAgent.SetAttribute("UnityBoolCustomAttr", false);
+NewRelicAgent.SetAttribute("UnityStringCustomAttr", "Cat");
+NewRelicAgent.SetAttribute('UnityCustomAttrNumber', 37);
 ```
 
         </TabsPageItem>      

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
@@ -19,7 +19,7 @@ freshnessValidatedDate: 2023-07-20
 ---
 
 <Tabs>
-	<TabsBar>
+    <TabsBar>
         <TabsBarItem id="android">
             Android
         </TabsBarItem>
@@ -79,7 +79,6 @@ The default value for the event harvest cycle is 600 seconds. See [Set max event
 </Callout>
 
 
-
 ## Parameters [#parameters]
 
 <table>
@@ -103,7 +102,7 @@ The default value for the event harvest cycle is 600 seconds. See [Set max event
         `$maxSize`
       </td>
 
-            <td>
+      <td>
         `int`
       </td>
 
@@ -231,7 +230,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -262,7 +261,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 ## Example [#example]
 
 ```typescript
-        NewRelicCapacitorPlugin.setMaxEventPoolSize({ maxPoolSize: 2000 })
+NewRelicCapacitorPlugin.setMaxEventPoolSize({ maxPoolSize: 2000 })
 ```
 
         </TabsPageItem>
@@ -272,7 +271,6 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 
 ```typescript
 setMaxEventPoolSize(maxSize: number): void;
-
 ```
 
 ## Description [#description]
@@ -288,7 +286,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -319,11 +317,11 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 ## Example [#example]
 
   ```js
-    NewRelic.setMaxEventPoolSize(2000);
+  NewRelic.setMaxEventPoolSize(2000);
   ```
 
         </TabsPageItem>
-       <TabsPageItem id="maui">
+        <TabsPageItem id="maui">
 
 ## Syntax [#syntax]
 
@@ -344,7 +342,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -374,8 +372,8 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 
 ## Example [#example]
 
-``` C#
-    CrossNewRelic.Current.SetMaxEventPoolSize(1500);
+```csharp
+CrossNewRelic.Current.SetMaxEventPoolSize(1500);
 ```
         </TabsPageItem>
     </TabsPages>
@@ -386,7 +384,6 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 
 ```typescript
 setMaxEventPoolSize(int maxSize): void;
-
 ```
 
 ## Description [#description]
@@ -402,7 +399,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -433,10 +430,10 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 ## Example [#example]
 
   ```dart
-NewrelicMobile.instance.setMaxEventPoolSize(10000);
+  NewrelicMobile.instance.setMaxEventPoolSize(10000);
   ```
 
-                    </TabsPageItem>
+        </TabsPageItem>
         <TabsPageItem id="react">
 
 ## Syntax [#syntax]
@@ -458,7 +455,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -488,8 +485,8 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 
 ## Example [#example]
 
- ```js
-    NewRelic.setMaxEventPoolSize(2000);
+  ```js
+  NewRelic.setMaxEventPoolSize(2000);
   ```
 
         </TabsPageItem>
@@ -514,7 +511,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -544,13 +541,12 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 
 ## Example [#example]
 
-``` csharp
-    CrossNewRelicClient.Current.SetMaxEventPoolSize(1500);
+```csharp
+CrossNewRelicClient.Current.SetMaxEventPoolSize(1500);
 ```
 
         </TabsPageItem>
-
-<TabsPageItem id="unity">
+        <TabsPageItem id="unity">
 
 ## Syntax [#syntax]
 
@@ -571,7 +567,7 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
         Parameter
       </th>
 
-            <th width={200}>
+      <th width={200}>
         Type
       </th>
 
@@ -601,10 +597,10 @@ Sets the maximum size of the event pool stored in memory until the next harvest 
 
 ## Example [#example]
 
-``` csharp
-    NewRelicAgent.SetMaxEventPoolSize(1500);
+```csharp
+NewRelicAgent.SetMaxEventPoolSize(1500);
 ```
 
-        </TabsPageItem>
+</TabsPageItem>
 
 </Tabs>


### PR DESCRIPTION
stray indentation inside codeblocks or the triple backticks being misaligned can throw off the formatting of markdown code.  In this case the c# wasn't formatting in one example

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.