### PR TITLE
Update php-directory-ini-settings.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-directory-ini-settings.mdx
@@ -269,6 +269,3 @@ newrelic.appname="Virtual Host 1;All Virtual Hosts"
 
 This will report to two New Relic applications: "Virtual Host 1" and "All Virtual Hosts".
 
-<Callout variant="important">
-  This feature is only available in versions 2.4 or higher of the PHP agent.
-</Callout>


### PR DESCRIPTION
Removed the note about multiple app naming being available only in PHP agent versions 2.4 or higher. Since versions below PHP agent 5.0 can no longer connect to New Relic, it's no longer necessary to call this out.

Reference:

https://forum.newrelic.com/s/hubtopic/aAX8W0000008aBMWAY/important-upcoming-changes-to-supported-agent-versions

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.