### PR TITLE
PHP Agent 10.20.0 release (5/6/2024)

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3248,18 +3248,19 @@ The values of these settings are used to control various tracer features.
           </th>
 
           <td>
-            `"all_callbacks"`
+            `"plugin_callbacks"`
           </td>
         </tr>
       </tbody>
     </table>
     Sets the options how WordPress hooks are instrumented. 
     New Relic agent can provide different levels of insights into WordPress hooks.
-    By default, all hook callbacks functions are instrumented ("all_callbacks").
-    To reduce agent's overhead it is possible to limit the instrumentation to only
-    plugin/theme callbacks ("plugin_callbacks"). Third option is to monitor hooks
-    without instrumenting callbacks ("threshold"). This option does not give insights
-    about plugins/themes. Read more about WordPress specific instrumentation [here](/docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality).
+    By default, only plugin/theme callbacks are instrumented ("plugin_callbacks").
+    At the cost of increased agent's overhead it is possible to extend the
+    instrumentation to all hook callbacks functions ("all_callbacks"). Third option
+    is to monitor hooks without instrumenting callbacks ("threshold"). This option
+    does not give insights about plugins/themes. Read more about WordPress specific
+    instrumentation [here](/docs/agents/php-agent/frameworks-libraries/wordpress-specific-functionality).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1844,7 +1844,7 @@ The PHP agent captures context data for the Monolog library and adds that contex
 </CollapserGroup>
 
 <Callout variant="important">
-  The PHP agent only forwards log context data that has a string key and a value which is a string or a scalar (int, double, boolean).
+  The PHP agent only forwards log context data that has a string key and a value, which is a string or a scalar (int, double, boolean).
 </Callout>
 
 ### Log decoration [#log-decoration]
@@ -2146,7 +2146,7 @@ The values of these settings are used to control transaction traces.
       </tbody>
     </table>
 
-    Sets the threshold beyond which queries are considered "slow" and thus candidates for the [<DoNotTranslate>**Slow Queries**</DoNotTranslate>](/docs/apm/applications-menu/monitoring/databases-slow-queries-dashboard) page. Specify duration as an absolute value with units. Default unit is in milliseconds if none is specified.
+    Sets the threshold beyond the queries that are considered "slow" and thus candidates for the [<DoNotTranslate>**Slow Queries**</DoNotTranslate>](/docs/apm/applications-menu/monitoring/databases-slow-queries-dashboard) page. Specify duration as an absolute value with units. Default unit is in milliseconds if none is specified.
 
     <DoNotTranslate>**Example durations**</DoNotTranslate>
 

--- a/src/content/docs/apm/agents/php-agent/features/browser-monitoring-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/features/browser-monitoring-php-agent.mdx
@@ -111,6 +111,13 @@ Here are some basic examples.
        <Callout variant="important">
          In Drupal 7.15, <DoNotTranslate>**Compress cached pages**</DoNotTranslate> is turned on by default. If you also select <DoNotTranslate>**Cache pages for anonymous users**</DoNotTranslate>, the JavaScript (newrelic.js) is not inserted into the served pages for anonymous users. This is because Drupal's pages are compressed directly from the database before they are stored in the cache (with gzip), so New Relic's PHP agent does not have a chance to parse any HTML. In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users.
        </Callout>
+
+       <Callout variant="important">
+	Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
+	New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.
+	To keep using browser monitoring, disable browser auto-instrumentation and manually insert the JavaScript header and footer into your templates.
+       </Callout>
+
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/php-agent/features/browser-monitoring-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/features/browser-monitoring-php-agent.mdx
@@ -113,7 +113,7 @@ Here are some basic examples.
        </Callout>
 
        <Callout variant="important">
-	Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
+	Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) that causes it to set a `content-length` header.
 	New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.
 	To keep using browser monitoring, disable browser auto-instrumentation and manually insert the JavaScript header and footer into your templates.
        </Callout>

--- a/src/content/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
+++ b/src/content/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
@@ -38,7 +38,7 @@ In Drupal 7.15, <DoNotTranslate>**Compress cached pages**</DoNotTranslate> is tu
 
 In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users. For more information, see [Browser monitoring and the PHP agent](/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/)
 
-Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
+Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) that causes it to set a `content-length` header.
 New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.
 To keep using browser monitoring, disable browser auto-instrumentation and manually insert the JavaScript header and footer into your templates.
 For more information, please see [here](/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/#auto_instrumentation).

--- a/src/content/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
+++ b/src/content/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
@@ -38,6 +38,11 @@ In Drupal 7.15, <DoNotTranslate>**Compress cached pages**</DoNotTranslate> is tu
 
 In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users. For more information, see [Browser monitoring and the PHP agent](/docs/php/page-load-timing-in-php).
 
+Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
+New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.
+To keep using browser monitoring, disable browser auto-instrumentation and manually insert the JavaScript header and footer into your templates.
+For more information, please see [here](/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/#auto_instrumentation).
+
 ## Cron tasks [#cron]
 
 Drupal supports periodically executing tasks to perform routine maintenance or similar work on behalf of installed Drupal modules. These tasks can be run without any manual involvement beyond the initial configuration. Commonly, these are referred to as [cron tasks](https://drupal.org/cron "Link opens in a new window"). Starting in version 4.3, the New Relic PHP agent detects the execution of these tasks and automatically marks them as [background transactions](/docs/features/monitoring-background-processes#ui) regardless of how they were started.

--- a/src/content/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
+++ b/src/content/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality.mdx
@@ -36,7 +36,7 @@ The PHP agent collects metrics for the following:
 
 In Drupal 7.15, <DoNotTranslate>**Compress cached pages**</DoNotTranslate> is turned on by default. If you also select <DoNotTranslate>**Cache pages for anonymous users**</DoNotTranslate>, the <InlinePopover type="browser" /> JavaScript is not inserted into the served pages for anonymous users. This is because Drupal's pages are compressed directly from the database before they are stored in the cache (with gzip), so New Relic's PHP agent does not have a chance to parse any HTML.
 
-In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users. For more information, see [Browser monitoring and the PHP agent](/docs/php/page-load-timing-in-php).
+In this situation, manual instrumentation provides a better opportunity to capture data for anonymous users. For more information, see [Browser monitoring and the PHP agent](/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/)
 
 Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
 New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.

--- a/src/content/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality.mdx
+++ b/src/content/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality.mdx
@@ -23,10 +23,10 @@ newrelic.framework.wordpress.hooks = false
 Although this setting uses the word `.hooks`, it controls capturing all WordPress-specific metrics.
 
 New Relic PHP Agent version 10.16 adds `newrelic.framework.wordpress.hooks.options` `ini` setting that allows to fine tune which WordPress-specific metricsand what data is sent in those metrics.
-This setting accepts following values: `"all_callbacks"`, `"plugin_callbacks"`, and `"threshold"`. By default, all hook callback functions are instrumented (`newrelic.framework.wordpress.hooks.options="all_callbacks"`).
-`"plugin_callbacks"` and `"threshold"` settings allow to reduce agent's overhead by fine tuning data collected by the agent. Setting `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"`
-limits the instrumentation to only plugin/theme callbacks. Setting `newrelic.framework.wordpress.hooks.options` to `"threshold"` disables plugins/themes monitoring and in this mode of operation
-New Relic PHP agent only records execution of hooks that exceed `newrelic.framework.wordpress.hooks.threshold` (1ms is the default threshold).
+This setting accepts following values: `"all_callbacks"` (New Relic PHP Agent version 10.16 default), `"plugin_callbacks"` (New Relic PHP Agent version 10.20 default), and `"threshold"`. `"all_callbacks"`
+option causes all hook callback functions to be instrumented. `"plugin_callbacks"` and `"threshold"` settings allow to reduce agent's overhead by fine tuning data collected by the agent. 
+Setting `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"` limits the instrumentation to only plugin/theme callbacks. Setting `newrelic.framework.wordpress.hooks.options` to `"threshold"`
+disables plugins/themes monitoring and in this mode of operation New Relic PHP agent only records execution of hooks that exceed `newrelic.framework.wordpress.hooks.threshold` (1ms is the default threshold).
 
 ## Metrics
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -192,10 +192,7 @@ The following frameworks are supported:
         [Drupal 7.x, 8.x, 9.1-9.5, 10.x](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
 
 	<Callout variant="important">
-           Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
-           New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.
-           To keep using browser monitoring, disable browser auto-instrumentation and manually insert the JavaScript header and footer into your templates.
-           For more information, please see [here](/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/#auto_instrumentation).
+           To use browser instrumentation with Drupal, please see [Drupal and Browser instrumentation](/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality/#page-load-timing-rum).
 	</Callout>
       </td>
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -189,7 +189,14 @@ The following frameworks are supported:
   <tbody>
     <tr>
       <td>
-        [Drupal 7.x, 8.x, 9.1-9.5](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
+        [Drupal 7.x, 8.x, 9.1-9.5, 10.x](/docs/agents/php-agent/frameworks-libraries/drupal-specific-functionality)
+
+	<Callout variant="important">
+           Drupal 10.2 introduced a [new change](https://www.drupal.org/node/3298551) which causes it to set a `content-length` header.
+           New Relic PHP agent is unable to auto-inject the browser auto-instrumentation when the HTTP header field `Content-Length` is set.
+           To keep using browser monitoring, disable browser auto-instrumentation and manually insert the JavaScript header and footer into your templates.
+           For more information, please see [here](/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/#auto_instrumentation).
+	</Callout>
       </td>
 
       <td>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -243,6 +243,9 @@ The following frameworks are supported:
 
     <tr>
 
+      <td>
+        Yii 2.0
+      </td>
 
     </tr>
     

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -1,6 +1,6 @@
 ---
 subject: PHP agent
-releaseDate: '2024-04-30'
+releaseDate: '2024-05-06'
 version: 10.20.0.10
 downloadLink: 'https://download.newrelic.com/php_agent/archive/10.20.0.10'
 features: ['Add support for Yii v2', 'Verified support for Drupal 10', 'Add supportability metrics for PHP package', 'Update default for `newrelic.framework.wordpress.hooks.options`']

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -1,0 +1,43 @@
+---
+subject: PHP agent
+releaseDate: '2024-04-30'
+version: 10.20.0.10
+downloadLink: 'https://download.newrelic.com/php_agent/archive/10.20.0.10'
+features: ['Add support for Yii v2', 'Add supportability metrics for PHP package', 'Update default for `newrelic.framework.wordpress.hooks.options`']
+bugs: ['Fix error reporting for errors converted by PHP to exceptions', 'Improve user exception handler instrumentation for PHPs 8.0+', 'Fix warning from mysqli', 'Fix json struct tag for docker id', 'Improve communications of PHP packages data to the backend']
+security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang.org/x/net from 0.20.0 to 0.23.0']
+---
+## New Relic PHP agent v10.20.0.10
+
+### New features
+* Add support for Yii v2 framework
+* Add supportability metrics for PHP packages that provide major version
+* Update default for `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"`
+
+### Bug fixes
+* Fix error reporting for errors converted by PHP to exceptions
+* Improve user exception handler instrumentation for PHPs 8.0+
+* Fix warning from mysqli when explaining slow SQL queries
+* Fix json struct tag for docker id
+* Improve communications of PHP packages data to the backend
+
+### Security
+* Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in `newrelic-daemon`
+* Bump golang.org/x/net from 0.20.0 to 0.23.0 in `newrelic-daemon`
+
+### Important end-of-life information
+
+* Support for PHP versions 7.0 and 7.1 will **EOL** on June 1st, 2024
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+**For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+The PHP agent packages that are affected are:
+   - newrelic-php5
+   - newrelic-php5-common
+   - newrelic-daemon
+</Callout>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -31,8 +31,8 @@ security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang
 
 ### Support statement
 
-* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
-* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+* New Relic recommends upgrading the agent regularly and at least every 3 months. For more information on supported agent versions and EOL timelines, check out our [PHP EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* For the latest information on supported PHP versions and platforms, consult the [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page.
 
 <Callout variant="important">
 **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -10,12 +10,14 @@ security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang
 ## New Relic PHP agent v10.20.0.10
 
 ### New features
+
 * Add support for Yii v2 framework
 * Verified support for Drupal 10 framework
 * Add supportability metrics for PHP packages that provide major version
 * Update default for `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"`
 
 ### Bug fixes
+
 * Fix error reporting for errors converted by PHP to exceptions
 * Improve user exception handler instrumentation for PHPs 8.0+
 * Fix warning from mysqli when explaining slow SQL queries
@@ -23,6 +25,7 @@ security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang
 * Improve communications of PHP packages data to the backend
 
 ### Security
+
 * Bump google.golang.org/protobuf from 1.32.0 to 1.33.0 in `newrelic-daemon`
 * Bump golang.org/x/net from 0.20.0 to 0.23.0 in `newrelic-daemon`
 
@@ -37,8 +40,10 @@ security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang
 
 <Callout variant="important">
 **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
 The PHP agent packages that are affected are:
-   - newrelic-php5
-   - newrelic-php5-common
-   - newrelic-daemon
+
+    - newrelic-php5
+    - newrelic-php5-common
+    - newrelic-daemon
 </Callout>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-20-0-10.mdx
@@ -3,7 +3,7 @@ subject: PHP agent
 releaseDate: '2024-04-30'
 version: 10.20.0.10
 downloadLink: 'https://download.newrelic.com/php_agent/archive/10.20.0.10'
-features: ['Add support for Yii v2', 'Add supportability metrics for PHP package', 'Update default for `newrelic.framework.wordpress.hooks.options`']
+features: ['Add support for Yii v2', 'Verified support for Drupal 10', 'Add supportability metrics for PHP package', 'Update default for `newrelic.framework.wordpress.hooks.options`']
 bugs: ['Fix error reporting for errors converted by PHP to exceptions', 'Improve user exception handler instrumentation for PHPs 8.0+', 'Fix warning from mysqli', 'Fix json struct tag for docker id', 'Improve communications of PHP packages data to the backend']
 security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang.org/x/net from 0.20.0 to 0.23.0']
 ---
@@ -11,6 +11,7 @@ security: ['Bump google.golang.org/protobuf from 1.32.0 to 1.33.0', 'Bump golang
 
 ### New features
 * Add support for Yii v2 framework
+* Verified support for Drupal 10 framework
 * Add supportability metrics for PHP packages that provide major version
 * Update default for `newrelic.framework.wordpress.hooks.options` to `"plugin_callbacks"`
 


### PR DESCRIPTION
Updates for the PHP agent v10.20.0:

Add 'PHP agent v10.20.0' release notes and supporting documentation that was updated to reflect functionality changes.