### PR TITLE
chore(browser): post-release core web vitals updates

### DIFF
--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -118,7 +118,7 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
       </td>
 
       <td>
-        [Cumulative layout shift (CLS)](https://web.dev/cls/) is available with [agent v1177 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177). CLS is an important, user-centric metric for measuring [visual stability](https://web.dev/user-centric-performance-metrics/#types-of-metrics) because it helps quantify how often users experience unexpected layout shifts. A low CLS helps ensure that the page is [delightful](https://web.dev/user-centric-performance-metrics/#questions). This is one of three metrics identified by Google as the [core web vitals](https://web.dev/vitals/).
+        [Cumulative layout shift (CLS)](https://web.dev/cls/) is available with [agent v1177 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177). CLS is an important, user-centric metric for measuring [visual stability](https://web.dev/user-centric-performance-metrics/#types-of-metrics) because it helps quantify how often users experience unexpected layout shifts. A low CLS helps ensure that the page is [delightful](https://web.dev/user-centric-performance-metrics/#questions).
 
         Cumulative layout shift is one of three metrics identified by Google as the [core web vitals](https://web.dev/vitals/). CLS scores up to 0.1 are considered "Good," between 0.1-0.25 are considered "Needs Improvement," and above 0.25 are considered "Poor."
       </td>

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -28,16 +28,6 @@ As of [agent version 1177](/docs/release-notes/new-relic-browser-release-notes/b
 
 Note that the metrics that make up core web vitals [evolve](https://web.dev/vitals/#evolving-web-vitals) over time. The current set focuses on three aspects of the user experience: loading, interactivity, and visual stability. It includes the following metrics and their respective thresholds:
 
-<img
-  title="Core web vitals diagram"
-  alt="A diagram showing the three components of the core web vitals metrics."
-  src={browserCoreWebVitals}
-/>
-
-<figcaption>
-  Core web vitals metrics include loading, interactivity, and visual stability.
-</figcaption>
-
 * <DoNotTranslate>**[Largest contentful paint (LCP)](https://web.dev/lcp/)**</DoNotTranslate>: measures loading performance. To provide a good user experience, LCP should occur <DoNotTranslate>**within 2.5 seconds**</DoNotTranslate> of when the page first starts loading.
 * <DoNotTranslate>**[Interaction to next paint (INP)](https://web.dev/inp/)**</DoNotTranslate>: measures latency of all user interactions with a page. To provide a good user experience, pages should have a INP of <DoNotTranslate>**less than 200 milliseconds**</DoNotTranslate>.
 * <DoNotTranslate>**[Cumulative layout shift (CLS)](https://web.dev/cls/)**</DoNotTranslate>: measures visual stability. To provide a good user experience, pages should maintain a CLS of <DoNotTranslate>**less than 0.1**</DoNotTranslate>.

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -9,10 +9,8 @@ redirects:
   - /docs/browser-pageviewtiming-event
   - /docs/browser/new-relic-browser/page-load-timing-resources/browser-pageviewtiming-event
   - /docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-get-async-page-load-details
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-03-27
 ---
-
-import browserCoreWebVitals from 'images/browser_diagram_core-web-vitals.webp'
 
 Browser monitoring's [`PageViewTiming` event](/attribute-dictionary/?event=PageViewTiming) sends each data point as a separate event as soon as it is available. Because we do not restrict the timing, you can receive first paint or first interaction data regardless of when it fires. This document describes why and how to use `PageViewTiming` and its attributes to query data about your site, component loading, and user performance metrics, both from visual and responsiveness standpoints.
 
@@ -24,20 +22,20 @@ For example, users may become impatient and begin clicking as soon as content is
 
 The `PageViewTiming` event provides a more real-time delivery mechanism that does not have a dependency on any other event. The additional metrics can help you understand how users experience your site, both from visual and responsiveness standpoints.
 
-## Support for Google's Core Web Vitals
+## Support for Google's core web vitals
 
-As of [agent version 1177](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177) for browser monitoring, we have full support for [Google's Core Web Vitals](https://web.dev/vitals/#core-web-vitals). This feature is available in all flavors of the agent (Lite, Pro, or Pro+SPA).
+As of [agent version 1177](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177) for browser monitoring, we have full support for [core web vitals](https://web.dev/vitals/#core-web-vitals). This feature is available in all flavors of the agent (Lite, Pro, or Pro+SPA).
 
-Note that the metrics that make up Core Web Vitals [evolve](https://web.dev/vitals/#evolving-web-vitals) over time. The current set focuses on three aspects of the user experience: loading, interactivity, and visual stability. It includes the following metrics and their respective thresholds:
+Note that the metrics that make up core web vitals [evolve](https://web.dev/vitals/#evolving-web-vitals) over time. The current set focuses on three aspects of the user experience: loading, interactivity, and visual stability. It includes the following metrics and their respective thresholds:
 
 <img
-  title="Core Web Vitals diagram"
-  alt="A diagram showing the three components of the Core Web Vitals metrics."
+  title="Core web vitals diagram"
+  alt="A diagram showing the three components of the core web vitals metrics."
   src={browserCoreWebVitals}
 />
 
 <figcaption>
-  Core Web Vitals metrics include loading, interactivity, and visual stability.
+  Core web vitals metrics include loading, interactivity, and visual stability.
 </figcaption>
 
 * <DoNotTranslate>**[Largest contentful paint (LCP)](https://web.dev/lcp/)**</DoNotTranslate>: measures loading performance. To provide a good user experience, LCP should occur <DoNotTranslate>**within 2.5 seconds**</DoNotTranslate> of when the page first starts loading.
@@ -88,13 +86,13 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
       </td>
 
       <td>
-        The [`largestContentfulPaint`](/attribute-dictionary/?event=PageViewTiming&attribute=largestContentfulPaint),metric is available with [agent version 1163 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1163). It reports the render time of the largest content element visible in the viewport.
+        The [`largestContentfulPaint`](/attribute-dictionary/?event=PageViewTiming&attribute=largestContentfulPaint) metric is available with [agent version 1163 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1163). It reports the render time of the largest content element visible in the viewport.
 
         Google's research found that looking at when the largest element was rendered was a more accurate way to measure when the main content of a page is loaded and useful. For more information about this metric, including limitations and considerations, see the [w3c draft](https://wicg.github.io/largest-contentful-paint/).
 
-        We also report the cumulative layout shift (CLS) score attribute with LCP. This attribute is reported as `cumulativeLayoutShift`.
+        We also report the cumulative layout shift score attribute with LCP. This attribute is reported as `cumulativeLayoutShift`.
 
-        Largest contentful paint is one of three metrics identified by Google as the [Core Web Vitals](https://web.dev/vitals/). LCP values up to 2.5 secs are considered "Good," between 2.5-4.0 secs are considered "Needs Improvement," and above 4.0 secs are considered "Poor."
+        Largest contentful paint is one of three metrics identified by Google as the [core web vitals](https://web.dev/vitals/). LCP values up to 2.5 seconds are considered "Good," between 2.5 and 4 seconds are considered "Needs Improvement," and above 4 seconds are considered "Poor."
       </td>
     </tr>
 
@@ -120,9 +118,9 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
       </td>
 
       <td>
-        [Cumulative layout shift (CLS)](https://web.dev/cls/) is available with [agent v1177 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177). CLS is an important, user-centric metric for measuring [visual stability](https://web.dev/user-centric-performance-metrics/#types-of-metrics) because it helps quantify how often users experience unexpected layout shifts. A low CLS helps ensure that the page is [delightful](https://web.dev/user-centric-performance-metrics/#questions). This is one of three metrics identified by Google as the [Core Web Vitals](https://web.dev/vitals/).
+        [Cumulative layout shift (CLS)](https://web.dev/cls/) is available with [agent v1177 or higher](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1177). CLS is an important, user-centric metric for measuring [visual stability](https://web.dev/user-centric-performance-metrics/#types-of-metrics) because it helps quantify how often users experience unexpected layout shifts. A low CLS helps ensure that the page is [delightful](https://web.dev/user-centric-performance-metrics/#questions). This is one of three metrics identified by Google as the [core web vitals](https://web.dev/vitals/).
 
-        Cumulative layout shift is one of three metrics identified by Google as the [Core Web Vitals](https://web.dev/vitals/). CLS scores up to 0.1 are considered "Good," between 0.1-0.25 are considered "Needs Improvement," and above 0.25 are considered "Poor."
+        Cumulative layout shift is one of three metrics identified by Google as the [core web vitals](https://web.dev/vitals/). CLS scores up to 0.1 are considered "Good," between 0.1-0.25 are considered "Needs Improvement," and above 0.25 are considered "Poor."
       </td>
     </tr>
 

--- a/src/content/docs/tutorial-improve-site-performance/guide-to-monitoring-core-web-vitals.mdx
+++ b/src/content/docs/tutorial-improve-site-performance/guide-to-monitoring-core-web-vitals.mdx
@@ -125,7 +125,7 @@ Each web vital has the following thresholds to help you track your app's perform
 
 <Callout variant="tip">
 
-### How is the CLS score calculated
+### How is the CLS score calculated?
 
 The cumulative layout shift score is a unitless value between 0 and infinity, not a time-based measurement like the other core web vitals. It reflects the sum of the impact of unexpected layout shifts that occur during the loading process of a webpage. Here's how the CLS score is calculated:
 * Layout shift score: This considers two factors:


### PR DESCRIPTION
Removed an old screenshot (containing first input delay) and addressed title case references of core web vitals