### PR TITLE
Nr 239607 export and display fb internal metrics

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/getting-started/polling-intervals-azure-integrations.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/getting-started/polling-intervals-azure-integrations.mdx
@@ -28,4 +28,4 @@ For visualizations of polling intervals, API calls, and other data for your Azur
 
 ## New Relic polling intervals [#aws-integrations]
 
-For polling and resolution details, see the [documentation for a specific integration](/docs/integrations/microsoft-azure-integrations/azure-integrations-list).
+For details on polling and resolution, see the documentation for a specific integration in the [Azure integrations list](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor/) section.

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -43,22 +43,22 @@ To forward your Kubernetes logs to New Relic with our plugin:
 
 Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, looking at the log forwarder internal metrics can be helpful to understand the cause of a potential bottleneck.
 
-The `newrelic-logging` Helm chart provides a configuration setting to enable the collection of such metrics for a given Kubernetes cluster. Our JSON-formatted dashboard template easily displays all these metrics in New Relic.
+The `newrelic-logging` Helm chart provides a configuration setting to enable the collection of such metrics for a given Kubernetes cluster. We also provide a JSON-formatted dashboard template to easily display all these metrics in New Relic.
 
 To configure your Kubernetes cluster to send the log forwarder internal metrics and represent them in a dashboard, follow these steps:
 
-  1. Install the Helm chart with the following extra configuration setting: 
+  1. Install the Helm chart with the following extra configuration setting:
     ```
     newrelic-logging:
       fluentBit:
         sendMetrics: true
     ```
