### PR TITLE
feat(PHP): Add troubleshooting page for PHP Agent

### DIFF
--- a/src/content/docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources.mdx
@@ -1,0 +1,135 @@
+---
+title: PHP Agent Troubleshooting Resources
+type: troubleshooting
+tags:
+  - Agents
+  - PHP agent
+  - Troubleshooting
+freshnessValidatedDate: never
+---
+
+Below are some common troubleshooting resources that could be helpful if you are experiencing problems with the PHP Agent.
+
+## Resources
+
+<table>
+
+  <tbody>
+    <tr>
+      <td>
+        [No data appears](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/no-data-appears-php/)
+      </td>
+
+      <td>
+        [Data stops reporting](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/data-stops-reporting/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [First PHP transaction is not reported](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/first-php-transaction-not-reported/)
+      </td>
+
+      <td>
+        [PHP agent not reporting errors](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/php-agent-not-reporting-errors/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Determine permissions requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/determine-permissions-requirements-php/)
+      </td>
+
+      <td>
+        [Generating logs for troubleshooting](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/generating-logs-troubleshooting-php/)
+      </td>      
+    </tr>
+
+    <tr>
+      <td>
+        [Data stops reporting while using SELinux](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/data-stops-reporting-while-using-selinux/)
+      </td>
+
+      <td>
+        [Agent stops working after updating PHP](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/agent-stops-working-after-updating-php/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Checking loaded configuration files directory](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/checking-loaded-configuration-files-directory/)
+      </td>
+
+      <td>
+        [Missing PHP Module](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/missing-php-module/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Protocol mismatch error](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/protocol-mismatch-error/)
+      </td>
+
+      <td>
+        [INI settings not taking effect immediately](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/ini-settings-not-taking-effect-immediately/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Submitting troubleshooting results](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/submitting-troubleshooting-results-php/)
+      </td>
+
+      <td>
+        [Threaded Apache worker MPMs](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/threaded-apache-worker-mpms/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Transactions named /index.php or /unknown](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/transactions-named-indexphp-or-unknown/)
+      </td>
+
+      <td>
+        [Troubleshoot the PHP agent instance count](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/troubleshoot-php-agent-instance-count/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Uninstrumented time in traces](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/uninstrumented-time-traces/)
+      </td>
+
+      <td>
+        [Using phpinfo to verify PHP](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/using-phpinfo-verify-php/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Verifying the PHP daemon](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/verifying-php-daemon/)
+      </td>
+
+      <td>
+        [Why and when to restart your web server](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/why-when-restart-your-web-server-php/)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [Performance issues within AWS Fargate](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/fargate-nitro-clock-performance-impact/)
+      </td>
+
+      <td>
+        [High memory load on long running PHP tasks](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/performance-issues-long-running-task/)
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        [Symfony 4.4 overhead with opcache.preload](https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/symfony44-performance/)
+      </td>
+
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources.mdx
@@ -7,6 +7,7 @@ tags:
   - Troubleshooting
 redirects:
   - /docs/agents/php-agent/troubleshooting/troubleshooting-resources
+  - /docs/agents/php-agent/troubleshooting
 freshnessValidatedDate: never
 ---
 

--- a/src/content/docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources.mdx
@@ -5,6 +5,8 @@ tags:
   - Agents
   - PHP agent
   - Troubleshooting
+redirects:
+  - /docs/agents/php-agent/troubleshooting/troubleshooting-resources
 freshnessValidatedDate: never
 ---
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1,4 +1,3 @@
-
 title: Application performance monitoring
 path: /docs/apm
 pages:

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1,3 +1,4 @@
+
 title: Application performance monitoring
 path: /docs/apm
 pages:
@@ -761,6 +762,8 @@ pages:
           - title: Troubleshooting
             path: /docs/apm/agents/php-agent/troubleshooting
             pages:
+              - title: Troubleshooting resources 
+                path: /docs/apm/agents/php-agent/troubleshooting/troubleshooting-resources
               - title: No data appears
                 path: /docs/apm/agents/php-agent/troubleshooting/no-data-appears-php
               - title: Data stops reporting


### PR DESCRIPTION
This PR creates a general troubleshooting page for the PHP agent, which contains links to various troubleshooting docs that the PHP agent provides. 