### PR TITLE
fix: move permalink to after heading

### DIFF
--- a/src/pages/attribute-dictionary.js
+++ b/src/pages/attribute-dictionary.js
@@ -228,12 +228,6 @@ const EventDefinition = memo(
               position: relative;
             `}
           >
-            <Link
-              to={`${location.pathname}?event=${event.name}`}
-              className="anchor before"
-            >
-              <Icon name="fe-link-2" focusable={false} size="1rem" />
-            </Link>
             <code
               css={css`
                 background: none !important;
@@ -242,6 +236,12 @@ const EventDefinition = memo(
             >
               {event.name}
             </code>
+            <Link
+              to={`${location.pathname}?event=${event.name}`}
+              className="anchor after"
+            >
+              <Icon name="fe-link-2" focusable={false} size="1rem" />
+            </Link>
           </div>
         </h2>
         <div


### PR DESCRIPTION
## Description

Moves the permalink to after heading instead of before.

It seems there are style rules available via `gatsby-plugin-autolink-headers`.

## Related

Closes https://new-relic.atlassian.net/browse/NR-248153

## Screenshot(s)

<img width="1171" alt="2024-03-12_13-41-07" src="https://github.com/newrelic/docs-website/assets/2952843/bf714c60-aa85-4824-b0eb-3bd32d453b96">