-  You only need to enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
+  You only need to enable the `newrelic-logging.fluentBit.sendMetrics` setting when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
   2. Download [this dashboard template file](https://raw.githubusercontent.com/newrelic/helm-charts/master/charts/newrelic-logging/fluent-bit-and-plugin-metrics-dashboard-template.json). Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
   3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
   4. The imported dashboard will be available in your [Dashboards page](https://one.newrelic.com/dashboards) as `Kubernetes Fluent Bit monitoring`.
 
-### Configure Fluent Bit 
+### Additional metric details
 The `newrelic-logging` Helm chart uses [Fluent Bit](https://fluentbit.io/) together with New Relic's [newrelic-fluent-bit-output plugin](https://github.com/newrelic/newrelic-fluent-bit-output) to send logs to New Relic. The `fluentBit.sendMetrics` configuration option enables the collection of their individual metrics:
 
   * **[Fluent Bit internal metrics](https://docs.fluentbit.io/manual/administration/monitoring#for-v2-metrics)**: emitted by Fluent Bit in Prometheus format and delivered to New Relic's Prometheus Export endpoint. **These are the recommended ones to troubleshoot a Kubernetes cluster** because they can be faceted by `cluster_name`, `node_name` and `hostname` (pod name).

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -47,17 +47,16 @@ The `newrelic-logging` Helm chart provides a configuration setting to enable the
 
 To configure your Kubernetes cluster to send the log forwarder internal metrics and represent them in a dashboard, follow these steps:
 
-1. Install the Helm chart with the following extra configuration setting:
-
-```
-newrelic-logging:
-    fluentBit:
-      sendMetrics: true
-```
-You only need to enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
-2. Download [this dashboard template file](https://raw.githubusercontent.com/newrelic/helm-charts/master/charts/newrelic-logging/fluent-bit-and-plugin-metrics-dashboard-template.json). Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
-3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
-4. The imported dashboard will be available in your [Dashboards page](https://one.newrelic.com/dashboards) as `Kubernetes Fluent Bit monitoring`.
+  1. Install the Helm chart with the following extra configuration setting: 
+    ```
+    newrelic-logging:
+      fluentBit:
+        sendMetrics: true
+    ```
+  You only need to enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
+  2. Download [this dashboard template file](https://raw.githubusercontent.com/newrelic/helm-charts/master/charts/newrelic-logging/fluent-bit-and-plugin-metrics-dashboard-template.json). Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
+  3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
+  4. The imported dashboard will be available in your [Dashboards page](https://one.newrelic.com/dashboards) as `Kubernetes Fluent Bit monitoring`.
 
 ### Configure Fluent Bit 
 The `newrelic-logging` Helm chart uses [Fluent Bit](https://fluentbit.io/) together with New Relic's [newrelic-fluent-bit-output plugin](https://github.com/newrelic/newrelic-fluent-bit-output) to send logs to New Relic. The `fluentBit.sendMetrics` configuration option enables the collection of their individual metrics:

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -41,36 +41,31 @@ To forward your Kubernetes logs to New Relic with our plugin:
 
 ## Troubleshoot your Kubernetes plugin for log forwarding installation [#troubleshoot-installation]
 
-Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, it can be helpful to look at the log forwarder internal metrics to understand what is the cause of a potential bottleneck.
+Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, looking at the log forwarder internal metrics can be helpful to understand the cause of a potential bottleneck.
 
-To this end, the `newrelic-logging` Helm chart provides a configuration setting to enable the collection of such metrics for a given Kubernetes cluster. Moreover, we provide a dashboard template in JSON format to easily display all these metrics in New Relic.
+The `newrelic-logging` Helm chart provides a configuration setting to enable the collection of such metrics for a given Kubernetes cluster. Our JSON-formatted dashboard template easily displays all these metrics in New Relic.
 
 To configure your Kubernetes cluster to send the log forwarder internal metrics and represent them in a dashboard, follow these steps:
+
 1. Install the Helm chart with the following extra configuration setting:
-  ```
-  newrelic-logging:
+
+```
+newrelic-logging:
     fluentBit:
       sendMetrics: true
-  ```
-  <Callout variant="tip">
-    Only enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
-  </Callout>
-
+```
+You only need to enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
 2. Download [this dashboard template file](https://raw.githubusercontent.com/newrelic/helm-charts/master/charts/newrelic-logging/fluent-bit-and-plugin-metrics-dashboard-template.json). Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
-
 3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
-
 4. The imported dashboard will be available in your [Dashboards page](https://one.newrelic.com/dashboards) as `Kubernetes Fluent Bit monitoring`.
 
-<Callout variant="tip">
-  The `newrelic-logging` Helm chart uses [Fluent Bit](https://fluentbit.io/) together with New Relic's [newrelic-fluent-bit-output plugin]((https://github.com/newrelic/newrelic-fluent-bit-output)) to send logs to New Relic. The `fluentBit.sendMetrics` configuration option enables the collection of their individual metrics:
-  - **[Fluent Bit internal metrics](https://docs.fluentbit.io/manual/administration/monitoring#for-v2-metrics)**: emitted by Fluent Bit in Prometheus format and delivered to New Relic's Prometheus Export endpoint. **These are the recommended ones to troubleshoot a Kubernetes cluster** because they can be faceted by `cluster_name`, `node_name` and `hostname` (pod name).
-  - **[newrelic-fluent-bit-output's internal plugin metrics](https://github.com/newrelic/newrelic-fluent-bit-output?tab=readme-ov-file#troubleshooting-metrics)**: collected by the output plugin and sent to New Relic's Metric API. These metrics do not contain dimensions, so they cannot be narrowed down to a particular cluster or host. Despite this, it is useful to capture them for a single cluster to assess what is the overall latency when delivering the logs to the New Relic Logs API or to observe potential packaging problems.
-</Callout>
+### Configure Fluent Bit 
+The `newrelic-logging` Helm chart uses [Fluent Bit](https://fluentbit.io/) together with New Relic's [newrelic-fluent-bit-output plugin](https://github.com/newrelic/newrelic-fluent-bit-output) to send logs to New Relic. The `fluentBit.sendMetrics` configuration option enables the collection of their individual metrics:
 
-<Callout variant="tip">
-  We capture Fluent Bit's internal metrics by using its [prometheus_scrape INPUT plugin](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus-scrape-metrics) in conjunction with its [prometheus_remote_write OUTPUT plugin](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-remote-write). All the Prometheus `counter` metrics are actually _cumulative counters_, but we automatically perform a _delta conversion_ when they are ingested at New Relic to ease querying them using NRQL later. You can find more details [here](/docs/data-apis/understand-data/metric-data/cumulative-metrics/).
-</Callout>
+  * **[Fluent Bit internal metrics](https://docs.fluentbit.io/manual/administration/monitoring#for-v2-metrics)**: emitted by Fluent Bit in Prometheus format and delivered to New Relic's Prometheus Export endpoint. **These are the recommended ones to troubleshoot a Kubernetes cluster** because they can be faceted by `cluster_name`, `node_name` and `hostname` (pod name).
+  * **[newrelic-fluent-bit-output's internal plugin metrics](https://github.com/newrelic/newrelic-fluent-bit-output?tab=readme-ov-file#troubleshooting-metrics)**: collected by the output plugin and sent to New Relic's Metric API. These metrics do not contain dimensions, so they cannot be narrowed down to a particular cluster or host. Despite this, capturing them for a single cluster is useful to assess the overall latency when delivering the logs to the New Relic Logs API or to observe potential packaging problems.
+
+We capture Fluent Bit's internal metrics by using its [prometheus_scrape INPUT plugin](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus-scrape-metrics) in conjunction with its [prometheus_remote_write OUTPUT plugin](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-remote-write). All the Prometheus `counter` metrics are actually _cumulative counters_, but we automatically perform a _delta conversion_ when they are ingested at New Relic to ease querying them using NRQL later. You can find more details [here](/docs/data-apis/understand-data/metric-data/cumulative-metrics/).
 
 ## View log data [#find-data]
 

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -25,7 +25,7 @@ To forward your Kubernetes logs to New Relic with our plugin:
 2. Optionally, you can further tune your installation in [Step 4 from the guided install](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/#kubernetes-install-navigation) using the numerous configuration options available in the [newrelic-logging repository](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging#configuration). However, we recommend the standard setup, as it is valid for most users.
 
   <Callout variant="important">
-  
+
   If you're [using a Kubernetes secret](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging/values.yaml#L8-L25) to store the New Relic license key, the `newrelic-logging` chart defaults to sending logs to the US API endpoint. If the license key belongs to an EU or FedRAMP account, and a secret is used for key storage, you must update the endpoint setting with the appropriate value from the [API reference docs](/docs/logs/log-api/introduction-log-api/#endpoint). Here's an example of how to set this for EU accounts:
 
   ```
@@ -38,6 +38,31 @@ To forward your Kubernetes logs to New Relic with our plugin:
 3. Generate some traffic and wait a few minutes, then [check your account](#find-data) for data.
 
 <InstallFeedback />
+
+## Troubleshoot your Kubernetes plugin for log forwarding installation
+
+Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, it can be helpful to look at the log forwarder ([Fluent Bit](https://fluentbit.io/)) internal metrics to understand what is the cause of a potential bottleneck.
+
+To this end, the `newrelic-logging` Helm chart provides a configuration setting to enable the collection of such metrics for a given Kubernetes cluster. Moreover, we provide a dashboard template in JSON format to easily display all these metrics in New Relic.
+
+To configure your Kubernetes cluster to send the log forwarder internal metrics and represent them in a dashboard, follow these steps:
+1. Install the Helm chart with the following extra configuration setting:
+```
+  newrelic-logging:
+    fluentBit:
+      sendMetrics: true
+  ```
+2. Download this dashboard template file. Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (42 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
+
+3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
+
+4. The imported dashboard will be available in your [Dashboards page](https://one.newrelic.com/dashboards) as `Kubernetes Fluent Bit monitoring`.
+
+5. (Optional) It is highly recommended to enable [facet filtering] based on the "Fluent Bit version" table. To do so, simply click on the "Edit" submenu of the "Fluent Bit version" table and select "Filter the current dashboard" under "Facet Linking".
+
+<Callout variant="tip">
+  We capture Fluent Bit's internal metrics by using its [prometheus_scrape INPUT plugin](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus-scrape-metrics) in conjunction with its [prometheus_remote_write OUTPUT plugin](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-remote-write). All the Prometheus `counter` metrics are actually _cumulative counters_, but we automatically perform a _delta conversion_ when they are ingested at New Relic to ease querying them using NRQL later. You can find more details [here](/docs/data-apis/understand-data/metric-data/cumulative-metrics/).
+</Callout>
 
 ## View log data [#find-data]
 

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -39,7 +39,7 @@ To forward your Kubernetes logs to New Relic with our plugin:
 
 <InstallFeedback />
 
-## Troubleshoot your Kubernetes plugin for log forwarding installation
+## Troubleshoot your Kubernetes plugin for log forwarding installation [#troubleshoot-installation]
 
 Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, it can be helpful to look at the log forwarder internal metrics to understand what is the cause of a potential bottleneck.
 
@@ -56,7 +56,7 @@ To configure your Kubernetes cluster to send the log forwarder internal metrics 
     Only enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
   </Callout>
 
-2. Download this dashboard template file. Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
+2. Download [this dashboard template file](https://raw.githubusercontent.com/newrelic/helm-charts/master/charts/newrelic-logging/fluent-bit-and-plugin-metrics-dashboard-template.json). Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
 
 3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
 

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -41,24 +41,32 @@ To forward your Kubernetes logs to New Relic with our plugin:
 
 ## Troubleshoot your Kubernetes plugin for log forwarding installation
 
-Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, it can be helpful to look at the log forwarder ([Fluent Bit](https://fluentbit.io/)) internal metrics to understand what is the cause of a potential bottleneck.
+Sometimes, despite correctly installing the Kubernetes plugin for log forwarding (`newrelic-logging` [Helm chart](https://github.com/newrelic/helm-charts/blob/master/charts/newrelic-logging)), you may encounter performance issues that affect the correct delivery of logs. In such circumstances, it can be helpful to look at the log forwarder internal metrics to understand what is the cause of a potential bottleneck.
 
 To this end, the `newrelic-logging` Helm chart provides a configuration setting to enable the collection of such metrics for a given Kubernetes cluster. Moreover, we provide a dashboard template in JSON format to easily display all these metrics in New Relic.
 
 To configure your Kubernetes cluster to send the log forwarder internal metrics and represent them in a dashboard, follow these steps:
 1. Install the Helm chart with the following extra configuration setting:
-```
+  ```
   newrelic-logging:
     fluentBit:
       sendMetrics: true
   ```
-2. Download this dashboard template file. Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (42 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
+  <Callout variant="tip">
+    Only enable the `newrelic-logging.fluentBit.sendMetrics` when troubleshooting a Kubernetes cluster. We recommend enabling it for a single Kubernetes cluster at a time to ease troubleshooting.
+  </Callout>
+
+2. Download this dashboard template file. Open it in a text editor and replace all the `YOUR_ACCOUNT_ID` occurrences (49 in total) by your [New Relic Account ID](/docs/accounts/accounts-billing/account-structure/account-id/).
 
 3. Import the resulting dashboard in JSON format by following [these instructions](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#import-json).
 
 4. The imported dashboard will be available in your [Dashboards page](https://one.newrelic.com/dashboards) as `Kubernetes Fluent Bit monitoring`.
 
-5. (Optional) It is highly recommended to enable [facet filtering] based on the "Fluent Bit version" table. To do so, simply click on the "Edit" submenu of the "Fluent Bit version" table and select "Filter the current dashboard" under "Facet Linking".
+<Callout variant="tip">
+  The `newrelic-logging` Helm chart uses [Fluent Bit](https://fluentbit.io/) together with New Relic's [newrelic-fluent-bit-output plugin]((https://github.com/newrelic/newrelic-fluent-bit-output)) to send logs to New Relic. The `fluentBit.sendMetrics` configuration option enables the collection of their individual metrics:
+  - **Fluent Bit internal metrics**: emitted by Fluent Bit in Prometheus format and delivered to New Relic's Prometheus Export endpoint. **These are the recommended ones to troubleshoot a Kubernetes cluster** because they can be faceted by `cluster_name`, `node_name` and `hostname` (pod name).
+  - **[newrelic-fluent-bit-output](https://github.com/newrelic/newrelic-fluent-bit-output)'s internal plugin metrics**: collected by the output plugin and sent to New Relic's Metric API. These metrics do not contain dimensions, so they cannot be narrowed down to a particular cluster or host. Despite this, it is useful to capture them for a single cluster to assess what is the overall latency when delivering the logs to the New Relic Logs API or to observe potential packaging problems.
+</Callout>
 
 <Callout variant="tip">
   We capture Fluent Bit's internal metrics by using its [prometheus_scrape INPUT plugin](https://docs.fluentbit.io/manual/pipeline/inputs/prometheus-scrape-metrics) in conjunction with its [prometheus_remote_write OUTPUT plugin](https://docs.fluentbit.io/manual/pipeline/outputs/prometheus-remote-write). All the Prometheus `counter` metrics are actually _cumulative counters_, but we automatically perform a _delta conversion_ when they are ingested at New Relic to ease querying them using NRQL later. You can find more details [here](/docs/data-apis/understand-data/metric-data/cumulative-metrics/).

--- a/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/kubernetes-plugin-log-forwarding.mdx
@@ -64,8 +64,8 @@ To configure your Kubernetes cluster to send the log forwarder internal metrics 
 
 <Callout variant="tip">
   The `newrelic-logging` Helm chart uses [Fluent Bit](https://fluentbit.io/) together with New Relic's [newrelic-fluent-bit-output plugin]((https://github.com/newrelic/newrelic-fluent-bit-output)) to send logs to New Relic. The `fluentBit.sendMetrics` configuration option enables the collection of their individual metrics:
-  - **Fluent Bit internal metrics**: emitted by Fluent Bit in Prometheus format and delivered to New Relic's Prometheus Export endpoint. **These are the recommended ones to troubleshoot a Kubernetes cluster** because they can be faceted by `cluster_name`, `node_name` and `hostname` (pod name).
-  - **[newrelic-fluent-bit-output](https://github.com/newrelic/newrelic-fluent-bit-output)'s internal plugin metrics**: collected by the output plugin and sent to New Relic's Metric API. These metrics do not contain dimensions, so they cannot be narrowed down to a particular cluster or host. Despite this, it is useful to capture them for a single cluster to assess what is the overall latency when delivering the logs to the New Relic Logs API or to observe potential packaging problems.
+  - **[Fluent Bit internal metrics](https://docs.fluentbit.io/manual/administration/monitoring#for-v2-metrics)**: emitted by Fluent Bit in Prometheus format and delivered to New Relic's Prometheus Export endpoint. **These are the recommended ones to troubleshoot a Kubernetes cluster** because they can be faceted by `cluster_name`, `node_name` and `hostname` (pod name).
+  - **[newrelic-fluent-bit-output's internal plugin metrics](https://github.com/newrelic/newrelic-fluent-bit-output?tab=readme-ov-file#troubleshooting-metrics)**: collected by the output plugin and sent to New Relic's Metric API. These metrics do not contain dimensions, so they cannot be narrowed down to a particular cluster or host. Despite this, it is useful to capture them for a single cluster to assess what is the overall latency when delivering the logs to the New Relic Logs API or to observe potential packaging problems.
 </Callout>
 
 <Callout variant="tip">


### PR DESCRIPTION
## Give us some context

* **What problems does this PR solve?**
It includes a new section to explain how to export troubleshooting metrics from one of our Helm charts and how to display them using a template dashboard file.

* **Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.**
The `newrelic-logging` Helm chart is a component that can be deployed on a Kubernetes cluster in order to forward logs from other components (pods) running in that cluster. This Helm chart is based on an open-source log forwarder named Fluent Bit. Sometimes, customers face problems when running Fluent Bit, and in this pull request we include instructions to collect metrics from Fluent Bit and represent them in a dashboard to facilitate the troubleshooting of that component.

* **If your issue relates to an existing GitHub issue, please link to it.
N/A/**