### PR TITLE
style(mobile APIs): Alphabetical order for tabs

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/add-tracked-headers.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/add-tracked-headers.mdx
@@ -21,11 +21,11 @@ freshnessValidatedDate: 2023-11-02
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-         <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
        <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -37,20 +37,20 @@ import mobileUnityEditorUI from 'images/mobile_screenshot-crop_Unity-editor-UI.w
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
     <TabsPages>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/create-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/create-attribute.mdx
@@ -30,20 +30,20 @@ freshnessValidatedDate: 2023-07-21
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-         <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
        <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/current-session-id.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/current-session-id.mdx
@@ -39,11 +39,11 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/increment-session-attribute-count.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/increment-session-attribute-count.mdx
@@ -29,20 +29,20 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-failures.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-failures.mdx
@@ -26,11 +26,11 @@ freshnessValidatedDate: 2023-07-19
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-         <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
        <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-success.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-success.mdx
@@ -27,20 +27,20 @@ freshnessValidatedDate: 2023-07-19
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-breadcrumb.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-breadcrumb.mdx
@@ -29,20 +29,20 @@ freshnessValidatedDate: 2023-07-18
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-           <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-events.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-events.mdx
@@ -31,21 +31,21 @@ freshnessValidatedDate: 2023-07-18
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>       
         <TabsBarItem id="xamarin">
             Xamarin
         </TabsBarItem>
-         <TabsBarItem id="unity">
-            Unity
-        </TabsBarItem>       
     </TabsBar>
 
     <TabsPages>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-metrics.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-metrics.mdx
@@ -26,20 +26,20 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-errors.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-errors.mdx
@@ -17,11 +17,11 @@ freshnessValidatedDate: 2023-07-26
         <TabsBarItem id="ios">
             iOS
         </TabsBarItem>
-        <TabsBarItem id="cordova">
-            Cordova
-        </TabsBarItem>
         <TabsBarItem id="capacitor">
             Capacitor
+        </TabsBarItem>
+        <TabsBarItem id="cordova">
+            Cordova
         </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-handled-exceptions.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-handled-exceptions.mdx
@@ -27,11 +27,11 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="maui">
             .NET MAUI
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-           <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/remove-all-attributes.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/remove-all-attributes.mdx
@@ -36,11 +36,11 @@ freshnessValidatedDate: 2023-07-21
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-         <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/remove-attribute.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/remove-attribute.mdx
@@ -39,11 +39,11 @@ freshnessValidatedDate: 2023-07-21
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-                <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-custom-user-id.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-custom-user-id.mdx
@@ -39,11 +39,11 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-         <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time.mdx
@@ -30,20 +30,20 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-         <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
@@ -32,20 +32,20 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-offline-storage.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-offline-storage.mdx
@@ -31,20 +31,20 @@ This method controls the maximum amount of offline storage that can be stored in
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/start-interaction.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/start-interaction.mdx
@@ -33,20 +33,20 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-        <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
-        <TabsBarItem id="xamarin">
-            Xamarin
-        </TabsBarItem>
         <TabsBarItem id="unity">
             Unity
+        </TabsBarItem>
+        <TabsBarItem id="xamarin">
+            Xamarin
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/stop-interaction.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/stop-interaction.mdx
@@ -30,20 +30,20 @@ freshnessValidatedDate: 2023-07-21
         <TabsBarItem id="cordova">
             Cordova
         </TabsBarItem>
-       <TabsBarItem id="maui">
-            .NET MAUI
-        </TabsBarItem>
         <TabsBarItem id="flutter">
             Flutter
+        </TabsBarItem>
+        <TabsBarItem id="maui">
+            .NET MAUI
         </TabsBarItem>
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-         <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/test-crash-reporting.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/test-crash-reporting.mdx
@@ -33,11 +33,11 @@ freshnessValidatedDate: 2023-07-20
         <TabsBarItem id="react">
             React Native
         </TabsBarItem>
+        <TabsBarItem id="unity">
+            Unity
+        </TabsBarItem>
         <TabsBarItem id="xamarin">
             Xamarin
-        </TabsBarItem>
-          <TabsBarItem id="unity">
-            Unity
         </TabsBarItem>
     </TabsBar>
 


### PR DESCRIPTION
Alphabetizes tabs in the mobile API docs, which are only semi-alphabetized today

Note: I kept Android and iOS up front b/c they're so much more critical than the various other agents