### PR TITLE
Networks: Remove legacy syntax

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -37,7 +37,7 @@ This table contains the endpoints for New Relic telemetry data ingest, and other
 For more detail on specific agents and integrations, and about ports, keep reading below the table. 
 
 <CONTRIBUTOR_NOTE>
-Do NOT change these endpoints unless you have the approval of the Unified API team.
+  Do NOT change these endpoints unless you have the approval of the team that owns the endpoints.
 </CONTRIBUTOR_NOTE>
 
 <table>
@@ -353,10 +353,10 @@ The telemetry endpoints in the table above are included below in easy-to-copy li
 Here's a list of the [US data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center) endpoints included in the endpoint table above in an easy-to-copy list: 
 
 <CONTRIBUTOR_NOTE>
-Do NOT change these endpoints unless you have the approval of the Unified API team.
+  Do NOT change these endpoints unless you have the approval of the team that owns the endpoints.
 </CONTRIBUTOR_NOTE> 
 
-* `collector*.newrelic.com`
+* `collector.newrelic.com`
 * `aws-api.newrelic.com`
 * `cloud-collector.newrelic.com`
 * `bam.nr-data.net`
@@ -382,11 +382,11 @@ Do NOT change these endpoints unless you have the approval of the Unified API te
 Here's a list of the [EU data center region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center) endpoints included in the endpoint table above in an easy-to-copy list: 
 
 <CONTRIBUTOR_NOTE>
-Do NOT change these endpoints unless you have the approval of the Unified API team.
+  Do NOT change these endpoints unless you have the approval of the team that owns the endpoints.
 </CONTRIBUTOR_NOTE>
 
-* `collector*.eu.newrelic.com`
-* `collector*.eu01.nr-data.net`
+* `collector.eu.newrelic.com`
+* `collector.eu01.nr-data.net`
 * `aws-api.eu.newrelic.com`
 * `aws-api.eu01.nr-data.net`
 * `cloud-collector.eu.newrelic.com`
@@ -428,7 +428,7 @@ The ports used for `otlp.nr-data.net` and `otlp.eu01.nr-data.net` are:
 ### Data ingest IP blocks [#ingest-blocks]
 
 <CONTRIBUTOR_NOTE>
-Do NOT change these endpoints unless you have the approval of the Unified API team.
+  Do NOT change these endpoints unless you have the approval of the team that owns the endpoints.
 </CONTRIBUTOR_NOTE>
 
 We use these blocks for data ingestion:
@@ -583,7 +583,7 @@ If your system needs a proxy to connect to New Relic, use the [Infrastructure `p
 Our infrastructure monitoring makes use of several other ingest endpoints, including the Metric API endpoint and the Log API endpoint (included in [the endpoint table](#new-relic-endpoints)). 
 
 <CONTRIBUTOR_NOTE>
-Do NOT change these endpoints unless you have the approval of the Unified API team.
+  Do NOT change these endpoints unless you have the approval of the team that owns the endpoints.
 </CONTRIBUTOR_NOTE>
 
 Details about the non-ingest-related endpoints: 
@@ -622,7 +622,7 @@ Synthetic private minions report to a specific endpoint based on region. To allo
 [TLS](#tls) is required for all domains. Use the IP connections for your [data center region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center) (US or EU):
 
 <CONTRIBUTOR_NOTE>
-Do NOT change these endpoints unless you have the approval of the Unified API team.
+  Do NOT change these endpoints unless you have the approval of the team that owns the endpoints.
 </CONTRIBUTOR_NOTE>
 
 <table>

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -95,7 +95,7 @@ For more detail on specific agents and integrations, and about ports, keep readi
        `aws-api.newrelic.com`
       </td>
       <td>
-       `aws-api.eu.newrelic.com`
+       `aws-api.eu.newrelic.com` <br/>
        `aws-api.eu01.nr-data.net`
       </td>
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -16,7 +16,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-<DoNotTranslate>**This list is current. Networks, IPs, domains, ports, and endpoints last updated May 1, 2023.**</DoNotTranslate>
+<DoNotTranslate>**This list is current. Networks, IPs, domains, ports, and endpoints last updated April 23, 2024.**</DoNotTranslate>
 
 This is a list of the networks, IP addresses, domains, ports, and endpoints used by API clients or agents to communicate with New Relic. [TLS is required for all domains](#tls).
 


### PR DESCRIPTION
We had some legacy syntax in our ingest URLs that used an astrisk. This PR removes three instances of those asterisks.

Also, we clarified the private note to writers about whom to contact for future requests about changing endpoints.