### PR TITLE
chore: update .NET agent verified compatible versions of core tech libraries

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -480,7 +480,7 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 
 <DoNotTranslate>**Microsoft.Data.SqlClient**</DoNotTranslate>
 * Minimum supported version: 1.0.19239.1
-* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1
+* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0
           </td>
         </tr>
 
@@ -521,7 +521,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1, 2.24.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * IMongoCollection.CountDocuments[Async]
@@ -573,7 +573,7 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
           <td>
 Minimum supported version: .0.488
 
-Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116, 2.7.4, 2.7.10, 2.7.17
+Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116, 2.7.4, 2.7.10, 2.7.17, 2.7.33
 		  </td>
         </tr>
 
@@ -796,7 +796,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            2.0.10, 2.0.12, 2.0.13, 2.0.14
+            2.0.10, 2.0.12, 2.0.13, 2.0.14, 2.0.16
           </td>
 
         </tr>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -548,7 +548,7 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 
 <DoNotTranslate>**Microsoft.Data.SqlClient**</DoNotTranslate>
 * Minimum supported version: 1.0.19239.1
-* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1
+* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0
 
 <DoNotTranslate>**System.Data**</DoNotTranslate>
 * Minimum supported version: .NET Framework 4.6.2
@@ -591,7 +591,7 @@ Known incompatible versions: Instance details aren't available in lower version 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1. 2.24.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * `IMongoCollection.CountDocuments[Async]`
@@ -695,7 +695,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           </td>
           <td>
             * Minimum supported version: 1.0.488
-            * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116, 2.7.4, 2.7.10, 2.7.17
+            * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116, 2.7.4, 2.7.10, 2.7.17, 2.7.33
           </td>
         </tr>
 
@@ -863,7 +863,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            1.2.10, 2.0.5, 2.0.14
+            1.2.10, 2.0.5, 2.0.14, 2.0.16
           </td>
         </tr>
 


### PR DESCRIPTION
The .NET agent team has verified that several new versions of our instrumented libraries are compatible with our agent, and we are updating our docs accordingly.