### PR TITLE
theme bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.4.5",
+    "@newrelic/gatsby-theme-newrelic": "9.4.6",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,10 +3629,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.4.5":
-  version "9.4.5"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.4.5.tgz#513a2693bc470c0869715d023569cde953342c47"
-  integrity sha512-2STTQ3mIXDl+Bon3z834BJMqzPpsI6eG/690Tb1bHVSDLQJxL28OAxtc3rbwk032uCkyBV0i+nNP9hVAWtt2FQ==
+"@newrelic/gatsby-theme-newrelic@9.4.6":
+  version "9.4.6"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.4.6.tgz#9a4c66e7590640b35daf1c482bac9b2d48e8b798"
+  integrity sha512-aJsrYaYPHsBXFBqYCqeCe6qq93TqdmwvtgWjUuxE96H+BmiE317+vlS7wh3p/VKPCieeyM9R3lhanae5yXyJcg==
   dependencies:
     "@segment/analytics-next" "1.63.0"
     "@wry/equality" "^0.4.0"


### PR DESCRIPTION
Some line height adjustments from theme updates [here](https://github.com/newrelic/gatsby-theme-newrelic/pull/1040) and [here](https://github.com/newrelic/gatsby-theme-newrelic/pull/1037) for some more examples
 - ### table of contents items
<img width="237" alt="Screenshot 2024-04-05 at 11 18 01 AM" src="https://github.com/newrelic/docs-website/assets/47728020/1b30fd53-b310-4c9b-a0a8-79964578bf0c">

 - ### code block lines
<img width="500" alt="Screenshot 2024-04-05 at 11 19 29 AM" src="https://github.com/newrelic/docs-website/assets/47728020/cd9cadae-4768-4ed1-b208-d05b8165456a">

 - ### h2's
<img width="500" alt="Screenshot 2024-04-05 at 11 18 17 AM" src="https://github.com/newrelic/docs-website/assets/47728020/538b3433-1626-4940-8446-166f585e0557">

[inline code in h2](https://deploy-preview-16818--docs-website-netlify.netlify.app/docs/ai-monitoring/drop-sensitive-data/)
<img width="500" alt="Screenshot 2024-04-05 at 11 16 58 AM" src="https://github.com/newrelic/docs-website/assets/47728020/126edb44-4ff6-4fff-bc34-f50a88fa5210">
