### PR TITLE
fix(CustomNodeModules): Updated minimum version

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -164,7 +164,7 @@ Some capabilities require a minimum version of job manager and runtime container
       </td>
 
       <td>
-        release-360
+        release-363
       </td>
 
       <td>


### PR DESCRIPTION
Changed the minimum version of Job Manager that supports custom node modules from release-360 to release-363. 