### PR TITLE
Update nerdgraph-api-workflows.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-workflows.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-workflows.mdx
@@ -235,7 +235,7 @@ mutation {
       }
       destinationConfigurations: {
         channelId: "CHANNEL_ID"
-        notificationTriggers: ["ACTIVATED", "ACKNOWLEDGED", "CLOSED"]
+        notificationTriggers: [ACTIVATED, ACKNOWLEDGED, CLOSED]
       }
       enrichmentsEnabled: true
       enrichments: { nrql: [] }


### PR DESCRIPTION
customer reported errors when using the example in the "create a workflow to catch all issues" section. Testing from members of the gts-alerts team showed that the double quotations around ACTIVATED, ACKNOWLEDGED, CLOSED might be causing the issue.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.