### PR TITLE
style(nav): `APM agents` instead of `Install`

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -16,7 +16,7 @@ pages:
         path: /docs/apm/new-relic-apm/apdex/apdex-measure-user-satisfaction
       - title: APM data security
         path: /docs/apm/new-relic-apm/getting-started/apm-agent-data-security
-  - title: Installation and configuration
+  - title: APM agents
     pages:
       - title: Go monitoring
         path: /docs/apm/agents/go-agent


### PR DESCRIPTION
Inspired by frequent confusion when I watch people navigate docs, most recently @jeff-colucci earlier today. 

Would like input from @bradleycamacho / @rhetoric101 , one of whom I believe originally made this change away from calling it APM agents?