### PR TITLE
chore(PHP agent): Updates compatibility based on 3/1/24 EOLs

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -191,32 +191,12 @@ The following frameworks are supported:
   <tbody>
     <tr>
       <td>
-        CakePHP 2.x
-      </td>
-
-      <td>
-        Magento 1.x and 2.x, CE and EE
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        CodeIgniter 2.x
-      </td>
-
-      <td>
-        MediaWiki
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         [Drupal 6.x, 7.x, 8.x, 9.1-9.5](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
       </td>
 
       <td>
-        Slim 2.x, 3.x, and 4.x
-      </td>      
+        Magento 2.x, CE and EE
+      </td>
     </tr>
 
     <tr>
@@ -227,8 +207,9 @@ The following frameworks are supported:
   Joomla 3.x is not supported on PHP 8.x.
 </Callout>
       </td>
+
       <td>
-        Symfony 3.x, 4.x, and 5.x
+        MediaWiki
       </td>
     </tr>
 
@@ -238,8 +219,8 @@ The following frameworks are supported:
       </td>
 
       <td>
-        [Wordpress](/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality/)
-      </td>
+        Slim 2.x, 3.x, and 4.x
+      </td>      
     </tr>
 
     <tr>
@@ -248,19 +229,29 @@ The following frameworks are supported:
       </td>
 
       <td>
+        Symfony 3.x, 4.x, and 5.x
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         Lumen 6.x, 7.x, 8.x, 9.x, and 10.x
       </td>
+
+      <td>
+        [Wordpress](/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality/)
+      </td>
+    </tr>
+
+    <tr>
+
+
     </tr>
     
     <tr>
       <td>
-        Zend Framework 1.x, 2.x, and 3.x
+        Zend Framework 3.x
       </td>
-    
-      <td>
-        Yii 1.x
-      </td>
-
 
     </tr>
   </tbody>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -191,7 +191,7 @@ The following frameworks are supported:
   <tbody>
     <tr>
       <td>
-        [Drupal 6.x, 7.x, 8.x, 9.1-9.5](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
+        [Drupal 7.x, 8.x, 9.1-9.5](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
       </td>
 
       <td>
@@ -229,7 +229,7 @@ The following frameworks are supported:
       </td>
 
       <td>
-        Symfony 3.x, 4.x, and 5.x
+        Symfony 4.x and 5.x
       </td>
     </tr>
 


### PR DESCRIPTION
On March 1st, 2024 several PHP frameworks were EOL'd and this PR updates the PHP agent compatibility page to reflect these changes.
