### PR TITLE
Update CLM and add link from Logs

### DIFF
--- a/src/content/docs/codestream/observability/code-level-metrics.mdx
+++ b/src/content/docs/codestream/observability/code-level-metrics.mdx
@@ -35,7 +35,7 @@ The New Relic agent attempts to automatically collect data for functions on clas
 
 Because all requests by the New Relic agent are not collected all the time, it’s possible that low-traffic methods won't see any data. If data is missing for a specific method that you wish to see results for, you can use custom instrumentation to fill any gaps. See guidance for [Java](/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation), [.NET](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation), [PHP](/docs/apm/agents/php-agent/features/php-custom-instrumentation), [Python](/docs/apm/agents/python-agent/custom-instrumentation/python-custom-instrumentation), [Ruby](/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation), [Go](/docs/apm/agents/go-agent/instrumentation/instrument-go-transactions) and [Node.js](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation).
 
-Run the following NRQL query to identify where you might see CodeLenses with code-level metrics for one of your services. Just replace the example entity.guid value with the one for the given service. In the query results, look at the code.* attributes to see if any of them represent your code, and not framework code.
+Run the following NRQL query to identify where you might see CodeLenses with code-level metrics for one of your services. Just replace the example `entity.guid` value with the one for the given service. In the query results, look at the `code.*` attributes to see if any of them represent your code, and not framework code.
 
 `select * from Span where entity.guid = 'MXxBUE18QVBQTElDQVRJT058MjM' where code.function is not null since 30 minutes ago LIMIT MAX`
 

--- a/src/content/docs/codestream/observability/code-level-metrics.mdx
+++ b/src/content/docs/codestream/observability/code-level-metrics.mdx
@@ -29,23 +29,19 @@ Click the CodeLens to see charts visualizing each of the metrics. If the reposit
 
 Along with a chart of the error rate you’ll also see a list of the actual errors happening in the same timeframe, including the number of occurrences for each. If the error rate is spiking, and you see one particular error is causing the problem, you can click on it to view the stack trace and [start collaborating](/docs/codestream/observability/error-investigation) on resolution.
 
-## Requirements [#requirements]
+## Coverage [#coverage]
 
-To see in-editor performance data, your service must meet the requirements listed below, and the service should have collected data in the last 30 minutes. The New Relic agent attempts to automatically collect data for functions on classes that are tied to HTTP requests. In many cases, and with many frameworks that use an MVC framework, these are often methods on a Controller class. 
+The New Relic agent attempts to automatically collect data for functions on classes that are tied to HTTP requests. In many cases, and with many frameworks that use an MVC framework, these are often methods on a Controller class. 
 
 Because all requests by the New Relic agent are not collected all the time, it’s possible that low-traffic methods won't see any data. If data is missing for a specific method that you wish to see results for, you can use custom instrumentation to fill any gaps. See guidance for [Java](/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation), [.NET](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation), [PHP](/docs/apm/agents/php-agent/features/php-custom-instrumentation), [Python](/docs/apm/agents/python-agent/custom-instrumentation/python-custom-instrumentation), [Ruby](/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation), [Go](/docs/apm/agents/go-agent/instrumentation/instrument-go-transactions) and [Node.js](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation).
 
-<CollapserGroup>
-  <Collapser
-    className="freq-link"
-    id="clmquery"
-    title="Check your code-level metrics coverage"
-  >
-    Run the following NRQL query to identify where you might see codelenses with code-level metrics for one of your services. Just replace the example entity.guid value with the one for the given service. In the query results, look at the code.* attributes to see if any of them represent your code, and not framework code.
+Run the following NRQL query to identify where you might see CodeLenses with code-level metrics for one of your services. Just replace the example entity.guid value with the one for the given service. In the query results, look at the code.* attributes to see if any of them represent your code, and not framework code.
 
-    `select * from Span where entity.guid = 'MXxBUE18QVBQTElDQVRJT058MjM' where code.function is not null since 30 minutes ago LIMIT MAX`
-  </Collapser>
-</CollapserGroup>
+`select * from Span where entity.guid = 'MXxBUE18QVBQTElDQVRJT058MjM' where code.function is not null since 30 minutes ago LIMIT MAX`
+
+## Requirements [#requirements]
+
+To see in-editor performance data, your service must meet the requirements listed below, and the service should have collected data in the last 30 minutes. 
 
 * [Distributed tracing](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing) must be enabled. Distributed tracing is on by default in recent versions of all agents, so you only need to worry about this if you've disabled distributed tracing.
 * <DoNotTranslate>**Go:**</DoNotTranslate> Requires Go agent version 3.24.0 or higher. If you're using VS Code, you must also have the [Go for VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) extension installed with the language server enabled.

