### PR TITLE
Fix callout image sizing

### DIFF
--- a/src/content/docs/tutorial-improve-app-performance/root-causes.mdx
+++ b/src/content/docs/tutorial-improve-app-performance/root-causes.mdx
@@ -12,8 +12,6 @@ freshnessValidatedDate: never
 
 import journeyWebTrans from 'images/journey_screenshot-web-transactions.webp'
 
-import journeyTime from 'images/journey_crop-time-picker.webp'
-
 Your app is slow. Perhaps it's so slow it's causing downtime or issues in related services, or perhaps it's simply a slow back-end response that makes your UX just a little bit worse. What do you do about it? 
 
 This tutorial walks you through how to use New Relic to triage your application and identify the root cause of your app's degraded performance. You'll start by "instrumenting" your app with an agent, which means installing a piece of code that reports data about your app to New Relic through language and framework specific integrations. Using this data in New Relic, you'll dig into the performance of your application and identify slow transactions, slow database queries, or slow external services as your issue—or possibly all three!
@@ -83,13 +81,8 @@ Once you've installed an agent, go to <DoNotTranslate>**[one.newrelic.com](https
 Look at the <DoNotTranslate>**Web transactions time**</DoNotTranslate> chart. This chart displays the average response time of certain metrics within your app. As your chart populates with data, take note of strange spikes in any line or segment. At the same time, take note of any segments or lines that consistantly take a large amount of time. 
 
 <Callout variant="tip">
-Use the time picker to look for spikes over various time ranges.
-<img
-  title="Time picker"
-  alt="Image showing the time picker for APM"
-  src={journeyTime}
-  style={{ maxWidth: '60%' }}
-/>
+Use the time picker in the top right of your page to look for spikes over various time ranges.
+
   </Callout>
   
     </Side>


### PR DESCRIPTION

This doc had a weird issue with a callout containing an image within a side/side component. Played around with it a bit, and I couldn't come up with a good way to keep the image in there, so I decided to just cut the image and give directional info within the callout. 


<img width="1127" alt="Screenshot 2024-03-11 at 2 53 22 PM" src="https://github.com/newrelic/docs-website/assets/42678939/ca152927-84a2-40f8-831f-1bd4e25680c4">
