### PR TITLE
Update name-your-php-application.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/name-your-php-application.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/name-your-php-application.mdx
@@ -27,10 +27,6 @@ Here are the ways to change your PHP application's name in New Relic:
 
 ## Use multiple app names [#multiple]
 
-<Callout variant="important">
-  The ability to set multiple app names is only available in PHP agent versions 2.4 or higher.
-</Callout>
-
 You can use multiple app names to aggregate data from several applications under the same name in APM (sometimes referred to as "rolling up" your data). For more about how multiple app names work, see [Use multiple app names](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app).
 
 For PHP, you can set up to three application names. The primary application name is first, and the second and third names are used for the more general data aggregation categories.


### PR DESCRIPTION
Removed the note about multiple app naming being available only in PHP agent versions 2.4 or higher. Since versions below PHP agent 5.0 can no longer connect to New Relic, it's no longer necessary to call this out.

Reference:

https://forum.newrelic.com/s/hubtopic/aAX8W0000008aBMWAY/important-upcoming-changes-to-supported-agent-versions

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.