### PR TITLE
Python release 9.7.1 -- MERGE March 11 PM

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3373,7 +3373,7 @@ Event harvest configuration settings include:
           </th>
 
           <td>
-            `1200`
+            `3600`
           </td>
         </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
@@ -1,0 +1,28 @@
+---
+subject: Python agent
+releaseDate: '2024-02-22'
+version: 9.7.1
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: []
+bugs: ['Fix log attribute dropping in NewRelicContextFormatter']
+security: []
+---
+
+## Notes
+
+This release of the Python agent fixes a bug in the NewRelicContextFormatter where attributes were dropped from logs.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+
+## Bug fixes
+
+* **Fix log attribute dropping in NewRelicContextFormatter**
+    *  In v9.5.0, a bug in the NewRelicContextFormatter was introduced where "message" was added to the default set of keys to exclude. This caused extra attributes not in the default list to be dropped. This bug has been fixed. 
+
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
@@ -10,15 +10,15 @@ security: []
 
 ## Notes
 
-This release of the Python agent fixes a bug in the NewRelicContextFormatter where attributes were dropped from logs.
+This release of the Python agent fixes a bug in the `NewRelicContextFormatter` where attributes were dropped from logs.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 
 
 ## Bug fixes
 
-* **Fix log attribute dropping in NewRelicContextFormatter**
-    *  In v9.5.0, a bug in the NewRelicContextFormatter was introduced where "message" was added to the default set of keys to exclude. This caused extra attributes not in the default list to be dropped. This bug has been fixed. 
+* **Fix log attribute dropping in `NewRelicContextFormatter`**
+    *  In v9.5.0, a bug in the `NewRelicContextFormatter` was introduced where `message` was added to the default set of keys to exclude. This caused extra attributes not in the default list to be dropped. This bug has been fixed. 
 
 
 ## Support statement

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Python agent
-releaseDate: '2024-02-22'
+releaseDate: '2024-03-07'
 version: 9.7.1
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90701.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Python agent
-releaseDate: '2024-03-07'
+releaseDate: '2024-03-11'
 version: 9.7.1
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: []


### PR DESCRIPTION
## Give us some context

* Add support notes for Python release 9.7.1.
* Fix incorrect default setting.