### PR TITLE
fix(CPMDockerSupport): Clarified Docker 26+ support

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -157,7 +157,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            Docker Engine versions between [17.12.1-ce](https://docs.docker.com/engine/release-notes/17.12/) and 25.x
+            Docker Engine versions between [17.12.1-ce](https://docs.docker.com/engine/release-notes/17.12/) and 25 or higher.
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -157,7 +157,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            Docker versions between [17.12.1-ce](https://docs.docker.com/engine/release-notes/17.12/) and 25.x
+            Docker Engine versions between [17.12.1-ce](https://docs.docker.com/engine/release-notes/17.12/) and 25.x
           </td>
         </tr>
 
@@ -174,7 +174,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
     </table>
 
     <Callout variant="caution">
-      The Docker CPM does not support Docker 26.0 or higher due to breaking changes. Customers seeking Docker 26+ support should migrate to [Synthetics Job Manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/)
+      The Docker CPM does not support Docker Engine 26.0 or higher due to breaking changes. Customers seeking Docker 26+ support should migrate to [Synthetics Job Manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/)
     </Callout>
 
     <Callout variant="caution">

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -157,7 +157,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           </td>
 
           <td>
-            Docker [17.12.1-ce](https://docs.docker.com/engine/release-notes/17.12/) or higher
+            Docker versions between [17.12.1-ce](https://docs.docker.com/engine/release-notes/17.12/) and 25.x
           </td>
         </tr>
 
@@ -172,6 +172,10 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
         </tr>
       </tbody>
     </table>
+
+    <Callout variant="caution">
+      The Docker CPM does not support Docker 26.0 or higher due to breaking changes. Customers seeking Docker 26+ support should migrate to [Synthetics Job Manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/)
+    </Callout>
 
     <Callout variant="caution">
       The Docker CPM is not designed for use with container orchestrators like AWS ECS, Docker Swarm, Apache Mesos, Azure Container Instances, etc. Running the Docker CPM in a container orchestrator will result in unexpected issues because it is itself a container orchestrator. If you're using container orchestration, see our [Kubernetes CPM requirements](/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms/#kubernetes-requirements).


### PR DESCRIPTION
Added a note that the CPM will not support Docker 26+. Customers should migrate to Synthetics Job Manager instead.