### PR TITLE
feat(Docs): Swapped the location of security and licenses category in top-level nav

### DIFF
--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -69,7 +69,8 @@ pages:
     path: telemetry-data-platform
   - title: Data dictionary
     path: /attribute-dictionary
-  - title: Licenses
-    path: licenses
   - title: Security and privacy
     path: new-relic-security
+  - title: Licenses
+    path: licenses
+


### PR DESCRIPTION
At @austin-schaefer's request