### PR TITLE
Remove accidental elasticsearch mention

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -116,7 +116,7 @@ To install the integration, follow the instructions for your environment:
 
 4. Edit the `mongodb3-config.yml` configuration file with your favorite editor. Check out some [configuration file examples](#examples).
 
-5. To enable automatic Mongodb error log parsing and forwarding, create a YAML file with the following content in `/etc/newrelic-infra/logging.d/elasticsearch-log.yml`. No need to restart the agent.
+5. To enable automatic Mongodb error log parsing and forwarding, create a YAML file with the following content in `/etc/newrelic-infra/logging.d/mongodb-log.yml`. No need to restart the agent.
     ```yaml
     logs:
     - name: "mongodblog"


### PR DESCRIPTION
Looks like the initial publication of this doc last year had an error that mentioned elasticsearch instead of mongodb. 