### PR TITLE
fix(nerdgraph): changing markdown tables to html

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
@@ -36,7 +36,7 @@ Here are operations related to creating, reading, updating, and deleting (CRUD).
 <table>
   <thead>
     <tr>
-      <th>Operation</th>
+      <th width={325}>Operation</th>
       <th>GraphQL operation type</th>
       <th>Notes</th>
     </tr>
@@ -77,7 +77,7 @@ Here are operations related to creating, reading, updating, and deleting (CRUD).
 <table>
   <thead>
     <tr>
-      <th>Operation</th>
+      <th width={325}>Operation</th> 
       <th>GraphQL operation type</th>
       <th>Notes</th>
     </tr>
@@ -106,7 +106,7 @@ Here are operations related to creating, reading, updating, and deleting (CRUD).
 <table>
   <thead>
     <tr>
-      <th>Operation</th>
+      <th width={325}>Operation</th>
       <th>GraphQL operation type</th>
       <th>Notes</th>
     </tr>
@@ -118,7 +118,7 @@ Here are operations related to creating, reading, updating, and deleting (CRUD).
       <td>Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL. The resulting URL will be deprecated three months after creation. </td>
     </tr>
     <tr>
-      <td>`actor &gt; dashboard &gt; liveUrls()`</td>
+      <td>`actor > dashboard > liveUrls()`</td>
       <td>query</td>
       <td>List all live URLs operation. You can get the complete list of live URLs you have access to. A live URL is a mechanism that allows you to share dashboard pages and widgets publicly with up-to-date or live data.</td>
     </tr>

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
@@ -115,7 +115,7 @@ Here are operations related to creating, reading, updating, and deleting (CRUD).
     <tr>
       <td>`dashboardCreateSnapshotUrl()`</td>
       <td>mutation</td>
-      <td>Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL.</td>
+      <td>Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL. The resulting URL will be deprecated three months after creation. </td>
     </tr>
     <tr>
       <td>`actor &gt; dashboard &gt; liveUrls()`</td>

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
@@ -33,29 +33,102 @@ We have defined a granular GraphQL API that lets you execute different dashboard
 
 Here are operations related to creating, reading, updating, and deleting (CRUD).  
 
-| Operation &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;              | GraphQL operation type | Notes                                                                                                                                                                                                |
-| ----------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `actor > entity()`    | query                  | Get dashboard operation. You can get all dashboard and widget data for a given dashboard entity GUID.                                                                                                |
-| `dashboardCreate()`   | mutation               | Create dashboard operation. You can create a dashboard attached to a specific account by specifying all its elements, from metadata to widget configuration.                                         |
-| `dashboardUpdate()`   | mutation               | Update dashboard operation. You can update an existing dashboard given a dashboard entity GUID. You need to specify the complete, updated dashboard elements, from metadata to widget configuration. |
-| `dashboardDelete()`   | mutation               | Delete dashboard operation. You can delete an existing dashboard given a dashboard entity GUID. This operation executes a logical delete that lets you recover your dashboard.                       |
-| `dashboardUndelete()` | mutation               | Undelete dashboard operation. You can recover a previously deleted dashboard given a dashboard entity GUID. Custom tags cannot be recovered.                                                                                         |
+<table>
+<thead>
+<tr>
+<th>Operation &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</th>
+<th>GraphQL operation type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>actor &gt; entity()</code></td>
+<td>query</td>
+<td>Get dashboard operation. You can get all dashboard and widget data for a given dashboard entity GUID.</td>
+</tr>
+<tr>
+<td><code>dashboardCreate()</code></td>
+<td>mutation</td>
+<td>Create dashboard operation. You can create a dashboard attached to a specific account by specifying all its elements, from metadata to widget configuration.</td>
+</tr>
+<tr>
+<td><code>dashboardUpdate()</code></td>
+<td>mutation</td>
+<td>Update dashboard operation. You can update an existing dashboard given a dashboard entity GUID. You need to specify the complete, updated dashboard elements, from metadata to widget configuration.</td>
+</tr>
+<tr>
+<td><code>dashboardDelete()</code></td>
+<td>mutation</td>
+<td>Delete dashboard operation. You can delete an existing dashboard given a dashboard entity GUID. This operation executes a logical delete that lets you recover your dashboard.</td>
+</tr>
+<tr>
+<td><code>dashboardUndelete()</code></td>
+<td>mutation</td>
+<td>
+Undelete dashboard operation. You can recover a previously deleted dashboard given a dashboard entity GUID. Custom tags cannot be recovered.
+</td>
+</tr>
+</tbody>
+</table>                                                                                 |
 
 ### Dashboard page operations [#page-operations]
 
