### PR TITLE
aws-private-link: add synthetics endpoint

### DIFF
--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -211,11 +211,23 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.us-east-2.vpce-svc-0bf91fb637cf37b4f`
             </td>
           </tr>
+
+          <tr>
+            <td>
+            Synthetics job manager
+            </td>
+            <td>
+            `synthetics-horde.nr-data.net`
+            </td>
+            <td>
+            `com.amazonaws.vpce.us-east-2.vpce-svc-09230bb8d16a9171e`
+            </td>
+          </tr>
         </tbody>
       </table>
 
       <Callout variant="important">
-        Review the following constraints when configuring the `identity-api.newrelic.com` and `infrastructure-command-api.newrelic.com` hostnames:
+        Review the following constraints when configuring the `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
         - These are only exposed in the `us-east-2` (Ohio) region.
         - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname. 
       </Callout>
@@ -335,6 +347,7 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.eu-central-1.vpce-svc-04308d96cf1012913`
             </td>
           </tr>
+
         </tbody>
       </table>
 


### PR DESCRIPTION
## Give us some context

* Adding the new supported endpoint for Synthetics in the AWS private link integration. It has the same limitations as the new endpoints for infrastructure monitoring. 