### PR TITLE
fix: in-page link ID was in plain text

### DIFF
--- a/src/content/docs/new-relic-partnerships/partnerships/partner-api/product-buckets.mdx
+++ b/src/content/docs/new-relic-partnerships/partnerships/partner-api/product-buckets.mdx
@@ -19,7 +19,7 @@ For partnership accounts on our original product pricing, you can use the [Partn
 
 This doc applies only for partnership accounts on our original pricing model. Before using this API, read the [Partnership API requirements](/docs/new-relic-partnerships/partner-integration-guide/partner-account-maintenance/partner-api/).
 
-## Overview (#overview)
+## Overview [#overview]
 
 When using the Partnership API for Insights, Browser, and Synthetics products, you must provide a valid [`quantity` value](/docs/accounts-partnerships/partnerships/partner-api/partner-api-subscription-object#attr-quantity). This indicates the number of [Insights Events](#h2_insights_events), [Browser PageViews](#h2_browser_page_views), and [Synthetics Checks](#h2_synthetics_checks) provisioned to that account.
 


### PR DESCRIPTION
The hotlink to this section used `()` instead of `[]` and was rendered as text, not a link

<img width="539" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/2c66676e-5efa-4775-aefb-f756496fb157">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.