### PR TITLE
always link to /whats-new/feed.xml

### DIFF
--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -14,9 +14,8 @@ import SEO from '../components/SEO';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { TYPES } from '../utils/constants';
 
-const WhatsNew = ({ data, location, pageContext }) => {
+const WhatsNew = ({ data, location }) => {
   const now = useMemo(() => new Date(), []);
-  const { slug } = pageContext;
   const { allMarkdownRemark } = data;
   const posts = allMarkdownRemark.edges.map(({ node }) => node);
   const postsByDate = Array.from(
@@ -64,7 +63,7 @@ const WhatsNew = ({ data, location, pageContext }) => {
         >
           <span>{t('strings.whatsNew.title')}</span>
           <Link
-            to={`${slug}/feed.xml`}
+            to="/whats-new/feed.xml"
             css={css`
               display: flex;
               align-items: center;
@@ -130,7 +129,6 @@ const WhatsNew = ({ data, location, pageContext }) => {
 WhatsNew.propTypes = {
   data: PropTypes.object.isRequired,
   location: PropTypes.object.isRequired,
-  pageContext: PropTypes.object.isRequired,
 };
 
 export const pageQuery = graphql`


### PR DESCRIPTION
i18n versions of this page were linking to `/<locale>/whats-new/feed.xml`, which doesn't exist, as the RSS feed isn't translated. this change makes sure we always properly link to the RSS feed