### PR TITLE
Add feedback form to install PageTools

### DIFF
--- a/src/pages/install/{installConfig.agentName}.js
+++ b/src/pages/install/{installConfig.agentName}.js
@@ -5,6 +5,7 @@ import {
   Walkthrough,
   TableOfContents,
   ContributingGuidelines,
+  ComplexFeedback,
   useQueryParams,
   Layout,
   addPageAction,
@@ -290,6 +291,7 @@ const InstallPage = ({ data, location }) => {
         >
           <ContributingGuidelines />
           <TableOfContents headings={headings} />
+          <ComplexFeedback pageTitle={title} />
         </Layout.PageTools>
       </Layout.Main>
     </ErrorBoundary>


### PR DESCRIPTION
This puts the ComplexFeedback component in the PageTools on all install pages

<img width="1394" alt="Screenshot 2024-03-13 at 10 43 15 AM" src="https://github.com/newrelic/docs-website/assets/47728020/cfba4daa-1318-4045-a181-0aedd8f13e1a">
