### PR TITLE
ProductTile mobile hover

### DIFF
--- a/src/components/Onboarding/OnboardingStep.js
+++ b/src/components/Onboarding/OnboardingStep.js
@@ -85,6 +85,7 @@ const Card = styled.div`
 
   @media screen and (max-width: 1000px) {
     margin-bottom: 24px;
+    margin-left: 0;
   }
 `;
 

--- a/src/components/ProductTile.js
+++ b/src/components/ProductTile.js
@@ -109,6 +109,17 @@ const ProductTile = ({ children, icon, title, to }) => {
           .dark-mode & {
             border: var(--secondary-background-color) solid 1px; // prevent shifting on hover
           }
+          @media screen and (max-width: 1000px) {
+            &:hover {
+              transform: none;
+              height: 100%;
+              width: 100%;
+
+              .text {
+                display: none;
+              }
+            }
+          }
         `}
         to={to}
       >


### PR DESCRIPTION
- Remove hover effect from ProductTiles on mobile so when i user clicks, the tile doesn't grow. 

- Also removed a left margin from the onboarding steps that works for desktop views, but makes the text off center in mobile layout.

### hover before
https://github.com/newrelic/docs-website/assets/47728020/079935ea-892b-48f5-a718-ea47c96e3922

### hover after

https://github.com/newrelic/docs-website/assets/47728020/6027e3e7-274c-4c9b-889e-b1c4fe9e1d41
