### PR TITLE
Update instances of "timeseries" to "time series"

### DIFF
--- a/src/content/docs/ai-monitoring/view-ai-data.mdx
+++ b/src/content/docs/ai-monitoring/view-ai-data.mdx
@@ -49,8 +49,8 @@ If you own several apps with various implementations of different AI frameworks,
 ### Track total responses, average response time, and token usage  
 
 <img
-    title="AI responses response billboard and timeseries graphs"
-    alt="A cropped screenshot displaying the timeseries graphs and billboard info about AI data"
+    title="AI responses response billboard and time series graphs"
+    alt="A cropped screenshot displaying the time series graphs and billboard info about AI data"
     src={aiTimeseriesBillboard}
 />
 
@@ -65,17 +65,17 @@ The three tiles show general performance metrics about your AI's responses. Thes
 * If you notice a drop in total responses or an increase in average response time, it can indicate that some technology in your AI toolchain has prevented your AI-powered app from posting a response.  
 * A drop or increase in average token usage per response can give you insight into how your model creates a response. Maybe it's pulling too much context, thus driving up token cost while generating its response. Maybe its responses are too spare, leading to lower token costs and unhelpful responses.
 
-### Adjust the timeseries graphs 
+### Adjust the time series graphs 
 
 <img
-    title="AI timeseries graphs"
-    alt="A cropped screenshot displaying timeseries info about AI data"
+    title="AI time series graphs"
+    alt="A cropped screenshot displaying time series info about AI data"
     src={aiCroppedImageofAItimeseries}
 />
 
 You can refer to the time series graphs to better visualize when an anamolous behavior first appears. 
 
-* Adjust the timeseries graph by dragging over a spike or drop. This scopes the timeseries to a certain time window.
+* Adjust the time series graph by dragging over a spike or drop. This scopes the time series to a certain time window.
 * Select the drop down to run comparative analysis for different performance parameters. You can choose between total responses, average response time, or average tokens per response. 
 * If you've enabled the [feedback feature](/docs/ai-monitoring/customize-agent-ai-monitoring), you can scope the graphs to analyze responses by positive and negative feedback. 
 
@@ -146,7 +146,7 @@ Selecting an AI entity takes you to the APM summary page for that app. From the 
 
 Selecting an AI entity takes you to the APM summary page. To find your AI data, choose <DoNotTranslate>**AI responses**</DoNotTranslate> in the left nav. We recommend using this page when you've identified that a particular AI entity has contributed to anomalies. 
 
-* The APM version of AI responses contains the same tiles, timeseries graphs, and response tables collected as the top-level AI responses page. 
+* The APM version of AI responses contains the same tiles, time series graphs, and response tables collected as the top-level AI responses page. 
 * Instead of showing aggregated data, the APM AI responses page shows data scoped to the service you selected from AI entities. 
 * While the top-level AI responses page lets you filter by service across all AI entities, the APM AI responses page limits filter functionality to the app's own attributes. 
 

--- a/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/change-applied-intelligence-correlation-logic-decisions.mdx
+++ b/src/content/docs/alerts-applied-intelligence/applied-intelligence/incident-intelligence/change-applied-intelligence-correlation-logic-decisions.mdx
@@ -221,7 +221,7 @@ The table below provides descriptions for all of the global decisions that are a
       </td>
 
       <td>
