### PR TITLE
fix(Docs): Removed trailing slashes from nav

### DIFF
--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -50,9 +50,9 @@ pages:
               - title: Manual installation
                 pages:
                   - title: Cocoapods
-                    path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/cocoapods-installation/
+                    path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/cocoapods-installation
                   - title: Swift package manager
-                    path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/spm-installation/
+                    path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/spm-installation
               - title: iOS compatibility and requirements
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
               - title: iOS distributed tracing


### PR DESCRIPTION
These were keeping these docs from showing up in the nav on page load

