### PR TITLE
Revert theme change

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.4.4",
+    "@newrelic/gatsby-theme-newrelic": "9.4.5",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,10 +3629,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.4.4":
-  version "9.4.4"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.4.4.tgz#3aac22be3bb9bb3d8f5fb277378319c4c2d1b59f"
-  integrity sha512-otD9wrfTh0dy22urcLU+d3vA0N8jFDwu03NWUfG5vT0tbRzNzRon4/rGU+bS6Gvb9hiwQs5J9vCmWL6Q3Xp6Rg==
+"@newrelic/gatsby-theme-newrelic@9.4.5":
+  version "9.4.5"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.4.5.tgz#513a2693bc470c0869715d023569cde953342c47"
+  integrity sha512-2STTQ3mIXDl+Bon3z834BJMqzPpsI6eG/690Tb1bHVSDLQJxL28OAxtc3rbwk032uCkyBV0i+nNP9hVAWtt2FQ==
   dependencies:
     "@segment/analytics-next" "1.63.0"
     "@wry/equality" "^0.4.0"


### PR DESCRIPTION
After merging a theme update localized links no longer show up as external but have an odd prefix. This reverts that theme update which means localized links will appear external again but will at least be functional