### PR TITLE
Python release notes v9.9.0

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3732,6 +3732,67 @@ Event loop visibility surfaces information about transactions that block the eve
   </Collapser>
 </CollapserGroup>
 
+## Runtime metrics for physical memory [#runtime-metrics]
+
+<Callout variant="important">
+  Requires [Python agent version 9.9.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+These runtime metrics settings are available via the agent configuration file:
+
+<CollapserGroup>
+  <Collapser
+    id="runtime-metrics-reporting-enabled"
+    title="memory_runtime_pid_metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            true
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_MEMORY_RUNTIME_METRICS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will generate and send runtime metrics.
+  </Collapser>
+
+
 ## Garbage collection runtime metrics settings [#garbage-collection-runtime-metrics]
 
 <Callout variant="important">

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3783,7 +3783,7 @@ These runtime metrics settings are available via the agent configuration file:
           </th>
 
           <td>
-            `NEW_RELIC_MEMORY_RUNTIME_METRICS_ENABLED`
+            `NEW_RELIC_MEMORY_RUNTIME_PID_METRICS_ENABLED`
           </td>
         </tr>
       </tbody>
@@ -3791,7 +3791,7 @@ These runtime metrics settings are available via the agent configuration file:
 
     When enabled, the agent will generate and send runtime metrics.
   </Collapser>
-
+</CollapserGroup>
 
 ## Garbage collection runtime metrics settings [#garbage-collection-runtime-metrics]
 

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3789,7 +3789,7 @@ These runtime metrics settings are available via the agent configuration file:
       </tbody>
     </table>
 
-    When enabled, the agent will generate and send runtime metrics.
+    When enabled, the agent will generate and send runtime metrics per process ID.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/python-agent/supported-features/python-runtime-metrics.mdx
+++ b/src/content/docs/apm/agents/python-agent/supported-features/python-runtime-metrics.mdx
@@ -11,7 +11,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-The Python agent records runtime metrics to allow you to analyze the performance of your Python processes and interpreter. This includes metrics related to CPU usage, memory usage, and garbage collection.
+The Python agent records runtime metrics to allow you to analyze the performance of your Python processes and interpreter. This includes metrics related to CPU usage, memory usage, and garbage collection.  This behavior is enabled by default.  To disable this, [disable the setting in either the configuration file or environment variable](/docs/apm/agents/python-agent/configuration/python-agent-configuration#runtime-metrics).
 
 ## CPU usage
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -4,7 +4,7 @@ releaseDate: '2024-04-18'
 version: 9.9.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['Update Celery instrumentation', 'Add new Langchain vectorstores', 'Add configuration to capture memory usage runtime metrics per process']
-bugs: ['Report only raw content dictionary for anthropic claude']
+bugs: ['Report only raw content dictionary for Anthropic Claude']
 security: ['Update internal version of urllib3 to v1.26.18']
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -1,7 +1,7 @@
 ---
 subject: Python agent
 releaseDate: '2024-04-18'
-version: 9.8.0
+version: 9.9.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['Update Celery instrumentation', 'Add new Langchain vectorstores', 'Add configuration to capture memory usage runtime metrics per process']
 bugs: ['Report only raw content dictionary for anthropic claude']

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -10,7 +10,7 @@ security: ['Update internal version of urllib3 to v1.26.18']
 
 ## Notes
 
-This release of the Python agent adds 
+This release of the Python agent updates Celery instrumentation, adds new Langchain vectorstores, adds configuration to capture memory usage runtime metrics per process, fixes a content reporting issue in Anthropic Claude, and upgrades internal version of urllib3 to v1.26.18.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -1,0 +1,52 @@
+---
+subject: Python agent
+releaseDate: '2024-04-18'
+version: 9.8.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Update Celery instrumentation', 'Add new Langchain vectorstores', 'Add configuration to capture memory usage runtime metrics per process']
+bugs: ['Report only raw content dictionary for anthropic claude']
+security: ['Update internal version of urllib3 to v1.26.18']
+---
+
+## Notes
+
+This release of the Python agent adds 
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## Security
+
+* **Update internal version of urllib3 to v1.26.18**
+
+    * Upgrade the internal version of [urllib3](https://pypi.org/project/urllib3/) used in the Python Agent to v1.26.18 to resolve security warnings.
+
+## New features
+
+* **Update Celery instrumentation**
+
+    * Add support for distributed tracing in [Celery](https://pypi.org/project/celery/) over AMQP headers.
+    * Remove duplicate function traces for some methods of running tasks.
+      * All tasks should now only be instrumented once, and will report either an OtherTransaction, or a FunctionTrace if run under an existing transaction.
+    * Fix instrumentation for grouped celery tasks APIs, such as `task.map()`, `celery.group()`, and `celery.chunks()`.
+      * Tasks run using `task.map()` or `task.starmap()` will now name tasks in the format `Celery/celery.map/my_task` to allow you to differentiate between map tasks.
+      * Individual task runs created by the `map()` and `starmap()` tasks will be traced with a FunctionTrace to capture individual timings.
+
+* **Add new [Langchain](https://pypi.org/project/langchain/) vectorstores**
+
+    * Support for the following Langchain vectorstores: `DuckDB`, `EcloudESVectorStore`, `InMemoryVectorStore`, `PathwayVectorClient`, `VDMS`
+
+* **Add configuration setting to enable capturing of memory usage runtime metrics per process**
+
+    * Add `memory_runtime_pid_metrics.enabled` configuration setting to toggle capturing of memory usage metrics (per process ID only) to reduce Metric Grouping Issues (MGI).
+
+## Bug fixes
+
+* **Report only raw content dictionary for anthropic claude**
+
+    * Previously, AWS Bedrock's Anthropic Claude model would report a list of dictionaries of message content. Now it reports a single dictionary of message content.
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -5,7 +5,7 @@ version: 9.9.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['Update Celery instrumentation', 'Add new Langchain vectorstores', 'Add configuration to capture memory usage runtime metrics per process']
 bugs: ['Report only raw content dictionary for Anthropic Claude']
-security: ['Update internal version of urllib3 to v1.26.18']
+security: ['Upgrade internal version of urllib3 to v1.26.18']
 ---
 
 ## Notes

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -16,7 +16,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Security
 
-* **Update internal version of urllib3 to v1.26.18**
+* **Upgrade internal version of urllib3 to v1.26.18**
 
     * Upgrade the internal version of [urllib3](https://pypi.org/project/urllib3/) used in the Python Agent to v1.26.18 to resolve security warnings.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-90900.mdx
@@ -41,7 +41,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 ## Bug fixes
 
-* **Report only raw content dictionary for anthropic claude**
+* **Report only raw content dictionary for Anthropic Claude**
 
     * Previously, AWS Bedrock's Anthropic Claude model would report a list of dictionaries of message content. Now it reports a single dictionary of message content.
 


### PR DESCRIPTION
This PR adds the release notes for the Python Agent v9.9.0 as well as a new configuration option