### PR TITLE
PHP Agent 10.20.0 release (April 30th)

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3248,18 +3248,19 @@ The values of these settings are used to control various tracer features.
           </th>
 
           <td>
-            `"all_callbacks"`
+            `"plugin_callbacks"`
           </td>
         </tr>
       </tbody>
     </table>
     Sets the options how WordPress hooks are instrumented. 
     New Relic agent can provide different levels of insights into WordPress hooks.
-    By default, all hook callbacks functions are instrumented ("all_callbacks").
-    To reduce agent's overhead it is possible to limit the instrumentation to only
-    plugin/theme callbacks ("plugin_callbacks"). Third option is to monitor hooks
-    without instrumenting callbacks ("threshold"). This option does not give insights
-    about plugins/themes. Read more about WordPress specific instrumentation [here](/docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality).
+    By default, only plugin/theme callbacks are instrumented ("plugin_callbacks").
+    At the cost of increased agent's overhead it is possible to extend the
+    instrumentation to all hook callbacks functions ("all_callbacks"). Third option
+    is to monitor hooks without instrumenting callbacks ("threshold"). This option
+    does not give insights about plugins/themes. Read more about WordPress specific
+    instrumentation [here](/docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality.mdx
+++ b/src/content/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality.mdx
@@ -23,10 +23,10 @@ newrelic.framework.wordpress.hooks = false
 Although this setting uses the word `.hooks`, it controls capturing all WordPress-specific metrics.
 
 New Relic PHP Agent version 10.16 adds `newrelic.framework.wordpress.hooks.options` `ini` setting that allows to fine tune which WordPress-specific metricsand what data is sent in those metrics.
-This setting accepts following values: `"all_callbacks"`, `"plugin_callbacks"`, and `"threshold"`. By default, all hook callback functions are instrumented (`newrelic.framework.wordpress.hooks.options="all_callbacks"`).
-`"plugin_callbacks"` and `"threshold"` settings allow to reduce agent's overhead by fine tuning data collected by the agent. Setting `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"`
-limits the instrumentation to only plugin/theme callbacks. Setting `newrelic.framework.wordpress.hooks.options` to `"threshold"` disables plugins/themes monitoring and in this mode of operation
-New Relic PHP agent only records execution of hooks that exceed `newrelic.framework.wordpress.hooks.threshold` (1ms is the default threshold).
+This setting accepts following values: `"all_callbacks"` (New Relic PHP Agent version 10.16 default), `"plugin_callbacks"` (New Relic PHP Agent version 10.20 default), and `"threshold"`. `"all_callbacks"`
+option causes all hook callback functions to be instrumented. `"plugin_callbacks"` and `"threshold"` settings allow to reduce agent's overhead by fine tuning data collected by the agent. 
+Setting `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"` limits the instrumentation to only plugin/theme callbacks. Setting `newrelic.framework.wordpress.hooks.options` to `"threshold"`
+disables plugins/themes monitoring and in this mode of operation New Relic PHP agent only records execution of hooks that exceed `newrelic.framework.wordpress.hooks.threshold` (1ms is the default threshold).
 
 ## Metrics
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -243,6 +243,9 @@ The following frameworks are supported:
 
     <tr>
 
+      <td>
+        Yii 2.0
+      </td>
 
     </tr>
     

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -1,0 +1,43 @@
+---
+subject: PHP agent
+releaseDate: '2024-04-30'
+version: 10.20.0.10
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.20.0.10'
+features: ['Add support for Yii v2', 'Add supportability metrics for PHP package', 'Update default for `newrelic.framework.wordpress.hooks.options`']
+bugs: ['Fix error reporting for errors converted by PHP to exceptions', 'Improve user exception handler instrumentation for PHPs 8.0+', 'Fix warning from mysqli', 'Fix json struct tag for docker id', 'Improve communications of PHP packages data to the backend']
+security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang.org/x/net from 0.20.0 to 0.23.0']
+---
+## New Relic PHP agent v10.20.0.10
+
+### New features
+* Add support for Yii v2 framework
+* Add supportability metrics for PHP packages that provide major version
+* Update default for `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"`
+
+### Bug fixes
+* Fix error reporting for errors converted by PHP to exceptions
+* Improve user exception handler instrumentation for PHPs 8.0+
+* Fix warning from mysqli when explaining slow SQL queries
+* Fix json struct tag for docker id
+* Improve communications of PHP packages data to the backend
+
+### Security
+* Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in `newrelic-daemon`
+* Bump golang.org/x/net from 0.20.0 to 0.23.0 in `newrelic-daemon`
+
+### Important end-of-life information
+
+* Support for PHP versions 7.0 and 7.1 will **EOL** on June 1st, 2024
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages that are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -31,8 +31,8 @@ security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang
 
 ### Support statement
 
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
-* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+* New Relic recommends upgrading the agent regularly and at least every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* For the latest information on supported PHP versions and platforms, consult the [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page.
 
 <Callout variant="important">
 **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.


### PR DESCRIPTION
Updates for the PHP agent v10.20.0:

Add 'PHP agent v10.20.0' release notes and supporting documentation that was updated to reflect functionality changes.