### PR TITLE
adjust content and sidebar spacing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -374,7 +374,7 @@ module.exports = {
           },
         },
         layout: {
-          contentPadding: '1.5rem',
+          contentPadding: '2.625rem 5rem',
           maxWidth: '1600px',
           component: require.resolve('./src/layouts'),
           mobileBreakpoint: '760px',

--- a/src/components/Layout/Sidebar.js
+++ b/src/components/Layout/Sidebar.js
@@ -27,7 +27,7 @@ const Sidebar = ({ children, className }) => {
           bottom: 0;
           left: 0;
           right: 0;
-          padding: var(--site-content-padding);
+          padding: 1.5rem;
           overflow: auto;
         `}
       >

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -94,7 +94,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
             'page-title page-tools'
             'content page-tools';
           grid-template-columns: minmax(0, 1fr) 12.8125rem;
-          grid-column-gap: 2rem;
+          grid-column-gap: 5rem;
 
           iframe {
             max-width: 100%;
@@ -190,7 +190,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         metaDescription
-        type
         tags
         translationType
       }


### PR DESCRIPTION
changes the spacing around the main content. see [newrelic/gatsby-teme-newrelic#1024](https://github.com/newrelic/gatsby-theme-newrelic/pull/1024) for the changes to line spacing

### before

<img width="1728" alt="Screenshot 2024-03-19 at 3 08 26 PM" src="https://github.com/newrelic/docs-website/assets/14365008/35cf441d-9c19-463d-8e1c-6a7d6de07c5a">

### after

<img width="1727" alt="Screenshot 2024-03-19 at 3 08 20 PM" src="https://github.com/newrelic/docs-website/assets/14365008/7d597f81-01ef-4320-9ce9-a519996e8db3">
