### PR TITLE
Add reference to CodeStream's query builder

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data.mdx
@@ -111,7 +111,7 @@ There are two ways to write your own queries to retrieve data and build charts:
 * [Query builder in NRQL mode](/docs/chart-builder/use-chart-builder/choose-data/use-advanced-nrql-mode-specify-data): Query using [New Relic query language](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) (NRQL), the same language we use to build most of our UI experiences, and the most advanced way of querying data in New Relic.
 * [Query builder in PromQL-style mode](/docs/query-your-data/explore-query-data/chart-builder/use-advanced-promql-mode-specify-data): Write queries using a PromQL-style query.
 
-You can also [query data from your IDE](/docs/codestream/observability/log-search) using New Relic's CodeStream extension.
+You can also [query data from your IDE](/docs/codestream/observability/query-builder/) using New Relic's CodeStream extension.
 
 ## Query data via API [#query-apis]
 

--- a/src/content/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/get-started/introduction-querying-new-relic-data.mdx
@@ -111,6 +111,8 @@ There are two ways to write your own queries to retrieve data and build charts:
 * [Query builder in NRQL mode](/docs/chart-builder/use-chart-builder/choose-data/use-advanced-nrql-mode-specify-data): Query using [New Relic query language](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language) (NRQL), the same language we use to build most of our UI experiences, and the most advanced way of querying data in New Relic.
 * [Query builder in PromQL-style mode](/docs/query-your-data/explore-query-data/chart-builder/use-advanced-promql-mode-specify-data): Write queries using a PromQL-style query.
 
+You can also [query data from your IDE](/docs/codestream/observability/log-search) using New Relic's CodeStream extension.
+
 ## Query data via API [#query-apis]
 
 When you need programmatic options, or want to unlock more querying power, you can use APIs to query your New Relic data. Our NerdGraph API gives you more powerful options not available in the UI, such as querying across accounts, and exporting longer-term historical data sets. For more information, see [Intro to NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).


### PR DESCRIPTION
Feel free to rework how this is included, but I wanted to include the fact that you can now also run NRQL queries from within CodeStream in your IDE.