### PR TITLE
fix(OptionalFields): Added optional fields

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -100,9 +100,24 @@ For [scripted browser monitors](#create-scripted-browser):
 * RUNTIME_TYPE_VERSION: The runtime type version used by your monitor. "100" is the only accepted value. 
 * SCRIPT_LANGUAGE: The language used in your monitor. "JAVASCRIPT" is the only accepted value. 
 
+For [step monitors](#create-step):
+
+* RUNTIME_TYPE: The runtime type used by your monitor. "CHROME_BROWSER" is the only accepted value.
+* RUNTIME_TYPE_VERSION: The runtime type version used by your monitor. "100" is the only accepted value. 
+* SCRIPT_LANGUAGE: The language used in your monitor. "JAVASCRIPT" is the only accepted value. 
+
 For [certificate check monitors](#create-certificate-check):
 
 * DAYS_UNTIL_EXPIRATION: Notifies you when you need to update your certificate. For example, if you wanted a notification 30 days before the certificate expires, you would input 30. 
+* RUNTIME_TYPE: The runtime type used by your monitor. "NODE_API" is the only accepted value.
+* RUNTIME_TYPE_VERSION: The runtime type version used by your monitor. The only accepted value is `16.10`. 
+* SCRIPT_LANGUAGE: The language used in your monitor. "JAVASCRIPT" is the only accepted value. 
+
+For [broken link monitors](#create-broken-links):
+
+* RUNTIME_TYPE: The runtime type used by your monitor. "NODE_API" is the only accepted value.
+* RUNTIME_TYPE_VERSION: The runtime type version used by your monitor. The only accepted value is `16.10`. 
+* SCRIPT_LANGUAGE: The language used in your monitor. "JAVASCRIPT" is the only accepted value. 
 
 For all monitors:
 


### PR DESCRIPTION
Added optional runtime related fields to broken link, cert check, and step monitors to match other monitor types. Using these fields allows you to create a monitor that utilizes newer synthetics runtimes and private job managers (if applicable). 