### PR TITLE
Examples: Use latest fluentbit version avaialble

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -1119,20 +1119,20 @@ The following instructions summarize how to increase these limits if you want to
     apt-cache showpkg fluent-bit
     ```
 
-    To upgrade to a particular Fluent Bit version, just run (in the following examples, version `2.0.8` is used):
+    To upgrade to a particular Fluent Bit version, just run (in the following examples, version `2.2.2` is used):
 
     RPM:
 
     ```bash
     # Remove command only required when downgrading to a previous version
     sudo yum remove fluent-bit
-    sudo yum install fluent-bit-2.0.8-1
+    sudo yum install fluent-bit-2.2.2-1
     ```
 
     DEB:
 
     ```bash
-    sudo apt install fluent-bit=2.0.8
+    sudo apt install fluent-bit=2.2.2
     ```
   </Collapser>
   <Collapser 


### PR DESCRIPTION
Fluent bit packages for version v2.2.2 are GA, so we think it makes sense to update our docs to use that version in the examples.