### PR TITLE
fix: removed html showing in codeblock

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-integrations/cloud-integrations/hcp-consul-monitoring.mdx
+++ b/src/content/docs/infrastructure/infrastructure-integrations/cloud-integrations/hcp-consul-monitoring.mdx
@@ -48,12 +48,12 @@ Deploy the Consul cluster following the steps for the appropriate environment in
 
 ## [gostatsd](https://github.com/atlassian/gostatsd) installation [#statsd-install]
 
-Copy [deploy-gostatsd.yaml](https://github.com/newrelic-experimental/hashicorp-quickstart-annex/blob/main/hcp-consul/deploy-gostatsd.yaml) and [rbac-gostatsd.yaml](https://github.com/newrelic-experimental/hashicorp-quickstart-annex/blob/main/hcp-consul/rbac-gostatsd.yaml) to your local Kubernetes client.
+Copy [`deploy-gostatsd.yaml`](https://github.com/newrelic-experimental/hashicorp-quickstart-annex/blob/main/hcp-consul/deploy-gostatsd.yaml) and [`rbac-gostatsd.yaml`](https://github.com/newrelic-experimental/hashicorp-quickstart-annex/blob/main/hcp-consul/rbac-gostatsd.yaml) to your local Kubernetes client.
 
 ### Edit deploy-gstatsd.yaml [#edit-yaml]
 
-1. Replace <DoNotTranslate>**YOUR_NEW_RELIC_ACCOUNT_ID**</DoNotTranslate> with your New Relic account ID.
-2. Replace <DoNotTranslate>**YOUR_NEW_RELIC_LICENSE_KEY**</DoNotTranslate> with your New Relic <InlinePopover type="licenseKey" />.
+1. Replace `YOUR_NEW_RELIC_ACCOUNT_ID` with your New Relic account ID.
+2. Replace `YOUR_NEW_RELIC_LICENSE_KEY` with your New Relic <InlinePopover type="licenseKey" />.
 3. Adjust URLs for EU or FedRAMP accounts if necessary (see comments in file).
 
 ### Deploy gostatsd [#deploy-statsd]
@@ -67,7 +67,7 @@ kubectl apply -f rbac-gostatsd.yaml
 
 ## Configure the Consul clients to report metrics [#configure-consul-client]
 
-### Edit consul-Client-configMap
+### Edit consul-client-config Map
 
 Add [Consule telemetry configuration](https://www.consul.io/docs/agent/telemetry) by editing the Consule Client's ConfigMap:
 
@@ -75,19 +75,18 @@ Add [Consule telemetry configuration](https://www.consul.io/docs/agent/telemetry
 kubectl edit cm consul-client-config
 ```
 
-Add the following under <DoNotTranslate>**data**</DoNotTranslate>:
+Add the following under `data`:
 
 ```yaml
- telemetry-config.json: |-
-    {   
-      "telemetry": {
-        "disable_hostname": false,
-        "disable_compat_1.9": true,
-        "dogstatsd_addr": "gostatsd.default.svc.cluster.local:8125",
-        "dogstatsd_tags": ["consul.source.datacenter:&lt;YOUR_CONSUL_DATACENTER_NAME_HERE&gt;"]
-      }   
-    }  
-
+telemetry-config.json: |-
+  {   
+    "telemetry": {
+      "disable_hostname": false,
+      "disable_compat_1.9": true,
+      "dogstatsd_addr": "gostatsd.default.svc.cluster.local:8125",
+      "dogstatsd_tags": ["consul.source.datacenter:YOUR_CONSUL_DATACENTER_NAME_HERE"]
+    }
+  }
 ```
 
 The result should look something like this:
@@ -110,16 +109,15 @@ data:
         "disable_hostname": false,
         "disable_compat_1.9": true,
         "dogstatsd_addr": "gostatsd.default.svc.cluster.local:8125",
-        "dogstatsd_tags": ["consul.source.datacenter:&lt;YOUR_CONSUL_DATACENTER_NAME_HERE&gt;"]
+        "dogstatsd_tags": ["consul.source.datacenter:YOUR_CONSUL_DATACENTER_NAME_HERE"]
       }   
     }  
-
 ```
 
 Notes: 
 
-1. We use the <DoNotTranslate>**dogstatsd_addr**</DoNotTranslate> here so we can add the <DoNotTranslate>**consul.source.datacenter**</DoNotTranslate>: tag to each metric. This lets you filter your dashboards by Consul Datacenter.
-2. Be sure to replace <DoNotTranslate>**&lt;YOUR_CONSUL_DATACENTER_NAME_HERE&gt;**</DoNotTranslate> with your Consul Datacenter name.
+1. We use the `dogstatsd_addr` here so we can add the `consul.source.datacenter` tag to each metric. This lets you filter your dashboards by Consul Datacenter.
+2. Be sure to replace `YOUR_CONSUL_DATACENTER_NAME_HERE` with your Consul Datacenter name.
 3. See [Consul telemetry configuration options](https://www.consul.io/docs/agent/config/config-files#telemetry).
 
 ### Edit consul-connect-injector deployment [#edit-consul-connect-injector-deployment]
@@ -130,9 +128,9 @@ Enable Consule metrics in the deployment by editing the deployment:
 kubectl edit deploy consul-connect-injector
 ```
 
-Search for <DoNotTranslate>**default-enable-metrics**</DoNotTranslate> and set it to <DoNotTranslate>**true**</DoNotTranslate>:
+Search for `default-enable-metrics` and set it to `true`:
 
-```yaml
+```bash
 -default-enable-metrics=true \
 ```
 
@@ -156,7 +154,7 @@ To see your HCP Consul data in New Relic, navigate to [query builder](/docs/quer
 
 Then, use the query below to see HCP Consul metrics:
 
-```SQL
+```sql
 SELECT * FROM Metric WHERE metricName LIKE 'consul.%' SINCE 1 minute ago
 ```
 


### PR DESCRIPTION
The text `&lt;YOUR_CONSUL_DATACENTER_NAME_HERE&gt;` appeared in the codeblock, looks like a cut/paste error. I also replaced bold `**` with `code` formatting which is more consistent for code/variables/filenames in our other docs

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.