### PR TITLE
fix(K8s): Clarified K8s support

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -209,7 +209,7 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
             <DoNotTranslate>**Linux kernel:**</DoNotTranslate> 3.10 or higher<br />
             <DoNotTranslate>**macOS:**</DoNotTranslate> 10.11 or higher<br />
                         
-            *Linux containers, including the containerized private minion, only run on Linux K8s nodes.*
+            Linux containers, including the containerized private minion, only run on Linux K8s nodes.
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -208,7 +208,8 @@ To host CPMs, your system must meet the minimum requirements for the chosen syst
           <td>
             <DoNotTranslate>**Linux kernel:**</DoNotTranslate> 3.10 or higher<br />
             <DoNotTranslate>**macOS:**</DoNotTranslate> 10.11 or higher<br />
-            <DoNotTranslate>**Windows:**</DoNotTranslate> Windows 10 64-bit or higher
+                        
+            *Linux containers, including the containerized private minion, only run on Linux K8s nodes.*
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
@@ -171,7 +171,8 @@ To host synthetics job managers, your system must meet the minimum requirements 
           <td>
             <DoNotTranslate>**Linux kernel:**</DoNotTranslate> 3.10 or higher<br />
             <DoNotTranslate>**macOS:**</DoNotTranslate> 10.11 or higher<br />
-            <DoNotTranslate>**Windows:**</DoNotTranslate> Windows 10 64-bit or higher
+            
+            *Linux containers, including job manager, only run on Linux K8s nodes.*
           </td>
         </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager.mdx
@@ -172,7 +172,7 @@ To host synthetics job managers, your system must meet the minimum requirements 
             <DoNotTranslate>**Linux kernel:**</DoNotTranslate> 3.10 or higher<br />
             <DoNotTranslate>**macOS:**</DoNotTranslate> 10.11 or higher<br />
             
-            *Linux containers, including job manager, only run on Linux K8s nodes.*
+            Linux containers, including job manager, only run on Linux K8s nodes.
           </td>
         </tr>
 


### PR DESCRIPTION
- Removed Windows as a supported deployment option for K8s
- Included that Linux containers can only be run on Linux K8s nodes