### PR TITLE
generate RSS feed at i18n paths

### DIFF
--- a/plugins/gatsby-plugin-whats-new-rss/gatsby-node.js
+++ b/plugins/gatsby-plugin-whats-new-rss/gatsby-node.js
@@ -77,7 +77,14 @@ const getFeedItem = (node, siteMetadata) => {
 const generateFeed = (publicDir, siteMetadata, reporter, whatsNewNodes) => {
   const title = `What's new in New Relic`;
 
-  const feedPath = path.join('whats-new', 'feed.xml');
+  let feedPath = path.join('whats-new', 'feed.xml');
+  const buildLang = process.env.BUILD_LANG;
+
+  // generate the XML at `<lang>/whats-new/feed.xml` for the i18n sites,
+  // otherwise they'll 404.
+  if (buildLang !== 'en') {
+    feedPath = path.join(buildLang, feedPath);
+  }
 
   // https://github.com/dylang/node-rss#feedoptions
   const feedOptions = {


### PR DESCRIPTION
trying pointing the link at `/whats-new/feed.xml` regardless of language didn't work. this updates the whats new RSS feed generation plugin to generate the feed at the appropriate i18n path for the non-English sites

i added this as a branch deploy branch for the JP site, it can be tested [here](https://sunny-rss-feed-fix--docs-website-jp.netlify.app/jp/whats-new/)