### PR TITLE
feat(infra-agent): configurable integrations tmp dir

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2070,14 +2070,13 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
     </table>
 
   </Collapser>
-</CollapserGroup>
 
-<Collapser
-    className="freq-link"
-    id="default_integrations_temp_dir"
-    title="default_integrations_temp_dir"
-  >
-     Defines the temp directory used as persisting storage for the integrations SDK synchronization.
+  <Collapser
+      className="freq-link"
+      id="default_integrations_temp_dir"
+      title="default_integrations_temp_dir"
+    >
+      Defines the temp directory used as persisting storage for the integrations SDK synchronization.
 
     <table>
       <thead>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -2072,6 +2072,66 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
   </Collapser>
 </CollapserGroup>
 
+<Collapser
+    className="freq-link"
+    id="default_integrations_temp_dir"
+    title="default_integrations_temp_dir"
+  >
+     Defines the temp directory used as persisting storage for the integrations SDK synchronization.
+
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            YML option name
+          </th>
+
+          <th style={{ width: "200px" }}>
+            Environment variable
+          </th>
+
+          <th>
+            Type
+          </th>
+
+          <th>
+            Default
+          </th>
+
+          <th>
+            Version
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `default_integrations_temp_dir`
+          </td>
+
+          <td>
+            `NRIA_DEFAULT_INTEGRATIONS_TEMP_DIR`
+          </td>
+
+          <td>
+            string
+          </td>
+
+          <td>
+            `/tmp/nr-integrations`
+          </td>
+
+          <td>
+            [1.50.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1500/)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+  </Collapser>
+</CollapserGroup>
+
 ## Inventory variables
 
 <CollapserGroup>


### PR DESCRIPTION
## Give us some context

* infra-agent 1.50.0 added an additional setting for the agent to configure the temp directory for integrations sync.