### PR TITLE
fix: wrong openAI version

### DIFF
--- a/src/content/docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements.mdx
@@ -542,7 +542,7 @@ The Go agent integrates with other features to give you observability across you
       <td>
         If you have version 3.31.0 or higher of Go agent, you can collect AI data from certain AI libraries and frameworks:
 
-          * [Go OpenAI library](https://github.com/sashabaranov/go-openai) versions 3.4.0 and above
+          * [Go OpenAI library](https://github.com/sashabaranov/go-openai) versions 1.19.4 and above
           * [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2) versions 1.6.0 and above
 
       </td>


### PR DESCRIPTION
Eng confirmed the correct version on slack here https://newrelic.slack.com/archives/C0MQ534AD/p1713306862888449?thread_ts=1713306193.528189&cid=C0MQ534AD

> I’m not sure where the [OpenAI Library] 3.4.0 is from. But the correct one is 1.19.4
> sashabaranov/go-openai version 3.4.0 doesn’t even exist. 

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.