### PR TITLE
chore(java): removing smart quotes from metadata in release notes 8.11

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8110.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8110.mdx
@@ -3,9 +3,9 @@ subject:  Java agent
 releaseDate:  '2024-04-11'
 version:  8.11.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.11.0/'
-features: [“Add HTTP/2 Support For Netty 4.1.16.Final +”, “Support external calls inside Spring Reactor call chains”, “Support for Apache Pekko. (Support for Pekko HTTP coming soon)”, “Add configuration to allow the OTel SDK integration to be completely disabled”, “Treat OpenTelemetry @WithSpan annotation as @Trace in the Java Agent API”, “IAST: Json Version bump to 1.2.0”]
-bugs: [“Fix high CPU usage with HttpURLConnection”, “Prevent duplicate HTTP external calls when using the DynamoDB SDK”,  “IAST: Fix issue related to the instrumentation of the Rhino JavaScript Engine that occurred while reading the script”]
-security: [“IAST: Replay header decryption due to Security Findings”]
+features: ["Add HTTP/2 Support For Netty 4.1.16.Final +", "Support external calls inside Spring Reactor call chains", "Support for Apache Pekko. (Support for Pekko HTTP coming soon)", "Add configuration to allow the OTel SDK integration to be completely disabled", "Treat OpenTelemetry @WithSpan annotation as @Trace in the Java Agent API", "IAST: Json Version bump to 1.2.0"]
+bugs: ["Fix high CPU usage with HttpURLConnection", "Prevent duplicate HTTP external calls when using the DynamoDB SDK",  "IAST: Fix issue related to the instrumentation of the Rhino JavaScript Engine that occurred while reading the script"]
+security: ["IAST: Replay header decryption due to Security Findings"]
 ---
 <ButtonGroup>
   <ButtonLink
@@ -20,14 +20,14 @@ security: [“IAST: Replay header decryption due to Security Findings”]
 ## New features and improvements
 
 - Add HTTP/2 support for Netty 4.1.16.Final + [1815](https://github.com/newrelic/newrelic-java-agent/pull/1815)
-- Support external calls inside Spring Reactor call chains [1828](https://github.com/newrelic/newrelic-java-agent/pull/1828) 
+- Support external calls inside Spring Reactor call chains [1828](https://github.com/newrelic/newrelic-java-agent/pull/1828)
 - Support for Apache Pekko (i.e. the pekko-actor library). *Support for Pekko HTTP coming soon.* [1811](https://github.com/newrelic/newrelic-java-agent/pull/1811)
 - Add configuration to allow the OTel SDK integration to be completely disabled [1821](https://github.com/newrelic/newrelic-java-agent/pull/1821)
 
   Configuration via yaml:
   ```
   opentelemetry:
-    sdk: 
+    sdk:
       autoconfigure:
         enabled: false
   ```


### PR DESCRIPTION
## Give us some context

The Java agent team was alerted by the APMS team that they were not able to parse the metadata on the release notes.
I believe it was due to the smart quotes that were used instead of the regular quotes.