### PR TITLE
align wording with synthetics job manager

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -138,7 +138,7 @@ Now you can add `"require('async');"` into the [script](/docs/synthetics/new-rel
 
 ### Change `package.json` for custom modules [#change-package-json]
 
-Along with hosted modules, you can also use [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules). To change the custom modules used by your CPM, modify `package.json` and reboot the CPM. It will detect the change in configuration during the reboot, and then clean up and re-install.
+Along with custom and hosted modules, you can also use [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules). To change the custom modules used by your CPM, modify `package.json` and reboot the CPM. It will detect the change in configuration during the reboot, and then clean up and re-install.
 
 <Callout variant="caution">
   Local modules: While your `package.json` can include any local module, these modules must reside inside the tree under your custom module directory. If stored outside the tree, the initialization process will fail and you will see an error message in the [docker logs](/docs/synthetics/new-relic-synthetics/private-locations/containerized-private-minion-cpm-maintenance-monitoring#monitor-docker-logs) after launching CPM.

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -38,9 +38,9 @@ All directories and files <DoNotTranslate>**must**</DoNotTranslate> be assigned 
 * Each PV must have a separate copy of the directories. For example, a cluster with _n_ Minion replicas must have _n_ PVs, each with their own copy of directories
 * The directories and files must be added prior to the Minion boot up, otherwise the Minion must be restarted to detect the updates
 
-## Custom npm modules [#custom-modules]
+## Custom node modules [#custom-modules]
 
-Custom npm modules are exclusive to the CPM. They allow you to provide an arbitrary set of [npm modules](https://docs.npmjs.com/about-packages-and-modules), and make them available for scripted monitors in synthetic monitoring.
+Custom node modules are exclusive to the CPM. They allow you to provide an arbitrary set of [node modules](https://docs.npmjs.com/about-packages-and-modules), and make them available for scripted monitors in synthetic monitoring.
 
 To set up the modules:
 
@@ -63,7 +63,7 @@ To set up the modules:
              └── package.json            ⇦ the only mandatory file
        ```
 
-       The `package.json` defines `dependencies` as both a local module (for example, `counter`) and an npm hosted modules (for example, `async` version `^2.6.1`):
+       The `package.json` defines `dependencies` as both a local module (for example, `counter`) and any hosted modules (for example, `async` version `^2.6.1`):
 
        ```
        {
@@ -71,8 +71,8 @@ To set up the modules:
              "version": "1.0.0",           ⇦ optional
              "description": "example custom modules directory", ⇦ optional
              "dependencies": {
-               "async": "^2.6.1",          ⇦ npm hosted module
-               "counter": "file:./counter" ⇦ Local module
+               "async": "^2.6.1",          ⇦ hosted module
+               "counter": "file:./counter" ⇦ local module
              }
            }
        ```
@@ -138,7 +138,7 @@ Now you can add `"require('async');"` into the [script](/docs/synthetics/new-rel
 
 ### Change `package.json` for custom modules [#change-package-json]
 
-Along with npm modules, you can also use [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules). To change the custom modules used by your CPM, modify `package.json` and reboot the CPM. It will detect the change in configuration during the reboot, and then clean up and re-install.
+Along with hosted modules, you can also use [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules). To change the custom modules used by your CPM, modify `package.json` and reboot the CPM. It will detect the change in configuration during the reboot, and then clean up and re-install.
 
 <Callout variant="caution">
   Local modules: While your `package.json` can include any local module, these modules must reside inside the tree under your custom module directory. If stored outside the tree, the initialization process will fail and you will see an error message in the [docker logs](/docs/synthetics/new-relic-synthetics/private-locations/containerized-private-minion-cpm-maintenance-monitoring#monitor-docker-logs) after launching CPM.

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -138,7 +138,7 @@ Now you can add `"require('async');"` into the [script](/docs/synthetics/new-rel
 
 ### Change `package.json` for custom modules [#change-package-json]
 
-Along with custom and hosted modules, you can also use [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules). To change the custom modules used by your CPM, modify `package.json` and reboot the CPM. It will detect the change in configuration during the reboot, and then clean up and re-install.
+Along with local and hosted modules, you can also use [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules). To change the custom modules used by your CPM, modify `package.json` and reboot the CPM. It will detect the change in configuration during the reboot, and then clean up and re-install.
 
 <Callout variant="caution">
   Local modules: While your `package.json` can include any local module, these modules must reside inside the tree under your custom module directory. If stored outside the tree, the initialization process will fail and you will see an error message in the [docker logs](/docs/synthetics/new-relic-synthetics/private-locations/containerized-private-minion-cpm-maintenance-monitoring#monitor-docker-logs) after launching CPM.

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -579,7 +579,7 @@ Some of our open-source software is listed under multiple software licenses, and
 
 ## Configure CPM [#configuration]
 
-You can configure the containerized private minion with custom npm modules, preserve data between launches, use environment variables, and more. For more information, see [CPM configuration](/docs/synthetics/new-relic-synthetics/private-locations/containerized-private-minion-cpm-configuration).
+You can configure the containerized private minion with custom node modules, preserve data between launches, use environment variables, and more. For more information, see [CPM configuration](/docs/synthetics/new-relic-synthetics/private-locations/containerized-private-minion-cpm-configuration).
 
 ## Networks
 


### PR DESCRIPTION
Wording of `custom npm modules` should be changed to `custom node modules`, which makes more sense and is how this feature is referred to in SJM docs. Also update `npm modules` to `hosted modules` which makes more sense in the context of `local` versus `hosted` modules.

cc @bpeckNR @kondracek-nr 