### PR TITLE
PHP Agent 10.19.0 release (March 18th)

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-19-0-9.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-19-0-9.mdx
@@ -1,0 +1,37 @@
+---
+subject: PHP agent
+releaseDate: '2024-03-18'
+version: 10.19.0.9
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.19.0.9'
+features: ['Link error traces using transaction ID']
+bugs: ['Fix Magento 2 detection', 'Fix errors prioritization', 'Fix error recording for PHPs 8.0+']
+security: []
+---
+## New Relic PHP agent v10.19.0.9
+
+### New features
+
+* Always link error traces using transaction ID
+
+### Bug fixes
+
+* Fixes a bug where the agent would not properly automatically detect the Magento 2 framework
+* Fixes error prioritization by adding support for E_RECOVERABLE_ERROR, E_DEPRECATED, E_USER_DEPRECATED error types
+* Fixes error recording for PHPs 8.0+
+
+### Important end-of-life information
+
+* Support for PHP versions 7.0 and 7.1 will **EOL** on June 1st, 2024
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages that are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-19-0-9.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-19-0-9.mdx
@@ -16,8 +16,8 @@ security: []
 ### Bug fixes
 
 * Fixes a bug where the agent would not properly automatically detect the Magento 2 framework
-* Fixes error prioritization by adding support for E_RECOVERABLE_ERROR, E_DEPRECATED, E_USER_DEPRECATED error types
-* Fixes error recording for PHPs 8.0+
+* Fixes error categorization and prioritization by adding support for `E_RECOVERABLE_ERROR`, `E_DEPRECATED`, `E_USER_DEPRECATED` error types. `E_RECOVERABLE_ERROR`, `E_DEPRECATED`, `E_USER_DEPRECATED` are no longer recorded as `Error`.
+* Fixes error recording for PHPs 8.0+: `user_error_handler` is honored, and the agent will not record an error if `user_error_handler` handled the error.
 
 ### Important end-of-life information
 


### PR DESCRIPTION
Updates for the PHP agent v10.18.0:

Add 'PHP agent v10.18.0' release notes