### PR TITLE
Fix: Collector configuration sample in opentelemetry-collector-infra-hosts.mdx; 

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts.mdx
@@ -154,7 +154,7 @@ exporters:
     endpoint: OTLP_ENDPOINT_HERE
     headers:
       api-key: YOUR_KEY_HERE
-logging:
+  logging:
 
 service:
   pipelines:


### PR DESCRIPTION
…ration indentation for logging exporters

Fix collector configuration indentation for logging exporter

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
> Fixes the indentation problem with the provided collector configuration.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc. 
> The logging exporter configuration is not properly aligned and fails the collector service. 

* If your issue relates to an existing GitHub issue, please link to it.