### PR TITLE
Fix jump link for compressed content encoding

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -5136,7 +5136,7 @@ Here are assorted other settings available via the agent configuration file.
   </Collapser>
 
   <Collapser
-    id="shutdown-timeout"
+    id="compressed-content-encoding"
     title="compressed_content_encoding"
   >
     <table>


### PR DESCRIPTION
This PR fixes the jump link for the `compressed-content-encoding` setting within the Python Agent's configuration page.