### PR TITLE
fix: update broken links

### DIFF
--- a/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/troubleshooting/log-audit-all-data-your-new-relic-agent-transmits.mdx
@@ -45,7 +45,7 @@ For details about the audit logging options for your APM agent's configuration f
       </td>
 
       <td>
-        Logging is optional with the Go agent. If you are using `newrelic.NewLogger(w)` and want more detailed output, change `newrelic.NewLogger(w)` to `newrelic.NewDebugLogger(w)`. For more information, see the [New Relic Go logging documentation on GitHub](https://github.com/newrelic/go-agent/blob/master/log.go).
+        Logging is optional with the Go agent. If you are using `newrelic.NewLogger(w)` and want more detailed output, change `newrelic.NewLogger(w)` to `newrelic.NewDebugLogger(w)`. For more information, see the [New Relic Go logging documentation on GitHub](https://github.com/newrelic/go-agent/blob/master/v3/newrelic/log.go).
       </td>
     </tr>
 
@@ -105,7 +105,7 @@ For details about the audit logging options for your APM agent's configuration f
       </td>
 
       <td>
-        Use [`audit_log` values](/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration#audit_log). For more information, see [Ruby agent audit log](/docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log).
+        Use [`audit_log` values](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#audit-log). For more information, see [Ruby agent audit log](/docs/agents/ruby-agent/troubleshooting/ruby-agent-audit-log).
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
this link also looks dead, it redirects to the link before it, but I don't know what the correct one might be:

```md
To customize your query, use any of the available [`NrAuditEvent` attributes](/docs/insights/insights-data-sources/default-data/nrauditevent-default-attributes-examples)
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.