### PR TITLE
infra_agent: detail core count calculation

### DIFF
--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -17036,7 +17036,7 @@
         "units": null
       },
       {
-        "definition": "<ul>\n<li><p>Linux: [/proc/cpuinfo: &#39;cpu cores&#39;] The number of cores within a single CPU.</p>\n</li>\n<li><p>Windows: [WMI win32_processor: &#39;NumberOfLogicalProcessors&#39;] The number of logical processors, including cores divided by hyperthreading.</p>\n</li>\n</ul>\n",
+        "definition": "<ul>\n<li><p>Linux: [/proc/cpuinfo: &#39;cpu cores&#39;] The number of cores within a single CPU.</p>\n</li>\n<li><p>Windows: [WMI win32_processor: &#39;NumberOfLogicalProcessors&#39;] The number of logical processors for the current instance of the processor, including cores divided by hyperthreading.</p>\n</li>\n</ul>\n",
         "events": [
           "SystemSample"
         ],


### PR DESCRIPTION
Added detail about core counts in SystemSample.

From the Windows docs:

> NumberOfLogicalProcessors
Data type: uint32
Access type: Read-only
Qualifiers: [MappingStrings][1] ("WMI")
Number of logical processors for the current instance of the processor. For processors capable of hyperthreading, this value includes only the processors which have hyperthreading enabled. For more information, see Remarks.

https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-processor