### PR TITLE
Update introduction-aws-integrations.mdx

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations.mdx
@@ -31,11 +31,9 @@ In order to obtain AWS data, follow the procedure to [connect AWS to New Relic](
 
 Additional <DoNotTranslate>**API Polling**</DoNotTranslate> integrations can be enabled on top of the AWS CloudWatch metric streams in order to pull data that's not available as CloudWatch metrics. The following integrations are not replaced by the metric streams:
 
-* AWS Billing
 * AWS CloudTrail
 * AWS Health
 * AWS Trusted Advisor
-* AWS VPC
 * AWS X-Ray
 
 Finally, other integrations may require additional configurations in your AWS account:


### PR DESCRIPTION
Removing AWS Billing and AWS VPC from the list of services that are not supported by AWS CloudWatch Metric Streams. Please merge these changes.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.