### PR TITLE
chore(.net agent): Add .NET Agent release notes for v10.22.0.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-22-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-22-0.mdx
@@ -1,0 +1,41 @@
+---
+subject: .NET agent
+releaseDate: '2024-03-20'
+version: 10.22.0
+downloadLink: 'https://download.newrelic.com/dot_net_agent/latest_release'
+features: ['Add a new API method to time currently unsupported datastore method calls.','Add transaction ID to intrinsic attributes for error events and traces regardless of DT/CAT settings.']
+bugs: ['Fix a context data capture when the Microsoft.Extensions.Logging console logger is used (thanks [@lowell-trimble](https":"//github.com/lowell-trimble)!).']
+security: []
+---
+
+### New features
+
+* Add a new API method to time currently unsupported datastore method calls. ([#2320](https://github.com/newrelic/newrelic-dotnet-agent/issues/2320)) ([81abc5c](https://github.com/newrelic/newrelic-dotnet-agent/commit/81abc5c78e39655f4153b2f9f0f7e5e8328f3577))
+* Add transaction ID to intrinsic attributes for error events and traces regardless of DT/CAT settings ([#2341](https://github.com/newrelic/newrelic-dotnet-agent/issues/2341)) ([1df0342](https://github.com/newrelic/newrelic-dotnet-agent/commit/1df03420a690b1f1e46b9ef17b2184d27d314667))
+
+### Fixes
+
+* Fix a context data capture when the Microsoft.Extensions.Logging console logger is used (thanks [@lowell-trimble](https://github.com/lowell-trimble)!) ([#2261](https://github.com/newrelic/newrelic-dotnet-agent/issues/2261)) ([#2315](https://github.com/newrelic/newrelic-dotnet-agent/issues/2315)) ([f8422d6](https://github.com/newrelic/newrelic-dotnet-agent/commit/f8422d6c538db6ff32e0b1055e824b3536245c59))
+
+### Checksums
+| File | SHA - 256  Hash |
+| ---| ---|
+| newrelic-dotnet-agent-10.22.0-1.x86_64.rpm | 3CD5AB7FA9801DE2647B9AB96972F39C411D2BA80ED23562FD45D998AFC150E2 |
+| newrelic-dotnet-agent_10.22.0_amd64.deb | A1DF21AAD826DF7C19F4BA78EA368A78E93DF73BDC90B30432859248D3F25487 |
+| newrelic-dotnet-agent_10.22.0_amd64.tar.gz | A3D5E5C0BD1B53BF7709538F078EB9383413EC8B3D2DDBEB01520B89A26AE3FD |
+| newrelic-dotnet-agent_10.22.0_arm64.deb | 1A8B8F57FFB2A9FF694E92D573BEA7915F698012252F802FF2ABFAAAC9A585AA |
+| newrelic-dotnet-agent_10.22.0_arm64.tar.gz | 2B3E1C063F114D46B141F5FC8B459A9181D7FDF05D93FBED315E7CB5AD362664 |
+| NewRelicDotNetAgent_10.22.0_x64.msi | CF1E5F39AD039EC3A27E6BB91291912008F248194968E76E147CFF713C4B2972 |
+| NewRelicDotNetAgent_10.22.0_x64.zip | F1AFFBC42D4716525DDBF6ECB72FB59A51DC30A411B3E4F09CCE705FA2A67D12 |
+| NewRelicDotNetAgent_10.22.0_x86.msi | 9228160738A52991E766F845CBFBB1E6186B24D5E4C00FE37A636E524C81B5DB |
+| NewRelicDotNetAgent_10.22.0_x86.zip | A899006B2F0CE7E634F56EA315FEAE2C0AD1B7FF7B92165E651D27C833FC8017 |
+
+
+### Updating your agent
+
+* Follow standard procedures to [update the .NET agent](/docs/agents/net-agent/installation-configuration/update-net-agent).
+* If you're using a particularly old agent, review the list of major changes and procedures for [updating legacy .NET agents](/docs/agents/net-agent/troubleshooting/upgrade-legacy-net-agents).
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent).
+See the New Relic .NET agent [EOL policy doc](/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy) for information about agent releases and support dates.
+


### PR DESCRIPTION
making for the dotnet team - replaces https://github.com/newrelic/docs-website/pull/16609