### PR TITLE
update: add CyberArk REST API details

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
@@ -613,13 +613,12 @@ variables:
           insecure_skip_verify: true
 ```
 
-<Callout variant="important">
-  The the above example, you'll need to call the username and password like this:
+  Referring to the above example, call the username and password like this:
+
   ```
    USERNAME: ${credentials.user}
    PASSWORD: ${credentials.password}
  ```
-</Callout>
 
 ## New Relic CLI Obfuscation [#newrelic-cli-obfuscation]
 

--- a/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
@@ -613,6 +613,14 @@ variables:
           insecure_skip_verify: true
 ```
 
+<Callout variant="important">
+  The the above example, you'll need to call the username and password like this:
+  ```
+   USERNAME: ${credentials.user}
+   PASSWORD: ${credentials.password}
+ ```
+</Callout>
+
 ## New Relic CLI Obfuscation [#newrelic-cli-obfuscation]
 
 <Callout variant="important">

--- a/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
@@ -615,7 +615,7 @@ variables:
 
   Referring to the above example, call the username and password like this:
 
-  ```
+```
    USERNAME: ${credentials.user}
    PASSWORD: ${credentials.password}
  ```


### PR DESCRIPTION
This should be documented since the CyberArk REST API returns a JSON payload with `UserName` for username and `Content` for password.

See code here for mapping:
https://github.com/newrelic/infrastructure-agent/blob/master/pkg/databind/internal/secrets/cyberarkapi.go#L45-L50

** What problems does this PR solve?**
Helps document the correct `username` and `password` variable to use CyberArk REST API for credentials.

**Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.**
Using the CyberArk REST API, you get a JSON payload that included `UserName` and `Content` which would be natural to use in the credential variable, which is not that case since the Infrastructure Agent is mapping them to `username` and `password` instead.

* If your issue relates to an existing GitHub issue, please link to it.
N/A