-        Correlation is activated because the New Relic [condition IDs](/docs/new-relic-solutions/get-started/glossary/#condition_id) and deep link url are the same. Deep link url provides timeseries and time range information in addition to [alert condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/). Correlating these issues make it easier for you to look at related incidents in the incident response flow with time-scoped metrics, and perform deep analysis. Deep link url can be automatically generated if incidents are triggered by New Relic alert conditions, while for REST source [deepLinkUrl](/docs/data-apis/ingest-apis/event-api/incident-event-rest-api/#api-specs) should be user defined.
+        Correlation is activated because the New Relic [condition IDs](/docs/new-relic-solutions/get-started/glossary/#condition_id) and deep link url are the same. Deep link url provides time series and time range information in addition to [alert condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions/). Correlating these issues make it easier for you to look at related incidents in the incident response flow with time-scoped metrics, and perform deep analysis. Deep link url can be automatically generated if incidents are triggered by New Relic alert conditions, while for REST source [deepLinkUrl](/docs/data-apis/ingest-apis/event-api/incident-event-rest-api/#api-specs) should be user defined.
       </td>
     </tr>
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
@@ -90,7 +90,7 @@ For how to create a dashboard with data from multiple accounts, see [the NerdGra
 
 ## Create embeddable charts [#embeddable-charts]
 
-In addition to returning raw data, you can fetch embeddable chart links for the data to use in an application. For example, instead of a single count of [transaction](/docs/insights/insights-data-sources/default-data/apm-default-event-attributes-insights#transaction-event), you can create a [chart](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-types) that illustrates a timeseries of bucketed counts over time. Add `TIMESERIES` to your query with `embeddedChartUrl`:
+In addition to returning raw data, you can fetch embeddable chart links for the data to use in an application. For example, instead of a single count of [transaction](/docs/insights/insights-data-sources/default-data/apm-default-event-attributes-insights#transaction-event), you can create a [chart](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-types) that illustrates a time series of bucketed counts over time. Add `TIMESERIES` to your query with `embeddedChartUrl`:
 
 ```graphql
 {

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -365,7 +365,7 @@ Here are some sample queries for the event data to help you get started.
 <CollapserGroup>
   <Collapser
     id="percentile-time"
-    title="Percentile over timeseries"
+    title="Percentile over time series"
   >
     Show the 95th percentile of first paint and first contentful paint over a time series:
 

--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -60,19 +60,19 @@ The following default limits apply for all Metric data:
 
     <tr>
       <td>
-        Max unique timeseries (cardinality) per account per day
+        Max unique time series (cardinality) per account per day
       </td>
 
       <td>
         1-15 million [(learn more)](#additional-considerations)
 
-        A timeseries is a single, unique combination of a metric name and any attributes.
+        A time series is a single, unique combination of a metric name and any attributes.
       </td>
     </tr>
 
     <tr>
       <td>
-        Max unique timeseries (cardinality) per metric name per day
+        Max unique time series (cardinality) per metric name per day
       </td>
 
       <td>
@@ -232,13 +232,13 @@ The following default limits apply only to data collected via the Prometheus Rem
   <tbody>
     <tr>
       <td>
-        Max unique Count and Summary timeseries (cardinality) per account per 5 minute interval
+        Max unique Count and Summary time series (cardinality) per account per 5 minute interval
       </td>
 
       <td>
         1-15 million [(learn more)](#additional-considerations)
 
-        A timeseries is a single, unique combination of a metric name and any attributes. Timeseries received above this limit are dropped. This limit is enforced prior to and in addition to standard metric limits.
+        A time series is a single, unique combination of a metric name and any attributes. Time series received above this limit are dropped. This limit is enforced prior to and in addition to standard metric limits.
       </td>
     </tr>
   </tbody>
@@ -268,22 +268,22 @@ This section describes how the Metric API behaves when you exceed the rate limit
 
   <Collapser
     id="incident-unique-timeseries"
-    title="Max unique timeseries per account per day"
+    title="Max unique time series per account per day"
   >
-    A timeseries is a single, unique combination of a metric name and any attributes assigned to that metric. For example, if a `CPU utilization` metric with a single attribute `hostname` is sent from ten different hosts, this equals ten distinct values for the `hostname` attribute and ten unique metric timeseries.
+    A time series is a single, unique combination of a metric name and any attributes assigned to that metric. For example, if a `CPU utilization` metric with a single attribute `hostname` is sent from ten different hosts, this equals ten distinct values for the `hostname` attribute and ten unique metric time series.
 
-    If the per-account, per-day unique metric timeseries (cardinality) limit is exceeded during a 24 hour period, the endpoint will continue to receive and store raw metric data. However, New Relic will stop creating additional aggregate rollups (1 minute, 5 minutes, etc.) for the remainder of the 24 hour period. (These rollups are used used by default to query time windows longer than 60 minutes.)
+    If the per-account, per-day unique metric time series (cardinality) limit is exceeded during a 24 hour period, the endpoint will continue to receive and store raw metric data. However, New Relic will stop creating additional aggregate rollups (1 minute, 5 minutes, etc.) for the remainder of the 24 hour period. (These rollups are used used by default to query time windows longer than 60 minutes.)
 
     You can continue to query your data when such an incident occurs by specifying a 60 minute or shorter time window or specifying the RAW keyword (for more on that, see [High cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics)). This can be helpful in identifying potential causes for the incident.
   </Collapser>
 
   <Collapser
     id="incident-unique-timeseries"
-    title="Max unique timeseries per metric name per day"
+    title="Max unique time series per metric name per day"
   >
-    A timeseries is a single, unique combination of a metric name and any attributes assigned to that metric. For example, if a `CPU utilization` metric with a single attribute `hostname` is sent from ten different hosts, this equals ten distinct values for the `hostname` attribute and ten unique metric timeseries.
+    A time series is a single, unique combination of a metric name and any attributes assigned to that metric. For example, if a `CPU utilization` metric with a single attribute `hostname` is sent from ten different hosts, this equals ten distinct values for the `hostname` attribute and ten unique metric time series.
 
-    If the per-metric name, per-day unique metric timeseries (cardinality) limit is exceeded during a 24 hour period, the endpoint will continue to receive and store raw metric data. However, New Relic will stop creating additional aggregate rollups (1 minute, 5 minutes, etc.) for the remainder of the 24 hour period. (These rollups are used used by default to query time windows longer than 60 minutes.)
+    If the per-metric name, per-day unique metric time series (cardinality) limit is exceeded during a 24 hour period, the endpoint will continue to receive and store raw metric data. However, New Relic will stop creating additional aggregate rollups (1 minute, 5 minutes, etc.) for the remainder of the 24 hour period. (These rollups are used used by default to query time windows longer than 60 minutes.)
 
     You can continue to query your data when such an incident occurs by specifying a 60 minute or shorter time window or specifying the RAW keyword (for more on that, see [High cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics)). This can be helpful in identifying potential causes for the incident.
   </Collapser>

--- a/src/content/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events.mdx
@@ -113,9 +113,9 @@ The `category` indicates the type of error and the `message` provides more detai
       </td>
 
       <td>
-        You have Prometheus servers reporting too many unique timeseries via [New Relic's remote_write endpoint](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#remote-write).
+        You have Prometheus servers reporting too many unique time series via [New Relic's remote_write endpoint](/docs/integrations/prometheus-integrations/get-started/monitor-prometheus-new-relic#remote-write).
 
-        Reduce the number of unique timeseries reported by modifying your [Prometheus server configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) to reduce the number of targets being scraped, or by using [relabel rules](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) in the [remote_write section](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) of your server configuration to drop timeseries or highly unique labels.
+        Reduce the number of unique time series reported by modifying your [Prometheus server configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) to reduce the number of targets being scraped, or by using [relabel rules](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) in the [remote_write section](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) of your server configuration to drop time series or highly unique labels.
       </td>
     </tr>
 

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -54,7 +54,7 @@ Limits are enforced per account (not per [organization](/docs/glossary/glossary/
 
 * We place a limit on the number of ingested requests per minute (RPM) per data type. When this limit is reached, we stop accepting data and return a 429 status code for the duration of the minute.
 * For queries, we place limits on the number of queries per minute and the number of records inspected (see [NRQL query rate limits](/docs/query-your-data/nrql-new-relic-query-language/get-started/rate-limits-nrql-queries)). 
-* For metrics, we place a limit on the number of unique timeseries (cardinality) per account and per metric. When this limit is reached, aggregated data is turned off for the rest of the UTC day.
+* For metrics, we place a limit on the number of unique time series (cardinality) per account and per metric. When this limit is reached, aggregated data is turned off for the rest of the UTC day.
 
 For every major limit incident, New Relic creates an [`NrIntegrationError` event](/docs/telemetry-data-platform/manage-data/nrintegrationerror) for that account, which has these limit-related attributes:
 

--- a/src/content/docs/data-apis/understand-data/metric-data/cumulative-metrics.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/cumulative-metrics.mdx
@@ -37,17 +37,17 @@ At a high level, delta conversion is performed by taking two data points sequent
 
 ### Resets [#resets]
 
-If data for a [timeseries](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#timeseries-model) suddenly decreases in value, we treat this as a reset and will emit that new measurement as its own delta value (in other words, as if it were preceded by a `0` measurement).
+If data for a [time series](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#time series-model) suddenly decreases in value, we treat this as a reset and will emit that new measurement as its own delta value (in other words, as if it were preceded by a `0` measurement).
 
 [OpenTelemetry also defines](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#resets-and-gaps) situations where a decrease in value is unexpected, and we do our best to detect these cases and notify you via [New Relic integration errors](/docs/data-apis/manage-data/nrintegrationerror) (see [troubleshooting](#troubleshooting) below).
 
 ### Reordering data [#reorder-data]
 
-We understand that many things can cause data points to arrive at New Relic out of order. As such, we will buffer data points and reorder them if we detect an unexpected gap in the reporting timeseries. Gaps are inferred by an expected reporting interval determined by the rate at which we receive data for a given timeseries. Buffering is bounded and eventually we will consider a data point "too late for resequencing". In this case, a delta is computed across the detected gap and processing of the timeseries continues.
+We understand that many things can cause data points to arrive at New Relic out of order. As such, we will buffer data points and reorder them if we detect an unexpected gap in the reporting time series. Gaps are inferred by an expected reporting interval determined by the rate at which we receive data for a given time series. Buffering is bounded and eventually we will consider a data point "too late for resequencing". In this case, a delta is computed across the detected gap and processing of the time series continues.
 
 ### Stale data [#stale-data]
 
-As delta conversion is a stateful operation, we must be cognizant of timeseries that may stop reporting and eventually drop its state. If a timeseries has not reported any new data points for <DoNotTranslate>**5 minutes**</DoNotTranslate>, we will flush the state we have, including computing deltas across any buffered gaps. This means that if a data point arrives at a later point in time, it will be treated as if it were the beginning of that timeseries, effectively losing the delta between the last data point before the flush and the first data point after the flush. This means that metric reporting intervals should be less than <DoNotTranslate>**5 minutes**</DoNotTranslate> to get the benefit of delta conversion.
+As delta conversion is a stateful operation, we must be cognizant of time series that may stop reporting and eventually drop its state. If a time series has not reported any new data points for <DoNotTranslate>**5 minutes**</DoNotTranslate>, we will flush the state we have, including computing deltas across any buffered gaps. This means that if a data point arrives at a later point in time, it will be treated as if it were the beginning of that time series, effectively losing the delta between the last data point before the flush and the first data point after the flush. This means that metric reporting intervals should be less than <DoNotTranslate>**5 minutes**</DoNotTranslate> to get the benefit of delta conversion.
 
 ### Special note about cumulative sums [#cumulative-sums]
 
@@ -73,7 +73,7 @@ The OpenTelemetry SDK allows you to [configure its cardinality limits](https://o
 
 ### Cardinality limits [#card-limits]
 
-During translation, we also loosely enforce metric cardinality limits that are based on your metric entitlements as a system protection. Rather than enforcing the limit [per day, as we do with rollups](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/#incident-unique-timeseries), this limit is enforced as the number of concurrent timeseries being tracked. Once there are too many concurrent [unique metric timeseries](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/#what-why), we will drop new incoming timeseries until an old one ages out (see [Stale data](#stale-data)).
+During translation, we also loosely enforce metric cardinality limits that are based on your metric entitlements as a system protection. Rather than enforcing the limit [per day, as we do with rollups](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/#incident-unique-time series), this limit is enforced as the number of concurrent time series being tracked. Once there are too many concurrent [unique metric time series](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/#what-why), we will drop new incoming time series until an old one ages out (see [Stale data](#stale-data)).
 
 ### Cumulative metric resets [#cumulative-resets]
 

--- a/src/content/docs/data-apis/understand-data/metric-data/cumulative-metrics.mdx
+++ b/src/content/docs/data-apis/understand-data/metric-data/cumulative-metrics.mdx
@@ -37,7 +37,7 @@ At a high level, delta conversion is performed by taking two data points sequent
 
 ### Resets [#resets]
 
-If data for a [time series](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#time series-model) suddenly decreases in value, we treat this as a reset and will emit that new measurement as its own delta value (in other words, as if it were preceded by a `0` measurement).
+If data for a [time series](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#timeseries-model) suddenly decreases in value, we treat this as a reset and will emit that new measurement as its own delta value (in other words, as if it were preceded by a `0` measurement).
 
 [OpenTelemetry also defines](https://opentelemetry.io/docs/reference/specification/metrics/data-model/#resets-and-gaps) situations where a decrease in value is unexpected, and we do our best to detect these cases and notify you via [New Relic integration errors](/docs/data-apis/manage-data/nrintegrationerror) (see [troubleshooting](#troubleshooting) below).
 

--- a/src/content/docs/errors-inbox/error-limiting.mdx
+++ b/src/content/docs/errors-inbox/error-limiting.mdx
@@ -23,7 +23,7 @@ To reduce the number of error groups, try removing the unique identifiers from t
 ### Problem [#problem]
 
 ```
-You’ve reached the daily maximum unique timeseries (cardinality) limit on account xxx.  This limit will be reset at 00:00 UTC.
+You’ve reached the daily maximum unique time series (cardinality) limit on account xxx.  This limit will be reset at 00:00 UTC.
 ```
 
 When this limit is reached, Errors inbox will no longer update and errors will seem to plateau or fall off.

--- a/src/content/docs/infrastructure/amazon-integrations/troubleshooting/no-data-metric-streams.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/troubleshooting/no-data-metric-streams.mdx
@@ -55,7 +55,7 @@ These guidelines should help understand the root cause of the discrepancy:
 
 * Check that the same function is used on the metrics (for example `average`, `min`, `max`).
 * On the New Relic side, make sure you filter the same timestamp or timeframe (considering the time zone) to show the exact same time as in AWS CloudWatch.
-* When using timeseries, the New Relic user interface might perform some rounding based on intervals.
+* When using time series, the New Relic user interface might perform some rounding based on intervals.
 
 You can get a list of the raw metric received by time using a query like this one (note that no function is applied to the selected metric):
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations.mdx
@@ -166,8 +166,8 @@ The `nri-prometheus-latest.yaml` manifest file includes the `nri-prometheus-cfg`
     #         - kube_resourcequota
     #         - nr_stats
     #     copy_attributes:
-    #       # Copy all the labels from the timeseries with metric name
-    #       # `kube_hpa_labels` into every timeseries with a metric name that
+    #       # Copy all the labels from the time series with metric name
+    #       # `kube_hpa_labels` into every time series with a metric name that
     #       # starts with `kube_hpa_` only if they share the same `namespace`
     #       # and `hpa` labels.
     #       - from_metric: "kube_hpa_labels"

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/ignore-or-include-prometheus-metrics.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/ignore-or-include-prometheus-metrics.mdx
@@ -29,7 +29,7 @@ To decide what data to include or exclude, use New Relic's [Metric API](/docs/da
 * To filter out targets instead of the metrics, use the `scrape_enabled_label` configuration option.
 
 <Callout variant="caution">
-  The [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) and [summary](https://prometheus.io/docs/concepts/metric_types/#summary) metrics type filtering apply to the `base name`. You can't filter by the `_bucket`, `_sum`, or `_count` timeseries for that metric.
+  The [histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) and [summary](https://prometheus.io/docs/concepts/metric_types/#summary) metrics type filtering apply to the `base name`. You can't filter by the `_bucket`, `_sum`, or `_count` time series for that metric.
 </Callout>
 
 The [`nri-prometheus-latest.yaml`](https://download.newrelic.com/infrastructure_agent/integrations/kubernetes/nri-prometheus-latest.yaml) manifest file includes the `nri-prometheus-cfg` config map showing an [example configuration](/docs/integrations/prometheus-integrations/configure/configure-prometheus-openmetrics-integration). The integration will ignore or include metrics before executing the other functions to [add, rename, or copy attributes](/docs/integrations/prometheus-integrations/view-query-data/add-rename-copy-prometheus-attributes).

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent.mdx
@@ -66,8 +66,8 @@ With this dashboard, you get meaningful insights about your Prometheus metrics a
 
 * Samples sent by Source
 * Unique metrics by Source
-* Timeseries by Source
-* Timeseries by Metric (Cardinality)
+* time series by Source
+* Time series by Metric (Cardinality)
 * Memory and CPU consumption
 * Targets Failed to scrape
 * Total Instances by cluster

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure/remote-write-drop-data.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure/remote-write-drop-data.mdx
@@ -54,7 +54,7 @@ remote_write:
       action: 'labeldrop'
 ...
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: 'node'
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s

--- a/src/content/docs/infrastructure/prometheus-integrations/integrations-list/node-exporter-integration.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/integrations-list/node-exporter-integration.mdx
@@ -50,7 +50,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 ```
 
@@ -71,7 +71,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
 remote_write:
@@ -104,7 +104,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -135,7 +135,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -165,7 +165,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -201,7 +201,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -238,7 +238,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -267,7 +267,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -311,7 +311,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -352,7 +352,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 
@@ -385,7 +385,7 @@ global:
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  # The job name is added as a label `job=<job_name>` to any time series scraped from this config.
   - job_name: node
 
     # Target setup 

--- a/src/content/docs/infrastructure/prometheus-integrations/troubleshooting/compare-rw-data-sent-billed-bytes.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/troubleshooting/compare-rw-data-sent-billed-bytes.mdx
@@ -25,7 +25,7 @@ Prometheus remote write data is sent to New Relic [compressed](https://prometheu
 
 You're billed based on the computational effort needed to ingest your data, as well as the size of the data stored within New Relic. The decompression process and data transformations can result in the final uncompressed bytes stored being around 15x the size of its compressed counterpart.
 
-For example, based on a sampling of timeseries data we gathered when simulating real world traffic, you might see something like this:
+For example, based on a sampling of time series data we gathered when simulating real world traffic, you might see something like this:
 
 ```
 ~124 GB/day compressed data sent = ~1.86TB uncompressed data stored

--- a/src/content/docs/infrastructure/prometheus-integrations/view-query-data/supported-promql-features.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/view-query-data/supported-promql-features.mdx
@@ -153,13 +153,13 @@ For this reason, it's best to follow all Prometheus recommendations when working
 
 ### Limits
 
-* In order to ensure the stability and performance of our system for all users, we place some limits on what queries can be run. In all cases, we enforce a limit of 366 steps in range queries. We also default to only returning 100 timeseries from queries by default.
+* In order to ensure the stability and performance of our system for all users, we place some limits on what queries can be run. In all cases, we enforce a limit of 366 steps in range queries. We also default to only returning 100 time series from queries by default.
 * If you want to see more (or fewer), you need to explicitly add a `topk()` to your query. (Note that the `topk()` implementation in our PromQL-style query is different from that of Prometheus.)
 * We limit the total memory a query can use. This means that requests for large numbers of time steps or large numbers of time series may be rejected, particularly if they are combined with an aggregation like unique `count` or `quantile` which require significantly more memory to compute than simple arithmetic aggregations.
 
 ### Range vector selectors (sliding windows and smoothing behavior) [#range-vector]
 
-We provide support for sliding window timeseries aggregations. For more information, see our [NRQL reference](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions#slide-by) and [sliding windows deep dive](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows).
+We provide support for sliding window time series aggregations. For more information, see our [NRQL reference](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions#slide-by) and [sliding windows deep dive](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows).
 
 For information on translating between NRQL and our PromQL-style language, see [Translate PromQL queries to NRQL](/docs/integrations/prometheus-integrations/view-query-data/translate-promql-queries-nrql).
 
@@ -167,4 +167,4 @@ For information on translating between NRQL and our PromQL-style language, see [
 
 * The range of your query in PromQL must be larger than the duration of the step size of the query to avoid the error "`TIMESERIES` bucket size is larger than the current time window".
 * We inspect data up to one minute old when servicing instant queries. If your scrape interval is greater than 1 minute, some queries may result in <DoNotTranslate>**No data found**</DoNotTranslate>. Avoid this by sending data at least once per minute.
-* If the timeseries unit for your NRQL query is less than the scrape interval for your application, some periods will lack data, and the resulting graph may be jagged or contain peaks and valleys. In general, set the step size to your scrape interval, or higher.
+* If the time series unit for your NRQL query is less than the scrape interval for your application, some periods will lack data, and the resulting graph may be jagged or contain peaks and valleys. In general, set the step size to your scrape interval, or higher.

--- a/src/content/docs/infrastructure/prometheus-integrations/view-query-data/translate-promql-queries-nrql.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/view-query-data/translate-promql-queries-nrql.mdx
@@ -243,11 +243,11 @@ This table shows the mapping between NRQL and our PromQL-style queries when expl
     container_memory_usage_bytes
     ```
 
-    This will chart all the unique metric timeseries for the input metric.
+    This will chart all the unique metric time series for the input metric.
 
     <DoNotTranslate>**2. Filter the query results.**</DoNotTranslate>
 
-    Looking at the data, you can add more query parameters to filter down the number of metric timeseries. For example, if you only want timeseries where the `id` is `/`, the PromQL-style query will be:
+    Looking at the data, you can add more query parameters to filter down the number of metric time series. For example, if you only want time series where the `id` is `/`, the PromQL-style query will be:
 
     ```promql
     container_memory_usage_bytes{id="/"}
@@ -289,7 +289,7 @@ This table shows the mapping between NRQL and our PromQL-style queries when expl
 
     To chart metrics using NRQL, you first need an aggregation function. For example, you can use `latest` for gauges, `sum` for counts, and `average` for summaries.
 
-    As the following chart shows, all the unique timeseries are aggregated into one unique timeseries by default:
+    As the following chart shows, all the unique time series are aggregated into one unique time series by default:
 
     <img
       src={infrastructureNrqlQueryExample}
@@ -302,7 +302,7 @@ This table shows the mapping between NRQL and our PromQL-style queries when expl
 
     <DoNotTranslate>**4. View metrics by ID.**</DoNotTranslate>
 
-    To view the unique metric timeseries with various `id` values, run the following query:
+    To view the unique metric time series with various `id` values, run the following query:
 
     ```sql
     FROM Metric SELECT latest(container_memory_usage_bytes) FACET id
@@ -338,7 +338,7 @@ This table shows the mapping between NRQL and our PromQL-style queries when expl
 
 ## Filter examples [#filter-data]
 
-Both our PromQL-style query language and NRQL provide syntax to filter down the number of unique metric timeseries.
+Both our PromQL-style query language and NRQL provide syntax to filter down the number of unique metric time series.
 
 * PromQL-style uses brackets to filter.
 * NRQL uses a `WHERE` clause.

--- a/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/understand-use-data/pixie-entities.mdx
+++ b/src/content/docs/kubernetes-pixie/auto-telemetry-pixie/understand-use-data/pixie-entities.mdx
@@ -52,7 +52,7 @@ You can find the Pixie entities under the <DoNotTranslate>**Other entities**</Do
 
 ## DNS [#dns]
 
-Select a service from the <DoNotTranslate>**DNS - Pixie**</DoNotTranslate> entity list to see timeseries graphs of response time, error rate and throughput for all DNS requests sent to that service. Inspect the Sampled DNS Requests table to see full-body DNS requests and responses received by this service.
+Select a service from the <DoNotTranslate>**DNS - Pixie**</DoNotTranslate> entity list to see time series graphs of response time, error rate and throughput for all DNS requests sent to that service. Inspect the Sampled DNS Requests table to see full-body DNS requests and responses received by this service.
 
 DNS requests automatically traced by Pixie can be used to:
 * Quickly determine which services are making DNS requests.
@@ -72,7 +72,7 @@ DNS requests automatically traced by Pixie can be used to:
 
 ## MySQL [#mysql]
 
-Select a service from the <DoNotTranslate>**MySQL - Pixie**</DoNotTranslate> entity list to see timeseries graphs of response time, error rate and throughput for all MySQL requests sent to that service. Inspect the "Sampled MySQL Requests" table to see full-body MySQL requests and responses received by this service.
+Select a service from the <DoNotTranslate>**MySQL - Pixie**</DoNotTranslate> entity list to see time series graphs of response time, error rate and throughput for all MySQL requests sent to that service. Inspect the "Sampled MySQL Requests" table to see full-body MySQL requests and responses received by this service.
 
 MySQL requests automatically traced by Pixie can be used to:
 
@@ -92,7 +92,7 @@ MySQL requests automatically traced by Pixie can be used to:
 
 ## PostgreSQL [#postgres]
 
-Select a service from the <DoNotTranslate>**Postgres - Pixie**</DoNotTranslate> entity list to see timeseries graphs of response time, error rate and throughput for all PostgreSQL requests sent to that service. Inspect the "Sampled Postgres Requests" table to see full-body PostgreSQL requests and responses received by this service.
+Select a service from the <DoNotTranslate>**Postgres - Pixie**</DoNotTranslate> entity list to see time series graphs of response time, error rate and throughput for all PostgreSQL requests sent to that service. Inspect the "Sampled Postgres Requests" table to see full-body PostgreSQL requests and responses received by this service.
 
 PostgreSQL requests automatically traced by Pixie can be used to:
 
@@ -112,7 +112,7 @@ PostgreSQL requests automatically traced by Pixie can be used to:
 
 ## Redis [#redis]
 
-Select a service from the <DoNotTranslate>**Redis - Pixie**</DoNotTranslate> entity list to see timeseries graphs of response time, error rate and throughput for all Redis requests sent to a service. Inspect the "Sampled Redis Requests" table to see full-body Redis requests and responses received by this service.
+Select a service from the <DoNotTranslate>**Redis - Pixie**</DoNotTranslate> entity list to see time series graphs of response time, error rate and throughput for all Redis requests sent to a service. Inspect the "Sampled Redis Requests" table to see full-body Redis requests and responses received by this service.
 
 Redis requests automatically traced by Pixie can be used to:
 
@@ -132,7 +132,7 @@ Redis requests automatically traced by Pixie can be used to:
 
 ## Kafka [#kafka]
 
-Select a service from the <DoNotTranslate>**Kafka - Pixie**</DoNotTranslate> entity list to see timeseries graphs of response time, error rate and throughput for all Kafka messages sent to that service. Inspect the "Sample of Kafka Requests" table to see full-body Kafka messages received by this service.
+Select a service from the <DoNotTranslate>**Kafka - Pixie**</DoNotTranslate> entity list to see time series graphs of response time, error rate and throughput for all Kafka messages sent to that service. Inspect the "Sample of Kafka Requests" table to see full-body Kafka messages received by this service.
 
 Kafka messages traced by Pixie can be used to:
 
@@ -153,7 +153,7 @@ Kafka messages traced by Pixie can be used to:
 
 ## AMQP [#amqp]
 
-Select a service from the <DoNotTranslate>**AMQP - Pixie**</DoNotTranslate> entity list to see timeseries graphs of response time, error rate and throughput for all AMQP messages sent to that service.
+Select a service from the <DoNotTranslate>**AMQP - Pixie**</DoNotTranslate> entity list to see time series graphs of response time, error rate and throughput for all AMQP messages sent to that service.
 
 AMQP messages traced by Pixie can be used to:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-go-runtime-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-go-runtime-page.mdx
@@ -14,7 +14,7 @@ After you've sent us your OpenTelemetry data and opened your service (entity) in
   You must install a separate instrumentation package to gather the runtime metrics used in this view. See [Runtime metric details](#metric-details) below.
 </Callout>
 
-You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' metrics using timeseries charts to spot problems and determine whether garbage collection, goroutines, or other runtime resources are involved.
+You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' metrics using time series charts to spot problems and determine whether garbage collection, goroutines, or other runtime resources are involved.
 
 Here's a typical workflow:
 

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-jvms-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-jvms-page.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 
 After you've sent us your OpenTelemetry data and opened your service (entity) in the UI, click <DoNotTranslate>**JVMs**</DoNotTranslate> to identify which service instances have unusual or unhealthy performance patterns related to the behavior of the Java Virtual Machine.
 
-You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using timeseries charts to spot problems.
+You can choose several service instances to compare based on summaries of key metrics: response time, throughput, error rate, garbage collection time, and memory usage. Then, you can compare all those instances' JVM metrics collected by OpenTelemetry instrumentation using time series charts to spot problems.
 
 Here's a typical workflow:
 
@@ -29,7 +29,7 @@ You can also view all the runtime metrics for a single JVM by clicking the name 
     id="metric-details"
     title="Runtime metric details"
   >
-    When you compare JVMs or drill into a single JVM, you will see several timeseries charts of runtime metric data, including garbage collection and memory usage. The JVM-specific runtime metrics are specified in the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/reference/specification/metrics/semantic_conventions/runtime-environment-metrics/#jvm-metrics) and [implemented](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) in recent versions of the OTel auto-instrumentation agent.
+    When you compare JVMs or drill into a single JVM, you will see several time series charts of runtime metric data, including garbage collection and memory usage. The JVM-specific runtime metrics are specified in the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/reference/specification/metrics/semantic_conventions/runtime-environment-metrics/#jvm-metrics) and [implemented](https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/runtime-metrics/library/src/main/java/io/opentelemetry/instrumentation/runtimemetrics) in recent versions of the OTel auto-instrumentation agent.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-baseline-ingest-guide.mdx
@@ -432,7 +432,7 @@ Use this when you need to remove the effects of regular variability of ingest to
 
 Telemetry is inherently noisy. Real world phenomena happen in spurts leaving many random peaks and troughs in the signal. This is good in a way as it lets us view the full complexity of a phenomenon. However, when we're seeking to see trends, we can be distracted by detail. NRQL provides a powerful way to smooth out any time series by combining each data point with slightly older points. This let's us focus on the overall temporal trend rather than one extreme `increase` or `decrease`.
 
-Note the jaggedness of the raw timeseries for 1 day ingest rate:
+Note the jaggedness of the raw time series for 1 day ingest rate:
 
 ```sql
 FROM NrConsumption SELECT rate(sum(GigabytesIngested), 1 day) WHERE productLine = 'DataPlatform' SINCE 26 weeks AGO TIMESERIES 1 DAY

--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -172,7 +172,7 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
       ...
     ```
 
-    Use the `AS` clause to label an attribute, aggregator, step in a funnel, or the result of a math function with a string delimited by single quotes. The label is used in the resulting chart. Note that `AS` clause labels in timeseries charts will not be displayed if a `FACET` clause is used.
+    Use the `AS` clause to label an attribute, aggregator, step in a funnel, or the result of a math function with a string delimited by single quotes. The label is used in the resulting chart. Note that `AS` clause labels in time series charts will not be displayed if a `FACET` clause is used.
 
 
     <CollapserGroup>
@@ -323,7 +323,7 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
 
     Use the `LIMIT` clause to specify how many facets appear (default is 10). For more complex grouping, use [`FACET CASES`](#sel-facet-cases). `FACET` clauses support up to five attributes, separated by commas.
 
-    The facets are sorted in descending order by the first field you provide in the `SELECT` clause. If you are faceting on attributes with more than 5,000 unique values, a subset of facet values is selected and sorted according to the query type. Note that if a timeseries chart returns no data (NRQL matches no matching data, invalid NRQL, etc.) then it will only show a flat line with the label matching the first table in the `FROM` clause.
+    The facets are sorted in descending order by the first field you provide in the `SELECT` clause. If you are faceting on attributes with more than 5,000 unique values, a subset of facet values is selected and sorted according to the query type. Note that if a time series chart returns no data (NRQL matches no matching data, invalid NRQL, etc.) then it will only show a flat line with the label matching the first table in the `FROM` clause.
 
     When selecting `min()`, `max()`, `percentile()`, `average()` or `count()`, `FACET` uses those functions to determine how facets are picked and sorted. When selecting any other [function](#functions), `FACET` uses the frequency of the attribute you are faceting on to determine how facets are picked and sorted.
 
@@ -470,7 +470,7 @@ As noted in our [basic NRQL syntax doc](/docs/query-your-data/nrql-new-relic-que
 
 
     <Callout variant="tip">
-      Because the operations are performed before the `LIMIT` clause is applied, `FACET ... ORDER BY` does not impact the sort of the final query results, which will be particularly noticeable in the results for non-timeseries queries.
+      Because the operations are performed before the `LIMIT` clause is applied, `FACET ... ORDER BY` does not impact the sort of the final query results, which will be particularly noticeable in the results for non-time series queries.
     </Callout>
 
     <Callout variant="important">
@@ -1326,7 +1326,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     id="func-aggregationendtime"
     title={<InlineCode>aggregationendtime()</InlineCode>}
   >
-    Use the `aggregationendtime()` function to return the time of the relevant aggregation. More specifically, for a given aggregate, the `aggregationendtime()` function provides the timestamp of the end of the time period of that aggregation. For example, in a timeseries query, for a data point that encompasses an hour’s worth of data, the function would return the timestamp of the end of that hour period.
+    Use the `aggregationendtime()` function to return the time of the relevant aggregation. More specifically, for a given aggregate, the `aggregationendtime()` function provides the timestamp of the end of the time period of that aggregation. For example, in a time series query, for a data point that encompasses an hour’s worth of data, the function would return the timestamp of the end of that hour period.
   </Collapser>
 
   <Collapser
@@ -1802,7 +1802,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     * Generally, `predictLinear()` is helpful for continuously growing values like disk space, or predictions on large trends.
     * Since `predictLinear()` is a linear regression, familiarity with the dataset being queried helps to ensure accurate long-term predictions.
     * Any dataset which grows exponentially, logarithmically, or by other nonlinear means will likely only be successful in very short-term predictions.
-    * New Relic recommends against using `predictLinear` in `TIMESERIES` queries. This is because each bucket will be making an individual prediction based on its relative timeframe within the query, meaning that such queries will not show predictions from the end of the timeseries forward.
+    * New Relic recommends against using `predictLinear` in `TIMESERIES` queries. This is because each bucket will be making an individual prediction based on its relative timeframe within the query, meaning that such queries will not show predictions from the end of the time series forward.
   </Collapser>
 
   <Collapser
@@ -2001,7 +2001,7 @@ Note: `aparse()` is case-insensitive.
     This function has the following restrictions:
     * Queries containing calls to `blob()` have a max LIMIT value of 20
     * `blob()` cannot be called in the `WHERE` clause of a query
-    * `blob()` cannot be used in faceted queries or timeseries queries
+    * `blob()` cannot be used in faceted queries or time series queries
 
     For more information about how this is used in Logging, see [Find data in long logs (blobs)](/docs/logs/log-management/ui-data/long-logs-blobs).
 
@@ -2253,7 +2253,7 @@ Note: `aparse()` is case-insensitive.
     FROM Metric SELECT count(node_filesystem_size) TIMESERIES FACET dimensions()
     ```
 
-    When used with a `FACET` clause, `dimensions()` produces a unique timeseries for all facets available on the event type, similar to how Prometheus behaves with non-aggregated queries.
+    When used with a `FACET` clause, `dimensions()` produces a unique time series for all facets available on the event type, similar to how Prometheus behaves with non-aggregated queries.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/nrql/nrql-tutorials/introduction-nrql-tutorial.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/introduction-nrql-tutorial.mdx
@@ -316,14 +316,14 @@ TIMESERIES
 ```
 
     <img
-  title="Select the average duration since 1 day ago over with a timeseries"
-  alt="A screenshot of a query that selects the average duration since 1 day ago with a timeseries"
+  title="Select the average duration since 1 day ago over with a time series"
+  alt="A screenshot of a query that selects the average duration since 1 day ago with a time series"
   src={queriesnrqltutorial12}
 />
         
     </Step>
     <Step>
-A timeseries query breaks the data into a number of regions called buckets over the specified time period. You can have NRDB pick a value for the width of that bucket or choose your own. Use this query to ask NRDB to show the average duration of application transactions with returned data organized into 1-hour buckets.
+A time series query breaks the data into a number of regions called buckets over the specified time period. You can have NRDB pick a value for the width of that bucket or choose your own. Use this query to ask NRDB to show the average duration of application transactions with returned data organized into 1-hour buckets.
     
 ```sql
 SELECT average(duration) 
@@ -340,7 +340,7 @@ TIMESERIES 1 hour
         
     </Step>
     <Step>
-Notice this may return a flatter graph, since we only have 24 data points across the 1-day period being plotted. But what if you want to see the maximum possible granularity? Any timeseries query can have up to 366 data buckets, meaning the maximum granularity possible for 24 hours is to bucket our data into 4 minute windows. Query this by using `TIMESERIES 4 minutes` or `TIMESERIES MAX`:
+Notice this may return a flatter graph, since we only have 24 data points across the 1-day period being plotted. But what if you want to see the maximum possible granularity? Any time series query can have up to 366 data buckets, meaning the maximum granularity possible for 24 hours is to bucket our data into 4 minute windows. Query this by using `TIMESERIES 4 minutes` or `TIMESERIES MAX`:
 ```sql
 SELECT average(duration) 
 FROM Transaction 
@@ -371,8 +371,8 @@ TIMESERIES
 ```
 
     <img
-  title="Select the avarege duration for Web transaction types with a timeseries"
-  alt="A screenshot of a query selecting the average duration for Web transaction types with a timeseries"
+  title="Select the avarege duration for Web transaction types with a time series"
+  alt="A screenshot of a query selecting the average duration for Web transaction types with a time series"
   src={queriesnrqltutorial15}
 />
 
@@ -391,8 +391,8 @@ TIMESERIES
 ```
 
     <img
-  title="Select the average duration for Web transaction types with a duration of less than 0.1 seconds with the response codes 200 or 302 with a timeseries"
-  alt="A screenshot of a query selecting the average duration for Web transaction types with a duration of less than 0.1 seconds with the response codes 200 or 302 with a timeseries"
+  title="Select the average duration for Web transaction types with a duration of less than 0.1 seconds with the response codes 200 or 302 with a time series"
+  alt="A screenshot of a query selecting the average duration for Web transaction types with a duration of less than 0.1 seconds with the response codes 200 or 302 with a time series"
   src={queriesnrqltutorial16}
 />
         
@@ -440,8 +440,8 @@ TIMESERIES
     </Side>
     <Side>
     <img
-  title="Select the average duration from the top 5 results since 3 hours ago grouped by name with a timeseries"
-  alt="A screenshot of a query selecting the average duration from the top 4 results since 3 hours ago grouped by name with a timeseries"
+  title="Select the average duration from the top 5 results since 3 hours ago grouped by name with a time series"
+  alt="A screenshot of a query selecting the average duration from the top 4 results since 3 hours ago grouped by name with a time series"
   src={queriesnrqltutorial18}
 />
     </Side>
@@ -462,8 +462,8 @@ LIMIT 20
     </Side>
     <Side>
     <img
-  title="Select the average duration from the top 20 results since 3 hours ago grouped by name without a timeseries"
-  alt="A screenshot of a query selecting the average duration from the top 20 results since 3 hours ago grouped by name without a timeseries"
+  title="Select the average duration from the top 20 results since 3 hours ago grouped by name without a time series"
+  alt="A screenshot of a query selecting the average duration from the top 20 results since 3 hours ago grouped by name without a time series"
   src={queriesnrqltutorial19}
 />
     </Side>
@@ -482,8 +482,8 @@ Finally, here's a slightly more complex query that compares the quantity of Web 
   ```
 
     <img
-  title="Select all web transactions from the top 5 results since 6 hours ago grouped by appName with a timeseries"
-  alt="A screenshot of a query selecting all web transactions from the top 5 results since 6 hours ago grouped by appName with a timeseries"
+  title="Select all web transactions from the top 5 results since 6 hours ago grouped by appName with a time series"
+  alt="A screenshot of a query selecting all web transactions from the top 5 results since 6 hours ago grouped by appName with a time series"
   src={queriesnrqltutorial20}
 />
 

--- a/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-dashboarding.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-dashboarding.mdx
@@ -206,8 +206,8 @@ TIMESERIES
     </Side>
     <Side>
 <img
-    title="Apdex timeseries"
-    alt="A screenshot showing an apdex timeseries"
+    title="Apdex time series"
+    alt="A screenshot showing an apdex time series"
     src={queriesnrql2tutorial7}
 />
     </Side>
@@ -341,8 +341,8 @@ SINCE 1 day ago
 TIMESERIES max
 ```
 <img
-    title="Event type with count and timeseries"
-    alt="A screenshot showing the event type functionality with count and timeseries"
+    title="Event type with count and time series"
+    alt="A screenshot showing the event type functionality with count and time series"
     src={queriesnrql2tutorial13}
 />
     </Step>

--- a/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-functions.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-functions.mdx
@@ -125,7 +125,7 @@ SINCE 1 day ago
 
     <Step>
 
-You can use clamping on an attribute to impose an upper or lower limit on its value. This has use for things like ensuring extreme outliers don't skew the scale of a timeseries graph. `clamp_max(duration, 10)` returns the duration, unless it exceeds 10, in which case it returns 10. Quite simply, anything greater than 10 still returns as to equal 10. `clamp_min(duration,1)` does the inverse; if any duration is below 1, it reports as equal to 1. 
+You can use clamping on an attribute to impose an upper or lower limit on its value. This has use for things like ensuring extreme outliers don't skew the scale of a time series graph. `clamp_max(duration, 10)` returns the duration, unless it exceeds 10, in which case it returns 10. Quite simply, anything greater than 10 still returns as to equal 10. `clamp_min(duration,1)` does the inverse; if any duration is below 1, it reports as equal to 1. 
 
 ```sql
 SELECT clamp_max(average(duration), 10), clamp_min(average(duration), 1) 

--- a/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-process-your-data.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-process-your-data.mdx
@@ -294,8 +294,8 @@ COMPARE WITH 1 week ago
 TIMESERIES
 ```
 <img
-    title="Compare time windows with timeseries"
-    alt="A screenshot displaying a query using the compare with function using a timeseries"
+    title="Compare time windows with time series"
+    alt="A screenshot displaying a query using the compare with function using a time series"
     src={queriesnrql3tutorial7}
 />
     </Step>
@@ -311,7 +311,7 @@ TIMESERIES
 ```
 <img
     title="Compare time windows using relative time periods"
-    alt="A screenshot displaying a query using the compare with function using a relative timeseries"
+    alt="A screenshot displaying a query using the compare with function using a relative time series"
     src={queriesnrql3tutorial7}
 />
     </Step>

--- a/src/content/docs/nrql/using-nrql/query-time-range.mdx
+++ b/src/content/docs/nrql/using-nrql/query-time-range.mdx
@@ -40,13 +40,13 @@ Looking at the JSON response to this query, this 47-hour-and-59-minute time rang
 
 ### `TIMESERIES` query snapping
 
-Queries with `TIMESERIES` may need to adjust the time range so the results do not include a partial timeseries bucket. For example:
+Queries with `TIMESERIES` may need to adjust the time range so the results do not include a partial time series bucket. For example:
 
   ```sql
     FROM Foo SELECT count(*) TIMESERIES 5 minutes SINCE '2023-12-20T00:04:59Z' UNTIL '2023-12-21T00:03:12Z'
   ```
 
-Looking at the JSON response to this query, the timeseries buckets base themselves on the end of the time range, and the start time is adjusted so the first bucket in the response covers a full 5 minutes: `"beginTime": "2023-12-20T00:08:12Z", "endTime": "2023-12-21T00:03:12Z"`.
+Looking at the JSON response to this query, the time series buckets base themselves on the end of the time range, and the start time is adjusted so the first bucket in the response covers a full 5 minutes: `"beginTime": "2023-12-20T00:08:12Z", "endTime": "2023-12-21T00:03:12Z"`.
 
 ## Specify a time with SINCE and UNTIL [#spec-time]
 You have a few ways to specify time in the `SINCE` and until `UNTIL` clauses.

--- a/src/content/docs/nrql/using-nrql/rate-function.mdx
+++ b/src/content/docs/nrql/using-nrql/rate-function.mdx
@@ -30,7 +30,7 @@ SELECT rate(count(*), 1 minute) AS 'Errors' FROM TransactionError TIMESERIES SIN
 ```
 
 <img
-  title="Rate function with timeseries"
+  title="Rate function with time series"
   alt="A screenshot displaying an example of the rate() function"
   src={exampleRateFunction}
 />
@@ -45,7 +45,7 @@ Running the same query without including `TIMESERIES` will display a single valu
     </Side>
     <Side>
         <img
-          title="Rate function without timeseries"
+          title="Rate function without time series"
           alt="A screenshot displaying an example of the rate() function without TIMESERIES"
           src={exampleRateFunctionNoTimeseries}
         />

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-types.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-types.mdx
@@ -534,7 +534,7 @@ This table contains all chart types. Whether a chart type is available for your 
     />
 
     <figcaption>
-      The line chart plots a timeseries for an attribute.
+      The line chart plots a time series for an attribute.
     </figcaption>
 
     When working in basic query mode, select a single attribute you can plot over time.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71400177.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-71400177.mdx
@@ -25,7 +25,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 * **Enhance support for redis and aredis**
 
-  The agent now instruments a more extensive list of commands for redis and aredis clients. This includes commands under the search, graph, timeseries, json, sentinel, and bf modules.
+  The agent now instruments a more extensive list of commands for redis and aredis clients. This includes commands under the search, graph, time series, json, sentinel, and bf modules.
 
 ## Bug Fixes
 

--- a/src/content/docs/tutorial-error-tracking/respond-outages.mdx
+++ b/src/content/docs/tutorial-error-tracking/respond-outages.mdx
@@ -153,10 +153,10 @@ At first this seems to lack granularity, but your time series gives you enough i
 
 * Based on number of occurrences alone, your first instinct might tell you to start with `ActivemModel:::ValidationError` as it has 4,000 occurrences. If you look at the time series, though, its peaks and troughs are relatively consistent. This could be an expected error, but let's look at the other five. 
 * The `Net::OpenTimeOut` error group has a similar pattern, and it actually makes up four of the six reporting groups. Across each error group, you can see consistent peaks and troughs that extend before the incident. With the same name and similar patterns, we can infer this is an expected error as well.
-* Our last option is `JsonapiClient:::Notfound`. Like `ActivemModel:::ValidationError`, it has a distinct shape and is consistently reporting. While it doesn’t have many occurrences, the timeseries is anomalous enough that it might be worth digging a bit deeper. 
+* Our last option is `JsonapiClient:::Notfound`. Like `ActivemModel:::ValidationError`, it has a distinct shape and is consistently reporting. While it doesn’t have many occurrences, the time series is anomalous enough that it might be worth digging a bit deeper. 
     </Step>
     <Step>
-    ## Adjust the timeseries [#timeseries]
+    ## Adjust the time series [#timeseries]
 
 To be certain, adjust the time parameter to show patterns from the last 12 hours:
 

--- a/src/content/docs/tutorial-troubleshoot-infra-hosts/investigate-your-resources.mdx
+++ b/src/content/docs/tutorial-troubleshoot-infra-hosts/investigate-your-resources.mdx
@@ -78,23 +78,23 @@ A resource-related problem doesn't always mean the solution is provisioning more
 * The app is running a redundant process that's causing CPU to spike. If this is the case, you should reach out to the owning team about optimizing that app. 
 * More end users are accessing that component and adding stress to your system. If this is the case, then you should provision more resources to meet that load.
 
-If we look at the summary page for `host-tower-portland`, we can identify which scenario applies to this situation by correlating timeseries patterns between different charts.  Let's compare network traffic against your infrastructure metrics. 
+If we look at the summary page for `host-tower-portland`, we can identify which scenario applies to this situation by correlating time series patterns between different charts.  Let's compare network traffic against your infrastructure metrics. 
 
 * In this case, you're expecting the <DoNotTranslate>**Network traffic**</DoNotTranslate> graph to trend similarly to your metric graphs for CPU usage, memory usage, and so on. 
-* If your resources are related to app issues instead of load, then your network timeseries would trend in an ordinary way, that is without any spikes or troughs. 
-* However, if load is the cause of high CPU, then you'd notice your network timeseries mirroring the trends across your other metric graphs. 
+* If your resources are related to app issues instead of load, then your network time series would trend in an ordinary way, that is without any spikes or troughs. 
+* However, if load is the cause of high CPU, then you'd notice your network time series mirroring the trends across your other metric graphs. 
 
 Let's compare our <DoNotTranslate>**CPU usage**</DoNotTranslate> and <DoNotTranslate>**Network traffic**</DoNotTranslate>:
 
 <img
-    title="Compare network timeseries with CPU timeseries"
+    title="Compare network time series with CPU time series"
     alt="A screenshot cropped to only display the network and CPU charts"
     src={checkLoad}
 />  
 
 * If load is stressing your system, your Network traffic would show an increase that paralells your metric graphs. 
 * You might also notice a slow decrease of traffic over time after a peak. This is because resources are running out and causing those processes to stop. In other words, if available resources can't support demand, then network traffic might throttle and cause a steady decrease. 
-* Network traffic, however, is showing consistent behavior. The overall behavior doesn't appear to change over time as resources run out. Instead, the timeseries shows regular peaks and troughs.
+* Network traffic, however, is showing consistent behavior. The overall behavior doesn't appear to change over time as resources run out. Instead, the time series shows regular peaks and troughs.
 * This indicates that the problem is actually with the app, rather than the app needing more resources to meet load.
 
 In this instance, you would **not** allocate additional resources to the app. Instead, reach out to the owning team and recommend they optimize the offending Ruby process. 

--- a/src/i18n/content/es/docs/ai-monitoring/view-ai-data.mdx
+++ b/src/i18n/content/es/docs/ai-monitoring/view-ai-data.mdx
@@ -58,8 +58,8 @@ Si posee varias aplicaciones con varias implementaciones de diferentes marcos de
 ### Realice un seguimiento del total de respuestas, el tiempo de respuesta promedio y el uso token
 
 <img
-  title="AI responses response billboard and timeseries graphs"
-  alt="A cropped screenshot displaying the timeseries graphs and billboard info about AI data"
+  title="AI responses response billboard and time series graphs"
+  alt="A cropped screenshot displaying the time series graphs and billboard info about AI data"
   src={aiTimeseriesBillboard}
 />
 
@@ -77,8 +77,8 @@ Los tres mosaicos muestran el rendimiento métrico general de las respuestas de 
 ### Ajustar los gráficos de series temporales.
 
 <img
-  title="AI timeseries graphs"
-  alt="A cropped screenshot displaying timeseries info about AI data"
+  title="AI time series graphs"
+  alt="A cropped screenshot displaying time series info about AI data"
   src={aiCroppedImageofAItimeseries}
 />
 


### PR DESCRIPTION
This sweep standardizes uses of time series to include a space, rather than be one word. This does not update `timeseries` when the word appears as a NRQL variable or as a value (indicated by backticks).

Review needs are:

- Make sure casing is correct. I did a reverse sweep and fixed what I found
- Ensure that no images are broken, no anchor tags, or valule `timeseries` are corrected in a sentence or in a NRQL query