-| Operation                          | GraphQL operation type | Notes                                                                                                                                                                                                                           |
-| ---------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dashboardUpdatePage()`          | mutation               | Update dashboard page operation. You can update one page of an existing dashboard given a dashboard page entity GUID. You need to specify the complete, updated dashboard page elements, from metadata to widget configuration. |
-| `dashboardUpdateWidgetsInPage()` | mutation               | Update widgets operation. You can update a set of existing widgets of a dashboard page given a dashboard page entity GUID. You need to specify the set of widgets to be updated and their complete configuration.               |
-| `dashboardAddWidgetsToPage()`    | mutation               | Add widgets operation. You can add a set of new widgets to a dashboard page given a dashboard page entity GUID. You need to specify the set of new widgets and their complete configuration.                                    |
+<table>
+<thead>
+<tr>
+<th>Operation</th>
+<th>GraphQL operation type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>dashboardUpdatePage()</code></td>
+<td>mutation</td>
+<td>Update dashboard page operation. You can update one page of an existing dashboard given a dashboard page entity GUID. You need to specify the complete, updated dashboard page elements, from metadata to widget configuration.</td>
+</tr>
+<tr>
+<td><code>dashboardUpdateWidgetsInPage()</code></td>
+<td>mutation</td>
+<td>Update widgets operation. You can update a set of existing widgets of a dashboard page given a dashboard page entity GUID. You need to specify the set of widgets to be updated and their complete configuration.</td>
+</tr>
+<tr>
+<td><code>dashboardAddWidgetsToPage()</code></td>
+<td>mutation</td>
+<td>Add widgets operation. You can add a set of new widgets to a dashboard page given a dashboard page entity GUID. You need to specify the set of new widgets and their complete configuration.           </td>
+</tr>
+</tbody>
+</table>                               |
 
 ### Other operations [#other-operations]
 
-| Operation                          | GraphQL operation type | Notes                                                                                                                                                                                                               |
-| ---------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dashboardCreateSnapshotUrl()`   | mutation               | Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL. |
-| `actor > dashboard > liveUrls()` | query                  | List all live URLs operation. You can get the complete list of live URLs you have access to. A live URL is a mechanism that allows you to share dashboard pages and widgets publicly with up-to-date or live data.  |
-| `dashboardWidgetRevokeLiveUrl()` | mutation               | Revoke widget live URL operation. You can revoke a previously created live URL of a widget. As a result, the live URL will become unavailable to the public.                                                        |
+<table>
+<thead>
+<tr>
+<th>Operation</th>
+<th>GraphQL operation type</th>
+<th>Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>dashboardCreateSnapshotUrl()</code></td>
+<td>mutation</td>
+<td>Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL.</td>
+</tr>
+<tr>
+<td><code>actor &gt; dashboard &gt; liveUrls()</code></td>
+<td>query</td>
+<td>List all live URLs operation. You can get the complete list of live URLs you have access to. A live URL is a mechanism that allows you to share dashboard pages and widgets publicly with up-to-date or live data.</td>
+</tr>
+<tr>
+<td><code>dashboardWidgetRevokeLiveUrl()</code></td>
+<td>mutation</td>
+<td>Revoke widget live URL operation. You can revoke a previously created live URL of a widget. As a result, the live URL will become unavailable to the public.</td>
+</tr>
+</tbody>
+</table>                                            |
 
 ## Cross-account dashboards [#cross-account]
 
@@ -150,34 +223,107 @@ We have limited the values you can set to some of the dashboard properties. This
 
 ### Dashboard limits [#dashboard-limits]
 
-| Limit                                     | Value |
-| ----------------------------------------- | ----- |
-| Maximum number of pages in a dashboard    | 25    |
-| Maximum length of a dashboard name        | 255   |
-| Maximum length of a dashboard description | 1024  |
+<table>
+<thead>
+<tr>
+<th>Limit</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Maximum number of pages in a dashboard</td>
+<td>25</td>
+</tr>
+<tr>
+<td>Maximum length of a dashboard name</td>
+<td>255</td>
+</tr>
+<tr>
+<td>Maximum length of a dashboard description</td>
+<td>1024</td>
+</tr>
+</tbody>
+</table>
 
 ### Dashboard page limits [#page-limits]
 
