### PR TITLE
Page background color

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.5.2",
+    "@newrelic/gatsby-theme-newrelic": "9.5.3",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/src/layouts/HomePageLayout.js
+++ b/src/layouts/HomePageLayout.js
@@ -31,6 +31,7 @@ const HomePageLayout = ({ children, pageContext }) => {
                 --sidebar-width: 0;
               }
               --link-color: rgb(243, 244, 244);
+              background: #f3f4f4;
             `}
           >
             <Layout.Sidebar

--- a/src/layouts/HomePageLayout.js
+++ b/src/layouts/HomePageLayout.js
@@ -32,6 +32,10 @@ const HomePageLayout = ({ children, pageContext }) => {
               }
               --link-color: rgb(243, 244, 244);
               background: #f3f4f4;
+
+              .dark-mode && {
+                background: var(--primary-background-color);
+              }
             `}
           >
             <Layout.Sidebar

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -61,7 +61,6 @@ const HomePage = ({ data }) => {
         layout={layout}
         css={css`
           border: none;
-          background: var(--tertiary-background-color);
           max-width: 1440px;
           margin: 2rem auto 0;
           padding: 0 calc(5% + 8px); // to match the product tiles outer edges

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,10 +3629,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.5.2":
-  version "9.5.2"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.5.2.tgz#668ae7eec1ca1beade2577db07a2a0ceead0ae9c"
-  integrity sha512-3B8hlSglxs8MazgGAGmaDP20+R+g17Xc8nUQGGkLN7roQJ5YPrrtcWFXymQ8OyjC7q+3weLq6YPVK6nxy8uZEA==
+"@newrelic/gatsby-theme-newrelic@9.5.3":
+  version "9.5.3"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.5.3.tgz#8abe60c90654199d21b57f3f5ca79484aea71a5f"
+  integrity sha512-02+5/lbYueDxcnrUfPVOpg8EBRoKv2/DZwMd1Y+bCi4f8KGR+eFXb4AUORpHWAtTPjGK7+fSJkkoUObn5wotvg==
   dependencies:
     "@segment/analytics-next" "1.63.0"
     "@wry/equality" "^0.4.0"


### PR DESCRIPTION
- theme bump that updates site page background color
- override homepage background to old color to maintain contrast
- double checked other components using this variable, and everything seems fine. Though DocTiles have lost some contrast, but I think the drop shadow still makes them stand out enough.

