### PR TITLE
feat(RuntimeUpgradeNerdGraph): Query examples

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -304,6 +304,59 @@ Queries make requests to fetch data. To learn additional query capabilities avai
 ```
     </Collapser>
 
+
+    <Collapser
+    id="query-runtime-upgrade-status"
+    title="Query to retrieve the status of all runtime upgrade tests"
+    >
+    Retrieve the status of all runtime upgrade tests for legacy runtime monitors. These tests populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/). The test result is stored in the `validationStatus` tag. If the upgrade test failed, the error message is available in the `validationError` tag. 
+```
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'") {
+      results {
+        entities {
+          accountId
+          guid
+          name
+          tags {
+            key
+            values
+          }
+        }
+      }
+    }
+  }
+}
+```
+    </Collapser>
+
+    <Collapser
+    id="query-runtime-upgrade-status-monitor"
+    title="Query to retrieve the status of a runtime upgrade test by monitor ID"
+    >
+    Retrieve the status of a runtime upgrade test for a single legacy runtime monitor. These test results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/). The test result is stored in the `validationStatus` tag. If the upgrade test failed, the error message is available in the `validationError` tag. 
+```
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' and domainId = 'MONITOR_ID'") {
+      results {
+        entities {
+          accountId
+          guid
+          name
+          tags {
+            key
+            values
+          }
+        }
+      }
+    }
+  }
+}
+```
+    </Collapser>
+
 </CollapserGroup>
 
 ## Create your synthetic monitors [#create-monitors]


### PR DESCRIPTION
I added query examples for the runtime validation entities used by the runtime upgrades UI. This will allow users to interact with these runtime upgrade tests programmatically if they choose to do so. 