### PR TITLE
chore: elixir identifier

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
+++ b/src/content/docs/security/security-privacy/compliance/fedramp-compliant-endpoints.mdx
@@ -392,7 +392,7 @@ To ensure FedRAMP compliance, all [APM agent configurations](/docs/using-new-rel
       <td>
         In `config.exs`:
 
-        ```exs
+        ```elixir
         config :new_relic_agent,
           host: "gov-collector.newrelic.com"
         ```


### PR DESCRIPTION
I'm not sure if `elixir` will be recognized by the docs site, but the current identifier was not and github only recognizes this one.
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.