### PR TITLE
Apdex only affects legacy transaction trace collection. These traces …

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-coming-new-relic.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-coming-new-relic.mdx
@@ -93,7 +93,6 @@ Options for adjusting <InlinePopover type="apm" /> data include:
 
 * Configure the sampling rate for transaction events. See agent configurations for [Java](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#Transaction_Events), [.Net](/docs/apm/agents/net-agent/configuration/net-agent-configuration), [Go](/docs/apm/agents/go-agent/configuration/go-agent-configuration#transaction-events-settings), [NodeJS](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration), [PHP](/docs/apm/agents/php-agent/configuration/php-agent-configuration), [Python](/docs/apm/agents/python-agent/configuration/python-agent-configuration), or [Ruby](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration).  
 * Adjust [distributed trace sampling](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works)
-* [Set appropriate Apdex scores](/docs/apm/new-relic-apm/apdex/change-your-apdex-settings/), for example, for frequency of traces.
 * Optimize [custom instrumentation](/docs/apm/agents/manage-apm-agents/agent-data/custom-instrumentation) and/or [custom metrics](/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics).
 * Manage [logs-in-context](/docs/logs/logs-context/get-started-logs-context). 
 </Collapser>


### PR DESCRIPTION
Apdex only affects legacy transaction trace collection. These traces are non-billable anyway so calibrating Apdex threshold isn't going to reduce spend. Transaction traces should not be confused with Distributed Traces which are in fact billable ingest.