### PR TITLE
manual build preview on PR open

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -12,7 +12,7 @@ jobs:
             
             Thanks for your pull request! Your PR is in a queue, and a writer will take a look soon. We generally publish small edits within one business day, and larger edits within three days.
             
-            Gatsby Cloud will automatically generate a preview of your request, and will comment with a link when the preview is ready (usually 20 to 30 minutes).
+            We will automatically generate a preview of your request, and will comment with a link when the preview is ready (usually 10 to 20 minutes). If you add any more commits, you can comment `netlify build` on this PR to update the preview.
 
           issuesOpened: |
             Hi @{{ author }} 👋

--- a/.github/workflows/build-notification.yml
+++ b/.github/workflows/build-notification.yml
@@ -15,7 +15,7 @@ on:
         options:
           - building
           - ready
-          - failed
+          - error
       deployUrl:
         description: URL of live branch deploy
         required: false
@@ -60,7 +60,7 @@ jobs:
           END
               )
               ;;
-            "failed")
+            "error")
               comment_body=$(cat <<-END
           ### <span aria-hidden="true">❌</span> Deploy Preview failed!
 
@@ -92,8 +92,8 @@ jobs:
             -f context='netlify/build' \
             /repos/${{ env.repo }}/statuses/${{ inputs.sha }}
 
-      - name: update PR check - failed
-        if: ${{ inputs.buildStatus == 'failed' }}
+      - name: update PR check - error
+        if: ${{ inputs.buildStatus == 'error' }}
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/manual-deploy-comment.yml
+++ b/.github/workflows/manual-deploy-comment.yml
@@ -3,10 +3,20 @@ name: Netlify build manual deploy comment
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened]
 
 jobs:
   deploy-preview:
+    # when a contributor comments 'netlify build',
+    # but only on pull requests, not issues.
+    # or if a contributor opens a PR for the first time.
+    if: |
+       (github.event.comment.body == 'netlify build'
+         && github.event.issue.pull_request)
+         || github.event.action == 'opened'
     runs-on: ubuntu-latest
+
     steps:
       # we use `jq` to parse the GH API response
       - name: setup jq
@@ -15,13 +25,8 @@ jobs:
       - name: send request to Netlify build hook
         env: 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # when a contributor comments 'netlify build',
-        # but only on pull requests, not issues
-        if: |
-          contains(github.event.comment.body, 'netlify build')
-          && ${{ github.event.issue.pull_request }}
         run: |
-          gh_api_url=$(echo ${{ github.event.issue.pull_request.url }} | sed 's/https:\/\/api.github.com//')
+          gh_api_url=$(echo ${{ github.event.issue.pull_request.url || github.event.pull_request.url }} | sed 's/https:\/\/api.github.com//')
           gh_api_response=$(gh api $gh_api_url)
           branch_name=$(echo $gh_api_response | jq -r .head.ref)
           sha=$(echo $gh_api_response | jq -r .head.sha)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,9 @@ If the workflows are enabled and running, you will want to disable them. You can
 2. Make your changes.
 3. Test your changes! Review the project's [READ ME](README.md) for instructions on how to build and run tests locally.
 4. Submit a `Pull Request` to this project with your changes.
-5. If/when your `PR` is accepted, the automation in this project will build the site and deploy a new version of the code to `docs.newrelic.com`.
-6. And you are done!
+5. A preview will start building automatically when a PR is opened. To update the preview after further commits, leave a comment on the PR that says `netlify build`.
+6. If/when your `PR` is accepted, the automation in this project will build the site and deploy a new version of the code to `docs.newrelic.com`.
+7. And you are done!
 
 ### Submitting a PR from a cloned repo
 
@@ -116,8 +117,9 @@ If the workflows are enabled and running, you will want to disable them. You can
 3. Make your changes.
 4. Test your changes! Review the project's [READ ME](README.md) for instructions on how to build and run tests locally.
 5. Submit a `Pull Request` to this project with your changes.
-6. If/when your `PR` is accepted, the automation in this project will build the site and deploy a new version of the code to `docs.newrelic.com`.
-7. And you are done!
+6. A preview will start building automatically when a PR is opened. To update the preview after further commits, leave a comment on the PR that says `netlify build`.
+7. If/when your `PR` is accepted, the automation in this project will build the site and deploy a new version of the code to `docs.newrelic.com`.
+8. And you are done!
 
 ### Using the `develop` branch
 


### PR DESCRIPTION
this updates the workflow so the manual build preview will kick off automatically the first time a PR is opened. it also moves the conditional higher so the entire job will skip if the conditions aren't met. also fixes the input choice from `failed` to `error`