### PR TITLE
fix: update misleading comment in kafka integration

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-integration.mdx
@@ -288,8 +288,8 @@ For more on how to set up offset monitoring, see [Configure KafkaOffsetSample co
   </Collapser>
 
   <Collapser
-    id="zookeeper-ssl"
-    title="Zookeeper SSL discovery"
+    id="zookeeper-jmx-ssl"
+    title="Zookeeper discovery with SSL based JMX connection"
   >
     This configuration collects Metrics and Inventory discovering the brokers from a JMX host with SSL :
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This PR updates the title of a configuration example in the nri-kafka integration. The previous title `Zookeeper SSL discovery` suggest that the configuration example will set up the integration to connect to Zookeeper using SSL (which is not supported). The example actually configures the integration to connect to Zookeeper with [no authentication](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/kafka/kafka-config/#zookeeper-autodiscovery) and to connect to JMX with SSL.