### PR TITLE
Fix broken links pr

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-ai-monitoring.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-ai-monitoring.mdx
@@ -6,12 +6,14 @@ tags:
   - API guides
 metaDescription: 'For information about customizing New Relic''s Ruby agent for AI monitoring.'
 freshnessValidatedDate: never
+redirects:
+    - /docs/apm/agents/ruby-agent/api-guides/ruby-ai-monitoring-apis
 ---
 
 When you've instrumented your app for AI monitoring, the New Relic Ruby agent automatically collects many AI metrics, but also provides APIs for collecting information on token count and user feedback.
 
 <Callout variant="tip">
-  AI monitoring APIs are available in Ruby agent version 9.8.0 and higher.
+    AI monitoring APIs are available in Ruby agent version 9.8.0 and higher.
 </Callout>
 
 ## Token count [#token-count]

--- a/src/content/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -22,18 +22,17 @@ Browser API used to start agent features when running in a deferred state.
 ## Requirements
 
 * Browser Lite, Pro, or Pro+SPA agent (v1.239.0 or higher)
- 
- <Callout variant="important">
-The configuration required to use this API is not currently connected to the larger deployment system within New Relic. As such, calling this API will only have an effect in copy/paste or npm browser installations until further changes are made.
- </Callout>
-
+  
+  <Callout variant="important">
+  The configuration required to use this API is not currently connected to the larger deployment system within New Relic. As such, calling this API will only have an effect in copy/paste or npm browser installations until further changes are made.
+  </Callout>
 
 ## Description
 
-Features can be loaded in a `deferred` state, which can be controlled by setting the appropriate features' `autoStart` property to `false` in the configuration block `NREUM.init.<feature>` used by the agent. This feature state means events will be observed and stored in the agent, but *will not be harvested to NR1 until told to do so* with the `.start()` API method. See [Feature Names]('#feature-names') for a list of feature names. See [Examples]('#examples') for examples showing how to set features into a deferred state.
+Features can be loaded in a `deferred` state, which can be controlled by setting the appropriate features' `autoStart` property to `false` in the configuration block `NREUM.init.<feature>` used by the agent. This feature state means events will be observed and stored in the agent, but *will not be harvested to NR1 until told to do so* with the `.start()` API method. See [Feature Names](#feature-names) for a list of feature names. See [Examples](#examples) for examples showing how to set features into a deferred state.
 
 Upon executing this function with a valid value, the browser agent will start the relevant features that have been deferred by the `autoStart: false` configuration. If called with no arguments, the method will start all features that have been deferred.
-If called with a list of strings representing the feature names, the feature names matching the strings will be started.  See [Feature Names]('#feature-names') for a list of feature names.
+If called with a list of strings representing the feature names, the feature names matching the strings will be started.  See [Feature Names](#feature-names) for a list of feature names.
 
 ## Parameters
 


### PR DESCRIPTION
This fixes broken links in a browser doc and an incorrect file name in our ruby API doc for ai monitoring