### PR TITLE
NRQL: Add missing anchor to h3 heading

### DIFF
--- a/src/content/docs/nrql/using-nrql/query-time-range.mdx
+++ b/src/content/docs/nrql/using-nrql/query-time-range.mdx
@@ -299,7 +299,7 @@ Note that `today AT [time]` in a `SINCE` clause will never reference a time in t
   </table>
 </Collapser>
 
-### Use a DateTime string
+### Use a DateTime string [#use-datetime-string]
 You can specify a time range time using a DateTime string. The parser generally supports the ISO 8601 DateTime format: `'2023-12-18T12:34:56.789-06:00'`. But, the DateTime parser can also recognize variants of the ISO standard format, like `'2023-12-18 12:34'`. The parser also supports date-only (`'2023-12-18'`) and time-only (`'12:34:56'`) strings. We have the options and examples for using a DateTime string below:
 
     <table style={{width: "auto"}}>


### PR DESCRIPTION
We had an h3 heading without an anchor and it surfaced a bug where a random anchor is generated for anchorless headings. Until we can fix that bug, I'm adding an anchor.