### PR TITLE
fix(Release notes): Fixed callout, replaced warning with caution

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8100.mdx
@@ -17,8 +17,8 @@ security: []
   </ButtonLink>
 </ButtonGroup>
 
-<Callout variant="warning">
-This agent version introduced a bug that can cause a deadlock if your application uses `HttpUrlConnection` (or any libraries that use it under the hood). This issue will be resolved in the 8.11.0 agent. Alternatively, downgrading to agent version 8.9.1 or disabling the `HttpUrlConnection` instrumentation would resolve the issue (i.e. `-Dnewrelic.config.class_transformer.com.newrelic.instrumentation.httpurlconnection.enabled=false`). Note that disabling this instrumentation will result in external calls made by the client no longer getting recorded and thus the recommended approach would be to use one of the recommended agent versions.
+<Callout variant="caution">
+This agent version introduced a bug that can cause a deadlock if your application uses `HttpUrlConnection` (or any libraries that use it under the hood). This issue will be resolved in the 8.11.0 agent. Alternatively, downgrading to agent version 8.9.1 or disabling the `HttpUrlConnection` instrumentation would resolve the issue (for example `-Dnewrelic.config.class_transformer.com.newrelic.instrumentation.httpurlconnection.enabled=false`). Note that disabling this instrumentation will result in external calls made by the client no longer getting recorded and thus the recommended approach would be to use one of the recommended agent versions.
 </Callout>
 
 ## New features and improvements
@@ -36,8 +36,8 @@ This agent version introduced a bug that can cause a deadlock if your applicatio
 
 - Prevent NullPointerException when setting the user id outside of a transaction [1762](https://github.com/newrelic/newrelic-java-agent/pull/1762)
 - Disallow Real Time Profiling when High Security Mode is enabled [1764](https://github.com/newrelic/newrelic-java-agent/pull/1764)
-- Prevent ClassCircularityErrors in some specific circumstances [1763](https://github.com/newrelic/newrelic-java-agent/pull/1763)
-- Properly removing files when log_daily is enabled [1754](https://github.com/newrelic/newrelic-java-agent/pull/1754)
+- Prevent `ClassCircularityErrors` in some specific circumstances [1763](https://github.com/newrelic/newrelic-java-agent/pull/1763)
+- Properly removing files when `log_daily` is enabled [1754](https://github.com/newrelic/newrelic-java-agent/pull/1754)
 - Decreased memory held by the agent when HTTP calls are made [1775](https://github.com/newrelic/newrelic-java-agent/pull/1775)
 - Prevent duplicate DT headers for gRPC [1783](https://github.com/newrelic/newrelic-java-agent/pull/1783)
 - Properly updating how many log messages are sent after configuration change [1784](https://github.com/newrelic/newrelic-java-agent/pull/1784)
@@ -61,11 +61,11 @@ The following instrumentation modules are deprecated and will be removed in the 
 ## IAST
 
 ### Changes
-- Ning Async HTTP client Support: The security agent now also supports com.ning:async-http-client 1.0.0 and above [152](https://github.com/newrelic/csec-java-agent/pull/152), [118](https://github.com/newrelic/csec-java-agent/pull/118), [116](https://github.com/newrelic/csec-java-agent/pull/116)
-- Jersey Support: The security agent now also supports Jersey 2.0 and above [150](https://github.com/newrelic/csec-java-agent/pull/150), [149](https://github.com/newrelic/csec-java-agent/pull/149)
+- Ning Async HTTP client Support: The security agent now also supports `com.ning:async-http-client` 1.0.0 and higher [152](https://github.com/newrelic/csec-java-agent/pull/152), [118](https://github.com/newrelic/csec-java-agent/pull/118), [116](https://github.com/newrelic/csec-java-agent/pull/116)
+- Jersey Support: The security agent now also supports Jersey 2.0 and higher [150](https://github.com/newrelic/csec-java-agent/pull/150), [149](https://github.com/newrelic/csec-java-agent/pull/149)
 - Mule Support: The security agent now also supports Mule server version 3.6 to 3.9.x [144](https://github.com/newrelic/csec-java-agent/pull/144), [143](https://github.com/newrelic/csec-java-agent/pull/143)
-- Jetty v12 Support: The security agent now also support Jetty version 12 and above [106](https://github.com/newrelic/csec-java-agent/pull/106)
-- Lettuce Support: The security agent now also supports Lettuce 4.4.0.Final and above [125](https://github.com/newrelic/csec-java-agent/pull/125)
+- Jetty v12 Support: The security agent now also support Jetty version 12 and higher [106](https://github.com/newrelic/csec-java-agent/pull/106)
+- Lettuce Support: The security agent now also supports Lettuce 4.4.0.Final and higher [125](https://github.com/newrelic/csec-java-agent/pull/125)
 
 ### Fixes
 - Extract Server Configuration to resolve IAST localhost connection with application for Wildfly server [192](https://github.com/newrelic/csec-java-agent/pull/192)
@@ -79,7 +79,7 @@ To identify which version of the Java agent you're currently using, run `java -j
 Then, to update to the latest Java agent version:
 
 1. Back up the **entire** [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent) to another location. Rename that directory to `NewRelic_Agent#.#.#`, where `#.#.#` is the agent version number.
-2. [Download the agent.](/docs/release-notes/agent-release-notes/java-release-notes)
+2. [Download the agent](/docs/release-notes/agent-release-notes/java-release-notes).
 3. Unzip the new agent download file, then copy `newrelic-api.jar` and `newrelic.jar` into the original [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent).
 4. Compare your old `newrelic.yml` with the newly downloaded `newrelic.yml` from the zip, and [update the file if needed](#diff).
 5. Restart your Java dispatcher.
@@ -92,7 +92,7 @@ We add new settings to `newrelic.yml` as we release new versions of the agent. Y
 
 For example, if you `diff` the default `newrelic.yml` files for Java agent versions 7.10.0 and 7.11.0, the results printed to the console will be like:
 
-```
+```yaml
 ➜ diff newrelic_7.10.0.yml newrelic_7.11.0.yml
 ...
 107a108,119
@@ -117,7 +117,7 @@ For example, if you `diff` the default `newrelic.yml` files for Java agent versi
 ...
 ```
 
-In this example, these lines were added to the default `newrelic.yml` in Java agent version 7.11.0. If you are moving to 7.11.0 or higher, you should add these new lines to your original `newrelic.yml`.
+In this example, these lines were added to the default `newrelic.yml` in Java agent version 7.11.0. If you're moving to 7.11.0 or higher, you should add these new lines to your original `newrelic.yml`.
 
 ## Support statement:
 

--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-5-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-5-0.mdx
@@ -18,7 +18,7 @@ This release will be supported for one year after its release date. For a full l
 As of this release, the oldest supported version is [.NET agent 8.23.107.0](/docs/release-notes/agent-release-notes/net-release-notes/agent-8231070).
 </Callout>
 
-<Callout variant="warning">
+<Callout variant="caution">
 Some of the NuGet packages from this release were incomplete and have been unpublished from nuget.org.  Please use 10.5.1 instead.
 </Callout>
 


### PR DESCRIPTION
This PR replaces the `<Callout variant="warning">` with `<Callout variant="caution">`.

This is a help-documentation request (04/15/2024).