-| Limit                                          | Value |
-| ---------------------------------------------- | ----- |
-| Maximum number of widgets in a dashboard page  | 150   |
-| Maximum length of a dashboard page name        | 255   |
-| Maximum length of a dashboard page description | 1024  |
+<table>
+<thead>
+<tr>
+<th>Limit</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Maximum number of widgets in a dashboard page</td>
+<td>150</td>
+</tr>
+<tr>
+<td>Maximum length of a dashboard page name</td>
+<td>255</td>
+</tr>
+<tr>
+<td>Maximum length of a dashboard page description</td>
+<td>1024</td>
+</tr>
+</tbody>
+</table>
+
 
 ### Widget limits [#widget-limits]
 
-| Limit                                         | Value |
-| --------------------------------------------- | ----- |
-| Maximum length of a widget title              | 255   |
-| Maximum number of entities linked to a widget | 1     |
-| Maximum number of queries in a widget         | 20    |
-| Maximum layout column of a widget             | 12    |
-| Minimum layout column of a widget             | 1     |
-| Minimum layout row of a widget                | 1     |
-| Maximum layout width of a widget              | 12    |
-| Minimum layout width of a widget              | 1     |
-| Maximum layout height of a widget             | 32    |
-| Minimum layout height of a widget             | 1     |
+<table>
+<thead>
+<tr>
+<th>Limit</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Maximum length of a widget title</td>
+<td>255</td>
+</tr>
+<tr>
+<td>Maximum number of entities linked to a widget</td>
+<td>1</td>
+</tr>
+<tr>
+<td>Maximum number of queries in a widget</td>
+<td>20</td>
+</tr>
+<tr>
+<td>Maximum layout column of a widget</td>
+<td>12</td>
+</tr>
+<tr>
+<td>Minimum layout column of a widget</td>
+<td>1</td>
+</tr>
+<tr>
+<td>Minimum layout row of a widget</td>
+<td>1</td>
+</tr>
+<tr>
+<td>Maximum layout width of a widget</td>
+<td>12</td>
+</tr>
+<tr>
+<td>Minimum layout width of a widget</td>
+<td>1</td>
+</tr>
+<tr>
+<td>Maximum layout height of a widget</td>
+<td>32</td>
+</tr>
+<tr>
+<td>Minimum layout height of a widget</td>
+<td>1</td>
+</tr>
+</tbody>
+</table>
 
 ## Errors as first class citizens [#errors-first-class]
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-dashboards.mdx
@@ -34,101 +34,101 @@ We have defined a granular GraphQL API that lets you execute different dashboard
 Here are operations related to creating, reading, updating, and deleting (CRUD).  
 
 <table>
-<thead>
-<tr>
-<th>Operation &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</th>
-<th>GraphQL operation type</th>
-<th>Notes</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>actor &gt; entity()</code></td>
-<td>query</td>
-<td>Get dashboard operation. You can get all dashboard and widget data for a given dashboard entity GUID.</td>
-</tr>
-<tr>
-<td><code>dashboardCreate()</code></td>
-<td>mutation</td>
-<td>Create dashboard operation. You can create a dashboard attached to a specific account by specifying all its elements, from metadata to widget configuration.</td>
-</tr>
-<tr>
-<td><code>dashboardUpdate()</code></td>
-<td>mutation</td>
-<td>Update dashboard operation. You can update an existing dashboard given a dashboard entity GUID. You need to specify the complete, updated dashboard elements, from metadata to widget configuration.</td>
-</tr>
-<tr>
-<td><code>dashboardDelete()</code></td>
-<td>mutation</td>
-<td>Delete dashboard operation. You can delete an existing dashboard given a dashboard entity GUID. This operation executes a logical delete that lets you recover your dashboard.</td>
-</tr>
-<tr>
-<td><code>dashboardUndelete()</code></td>
-<td>mutation</td>
-<td>
-Undelete dashboard operation. You can recover a previously deleted dashboard given a dashboard entity GUID. Custom tags cannot be recovered.
-</td>
-</tr>
-</tbody>
-</table>                                                                                 |
+  <thead>
+    <tr>
+      <th>Operation</th>
+      <th>GraphQL operation type</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`actor > entity()`</td>
+      <td>query</td>
+      <td>Get dashboard operation. You can get all dashboard and widget data for a given dashboard entity GUID.</td>
+    </tr>
+    <tr>
+      <td>`dashboardCreate()`</td>
+      <td>mutation</td>
+      <td>Create dashboard operation. You can create a dashboard attached to a specific account by specifying all its elements, from metadata to widget configuration.</td>
+    </tr>
+    <tr>
+      <td>`dashboardUpdate()`</td>
+      <td>mutation</td>
+      <td>Update dashboard operation. You can update an existing dashboard given a dashboard entity GUID. You need to specify the complete, updated dashboard elements, from metadata to widget configuration.</td>
+    </tr>
+    <tr>
+      <td>`dashboardDelete()`</td>
+      <td>mutation</td>
+      <td>Delete dashboard operation. You can delete an existing dashboard given a dashboard entity GUID. This operation executes a logical delete that lets you recover your dashboard.</td>
+    </tr>
+    <tr>
+      <td>`dashboardUndelete()`</td>
+      <td>mutation</td>
+      <td>
+        Undelete dashboard operation. You can recover a previously deleted dashboard given a dashboard entity GUID. Custom tags cannot be recovered.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### Dashboard page operations [#page-operations]
 
 <table>
