### PR TITLE
[chore] mongodb-monitoring-integration-new.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -509,14 +509,15 @@ The following configuration options are available:
     id="basic-config"
     title="Basic configuration"
   >
-    This is the basic configuration used to collect all metrics. Add credentials to your mongodb UR if they are required.
+    This is the basic configuration used to collect all metrics. Add credentials to your mongodb URI if they are required.
+    NOTE: If your password has special characters in it, you will need to put single quotes around the URI
 
     ```yml
     integrations:
       - name: nri-mongodb3
         config:
           mongodb_cluster_name: my_cluster
-          mongodb_uri: mongodb://username:password@localhost:27017
+          mongodb_uri: 'mongodb://username:password@localhost:27017'
           exporter_port: 9126
     ```
   </Collapser>
@@ -547,12 +548,12 @@ The following configuration options are available:
       - name: nri-mongodb3
         config:
           mongodb_cluster_name: my_cluster
-          mongodb_uri: mongodb://username:password@cluster1:27017
+          mongodb_uri: 'mongodb://username:password@cluster1:27017'
           exporter_port: 9126
       - name: nri-mongodb3
         config:
           mongodb_cluster_name: my_second_cluster
-          mongodb_uri: mongodb://username:password@cluster2:27017
+          mongodb_uri: 'mongodb://username:password@cluster2:27017'
           exporter_port: 9127
     ```
   </Collapser>
@@ -567,7 +568,7 @@ The following configuration options are available:
       - name: nri-mongodb3
         config:
           mongodb_cluster_name: my_cluster
-          mongodb_uri: mongodb://username:password@localhost:27017
+          mongodb_uri: 'mongodb://username:password@localhost:27017'
           collection_filters: "db1,db2.collection2"
           exporter_port: 9126
     ```
@@ -583,7 +584,7 @@ The following configuration options are available:
       - name: nri-mongodb3
         config:
           mongodb_cluster_name: my_cluster
-          mongodb_uri: mongodb://username:password@localhost:27017/my_auth_source
+          mongodb_uri: 'mongodb://username:password@localhost:27017/my_auth_source'
           exporter_port: 9126
     ```
   </Collapser>
@@ -613,7 +614,7 @@ The following configuration options are available:
       - name: nri-mongodb3
         config:
           mongodb_cluster_name: my_cluster
-          mongodb_uri: mongodb+srv://username:password@my_atlas_url.mongodb.net/?retryWrites=true&w=majority
+          mongodb_uri: 'mongodb+srv://username:password@my_atlas_url.mongodb.net/?retryWrites=true&w=majority'
           mongodb_direct_connect: false
           exporter_port: 9126
     ```


### PR DESCRIPTION
(opening on behalf of @lartita)

Fixed typo under Example configurations > Basic configuration. UR was missing the I. 

Also added a note under Basic configuration to note that if the users password has special characters in it, then they will need to add single quotes to their URI. 

I then added single quotes to all examples that had a `username:password` in their URI.

