### PR TITLE
[WHAT'S NEW]: PUBLISH 4/22. Add Synthetics EOL post

### DIFF
--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -1,5 +1,5 @@
 ---
-title: 'Upgrade to the new synthetic monitor runtime to prevent impacts to your synthetic monitors'
+title: 'Update to the new synthetic monitor runtime to prevent impacts to your synthetic monitors'
 summary: 'Support for legacy synthetics runtimes and Containerized Private Minion will be concluded on October 22, 2024'
 releaseDate: '2024-04-22'
 learnMoreLink: 'https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui'
@@ -8,34 +8,43 @@ getStartedLink: ''
 
 On October 22, 2024, New Relic will end-of-life (EOL):
 
- * The Containerized Private Minion (CPM) capability
- * Legacy synthetics runtimes, including our legacy Chrome 72 (and older) and Node version 10 (and older) runtimes. 
+    * The Containerized Private Minion (CPM) capability
+    * Legacy synthetic monitoring runtimes, including our legacy Chrome 72 (or older) and Node version 10 (or older) runtimes 
 
-Please refer to our [transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/) to update to the latest runtimes or contact support. 
+Update to the latest runtimes by [following procedures in our transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/), or by contacting support.
 
-The new runtimes provide many customer benefits that cannot be replicated in the legacy runtime environment, including but not limited to: 
-- The elimination of security CVE findings that cannot be resolved due to the legacy runtime design and backward compatibility requirements of the Containerized Private Minion (CPM)
-- Support for newer Chrome and Node.js versions, including easier upgrade paths
-- More frequent browser version updates
-- Access to newer capabilities, such as device emulation
+The new runtimes improve on our legacy runtime environment, including but not limited to these changes:  
+
+    - Updating to the new runtime will remove certain CVE findings that cannot be resolved with legacy runtime environments. The legacy runtime design and Containerized Private Minion (CPM) include deprecated technologies that may trigger CVE findings that cannot be resolved without impacting the functionality of legacy runtimes.
+    - Support for newer Chrome and Node.js versions, including easier upgrade paths
+    - More frequent browser version updates
+    - Access device emulation and other new capabilities 
 
 ## What you need to do:
+
 **All customers must be on the new runtime by October 22, 2024 in order to prevent synthetic monitoring degradation from occurring.**
 
+Below are instructions for updating your public and private locations. 
+
 ### For public locations:
-1. New Relic will upgrade all broken link and certificate check monitors to the new runtime
-2. Customers should upgrade their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 22, 2024. If not, we will upgrade your monitors to the new runtime **which may result in check failures and triggered alerts.**
-    - Remember to use the test results from the runtime upgrade UI to determine which monitors may require modifications before being upgraded to the new runtime.
-3. Customers will be unable to create new monitors using legacy runtimes on public locations as of June 30, 2024.
+
+1. New Relic will update all broken link and certificate check monitors to the new runtime.
+1. Customers should update their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 22, 2024. 
+   - If you do not update, we’ll force update your monitors to the new runtime on the EOL date. **This may result in check failures and triggered alerts.**
+   - Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
+1. As of June 30, 2024, customers will be unable to create new monitors using legacy runtimes on public locations.
 
 ### For private locations:
-1. Customers should [upgrade to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), that allows support of our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
-2. Once on the new job manager, customers should upgrade their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. If not, we will upgrade monitors to the new runtime, **which may result in check failures and triggered alerts.**
-    - Remember to use the test results from the runtime upgrade UI to determine which monitors may require modifications before being upgraded to the new runtime.
-3. If you are using advanced features of the containerized private minion such as verified script execution (VSE), custom environment variables, or custom node modules, we anticipate support for these features will be available in Synthetics Job Manager by April 5, 2024.
-4. Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
+
+1. Customers should [update to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), which provides support for our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
+1. Once you're using the new job manager, customers should update their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. 
+   - If you do not update, we'll force update your monitors to the new runtime. **This may result in check failures and triggered alerts.**
+   - Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
+1. If you're using advanced features of the containerized private minion such as verified script execution (VSE), custom environment variables, or custom node modules, we anticipate support for these features will be available in Synthetics Job Manager by April 5, 2024.
+1. Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
 
 ## Links to additional resources:
+
 - [Runtime Transition Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/)
 - [Runtime Upgrade Troubleshooting Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting/)
 - [Runtime Upgrade UI Documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui)

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -15,10 +15,10 @@ Update to the latest runtimes by [following procedures in our transition guide](
 
 The new runtimes improve on our legacy runtime environment, including but not limited to these changes:  
 
-    - Updating to the new runtime will remove certain CVE findings that cannot be resolved with legacy runtime environments. The legacy runtime design and Containerized Private Minion (CPM) include deprecated technologies that may trigger CVE findings that cannot be resolved without impacting the functionality of legacy runtimes.
-    - Support for newer Chrome and Node.js versions, including easier upgrade paths
-    - More frequent browser version updates
-    - Access device emulation and other new capabilities 
+    * Updating to the new runtime will remove certain CVE findings that cannot be resolved with legacy runtime environments. The legacy runtime design and Containerized Private Minion (CPM) include deprecated technologies that may trigger CVE findings that cannot be resolved without impacting the functionality of legacy runtimes.
+    * Support for newer Chrome and Node.js versions, including easier upgrade paths
+    * More frequent browser version updates
+    * Access device emulation and other new capabilities 
 
 ## What you need to do:
 
@@ -30,21 +30,24 @@ Below are instructions for updating your public and private locations.
 
 1. New Relic will update all broken link and certificate check monitors to the new runtime.
 1. Customers should update their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 22, 2024. 
-   - If you do not update, we’ll force update your monitors to the new runtime on the EOL date. **This may result in check failures and triggered alerts.**
-   - Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
-1. As of June 30, 2024, customers will be unable to create new monitors using legacy runtimes on public locations.
+   * If you do not update, we’ll force update your monitors to the new runtime on the EOL date. **This may result in check failures and triggered alerts.**
+   * Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
+2. As of June 30, 2024, customers will be unable to create new monitors using legacy runtimes on public locations.
 
 ### For private locations:
 
 1. Customers should [update to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), which provides support for our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
 1. Once you're using the new job manager, customers should update their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. 
-   - If you do not update, we'll force update your monitors to the new runtime. **This may result in check failures and triggered alerts.**
-   - Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
-1. If you're using advanced features of the containerized private minion such as verified script execution (VSE), custom environment variables, or custom node modules, we anticipate support for these features will be available in Synthetics Job Manager by April 5, 2024.
-1. Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
+   * If you do not update, we'll force update your monitors to the new runtime. **This may result in check failures and triggered alerts.**
+   * Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
+2. On April 5, 2024, we added support for advanced features of the Containerized Private Minion (CPM) to the Synthetics Job Manager:
+   * Verified script execution (VSE)
+   * Custom environment variables
+   * Custom node modules
+3. Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
 
 ## Links to additional resources:
 
-- [Runtime Transition Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/)
-- [Runtime Upgrade Troubleshooting Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting/)
-- [Runtime Upgrade UI Documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui)
+* [Runtime Transition Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/)
+* [Runtime Upgrade Troubleshooting Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting/)
+* [Runtime Upgrade UI Documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui)

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -1,12 +1,12 @@
 ---
 title: 'Upgrade to the new synthetic monitor runtime to prevent impacts to your synthetic monitors'
-summary: 'Support for legacy synthetics runtimes and Containerized Private Minion will be concluded on October 9, 2024'
-releaseDate: '2024-02-21'
+summary: 'Support for legacy synthetics runtimes and Containerized Private Minion will be concluded on October 22, 2024'
+releaseDate: '2024-04-22'
 learnMoreLink: 'https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui'
 getStartedLink: ''
 ---
 
-On October 9, 2024, New Relic will end-of-life (EOL):
+On October 22, 2024, New Relic will end-of-life (EOL):
 
  * The Containerized Private Minion (CPM) capability
  * Legacy synthetics runtimes, including our legacy Chrome 72 (and older) and Node version 10 (and older) runtimes. 
@@ -20,20 +20,20 @@ The new runtimes provide many customer benefits that cannot be replicated in the
 - Access to newer capabilities, such as device emulation
 
 ## What you need to do:
-**All customers must be on the new runtime by October 9, 2024 in order to prevent synthetic monitoring degradation from occurring.**
+**All customers must be on the new runtime by October 22, 2024 in order to prevent synthetic monitoring degradation from occurring.**
 
 ### For public locations:
 1. New Relic will upgrade all broken link and certificate check monitors to the new runtime
-2. Customers should upgrade their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 9, 2024. If not, we will upgrade your monitors to the new runtime **which may result in check failures and triggered alerts.**
+2. Customers should upgrade their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 22, 2024. If not, we will upgrade your monitors to the new runtime **which may result in check failures and triggered alerts.**
     - Remember to use the test results from the runtime upgrade UI to determine which monitors may require modifications before being upgraded to the new runtime.
-3. Customers will be unable to create new monitors using legacy runtimes on public locations as of May 14, 2024.
+3. Customers will be unable to create new monitors using legacy runtimes on public locations as of June 30, 2024.
 
 ### For private locations:
 1. Customers should [upgrade to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), that allows support of our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
 2. Once on the new job manager, customers should upgrade their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. If not, we will upgrade monitors to the new runtime, **which may result in check failures and triggered alerts.**
     - Remember to use the test results from the runtime upgrade UI to determine which monitors may require modifications before being upgraded to the new runtime.
 3. If you are using advanced features of the containerized private minion such as verified script execution (VSE), custom environment variables, or custom node modules, we anticipate support for these features will be available in Synthetics Job Manager by April 5, 2024.
-4. Customers will be unable to create new monitors using legacy runtimes on private locations as of May 14, 2024.
+4. Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
 
 ## Links to additional resources:
 - [Runtime Transition Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/)

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -15,7 +15,7 @@ Update to the latest runtimes by [following procedures in our transition guide](
 
 The new runtimes improve on our legacy runtime environment, including but not limited to these changes:  
 
-* Updating to the new runtime will remove certain CVE findings that cannot be resolved with legacy runtime environments. The legacy runtime design and Containerized Private Minion (CPM) include deprecated technologies that may trigger CVE findings that cannot be resolved without impacting the functionality of legacy runtimes.
+* Updating to the new runtime will remove certain CVE findings that cannot be resolved due to  the legacy runtime design and backward compatibility requirements of the Containerized Private Minion (CPM)
 * Support for newer Chrome and Node.js versions, including easier upgrade paths
 * More frequent browser version updates
 * Access device emulation and other new capabilities 

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -8,45 +8,45 @@ getStartedLink: ''
 
 On October 22, 2024, New Relic will end-of-life (EOL):
 
-    * The Containerized Private Minion (CPM) capability
-    * Legacy synthetic monitoring runtimes, including our legacy Chrome 72 (or older) and Node version 10 (or older) runtimes 
+* The Containerized Private Minion (CPM) capability
+* Legacy synthetic monitoring runtimes, including our legacy Chrome 72 (or older) and Node version 10 (or older) runtimes 
 
 Update to the latest runtimes by [following procedures in our transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/), or by contacting support.
 
 The new runtimes improve on our legacy runtime environment, including but not limited to these changes:  
 
-    * Updating to the new runtime will remove certain CVE findings that cannot be resolved with legacy runtime environments. The legacy runtime design and Containerized Private Minion (CPM) include deprecated technologies that may trigger CVE findings that cannot be resolved without impacting the functionality of legacy runtimes.
-    * Support for newer Chrome and Node.js versions, including easier upgrade paths
-    * More frequent browser version updates
-    * Access device emulation and other new capabilities 
+* Updating to the new runtime will remove certain CVE findings that cannot be resolved with legacy runtime environments. The legacy runtime design and Containerized Private Minion (CPM) include deprecated technologies that may trigger CVE findings that cannot be resolved without impacting the functionality of legacy runtimes.
+* Support for newer Chrome and Node.js versions, including easier upgrade paths
+* More frequent browser version updates
+* Access device emulation and other new capabilities 
 
-## What you need to do:
+## What you need to do
 
 **All customers must be on the new runtime by October 22, 2024 in order to prevent synthetic monitoring degradation from occurring.**
 
-Below are instructions for updating your public and private locations. 
+Below are some notes about how the update affects your public or private locations.
 
-### For public locations:
+### For public locations
 
-1. New Relic will update all broken link and certificate check monitors to the new runtime.
-1. Customers should update their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 22, 2024. 
+* New Relic will update all broken link and certificate check monitors to the new runtime.
+* Customers should update their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 22, 2024. 
    * If you do not update, we’ll force update your monitors to the new runtime on the EOL date. **This may result in check failures and triggered alerts.**
    * Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
-2. As of June 30, 2024, customers will be unable to create new monitors using legacy runtimes on public locations.
+* As of June 30, 2024, customers will be unable to create new monitors using legacy runtimes on public locations.
 
-### For private locations:
+### For private locations
 
-1. Customers should [update to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), which provides support for our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
-1. Once you're using the new job manager, customers should update their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. 
+* Customers should [update to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), which provides support for our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
+* Once you're using the new job manager, customers should update their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. 
    * If you do not update, we'll force update your monitors to the new runtime. **This may result in check failures and triggered alerts.**
    * Remember to use the test results from the runtime upgrade UI to determine the monitors that may require modifications before updating to the new runtime.
-2. On April 5, 2024, we added support for advanced features of the Containerized Private Minion (CPM) to the Synthetics Job Manager:
+* On April 5, 2024, we added support for advanced features of the Containerized Private Minion (CPM) to the Synthetics Job Manager:
    * Verified script execution (VSE)
    * Custom environment variables
    * Custom node modules
-3. Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
+* Customers will be unable to create new monitors using legacy runtimes on private locations as of June 30, 2024.
 
-## Links to additional resources:
+## Links to additional resources
 
 * [Runtime Transition Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/)
 * [Runtime Upgrade Troubleshooting Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting/)

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -9,7 +9,7 @@ getStartedLink: ''
 On October 9, 2024, New Relic will end-of-life (EOL):
 
  * The Containerized Private Minion (CPM) capability
- * Legacy synthetics runtimes, including our legacy Chrome 72 (and older) and Node.js 10 (and older) runtimes. 
+ * Legacy synthetics runtimes, including our legacy Chrome 72 (and older) and Node version 10 (and older) runtimes. 
 
 Please refer to our [transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/) to update to the latest runtimes or contact support. 
 

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -6,7 +6,12 @@ learnMoreLink: 'https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/u
 getStartedLink: ''
 ---
 
-On October 9, 2024, New Relic will end-of-life (EOL) legacy synthetics runtimes including our legacy Chrome 72 (and older) and Node 10 (and older) Synthetics runtimes and the Containerized Private Minion (CPM). Please refer to our [transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/) to update to the latest runtimes or contact support. 
+On October 9, 2024, New Relic will end-of-life (EOL):
+
+ * The Containerized Private Minion (CPM) capability
+ * Legacy synthetics runtimes, including our legacy Chrome 72 (and older) and Node.js 10 (and older) runtimes. 
+
+Please refer to our [transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/) to update to the latest runtimes or contact support. 
 
 The new runtimes provide many customer benefits that cannot be replicated in the legacy runtime environment, including but not limited to: 
 - The elimination of security CVE findings that cannot be resolved due to the legacy runtime design and backward compatibility requirements of the Containerized Private Minion (CPM)

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -15,7 +15,7 @@ Please refer to our [transition guide](https://docs.newrelic.com/docs/synthetics
 
 The new runtimes provide many customer benefits that cannot be replicated in the legacy runtime environment, including but not limited to: 
 - The elimination of security CVE findings that cannot be resolved due to the legacy runtime design and backward compatibility requirements of the Containerized Private Minion (CPM)
-- Support for newer Chrome and Node versions, including easier upgrade paths
+- Support for newer Chrome and Node.js versions, including easier upgrade paths
 - More frequent browser version updates
 - Access to newer capabilities, such as device emulation
 

--- a/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
+++ b/src/content/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm.md
@@ -1,0 +1,36 @@
+---
+title: 'Upgrade to the new synthetic monitor runtime to prevent impacts to your synthetic monitors'
+summary: 'Support for legacy synthetics runtimes and Containerized Private Minion will be concluded on October 9, 2024'
+releaseDate: '2024-02-21'
+learnMoreLink: 'https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui'
+getStartedLink: ''
+---
+
+On October 9, 2024, New Relic will end-of-life (EOL) legacy synthetics runtimes including our legacy Chrome 72 (and older) and Node 10 (and older) Synthetics runtimes and the Containerized Private Minion (CPM). Please refer to our [transition guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/) to update to the latest runtimes or contact support. 
+
+The new runtimes provide many customer benefits that cannot be replicated in the legacy runtime environment, including but not limited to: 
+- The elimination of security CVE findings that cannot be resolved due to the legacy runtime design and backward compatibility requirements of the Containerized Private Minion (CPM)
+- Support for newer Chrome and Node versions, including easier upgrade paths
+- More frequent browser version updates
+- Access to newer capabilities, such as device emulation
+
+## What you need to do:
+**All customers must be on the new runtime by October 9, 2024 in order to prevent synthetic monitoring degradation from occurring.**
+
+### For public locations:
+1. New Relic will upgrade all broken link and certificate check monitors to the new runtime
+2. Customers should upgrade their scripted API, scripted browser, and step monitors to the new runtime [using the runtime upgrade UI](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui) before October 9, 2024. If not, we will upgrade your monitors to the new runtime **which may result in check failures and triggered alerts.**
+    - Remember to use the test results from the runtime upgrade UI to determine which monitors may require modifications before being upgraded to the new runtime.
+3. Customers will be unable to create new monitors using legacy runtimes on public locations as of May 14, 2024.
+
+### For private locations:
+1. Customers should [upgrade to our new job manager](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/), that allows support of our new runtime on private locations. **If not, your monitors will stop running at the EOL date.**
+2. Once on the new job manager, customers should upgrade their monitors to the new runtime using the runtime upgrade UI. This includes all non-ping monitor types. If not, we will upgrade monitors to the new runtime, **which may result in check failures and triggered alerts.**
+    - Remember to use the test results from the runtime upgrade UI to determine which monitors may require modifications before being upgraded to the new runtime.
+3. If you are using advanced features of the containerized private minion such as verified script execution (VSE), custom environment variables, or custom node modules, we anticipate support for these features will be available in Synthetics Job Manager by April 5, 2024.
+4. Customers will be unable to create new monitors using legacy runtimes on private locations as of May 14, 2024.
+
+## Links to additional resources:
+- [Runtime Transition Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime/)
+- [Runtime Upgrade Troubleshooting Guide](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting/)
+- [Runtime Upgrade UI Documentation](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui)


### PR DESCRIPTION
Adding what's new post to announce the EOL of legacy synthetics runtimes and Containerized Private Minion on October 9th, 2024. To be published on April 9th.
