### PR TITLE
Add edge function to load eu osano variant when in eu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ yarn-error.log
 .devcontainer
 
 src/images/infrastructure_screenshot_full_sonarqube-dashboard.webp
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,10 @@ package = "@netlify/plugin-gatsby"
 [functions]
   included_files = ["!.cache/data/datastore/data.mdb","!.cache/query-engine"]
 
+[[edge_functions]]
+  path = "/*"
+  function = "osano-country"
+
 [[headers]]
 for = "/*"
 

--- a/netlify/edge-functions/osano-country.js
+++ b/netlify/edge-functions/osano-country.js
@@ -1,0 +1,67 @@
+import { HTMLRewriter } from 'https://ghuc.cc/worker-tools/html-rewriter/index.ts';
+
+export default async (request, context) => {
+  const response = await context.next();
+  const hasGdpr = [
+    'AT',
+    'BE',
+    'BG',
+    'HR',
+    'CY',
+    'CZ',
+    'DK',
+    'EE',
+    'FI',
+    'FR',
+    'DE',
+    'GR',
+    'HU',
+    'IE',
+    'IT',
+    'LV',
+    'LT',
+    'LU',
+    'MT',
+    'NL',
+    'PL',
+    'PT',
+    'RO',
+    'SK',
+    'SI',
+    'ES',
+    'SE',
+  ].includes(context.geo.country.code);
+
+  if (hasGdpr) {
+    return (
+      new HTMLRewriter()
+        // .on('script', {
+        //   text(text) {
+        //     buffer += text.text;
+
+        //     if (text.lastInTextNode) {
+        //       text.replace(buffer.replace(/variant=one/gi, 'variant=two'));
+        //       buffer = '';
+        //     } else {
+        //       text.remove();
+        //     }
+        //   },
+        // })
+        .on('script', {
+          element(element) {
+            const scriptSrc = element.getAttribute('src');
+            if (
+              typeof scriptSrc === 'string' &&
+              scriptSrc.includes('cmp.osano.com/')
+            ) {
+              element.setAttribute(
+                'src',
+                scriptSrc.replace(/variant=one/gi, 'variant=two')
+              );
+            }
+          },
+        })
+        .transform(response)
+    );
+  }
+};

--- a/netlify/edge-functions/osano-country.js
+++ b/netlify/edge-functions/osano-country.js
@@ -2,7 +2,7 @@ import { HTMLRewriter } from 'https://ghuc.cc/worker-tools/html-rewriter/index.t
 
 export default async (request, context) => {
   const response = await context.next();
-  const hasGdpr = [
+  const hasGdpr = new Set([
     'AT',
     'BE',
     'BG',
@@ -30,7 +30,7 @@ export default async (request, context) => {
     'SI',
     'ES',
     'SE',
-  ].includes(context.geo.country.code);
+  ]).has(context.geo.country.code);
 
   if (hasGdpr) {
     return new HTMLRewriter()

--- a/netlify/edge-functions/osano-country.js
+++ b/netlify/edge-functions/osano-country.js
@@ -33,35 +33,21 @@ export default async (request, context) => {
   ].includes(context.geo.country.code);
 
   if (hasGdpr) {
-    return (
-      new HTMLRewriter()
-        // .on('script', {
-        //   text(text) {
-        //     buffer += text.text;
-
-        //     if (text.lastInTextNode) {
-        //       text.replace(buffer.replace(/variant=one/gi, 'variant=two'));
-        //       buffer = '';
-        //     } else {
-        //       text.remove();
-        //     }
-        //   },
-        // })
-        .on('script', {
-          element(element) {
-            const scriptSrc = element.getAttribute('src');
-            if (
-              typeof scriptSrc === 'string' &&
-              scriptSrc.includes('cmp.osano.com/')
-            ) {
-              element.setAttribute(
-                'src',
-                scriptSrc.replace(/variant=one/gi, 'variant=two')
-              );
-            }
-          },
-        })
-        .transform(response)
-    );
+    return new HTMLRewriter()
+      .on('script', {
+        element(element) {
+          const scriptSrc = element.getAttribute('src');
+          if (
+            typeof scriptSrc === 'string' &&
+            scriptSrc.includes('cmp.osano.com/')
+          ) {
+            element.setAttribute(
+              'src',
+              scriptSrc.replace(/variant=one/gi, 'variant=two')
+            );
+          }
+        },
+      })
+      .transform(response);
   }
 };

--- a/netlify/edge-functions/osano-country.js
+++ b/netlify/edge-functions/osano-country.js
@@ -30,6 +30,7 @@ export default async (request, context) => {
     'SI',
     'ES',
     'SE',
+    'US',
   ].includes(context.geo.country.code);
 
   if (hasGdpr) {
@@ -39,7 +40,7 @@ export default async (request, context) => {
           const scriptSrc = element.getAttribute('src');
           if (
             typeof scriptSrc === 'string' &&
-            scriptSrc.includes('cmp.osano.com/')
+            scriptSrc.includes('https://cmp.osano.com/')
           ) {
             element.setAttribute(
               'src',

--- a/netlify/edge-functions/osano-country.js
+++ b/netlify/edge-functions/osano-country.js
@@ -39,7 +39,7 @@ export default async (request, context) => {
           const scriptSrc = element.getAttribute('src');
           if (
             typeof scriptSrc === 'string' &&
-            scriptSrc.includes('https://cmp.osano.com/')
+            scriptSrc.startsWith('https://cmp.osano.com/')
           ) {
             element.setAttribute(
               'src',

--- a/netlify/edge-functions/osano-country.js
+++ b/netlify/edge-functions/osano-country.js
@@ -30,7 +30,6 @@ export default async (request, context) => {
     'SI',
     'ES',
     'SE',
-    'US',
   ].includes(context.geo.country.code);
 
   if (hasGdpr) {


### PR DESCRIPTION
When users in the EU load the site this function will run and replace the osano script's variant 1 with variant 2 which is gdpr friendly. with htmlrewriter I wasn't totally sure if we wanted to use the [element](https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/#element) over the [text](https://developers.cloudflare.com/workers/runtime-apis/html-rewriter/#text-chunks) option but even loading the site on slow 3g the script seems to come in with the correct variant from the start which seems adequate

to test:
set the ENVRIONMENT env var to production in your .env file to get osano to show up. download the netlify cli and run `netlify dev` to run the edge function locally. in osano-country.js you can add the US to the list of countries to get the variant=two to show up in the script, and remove it to see variant=one