### PR TITLE
OpenTelemetry: Add tabs and step components to Python tutorial

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-java.mdx
@@ -72,10 +72,10 @@ To get started, make sure you have the following:
 
 ## Tutorials [#tutorials]
 
-While each tutorial uses the same demo app, they have different approaches to help you become acquainted with OpenTelemetry and New Relic.
-* <DoNotTranslate>**Pre-instrumented app**</DoNotTranslate>: Run our pre-instrumented demo app for a quick way to see data in our UI.
-* <DoNotTranslate>**OpenTelemetry Java agent**</DoNotTranslate>: Monitor our demo app with the OpenTelemetry Java agent.
-* <DoNotTranslate>**Manual setup**</DoNotTranslate>: Instrument our demo app manually.
+Although each tutorial uses the same demo app, they have different approaches to help you become acquainted with OpenTelemetry and New Relic.
+* [Pre-instrumented app](#pre-instrumented-tutorial): Run our pre-instrumented demo app for a quick way to see data in our UI.
+* [OpenTelemetry Java agent](#java-agent-tutorial): Monitor our demo app with the OpenTelemetry Java agent.
+* [Manual setup](#manual-setup-tutorial): Instrument our demo app manually.
 
 Click on the tab below for the tutorial you want to complete.
 
@@ -223,9 +223,7 @@ To monitor our demo app with the OpenTelemetry Java agent:
 
 ### Set up the demo app manually [#manual-instrum]
 
-In this track, you'll roll up your sleeves and tinker with the engine of the car. This is the approach to take if you want to have the most control over what telemetry is reported and want to see details about how it's done.
-
-You'll manually insert instrumentation into our demo app to capture telemetry, and you'll configure the SDK to export that data to New Relic.
+The previous tutorial helped you explore automatic instrumentation with the OpenTelemetry Java agent. This tutorial will show you how to use custom instrumentation to have more control over the telemetry you gather. You'll manually insert instrumentation into our demo app to capture telemetry, and then you'll configure the SDK to export that data to New Relic.
 
 <Callout variant="tip">
   While you can manually configure the SDK, we will show you how to configure the SDK using the [autoconfigure option](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure), which simplifies the the process by using environment variables and system properties.

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
@@ -40,9 +40,9 @@ import opentelemetryPythonLogCapturedinTraceSpan from 'images/opentelemetry_scre
 
 
 
-Try out any of these Python tutorials to see what the New Relic platform can do with your OTLP data. We have three tutorials you can choose from, each one using the same demo Flask app. The app will calculate the nth number in the Fibonacci sequence and generate traces, metrics, and logs.
+Try out any of these Python tutorials to see what the New Relic platform can do with your OTLP data. We have three tutorials you can choose from, each one using the same demo Flask app. The app calculates the nth number in the Fibonacci sequence and generates traces, metrics, and logs.
 
-By working through these tutorials, you can learn skills to help you set up your own app with OpenTelemetry and New Relic.
+By working through any of these tutorials, you can learn skills to help you set up your own app with OpenTelemetry and New Relic.
 
 <img
   title="Screenshot showing response time, throughput, and error rate"

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-tutorial-python.mdx
@@ -40,39 +40,20 @@ import opentelemetryPythonLogCapturedinTraceSpan from 'images/opentelemetry_scre
 
 
 
-<SideBySide>
-  <Side>
-    Try out any of these Python tutorials to see what the New Relic platform can do with your OTLP data. We have three tutorials you can choose from, each one using the same demo Flask app. The app will calculate the nth number in the Fibonacci sequence and generate traces, metrics, and logs.
+Try out any of these Python tutorials to see what the New Relic platform can do with your OTLP data. We have three tutorials you can choose from, each one using the same demo Flask app. The app will calculate the nth number in the Fibonacci sequence and generate traces, metrics, and logs.
 
-    By working through these tutorials, you can learn skills to help you set up your own app with OpenTelemetry and New Relic.
+By working through these tutorials, you can learn skills to help you set up your own app with OpenTelemetry and New Relic.
 
-  </Side>
-  <Side>
-    <img
-      title="Screenshot showing response time, throughput, and error rate"
-      alt="Screenshot showing response time, throughput, and error rate"
-      src={openttelemetryPythonIntroImage}
-    />
+<img
+  title="Screenshot showing response time, throughput, and error rate"
+  alt="Screenshot showing response time, throughput, and error rate"
+  src={openttelemetryPythonIntroImage}
+/>
 
-    <figcaption>
-      After you finish any of these tutorials, you can view span metrics in charts like these.
-    </figcaption>
-  </Side>
-</SideBySide>
+<figcaption>
+  After you finish any of these tutorials, you can view span metrics in charts like these.
+</figcaption>
 
-While each tutorial uses the same demo app, they have different approaches to help you become acquainted with OpenTelemetry and New Relic. Try out the options that are interesting to you:
-
-    * [Tutorial 1: Run the pre-instrumented demo app:](#pre-instrum) This is the fastest way to send some demo data to New Relic and see how it is displayed in the UI. In this tutorial, the demo app has pre-loaded instrumentation and SDK configurations that follow our [best practices](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-overview/) to generate and export metrics, logs, and traces. You can inspect our code and apply relevant sections to your own apps.
-    * [Tutorial 2: Monitor the demo app with the OpenTelemetry Python agent:](#python-agent) Instead of using our pre-instrumented demo app, you can use the OpenTelemetry Python agent to automatically monitor our demo app. You don't need to open the demo code and make any changes&mdash;just install and run the agent alongside the app.
-    * [Tutorial 3: Set up the demo app manually:](#manual-instrum) In this track, you'll roll up your sleeves and tinker with the engine of the car. This is the approach to take if you want to have the most control over what telemetry is reported and want to see details about how it's done. You'll manually insert instrumentation into our demo app to capture telemetry and you'll configure the SDK to export that data to New Relic.
-
-<Callout variant="tip">
-You have two choices for exporting data from your application to New Relic via OTLP:
-* Directly from your app
-* Via an OpenTelemetry collector
-
-This guide covers the first option. If you wish to export your data via a collector, check out this [collector documentation](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic/) for details.
-</Callout>
 ## Requirements [#requirements]
 
 Before you get started, make sure you have the following:
@@ -80,7 +61,40 @@ Before you get started, make sure you have the following:
 * A New Relic account: Sign up for a [free account](https://newrelic.com/signup) if you don't already have one.
 * Python 3.8 or higher, and pip (included in Python version 3.4 and later): If you don't already have these, see these [download options](https://www.python.org/downloads/).
 
-## Tutorial 1: Run the pre-instrumented demo app [#pre-instrum]
+## Tutorials [#tutorials]
+
+Although each tutorial uses the same demo app, they have different approaches to help you become acquainted with OpenTelemetry and New Relic.
+
+* [Pre-instrumented app](#pre-instrumented-tutorial): Run our pre-instrumented demo app for a quick way to see data in our UI.
+* [OpenTelemetry Python agent](#python-agent-tutorial): Monitor our demo app with the OpenTelemetry Python agent.
+* [Manual setup](#manual-setup-tutorial): Instrument our demo app manually.
+
+Click on the tab below for the tutorial you want to complete.
+
+<Callout variant="tip">
+When using OpenTelemetry, you'll have two choices for exporting data from your application to New Relic via OTLP:
+* Directly from your app to New Relic
+* Your app sends data to an OpenTelemetry Collector where it is then exported to New Relic
+
+These tutorials cover the first option. If you want to export your data via a collector, check out this [collector documentation](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic/) for details.
+</Callout>
+
+<Tabs>
+	  <TabsBar>
+        <TabsBarItem id="pre-instrumented-tutorial">
+           Pre-instrumented app 
+        </TabsBarItem>
+        <TabsBarItem id="python-agent-tutorial">
+            OpenTelemetry Python agent 
+        </TabsBarItem>
+        <TabsBarItem id="manual-setup-tutorial">
+            Manual setup 
+        </TabsBarItem>
+    </TabsBar>
+    <TabsPages>
+        <TabsPageItem id="pre-instrumented-tutorial">
+
+### Run the pre-instrumented demo app [#pre-instrum]
 
 This is a great option if you want us to do the instrumentation so you can quickly see what's it's like to send data to New Relic and view it in our UI.
 
@@ -131,11 +145,14 @@ This is a great option if you want us to do the instrumentation so you can quick
 6. Click your new entity (service) called `getting-started-python` and explore the UI. For more tips about what to look for in the UI, see [View your data in New Relic](#view-data).
 7. When you're finished looking at your data in the UI, shut down the application by pressing `CONTROL+C` in both terminal sessions.
 
-## Tutorial 2: Monitor the demo app with the OpenTelemetry Python agent [#python-agent]
+        </TabsPageItem>
+        <TabsPageItem id="python-agent-tutorial">
+
+### Monitor the demo app with the OpenTelemetry Python agent [#python-agent]
 
 Here's a different tutorial that also uses the same demo app, but in this case, you'll use the OpenTelemetry Python agent to automatically monitor the demo app. You don't need to modify the Python source code. By using the agent, you can quickly start exporting sample data to New Relic.
 
-Note, however, that you will need to add custom instrumentation to capture deeper levels of information about the app, such as logs and custom metrics.
+Note, however, that you'll need to add custom instrumentation to capture deeper levels of information about the app, such as logs and custom metrics.
 
 The auto-instrumentation agent is a series PyPI package that dynamically injects bytecode to capture telemetry from popular libraries and frameworks. You can also use it to capture data such as inbound requests, outbound HTTP calls, and database calls. It can be attached to any Python 3 application.
 
@@ -198,27 +215,17 @@ To monitor our demo app with the OpenTelemetry Python agent:
 
 8. When you're finished looking at your data in the UI, shut down the application by pressing `CONTROL+C` in both terminal sessions.
 
+        </TabsPageItem>
+        <TabsPageItem id="manual-setup-tutorial">
 
-## Tutorial 3: Set up the demo app manually [#manual-instrum]
+### Set up the demo app manually [#manual-instrum]
 
-The previous section helped you explore automatic instrumentation with the OpenTelemetry Python agent. If you prefer to have more control over the telemetry you gather, you can try out this tutorial to learn how to add custom instrumentation. Then, you'll see how to configure the OpenTelemetry SDK to export the data to New Relic, using our recommended best practices.
+The previous tutorial helped you explore automatic instrumentation with the OpenTelemetry Python agent. This tutorial will show you how to use custom instrumentation to have more control over the telemetry you gather. Then, you'll see how to configure the OpenTelemetry SDK to export the data to New Relic.
 
-Here are the steps you'll complete for this manual setup:
+        <Steps>
+        <Step>
 
-* [A. Download the demo application](#download)
-* [B. Install required libraries](#libraries)
-* [C. Configure the SDK](#config-sdk)
-* [D. Add instrumentation libraries: traces](#library-traces)
-* [E. Add instrumentation libraries: metrics](#library-metrics)
-* [F. Add instrumentation libraries: logs](#library-logs)
-* [G. Add Flask instrumentation](#flask-instrum)
-* [H. Custom trace instrumentation: Create a custom span](#cust-span)
-* [I. Custom trace instrumentation: Record an exception](#span-exception)
-* [J. Custom metric instrumentation: Add a custom metric counter](#cust-metrics)
-* [K. Custom log instrumentation](#cust-log)
-* [L. Exercise the app to generate some traffic](#exercise-app)
-
-### A. Download the demo application [#download]
+### Download the demo application [#download]
 
 Run the following to download our demo app:
 
@@ -226,7 +233,9 @@ Run the following to download our demo app:
 git clone https://github.com/newrelic/newrelic-opentelemetry-examples.git
 ```
 
-### B. Install required libraries [#libraries]
+        </Step>
+        <Step>
+### Install required libraries [#libraries]
 
 To add the required libraries:
 
@@ -257,7 +266,9 @@ To add the required libraries:
     pip install opentelemetry-distro
     ```
 
-### C. Configure the SDK [#config-sdk]
+        </Step>
+        <Step>
+### Configure the SDK [#config-sdk]
 
 1. In `app.py`, add the highlighted lines below to the <DoNotTranslate>**top of the file**</DoNotTranslate>. Change the value for the custom attribute `environment` as needed.
 
@@ -280,7 +291,9 @@ app = Flask(__name__)
 
 2. Go to our [environment variables reference section](#ref-env-vars) below to see which variables you need to export, and then move forward to the next step to add instrumentation libraries.
 
-### D. Add instrumentation libraries: traces [#library-traces]
+        </Step>
+        <Step>
+### Add instrumentation libraries: traces [#library-traces]
 
 In `app.py`, insert the following after the `OpenTelemetry Settings` you added:
 
@@ -300,7 +313,9 @@ trace.set_tracer_provider(TracerProvider(resource=Resource.create(OTEL_RESOURCE_
 trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
 ```
 
-### E. Add instrumentation libraries: metrics [#library-metrics]
+        </Step>
+        <Step>
+### Add instrumentation libraries: metrics [#library-metrics]
 
 In `app.py` add the following after the `Traces` section you added in Step D:
 
@@ -320,7 +335,9 @@ metrics.get_meter_provider()
 fib_counter = metrics.get_meter("opentelemetry.instrumentation.custom").create_counter("fibonacci.invocations", unit="1", description="Measures the number of times the fibonacci method is invoked.")
 ```
 
-### F. Add instrumentation libraries: logs [#library-logs]
+        </Step>
+        <Step>
+### Add instrumentation libraries: logs [#library-logs]
 
 In `app.py`, add the following after the `Metrics` section. This will import the logging module and set the `basicConfig` logging level to `DEBUG`:
 
@@ -342,7 +359,9 @@ _logs.set_logger_provider(LoggerProvider(resource=Resource.create(OTEL_RESOURCE_
 logging.getLogger().addHandler(LoggingHandler(logger_provider=_logs.get_logger_provider().add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter()))))
 ```
 
-### G. Add Flask instrumentation [#flask-instrum]
+        </Step>
+        <Step>
+### Add Flask instrumentation [#flask-instrum]
 
 In `app.py` add the highlighted lines below, after the `Logs` section. This helps with linking spans for distributed tracing and logs-in-context:
 
@@ -358,7 +377,9 @@ app = Flask(__name__)
 FlaskInstrumentor().instrument_app(app)
 ```
 
-### H. Custom trace instrumentation: Create a custom span [#cust-span]
+        </Step>
+        <Step>
+### Custom trace instrumentation: Create a custom span [#cust-span]
 
 You can create whatever spans you want, and it is up to you to annotate your spans with attributes on specific operations. The attributes you set will provide additional context about the specific operation you are tracking, such as results or operation properties.
 
@@ -392,7 +413,9 @@ In `app.py`, insert the highlighted lines below to start a new span called `/fib
     app.run(host='0.0.0.0', port=8080)
     ```
 
-### I. Custom trace instrumentation: Record an exception [#span-exception]
+        </Step>
+        <Step>
+### Custom trace instrumentation: Record an exception [#span-exception]
 
 You may want to record exceptions as they happen. We recommend you do this in conjunction with setting the span status.
 
@@ -437,7 +460,9 @@ def fibonacci():
 app.run(host='0.0.0.0', port=8080)
 ```
 
-### J. Custom metric instrumentation: Add a custom metric counter [#cust-metrics]
+        </Step>
+        <Step>
+### Custom metric instrumentation: Add a custom metric counter [#cust-metrics]
 
 Metrics are a telemetry data type that are really helpful because they combine individual measurements into aggregations, and produce data that is constant as a function of system load. You can use this data in conjunction with spans to help spot trends and provide application runtime telemetry. You can also annotate any metric with attributes to help describe what subdivision of the measurements the metric represents.
 
@@ -498,7 +523,9 @@ def fibonacci():
 app.run(host='0.0.0.0', port=8080)
 ```
 
-### K. Custom log instrumentation [#cust-log]
+        </Step>
+        <Step>
+### Custom log instrumentation [#cust-log]
 
 The status of the logs signal in OpenTelemetry Python is currently [experimental](https://github.com/open-telemetry/opentelemetry-python#project-status).
 
@@ -537,7 +564,9 @@ def fibonacci():
 app.run(host='0.0.0.0', port=8080)
 ```
 
-### L. Exercise the app to generate some traffic [#exercise-app]
+        </Step>
+        <Step>
+### Exercise the app to generate some traffic [#exercise-app]
 
 You're ready to send some data to New Relic!
 
@@ -566,6 +595,12 @@ You're ready to send some data to New Relic!
     </Callout>
 
 3. Now that you've sent some data to New Relic, see our [instructions on viewing the data in the UI](#view-data).
+
+        </Step>
+        </Steps>
+        </TabsPageItem>
+    </TabsPages>
+</Tabs>
 
 ## View your demo data in New Relic [#view-data]
 


### PR DESCRIPTION
The goal is to make the Python tutorial similar to the Java tutorial that already has tabs and step components.

Also, add links in the OpenTelemetry Java tutorial's table of contents that lead readers to each tab.

Here are the specific changes in the Python tutorial:

* Removed the side-by-side component in the introduction, so the image now follows the text.
* Added a new heading "Tutorials" that has a streamlined mini-table-of-contents with links to tutorial tabs.
* Revised the text of the first tip under "Tutorials."
* Updated the introductory information in the third (manual) tutorial.