### PR TITLE
fix: link and typo

### DIFF
--- a/src/content/docs/ai-monitoring/customize-agent-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/customize-agent-ai-monitoring.mdx
@@ -24,10 +24,10 @@ Update default agent behavior for AI monitoring at these agent configuration doc
         id="dotnet-config"
         title=".NET configurations"
     >
-        * [`ai_monitoring.enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#ai-monitoring-enabled)
+        * [`ai_monitoring.enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#ai_monitoring)
         * [`ai_monitoring.record_content.enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#aiMonitoring_recordContent)
-        * [Custom events `maximumSamplesStored`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#customevents-maximumSamplesStored)
-        * [Span events `maximumSamplesStored`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#span-max-samples-stored)
+        * [`customEvents.maximumSamplesStored`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#customevents-maximumSamplesStored)
+        * [`spanEvents.maximumSamplesStored`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#span-max-samples-stored)
     </Collapser>
     <Collapser
         id="nodejs-config"

--- a/src/content/docs/ai-monitoring/drop-sensitive-data.mdx
+++ b/src/content/docs/ai-monitoring/drop-sensitive-data.mdx
@@ -10,7 +10,7 @@ import aiDropFilterTable from 'images/ai_screenshot-crop_drop-filter-table.webp'
 
 You have two options for dropping sensitive AI data before you send it to New Relic. This doc guides you through these two methods so you can have better control over the kinds of data the agent collects. 
 
-## Disable ai.monitoring.record_content_enabled [#disable-event]
+## Disable ai.monitoring.record_content.enabled [#disable-event]
 
 When you disable `ai_monitoring.record_content.enabled`, event data containing end user prompts and AI responses won’t be sent to NRDB. You can read more about agent configurations at our [AI monitoring configuration doc](/docs/ai-monitoring/customize-agent-ai-monitoring).
 
@@ -80,7 +80,7 @@ Refer to the regex below to start building your first queries:
     title="Canada health card number"
   >
     **Expression:**
-    ```
+    ```regex
     (\d{10})
     ```
   </Collapser>
@@ -90,7 +90,7 @@ Refer to the regex below to start building your first queries:
     title="Canada personal health/social insurance number (PHIN/SIN)"
   >
     **Expression:**
-    ```
+    ```regex
     (\d{3}[-\s\.]?\d{3}[-\s\.]?\d{3})
     ```
   </Collapser>
@@ -100,7 +100,7 @@ Refer to the regex below to start building your first queries:
     title="Email address"
   >
     **Expression:**
-    ```
+    ```regex
     ([a-zA-Z0-9!#$'*+?^_`{|}~.-]+(?:@|%40)(?:[a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+)
     ```
   </Collapser>
@@ -110,7 +110,7 @@ Refer to the regex below to start building your first queries:
     title="India PAN ID"
   >
     **Expression:**
-    ```
+    ```regex
     ([a-zA-Z]){5}([0-9]){4}([a-zA-Z]){1}?
     ```
   </Collapser>
@@ -120,7 +120,7 @@ Refer to the regex below to start building your first queries:
     title="India AADHAAR ID"
   >
     **Expression:**
-    ```
+    ```regex
     ([2-9]{1}[0-9]{3}\s\d{4}\s\d{4})
     ```
   </Collapser>
@@ -130,7 +130,7 @@ Refer to the regex below to start building your first queries:
     title="IP address (ipv4)"
   >
     **Expression:**
-    ```
+    ```regex
     ([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})
     ```
   </Collapser>
@@ -141,7 +141,7 @@ Refer to the regex below to start building your first queries:
   >
     **Expression:**
     
-    ```
+    ```regex
     (d{4}\sd{4}\sd{4})
     ```
   </Collapser>
@@ -151,7 +151,7 @@ Refer to the regex below to start building your first queries:
     title="Spain National ID (NIE/DNI/NIF)"
   >
     **Expression:**
-    ```
+    ```regex
     ([a-zA-Z]?[-\s]?\d{7,8}[-\s]?[a-zA-Z])
     ```
   </Collapser>
@@ -161,7 +161,7 @@ Refer to the regex below to start building your first queries:
     title="US social security number"
   >
     **Expression:**
-    ```
+    ```regex
     (\d{3}[-\s\.]?\d{2}[-\s\.]?\d{4})
     ```
   </Collapser>
@@ -171,7 +171,7 @@ Refer to the regex below to start building your first queries:
     title="UK national insurance number (NINO)"
   >
     **Expression:**
-    ```
+    ```regex
     ([a-zA-Z]{2}[-\s]?\d{2}[-\s]?\d{2}[-\s]?\d{2}[-\s]?[a-dA-D])
     ```
   </Collapser>
@@ -181,7 +181,7 @@ Refer to the regex below to start building your first queries:
     title="US street address"
   >
     **Expression:**
-    ```
+    ```regex
     \d{1,}(\s{1}\w{1,})(\s{1}?\w{1,})
     ```
   </Collapser>
@@ -191,7 +191,7 @@ Refer to the regex below to start building your first queries:
     title="US phone number"
   >
     **Expression:**
-    ```
+    ```regex
     (^[\+]?[1]?[\W]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4})
     ```
   </Collapser>
@@ -201,7 +201,7 @@ Refer to the regex below to start building your first queries:
     title="US passport number"
   >
     **Expression:**
-    ```
+    ```regex
     ([a-zA-Z]?\d?\d{5,8})
     ```
   </Collapser>
@@ -211,7 +211,7 @@ Refer to the regex below to start building your first queries:
     title="US Date of birth"
   >
     **Expression:**
-    ```
+    ```regex
     ((?:\d{2})?\d\d(?:\\)?(?:\/)?\d\d(?:\\)?(?:\/)?\d{2}(?:\d{2})?)
     ```
   </Collapser>
@@ -221,7 +221,7 @@ Refer to the regex below to start building your first queries:
     title="Credit card number"
   >
     **Expression:**
-    ```
+    ```regex
     ((?:(?:4\d{3})|(?:5[1-5]\d{2})|6(?:011|5[0-9]{2}))(?:-?|\040?)(?:\d{4}(?:-?|\040?)){3}|(?:3[4,7]\d{2})(?:-?|\040?)\d{6}(?:-?|\040?)\d{5})
     ```
   </Collapser>


### PR DESCRIPTION
The id link for the .NET AI section was incorrect. There was also a typo, `record_content.enabled` not `record_content_enabled`. I also add regex identifier, I don't know if prisma will need `regex` added to the config options

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.