-<thead>
-<tr>
-<th>Operation</th>
-<th>GraphQL operation type</th>
-<th>Notes</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>dashboardUpdatePage()</code></td>
-<td>mutation</td>
-<td>Update dashboard page operation. You can update one page of an existing dashboard given a dashboard page entity GUID. You need to specify the complete, updated dashboard page elements, from metadata to widget configuration.</td>
-</tr>
-<tr>
-<td><code>dashboardUpdateWidgetsInPage()</code></td>
-<td>mutation</td>
-<td>Update widgets operation. You can update a set of existing widgets of a dashboard page given a dashboard page entity GUID. You need to specify the set of widgets to be updated and their complete configuration.</td>
-</tr>
-<tr>
-<td><code>dashboardAddWidgetsToPage()</code></td>
-<td>mutation</td>
-<td>Add widgets operation. You can add a set of new widgets to a dashboard page given a dashboard page entity GUID. You need to specify the set of new widgets and their complete configuration.           </td>
-</tr>
-</tbody>
-</table>                               |
+  <thead>
+    <tr>
+      <th>Operation</th>
+      <th>GraphQL operation type</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`dashboardUpdatePage()`</td>
+      <td>mutation</td>
+      <td>Update dashboard page operation. You can update one page of an existing dashboard given a dashboard page entity GUID. You need to specify the complete, updated dashboard page elements, from metadata to widget configuration.</td>
+    </tr>
+    <tr>
+      <td>`dashboardUpdateWidgetsInPage()`</td>
+      <td>mutation</td>
+      <td>Update widgets operation. You can update a set of existing widgets of a dashboard page given a dashboard page entity GUID. You need to specify the set of widgets to be updated and their complete configuration.</td>
+    </tr>
+    <tr>
+      <td>`dashboardAddWidgetsToPage()`</td>
+      <td>mutation</td>
+      <td>Add widgets operation. You can add a set of new widgets to a dashboard page given a dashboard page entity GUID. You need to specify the set of new widgets and their complete configuration.</td>
+    </tr>
+  </tbody>
+</table>
 
 ### Other operations [#other-operations]
 
 <table>
-<thead>
-<tr>
-<th>Operation</th>
-<th>GraphQL operation type</th>
-<th>Notes</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>dashboardCreateSnapshotUrl()</code></td>
-<td>mutation</td>
-<td>Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL.</td>
-</tr>
-<tr>
-<td><code>actor &gt; dashboard &gt; liveUrls()</code></td>
-<td>query</td>
-<td>List all live URLs operation. You can get the complete list of live URLs you have access to. A live URL is a mechanism that allows you to share dashboard pages and widgets publicly with up-to-date or live data.</td>
-</tr>
-<tr>
-<td><code>dashboardWidgetRevokeLiveUrl()</code></td>
-<td>mutation</td>
-<td>Revoke widget live URL operation. You can revoke a previously created live URL of a widget. As a result, the live URL will become unavailable to the public.</td>
-</tr>
-</tbody>
-</table>                                            |
+  <thead>
+    <tr>
+      <th>Operation</th>
+      <th>GraphQL operation type</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`dashboardCreateSnapshotUrl()`</td>
+      <td>mutation</td>
+      <td>Create dashboard page snapshot operation. You can create a public URL for a given dashboard page entity GUID. The dashboard page can then be accessed in the form of a static snapshot in the resulting public URL.</td>
+    </tr>
+    <tr>
+      <td>`actor &gt; dashboard &gt; liveUrls()`</td>
+      <td>query</td>
+      <td>List all live URLs operation. You can get the complete list of live URLs you have access to. A live URL is a mechanism that allows you to share dashboard pages and widgets publicly with up-to-date or live data.</td>
+    </tr>
+    <tr>
+      <td>`dashboardWidgetRevokeLiveUrl()`</td>
+      <td>mutation</td>
+      <td>Revoke widget live URL operation. You can revoke a previously created live URL of a widget. As a result, the live URL will become unavailable to the public.</td>
+    </tr>
+  </tbody>
+</table>                                          
 
 ## Cross-account dashboards [#cross-account]
 
