### PR TITLE
chore(java): removing security agent updates from security updates

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8100.mdx
@@ -5,7 +5,7 @@ version:  8.10.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.10.0/'
 features: ["Support for Spring Webflux 6.1.x", "Support for Spring Batch v4.0+", "Scala 3 API", "Zio 1 instrumentation improvements", "Support for Zio 2", "Enhanced clustered Solr JMX metrics", "Add transaction GUID to Errors"]
 bugs: ["Prevent NullPointerException when setting the user id outside of a transaction", "Disallow Real Time Profiling when High Security Mode is enabled", "Prevent ClassCircularityErrors in some specific circumstances", "Properly removing files when log_daily is enabled", "Decreased memory held by the agent when HTTP calls are made", "Prevent duplicate DT headers for gRPC", "Properly updating how many log messages are sent after configuration change", "Prevent exceptions when reading lambda bytecode", "Reduce interval for JDBC caches"]
-security: ["Ning Async HTTP client Support", "Jersey 2.0+ Support", "Mule 3.6 to 3.9.x Support", "Jetty 12 Support", "Lettuce 4.4.0+ Support", "Extract Server Configuration to resolve IAST localhost connection with application for Wildfly server", "Trustboundary events now will have list of string as parameter schema"]
+security: []
 ---
 <ButtonGroup>
   <ButtonLink


### PR DESCRIPTION
## Give us some context

When the Java agent 8.10.0 release notes were created, the security agent updates were added to the list of security updates.

Removing those as those show with a high priority on the update agent widget inside NR.