### PR TITLE
Increase InlinePopover text size

### DIFF
--- a/src/components/InlinePopover/layouts/TwoButton.js
+++ b/src/components/InlinePopover/layouts/TwoButton.js
@@ -90,7 +90,7 @@ const Container = styled.div`
 
 const Heading = styled.h2`
   color: currentColor;
-  font-size: 0.75rem;
+  font-size: 1rem;
   font-weight: 500;
   grid-column: 1 / 3;
   justify-self: start;
@@ -123,7 +123,8 @@ const SecondaryButton = styled(Button)`
 `;
 
 const Text = styled.p`
-  font-size: 0.75rem;
+  font-size: 1rem;
+  font-weight: 300;
   grid-column: 1 / 3;
   margin: 0 0 8px;
 `;


### PR DESCRIPTION
Improves text design in `InlinePopover` component.

before
<img width="1008" alt="Screenshot 2024-03-13 at 4 19 35 PM" src="https://github.com/newrelic/docs-website/assets/47728020/cf4b4104-e0a5-4715-bedd-4d0ec362d8cf">

after
<img width="1008" alt="Screenshot 2024-03-13 at 4 25 29 PM" src="https://github.com/newrelic/docs-website/assets/47728020/8923753c-ed17-45b1-9b64-7880d5eded4c">
