### PR TITLE
fix(NRQL): address fixes from a #help-documentation request

### DIFF
--- a/src/content/docs/nrql/using-nrql/rate-function.mdx
+++ b/src/content/docs/nrql/using-nrql/rate-function.mdx
@@ -95,7 +95,7 @@ Here's an example query that will return the change in duration per second for t
 
   <Collapser
       id="average-appname-errors"
-      title="Average errors over the last 30 minutes by appName"
+      title="Average errors over the past 30 minutes by appName"
     >
       If you want to view errors by application, you can `FACET` by `appName`. This example shows how you can identify the average errors by application over the past hour:
 

--- a/src/content/docs/nrql/using-nrql/rate-function.mdx
+++ b/src/content/docs/nrql/using-nrql/rate-function.mdx
@@ -95,7 +95,7 @@ Here's an example query that will return the change in duration per second for t
 
   <Collapser
       id="average-appname-errors"
-      title="Average errors over the past hour by appName"
+      title="Average errors over the last 30 minutes by appName"
     >
       If you want to view errors by application, you can `FACET` by `appName`. This example shows how you can identify the average errors by application over the past hour:
 


### PR DESCRIPTION
Requests:

* The first is a warning that when [FACETing by time](https://docs.newrelic.com/docs/nrql/nrql-references/nrql-group-results-across-time/#cohorts), or when using a time function in the WHERE clause, the rate() function will still return data for the entire time range specified.  FACET and WHERE do not scope the data down.
* The second is just a typo.  In the [last example](https://docs.newrelic.com/docs/nrql/using-nrql/rate-function/#average-appname-errors) it should say "over the past half hour" not "over the past hour".