### PR TITLE
fix(link): Add first.org link to NRVM

### DIFF
--- a/src/content/docs/vulnerability-management/understanding-prioritization.mdx
+++ b/src/content/docs/vulnerability-management/understanding-prioritization.mdx
@@ -86,6 +86,8 @@ The priority ranking is based on all known data about a vulnerability. The **Rea
     >
         **Exploit probability** scores are based on EPSS, which rates the probability that a vulnerability will be exploited in the wild. In these cases, there are known instances of threat actors taking advantage of the vulnerability. EPSS scores can look low out of context, but security experts recommend giving higher priority to all vulnerabilities with an exploit probability above the 85th percentile. This indicates a significant risk that that vulnerability will be exploited.
 
+        Explore FIRST's page for [The EPSS Model](https://www.first.org/epss/model) to learn more. 
+
         This table shows the tags we've assigned to each level of exploit probability.
         <table>
         <thead>
@@ -109,6 +111,7 @@ The priority ranking is based on all known data about a vulnerability. The **Rea
             </tr>
         </tbody>
         </table>
+
     </Collapser>
     <Collapser
         className="freq-link"


### PR DESCRIPTION
## Give us some context

* We want to provide users a location where they can read more about EPSS model and link to the source of where EPSS data originates from.