### PR TITLE
chore(metrics): Expand getField examples to include long hand queries

### DIFF
--- a/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
@@ -211,10 +211,13 @@ You can use `getField()` to extract those fields. For example, if you want to us
     The average value of a metric is computed as `total` over `count`, so the following query returns metric data where the result of the `average()` value function is greater than 2.
 
     ```
-    FROM Metric SELECT average(apm.service.transaction.duration) WHERE appName = 'MyApp' AND getField(apm.service.transaction.duration, total) / getField(apm.service.transaction.duration, count) > 2
+    FROM Metric 
+    SELECT average(apm.service.transaction.duration) 
+    WHERE appName = 'MyApp' 
+    AND getField(apm.service.transaction.duration, total) / getField(apm.service.transaction.duration, count) > 2
     ```
 
-    or with the shorthand:
+    Or, you can use the shorthand:
 
     ```
     FROM Metric SELECT average(apm.service.transaction.duration) WHERE appName = 'MyApp' AND apm.service.transaction.duration[total] / apm.service.transaction.duration[count] > 2
@@ -227,12 +230,16 @@ You can use `getField()` to extract those fields. For example, if you want to us
     This example query returns a list of gauge metrics:
 
     ```
-    FROM Metric SELECT uniques(metricName) WHERE getField(%, type) = 'gauge'
+    FROM Metric 
+    SELECT uniques(metricName) 
+    WHERE getField(%, type) = 'gauge'
     ```
 
-    or with the shorthand:
+    Or, you can use the shorthand:
     ```
-    FROM Metric SELECT uniques(metricName) WHERE %[type] = 'gauge'
+    FROM Metric 
+    SELECT uniques(metricName) 
+    WHERE %[type] = 'gauge'
     ```
 
     Note the use of the `%` wildcard to target any matching `metricName`.

--- a/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
@@ -205,25 +205,37 @@ You can use `getField()` to extract those fields. For example, if you want to us
 
 <CollapserGroup>
   <Collapser
-    id="example-list-gauge-metrics"
-    title="List of gauge metrics"
-  >
-    This example query returns a list of gauge metrics:
-
-    ```
-    FROM Metric SELECT uniques(metricName) WHERE %[type] = 'gauge'
-    ```
-  </Collapser>
-
-  <Collapser
     id="example-list-names-host"
     title="List all metric names for a particular host"
   >
     The average value of a metric is computed as `total` over `count`, so the following query returns metric data where the result of the `average()` value function is greater than 2.
 
     ```
+    FROM Metric SELECT average(apm.service.transaction.duration) WHERE appName = 'MyApp' AND getField(apm.service.transaction.duration, total) / getField(apm.service.transaction.duration, count) > 2
+    ```
+
+    or with the shorthand:
+
+    ```
     FROM Metric SELECT average(apm.service.transaction.duration) WHERE appName = 'MyApp' AND apm.service.transaction.duration[total] / apm.service.transaction.duration[count] > 2
     ```
+  </Collapser>
+  <Collapser
+    id="example-list-gauge-metrics"
+    title="List of gauge metrics"
+  >
+    This example query returns a list of gauge metrics:
+
+    ```
+    FROM Metric SELECT uniques(metricName) WHERE getField(%, type) = 'gauge'
+    ```
+
+    or with the shorthand:
+    ```
+    FROM Metric SELECT uniques(metricName) WHERE %[type] = 'gauge'
+    ```
+
+    Note the use of the `%` wildcard to target any matching `metricName`.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
@@ -201,7 +201,7 @@ If used in a query, `myNeatProcess.%.duration` will return results for all three
 
 There are [multiple types of `Metric` data](/docs/data-apis/understand-data/metric-data/metric-data-type/#metric-types) (for example, `gauge` and `count`) and each type has several associated <DoNotTranslate>**fields**</DoNotTranslate>. For details on the types of fields available, see [`getField()`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#func-getfield). 
 
-You can use `getField()` to extract those fields. For example, if you want to use a single value within a metric to do a comparison in a `WHERE` clause, you can use `getField(metricName, field)` or `metricName[field]`.
+You can use `getField()` to extract those fields. For example, if you want to use a single value within a metric to do a comparison in a `WHERE` clause, you can use `getField(metricName, field)` or the shorthand syntax `metricName[field]`.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/query-metric-data-type.mdx
@@ -220,7 +220,10 @@ You can use `getField()` to extract those fields. For example, if you want to us
     Or, you can use the shorthand:
 
     ```
-    FROM Metric SELECT average(apm.service.transaction.duration) WHERE appName = 'MyApp' AND apm.service.transaction.duration[total] / apm.service.transaction.duration[count] > 2
+    FROM Metric 
+    SELECT average(apm.service.transaction.duration) 
+    WHERE appName = 'MyApp' 
+    AND apm.service.transaction.duration[total] / apm.service.transaction.duration[count] > 2
     ```
   </Collapser>
   <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * This PR expands on the examples for `getField()` to include both the long-hand and short-hand versions of the queries. It also changes the order of the examples, moving the wildcard (`%`) query as the second example since it may have been contributing to user confusion. The form `%[field_name]` is a more complex query.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.