### PR TITLE
APM Java agent: Link to the storefront report about Java usage

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -26,20 +26,9 @@ With New Relic's Java agent, you can track everything from performance issues to
 
 Use the New Relic Java agent to solve your app's performance issues with our [My app is slow tutorial](/docs/journey-app-slow/root-causes/). 
 
-<SideBySide>
-  <side>
-    Are you curious about trends in the Java ecosystem? Through our Java agent, we've been monitoring which vendors developers have been using for the past year. Check out our 2024 report to see the most-used Java versions, popular JDK vendors, and more! 
-  </side>
-  <side>
-    <TechTileGrid>
-      <TechTile
-        name="2024 State of the Java Ecosystem"
-        to="https://live-d9newrelic.pantheonsite.io/resources/report/2024-state-of-the-java-ecosystem?auHash=tCIzwL6sNWAYTx7gSKlfhlRZCtZewpsxdweaqNRjX5w"
-        icon={<img src={distributedtracingJava} alt="Java"/>}        
-      />
-    </TechTileGrid>
-  </side>
-</SideBySide>
+<Callout variant="tip">
+  Are you curious about trends in Java? See our report [2024 State of the Java Ecosystem](https://newrelic.com/resources/report/2024-state-of-the-java-ecosystem).
+</Callout>
 
 ## Installation [#java-installation]
 

--- a/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/introduction-new-relic-java.mdx
@@ -26,7 +26,22 @@ With New Relic's Java agent, you can track everything from performance issues to
 
 Use the New Relic Java agent to solve your app's performance issues with our [My app is slow tutorial](/docs/journey-app-slow/root-causes/). 
 
-## Installation
+<SideBySide>
+  <side>
+    Are you curious about trends in the Java ecosystem? Through our Java agent, we've been monitoring which vendors developers have been using for the past year. Check out our 2024 report to see the most-used Java versions, popular JDK vendors, and more! 
+  </side>
+  <side>
+    <TechTileGrid>
+      <TechTile
+        name="2024 State of the Java Ecosystem"
+        to="https://live-d9newrelic.pantheonsite.io/resources/report/2024-state-of-the-java-ecosystem?auHash=tCIzwL6sNWAYTx7gSKlfhlRZCtZewpsxdweaqNRjX5w"
+        icon={<img src={distributedtracingJava} alt="Java"/>}        
+      />
+    </TechTileGrid>
+  </side>
+</SideBySide>
+
+## Installation [#java-installation]
 
 To use the Java agent:
 


### PR DESCRIPTION
This is an effort to cross link between the storefront and our docs site. 