### PR TITLE
DOESN'T NEED A REVIEW YET - Add user-facing documentation for custom node modules feature

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
@@ -11,6 +11,7 @@ freshnessValidatedDate: never
 
 This doc will guide you through configuring your [synthetics job manager](/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager) by showing you how to: 
 		
+* Set up [custom modules](#custom-modules) for [scripted API](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/) or [scripted browser](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) monitors.
 * Provide [user-defined variables](#user-defined-vars) in your configuration.
 * Update other [environment-variables](#environment-variables) when launching your synthetics job manager.
 		
@@ -98,6 +99,114 @@ For example, `$env.USER_DEFINED_VARIABLES.MY_VARIABLE`
 	
 <Callout variant="caution">
 User-defined environment variables are not sanitized from logs. Consider using the [secure credentials](/docs/synthetics/new-relic-synthetics/using-monitors/secure-credentials-store-credentials-information-scripted-browsers) feature for sensitive information.
+</Callout>
+
+## Custom node modules [#custom-modules]
+
+Custom node modules are provided in both CPM and SJM. They allow you to create a customized set of [node modules](https://docs.npmjs.com/about-packages-and-modules) and use them in scripted monitors (scripted API and scripted browser) for synthetic monitoring.
+
+To set up the modules: 
+
+1. Create a directory with a `package.json` file following [npm official guidelines](https://docs.npmjs.com/files/package.json) in the root folder. The SJM will install any dependencies listed in the package.json's `dependencies` field. These dependencies will be available when running monitors on the private synthetics job manager.
+
+  Optionally, you can override the `package.json` file at the root level with a directory specific to a [Node.js version](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment). This allows you to update a script per monitor runtime if a specific Node.js version becomes incompatible with your dependencies. See an example of this below.
+
+<CollapserGroup id="custom-module-dir">
+     <Collapser
+       id="example-module-directory"
+       title="Custom module directory"
+     >
+       In this example, a custom module directory is used with the following structure:
+
+       ```
+       /example-custom-modules-dir/
+             ├── counter
+             │   ├── index.js
+             │   └── package.json
+             └── package.json            ⇦ the only mandatory file
+       ```
+
+       The `package.json` defines `dependencies` as both a local module (for example, `counter`) and any hosted modules (for example, `smallest` version `1.0.1`):
+
+       ```
+       {
+             "name": "custom-modules",
+             "version": "1.0.0",           ⇦ optional
+             "description": "example custom modules directory", ⇦ optional
+             "dependencies": {
+               "smallest": "1.0.1",          ⇦ hosted module
+               "counter": "file:./counter" ⇦ local module
+             }
+           }
+       ```
+</Collapser>
+
+<Collapser
+       id="example-overrides"
+       title="Node.js version-specific overrides"
+     >
+       To update a monitor script per monitor runtime in case the Node.js version becomes incompatible with your dependencies, you can create a `package.json` file specific to each Node.js version. This version-specific package.json will override the root level `package.json`. You can still define local modules within the version specific directory, as shown in the [first example](#example-module-directory). If a `package.json` is not defined for a particular [Node.js version](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment), the dependencies will be installed based on the root level `package.json`. This approach provides flexibility to tailor dependencies based on different Node.js versions.
+
+       In this example, a custom module directory is used with the following structure:
+
+       ```
+       /example-custom-modules-dir/
+             ├── 6.11.2            ⇦ optional Node.js specific directory
+             │   └── package.json
+             └── 10.15.0           ⇦ optional Node.js specific directory
+             │   └── package.json
+             ├── counter
+             │   ├── index.js
+             │   └── package.json
+             └── package.json      ⇦ the only mandatory file
+         ​
+       ```
+     </Collapser>
+   </CollapserGroup>
+
+2. Once you create the custom modules directory and the `package.json` you can apply it to your SJM for Docker and Kubernetes. 
+
+   <CollapserGroup id="apply-to-docker-kubernetes">
+     <Collapser
+       id="docker"
+       title="Docker"
+     >
+       For Docker, launch SJM mounting the directory at `/var/lib/newrelic/synthetics/modules`. For example:
+
+       ```
+       docker run ... -v /example-custom-modules-dir:/var/lib/newrelic/synthetics/modules:rw ...
+       ```
+     </Collapser>
+
+<Collapser
+       id="kubernetes"
+       title="Kubernetes"
+     >
+       Complete the following:
+
+       1. Launch the SJM, setting a value for the `persistence.customModules` configuration value either in the command line or in a YAML file during installation. The value should specify the subpath on your synthetics job manager Persistent Volume where your custom modules files exist. For example:
+
+          ```
+          helm install ... --set persistence.customModules=<custom-modules-subpath> ...
+          ```
+       2. Make sure that your custom modules directory is available on the Minion Pod. You can use `kubectl cp` as one method to copy the directory from your host to the Minion. For example:
+
+          ```
+          kubectl cp /example-custom-modules-dir <namespace>/<pod_name>:/var/lib/newrelic/synthetics/modules
+          ```
+     </Collapser>
+   </CollapserGroup>
+
+3. To check if the modules were installed correctly or if any errors occurred, review the [SJM logs](/docs/synthetics/new-relic-synthetics/private-locations/job-manager-maintenance-monitoring#monitor-docker-logs) for the section titled `"... Initialization of Custom Modules ..."`. These logs will include the npm installation logs, providing information regarding the installation process and any potential errors encountered.
+
+Now you can add “require(‘smallest’);” into the [script](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) of monitors you send to this private location.
+
+### Change `package.json` for custom modules [#change-package-json]
+
+In addition to local and hosted modules, you can utilize [Node.js modules](/docs/synthetics/new-relic-synthetics/scripting-monitors/import-nodejs-modules) as well. To update the custom modules used by your SJM, make changes to the `package.json` file, and restart the SJM. During the reboot process, the SJM will recognize the configuration change and automatically perform cleanup and re-installation operations to ensure the updated modules are applied.
+
+<Callout variant="caution">
+  Local modules: While your `package.json` can include any local module, these modules must reside inside the tree under your custom module directory. If stored outside the tree, the initialization process will fail and you will see an error message in the [docker logs](/docs/synthetics/new-relic-synthetics/private-locations/job-manager-maintenance-monitoring#monitor-docker-logs) after launching SJM.
 </Callout>
 
 ## Permanent data storage [#permanent-data-storage]

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
@@ -107,9 +107,7 @@ Custom node modules are provided in both CPM and SJM. They allow you to create a
 
 To set up the modules: 
 
-1. Create a directory with a `package.json` file following [npm official guidelines](https://docs.npmjs.com/files/package.json) in the root folder. The SJM will install any dependencies listed in the package.json's `dependencies` field. These dependencies will be available when running monitors on the private synthetics job manager.
-
-  Optionally, you can override the `package.json` file at the root level with a directory specific to a [Node.js version](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment). This allows you to update a script per monitor runtime if a specific Node.js version becomes incompatible with your dependencies. See an example of this below.
+1. Create a directory with a `package.json` file following [npm official guidelines](https://docs.npmjs.com/files/package.json) in the root folder. The SJM will install any dependencies listed in the package.json's `dependencies` field. These dependencies will be available when running monitors on the private synthetics job manager. See an example of this below.
 
 <CollapserGroup id="custom-module-dir">
      <Collapser
@@ -140,29 +138,6 @@ To set up the modules:
            }
        ```
 </Collapser>
-
-<Collapser
-       id="example-overrides"
-       title="Node.js version-specific overrides"
-     >
-       To update a monitor script per monitor runtime in case the Node.js version becomes incompatible with your dependencies, you can create a `package.json` file specific to each Node.js version. This version-specific package.json will override the root level `package.json`. You can still define local modules within the version specific directory, as shown in the [first example](#example-module-directory). If a `package.json` is not defined for a particular [Node.js version](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment), the dependencies will be installed based on the root level `package.json`. This approach provides flexibility to tailor dependencies based on different Node.js versions.
-
-       In this example, a custom module directory is used with the following structure:
-
-       ```
-       /example-custom-modules-dir/
-             ├── 6.11.2            ⇦ optional Node.js specific directory
-             │   └── package.json
-             └── 10.15.0           ⇦ optional Node.js specific directory
-             │   └── package.json
-             ├── counter
-             │   ├── index.js
-             │   └── package.json
-             └── package.json      ⇦ the only mandatory file
-         ​
-       ```
-     </Collapser>
-   </CollapserGroup>
 
 2. Once you create the custom modules directory and the `package.json` you can apply it to your SJM for Docker and Kubernetes. 
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
Adds user-facing documentation for the custom node modules feature for private Synthetics Job Managers.

## Note: This PR doesn't need a review yet since the feature hasn't been pushed out to production yet. Will ping the docs hero once the feature is out into production. 