### PR TITLE
fix: typos and codeblocks

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -439,6 +439,7 @@ module.exports = {
             'md',
             'java',
             'razor',
+            'hcl'
           ],
         },
         newrelic: {

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -435,14 +435,14 @@ What you use for the log source depends on the location your logs are sourced fr
               logtype: windows_system
 
         # Example/Optional entry for Windows Defender Logs
-        #- name: windows-defender
-        #  winlog:
-        #    channel: Microsoft-Windows-Windows Defender/Operational
+        - name: windows-defender
+          winlog:
+            channel: Microsoft-Windows-Windows Defender/Operational
 
         # Example/Optional entry for Windows Clustering Logs
-        #- name: windows-clustering
-        #  winlog:
-        #    channel: Microsoft-Windows-FailoverClustering/Operational
+        - name: windows-clustering
+          winlog:
+            channel: Microsoft-Windows-FailoverClustering/Operational
       ```
   </Collapser>
 </CollapserGroup>
@@ -622,12 +622,12 @@ Although these configuration parameters aren't required, we still recommend you 
 
 ### Sample configuration file [#running-modes]
 
-Here is an example of a `logging.d/` configuration file in YAML format. For more configuration examples, [see the infrastructure agent repository](https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging).
+Here is an example of a `logging.d` configuration file in YAML format. For more configuration examples, [see the infrastructure agent repository](https://github.com/newrelic/infrastructure-agent/tree/master/assets/examples/logging).
 
 <CollapserGroup>
   <Collapser
     id="configuration-file"
-    title="logging.d/ sample.yaml"
+    title="logging.d/sample.yaml"
   >
     ```yml
     # Remember to only use spaces for indentation
@@ -636,10 +636,10 @@ Here is an example of a `logging.d/` configuration file in YAML format. For more
       # Example of 'file' source
       - name: file-with-attributes
         file: /var/log/test.log # Path to a single file or pattern
-        attributes: # You can use custom attributes to enrich your data
+        attributes:             # You can use custom attributes to enrich your data
           logtype: nginx
           team: The A Team
-        pattern: Error # Regular expression to filter log entries
+        pattern: Error          # Regular expression to filter log entries
 
       # Example of 'systemd' source (Linux only)
       - name: systemd-example
@@ -650,7 +650,7 @@ Here is an example of a `logging.d/` configuration file in YAML format. For more
       - name: syslog-tcp-test
         syslog:
           uri: tcp://0.0.0.0:5140 # Use the tcp://LISTEN_ADDRESS:PORT format
-          parser: rfc5424 # Default syslog parser is rfc3164
+          parser: rfc5424         # Default syslog parser is rfc3164
       # UDP network socket
       - name: syslog-udp-test
         syslog:
@@ -674,9 +674,9 @@ Here is an example of a `logging.d/` configuration file in YAML format. For more
       - name: tcp-simple-test
         tcp:
           uri: tcp://0.0.0.0:1234 # Use the tcp://LISTEN_ADDRESS:PORT format
-          format: none # Raw text - this is default for 'tcp'
-          separator: \t # String for separating raw text entries
-        attributes: # You can add custom attributes to any source of logs
+          format: none            # Raw text - this is default for 'tcp'
+          separator: \t           # String for separating raw text entries
+        attributes:               # You can add custom attributes to any source of logs
           tcpFormat: none
           someOtherAttribute: associatedValue
         max_line_kb: 32
@@ -796,7 +796,7 @@ Our custom Linux installation process for infrastructure monitoring allows you t
 2. Download and install New Relic's [fluent-bit-package (RPM)](https://github.com/newrelic/fluent-bit-package/releases) by running a command similar to:
 
     ```shell
-    yum localinstall fluent-bit-<some-version>.rpm`
+    yum localinstall fluent-bit-<some-version>.rpm
     ```
 
 3. Download New Relic's [fluentbit plugin](https://github.com/newrelic/newrelic-fluent-bit-output/releases) and save it as `/var/db/newrelic-infra/newrelic-integrations/logging/out_newrelic.so`.
@@ -831,12 +831,12 @@ If you encounter problems with configuring your log forwarder, try these trouble
 
     ```bash
     sudo -u nri-agent namei -ml /var/log/restrictedLogs/logFile.log
-    f: /var/log/restrictedLogs/logFile.log
-    drwxr-xr-x root root /
-    drwxr-xr-x root root var
-    drwxrwxr-x root syslog log
-    drwxr--r-- root root restrictedLogs
-    logFile.log - No such file or directory
+    [output] f: /var/log/restrictedLogs/logFile.log
+    [output] drwxr-xr-x root root /
+    [output] drwxr-xr-x root root var
+    [output] drwxrwxr-x root syslog log
+    [output] drwxr--r-- root root restrictedLogs
+    [output] logFile.log - No such file or directory
     ```
 
     This command failed because the file is not visible to the `nri-agent` user. By inspecting the previous output, we can detect that the `restrictedLogs` directory is missing the execution flag for `others`.
@@ -850,20 +850,20 @@ If you encounter problems with configuring your log forwarder, try these trouble
     And then check for file access again:
 
     ```bash
-    # sudo -u nri-agent namei -ml /var/log/restrictedLogs/logFile.log
-    f: /var/log/restrictedLogs/logFile.log
-    drwxr-xr-x root root /
-    drwxr-xr-x root root var
-    drwxrwxr-x root syslog log
-    drwxr-xr-x root root restrictedLogs
-    -rw-r----- vagrant vagrant logFile.log
+    sudo -u nri-agent namei -ml /var/log/restrictedLogs/logFile.log
+    [output] f: /var/log/restrictedLogs/logFile.log
+    [output] rwxr-xr-x root root /
+    [output] drwxr-xr-x root root var
+    [output] drwxrwxr-x root syslog log
+    [output] drwxr-xr-x root root restrictedLogs
+    [output] -rw-r----- vagrant vagrant logFile.log
     ```
 
     The file is now visible to the `nri-agent` user. You must ensure that the file is also readable by the `nri-agent` user. To check this, use:
 
     ```bash
-    # sudo -u nri-agent head /var/log/restrictedLogs/logFile.log
-    head: cannot open '/var/log/restrictedLogs/logFile.log' for reading: Permission denied
+    sudo -u nri-agent head /var/log/restrictedLogs/logFile.log
+    [output] head: cannot open '/var/log/restrictedLogs/logFile.log' for reading: Permission denied
     ```
 
     In this example, the file is missing the read rights for the `others` group (users other than `vagrant` and the `vagrant` user group). You could fix this by granting read permissions to `others`, but the application could change these permissions upon restart.
@@ -923,7 +923,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
       You can check the certificates by running:
 
       ```bash
-      # openssl s_client -connect log-api.newrelic.com:443 -servername log-api.newrelic.com
+      openssl s_client -connect log-api.newrelic.com:443 -servername log-api.newrelic.com
       ```
   </Collapser>
 
@@ -944,9 +944,9 @@ If you encounter problems with configuring your log forwarder, try these trouble
     2. Enable logs forwarding to New Relic by adding the following config snippet:
        ```yml
        log:
-         level: trace # Recommended: Helps with troubleshooting
+         level: trace  # Recommended: Helps with troubleshooting
          forward: true # Enables sending logs to New Relic
-         format: json # Recommended: Enable agent logging in JSON format
+         format: json  # Recommended: Enable agent logging in JSON format
          stdout: false # On Windows and systems that don't use `systemd` or where `journald` is inaccessible
        ```
     3. [Restart the agent](/docs/infrastructure/new-relic-infrastructure/configuration/start-stop-restart-check-infrastructure-agent-status) to load the new settings.
@@ -971,7 +971,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
        log:
          level: trace
          forward: true # Enables sending logs to New Relic
-         format: json # Recommended: Enable agent logging in JSON format
+         format: json  # Recommended: Enable agent logging in JSON format
          stdout: false # On Windows and systems that don't use `systemd` or where `journald` is inaccessible
          include_filters:
            traces:
@@ -1063,7 +1063,7 @@ The following instructions summarize how to increase these limits if you want to
 2. Add the following line to `/etc/security/limits.conf`. We specified a limit of `10100` here instead of just `10000` to allow Fluent Bit to allocate the extra file descriptors it may need to work.
 
    ```bash
-   root    soft    nofile  10100  # replace root by nri-agent for non-root (privileged and unprivileged) installations
+   root soft nofile 10100 # replace root by nri-agent for non-root (privileged and unprivileged) installations
    ```
 
 3. Add the following line to `/etc/pam.d/common-session` so that the previous limit is applied upon restart:
@@ -1083,8 +1083,8 @@ The following instructions summarize how to increase these limits if you want to
 6. Ensure that the new limits have been enforced by running:
 
    ```bash
-   ulimit -Sn                                    # Should return 10100
-   cat /proc/sys/fs/inotify/max_user_watches     # Should return 18192
+   ulimit -Sn                                 # Should return 10100
+   cat /proc/sys/fs/inotify/max_user_watches  # Should return 18192
    ```
 
    [Learn more on how to increase open file limits](https://tecadmin.net/increase-open-files-limit-ubuntu/), or on [how to increase the inotify watches](https://dev.to/rubiin/ubuntu-increase-inotify-watcher-file-watch-limit-kf4).

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -852,7 +852,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
     ```bash
     sudo -u nri-agent namei -ml /var/log/restrictedLogs/logFile.log
     [output] f: /var/log/restrictedLogs/logFile.log
-    [output] rwxr-xr-x root root /
+    [output] drwxr-xr-x root root /
     [output] drwxr-xr-x root root var
     [output] drwxrwxr-x root syslog log
     [output] drwxr-xr-x root root restrictedLogs

--- a/src/content/docs/more-integrations/terraform/terraform-modules.mdx
+++ b/src/content/docs/more-integrations/terraform/terraform-modules.mdx
@@ -48,7 +48,7 @@ mkdir HostConditions && cd HostConditions
 touch main.tf
 ```
 
-Remove the two alert conditions from the root project's `main.tf` file and copy it to the new `main.tf` file in the HostConditions directory.
+Remove the two alert conditions from the root project's `main.tf` file and copy it to the new `main.tf` file in the `HostConditions` directory.
 
 In the root directory's `main.tf` file call the new module using a module block:
 ```hcl
@@ -89,7 +89,7 @@ Try testing your configurations, run `terraform plan` and
 [output] Module directory  does not exist or cannot be read.
 ```
 
-You see an error in your console due to the lack of provider details in your modules directory. To fix the error, create a copy of the root provider.tf in your HostConditions directory :
+You see an error in your console due to the lack of provider details in your modules directory. To fix the error, create a copy of the root provider.tf in your `HostConditions` directory :
 
 ```hcl
 provider "newrelic" {
@@ -99,8 +99,7 @@ provider "newrelic" {
 }
 ```
 
-Try testing your configurations, run `terraform plan` and
-`terraform init`:
+Try testing your configurations, run `terraform plan` and `terraform init`:
 
 ```bash copyable=false
 [output] {muted}# Example output
@@ -137,7 +136,7 @@ The error is due to the policy id used in the `./modules/HostConditions/provider
 
 Variables pass details into your module and set default values.
 
-First, at the top of your `HostConditions` `provider.tf` create a new variable:
+First, at the top of your `HostConditions/provider.tf` create a new variable:
 ```hcl
 variable "providerId" {}
 ```
@@ -166,14 +165,14 @@ terraform plan
 
 Now, add more variables and replace the values CPU critical, CPU warning, and disk percent. Then, pass the new variables into the module.
 
-Add the new variables to HostConditions `main.tf`:
+Add the new variables to `HostConditions/main.tf`:
 ```hcl
 variable cpu_warning {}
 variable cpu_critical {}
 variable diskPercent {}
 ```
 
-Update the alert conditions to use the new variables added in the HostConditons `main.tf`:
+Update the alert conditions to use the new variables added in the `HostConditons/main.tf`:
 ```hcl
 resource "newrelic_infra_alert_condition" "cpuhot" {
   policy_id = var.policyId
@@ -222,7 +221,7 @@ terraform plan
 
 ### Adding default values
 
-Add default variable values to HostConditions `main.tf`:
+Add default variable values to `HostConditions/main.tf`:
 ```hcl
 variable cpu_warning { default=80}
 variable cpu_critical { default=90}
@@ -310,7 +309,7 @@ git push -u origin main
 
 Check the Github repo and see the `main.tf` and `provider.tf` are now in your repo. Copy the GitHub repo's web URL to clone your repo.
 
-Update the root `main.tf` file using GitHub as the source for the HostConditions:
+Update the root `main.tf` file using GitHub as the source for the `HostConditions`:
 ```hcl
 module "HostConditions" {
   source = "git::https://github.com/<your_username>/<your_repo_name>" # Add your repo URL

--- a/src/content/docs/more-integrations/terraform/terraform-modules.mdx
+++ b/src/content/docs/more-integrations/terraform/terraform-modules.mdx
@@ -29,7 +29,6 @@ To follow the examples in this gude, the accompanying example code is available 
 git clone https://github.com/jsbnr/nr-terraform-intro-example.git
 ```
 
-
 <Steps>
 
 <Step>
@@ -38,23 +37,23 @@ git clone https://github.com/jsbnr/nr-terraform-intro-example.git
 
 Terraform modules allow you to reuse, share, and store your Terraform configurations using version control like Github. In the next steps, you will move your New Relic configurations into a reusable module.
 
-First, in your project root, create a new directory to store your modules named  __modules:__
+First, in your project root, create a new directory to store your modules named  `modules`:
 ```bash
 mkdir modules && cd modules
 ```
 
-In the modules directory, create a new directory for a new module called HostConditions and create a new file named __main.tf:__
+In the modules directory, create a new directory for a new module called HostConditions and create a new file named `main.tf`:
 ```bash
 mkdir HostConditions && cd HostConditions
 touch main.tf
 ```
 
-Remove the two alert conditions from the root project's __main.tf__ file and copy it to the new __main.tf__ file in the HostConditions directory.
+Remove the two alert conditions from the root project's `main.tf` file and copy it to the new `main.tf` file in the HostConditions directory.
 
-In the root directory's __main.tf__ file call the new module using a module block:
+In the root directory's `main.tf` file call the new module using a module block:
 ```hcl
 module "HostConditions" {
-source = "./modules/HostConditions"
+  source = "./modules/HostConditions"
 }
 ```
 
@@ -64,30 +63,30 @@ Try testing your configurations, run `terraform plan` and
 ```bash copyable=false
 [output] {muted}# Example output
 [output] ------------------------------------------------------------------------
-[output]
-[output]Initializing modules...
-[output]- HostConditions in
-[output]
-[output]Error: Unreadable module directory
-[output]
-[output]Unable to evaluate directory symlink: lstat modules/HostConditions: no such
-[output]file or directory
-[output]
-[output]
-[output]Error: Failed to read module directory
-[output]
-[output]Module directory  does not exist or cannot be read.
-[output]
-[output]
-[output]Error: Unreadable module directory
-[output]
-[output]Unable to evaluate directory symlink: lstat modules/HostConditions: no such
-[output]file or directory
-[output]
-[output]
-[output]Error: Failed to read module directory
-[output]
-[output]Module directory  does not exist or cannot be read.
+[output] 
+[output] Initializing modules...
+[output] - HostConditions in
+[output] 
+[output] Error: Unreadable module directory
+[output] 
+[output] Unable to evaluate directory symlink: lstat modules/HostConditions: no such
+[output] file or directory
+[output] 
+[output] 
+[output] Error: Failed to read module directory
+[output] 
+[output] Module directory  does not exist or cannot be read.
+[output] 
+[output] 
+[output] Error: Unreadable module directory
+[output] 
+[output] Unable to evaluate directory symlink: lstat modules/HostConditions: no such
+[output] file or directory
+[output] 
+[output] 
+[output] Error: Failed to read module directory
+[output] 
+[output] Module directory  does not exist or cannot be read.
 ```
 
 You see an error in your console due to the lack of provider details in your modules directory. To fix the error, create a copy of the root provider.tf in your HostConditions directory :
@@ -106,32 +105,31 @@ Try testing your configurations, run `terraform plan` and
 ```bash copyable=false
 [output] {muted}# Example output
 [output] ------------------------------------------------------------------------
-[output]
-[output]Error: Reference to undeclared resource
-[output]
-[output]  on modules/HostConditions/main.tf line 2, in resource "newrelic_infra_alert_condition"
-[output]"cpuhot":
-[output]   2:   policy_id = newrelic_alert_policy.DemoPolicy.id
-[output]
-[output]A managed resource "newrelic_alert_policy" "DemoPolicy" has not been declared
-[output]in module.HostConditions.
-[output]
-[output]
-[output]Error: Reference to undeclared resource
-[output]
-[output]  on modules/HostConditions/main.tf line 24, in resource "newrelic_infra_alert_condition"
-[output]"highDiskUsage":
-[output]  24:   policy_id = newrelic_alert_policy.DemoPolicy.id
-[output]
-[output]A managed resource "newrelic_alert_policy" "DemoPolicy" has not been declared
-[output]in module.HostConditions.
+[output] 
+[output] Error: Reference to undeclared resource
+[output] 
+[output]   on modules/HostConditions/main.tf line 2, in resource "newrelic_infra_alert_condition"
+[output] "cpuhot":
+[output]    2:   policy_id = newrelic_alert_policy.DemoPolicy.id
+[output] 
+[output] A managed resource "newrelic_alert_policy" "DemoPolicy" has not been declared
+[output] in module.HostConditions.
+[output] 
+[output] 
+[output] Error: Reference to undeclared resource
+[output] 
+[output]   on modules/HostConditions/main.tf line 24, in resource "newrelic_infra_alert_condition"
+[output] "highDiskUsage":
+[output]   24:   policy_id = newrelic_alert_policy.DemoPolicy.id
+[output] 
+[output] A managed resource "newrelic_alert_policy" "DemoPolicy" has not been declared
+[output] in module.HostConditions.
 ```
 
 Terraform init no longer shows an error, but running terraform plan still causes an error to occur.
 
-The error is due to the policy id used in the ./modules/HostConditions/provider.tf doesn't exist. A variable is needed to pass into the module.
+The error is due to the policy id used in the `./modules/HostConditions/provider.tf` doesn't exist. A variable is needed to pass into the module.
 </Step>
-
 
 <Step>
 
@@ -139,12 +137,12 @@ The error is due to the policy id used in the ./modules/HostConditions/provider.
 
 Variables pass details into your module and set default values.
 
-First, at the top of your HostConditions provider.tf create a new variable:
+First, at the top of your `HostConditions` `provider.tf` create a new variable:
 ```hcl
 variable "providerId" {}
 ```
 
-Next, in the resource block, replace the existing policyId with the new variable:
+Next, in the resource block, replace the existing `policyId` with the new variable:
 ```hcl
 var.policy
 ```
@@ -153,11 +151,11 @@ var.policy
 
 To make a module dynamic, you will pass your variables into the module using the module resource block.
 
-In the root directory __main.tf__, update the module block to add the policyId variable:
+In the root directory `main.tf`, update the module block to add the `policyId` variable:
 ```hcl
 module "HostConditions" {
-source = "./modules/HostConditions"
-policyId = newrelic_alert_policy.DemoPolicy.id
+  source = "./modules/HostConditions"
+  policyId = newrelic_alert_policy.DemoPolicy.id
 }
 ```
 
@@ -168,14 +166,14 @@ terraform plan
 
 Now, add more variables and replace the values CPU critical, CPU warning, and disk percent. Then, pass the new variables into the module.
 
-Add the new variables to HostConditions __main.tf:__
+Add the new variables to HostConditions `main.tf`:
 ```hcl
 variable cpu_warning {}
 variable cpu_critical {}
 variable diskPercent {}
 ```
 
-Update the alert conditions to use the new variables added in the HostConditons __main.tf:__
+Update the alert conditions to use the new variables added in the HostConditons `main.tf`:
 ```hcl
 resource "newrelic_infra_alert_condition" "cpuhot" {
   policy_id = var.policyId
@@ -224,7 +222,7 @@ terraform plan
 
 ### Adding default values
 
-Add default variable values to HostConditions __main.tf:__
+Add default variable values to HostConditions `main.tf`:
 ```hcl
 variable cpu_warning { default=80}
 variable cpu_critical { default=90}
@@ -233,14 +231,14 @@ variable diskPercent { default=60 }
 
 ### Pass variable values using module block
 
-In the root directory __main.tf__, update the module block to add the cpu_critical, cpu_warning, and diskPercentage variables:
+In the root directory `main.tf`, update the module block to add the `cpu_critical`, `cpu_warning`, and `diskPercentage` variables:
 ```hcl
 module "HostConditions" {
-source = "./modules/HostConditions"
-policyId = newrelic_alert_policy.DemoPolicy.id
-cpu_critical = 88
-cpu_warning = 78
-diskPercentage = 66
+  source = "./modules/HostConditions"
+  policyId = newrelic_alert_policy.DemoPolicy.id
+  cpu_critical = 88
+  cpu_warning = 78
+  diskPercentage = 66
 }
 ```
 
@@ -251,36 +249,34 @@ terraform plan
 
 </Step>
 
-
-
 <Step>
 
 ## Reusing a module
 
-You can reuse your module connecting to a New Relic policy that already exists. Before you start, in your New Relic account, create a new alert policy named __Preexisting Policy.__
+You can reuse your module connecting to a New Relic policy that already exists. Before you start, in your New Relic account, create a new alert policy named __Preexisting Policy__.
 
 ### Connecting an existing alert policy
 
-First, In your root __main.tf__ file add the data block to import an existing policy:
+First, In your root `main.tf` file add the data block to import an existing policy:
 ```hcl
 data "newrelic_alert_policy" "ExistingPolicy" {
 	name = "Preexisting Policy"
 }
 ```
 
-Next, create a second module block name __HostConditions2.__ Add the alert conditions to the Preexisting Policy.
+Next, create a second module block name `HostConditions2`. Add the alert conditions to the Preexisting Policy.
 ```hcl
 module "HostConditions2" {
-source = "./modules/HostConditions"
-policyId = data.newrelic_alert_policy.ExistingPolicy.id
-cpu_critical = 87
-cpu_warning = 77
-diskPercentage = 67
+  source = "./modules/HostConditions"
+  policyId = data.newrelic_alert_policy.ExistingPolicy.id
+  cpu_critical = 87
+  cpu_warning = 77
+  diskPercentage = 67
 }
 ```
 
 Run `terraform init` to initialize the new module and
-run 'terraform apply' to apply the changes to your New Relic account.
+run `terraform apply` to apply the changes to your New Relic account.
 
 The terraform scripts create a new alert policy and two conditions, but it also applies the alert conditions to the Preexisting Policy.
 
@@ -297,7 +293,7 @@ After you have created a module, if you want to store the module somewhere other
 
 ### Create a new Github repo
 
-First, inside of your HostModules directory, initialize a new Github repo. Add your __main.tf__ and __provider.tf__ to the stage for commit:
+First, inside of your HostModules directory, initialize a new Github repo. Add your `main.tf` and `provider.tf` to the stage for commit:
 ```bash
 git add main.tf provider.tf
 git commit -m "init"
@@ -309,26 +305,27 @@ git remote add origin <repo_url>
 git branch -M main
 git push -u origin main
 ```
+
 ### Using a module saved on Github
 
-Check the Github repo and see the __main.tf__ and __provider.tf__ are now in your repo. Copy the GitHub repo's web URL to clone your repo.
+Check the Github repo and see the `main.tf` and `provider.tf` are now in your repo. Copy the GitHub repo's web URL to clone your repo.
 
-Update the root __main.tf__ file using GitHub as the source for the HostConditions:
+Update the root `main.tf` file using GitHub as the source for the HostConditions:
 ```hcl
 module "HostConditions" {
-source = "git::https://github.com/<your_username>/<your_repo_name>" # Add your repo URL
-policyId = newrelic_alert_policy.DemoPolicy.id
-cpu_critical = 88
-cpu_warning = 78
-diskPercentage = 66
+  source = "git::https://github.com/<your_username>/<your_repo_name>" # Add your repo URL
+  policyId = newrelic_alert_policy.DemoPolicy.id
+  cpu_critical = 88
+  cpu_warning = 78
+  diskPercentage = 66
 }
 
 module "HostConditions2" {
-source = "git::https://github.com/<your_username>/<your_repo_name>" # Add your repo URL
-policyId = data.newrelic_alert_policy.ExistingPolicy.id
-cpu_critical = 87
-cpu_warning = 77
-diskPercentage = 67
+  source = "git::https://github.com/<your_username>/<your_repo_name>" # Add your repo URL
+  policyId = data.newrelic_alert_policy.ExistingPolicy.id
+  cpu_critical = 87
+  cpu_warning = 77
+  diskPercentage = 67
 }
 ```
 
@@ -346,7 +343,7 @@ If you need to update your local module with updates made to the git repo, run `
 The state file is the representation that terraform holds about the created resources. The state file is in the root directory, but if deleted or corrupted would cause trouble.
 Storing the state file remote provides security and allows sharing and remote access.
 
-In the __provider.tf__ in the root directory, add a terraform backend block for Amazon S3:
+In the `provider.tf` in the root directory, add a terraform backend block for Amazon S3:
 ```hcl
 terraform {
 	backend "s3" {


### PR DESCRIPTION
there were a lot of cut/paste errors in here, like stray characters that make no sense or commented out code samples

I added `[output]` to some code blocks so it formats as terminal output, those strings won't be rendered literally. It looks like people were commenting out the code you should run to highlight the output, but that's something you can do with the codeblock with `[output]`.

I also lined up some code comments because I think it's easier to read

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.