### PR TITLE
chore: Add Ruby agent team codeowners to Ruby docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,5 +14,7 @@ yarn.lock @newrelic/docs-engineering
 /scripts/ @newrelic/docs-engineering
 
 # Whats new files (pings individual project marketing managers)
-
 /src/content/whats-new/ @john-withers @aalfano7
+
+# Ruby agent docs
+**/ruby* @newrelic/ruby-agent


### PR DESCRIPTION
The Ruby agent team uses automation to update the agent's [configuration documentation](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/) during our release process. 

We added a "CONTRIBUTORS_NOTE" component to the file to redirect anyone editing the file to the Ruby agent team to make sure their changes were reflected in the code that automatically generates the doc. Recently, we noticed some edits made directly to the file that were overwritten by our automation. As a result, we'd like to add a little more protection to the config file. 

When we initially discussed the problem, [one of the ideas shared](https://newrelic.slack.com/archives/C0DSGL3FZ/p1686244364806549?thread_ts=1686240002.722739&cid=C0DSGL3FZ) to add a little protection was to add a codeowner for this file.

This PR adds @newrelic/ruby-agent team to notifications whenever a file from a directory with "ruby" in the name is changed. Also, it removes an extra space from the "Whats new" section.

This solution is quite broad. It also includes the full Ruby agent team, including managers. 

Alternatively, we could start with notifying specific engineers or scope the notification just to the configuration file. We're open to alternative approaches and solutions.

`@newrelic/ruby-agent` is an alias the currently exists, but given the CODEOWNERS file error, the team might need specific write permissions to resolve it.