### PR TITLE
chore(docs): update kafka docs and related ones

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/jmx-monitoring-install.mdx
@@ -101,7 +101,6 @@ If you're not using the guided install, follow the instructions for your environ
        sudo cp tomcat-metrics.yml.sample tomcat-metrics.yml
        ```
     6. Edit the `jmx-config.yml` file as described in the [configuration settings](#config).
-    7. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
 
        <Callout variant="important">
          If the sample files are not present in your installation, you can download them directly from the [GitHub repository](https://github.com/newrelic/nri-jmx).
@@ -112,9 +111,7 @@ If you're not using the guided install, follow the instructions for your environ
     id="windows-install"
     title="Windows"
   >
-    1. Download the `nri-jmx` .MSI installer image from:
-
-       [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe)
+    1. [Download the .exe installer for New Relic's jmx integration](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-jmx/nri-jmx-amd64-installer.exe)
     2. To install from the Windows command prompt, run:
 
        ```
@@ -126,7 +123,6 @@ If you're not using the guided install, follow the instructions for your environ
        cp jmx-config.yml.sample jmx-config.yml
        ```
     4. Edit the `jmx-config.yml` configuration file using the [configuration settings](#config).
-    5. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -169,11 +169,11 @@ To install the Kafka integration, follow the instructions for your environment:
     id="windows-install"
     title={<><img src={osWindows} title="Windows installation" alt="Windows installation" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Windows installation</>}
   >
-    1. [Download the .MSI installer image for New Relic's Kafka integration](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-kafka/nri-kafka-amd64.msi).
+    1. [Download the .exe installer for New Relic's Kafka integration](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-kafka/nri-kafka-amd64-installer.exe).
 
-    2. Install New Relic's Kafka integration by opening command prompt and running:
+    2. To install from the Windows command prompt, run:
        ```shell
-       msiexec.exe /qn /i $PATH_TO\nri-kafka-amd64.msi
+       PATH\TO\nri-kafka-amd64-installer.exe
        ```
 
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration.mdx
@@ -66,8 +66,7 @@ If you want to install our legacy MongoDB integration, follow the instructions f
        sudo cp mongodb-config.yml.sample mongodb-config.yml
        ```
     4. Edit the `mongodb-config.yml` file as described in the [configuration settings](#config).
-    5. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
-    6. To enable automatic MongoDB error log parsing and forwarding, copy (or rename) the `mongodb-log.yml.example` file to `mongodb-log.yml`. No need to restart the agent.
+    5. To enable automatic MongoDB error log parsing and forwarding, copy (or rename) the `mongodb-log.yml.example` file to `mongodb-log.yml`. No need to restart the agent.
 
        <DoNotTranslate>**Example:**</DoNotTranslate>
 
@@ -94,7 +93,6 @@ If you want to install our legacy MongoDB integration, follow the instructions f
        cp mongodb-config.yml.sample mongodb-config.yml
        ```
     4. Edit the `mongodb-config.yml` configuration file using the [configuration settings](#config).
-    5. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -72,12 +72,12 @@ To install the PostgreSQL integration, follow the instructions for your environm
    ```shell
    cd /etc/newrelic-infra/integrations.d
    ```
-3. Copy the sample configuration file by running:
+3. [Create a user](#create-user) with `READ` permissions on the required functions.
+4. Copy the sample configuration file by running:
    ```shell
    sudo cp postgresql-config.yml.sample postgresql-config.yml
    ```
-4. Edit the `postgresql-config.yml` configuration file with your favorite editor. Check out some [configuration file examples.](#examples).
-5. Before you restart the infrastructure agent, [create a user](#create-user) with `READ` permissions on the required functions.
+5. Edit the `postgresql-config.yml` configuration file with your favorite editor. Check out some [configuration file examples.](#examples).
 6. To enable automatic Postgresql parsing and forwarding, copy or rename the `postgresql-log.yml.example` file to `postgresql-log.yml`. You don't need to restart the agent but you may need to update the YML file with the location of your postgresql log files, if you aren't using the default locations. 
 
    For example:

--- a/src/content/docs/infrastructure/host-integrations/installation/update-infrastructure-host-integration-package.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/update-infrastructure-host-integration-package.mdx
@@ -123,11 +123,21 @@ If you're running services without orchestration or on-premises, choose your sce
     id="windows"
     title={<>Update using MSI files (<img src={osWindows} title="Windows Server" alt="Windows Server" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Windows Server)</>}
   >
-    Here are two approaches, depending on the integration you're using.
+    Here are three approaches, depending on the integration you're using.
 
     <DoNotTranslate>**On-host Microsoft Windows services integration**</DoNotTranslate>
 
     The [Microsoft Windows services integration](/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration/) is bundled with the New Relic infrastructure agent, so to update the integration, you need to update the infrastructure agent. See [Update the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent).
+
+    <DoNotTranslate>** Nri-kafka, nri-jmx integration**</DoNotTranslate>
+
+    These two integrations have .exe installers
+    1. Download the latest .exe installer for New Relic's integration [from out repository](https://download.newrelic.com/infrastructure_agent/windows/integrations)
+    2. To install from the Windows command prompt, run:
+
+       ```
+       PATH\TO\YOUR_INTEGRATION_FILE_NAME.exe
+       ```
 
     <DoNotTranslate>**All other on-host Microsoft Windows integrations**</DoNotTranslate>
 
@@ -139,7 +149,6 @@ If you're running services without orchestration or on-premises, choose your sce
       ```
       msiexec.exe /qn /i PATH\TO\YOUR_INTEGRATION_FILE_NAME.msi
       ```
-    3. [Restart the infrastructure agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status).
   </Collapser>
 
   <Collapser

--- a/src/install/jmx/linux/install-linux.mdx
+++ b/src/install/jmx/linux/install-linux.mdx
@@ -43,4 +43,3 @@ headingText: Configure the JMX integration
   sudo cp tomcat-metrics.yml.sample tomcat-metrics.yml
   ```
 
-6. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).

