### PR TITLE
Update Metrics Streams available metrics

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/aws-metric-stream.mdx
@@ -167,10 +167,3 @@ Integrations based on CloudWatch Logs, [forwarded to New Relic via Lambda](/docs
 
 * AWS RDS Enhanced
 * AWS VPC Flow Logs
-
-## Metrics not available with CloudWatch metric streams
-
-When metrics are available to AWS CloudWatch metric stream with more than 2 hours delay, these metrics aren't included in the stream.
-
-Examples of AWS namespaces that might contain metrics that are aggregated and exposed after 2 hours include: AWS DMS, AWS RDS, AWS DocDB, AWS S3, and AWS DAX.
-See [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-setup.html) to learn more.


### PR DESCRIPTION
AWS has released an option to stream metrics that are 48hrs in the past https://aws.amazon.com/about-aws/whats-new/2024/03/cloudwatch-metric-streams-streaming-daily-metrics/

This limitation is no longer valid.