### PR TITLE
feat(private-link): add new infra endpoints

### DIFF
--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -217,7 +217,7 @@ These are the New Relic endpoint services available via AWS PrivateLink:
       <Callout variant="important">
         Review the following constraints when configuring the `identity-api.newrelic.com` and `infrastructure-command-api.newrelic.com` hostnames:
         - These are only exposed in the `us-east-2` (Ohio) region.
-        - The endpoint service does not have an associated DNS private name associated. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname. 
+        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname. 
       </Callout>
 
     </TabsPageItem>

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -185,6 +185,20 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.us-east-2.vpce-svc-0df10112dc8c0f0b0`
             </td>
           </tr>
+
+          <tr>
+            <td>
+            
+            </td>
+            <td>
+            `identity-api.newrelic.com`
+            `infrastructure-command-api.newrelic.com`
+            </td>
+  
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-09230bb8d16a9171e`
+            </td>
+          </tr>
   
           <tr>
             <td>
@@ -322,6 +336,11 @@ These are the New Relic endpoint services available via AWS PrivateLink:
   </TabsPages>
 </Tabs>
 
+<Callout variant="important">
+  Review the following constraints when configuring the `identity-api.newrelic.com` and `infrastructure-command-api.newrelic.com` endpoints:
+  - These are only exposed in the `us-east-2` (Ohio) region.
+  - The endpoint service does not have DNS Private name associated. Create a PrivateLink connected to this Service Endpoint for each API, and create the Private Hosted Zone (PHZ) for each API Domain. 
+</Callout>
 <Callout variant="tip">
   Endpoints are **not** yet available for:
     * FedRAMP data

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -214,6 +214,12 @@ These are the New Relic endpoint services available via AWS PrivateLink:
         </tbody>
       </table>
 
+      <Callout variant="important">
+        Review the following constraints when configuring the `identity-api.newrelic.com` and `infrastructure-command-api.newrelic.com` hostnames:
+        - These are only exposed in the `us-east-2` (Ohio) region.
+        - The endpoint service does not have an associated DNS private name associated. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname. 
+      </Callout>
+
     </TabsPageItem>
     <TabsPageItem id="eu-endpoints">
 
@@ -336,11 +342,6 @@ These are the New Relic endpoint services available via AWS PrivateLink:
   </TabsPages>
 </Tabs>
 
-<Callout variant="important">
-  Review the following constraints when configuring the `identity-api.newrelic.com` and `infrastructure-command-api.newrelic.com` endpoints:
-  - These are only exposed in the `us-east-2` (Ohio) region.
-  - The endpoint service does not have DNS Private name associated. Create a PrivateLink connected to this Service Endpoint for each API, and create the Private Hosted Zone (PHZ) for each API Domain. 
-</Callout>
 <Callout variant="tip">
   Endpoints are **not** yet available for:
     * FedRAMP data


### PR DESCRIPTION
## Give us some context

* The PrivateLink integration has been updated to also support non-ingest related endpoints for the infra-agent and integrations (identity and command-api endpoints).