### PR TITLE
Add data consumption section to session-replay.mdx

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay.mdx
@@ -46,12 +46,21 @@ Session replay works by taking a snapshot of the end-user's DOM (Document Object
 
 ## Impact of session replay [#session-replay-impact]
 
-### User data and security concerns [#data-security]
+### User privacy and security concerns [#data-security]
 
 We take data privacy seriously, so we built session replay with:
 
+* <DoNotTranslate>**Robust default privacy settings**</DoNotTranslate>: Session replay includes default privacy settings designed to limit the potential sharing of sensitive customer information. These settings [can be further customized](#configure-privacy-settings) to meet specific privacy requirements.
+
+### Data consumption [#view-consumption]
+
+Session replay follows the same consumption pricing as your other Browser bytes. The amount of bytes produced depends on the count, length, and user-activity levels of sessions, as well as the complexity of your site's DOM.
+
 * <DoNotTranslate>**Minimal data storage**</DoNotTranslate>: Session replay does not store screenshots or videos. It only records the essential DOM state changes required to recreate the user's experience. This results in a much smaller amount of data being stored.
-* <DoNotTranslate>**Robust default privacy settings**</DoNotTranslate>: Session replay includes default privacy settings designed to limit the potential sharing of sensitive customer information. These settings can be further customized to meet specific privacy requirements.
+* <DoNotTranslate>**Manage costs**</DoNotTranslate>: You can control your spend by [adjusting your sampling rates](#configure-sampling-rates). The most accurate way to project your cost per replay is to enable the feature for a short test period and measure your actual consumption. Alternatively, 5.3 MB per replay is an average that can be used for rough approximation, just be aware your actual cost may vary significantly.
+	  * During the limited preview when session replay bytes are free and therefore not shown in the [data ingest UI](https://docs.newrelic.com/docs/data-apis/manage-data/manage-data-coming-new-relic/#ui), we've made this data available by clicking <DoNotTranslate>**View your account's consumption**</DoNotTranslate> in the <DoNotTranslate>**Session replay > Session sample size**</DoNotTranslate> section of <DoNotTranslate>**Browser > Your application > Application Settings **</DoNotTranslate> page.
+    * A simple formula to project your approximate costs is: `sessions` * `sampling_rate` * `gb_per_replay` * `cost_per_gb`
+	  * Example: `sessions: 1 million` * `sampling_rate: 5%` * `gb_per_replay: 0.0053` * `cost_per_gb: $0.30` = $79.50 for 50,000 replays
 
 ### App performance [#performance-impact]
 


### PR DESCRIPTION
Added instructions for viewing consumption during the Limited Preview and projecting costs based on that date.

Also made a small edit to add an anchor link to the 'Configure privacy settings' details from the 'Impact of session replay / User privacy and security concerns' section.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.