--- a/src/content/docs/codestream/observability/code-level-metrics.mdx
+++ b/src/content/docs/codestream/observability/code-level-metrics.mdx
@@ -37,7 +37,6 @@ Because all requests by the New Relic agent are not collected all the time, itâ€
 
 Run the following NRQL query to identify where you might see CodeLenses with code-level metrics for one of your services. Just replace the example `entity.guid` value with the one for the given service. In the query results, look at the `code.*` attributes to see if any of them represent your code, and not framework code.
 
-`select * from Span where entity.guid = 'MXxBUE18QVBQTElDQVRJT058MjM' where code.function is not null since 30 minutes ago LIMIT MAX`
 
 ## Requirements [#requirements]
 

--- a/src/content/docs/codestream/observability/code-level-metrics.mdx
+++ b/src/content/docs/codestream/observability/code-level-metrics.mdx
@@ -2,7 +2,7 @@
 title: Code-level metrics
 metaDescription: "See performance data at the method level."
 redirects:
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-03-14
 ---
 
 import codestreamCodeLevelMetricsExample from 'images/codestream_screenshot-crop_code-level-metrics-example.webp'
@@ -34,6 +34,18 @@ Along with a chart of the error rate you’ll also see a list of the actual erro
 To see in-editor performance data, your service must meet the requirements listed below, and the service should have collected data in the last 30 minutes. The New Relic agent attempts to automatically collect data for functions on classes that are tied to HTTP requests. In many cases, and with many frameworks that use an MVC framework, these are often methods on a Controller class. 
 
 Because all requests by the New Relic agent are not collected all the time, it’s possible that low-traffic methods won't see any data. If data is missing for a specific method that you wish to see results for, you can use custom instrumentation to fill any gaps. See guidance for [Java](/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation), [.NET](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation), [PHP](/docs/apm/agents/php-agent/features/php-custom-instrumentation), [Python](/docs/apm/agents/python-agent/custom-instrumentation/python-custom-instrumentation), [Ruby](/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation), [Go](/docs/apm/agents/go-agent/instrumentation/instrument-go-transactions) and [Node.js](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation).
+
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="clmquery"
+    title="Check your code-level metrics coverage"
+  >
+    Run the following NRQL query to identify where you might see codelenses with code-level metrics for one of your services. Just replace the example entity.guid value with the one for the given service. In the query results, look at the code.* attributes to see if any of them represent your code, and not framework code.
+
+    `select * from Span where entity.guid = 'MXxBUE18QVBQTElDQVRJT058MjM' where code.function is not null since 30 minutes ago LIMIT MAX`
+  </Collapser>
+</CollapserGroup>
 
 * [Distributed tracing](/docs/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing) must be enabled. Distributed tracing is on by default in recent versions of all agents, so you only need to worry about this if you've disabled distributed tracing.
 * <DoNotTranslate>**Go:**</DoNotTranslate> Requires Go agent version 3.24.0 or higher. If you're using VS Code, you must also have the [Go for VS Code](https://marketplace.visualstudio.com/items?itemName=golang.go) extension installed with the language server enabled.

--- a/src/content/docs/codestream/observability/code-level-metrics.mdx
+++ b/src/content/docs/codestream/observability/code-level-metrics.mdx
@@ -37,7 +37,12 @@ Because all requests by the New Relic agent are not collected all the time, itâ€
 
 Run the following NRQL query to identify where you might see CodeLenses with code-level metrics for one of your services. Just replace the example `entity.guid` value with the one for the given service. In the query results, look at the `code.*` attributes to see if any of them represent your code, and not framework code.
 
-
+```
+SELECT *
+FROM Span
+WHERE entity.guid = 'MXxBUE18QVBQTElDQVRJT058MjM' AND code.function is not null
+SINCE 30 minutes ago LIMIT MAX
+```
 ## Requirements [#requirements]
 
 To see in-editor performance data, your service must meet the requirements listed below, and the service should have collected data in the last 30 minutes. 

--- a/src/content/docs/logs/ui-data/use-logs-ui.mdx
+++ b/src/content/docs/logs/ui-data/use-logs-ui.mdx
@@ -404,6 +404,16 @@ Depending on your New Relic subscription, you can access your logs from several 
         Go to <DoNotTranslate>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > All entities > (select an entity) > Logs**</DoNotTranslate>.
       </td>
     </tr>
+
+    <tr>
+      <td>
+        From your IDE
+      </td>
+
+      <td>
+        [Install New Relic's CodeStream extension](/docs/codestream/start-here/install-codestream) to view logs in your IDE.
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Two changes:

1. Add a query to Code-Level Metrics section so users can check their coverage.
2. Add a link to CS from Logs, as an additional way to view logs.