### PR TITLE
Update CodeStream section. in DD migration article

### DIFF
--- a/src/content/docs/codestream/start-here/what-is-codestream.mdx
+++ b/src/content/docs/codestream/start-here/what-is-codestream.mdx
@@ -14,7 +14,7 @@ redirects:
   - /docs/codestream/troubleshooting/jira-server-version
   - /docs/codestream/troubleshooting/reverse-proxy
   - /docs/codestream/troubleshooting/security
-freshnessValidatedDate: 2024-04-10
+freshnessValidatedDate: 2024-04-15
 ---
 
 import codestreamVscClm from 'images/codestream_screenshot-full_marketplace-vsc-clm.webp'
@@ -25,10 +25,11 @@ import codestreamLogSearch from 'images/codestream_screenshot-crop_log-search.we
 
 New Relic CodeStream is an IDE extension that allows you to shift left by making code performance part of the earliest stages of the development process. 
 
-* Get actionable information, such as errors, poorly performing transactions and non-compliant SLOs, for the services built from your code.
+* See how the services built from your code are performaing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
 * Investigate errors more quickly by stepping through the stack trace and collaborating with teammates.
-* See performance data for individual methods in the code, right in the editor.
 * Search logs from your IDE to investigate issues without context switching.
+* Run NRQL queries, and save and share queries with your teammates via `.nrql` files.
+* See performance data for individual methods in the code, right in the editor.
 
 ## Error investigation
 

--- a/src/content/docs/codestream/start-here/what-is-codestream.mdx
+++ b/src/content/docs/codestream/start-here/what-is-codestream.mdx
@@ -25,7 +25,7 @@ import codestreamLogSearch from 'images/codestream_screenshot-crop_log-search.we
 
 New Relic CodeStream is an IDE extension that allows you to shift left by making code performance part of the earliest stages of the development process. 
 
-* See how the services built from your code are performing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
+* See how the services built from your code are performing, with information about golden metrics, errors, transaction anomalies, SLOs, and more.
 * Investigate errors more quickly by stepping through the stack trace and collaborating with teammates.
 * Search logs from your IDE to investigate issues without context switching.
 * Run NRQL queries, and save and share queries with your teammates via `.nrql` files.

--- a/src/content/docs/codestream/start-here/what-is-codestream.mdx
+++ b/src/content/docs/codestream/start-here/what-is-codestream.mdx
@@ -25,7 +25,7 @@ import codestreamLogSearch from 'images/codestream_screenshot-crop_log-search.we
 
 New Relic CodeStream is an IDE extension that allows you to shift left by making code performance part of the earliest stages of the development process. 
 
-* See how the services built from your code are performaing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
+* See how the services built from your code are performing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
 * Investigate errors more quickly by stepping through the stack trace and collaborating with teammates.
 * Search logs from your IDE to investigate issues without context switching.
 * Run NRQL queries, and save and share queries with your teammates via `.nrql` files.

--- a/src/content/docs/tutorial-dd-migration/making-the-switch.mdx
+++ b/src/content/docs/tutorial-dd-migration/making-the-switch.mdx
@@ -91,12 +91,12 @@ Learn more about vulnerability management in our [short overview](https://newrel
     id="CodeStream"
     title="CodeStream"
 >
-New Relic CodeStream is an IDE extension that allows you to shift left by making code performance part of the earliest stages of the development process. 
+New Relic CodeStream is an IDE extension that allows you to make code performance part of the earliest stages of the development process. 
 
-* See how the services built from your code are performing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
+* See how the services built from your code are performing, with information about golden metrics, errors, transaction anomalies, SLOs, and more.
 * Investigate errors more quickly by stepping through the stack trace and collaborating with teammates.
 * Search logs from your IDE to investigate issues without context switching.
-* Run NRQL queries, and save and share queries with your teammates via `.nrql` files.
+* Run NRQL queries, save, and share queries with your teammates via `.nrql` files.
 * See performance data for individual methods in the code, right in the editor.
 
 Learn more about CodeStream in our [short overview](https://newrelic.com/codestream), or see our [introduction to CodeStream](/docs/codestream/start-here/what-is-codestream/) documentation.         

--- a/src/content/docs/tutorial-dd-migration/making-the-switch.mdx
+++ b/src/content/docs/tutorial-dd-migration/making-the-switch.mdx
@@ -91,11 +91,13 @@ Learn more about vulnerability management in our [short overview](https://newrel
     id="CodeStream"
     title="CodeStream"
 >
-Collaboration across different development teams can be challenging, requiring developers to go back and forth between multiple tools to get anything done. New Relic's CodeStream makes it easier by allowing you to see your data, then discuss and review code, all within your IDE.
-    * See your telemetry in context, allowing developers across teams to collaborate without missing out on valuable information
-    * Integrate with VS Code, Visual Studio, and all JetBrains editors as easily as adding an extension
-    * View code-level metrics to fully understand production environment performance
-    * Collaborate more easily across all your tools, such as GitHub, Slack, Teams, and email
+New Relic CodeStream is an IDE extension that allows you to shift left by making code performance part of the earliest stages of the development process. 
+
+* See how the services built from your code are performaing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
+* Investigate errors more quickly by stepping through the stack trace and collaborating with teammates.
+* Search logs from your IDE to investigate issues without context switching.
+* Run NRQL queries, and save and share queries with your teammates via `.nrql` files.
+* See performance data for individual methods in the code, right in the editor.
 
 Learn more about CodeStream in our [short overview](https://newrelic.com/codestream), or see our [introduction to CodeStream](/docs/codestream/start-here/what-is-codestream/) documentation.         
 </Collapser>

--- a/src/content/docs/tutorial-dd-migration/making-the-switch.mdx
+++ b/src/content/docs/tutorial-dd-migration/making-the-switch.mdx
@@ -93,7 +93,7 @@ Learn more about vulnerability management in our [short overview](https://newrel
 >
 New Relic CodeStream is an IDE extension that allows you to shift left by making code performance part of the earliest stages of the development process. 
 
-* See how the services built from your code are performaing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
+* See how the services built from your code are performing, with information about golden metrics, errors, transaction anomalies, SLOs and more.
 * Investigate errors more quickly by stepping through the stack trace and collaborating with teammates.
 * Search logs from your IDE to investigate issues without context switching.
 * Run NRQL queries, and save and share queries with your teammates via `.nrql` files.


### PR DESCRIPTION
The CodeStream section was way out of date so I updated it, and also tweaked the corresponding section in the "What is CodeStream" article.