### PR TITLE
Serverless: Change AWS legacy file name to layerless in navigation.

### DIFF
--- a/src/nav/serverless-function-monitoring.yml
+++ b/src/nav/serverless-function-monitoring.yml
@@ -25,8 +25,8 @@ pages:
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own
           - title: 'Step 5: Additional configuration'
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/configure-serverless-monitoring-aws-lambda
-          - title: Legacy manual instrumentation
-            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-legacy
+          - title: Layerless manual instrumentation
+            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-layerless
           - title: Update serverless monitoring
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/update-serverless-monitoring-aws-lambda
           - title: Enable Lambda containerized functions


### PR DESCRIPTION
I had previously changed the actual filename so it ends in "-layerless" instead of "-legacy" but evidently, I missed the related navigation link and label change in that previous commit.