@@ -224,105 +224,105 @@ We have limited the values you can set to some of the dashboard properties. This
 ### Dashboard limits [#dashboard-limits]
 
 <table>
-<thead>
-<tr>
-<th>Limit</th>
-<th>Value</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Maximum number of pages in a dashboard</td>
-<td>25</td>
-</tr>
-<tr>
-<td>Maximum length of a dashboard name</td>
-<td>255</td>
-</tr>
-<tr>
-<td>Maximum length of a dashboard description</td>
-<td>1024</td>
-</tr>
-</tbody>
+  <thead>
+    <tr>
+      <th>Limit</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Maximum number of pages in a dashboard</td>
+      <td>25</td>
+    </tr>
+    <tr>
+      <td>Maximum length of a dashboard name</td>
+      <td>255</td>
+    </tr>
+    <tr>
+      <td>Maximum length of a dashboard description</td>
+      <td>1024</td>
+    </tr>
+  </tbody>
 </table>
 
 ### Dashboard page limits [#page-limits]
 
 <table>
-<thead>
-<tr>
-<th>Limit</th>
-<th>Value</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Maximum number of widgets in a dashboard page</td>
-<td>150</td>
-</tr>
-<tr>
-<td>Maximum length of a dashboard page name</td>
-<td>255</td>
-</tr>
-<tr>
-<td>Maximum length of a dashboard page description</td>
-<td>1024</td>
-</tr>
-</tbody>
+  <thead>
+    <tr>
+      <th>Limit</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Maximum number of widgets in a dashboard page</td>
+      <td>150</td>
+    </tr>
+    <tr>
+      <td>Maximum length of a dashboard page name</td>
+      <td>255</td>
+    </tr>
+    <tr>
+      <td>Maximum length of a dashboard page description</td>
+      <td>1024</td>
+    </tr>
+  </tbody>
 </table>
 
 
 ### Widget limits [#widget-limits]
 
 <table>
-<thead>
-<tr>
-<th>Limit</th>
-<th>Value</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Maximum length of a widget title</td>
-<td>255</td>
-</tr>
-<tr>
-<td>Maximum number of entities linked to a widget</td>
-<td>1</td>
-</tr>
-<tr>
-<td>Maximum number of queries in a widget</td>
-<td>20</td>
-</tr>
-<tr>
-<td>Maximum layout column of a widget</td>
-<td>12</td>
-</tr>
-<tr>
-<td>Minimum layout column of a widget</td>
-<td>1</td>
-</tr>
-<tr>
-<td>Minimum layout row of a widget</td>
-<td>1</td>
-</tr>
-<tr>
-<td>Maximum layout width of a widget</td>
-<td>12</td>
-</tr>
-<tr>
-<td>Minimum layout width of a widget</td>
-<td>1</td>
-</tr>
-<tr>
-<td>Maximum layout height of a widget</td>
-<td>32</td>
-</tr>
-<tr>
-<td>Minimum layout height of a widget</td>
-<td>1</td>
-</tr>
-</tbody>
+  <thead>
+    <tr>
+      <th>Limit</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Maximum length of a widget title</td>
+      <td>255</td>
+    </tr>
+    <tr>
+      <td>Maximum number of entities linked to a widget</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Maximum number of queries in a widget</td>
+      <td>20</td>
+    </tr>
+    <tr>
+      <td>Maximum layout column of a widget</td>
+      <td>12</td>
+    </tr>
+    <tr>
+      <td>Minimum layout column of a widget</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Minimum layout row of a widget</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Maximum layout width of a widget</td>
+      <td>12</td>
+    </tr>
+    <tr>
+      <td>Minimum layout width of a widget</td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td>Maximum layout height of a widget</td>
+      <td>32</td>
+    </tr>
+    <tr>
+      <td>Minimum layout height of a widget</td>
+      <td>1</td>
+    </tr>
+  </tbody>
 </table>
 
 ## Errors as first class citizens [#errors-first-class]


### PR DESCRIPTION
There was a request to add a line to one of these tables in the help-doc channel. I noticed the tables were in markdown. Converted them and added the line. 