### PR TITLE
Accounts: Remove permissions screenshot

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -177,20 +177,6 @@ Here's a table with our standard roles. To better understand these roles, go to 
       </td>
     </tr>
 
-    <tr>
-      <td>
-        <DoNotTranslate>**Manage v1 users**</DoNotTranslate>
-      </td>
-
-      <td>
-        For New Relic organizations that existed before July 30 2020 and have users on our [original user model](/docs/accounts/original-accounts-billing/original-users-roles/overview-user-models), this role lets you manage those "v1" users. This is used primarily for overseeing a [user migration process](/docs/accounts/original-accounts-billing/original-users-roles/user-migration/).
-      </td>
-
-      <td>
-        Required: full platform.
-      </td>
-    </tr>
-
   </tbody>
 </table>
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -44,7 +44,7 @@ Our pre-built roles have various groupings of permissions. How our pre-built rol
 
 ## Permission definitions [#permission-definitions]
 
-You can see the permissions for each of our pre-built roles by clicking your name in the [lower-left corner of the UI](https://one.newrelic.com) and going to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
+You can see the permissions for each of our pre-built roles by clicking your name in the [lower-left corner of the UI](https://one.newrelic.com) and going to **Administration > Access management > Roles**. Lists of permissions are available for the following roles in our newer user model:
 
 * All product admin
 * Standard user

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -44,7 +44,7 @@ Our pre-built roles have various groupings of permissions. How our pre-built rol
 
 ## Permission definitions [#permission-definitions]
 
-You can see the permissions for each of our pre-built roles by clicking your name in the [lower-left corner of the UI](https://one.newrelic.com) and going to **Administration > Access management > Roles**. Lists of permissions are available for the following roles in our newer user model:
+You can go to the UI to view the permissions for each of our pre-built roles. Click on your name in the lower-left corner to open the [user menu](https://one.newrelic.com), and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles in our newer user model:
 
 * All product admin
 * Standard user

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -44,12 +44,11 @@ Our pre-built roles have various groupings of permissions. How our pre-built rol
 
 ## Permission definitions [#permission-definitions]
 
-You can go to the UI to view the permissions for each of our pre-built roles in the newer user model. In the lower-left corner of the [UI](https://one.newrelic.com), click on your name to open the user menu, and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
+You can go to the UI to view the permissions for each of our pre-built roles. In the lower-left corner of the [UI](https://one.newrelic.com), click on your name to open the user menu, and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
 
 * All product admin
 * Standard user
 * Read only
-* Manage v1 users
 
 To learn more about specific permissions, select a category below, or try searching this doc for a specific term you're looking for.
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -44,7 +44,7 @@ Our pre-built roles have various groupings of permissions. How our pre-built rol
 
 ## Permission definitions [#permission-definitions]
 
-You can go to the UI to view the permissions for each of our pre-built roles. Click on your name in the lower-left corner to open the [user menu](https://one.newrelic.com), and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles in our newer user model:
+You can go to the UI to view the permissions for each of our pre-built roles in the newer user model. Click on your name in the lower-left corner to open the [user menu](https://one.newrelic.com), and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
 
 * All product admin
 * Standard user

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -44,15 +44,12 @@ Our pre-built roles have various groupings of permissions. How our pre-built rol
 
 ## Permission definitions [#permission-definitions]
 
-Here's a screenshot of the permissions available in the permissions UI. These are only a subset of everything you can do in New Relic and represent the specific permissions we believe are likely to be valuable for creating custom roles. 
+You can see the permissions for each of our pre-built roles by clicking your name in the [lower-left corner of the UI](https://one.newrelic.com) and going to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
 
-<img
-  title="New Relic user permissions screenshot"
-  alt="New Relic user permissions UI screenshot"
-  src={accountsUserManagementCapabilitiesUI}
-/>
-
-Note that permissions can change. The permissions in this doc were last updated April 3, 2023. 
+* All product admin
+* Standard user
+* Read only
+* Manage v1 users
 
 To learn more about specific permissions, select a category below, or try searching this doc for a specific term you're looking for.
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -44,7 +44,7 @@ Our pre-built roles have various groupings of permissions. How our pre-built rol
 
 ## Permission definitions [#permission-definitions]
 
-You can go to the UI to view the permissions for each of our pre-built roles in the newer user model. Click on your name in the lower-left corner to open the [user menu](https://one.newrelic.com), and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
+You can go to the UI to view the permissions for each of our pre-built roles in the newer user model. In the lower-left corner of the [UI](https://one.newrelic.com), click on your name to open the user menu, and then go to **Administration > Access management > Roles**. Lists of permissions are available for the following roles:
 
 * All product admin
 * Standard user


### PR DESCRIPTION
Replace permissions screen shot with steps for viewing permissions in roles.

Also, remove the reference to a role that is being retired: "Manage v1 users" (per SME).