--- a/src/install/jmx/windows/install-windows.mdx
+++ b/src/install/jmx/windows/install-windows.mdx
@@ -32,6 +32,3 @@ headingText: Install the JMX monitoring integration
         labels:
           env: production
     ```
-
-5. Restart the infrastructure agent. See how to [restart the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#windows).
-

--- a/src/install/mysql/default-install-linux.mdx
+++ b/src/install/mysql/default-install-linux.mdx
@@ -17,9 +17,7 @@ headingText: Install the MySQL integration
 
 4. Edit the `mysql-config.yml` configuration file with your favorite editor. Check out some [configuration file examples.](#examples).
 
-5. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).
-
-6. To enable automatic MySQL error log parsing and forwarding, copy or rename the `mysql-log.yml.example` file to `mysql-log.yml`, without needing to restart the agent:
+5. To enable automatic MySQL error log parsing and forwarding, copy or rename the `mysql-log.yml.example` file to `mysql-log.yml`, without needing to restart the agent:
     ```shell
     sudo cp /etc/newrelic-infra/logging.d/mysql-log.yml.example /etc/newrelic-infra/logging.d/mysql-log.yml
     ```

--- a/src/install/mysql/linux/install-linux.mdx
+++ b/src/install/mysql/linux/install-linux.mdx
@@ -17,9 +17,7 @@ headingText: Install the MySQL integration
 
 4. Edit the `mysql-config.yml` configuration file with your favorite editor. Check out some [configuration file examples](#examples).
 
-5. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).
-
-6. To enable automatic MySQL error log parsing and forwarding, copy or rename the `mysql-log.yml.example` file to `mysql-log.yml`, without needing to restart the agent:
+5. To enable automatic MySQL error log parsing and forwarding, copy or rename the `mysql-log.yml.example` file to `mysql-log.yml`, without needing to restart the agent:
     ```shell
     sudo rename /etc/newrelic-infra/logging.d/mysql-log.yml.example /etc/newrelic-infra/logging.d/mysql-log.yml
     ```

--- a/src/install/mysql/windows/install-windows.mdx
+++ b/src/install/mysql/windows/install-windows.mdx
@@ -21,5 +21,3 @@ headingText: Install the MySQL integration
     ```shell
     ren "C:\Program Files\New Relic\newrelic-infra\logging.d\mysql-log-win.yml.example" mysql-log-win.yml
     ```
-
-6. Restart the infrastructure agent. See how to [restart the infrastructure agent in different Linux environments](/docs/infrastructure/install-infrastructure-agent/manage-your-agent/start-stop-restart-infrastructure-agent/#linux).


### PR DESCRIPTION
This PR:
 - fixes the link for the latest kafka installer pointing to the exe one
 - clarify the jmx page
 - removed in different places the requirement to restart the agent