### PR TITLE
Net api restructuring h2 variant

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -1023,93 +1023,1501 @@ To use the .NET agent API, make sure you have the [latest .NET agent release](/d
 </CollapserGroup>
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="ISpan"
+        title="ISpan"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    Public interfac ISpan
+    ```
+
+    Provides access to span-specific methods in the New Relic API.
+
+    ### Description
+
+    Provides access to span-specific methods in the New Relic .NET agent API. To obtain a reference to `ISpan`, use:
+
+    * The `CurrentSpan` property on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent) (Recommended).
+    * The `CurrentSpan` property on [`ITransaction`](/docs/agents/net-agent/net-agent-api/itransaction).
+
+    This section contains descriptions and parameters of `ISpan` methods:
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Name
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            [`AddCustomAttribute`](#addcustomattribute)
+        </td>
+
+        <td>
+            Add contextual information from your application to the current span in form of attributes.
+        </td>
+        </tr>
+        <tr>
+        <td>
+            [`SetName`](#setname)
+        </td>
+
+        <td>
+            Changes the name of the current span/segment/metrics that will be reported to New Relic.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### AddCustomAttribute [#addcustomattribute]
+
+    Adds contextual information about your application to the current span in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
+
+    This method requires .NET agent version and .NET agent API [version 8.25](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440) or higher.
+
+    ### Syntax
+
+    ```cs
+    ISpan AddCustomAttribute(string key, object value)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `key`
+
+            _string_
+        </td>
+
+        <td>
+            Identifies the information being reported. Also known as the name.
+
+            * Empty keys are not supported.
+            * Keys are limited to 255-bytes. Attributes with keys larger than 255-bytes will be ignored.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `value`
+
+            _object_
+        </td>
+
+        <td>
+            The value being reported.
+            
+            <DoNotTranslate>**Note**</DoNotTranslate>: `null` values will not be recorded.
+            
+            <table>
+            <thead>
+                <tr>
+                <th>
+                    .NET type
+                </th>
+
+                <th>
+                    How the value will be represented
+                </th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr>
+                <td>
+                    `byte`, `Int16`, `Int32`, `Int64`
+
+                    `sbyte`, `UInt16`, `UInt32`, `UInt64`
+                </td>
+
+                <td>
+                    As an integral value.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `float`, `double`, `decimal`
+                </td>
+
+                <td>
+                    A decimal-based number.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `string`
+                </td>
+
+                <td>
+                    A string truncated after 255-bytes.
+
+                    Empty strings are supported.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `bool`
+                </td>
+
+                <td>
+                    True or false.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `DateTime`
+                </td>
+
+                <td>
+                    A string representation following the ISO-8601 format, including time zone information:
+
+                    Example: `2020-02-13T11:31:19.5767650-08:00`
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `TimeSpan`
+                </td>
+
+                <td>
+                    A decimal-based number representing number of seconds.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    everything else
+                </td>
+
+                <td>
+                    The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
+                </td>
+                </tr>
+            </tbody>
+            </table>
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Returns
+
+    A reference to the current span.
+
+    ### Usage considerations
+
+    For details about supported data types, see the [Custom Attributes guide](/docs/agents/net-agent/attributes/custom-attributes).
+
+    ### Examples
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+    ISpan currentSpan = agent.CurrentSpan; 
+
+    currentSpan
+        .AddCustomAttribute("customerName","Bob Smith")
+        .AddCustomAttribute("currentAge",31)
+        .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
+        .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+    ```
+
+    ### SetName [#setname]
+
+    Changes the name of the current segment/span that will be reported to New Relic. For segments/spans resulting from custom instrumentation, the metric name reported to New Relic will be altered as well. 
+
+    This method requires .NET agent version and .NET agent API version 10.1.0 or higher.
+
+    ### Syntax
+
+    ```cs
+    ISpan SetName(string name)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `name`
+
+            _string_
+        </td>
+
+        <td>
+            The new name for the span/segment.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Returns
+
+    A reference to the current span.
+
+    ## Examples
+
+    ```cs
+    [Trace]
+    public void MyTracedMethod()
+    {
+        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+        ISpan currentSpan = agent.CurrentSpan; 
+
+        currentSpan.SetName("MyCustomName");
+    }
+    ```
+    </Collapser>
+    <Collapser
+        id="IgnoreApdex"
+        title="IgnoreApdex"
+    >
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.IgnoreApdex()
+    ```
+
+    Ignore the current transaction when calculating Apdex.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    ### Description
+
+    Ignores the current transaction when calculating your [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction). This is useful when you have either very short or very long transactions (such as file downloads) that can skew your Apdex score.
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.IgnoreApdex();
+    ```
+    </Collapser>
+    <Collapser
+        id="IgnoreTransaction"
+        title="IgnoreTransaction"
+    >
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.IgnoreTransaction()
+    ```
+
+    Do not instrument the current transaction.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+    ### Description
+
+    Ignores the current transaction.
+
+    <Callout variant="tip">
+    You can also ignore transactions [via a custom instrumentation XML file](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net#blocking-instrumentation).
+    </Callout>
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.IgnoreTransaction();
+    ```
+
     </Collapser>
     <Collapser
         id="INSERT_ID_HERE"
         title="INSERT_TITLE_HERE"
     >
-        INSERT_TEXT_HERE
+    ### Overloads [#overloads]
+
+    Notice an error and report to New Relic, along with optional custom attributes.
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception);
+    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception, IDictionary<TKey, TValue> $attributes);
+    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes);
+    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes, bool $is_expected);
+    ```
+
+    ### Requirements [#requirements]
+
+    This API call is compatible with:
+
+    * All agent versions
+    * All app types
+
+    ### Description [#description]
+
+    Notice an error and report it to New Relic along with optional custom attributes. For each transaction, the agent only retains the exception and attributes from the first call to `NoticeError()`. You can pass an actual exception, or pass a string to capture an arbitrary error message.
+
+    If this method is invoked within a [transaction](/docs/glossary/glossary/#transaction), the agent reports the exception within the parent transaction. If it is invoked outside of a transaction, the agent creates an [error trace](/docs/errors-inbox/errors-inbox) and categorizes the error in the New Relic UI as a `NewRelic.Api.Agent.NoticeError` API call. If invoked outside of a transaction, the `NoticeError()` call will not contribute to the error rate of an application.
+
+    The agent adds the attributes only to the traced error; it does not send them to New Relic. For more information, see [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
+
+    Errors reported with this API are still sent to New Relic when they are reported within a transaction that results in an HTTP status code, such as a `404`, that is configured to be ignored by agent configuration. For more information, see our documentation about [managing errors in APM](/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected).
+
+    Review the sections below to see examples of how to use this call.
+
+    ### NoticeError(Exception) [#exception-overload]
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception)
+    ```
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$exception`
+
+            _Exception_
+        </td>
+
+        <td>
+            Required. The `Exception` you want to instrument. Only the first 10,000 characters from the stack trace are retained.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### NoticeError(Exception, IDictionary) [#exception-idictionary-overload]
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception, IDictionary<TKey, TValue> $attributes)
+    ```
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$exception`
+
+            _Exception_
+        </td>
+
+        <td>
+            Required. The `Exception` you want to instrument. Only the first 10,000 characters from the stack trace are retained.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$attributes`
+
+            _IDictionary&lt;TKey, TValue&gt;_
+        </td>
+
+        <td>
+            Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### NoticeError(String, IDictionary) [#string-idictionary-overload]
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes)
+    ```
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$error_message`
+
+            _string_
+        </td>
+
+        <td>
+            Required. Specify a string to report to New Relic as though it's an exception. This method creates both [error events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [error traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 1023 characters are retained in error events, while error traces retain the full message.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$attributes`
+
+            _IDictionary&lt;TKey, TValue&gt;_
+        </td>
+
+        <td>
+            Required (can be null). Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object, to send no attributes, pass `null`.  
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### NoticeError(String, IDictionary, bool) [#string-idictionary-bool-overload]
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes, bool $is_expected)
+    ```
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$error_message`
+
+            _string_
+        </td>
+
+        <td>
+            Required. Specify a string to report to New Relic as though it's an exception. This method creates both [error events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [error traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 1023 characters are retained in error events, while error traces retain the full message.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$attributes`
+
+            _IDictionary&lt;TKey, TValue&gt;_
+        </td>
+
+        <td>
+            Required (can be null). Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object, to send no attributes, pass `null`.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$is_expected`
+
+            _bool_
+        </td>
+
+        <td>
+            Mark error as expected so that it won't affect Apdex score and error rate.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    #### Pass an exception without custom attributes [#exception-no-attributes]
+
+    ```cs
+    try
+    {
+        string ImNotABool = "43";
+        bool.Parse(ImNotABool);
+    }
+    catch (Exception ex)
+    {
+        NewRelic.Api.Agent.NewRelic.NoticeError(ex);
+    }
+    ```
+
+    #### Pass an exception with custom attributes [#exception-yes-attributes]
+
+    ```cs
+    try
+    {
+        string ImNotABool = "43";
+        bool.Parse(ImNotABool);
+    }
+    catch (Exception ex)
+    {
+        var errorAttributes = new Dictionary<string, string>() {{"foo", "bar"},{"baz", "luhr"}};
+        NewRelic.Api.Agent.NewRelic.NoticeError(ex, errorAttributes);
+    }
+    ```
+
+    #### Pass an error message string with custom attributes [#string-yes-attributes]
+
+    ```cs
+    try
+    {
+        string ImNotABool = "43";
+        bool.Parse(ImNotABool);
+    }
+    catch (Exception ex)
+    {
+        var errorAttributes = new Dictionary<string, string>{{"foo", "bar"},{"baz", "luhr"}};
+        NewRelic.Api.Agent.NewRelic.NoticeError("String error message", errorAttributes);
+    }
+    ```
+
+    #### Pass an error message string without custom attributes [#string-no-attributes]
+
+    ```cs
+    try
+    {
+        string ImNotABool = "43";
+        bool.Parse(ImNotABool);
+    }
+    catch (Exception ex)
+    {
+        NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null);
+    }
+    ```
+
+    #### Pass an error message string and mark it as expected [#string-no-attributes]
+
+    ```cs
+    try
+    {
+        string ImNotABool = "43";
+        bool.Parse(ImNotABool);
+    }
+    catch (Exception ex)
+    {
+        NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null, true);
+    }
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="IncrementCounter"
+        title="IncrementCounter"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.IncrementCounter(string $metric_name)
+    ```
+
+    Increment the counter for a custom metric by 1.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    Compatible with all app types.
+
+    ### Description
+
+    Increment the counter for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) by 1. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
+
+    <Callout variant="important">
+    When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`). For more on naming, see [Collect custom metrics](/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics/).
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$metric_name`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The name of the metric to increment.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/ExampleMetric");
+    ```
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="RecordCustomEvent"
+        title="RecordCustomEvent"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.RecordCustomEvent(string eventType, IEnumerable<string, object> attributeValues)
+    ```
+
+    Records a custom event with the given name and attributes.
+
+    ### Requirements
+
+    Agent version 4.6.29.0 or higher.
+
+    Compatible with all app types.
+
+    ### Description
+
+    Records a [custom event](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data#event-data) with the given name and attributes, which you can query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). To verify if an event is being recorded correctly, look for the data in [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
+
+    For related API calls, see the [.NET agent API guide](/docs/agents/net-agent/api-guides/guide-using-net-agent-api#custom-data).
+
+    <Callout variant="important">
+    * Sending a lot of events can increase the memory overhead of the agent.
+    * Additionally, posts greater than 1MB (10^6 bytes) in size will not be recorded regardless of the maximum number of events.
+    * Custom Events are limited to 64-attributes.
+    * For more information about how custom attribute values are processed, see the [custom attributes](/docs/agents/net-agent/attributes/custom-attributes) guide.
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `eventType`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The name of the event type to record. Strings over 255 characters will result in the API call not being sent to New Relic. The name can only contain alphanumeric characters, underscores `_`, and colons `:`. For additional restrictions on event type names, see [Reserved words](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+        `attributeValues`
+
+            _IEnumerable&lt;string, object>_
+        </td>
+
+        <td>
+            Required. Specify key/value pairs of attributes to annotate the event.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    #### Record values [#record-strings]
+
+    ```cs
+    var eventAttributes = new Dictionary<string, object>() 
+    {
+        {"foo", "bar"},
+        {"alice", "bob"}, 
+        {"age", 32}, 
+        {"height", 21.3f}
+    };
+
+    NewRelic.Api.Agent.NewRelic.RecordCustomEvent("MyCustomEvent", eventAttributes);
+    ```
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="RecordMetric"
+        title="RecordMetric"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.RecordMetric(string $metric_name, single $metric_value)
+    ```
+
+    Records a custom metric with the given name.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    Compatible with all app types.
+
+    ### Description
+
+    Records a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) with the given name. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`IncrementCounter()`](/docs/agents/net-agent/net-agent-api/incrementcounter-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
+
+    <Callout variant="important">
+    When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$metric_name`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The name of the metric to record. Only the first 255 characters are retained.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$metric_value`
+
+            _single_
+        </td>
+
+        <td>
+            Required. The quantity to record for the metric.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    #### Record response time of a sleeping process [#record-stopwatch]
+
+    ```cs
+    Stopwatch stopWatch = Stopwatch.StartNew();
+    System.Threading.Thread.Sleep(5000);
+    stopWatch.Stop();
+    NewRelic.Api.Agent.NewRelic.RecordMetric("Custom/DEMO_Record_Metric", stopWatch.ElapsedMilliseconds);
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="RecordResponseTimeMetric"
+        title="RecordResponseTimeMetric"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.RecordResponseTimeMetric(string $metric_name, Int64 $metric_value)
+    ```
+
+    Records a custom metric with the given name and response time in milliseconds.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    Compatible with all app types.
+
+    ### Description
+
+    Records the response time in milliseconds for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics). To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`IncrementCounter()`](/docs/agents/net-agent/net-agent-api/incrementcounter-net-agent) and [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent).
+
+    <Callout variant="important">
+    When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$metric_name`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The name of the response time metric to record. Only the first 255 characters are retained.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$metric_value`
+
+            _Int64_
+        </td>
+
+        <td>
+            Required. The response time to record in milliseconds.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    #### Record response time of a sleeping process [#record-stopwatch]
+
+    ```cs
+    Stopwatch stopWatch = Stopwatch.StartNew();
+    System.Threading.Thread.Sleep(5000);
+    stopWatch.Stop();
+    NewRelic.Api.Agent.NewRelic.RecordResponseTimeMetric("Custom/DEMO_Record_Response_Time_Metric", stopWatch.ElapsedMilliseconds);
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="SetApplicationName"
+        title="SetApplicationName"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetApplicationName(string $name[, string $name_2, string $name_3])
+    ```
+
+    Set the app name for data rollup.
+
+    ### Requirements
+
+    Agent version 5.0.136.0 or higher.
+
+    Compatible with all app types.
+
+    ### Description
+
+    Set the application name(s) reported to New Relic. For more information about application naming, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application). This method is intended to be called once, during startup of an application.
+
+    <Callout variant="important">
+    Updating the app name forces the agent to restart. The agent discards any unreported data associated with previous app names. Changing the app name multiple times during the lifecycle of an application is not recommended due to the associated data loss.
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$name`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The primary application name.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$name_2`
+
+            `$name_3`
+
+            _string_
+        </td>
+
+        <td>
+            Optional. Second and third names for app rollup. For more information, see [Use multiple names for an app](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app).
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetApplicationName("AppName1", "AppName2");
+    ```
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="SetErrorGroupCallback"
+        title="SetErrorGroupCallback"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(Func<IReadOnlyDictionary<string,object>, string> errorGroupCallback);
+    ```
+    Provide a callback method that takes an `IReadOnlyDictionary<string,object>` of attribute data, and returns an error group name.
+
+    ### Requirements [#requirements]
+
+    This API call is compatible with:
+
+    * Agent versions >= 10.9.0
+    * All app types
+
+    ### Description [#description]
+
+    Set a callback method that the agent will use to determine the error group name for error events and traces.  This name is used in the Errors Inbox to group errors into logical groups.
+
+    The callback method must accept a single argument of type `IReadOnlyDictionary<string,object>`, and return a string (the error group name). The `IReadOnlyDictionary` is a collection of [attribute data](/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes/) associated with each error event, including custom attributes.
+
+    The exact list of attributes available for each error will vary depending on:
+
+    * What application code generated the error
+    * Agent configuration settings
+    * Whether any custom attributes were added
+
+    However, the following attributes should always exist:
+
+    * `error.class`
+    * `error.message`
+    * `stack_trace`
+    * `transactionName`
+    * `request.uri`
+    * `error.expected`
+
+    An empty string may be returned for the error group name when the error can't be assigned to a logical error group.
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$callback`
+
+            _{'Func<IReadOnlyDictionary<string,object>,string>'}_
+            
+        </td>
+
+        <td>
+            The callback to determine the error group name based on attribute data.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    Group errors by error class name:
+
+    ```cs
+    Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback = (attributes) => {
+        string errorGroupName = string.Empty;
+        if (attributes.TryGetValue("error.class", out var errorClass))
+        {
+            if (errorClass.ToString() == "System.ArgumentOutOfRangeException" || errorClass.ToString() == "System.ArgumentNullException")
+            {
+                errorGroupName = "ArgumentErrors";
+            }
+            else
+            {
+                errorGroupName = "OtherErrors";
+            }
+        }
+        return errorGroupName;
+    };
+
+    NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(errorGroupCallback);
+    ```
+
+    Group errors by transaction name:
+
+    ```cs
+    Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback = (attributes) => {
+        string errorGroupName = string.Empty;
+        if (attributes.TryGetValue("transactionName", out var transactionName))
+        {
+        if (transactionName.ToString().IndexOf("WebTransaction/MVC/Home") != -1)
+        {
+        errorGroupName = "HomeControllerErrors";
+        }
+            else
+            {
+                errorGroupName = "OtherControllerErrors";
+            }
+        }
+        return errorGroupName;
+    };
+
+    NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(errorGroupCallback);
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="SetTransactionName"
+        title="SetTransactionName"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetTransactionName(string $category, string $name)
+    ```
+
+    Sets the name of the current transaction.
+
+    ### Requirements
+
+    * Compatible with all agent versions.
+    * Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+    ### Description
+
+    Sets the name of the current transaction. Before you use this call, ensure you understand the implications of [metric grouping issues](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues).
+
+    If you use this call multiple times within the same transaction, each call overwrites the previous call and the last call sets the name.
+
+    <Callout variant="important">
+    Do not use brackets `[suffix]` at the end of your transaction name. New Relic automatically strips brackets from the name. Instead, use parentheses `(suffix)` or other symbols if needed.
+    </Callout>
+
+    Unique values like URLs, page titles, hex values, session IDs, and uniquely identifiable values should not be used in naming your transactions. Instead, add that data to the transaction as a custom parameter with the [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) call.
+
+    <Callout variant="important">
+    Do not create more than 1000 unique transaction names (for example, avoid naming by URL if possible). This will make your charts less useful, and you may run into limits New Relic sets on the number of unique transaction names per account. It also can slow down the performance of your application.
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$category`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The category of this transaction, which you can use to distinguish different types of transactions. Defaults to <DoNotTranslate>**`Custom`**</DoNotTranslate>. Only the first 255 characters are retained.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$name`
+
+            _string_
+        </td>
+
+        <td>
+            Required. The name of the transaction. Only the first 255 characters are retained.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetTransactionName("Other", "MyTransaction");
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="SetTransactionUri"
+        title="SetTransactionUri"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetTransactionUri(Uri $uri)
+    ```
+
+    Sets the URI of the current transaction.
+
+    ### Requirements
+
+    * Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+    * Agent version 6.16 or higher.
+
+    <Callout variant="important">
+    This method only works when used within a transaction created using the `Transaction` attribute with the `Web` property set to `true`. (See [Instrument using attributes](/docs/agents/net-agent/api-guides/net-agent-api-instrument-using-attributes).) It provides support for custom web-based frameworks that the agent does not automatically support.
+    </Callout>
+
+    ### Description
+
+    Sets the URI of the current transaction. The URI appears in the 'request.uri' [attribute](/docs/agents/net-agent/attributes/net-agent-attributes) of [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces) and [transaction events](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data), and also can affect transaction naming.
+
+    If you use this call multiple times within the same transaction, each call overwrites the previous call. The last call sets the URI.
+
+    <DoNotTranslate>**Note**</DoNotTranslate>: as of agent version 8.18, the `request.uri` attribute's value is set to the value of the `Uri.AbsolutePath` property of the `System.Uri` object passed to the API.
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$uri`
+
+            _Uri_
+        </td>
+
+        <td>
+            The URI of this transaction.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    ```cs
+    var uri = new System.Uri("https://www.mydomain.com/path");
+    NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="SetUserParameters"
+        title="SetUserParameters"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetUserParameters(string $user_value, string $account_value, string $product_value)
+    ```
+
+    Create user-related custom attributes. [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) is more flexible.
+
+    ### Requirements
+
+    * Compatible with all agent versions.
+    * Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+    ### Description
+
+    <Callout variant="tip">
+    This call only allows you to assign values to pre-existing keys. For a more flexible method to create key/value pairs, use [`AddCustomAttribute()`](/docs/agents/net-agent/net-agent-api/itransaction).
+    </Callout>
+
+    Define user-related [custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)to associate with a browser page view (user name, account name, and product name). The values are automatically associated with pre-existing keys (`user`, `account`, and `product`), then attached to the parent APM transaction. You can also [attach (or "forward") these attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#forwarding-attributes) to browser [PageView](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes#destinations) events.
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$user_value`
+
+            _string_
+        </td>
+
+        <td>
+            Required (can be null). Specify a name or username to associate with this page view. This value is assigned to the `user` key.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$account_value`
+
+            _string_
+        </td>
+
+        <td>
+            Required (can be null). Specify the name of a user account to associate with this page view. This value is assigned to the `account` key.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `$product_value`
+
+            _string_
+        </td>
+
+        <td>
+            Required (can be null). Specify the name of a product to associate with this page view. This value is assigned to the `product` key.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    #### Record three user attributes [#report-three]
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetUserParameters("MyUserName", "MyAccountName", "MyProductName");
+    ```
+
+    #### Record two user attributes and one empty attribute [#report-two]
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.SetUserParameters("MyUserName", "", "MyProductName");
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="StartAgent"
+        title="StartAgent"
     >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.StartAgent()
+    ```
+
+    Start the agent if it hasn't already started. Usually unnecessary.
+
+    ### Requirements
+
+    * Agent version 5.0.136.0 or higher.
+    * Compatible with all app types.
+
+    ### Description
+
+    Starts the agent if it hasn't already been started. This call is usually unnecessary, since the agent starts automatically when it hits an instrumented method unless you disable [`autoStart`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-autoStart). If you use [`SetApplicationName()`](/docs/agents/net-agent/net-agent-api/setapplicationname-net-agent), ensure you set the app name <DoNotTranslate>**before**</DoNotTranslate> you start the agent.
+
+    <Callout variant="tip">
+    This method starts the agent asynchronously (meaning it won't block app startup) unless you enable [`syncStartup`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-syncStartup) or [`sendDataOnExit`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-sendDataOnExit).
+    </Callout>
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.StartAgent();
+    ```
+
     </Collapser>
     <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
+        id="TraceMetadata"
+        title="TraceMetadata"
     >
-        INSERT_TEXT_HERE
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-        INSERT_TEXT_HERE
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-        INSERT_TEXT_HERE
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.TraceMetadata;
+    ```
+
+    Returns properties in the current execution environment used to support tracing.
+
+    ### Requirements
+
+    * Agent version 8.19 or higher.
+    * Compatible with all app types.
+    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing) to get meaningful values.
+
+    ## Description
+
+    Provides access to the following properties:
+
+    ### Properties
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Name
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `TraceId`
+        </td>
+
+        <td>
+            Returns a string representing the currently executing trace. If the trace ID is not available, or distributed tracing is disabled, the value will be `string.Empty`.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `SpanId`
+        </td>
+
+        <td>
+            Returns a string representing the currently executing span. If the span ID is not available, or distributed tracing is disabled, the value will be `string.Empty`.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `IsSampled`
+        </td>
+
+        <td>
+            Returns `true` if the current trace is sampled for inclusion, `false` if it is sampled out.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ## Examples
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    TraceMetadata traceMetadata = agent.TraceMetadata;
+    string traceId = traceMetadata.TraceId;
+    string spanId = traceMetadata.SpanId;
+    bool isSampled = traceMetadata.IsSampled;
+    ```
+
     </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -1,0 +1,1115 @@
+---
+title: .NET agent API
+tags:
+  - Agents
+  - NET agent
+  - API guides
+metaDescription: 'A goal-focused guide to the New Relic .NET agent API.'
+redirects:
+  - /docs/agents/net-agent/api-guides/guide-using-net-agent-api
+  - /docs/agents/net-agent/net-agent-api/net-agent-api-guide
+  - /docs/agents/net-agent/net-agent-api/guide-using-net-agent-api
+  - /docs/apm/agents/net-agent/net-agent-api
+  - /docs/apm/agents/net-agent/api-guides/guide-using-net-agent-api
+  - /docs/agents/net-agent/net-agent-api
+  - /docs/agents/net-agent/features/net-agent-api
+  - /docs/apm/agents/net-agent/net-agent-api/guide-using-net-agent-api
+freshnessValidatedDate: never
+---
+
+New Relic's .NET agent includes an API that allows you to extend the agent's standard functionality. For example, you can use the .NET agent API for:
+
+* Customizing your app name
+* Creating custom transaction parameters
+* Reporting custom errors and metrics
+
+You can also customize some of the .NET agent's default behavior by adjusting [configuration settings](/docs/agents/net-agent/configuration/net-agent-configuration) or using [custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation).
+
+## Requirements
+
+<Callout variant="important">
+  As of September 2021, a small subset of APIs, configuration options, and installation options for .NET will be replaced by new methods. For more details, including how you can easily prepare for this transition, see our [Support Forum post](https://discuss.newrelic.com/t/important-upcoming-changes-to-support-and-capabilities-across-browser-node-js-agent-query-builder-net-agent-apm-errors-distributed-tracing/153373).
+</Callout>
+
+To use the .NET agent API, make sure you have the [latest .NET agent release](/docs/release-notes/agent-release-notes/net-release-notes). Then, add a reference to the agent in your project using one of the two options below:
+
+   * Add a reference to `NewRelic.Api.Agent.dll` to your project.
+    
+    OR
+
+   * View and download the API package from the [NuGet Package Library](https://www.nuget.org/packages/NewRelic.Agent.Api/).
+
+   The following list contains the different calls you can make with the API, including syntax, requirements, functionality, and examples:
+
+<CollapserGroup>
+    <Collapser
+        id="DisableBrowserMonitoring"
+        title="DisableBrowserMonitoring"
+    >
+    ### Syntax
+
+        ```cs
+        NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring([boolean $override])
+        ```
+
+        Disable automatic injection of browser monitoring snippet on specific pages.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    Must be called inside a [transaction](/docs/glossary/glossary/#transaction).
+
+    ### Description
+
+    Add this call to disable the <DoNotTranslate>**automatic**</DoNotTranslate> injection of [<InlinePopover type="browser" />](/docs/browser/new-relic-browser/getting-started/new-relic-browser) scripts on specific pages. You can also add an optional override to disable <DoNotTranslate>**both**</DoNotTranslate> manual and automatic injection. In either case, put this API call as close as possible to the top of the view in which you want browser disabled.
+
+    <Callout variant="tip">
+    Compare [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent), which <DoNotTranslate>**adds**</DoNotTranslate> the browser script to the page.
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `$override`
+
+            _boolean_
+        </td>
+
+        <td>
+            Optional. When `true`, disables all injection of browser scripts. This flag affects both manual and automatic injection. This also overrides the [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent) call.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Examples
+
+    #### Disable automatic injection [#automatic-only]
+
+    This example disables only the <DoNotTranslate>**automatic**</DoNotTranslate> injection of the snippet:
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring();
+    ```
+
+    #### Disable automatic and manual injection [#disable-both]
+
+    This example disables <DoNotTranslate>**both**</DoNotTranslate> automatic and manual injection of the snippet:
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring(true);
+    ```
+    </Collapser>
+    <Collapser
+        id="GetAgent"
+        title="GetAgent"
+    >
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.GetAgent()
+    ```
+
+    Get access to the agent via the `IAgent` interface.
+
+    ### Requirements
+
+    Agent version 8.9 or higher.
+
+    Compatible with all app types.
+
+    ### Description
+
+    Get access to agent API methods via the [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent) interface.
+
+    ### Return values
+
+    An implementation of [IAgent](/docs/agents/net-agent/net-agent-api/iagent-net-agent-api) providing access to the [IAgent API](/docs/agents/net-agent/net-agent-api/iagent-net-agent-api).
+
+    ### Examples
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    ```
+
+    </Collapser>
+    <Collapser
+        id="GetBrowserTimingHeader"
+        title="GetBrowserTimingHeader"
+    >
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader();
+    NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader(string nonce);
+    ```
+
+    Generate a browser monitoring HTML snippet to instrument end-user browsers.
+
+    ### Requirements
+
+    Compatible with all agent versions.
+
+    Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+
+
+    ### Description
+
+    Returns an HTML snippet used to enable [<InlinePopover type="browser" />](/docs/browser/new-relic-browser/getting-started/new-relic-browser). The snippet instructs the browser to fetch a small JavaScript file and start the page timer. You can then insert the returned snippet into the header of your HTML webpages. For more information, see [Adding apps to Browser monitoring](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser).
+
+    <Callout variant="tip">
+    Compare [`DisableBrowserMonitoring()`](/docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent), which <DoNotTranslate>**disables**</DoNotTranslate> the browser script on a page.
+    </Callout>
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th width="25%">
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `nonce`
+
+            _string_
+        </td>
+
+        <td>
+            The per-request, cryptographic nonce used by Content-Security-Policy policies.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    <Callout variant="tip">
+    This API call requires updates to security allow lists. For more information about Content Security Policy (CSP) considerations, visit the [browser monitoring compatibility and requirements](/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring) page.
+    </Callout>
+
+    ### Return values
+
+    An HTML string to be embedded in a page header.
+
+    ### Examples
+
+    #### With ASPX [#aspx]
+
+    ```aspnet
+    <html>
+    <head>
+        <%= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()%>
+        ...
+    </head>
+    <body>
+    ...
+    ```
+
+    ```aspnet
+    <html>
+    <head>
+        <%= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE")%>
+        ...
+    </head>
+    <body>
+    ...
+    ```
+
+    #### With Razor [#razor]
+
+    ```cshtml
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
+        ...
+    </head>
+    <body>
+    ...
+    ```
+
+    ```cshtml
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
+        ...
+    </head>
+    <body>
+    ...
+    ```
+
+    #### With Blazor [#blazor]
+
+    <Callout variant="important">
+    This API is not supported for Blazor Webassembly, because the agent is unable to instrument Webassembly code.  The following examples are for Blazor Server applications only.  Use the [copy-paste method](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#copy-paste) of adding the browser agent to Blazor Webassembly pages.
+    </Callout>
+
+    <Callout variant="important">
+    This API can not be placed in a `<HeadContent>` element of a `.razor` page.  Instead, it should be called from `_Layout.cshtml` or an equivalent layout file.
+    </Callout>
+
+    ```cshtml
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
+        ...
+    </head>
+    <body>
+    ...
+    ```
+
+    ```cshtml
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
+        ...
+    </head>
+    <body>
+    ...
+    ```
+
+    </Collapser>
+    <Collapser
+        id="GetLinkingMetadata"
+        title="GetLinkingMetadata"
+    >
+    ### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.GetLinkingMetadata();
+    ```
+
+    Returns key/value pairs which can be used to link traces or entities.
+
+    ### Requirements
+
+    Agent version 8.19 or higher.
+
+    Compatible with all app types.
+
+    ### Description
+
+    The Dictionary of key/value pairs returned includes items used to link traces and entities in the APM product. It will only contain items with meaningful values. For instance, if distributed tracing is disabled, `trace.id` will not be included.
+
+    ### Return values
+
+    `Dictionary <string, string>()` returned includes items used to link traces and entities in the APM product.
+
+    ### Examples
+
+    ```cs
+    NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    var linkingMetadata = Agent.GetLinkingMetadata();
+    foreach (KeyValuePair<string, string> kvp in linkingMetadata)
+    {
+        Console.WriteLine("Key = {0}, Value = {1}", kvp.Key, kvp.Value);
+    }
+    ```
+
+    </Collapser>
+    <Collapser
+        id="IAgent"
+        title="IAgent"
+    >
+        ### Syntax
+
+            ```cs
+            public interfac IAgent
+            ```
+
+        Provides access to agent artifacts and methods, such as the currently executing transaction.
+
+        ### Requirements
+
+        Agent version 8.9 or higher.
+
+        Compatible with all app types.
+
+        ### Description
+
+        Provides access to agent artifacts and methods, such as the currently executing transaction. To obtain a reference to `IAgent`, use [`GetAgent`](/docs/agents/net-agent/net-agent-api/getagent).
+
+        ### Properties
+
+        <table>
+        <thead>
+            <tr>
+            <th width="25%">
+                Name
+            </th>
+
+            <th>
+                Description
+            </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <tr>
+            <td>
+                CurrentTransaction
+            </td>
+
+            <td>
+                Property providing access to the currently executing transaction via the [ITransaction](/docs/agents/net-agent/net-agent-api/itransaction) interface. Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                CurrentSpan
+            </td>
+
+            <td>
+                Property providing access to the currently executing span via the [ISpan](/docs/agents/net-agent/net-agent-api/iSpan) interface.
+            </td>
+            </tr>
+        </tbody>
+        </table>
+
+        ### Examples
+
+        ```cs
+        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+        ITransaction transaction = agent.CurrentTransaction;
+        ```
+
+        </Collapser>
+        <Collapser
+            id="ITransaction"
+            title="ITransaction"
+        >
+    ### Syntax
+
+    ```cs
+    public interfac ITransaction
+    ```
+
+    Provides access to transaction-specific methods in the New Relic API.
+
+    ### Description
+
+    Provides access to transaction-specific methods in the New Relic .NET agent API. To obtain a reference to `ITransaction`, use the current transaction method available on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent).
+
+    The following methods are available on `ITransaction`:
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Name
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            [`AcceptDistributedTraceHeaders`](#acceptdistributedtraceheaders)
+        </td>
+
+        <td>
+            Accepts incoming trace context headers from another service.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            [`InsertDistributedTraceHeaders`](#insertdistributedtraceheaders)
+        </td>
+
+        <td>
+            Adds trace context headers to an outgoing request.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            [`AcceptDistributedTracePayload` (obsolete)](#acceptdistributedtracepayload)
+        </td>
+
+        <td>
+            Accepts an incoming distributed trace payload from another service.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            [`CreateDistributedTracePayload` (obsolete)](#createdistributedtracepayload)
+        </td>
+
+        <td>
+            Creates a distributed trace payload for inclusion in an outgoing request.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            [`AddCustomAttribute`](#addcustomattribute)
+        </td>
+
+        <td>
+            Add contextual information from your application to the current transaction in form of attributes.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            [`CurrentSpan`](#currentspan)
+        </td>
+
+        <td>
+            Provides access to the currently executing [span](/docs/agents/net-agent/net-agent-api/ispan), which provides access to span-specific methods in the New Relic API.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            [`SetUserId`](#setuserid)
+        </td>
+
+        <td>
+            Associates a User Id to the current transaction.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+    <CollapserGroup>
+    <Collapser
+        id="AcceptDistributedTraceHeaders"
+        title="AcceptDistributedTraceHeaders"
+    >
+        `ITransaction.AcceptDistributedTraceHeaders` is used to instrument the called service for inclusion in a distributed trace. It links the spans in a trace by accepting a payload generated by [`InsertDistributedTraceHeaders`](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-insertDistributedTraceHeaders) or generated by some other W3C Trace Context compliant tracer. This method accepts the headers of an incoming request, looks for W3C Trace Context headers, and if not found, falls back to New Relic distributed trace headers. This method replaces the deprecated [`AcceptDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#acceptdistributedtracepayload) method, which only handles New Relic distributed trace payloads.
+
+        ### Syntax
+
+        ```cs
+        void AcceptDistributedTraceHeaders(carrier, getter, transportType)
+        ```
+
+        ### Parameters
+
+        <table>
+        <thead>
+            <tr>
+            <th>
+                Name
+            </th>
+
+            <th>
+                Description
+            </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <tr>
+            <td>
+                `carrier`
+
+                _&lt;T>_
+            </td>
+
+            <td>
+                Required. Source of incoming Trace Context headers.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `getter`
+
+                _Func&lt;T, string, IEnumerable&lt;string>>_
+            </td>
+
+            <td>
+                Required. Caller-defined function to extract header data from the carrier.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `transportType`
+
+                _TransportType enum_
+            </td>
+
+            <td>
+                Required. Describes the transport of the incoming payload (for example `TransportType.HTTP`).
+            </td>
+            </tr>
+        </tbody>
+        </table>
+
+        ### Usage considerations
+
+        * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+        * `AcceptDistributedTraceHeaders` will be ignored if `InsertDistributedTraceHeaders` or `AcceptDistributedTraceHeaders` has already been called for this transaction.
+
+        ### Example
+
+        ```cs
+        HttpContext httpContext = HttpContext.Current;
+        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+        ITransaction currentTransaction = agent.CurrentTransaction;
+        currentTransaction.AcceptDistributedTraceHeaders(httpContext, Getter, TransportType.HTTP);
+        IEnumerable<string> Getter(HttpContext carrier, string key) 
+        { 
+            string value = carrier.Request.Headers[key];   
+            return value == null ? null : new string[] { value }; 
+        }
+        ```
+    </Collapser>
+    <Collapser
+        id="InsertDistributedTraceHeaders"
+        title="InsertDistributedTraceHeaders"
+    >
+        `ITransaction.InsertDistributedTraceHeaders` is used to implement distributed tracing. It modifies the carrier object that is passed in by adding W3C Trace Context headers and New Relic Distributed Trace headers. The New Relic headers can be disabled with `<distributedTracing excludeNewrelicHeader="true" />` in the config. This method replaces the deprecated [`CreateDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#createdistributedtracepayload) method, which only creates New Relic Distributed Trace payloads.
+
+        ### Syntax
+
+        ```cs
+        void InsertDistributedTraceHeaders(carrier, setter)
+        ```
+
+        ### Parameters
+
+        <table>
+        <thead>
+            <tr>
+            <th>
+                Name
+            </th>
+
+            <th>
+                Description
+            </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <tr>
+            <td>
+                `carrier`
+
+                _&lt;T>_
+            </td>
+
+            <td>
+                Required. Container where Trace Context headers are inserted..
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `setter`
+
+                _Action&lt;T, string, string>_
+            </td>
+
+            <td>
+                Required. Caller-defined Action to insert header data into the carrier.
+            </td>
+            </tr>
+        </tbody>
+        </table>
+
+        ### Usage considerations
+
+        * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+
+        ### Example
+
+        ```cs
+        HttpWebRequest requestMessage = (HttpWebRequest)WebRequest.Create("https://remote-address");
+        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+        ITransaction currentTransaction = agent.CurrentTransaction;
+        var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) => { carrier.Headers?.Set(key, value); });
+        currentTransaction.InsertDistributedTraceHeaders(requestMessage, setter);
+        ```
+    </Collapser>
+    <Collapser
+        id="AcceptDistributedTracePayload"
+        title="AcceptDistributedTracePayload"
+    >
+
+    <Callout variant="caution">
+    This API is not available in the .NET agent v9.0 or higher. Please use [`AcceptDistributedTraceHeaders`](/docs/agents/net-agent/net-agent-api/itransaction/#acceptdistributedtraceheaders) instead.
+    </Callout>
+
+    Accepts an incoming distributed trace payload from an upstream service. Calling this method links the transaction from the upstream service to this transaction.
+
+    ### Syntax
+
+    ```cs
+    void AcceptDistributedPayload(payload, transportType)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Name
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `payload`
+
+            _string_
+        </td>
+
+        <td>
+            Required. A string representation of the incoming distributed trace payload.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `transportType`
+
+            _TransportType_  
+                                    _enum_
+        </td>
+
+        <td>
+            Recommended. Describes the transport of the incoming payload (for example, `http`).
+
+            Default `TransportType.Unknown`.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Usage considerations
+
+    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+    * The payload can be a Base64-encoded or plain text string.
+    * `AcceptDistributedTracePayload` will be ignored if `CreateDistributedTracePayload` has already been called for this transaction.
+
+    ### Example
+
+    ```cs
+    //Obtain the information from the request object from the upstream caller.
+    //The method by which this information is obtain is specific to the transport 
+    //type being used. For example, in an HttpRequest, this information is
+    //contained in the 
+    header.KeyValuePair<string, string> metadata = GetMetaDataFromRequest("requestPayload");
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+    ITransaction transaction = agent.CurrentTransaction; 
+    transaction.AcceptDistributedTracePayload(metadata.Value, TransportType.Queue);
+    ```
+
+    </Collapser>
+    <Collapser
+        id="CreateDistributedTracePayload"
+        title="CreateDistributedTracePayload (obsolete)"
+    >
+    <Callout variant="caution">
+    This API is not available in the .NET agent v9.0 or higher. Please use [`InsertDistributedTraceHeaders`](/docs/agents/net-agent/net-agent-api/itransaction/#insertdistributedtraceheaders) instead.
+    </Callout>
+
+    Creates a distributed trace payload for inclusion in an outgoing request to a downstream system.
+
+    ### Syntax
+
+    ```cs
+    IDistributedTracePayload CreateDistributedTracePayload()
+    ```
+
+    ### Returns
+
+    An object that implements `IDistributedTracePayload` which provides access to the distributed trace payload that was created.
+
+    ### Usage considerations
+
+    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+    * `CreateDistributedTracePayload` will be ignored if `AcceptDistributedTracePayload` has already been called for this transaction.
+
+    ### Example
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    ITransaction transaction = agent.CurrentTransaction;
+    IDistributedTracePayload payload = transaction.CreateDistributedTracePayload();
+    ```
+
+    </Collapser>
+    <Collapser
+        id="AddCustomAttribute"
+        title="AddCustomAttribute"
+    >
+    Adds contextual information about your application to the current transaction in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
+
+    This method requires .NET agent version and .NET agent API [version 8.24.244.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440) or higher. It replaced the deprecated [`AddCustomParameter`](/docs/agents/net-agent/net-agent-api/add-custom-parameter).
+
+    ### Syntax
+
+    ```cs
+    ITransaction AddCustomAttribute(string key, object value)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `key`
+
+            _string_
+        </td>
+
+        <td>
+            Identifies the information being reported. Also known as the name.
+
+            * Empty keys are not supported.
+            * Keys are limited to 255-bytes. Attributes with keys larger than 255-bytes will be ignored.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `value`
+
+            _object_
+        </td>
+
+        <td>
+            The value being reported.
+            
+            <DoNotTranslate>**Note**</DoNotTranslate>: `null` values will not be recorded.
+            
+            <table>
+            <thead>
+                <tr>
+                <th>
+                    .NET type
+                </th>
+
+                <th>
+                    How the value will be represented
+                </th>
+                </tr>
+            </thead>
+
+            <tbody>
+                <tr>
+                <td>
+                    `byte`, `Int16`, `Int32`, `Int64`
+
+                    `sbyte`, `UInt16`, `UInt32`, `UInt64`
+                </td>
+
+                <td>
+                    As an integral value.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `float`, `double`, `decimal`
+                </td>
+
+                <td>
+                    A decimal-based number.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `string`
+                </td>
+
+                <td>
+                    A string truncated after 255-bytes.
+
+                    Empty strings are supported.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `bool`
+                </td>
+
+                <td>
+                    True or false.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `DateTime`
+                </td>
+
+                <td>
+                    A string representation following the ISO-8601 format, including time zone information:
+
+                    Example: `2020-02-13T11:31:19.5767650-08:00`
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    `TimeSpan`
+                </td>
+
+                <td>
+                    A decimal-based number representing number of seconds.
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    everything else
+                </td>
+
+                <td>
+                    The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
+                </td>
+                </tr>
+            </tbody>
+            </table>
+
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Returns
+
+    A reference to the current transaction.
+
+    ### Usage considerations
+
+    For details about supported data types, see the [Custom Attributes Guide](/docs/agents/net-agent/attributes/custom-attributes).
+
+    ### Example
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    ITransaction transaction = agent.CurrentTransaction;
+    transaction.AddCustomAttribute("customerName","Bob Smith")
+        .AddCustomAttribute("currentAge",31)
+        .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
+        .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+    ```
+    </Collapser>
+    <Collapser
+        id="CurrentSpan"
+        title="CurrentSpan"
+    >
+    
+    Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/ispan/), making [span-specific methods](/docs/apm/agents/net-agent/net-agent-api/ispan) available within the New Relic API.
+
+    ### Example
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+    ITransaction transaction = agent.CurrentTransaction; 
+    ISpan currentSpan = transaction.CurrentSpan;
+    ```
+
+    </Collapser>
+    <Collapser
+        id="SetUserId"
+        title="SetUserId"
+    >
+    Associates a User Id with the current transaction.
+
+    This method requires .NET agent and .NET agent API [version 10.9.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1090) or higher.
+
+    ### Syntax
+
+    ```cs
+    ITransaction SetUserId(string userId)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Parameter
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `userId`
+
+            _string_
+        </td>
+
+        <td>
+            The User Id to be associated with this transaction.
+
+            * `null`, empty and whitespace values will be ignored.
+        </td>
+        </tr>
+
+    </tbody>
+    </table>
+
+    ### Example
+
+    ```cs
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+    ITransaction transaction = agent.CurrentTransaction; 
+    transaction.SetUserId("BobSmith123");
+    ```
+    </Collapser>
+</CollapserGroup>
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+    <Collapser
+        id="INSERT_ID_HERE"
+        title="INSERT_TITLE_HERE"
+    >
+        INSERT_TEXT_HERE
+    </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -41,92 +41,300 @@ To use the .NET agent API, make sure you have the [latest .NET agent release](/d
 
    The following list contains the different calls you can make with the API, including syntax, requirements, functionality, and examples:
 
-<CollapserGroup>
-    <Collapser
-        id="DisableBrowserMonitoring"
-        title="DisableBrowserMonitoring"
-    >
+## DisableBrowserMonitoring [#disablebrowsermonitoring]
+
+### Syntax
+
+    ```cs
+    NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring([boolean $override])
+    ```
+
+    Disable automatic injection of browser monitoring snippet on specific pages.
+
+### Requirements
+
+Compatible with all agent versions.
+
+Must be called inside a [transaction](/docs/glossary/glossary/#transaction).
+
+### Description
+
+Add this call to disable the <DoNotTranslate>**automatic**</DoNotTranslate> injection of [<InlinePopover type="browser" />](/docs/browser/new-relic-browser/getting-started/new-relic-browser) scripts on specific pages. You can also add an optional override to disable <DoNotTranslate>**both**</DoNotTranslate> manual and automatic injection. In either case, put this API call as close as possible to the top of the view in which you want browser disabled.
+
+<Callout variant="tip">
+Compare [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent), which <DoNotTranslate>**adds**</DoNotTranslate> the browser script to the page.
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$override`
+
+        _boolean_
+    </td>
+
+    <td>
+        Optional. When `true`, disables all injection of browser scripts. This flag affects both manual and automatic injection. This also overrides the [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent) call.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+#### Disable automatic injection [#automatic-only]
+
+This example disables only the <DoNotTranslate>**automatic**</DoNotTranslate> injection of the snippet:
+
+```cs
+NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring();
+```
+
+#### Disable automatic and manual injection [#disable-both]
+
+This example disables <DoNotTranslate>**both**</DoNotTranslate> automatic and manual injection of the snippet:
+
+```cs
+NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring(true);
+```
+
+## GetAgent [#getagent]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.GetAgent()
+```
+
+Get access to the agent via the `IAgent` interface.
+
+### Requirements
+
+Agent version 8.9 or higher.
+
+Compatible with all app types.
+
+### Description
+
+Get access to agent API methods via the [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent) interface.
+
+### Return values
+
+An implementation of [IAgent](/docs/agents/net-agent/net-agent-api/iagent-net-agent-api) providing access to the [IAgent API](/docs/agents/net-agent/net-agent-api/iagent-net-agent-api).
+
+### Examples
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+```
+
+
+## GetBrowserTimingHeader [#getbrowsertimingheader]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader();
+NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader(string nonce);
+```
+
+Generate a browser monitoring HTML snippet to instrument end-user browsers.
+
+### Requirements
+
+Compatible with all agent versions.
+
+Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+
+
+### Description
+
+Returns an HTML snippet used to enable [<InlinePopover type="browser" />](/docs/browser/new-relic-browser/getting-started/new-relic-browser). The snippet instructs the browser to fetch a small JavaScript file and start the page timer. You can then insert the returned snippet into the header of your HTML webpages. For more information, see [Adding apps to Browser monitoring](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser).
+
+<Callout variant="tip">
+Compare [`DisableBrowserMonitoring()`](/docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent), which <DoNotTranslate>**disables**</DoNotTranslate> the browser script on a page.
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `nonce`
+
+        _string_
+    </td>
+
+    <td>
+        The per-request, cryptographic nonce used by Content-Security-Policy policies.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+<Callout variant="tip">
+This API call requires updates to security allow lists. For more information about Content Security Policy (CSP) considerations, visit the [browser monitoring compatibility and requirements](/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring) page.
+</Callout>
+
+### Return values
+
+An HTML string to be embedded in a page header.
+
+### Examples
+
+#### With ASPX [#aspx]
+
+```aspnet
+<html>
+<head>
+    <%= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()%>
+    ...
+</head>
+<body>
+...
+```
+
+```aspnet
+<html>
+<head>
+    <%= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE")%>
+    ...
+</head>
+<body>
+...
+```
+
+#### With Razor [#razor]
+
+```cshtml
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
+    ...
+</head>
+<body>
+...
+```
+
+```cshtml
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
+    ...
+</head>
+<body>
+...
+```
+
+#### With Blazor [#blazor]
+
+<Callout variant="important">
+This API is not supported for Blazor Webassembly, because the agent is unable to instrument Webassembly code.  The following examples are for Blazor Server applications only.  Use the [copy-paste method](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#copy-paste) of adding the browser agent to Blazor Webassembly pages.
+</Callout>
+
+<Callout variant="important">
+This API can not be placed in a `<HeadContent>` element of a `.razor` page.  Instead, it should be called from `_Layout.cshtml` or an equivalent layout file.
+</Callout>
+
+```cshtml
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
+    ...
+</head>
+<body>
+...
+```
+
+```cshtml
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
+    ...
+</head>
+<body>
+...
+```
+
+
+## GetLinkingMetadata [#getlinkingmetadata]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.GetLinkingMetadata();
+```
+
+Returns key/value pairs which can be used to link traces or entities.
+
+### Requirements
+
+Agent version 8.19 or higher.
+
+Compatible with all app types.
+
+### Description
+
+The Dictionary of key/value pairs returned includes items used to link traces and entities in the APM product. It will only contain items with meaningful values. For instance, if distributed tracing is disabled, `trace.id` will not be included.
+
+### Return values
+
+`Dictionary <string, string>()` returned includes items used to link traces and entities in the APM product.
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+var linkingMetadata = Agent.GetLinkingMetadata();
+foreach (KeyValuePair<string, string> kvp in linkingMetadata)
+{
+    Console.WriteLine("Key = {0}, Value = {1}", kvp.Key, kvp.Value);
+}
+```
+
+
+## IAgent [#iagent]
+
     ### Syntax
 
         ```cs
-        NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring([boolean $override])
+        public interfac IAgent
         ```
 
-        Disable automatic injection of browser monitoring snippet on specific pages.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    Must be called inside a [transaction](/docs/glossary/glossary/#transaction).
-
-    ### Description
-
-    Add this call to disable the <DoNotTranslate>**automatic**</DoNotTranslate> injection of [<InlinePopover type="browser" />](/docs/browser/new-relic-browser/getting-started/new-relic-browser) scripts on specific pages. You can also add an optional override to disable <DoNotTranslate>**both**</DoNotTranslate> manual and automatic injection. In either case, put this API call as close as possible to the top of the view in which you want browser disabled.
-
-    <Callout variant="tip">
-    Compare [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent), which <DoNotTranslate>**adds**</DoNotTranslate> the browser script to the page.
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$override`
-
-            _boolean_
-        </td>
-
-        <td>
-            Optional. When `true`, disables all injection of browser scripts. This flag affects both manual and automatic injection. This also overrides the [`GetBrowserTimingHeader()`](/docs/agents/net-agent/net-agent-api/getbrowsertimingheader-net-agent) call.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    #### Disable automatic injection [#automatic-only]
-
-    This example disables only the <DoNotTranslate>**automatic**</DoNotTranslate> injection of the snippet:
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring();
-    ```
-
-    #### Disable automatic and manual injection [#disable-both]
-
-    This example disables <DoNotTranslate>**both**</DoNotTranslate> automatic and manual injection of the snippet:
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.DisableBrowserMonitoring(true);
-    ```
-    </Collapser>
-    <Collapser
-        id="GetAgent"
-        title="GetAgent"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.GetAgent()
-    ```
-
-    Get access to the agent via the `IAgent` interface.
+    Provides access to agent artifacts and methods, such as the currently executing transaction.
 
     ### Requirements
 
@@ -136,2330 +344,7 @@ To use the .NET agent API, make sure you have the [latest .NET agent release](/d
 
     ### Description
 
-    Get access to agent API methods via the [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent) interface.
-
-    ### Return values
-
-    An implementation of [IAgent](/docs/agents/net-agent/net-agent-api/iagent-net-agent-api) providing access to the [IAgent API](/docs/agents/net-agent/net-agent-api/iagent-net-agent-api).
-
-    ### Examples
-
-    ```cs
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-    ```
-
-    </Collapser>
-    <Collapser
-        id="GetBrowserTimingHeader"
-        title="GetBrowserTimingHeader"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader();
-    NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader(string nonce);
-    ```
-
-    Generate a browser monitoring HTML snippet to instrument end-user browsers.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
-
-
-
-    ### Description
-
-    Returns an HTML snippet used to enable [<InlinePopover type="browser" />](/docs/browser/new-relic-browser/getting-started/new-relic-browser). The snippet instructs the browser to fetch a small JavaScript file and start the page timer. You can then insert the returned snippet into the header of your HTML webpages. For more information, see [Adding apps to Browser monitoring](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser).
-
-    <Callout variant="tip">
-    Compare [`DisableBrowserMonitoring()`](/docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent), which <DoNotTranslate>**disables**</DoNotTranslate> the browser script on a page.
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `nonce`
-
-            _string_
-        </td>
-
-        <td>
-            The per-request, cryptographic nonce used by Content-Security-Policy policies.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    <Callout variant="tip">
-    This API call requires updates to security allow lists. For more information about Content Security Policy (CSP) considerations, visit the [browser monitoring compatibility and requirements](/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring) page.
-    </Callout>
-
-    ### Return values
-
-    An HTML string to be embedded in a page header.
-
-    ### Examples
-
-    #### With ASPX [#aspx]
-
-    ```aspnet
-    <html>
-    <head>
-        <%= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader()%>
-        ...
-    </head>
-    <body>
-    ...
-    ```
-
-    ```aspnet
-    <html>
-    <head>
-        <%= NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE")%>
-        ...
-    </head>
-    <body>
-    ...
-    ```
-
-    #### With Razor [#razor]
-
-    ```cshtml
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
-        ...
-    </head>
-    <body>
-    ...
-    ```
-
-    ```cshtml
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
-        ...
-    </head>
-    <body>
-    ...
-    ```
-
-    #### With Blazor [#blazor]
-
-    <Callout variant="important">
-    This API is not supported for Blazor Webassembly, because the agent is unable to instrument Webassembly code.  The following examples are for Blazor Server applications only.  Use the [copy-paste method](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#copy-paste) of adding the browser agent to Blazor Webassembly pages.
-    </Callout>
-
-    <Callout variant="important">
-    This API can not be placed in a `<HeadContent>` element of a `.razor` page.  Instead, it should be called from `_Layout.cshtml` or an equivalent layout file.
-    </Callout>
-
-    ```cshtml
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader())
-        ...
-    </head>
-    <body>
-    ...
-    ```
-
-    ```cshtml
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        @Html.Raw(NewRelic.Api.Agent.NewRelic.GetBrowserTimingHeader("YOUR_NONCE_VALUE"))
-        ...
-    </head>
-    <body>
-    ...
-    ```
-
-    </Collapser>
-    <Collapser
-        id="GetLinkingMetadata"
-        title="GetLinkingMetadata"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.GetLinkingMetadata();
-    ```
-
-    Returns key/value pairs which can be used to link traces or entities.
-
-    ### Requirements
-
-    Agent version 8.19 or higher.
-
-    Compatible with all app types.
-
-    ### Description
-
-    The Dictionary of key/value pairs returned includes items used to link traces and entities in the APM product. It will only contain items with meaningful values. For instance, if distributed tracing is disabled, `trace.id` will not be included.
-
-    ### Return values
-
-    `Dictionary <string, string>()` returned includes items used to link traces and entities in the APM product.
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.IAgent Agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-    var linkingMetadata = Agent.GetLinkingMetadata();
-    foreach (KeyValuePair<string, string> kvp in linkingMetadata)
-    {
-        Console.WriteLine("Key = {0}, Value = {1}", kvp.Key, kvp.Value);
-    }
-    ```
-
-    </Collapser>
-    <Collapser
-        id="IAgent"
-        title="IAgent"
-    >
-        ### Syntax
-
-            ```cs
-            public interfac IAgent
-            ```
-
-        Provides access to agent artifacts and methods, such as the currently executing transaction.
-
-        ### Requirements
-
-        Agent version 8.9 or higher.
-
-        Compatible with all app types.
-
-        ### Description
-
-        Provides access to agent artifacts and methods, such as the currently executing transaction. To obtain a reference to `IAgent`, use [`GetAgent`](/docs/agents/net-agent/net-agent-api/getagent).
-
-        ### Properties
-
-        <table>
-        <thead>
-            <tr>
-            <th width="25%">
-                Name
-            </th>
-
-            <th>
-                Description
-            </th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <tr>
-            <td>
-                CurrentTransaction
-            </td>
-
-            <td>
-                Property providing access to the currently executing transaction via the [ITransaction](/docs/agents/net-agent/net-agent-api/itransaction) interface. Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
-            </td>
-            </tr>
-
-            <tr>
-            <td>
-                CurrentSpan
-            </td>
-
-            <td>
-                Property providing access to the currently executing span via the [ISpan](/docs/agents/net-agent/net-agent-api/iSpan) interface.
-            </td>
-            </tr>
-        </tbody>
-        </table>
-
-        ### Examples
-
-        ```cs
-        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-        ITransaction transaction = agent.CurrentTransaction;
-        ```
-
-        </Collapser>
-        <Collapser
-            id="ITransaction"
-            title="ITransaction"
-        >
-    ### Syntax
-
-    ```cs
-    public interfac ITransaction
-    ```
-
-    Provides access to transaction-specific methods in the New Relic API.
-
-    ### Description
-
-    Provides access to transaction-specific methods in the New Relic .NET agent API. To obtain a reference to `ITransaction`, use the current transaction method available on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent).
-
-    The following methods are available on `ITransaction`:
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Name
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            [`AcceptDistributedTraceHeaders`](#acceptdistributedtraceheaders)
-        </td>
-
-        <td>
-            Accepts incoming trace context headers from another service.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            [`InsertDistributedTraceHeaders`](#insertdistributedtraceheaders)
-        </td>
-
-        <td>
-            Adds trace context headers to an outgoing request.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            [`AcceptDistributedTracePayload` (obsolete)](#acceptdistributedtracepayload)
-        </td>
-
-        <td>
-            Accepts an incoming distributed trace payload from another service.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            [`CreateDistributedTracePayload` (obsolete)](#createdistributedtracepayload)
-        </td>
-
-        <td>
-            Creates a distributed trace payload for inclusion in an outgoing request.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            [`AddCustomAttribute`](#addcustomattribute)
-        </td>
-
-        <td>
-            Add contextual information from your application to the current transaction in form of attributes.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            [`CurrentSpan`](#currentspan)
-        </td>
-
-        <td>
-            Provides access to the currently executing [span](/docs/agents/net-agent/net-agent-api/ispan), which provides access to span-specific methods in the New Relic API.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            [`SetUserId`](#setuserid)
-        </td>
-
-        <td>
-            Associates a User Id to the current transaction.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-    <CollapserGroup>
-    <Collapser
-        id="AcceptDistributedTraceHeaders"
-        title="AcceptDistributedTraceHeaders"
-    >
-        `ITransaction.AcceptDistributedTraceHeaders` is used to instrument the called service for inclusion in a distributed trace. It links the spans in a trace by accepting a payload generated by [`InsertDistributedTraceHeaders`](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-insertDistributedTraceHeaders) or generated by some other W3C Trace Context compliant tracer. This method accepts the headers of an incoming request, looks for W3C Trace Context headers, and if not found, falls back to New Relic distributed trace headers. This method replaces the deprecated [`AcceptDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#acceptdistributedtracepayload) method, which only handles New Relic distributed trace payloads.
-
-        ### Syntax
-
-        ```cs
-        void AcceptDistributedTraceHeaders(carrier, getter, transportType)
-        ```
-
-        ### Parameters
-
-        <table>
-        <thead>
-            <tr>
-            <th>
-                Name
-            </th>
-
-            <th>
-                Description
-            </th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <tr>
-            <td>
-                `carrier`
-
-                _&lt;T>_
-            </td>
-
-            <td>
-                Required. Source of incoming Trace Context headers.
-            </td>
-            </tr>
-
-            <tr>
-            <td>
-                `getter`
-
-                _Func&lt;T, string, IEnumerable&lt;string>>_
-            </td>
-
-            <td>
-                Required. Caller-defined function to extract header data from the carrier.
-            </td>
-            </tr>
-
-            <tr>
-            <td>
-                `transportType`
-
-                _TransportType enum_
-            </td>
-
-            <td>
-                Required. Describes the transport of the incoming payload (for example `TransportType.HTTP`).
-            </td>
-            </tr>
-        </tbody>
-        </table>
-
-        ### Usage considerations
-
-        * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
-        * `AcceptDistributedTraceHeaders` will be ignored if `InsertDistributedTraceHeaders` or `AcceptDistributedTraceHeaders` has already been called for this transaction.
-
-        ### Example
-
-        ```cs
-        HttpContext httpContext = HttpContext.Current;
-        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-        ITransaction currentTransaction = agent.CurrentTransaction;
-        currentTransaction.AcceptDistributedTraceHeaders(httpContext, Getter, TransportType.HTTP);
-        IEnumerable<string> Getter(HttpContext carrier, string key) 
-        { 
-            string value = carrier.Request.Headers[key];   
-            return value == null ? null : new string[] { value }; 
-        }
-        ```
-    </Collapser>
-    <Collapser
-        id="InsertDistributedTraceHeaders"
-        title="InsertDistributedTraceHeaders"
-    >
-        `ITransaction.InsertDistributedTraceHeaders` is used to implement distributed tracing. It modifies the carrier object that is passed in by adding W3C Trace Context headers and New Relic Distributed Trace headers. The New Relic headers can be disabled with `<distributedTracing excludeNewrelicHeader="true" />` in the config. This method replaces the deprecated [`CreateDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#createdistributedtracepayload) method, which only creates New Relic Distributed Trace payloads.
-
-        ### Syntax
-
-        ```cs
-        void InsertDistributedTraceHeaders(carrier, setter)
-        ```
-
-        ### Parameters
-
-        <table>
-        <thead>
-            <tr>
-            <th>
-                Name
-            </th>
-
-            <th>
-                Description
-            </th>
-            </tr>
-        </thead>
-
-        <tbody>
-            <tr>
-            <td>
-                `carrier`
-
-                _&lt;T>_
-            </td>
-
-            <td>
-                Required. Container where Trace Context headers are inserted..
-            </td>
-            </tr>
-
-            <tr>
-            <td>
-                `setter`
-
-                _Action&lt;T, string, string>_
-            </td>
-
-            <td>
-                Required. Caller-defined Action to insert header data into the carrier.
-            </td>
-            </tr>
-        </tbody>
-        </table>
-
-        ### Usage considerations
-
-        * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
-
-        ### Example
-
-        ```cs
-        HttpWebRequest requestMessage = (HttpWebRequest)WebRequest.Create("https://remote-address");
-        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-        ITransaction currentTransaction = agent.CurrentTransaction;
-        var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) => { carrier.Headers?.Set(key, value); });
-        currentTransaction.InsertDistributedTraceHeaders(requestMessage, setter);
-        ```
-    </Collapser>
-    <Collapser
-        id="AcceptDistributedTracePayload"
-        title="AcceptDistributedTracePayload"
-    >
-
-    <Callout variant="caution">
-    This API is not available in the .NET agent v9.0 or higher. Please use [`AcceptDistributedTraceHeaders`](/docs/agents/net-agent/net-agent-api/itransaction/#acceptdistributedtraceheaders) instead.
-    </Callout>
-
-    Accepts an incoming distributed trace payload from an upstream service. Calling this method links the transaction from the upstream service to this transaction.
-
-    ### Syntax
-
-    ```cs
-    void AcceptDistributedPayload(payload, transportType)
-    ```
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Name
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `payload`
-
-            _string_
-        </td>
-
-        <td>
-            Required. A string representation of the incoming distributed trace payload.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `transportType`
-
-            _TransportType_  
-                                    _enum_
-        </td>
-
-        <td>
-            Recommended. Describes the transport of the incoming payload (for example, `http`).
-
-            Default `TransportType.Unknown`.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Usage considerations
-
-    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
-    * The payload can be a Base64-encoded or plain text string.
-    * `AcceptDistributedTracePayload` will be ignored if `CreateDistributedTracePayload` has already been called for this transaction.
-
-    ### Example
-
-    ```cs
-    //Obtain the information from the request object from the upstream caller.
-    //The method by which this information is obtain is specific to the transport 
-    //type being used. For example, in an HttpRequest, this information is
-    //contained in the 
-    header.KeyValuePair<string, string> metadata = GetMetaDataFromRequest("requestPayload");
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
-    ITransaction transaction = agent.CurrentTransaction; 
-    transaction.AcceptDistributedTracePayload(metadata.Value, TransportType.Queue);
-    ```
-
-    </Collapser>
-    <Collapser
-        id="CreateDistributedTracePayload"
-        title="CreateDistributedTracePayload (obsolete)"
-    >
-    <Callout variant="caution">
-    This API is not available in the .NET agent v9.0 or higher. Please use [`InsertDistributedTraceHeaders`](/docs/agents/net-agent/net-agent-api/itransaction/#insertdistributedtraceheaders) instead.
-    </Callout>
-
-    Creates a distributed trace payload for inclusion in an outgoing request to a downstream system.
-
-    ### Syntax
-
-    ```cs
-    IDistributedTracePayload CreateDistributedTracePayload()
-    ```
-
-    ### Returns
-
-    An object that implements `IDistributedTracePayload` which provides access to the distributed trace payload that was created.
-
-    ### Usage considerations
-
-    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
-    * `CreateDistributedTracePayload` will be ignored if `AcceptDistributedTracePayload` has already been called for this transaction.
-
-    ### Example
-
-    ```cs
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-    ITransaction transaction = agent.CurrentTransaction;
-    IDistributedTracePayload payload = transaction.CreateDistributedTracePayload();
-    ```
-
-    </Collapser>
-    <Collapser
-        id="AddCustomAttribute"
-        title="AddCustomAttribute"
-    >
-    Adds contextual information about your application to the current transaction in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
-
-    This method requires .NET agent version and .NET agent API [version 8.24.244.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440) or higher. It replaced the deprecated [`AddCustomParameter`](/docs/agents/net-agent/net-agent-api/add-custom-parameter).
-
-    ### Syntax
-
-    ```cs
-    ITransaction AddCustomAttribute(string key, object value)
-    ```
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `key`
-
-            _string_
-        </td>
-
-        <td>
-            Identifies the information being reported. Also known as the name.
-
-            * Empty keys are not supported.
-            * Keys are limited to 255-bytes. Attributes with keys larger than 255-bytes will be ignored.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `value`
-
-            _object_
-        </td>
-
-        <td>
-            The value being reported.
-            
-            <DoNotTranslate>**Note**</DoNotTranslate>: `null` values will not be recorded.
-            
-            <table>
-            <thead>
-                <tr>
-                <th>
-                    .NET type
-                </th>
-
-                <th>
-                    How the value will be represented
-                </th>
-                </tr>
-            </thead>
-
-            <tbody>
-                <tr>
-                <td>
-                    `byte`, `Int16`, `Int32`, `Int64`
-
-                    `sbyte`, `UInt16`, `UInt32`, `UInt64`
-                </td>
-
-                <td>
-                    As an integral value.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `float`, `double`, `decimal`
-                </td>
-
-                <td>
-                    A decimal-based number.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `string`
-                </td>
-
-                <td>
-                    A string truncated after 255-bytes.
-
-                    Empty strings are supported.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `bool`
-                </td>
-
-                <td>
-                    True or false.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `DateTime`
-                </td>
-
-                <td>
-                    A string representation following the ISO-8601 format, including time zone information:
-
-                    Example: `2020-02-13T11:31:19.5767650-08:00`
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `TimeSpan`
-                </td>
-
-                <td>
-                    A decimal-based number representing number of seconds.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    everything else
-                </td>
-
-                <td>
-                    The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
-                </td>
-                </tr>
-            </tbody>
-            </table>
-
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Returns
-
-    A reference to the current transaction.
-
-    ### Usage considerations
-
-    For details about supported data types, see the [Custom Attributes Guide](/docs/agents/net-agent/attributes/custom-attributes).
-
-    ### Example
-
-    ```cs
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-    ITransaction transaction = agent.CurrentTransaction;
-    transaction.AddCustomAttribute("customerName","Bob Smith")
-        .AddCustomAttribute("currentAge",31)
-        .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
-        .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
-    ```
-    </Collapser>
-    <Collapser
-        id="CurrentSpan"
-        title="CurrentSpan"
-    >
-    
-    Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/ispan/), making [span-specific methods](/docs/apm/agents/net-agent/net-agent-api/ispan) available within the New Relic API.
-
-    ### Example
-
-    ```cs
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
-    ITransaction transaction = agent.CurrentTransaction; 
-    ISpan currentSpan = transaction.CurrentSpan;
-    ```
-
-    </Collapser>
-    <Collapser
-        id="SetUserId"
-        title="SetUserId"
-    >
-    Associates a User Id with the current transaction.
-
-    This method requires .NET agent and .NET agent API [version 10.9.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1090) or higher.
-
-    ### Syntax
-
-    ```cs
-    ITransaction SetUserId(string userId)
-    ```
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `userId`
-
-            _string_
-        </td>
-
-        <td>
-            The User Id to be associated with this transaction.
-
-            * `null`, empty and whitespace values will be ignored.
-        </td>
-        </tr>
-
-    </tbody>
-    </table>
-
-    ### Example
-
-    ```cs
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
-    ITransaction transaction = agent.CurrentTransaction; 
-    transaction.SetUserId("BobSmith123");
-    ```
-    </Collapser>
-</CollapserGroup>
-    </Collapser>
-    <Collapser
-        id="ISpan"
-        title="ISpan"
-    >
-    ### Syntax
-
-    ```cs
-    Public interfac ISpan
-    ```
-
-    Provides access to span-specific methods in the New Relic API.
-
-    ### Description
-
-    Provides access to span-specific methods in the New Relic .NET agent API. To obtain a reference to `ISpan`, use:
-
-    * The `CurrentSpan` property on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent) (Recommended).
-    * The `CurrentSpan` property on [`ITransaction`](/docs/agents/net-agent/net-agent-api/itransaction).
-
-    This section contains descriptions and parameters of `ISpan` methods:
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Name
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            [`AddCustomAttribute`](#addcustomattribute)
-        </td>
-
-        <td>
-            Add contextual information from your application to the current span in form of attributes.
-        </td>
-        </tr>
-        <tr>
-        <td>
-            [`SetName`](#setname)
-        </td>
-
-        <td>
-            Changes the name of the current span/segment/metrics that will be reported to New Relic.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### AddCustomAttribute [#addcustomattribute]
-
-    Adds contextual information about your application to the current span in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
-
-    This method requires .NET agent version and .NET agent API [version 8.25](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440) or higher.
-
-    ### Syntax
-
-    ```cs
-    ISpan AddCustomAttribute(string key, object value)
-    ```
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `key`
-
-            _string_
-        </td>
-
-        <td>
-            Identifies the information being reported. Also known as the name.
-
-            * Empty keys are not supported.
-            * Keys are limited to 255-bytes. Attributes with keys larger than 255-bytes will be ignored.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `value`
-
-            _object_
-        </td>
-
-        <td>
-            The value being reported.
-            
-            <DoNotTranslate>**Note**</DoNotTranslate>: `null` values will not be recorded.
-            
-            <table>
-            <thead>
-                <tr>
-                <th>
-                    .NET type
-                </th>
-
-                <th>
-                    How the value will be represented
-                </th>
-                </tr>
-            </thead>
-
-            <tbody>
-                <tr>
-                <td>
-                    `byte`, `Int16`, `Int32`, `Int64`
-
-                    `sbyte`, `UInt16`, `UInt32`, `UInt64`
-                </td>
-
-                <td>
-                    As an integral value.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `float`, `double`, `decimal`
-                </td>
-
-                <td>
-                    A decimal-based number.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `string`
-                </td>
-
-                <td>
-                    A string truncated after 255-bytes.
-
-                    Empty strings are supported.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `bool`
-                </td>
-
-                <td>
-                    True or false.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `DateTime`
-                </td>
-
-                <td>
-                    A string representation following the ISO-8601 format, including time zone information:
-
-                    Example: `2020-02-13T11:31:19.5767650-08:00`
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    `TimeSpan`
-                </td>
-
-                <td>
-                    A decimal-based number representing number of seconds.
-                </td>
-                </tr>
-
-                <tr>
-                <td>
-                    everything else
-                </td>
-
-                <td>
-                    The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
-                </td>
-                </tr>
-            </tbody>
-            </table>
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Returns
-
-    A reference to the current span.
-
-    ### Usage considerations
-
-    For details about supported data types, see the [Custom Attributes guide](/docs/agents/net-agent/attributes/custom-attributes).
-
-    ### Examples
-
-    ```cs
-    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
-    ISpan currentSpan = agent.CurrentSpan; 
-
-    currentSpan
-        .AddCustomAttribute("customerName","Bob Smith")
-        .AddCustomAttribute("currentAge",31)
-        .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
-        .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
-    ```
-
-    ### SetName [#setname]
-
-    Changes the name of the current segment/span that will be reported to New Relic. For segments/spans resulting from custom instrumentation, the metric name reported to New Relic will be altered as well. 
-
-    This method requires .NET agent version and .NET agent API version 10.1.0 or higher.
-
-    ### Syntax
-
-    ```cs
-    ISpan SetName(string name)
-    ```
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th>
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `name`
-
-            _string_
-        </td>
-
-        <td>
-            The new name for the span/segment.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Returns
-
-    A reference to the current span.
-
-    ## Examples
-
-    ```cs
-    [Trace]
-    public void MyTracedMethod()
-    {
-        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
-        ISpan currentSpan = agent.CurrentSpan; 
-
-        currentSpan.SetName("MyCustomName");
-    }
-    ```
-    </Collapser>
-    <Collapser
-        id="IgnoreApdex"
-        title="IgnoreApdex"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.IgnoreApdex()
-    ```
-
-    Ignore the current transaction when calculating Apdex.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    ### Description
-
-    Ignores the current transaction when calculating your [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction). This is useful when you have either very short or very long transactions (such as file downloads) that can skew your Apdex score.
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.IgnoreApdex();
-    ```
-    </Collapser>
-    <Collapser
-        id="IgnoreTransaction"
-        title="IgnoreTransaction"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.IgnoreTransaction()
-    ```
-
-    Do not instrument the current transaction.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
-
-    ### Description
-
-    Ignores the current transaction.
-
-    <Callout variant="tip">
-    You can also ignore transactions [via a custom instrumentation XML file](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net#blocking-instrumentation).
-    </Callout>
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.IgnoreTransaction();
-    ```
-
-    </Collapser>
-    <Collapser
-        id="INSERT_ID_HERE"
-        title="INSERT_TITLE_HERE"
-    >
-    ### Overloads [#overloads]
-
-    Notice an error and report to New Relic, along with optional custom attributes.
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception);
-    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception, IDictionary<TKey, TValue> $attributes);
-    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes);
-    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes, bool $is_expected);
-    ```
-
-    ### Requirements [#requirements]
-
-    This API call is compatible with:
-
-    * All agent versions
-    * All app types
-
-    ### Description [#description]
-
-    Notice an error and report it to New Relic along with optional custom attributes. For each transaction, the agent only retains the exception and attributes from the first call to `NoticeError()`. You can pass an actual exception, or pass a string to capture an arbitrary error message.
-
-    If this method is invoked within a [transaction](/docs/glossary/glossary/#transaction), the agent reports the exception within the parent transaction. If it is invoked outside of a transaction, the agent creates an [error trace](/docs/errors-inbox/errors-inbox) and categorizes the error in the New Relic UI as a `NewRelic.Api.Agent.NoticeError` API call. If invoked outside of a transaction, the `NoticeError()` call will not contribute to the error rate of an application.
-
-    The agent adds the attributes only to the traced error; it does not send them to New Relic. For more information, see [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
-
-    Errors reported with this API are still sent to New Relic when they are reported within a transaction that results in an HTTP status code, such as a `404`, that is configured to be ignored by agent configuration. For more information, see our documentation about [managing errors in APM](/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected).
-
-    Review the sections below to see examples of how to use this call.
-
-    ### NoticeError(Exception) [#exception-overload]
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception)
-    ```
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$exception`
-
-            _Exception_
-        </td>
-
-        <td>
-            Required. The `Exception` you want to instrument. Only the first 10,000 characters from the stack trace are retained.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### NoticeError(Exception, IDictionary) [#exception-idictionary-overload]
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception, IDictionary<TKey, TValue> $attributes)
-    ```
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$exception`
-
-            _Exception_
-        </td>
-
-        <td>
-            Required. The `Exception` you want to instrument. Only the first 10,000 characters from the stack trace are retained.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$attributes`
-
-            _IDictionary&lt;TKey, TValue&gt;_
-        </td>
-
-        <td>
-            Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### NoticeError(String, IDictionary) [#string-idictionary-overload]
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes)
-    ```
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$error_message`
-
-            _string_
-        </td>
-
-        <td>
-            Required. Specify a string to report to New Relic as though it's an exception. This method creates both [error events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [error traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 1023 characters are retained in error events, while error traces retain the full message.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$attributes`
-
-            _IDictionary&lt;TKey, TValue&gt;_
-        </td>
-
-        <td>
-            Required (can be null). Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object, to send no attributes, pass `null`.  
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### NoticeError(String, IDictionary, bool) [#string-idictionary-bool-overload]
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes, bool $is_expected)
-    ```
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$error_message`
-
-            _string_
-        </td>
-
-        <td>
-            Required. Specify a string to report to New Relic as though it's an exception. This method creates both [error events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [error traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 1023 characters are retained in error events, while error traces retain the full message.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$attributes`
-
-            _IDictionary&lt;TKey, TValue&gt;_
-        </td>
-
-        <td>
-            Required (can be null). Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object, to send no attributes, pass `null`.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$is_expected`
-
-            _bool_
-        </td>
-
-        <td>
-            Mark error as expected so that it won't affect Apdex score and error rate.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    #### Pass an exception without custom attributes [#exception-no-attributes]
-
-    ```cs
-    try
-    {
-        string ImNotABool = "43";
-        bool.Parse(ImNotABool);
-    }
-    catch (Exception ex)
-    {
-        NewRelic.Api.Agent.NewRelic.NoticeError(ex);
-    }
-    ```
-
-    #### Pass an exception with custom attributes [#exception-yes-attributes]
-
-    ```cs
-    try
-    {
-        string ImNotABool = "43";
-        bool.Parse(ImNotABool);
-    }
-    catch (Exception ex)
-    {
-        var errorAttributes = new Dictionary<string, string>() {{"foo", "bar"},{"baz", "luhr"}};
-        NewRelic.Api.Agent.NewRelic.NoticeError(ex, errorAttributes);
-    }
-    ```
-
-    #### Pass an error message string with custom attributes [#string-yes-attributes]
-
-    ```cs
-    try
-    {
-        string ImNotABool = "43";
-        bool.Parse(ImNotABool);
-    }
-    catch (Exception ex)
-    {
-        var errorAttributes = new Dictionary<string, string>{{"foo", "bar"},{"baz", "luhr"}};
-        NewRelic.Api.Agent.NewRelic.NoticeError("String error message", errorAttributes);
-    }
-    ```
-
-    #### Pass an error message string without custom attributes [#string-no-attributes]
-
-    ```cs
-    try
-    {
-        string ImNotABool = "43";
-        bool.Parse(ImNotABool);
-    }
-    catch (Exception ex)
-    {
-        NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null);
-    }
-    ```
-
-    #### Pass an error message string and mark it as expected [#string-no-attributes]
-
-    ```cs
-    try
-    {
-        string ImNotABool = "43";
-        bool.Parse(ImNotABool);
-    }
-    catch (Exception ex)
-    {
-        NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null, true);
-    }
-    ```
-
-    </Collapser>
-    <Collapser
-        id="IncrementCounter"
-        title="IncrementCounter"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.IncrementCounter(string $metric_name)
-    ```
-
-    Increment the counter for a custom metric by 1.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    Compatible with all app types.
-
-    ### Description
-
-    Increment the counter for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) by 1. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
-
-    <Callout variant="important">
-    When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`). For more on naming, see [Collect custom metrics](/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics/).
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$metric_name`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The name of the metric to increment.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/ExampleMetric");
-    ```
-    </Collapser>
-    <Collapser
-        id="RecordCustomEvent"
-        title="RecordCustomEvent"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.RecordCustomEvent(string eventType, IEnumerable<string, object> attributeValues)
-    ```
-
-    Records a custom event with the given name and attributes.
-
-    ### Requirements
-
-    Agent version 4.6.29.0 or higher.
-
-    Compatible with all app types.
-
-    ### Description
-
-    Records a [custom event](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data#event-data) with the given name and attributes, which you can query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). To verify if an event is being recorded correctly, look for the data in [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
-
-    For related API calls, see the [.NET agent API guide](/docs/agents/net-agent/api-guides/guide-using-net-agent-api#custom-data).
-
-    <Callout variant="important">
-    * Sending a lot of events can increase the memory overhead of the agent.
-    * Additionally, posts greater than 1MB (10^6 bytes) in size will not be recorded regardless of the maximum number of events.
-    * Custom Events are limited to 64-attributes.
-    * For more information about how custom attribute values are processed, see the [custom attributes](/docs/agents/net-agent/attributes/custom-attributes) guide.
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `eventType`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The name of the event type to record. Strings over 255 characters will result in the API call not being sent to New Relic. The name can only contain alphanumeric characters, underscores `_`, and colons `:`. For additional restrictions on event type names, see [Reserved words](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-        `attributeValues`
-
-            _IEnumerable&lt;string, object>_
-        </td>
-
-        <td>
-            Required. Specify key/value pairs of attributes to annotate the event.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    #### Record values [#record-strings]
-
-    ```cs
-    var eventAttributes = new Dictionary<string, object>() 
-    {
-        {"foo", "bar"},
-        {"alice", "bob"}, 
-        {"age", 32}, 
-        {"height", 21.3f}
-    };
-
-    NewRelic.Api.Agent.NewRelic.RecordCustomEvent("MyCustomEvent", eventAttributes);
-    ```
-    </Collapser>
-    <Collapser
-        id="RecordMetric"
-        title="RecordMetric"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.RecordMetric(string $metric_name, single $metric_value)
-    ```
-
-    Records a custom metric with the given name.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    Compatible with all app types.
-
-    ### Description
-
-    Records a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) with the given name. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`IncrementCounter()`](/docs/agents/net-agent/net-agent-api/incrementcounter-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
-
-    <Callout variant="important">
-    When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$metric_name`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The name of the metric to record. Only the first 255 characters are retained.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$metric_value`
-
-            _single_
-        </td>
-
-        <td>
-            Required. The quantity to record for the metric.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    #### Record response time of a sleeping process [#record-stopwatch]
-
-    ```cs
-    Stopwatch stopWatch = Stopwatch.StartNew();
-    System.Threading.Thread.Sleep(5000);
-    stopWatch.Stop();
-    NewRelic.Api.Agent.NewRelic.RecordMetric("Custom/DEMO_Record_Metric", stopWatch.ElapsedMilliseconds);
-    ```
-
-    </Collapser>
-    <Collapser
-        id="RecordResponseTimeMetric"
-        title="RecordResponseTimeMetric"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.RecordResponseTimeMetric(string $metric_name, Int64 $metric_value)
-    ```
-
-    Records a custom metric with the given name and response time in milliseconds.
-
-    ### Requirements
-
-    Compatible with all agent versions.
-
-    Compatible with all app types.
-
-    ### Description
-
-    Records the response time in milliseconds for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics). To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`IncrementCounter()`](/docs/agents/net-agent/net-agent-api/incrementcounter-net-agent) and [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent).
-
-    <Callout variant="important">
-    When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$metric_name`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The name of the response time metric to record. Only the first 255 characters are retained.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$metric_value`
-
-            _Int64_
-        </td>
-
-        <td>
-            Required. The response time to record in milliseconds.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    #### Record response time of a sleeping process [#record-stopwatch]
-
-    ```cs
-    Stopwatch stopWatch = Stopwatch.StartNew();
-    System.Threading.Thread.Sleep(5000);
-    stopWatch.Stop();
-    NewRelic.Api.Agent.NewRelic.RecordResponseTimeMetric("Custom/DEMO_Record_Response_Time_Metric", stopWatch.ElapsedMilliseconds);
-    ```
-
-    </Collapser>
-    <Collapser
-        id="SetApplicationName"
-        title="SetApplicationName"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetApplicationName(string $name[, string $name_2, string $name_3])
-    ```
-
-    Set the app name for data rollup.
-
-    ### Requirements
-
-    Agent version 5.0.136.0 or higher.
-
-    Compatible with all app types.
-
-    ### Description
-
-    Set the application name(s) reported to New Relic. For more information about application naming, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application). This method is intended to be called once, during startup of an application.
-
-    <Callout variant="important">
-    Updating the app name forces the agent to restart. The agent discards any unreported data associated with previous app names. Changing the app name multiple times during the lifecycle of an application is not recommended due to the associated data loss.
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$name`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The primary application name.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$name_2`
-
-            `$name_3`
-
-            _string_
-        </td>
-
-        <td>
-            Optional. Second and third names for app rollup. For more information, see [Use multiple names for an app](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app).
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetApplicationName("AppName1", "AppName2");
-    ```
-    </Collapser>
-    <Collapser
-        id="SetErrorGroupCallback"
-        title="SetErrorGroupCallback"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(Func<IReadOnlyDictionary<string,object>, string> errorGroupCallback);
-    ```
-    Provide a callback method that takes an `IReadOnlyDictionary<string,object>` of attribute data, and returns an error group name.
-
-    ### Requirements [#requirements]
-
-    This API call is compatible with:
-
-    * Agent versions >= 10.9.0
-    * All app types
-
-    ### Description [#description]
-
-    Set a callback method that the agent will use to determine the error group name for error events and traces.  This name is used in the Errors Inbox to group errors into logical groups.
-
-    The callback method must accept a single argument of type `IReadOnlyDictionary<string,object>`, and return a string (the error group name). The `IReadOnlyDictionary` is a collection of [attribute data](/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes/) associated with each error event, including custom attributes.
-
-    The exact list of attributes available for each error will vary depending on:
-
-    * What application code generated the error
-    * Agent configuration settings
-    * Whether any custom attributes were added
-
-    However, the following attributes should always exist:
-
-    * `error.class`
-    * `error.message`
-    * `stack_trace`
-    * `transactionName`
-    * `request.uri`
-    * `error.expected`
-
-    An empty string may be returned for the error group name when the error can't be assigned to a logical error group.
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$callback`
-
-            _{'Func<IReadOnlyDictionary<string,object>,string>'}_
-            
-        </td>
-
-        <td>
-            The callback to determine the error group name based on attribute data.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    Group errors by error class name:
-
-    ```cs
-    Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback = (attributes) => {
-        string errorGroupName = string.Empty;
-        if (attributes.TryGetValue("error.class", out var errorClass))
-        {
-            if (errorClass.ToString() == "System.ArgumentOutOfRangeException" || errorClass.ToString() == "System.ArgumentNullException")
-            {
-                errorGroupName = "ArgumentErrors";
-            }
-            else
-            {
-                errorGroupName = "OtherErrors";
-            }
-        }
-        return errorGroupName;
-    };
-
-    NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(errorGroupCallback);
-    ```
-
-    Group errors by transaction name:
-
-    ```cs
-    Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback = (attributes) => {
-        string errorGroupName = string.Empty;
-        if (attributes.TryGetValue("transactionName", out var transactionName))
-        {
-        if (transactionName.ToString().IndexOf("WebTransaction/MVC/Home") != -1)
-        {
-        errorGroupName = "HomeControllerErrors";
-        }
-            else
-            {
-                errorGroupName = "OtherControllerErrors";
-            }
-        }
-        return errorGroupName;
-    };
-
-    NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(errorGroupCallback);
-    ```
-
-    </Collapser>
-    <Collapser
-        id="SetTransactionName"
-        title="SetTransactionName"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetTransactionName(string $category, string $name)
-    ```
-
-    Sets the name of the current transaction.
-
-    ### Requirements
-
-    * Compatible with all agent versions.
-    * Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
-
-    ### Description
-
-    Sets the name of the current transaction. Before you use this call, ensure you understand the implications of [metric grouping issues](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues).
-
-    If you use this call multiple times within the same transaction, each call overwrites the previous call and the last call sets the name.
-
-    <Callout variant="important">
-    Do not use brackets `[suffix]` at the end of your transaction name. New Relic automatically strips brackets from the name. Instead, use parentheses `(suffix)` or other symbols if needed.
-    </Callout>
-
-    Unique values like URLs, page titles, hex values, session IDs, and uniquely identifiable values should not be used in naming your transactions. Instead, add that data to the transaction as a custom parameter with the [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) call.
-
-    <Callout variant="important">
-    Do not create more than 1000 unique transaction names (for example, avoid naming by URL if possible). This will make your charts less useful, and you may run into limits New Relic sets on the number of unique transaction names per account. It also can slow down the performance of your application.
-    </Callout>
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$category`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The category of this transaction, which you can use to distinguish different types of transactions. Defaults to <DoNotTranslate>**`Custom`**</DoNotTranslate>. Only the first 255 characters are retained.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$name`
-
-            _string_
-        </td>
-
-        <td>
-            Required. The name of the transaction. Only the first 255 characters are retained.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetTransactionName("Other", "MyTransaction");
-    ```
-
-    </Collapser>
-    <Collapser
-        id="SetTransactionUri"
-        title="SetTransactionUri"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetTransactionUri(Uri $uri)
-    ```
-
-    Sets the URI of the current transaction.
-
-    ### Requirements
-
-    * Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
-    * Agent version 6.16 or higher.
-
-    <Callout variant="important">
-    This method only works when used within a transaction created using the `Transaction` attribute with the `Web` property set to `true`. (See [Instrument using attributes](/docs/agents/net-agent/api-guides/net-agent-api-instrument-using-attributes).) It provides support for custom web-based frameworks that the agent does not automatically support.
-    </Callout>
-
-    ### Description
-
-    Sets the URI of the current transaction. The URI appears in the 'request.uri' [attribute](/docs/agents/net-agent/attributes/net-agent-attributes) of [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces) and [transaction events](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data), and also can affect transaction naming.
-
-    If you use this call multiple times within the same transaction, each call overwrites the previous call. The last call sets the URI.
-
-    <DoNotTranslate>**Note**</DoNotTranslate>: as of agent version 8.18, the `request.uri` attribute's value is set to the value of the `Uri.AbsolutePath` property of the `System.Uri` object passed to the API.
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$uri`
-
-            _Uri_
-        </td>
-
-        <td>
-            The URI of this transaction.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    ```cs
-    var uri = new System.Uri("https://www.mydomain.com/path");
-    NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
-    ```
-
-    </Collapser>
-    <Collapser
-        id="SetUserParameters"
-        title="SetUserParameters"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetUserParameters(string $user_value, string $account_value, string $product_value)
-    ```
-
-    Create user-related custom attributes. [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) is more flexible.
-
-    ### Requirements
-
-    * Compatible with all agent versions.
-    * Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
-
-    ### Description
-
-    <Callout variant="tip">
-    This call only allows you to assign values to pre-existing keys. For a more flexible method to create key/value pairs, use [`AddCustomAttribute()`](/docs/agents/net-agent/net-agent-api/itransaction).
-    </Callout>
-
-    Define user-related [custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)to associate with a browser page view (user name, account name, and product name). The values are automatically associated with pre-existing keys (`user`, `account`, and `product`), then attached to the parent APM transaction. You can also [attach (or "forward") these attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#forwarding-attributes) to browser [PageView](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes#destinations) events.
-
-    ### Parameters
-
-    <table>
-    <thead>
-        <tr>
-        <th width="25%">
-            Parameter
-        </th>
-
-        <th>
-            Description
-        </th>
-        </tr>
-    </thead>
-
-    <tbody>
-        <tr>
-        <td>
-            `$user_value`
-
-            _string_
-        </td>
-
-        <td>
-            Required (can be null). Specify a name or username to associate with this page view. This value is assigned to the `user` key.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$account_value`
-
-            _string_
-        </td>
-
-        <td>
-            Required (can be null). Specify the name of a user account to associate with this page view. This value is assigned to the `account` key.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `$product_value`
-
-            _string_
-        </td>
-
-        <td>
-            Required (can be null). Specify the name of a product to associate with this page view. This value is assigned to the `product` key.
-        </td>
-        </tr>
-    </tbody>
-    </table>
-
-    ### Examples
-
-    #### Record three user attributes [#report-three]
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetUserParameters("MyUserName", "MyAccountName", "MyProductName");
-    ```
-
-    #### Record two user attributes and one empty attribute [#report-two]
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.SetUserParameters("MyUserName", "", "MyProductName");
-    ```
-
-    </Collapser>
-    <Collapser
-        id="StartAgent"
-        title="StartAgent"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.StartAgent()
-    ```
-
-    Start the agent if it hasn't already started. Usually unnecessary.
-
-    ### Requirements
-
-    * Agent version 5.0.136.0 or higher.
-    * Compatible with all app types.
-
-    ### Description
-
-    Starts the agent if it hasn't already been started. This call is usually unnecessary, since the agent starts automatically when it hits an instrumented method unless you disable [`autoStart`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-autoStart). If you use [`SetApplicationName()`](/docs/agents/net-agent/net-agent-api/setapplicationname-net-agent), ensure you set the app name <DoNotTranslate>**before**</DoNotTranslate> you start the agent.
-
-    <Callout variant="tip">
-    This method starts the agent asynchronously (meaning it won't block app startup) unless you enable [`syncStartup`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-syncStartup) or [`sendDataOnExit`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-sendDataOnExit).
-    </Callout>
-
-    ### Examples
-
-    ```cs
-    NewRelic.Api.Agent.NewRelic.StartAgent();
-    ```
-
-    </Collapser>
-    <Collapser
-        id="TraceMetadata"
-        title="TraceMetadata"
-    >
-    ### Syntax
-
-    ```cs
-    NewRelic.Api.Agent.TraceMetadata;
-    ```
-
-    Returns properties in the current execution environment used to support tracing.
-
-    ### Requirements
-
-    * Agent version 8.19 or higher.
-    * Compatible with all app types.
-    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing) to get meaningful values.
-
-    ## Description
-
-    Provides access to the following properties:
+    Provides access to agent artifacts and methods, such as the currently executing transaction. To obtain a reference to `IAgent`, use [`GetAgent`](/docs/agents/net-agent/net-agent-api/getagent).
 
     ### Properties
 
@@ -2479,45 +364,2097 @@ To use the .NET agent API, make sure you have the [latest .NET agent release](/d
     <tbody>
         <tr>
         <td>
-            `TraceId`
+            CurrentTransaction
         </td>
 
         <td>
-            Returns a string representing the currently executing trace. If the trace ID is not available, or distributed tracing is disabled, the value will be `string.Empty`.
-        </td>
-        </tr>
-
-        <tr>
-        <td>
-            `SpanId`
-        </td>
-
-        <td>
-            Returns a string representing the currently executing span. If the span ID is not available, or distributed tracing is disabled, the value will be `string.Empty`.
+            Property providing access to the currently executing transaction via the [ITransaction](/docs/agents/net-agent/net-agent-api/itransaction) interface. Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
         </td>
         </tr>
 
         <tr>
         <td>
-            `IsSampled`
+            CurrentSpan
         </td>
 
         <td>
-            Returns `true` if the current trace is sampled for inclusion, `false` if it is sampled out.
+            Property providing access to the currently executing span via the [ISpan](/docs/agents/net-agent/net-agent-api/iSpan) interface.
         </td>
         </tr>
     </tbody>
     </table>
 
-    ## Examples
+    ### Examples
 
     ```cs
     IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-    TraceMetadata traceMetadata = agent.TraceMetadata;
-    string traceId = traceMetadata.TraceId;
-    string spanId = traceMetadata.SpanId;
-    bool isSampled = traceMetadata.IsSampled;
+    ITransaction transaction = agent.CurrentTransaction;
     ```
 
-    </Collapser>
-</CollapserGroup>
+    
+## ITransaction [#idtransaction]
+
+### Syntax
+
+```cs
+public interfac ITransaction
+```
+
+Provides access to transaction-specific methods in the New Relic API.
+
+### Description
+
+Provides access to transaction-specific methods in the New Relic .NET agent API. To obtain a reference to `ITransaction`, use the current transaction method available on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent).
+
+The following methods are available on `ITransaction`:
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Name
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        [`AcceptDistributedTraceHeaders`](#acceptdistributedtraceheaders)
+    </td>
+
+    <td>
+        Accepts incoming trace context headers from another service.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        [`InsertDistributedTraceHeaders`](#insertdistributedtraceheaders)
+    </td>
+
+    <td>
+        Adds trace context headers to an outgoing request.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        [`AcceptDistributedTracePayload` (obsolete)](#acceptdistributedtracepayload)
+    </td>
+
+    <td>
+        Accepts an incoming distributed trace payload from another service.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        [`CreateDistributedTracePayload` (obsolete)](#createdistributedtracepayload)
+    </td>
+
+    <td>
+        Creates a distributed trace payload for inclusion in an outgoing request.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        [`AddCustomAttribute`](#addcustomattribute)
+    </td>
+
+    <td>
+        Add contextual information from your application to the current transaction in form of attributes.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        [`CurrentSpan`](#currentspan)
+    </td>
+
+    <td>
+        Provides access to the currently executing [span](/docs/agents/net-agent/net-agent-api/ispan), which provides access to span-specific methods in the New Relic API.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        [`SetUserId`](#setuserid)
+    </td>
+
+    <td>
+        Associates a User Id to the current transaction.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+## AcceptDistributedTraceHeaders [#acceptdistributedtraceheaders]
+
+    `ITransaction.AcceptDistributedTraceHeaders` is used to instrument the called service for inclusion in a distributed trace. It links the spans in a trace by accepting a payload generated by [`InsertDistributedTraceHeaders`](/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#transaction-handle-insertDistributedTraceHeaders) or generated by some other W3C Trace Context compliant tracer. This method accepts the headers of an incoming request, looks for W3C Trace Context headers, and if not found, falls back to New Relic distributed trace headers. This method replaces the deprecated [`AcceptDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#acceptdistributedtracepayload) method, which only handles New Relic distributed trace payloads.
+
+    ### Syntax
+
+    ```cs
+    void AcceptDistributedTraceHeaders(carrier, getter, transportType)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Name
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `carrier`
+
+            _&lt;T>_
+        </td>
+
+        <td>
+            Required. Source of incoming Trace Context headers.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `getter`
+
+            _Func&lt;T, string, IEnumerable&lt;string>>_
+        </td>
+
+        <td>
+            Required. Caller-defined function to extract header data from the carrier.
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `transportType`
+
+            _TransportType enum_
+        </td>
+
+        <td>
+            Required. Describes the transport of the incoming payload (for example `TransportType.HTTP`).
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Usage considerations
+
+    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+    * `AcceptDistributedTraceHeaders` will be ignored if `InsertDistributedTraceHeaders` or `AcceptDistributedTraceHeaders` has already been called for this transaction.
+
+    ### Example
+
+    ```cs
+    HttpContext httpContext = HttpContext.Current;
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    ITransaction currentTransaction = agent.CurrentTransaction;
+    currentTransaction.AcceptDistributedTraceHeaders(httpContext, Getter, TransportType.HTTP);
+    IEnumerable<string> Getter(HttpContext carrier, string key) 
+    { 
+        string value = carrier.Request.Headers[key];   
+        return value == null ? null : new string[] { value }; 
+    }
+    ```
+
+## InsertDistributedTraceHeaders [#insertdistributedtraceheaders]
+
+    `ITransaction.InsertDistributedTraceHeaders` is used to implement distributed tracing. It modifies the carrier object that is passed in by adding W3C Trace Context headers and New Relic Distributed Trace headers. The New Relic headers can be disabled with `<distributedTracing excludeNewrelicHeader="true" />` in the config. This method replaces the deprecated [`CreateDistributedTracePayload`](/docs/agents/net-agent/net-agent-api/itransaction#createdistributedtracepayload) method, which only creates New Relic Distributed Trace payloads.
+
+    ### Syntax
+
+    ```cs
+    void InsertDistributedTraceHeaders(carrier, setter)
+    ```
+
+    ### Parameters
+
+    <table>
+    <thead>
+        <tr>
+        <th>
+            Name
+        </th>
+
+        <th>
+            Description
+        </th>
+        </tr>
+    </thead>
+
+    <tbody>
+        <tr>
+        <td>
+            `carrier`
+
+            _&lt;T>_
+        </td>
+
+        <td>
+            Required. Container where Trace Context headers are inserted..
+        </td>
+        </tr>
+
+        <tr>
+        <td>
+            `setter`
+
+            _Action&lt;T, string, string>_
+        </td>
+
+        <td>
+            Required. Caller-defined Action to insert header data into the carrier.
+        </td>
+        </tr>
+    </tbody>
+    </table>
+
+    ### Usage considerations
+
+    * [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+
+    ### Example
+
+    ```cs
+    HttpWebRequest requestMessage = (HttpWebRequest)WebRequest.Create("https://remote-address");
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+    ITransaction currentTransaction = agent.CurrentTransaction;
+    var setter = new Action<HttpWebRequest, string, string>((carrier, key, value) => { carrier.Headers?.Set(key, value); });
+    currentTransaction.InsertDistributedTraceHeaders(requestMessage, setter);
+    ```
+
+## AcceptDistributedTracePayload [#acceptdistributedtracepayload]
+
+
+<Callout variant="caution">
+This API is not available in the .NET agent v9.0 or higher. Please use [`AcceptDistributedTraceHeaders`](/docs/agents/net-agent/net-agent-api/itransaction/#acceptdistributedtraceheaders) instead.
+</Callout>
+
+Accepts an incoming distributed trace payload from an upstream service. Calling this method links the transaction from the upstream service to this transaction.
+
+### Syntax
+
+```cs
+void AcceptDistributedPayload(payload, transportType)
+```
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Name
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `payload`
+
+        _string_
+    </td>
+
+    <td>
+        Required. A string representation of the incoming distributed trace payload.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `transportType`
+
+        _TransportType_  
+                                _enum_
+    </td>
+
+    <td>
+        Recommended. Describes the transport of the incoming payload (for example, `http`).
+
+        Default `TransportType.Unknown`.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Usage considerations
+
+* [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+* The payload can be a Base64-encoded or plain text string.
+* `AcceptDistributedTracePayload` will be ignored if `CreateDistributedTracePayload` has already been called for this transaction.
+
+### Example
+
+```cs
+//Obtain the information from the request object from the upstream caller.
+//The method by which this information is obtain is specific to the transport 
+//type being used. For example, in an HttpRequest, this information is
+//contained in the 
+header.KeyValuePair<string, string> metadata = GetMetaDataFromRequest("requestPayload");
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ITransaction transaction = agent.CurrentTransaction; 
+transaction.AcceptDistributedTracePayload(metadata.Value, TransportType.Queue);
+```
+
+
+## CreateDistributedTracePayload [#createdistributedtracepayload]
+
+<Callout variant="caution">
+This API is not available in the .NET agent v9.0 or higher. Please use [`InsertDistributedTraceHeaders`](/docs/agents/net-agent/net-agent-api/itransaction/#insertdistributedtraceheaders) instead.
+</Callout>
+
+Creates a distributed trace payload for inclusion in an outgoing request to a downstream system.
+
+### Syntax
+
+```cs
+IDistributedTracePayload CreateDistributedTracePayload()
+```
+
+### Returns
+
+An object that implements `IDistributedTracePayload` which provides access to the distributed trace payload that was created.
+
+### Usage considerations
+
+* [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing).
+* `CreateDistributedTracePayload` will be ignored if `AcceptDistributedTracePayload` has already been called for this transaction.
+
+### Example
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+ITransaction transaction = agent.CurrentTransaction;
+IDistributedTracePayload payload = transaction.CreateDistributedTracePayload();
+```
+
+
+## AddCustomAttribute [#addcustomattribute]
+
+Adds contextual information about your application to the current transaction in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
+
+This method requires .NET agent version and .NET agent API [version 8.24.244.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440) or higher. It replaced the deprecated [`AddCustomParameter`](/docs/agents/net-agent/net-agent-api/add-custom-parameter).
+
+### Syntax
+
+```cs
+ITransaction AddCustomAttribute(string key, object value)
+```
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `key`
+
+        _string_
+    </td>
+
+    <td>
+        Identifies the information being reported. Also known as the name.
+
+        * Empty keys are not supported.
+        * Keys are limited to 255-bytes. Attributes with keys larger than 255-bytes will be ignored.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `value`
+
+        _object_
+    </td>
+
+    <td>
+        The value being reported.
+        
+        <DoNotTranslate>**Note**</DoNotTranslate>: `null` values will not be recorded.
+        
+        <table>
+        <thead>
+            <tr>
+            <th>
+                .NET type
+            </th>
+
+            <th>
+                How the value will be represented
+            </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <tr>
+            <td>
+                `byte`, `Int16`, `Int32`, `Int64`
+
+                `sbyte`, `UInt16`, `UInt32`, `UInt64`
+            </td>
+
+            <td>
+                As an integral value.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `float`, `double`, `decimal`
+            </td>
+
+            <td>
+                A decimal-based number.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `string`
+            </td>
+
+            <td>
+                A string truncated after 255-bytes.
+
+                Empty strings are supported.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `bool`
+            </td>
+
+            <td>
+                True or false.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `DateTime`
+            </td>
+
+            <td>
+                A string representation following the ISO-8601 format, including time zone information:
+
+                Example: `2020-02-13T11:31:19.5767650-08:00`
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `TimeSpan`
+            </td>
+
+            <td>
+                A decimal-based number representing number of seconds.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                everything else
+            </td>
+
+            <td>
+                The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
+            </td>
+            </tr>
+        </tbody>
+        </table>
+
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Returns
+
+A reference to the current transaction.
+
+### Usage considerations
+
+For details about supported data types, see the [Custom Attributes Guide](/docs/agents/net-agent/attributes/custom-attributes).
+
+### Example
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+ITransaction transaction = agent.CurrentTransaction;
+transaction.AddCustomAttribute("customerName","Bob Smith")
+    .AddCustomAttribute("currentAge",31)
+    .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
+    .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+```
+
+## CurrentSpan [#currentspan]
+
+
+Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/ispan/), making [span-specific methods](/docs/apm/agents/net-agent/net-agent-api/ispan) available within the New Relic API.
+
+### Example
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ITransaction transaction = agent.CurrentTransaction; 
+ISpan currentSpan = transaction.CurrentSpan;
+```
+
+
+## SetUserId [#setuserid]
+
+Associates a User Id with the current transaction.
+
+This method requires .NET agent and .NET agent API [version 10.9.0](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-1090) or higher.
+
+### Syntax
+
+```cs
+ITransaction SetUserId(string userId)
+```
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `userId`
+
+        _string_
+    </td>
+
+    <td>
+        The User Id to be associated with this transaction.
+
+        * `null`, empty and whitespace values will be ignored.
+    </td>
+    </tr>
+
+</tbody>
+</table>
+
+### Example
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ITransaction transaction = agent.CurrentTransaction; 
+transaction.SetUserId("BobSmith123");
+```
+
+
+
+## ISpan [#ispan]
+
+### Syntax
+
+```cs
+Public interfac ISpan
+```
+
+Provides access to span-specific methods in the New Relic API.
+
+### Description
+
+Provides access to span-specific methods in the New Relic .NET agent API. To obtain a reference to `ISpan`, use:
+
+* The `CurrentSpan` property on [`IAgent`](/docs/agents/net-agent/net-agent-api/iagent) (Recommended).
+* The `CurrentSpan` property on [`ITransaction`](/docs/agents/net-agent/net-agent-api/itransaction).
+
+This section contains descriptions and parameters of `ISpan` methods:
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Name
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        [`AddCustomAttribute`](#addcustomattribute)
+    </td>
+
+    <td>
+        Add contextual information from your application to the current span in form of attributes.
+    </td>
+    </tr>
+    <tr>
+    <td>
+        [`SetName`](#setname)
+    </td>
+
+    <td>
+        Changes the name of the current span/segment/metrics that will be reported to New Relic.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### AddCustomAttribute [#addcustomattribute]
+
+Adds contextual information about your application to the current span in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
+
+This method requires .NET agent version and .NET agent API [version 8.25](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-8242440) or higher.
+
+### Syntax
+
+```cs
+ISpan AddCustomAttribute(string key, object value)
+```
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `key`
+
+        _string_
+    </td>
+
+    <td>
+        Identifies the information being reported. Also known as the name.
+
+        * Empty keys are not supported.
+        * Keys are limited to 255-bytes. Attributes with keys larger than 255-bytes will be ignored.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `value`
+
+        _object_
+    </td>
+
+    <td>
+        The value being reported.
+        
+        <DoNotTranslate>**Note**</DoNotTranslate>: `null` values will not be recorded.
+        
+        <table>
+        <thead>
+            <tr>
+            <th>
+                .NET type
+            </th>
+
+            <th>
+                How the value will be represented
+            </th>
+            </tr>
+        </thead>
+
+        <tbody>
+            <tr>
+            <td>
+                `byte`, `Int16`, `Int32`, `Int64`
+
+                `sbyte`, `UInt16`, `UInt32`, `UInt64`
+            </td>
+
+            <td>
+                As an integral value.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `float`, `double`, `decimal`
+            </td>
+
+            <td>
+                A decimal-based number.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `string`
+            </td>
+
+            <td>
+                A string truncated after 255-bytes.
+
+                Empty strings are supported.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `bool`
+            </td>
+
+            <td>
+                True or false.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `DateTime`
+            </td>
+
+            <td>
+                A string representation following the ISO-8601 format, including time zone information:
+
+                Example: `2020-02-13T11:31:19.5767650-08:00`
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                `TimeSpan`
+            </td>
+
+            <td>
+                A decimal-based number representing number of seconds.
+            </td>
+            </tr>
+
+            <tr>
+            <td>
+                everything else
+            </td>
+
+            <td>
+                The `ToString()` method will be applied. Custom types must have an implementation of `Object.ToString()` or they will throw an exception.
+            </td>
+            </tr>
+        </tbody>
+        </table>
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Returns
+
+A reference to the current span.
+
+### Usage considerations
+
+For details about supported data types, see the [Custom Attributes guide](/docs/agents/net-agent/attributes/custom-attributes).
+
+### Examples
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+ISpan currentSpan = agent.CurrentSpan; 
+
+currentSpan
+    .AddCustomAttribute("customerName","Bob Smith")
+    .AddCustomAttribute("currentAge",31)
+    .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
+    .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+```
+
+### SetName [#setname]
+
+Changes the name of the current segment/span that will be reported to New Relic. For segments/spans resulting from custom instrumentation, the metric name reported to New Relic will be altered as well. 
+
+This method requires .NET agent version and .NET agent API version 10.1.0 or higher.
+
+### Syntax
+
+```cs
+ISpan SetName(string name)
+```
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th>
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `name`
+
+        _string_
+    </td>
+
+    <td>
+        The new name for the span/segment.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Returns
+
+A reference to the current span.
+
+### Examples
+
+```cs
+[Trace]
+public void MyTracedMethod()
+{
+    IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
+    ISpan currentSpan = agent.CurrentSpan; 
+
+    currentSpan.SetName("MyCustomName");
+}
+```
+
+## IgnoreApdex [#ignoreapdex]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.IgnoreApdex()
+```
+
+Ignore the current transaction when calculating Apdex.
+
+### Requirements
+
+Compatible with all agent versions.
+
+### Description
+
+Ignores the current transaction when calculating your [Apdex score](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction). This is useful when you have either very short or very long transactions (such as file downloads) that can skew your Apdex score.
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.NewRelic.IgnoreApdex();
+```
+
+## IgnoreTransaction [#ignoretransaction]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.IgnoreTransaction()
+```
+
+Do not instrument the current transaction.
+
+### Requirements
+
+Compatible with all agent versions.
+
+Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+### Description
+
+Ignores the current transaction.
+
+<Callout variant="tip">
+You can also ignore transactions [via a custom instrumentation XML file](/docs/agents/net-agent/custom-instrumentation/add-detail-transactions-xml-net#blocking-instrumentation).
+</Callout>
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.NewRelic.IgnoreTransaction();
+```
+
+### Overloads [#overloads]
+
+Notice an error and report to New Relic, along with optional custom attributes.
+
+```cs
+NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception);
+NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception, IDictionary<TKey, TValue> $attributes);
+NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes);
+NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes, bool $is_expected);
+```
+
+### Requirements [#requirements]
+
+This API call is compatible with:
+
+* All agent versions
+* All app types
+
+### Description [#description]
+
+Notice an error and report it to New Relic along with optional custom attributes. For each transaction, the agent only retains the exception and attributes from the first call to `NoticeError()`. You can pass an actual exception, or pass a string to capture an arbitrary error message.
+
+If this method is invoked within a [transaction](/docs/glossary/glossary/#transaction), the agent reports the exception within the parent transaction. If it is invoked outside of a transaction, the agent creates an [error trace](/docs/errors-inbox/errors-inbox) and categorizes the error in the New Relic UI as a `NewRelic.Api.Agent.NoticeError` API call. If invoked outside of a transaction, the `NoticeError()` call will not contribute to the error rate of an application.
+
+The agent adds the attributes only to the traced error; it does not send them to New Relic. For more information, see [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
+
+Errors reported with this API are still sent to New Relic when they are reported within a transaction that results in an HTTP status code, such as a `404`, that is configured to be ignored by agent configuration. For more information, see our documentation about [managing errors in APM](/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected).
+
+Review the sections below to see examples of how to use this call.
+
+### NoticeError(Exception) [#exception-overload]
+
+```cs
+NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception)
+```
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$exception`
+
+        _Exception_
+    </td>
+
+    <td>
+        Required. The `Exception` you want to instrument. Only the first 10,000 characters from the stack trace are retained.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### NoticeError(Exception, IDictionary) [#exception-idictionary-overload]
+
+```cs
+NewRelic.Api.Agent.NewRelic.NoticeError(Exception $exception, IDictionary<TKey, TValue> $attributes)
+```
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$exception`
+
+        _Exception_
+    </td>
+
+    <td>
+        Required. The `Exception` you want to instrument. Only the first 10,000 characters from the stack trace are retained.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$attributes`
+
+        _IDictionary&lt;TKey, TValue&gt;_
+    </td>
+
+    <td>
+        Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### NoticeError(String, IDictionary) [#string-idictionary-overload]
+
+```cs
+NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes)
+```
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$error_message`
+
+        _string_
+    </td>
+
+    <td>
+        Required. Specify a string to report to New Relic as though it's an exception. This method creates both [error events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [error traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 1023 characters are retained in error events, while error traces retain the full message.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$attributes`
+
+        _IDictionary&lt;TKey, TValue&gt;_
+    </td>
+
+    <td>
+        Required (can be null). Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object, to send no attributes, pass `null`.  
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### NoticeError(String, IDictionary, bool) [#string-idictionary-bool-overload]
+
+```cs
+NewRelic.Api.Agent.NewRelic.NoticeError(string $error_message, IDictionary<TKey, TValue> $attributes, bool $is_expected)
+```
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$error_message`
+
+        _string_
+    </td>
+
+    <td>
+        Required. Specify a string to report to New Relic as though it's an exception. This method creates both [error events](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#events) and [error traces](/docs/apm/apm-ui-pages/error-analytics/manage-error-data#trace-details).  Only the first 1023 characters are retained in error events, while error traces retain the full message.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$attributes`
+
+        _IDictionary&lt;TKey, TValue&gt;_
+    </td>
+
+    <td>
+        Required (can be null). Specify key/value pairs of attributes to annotate the error message. The `TKey` must be a string, the `TValue` can be a string or object, to send no attributes, pass `null`.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$is_expected`
+
+        _bool_
+    </td>
+
+    <td>
+        Mark error as expected so that it won't affect Apdex score and error rate.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+#### Pass an exception without custom attributes [#exception-no-attributes]
+
+```cs
+try
+{
+    string ImNotABool = "43";
+    bool.Parse(ImNotABool);
+}
+catch (Exception ex)
+{
+    NewRelic.Api.Agent.NewRelic.NoticeError(ex);
+}
+```
+
+#### Pass an exception with custom attributes [#exception-yes-attributes]
+
+```cs
+try
+{
+    string ImNotABool = "43";
+    bool.Parse(ImNotABool);
+}
+catch (Exception ex)
+{
+    var errorAttributes = new Dictionary<string, string>() {{"foo", "bar"},{"baz", "luhr"}};
+    NewRelic.Api.Agent.NewRelic.NoticeError(ex, errorAttributes);
+}
+```
+
+#### Pass an error message string with custom attributes [#string-yes-attributes]
+
+```cs
+try
+{
+    string ImNotABool = "43";
+    bool.Parse(ImNotABool);
+}
+catch (Exception ex)
+{
+    var errorAttributes = new Dictionary<string, string>{{"foo", "bar"},{"baz", "luhr"}};
+    NewRelic.Api.Agent.NewRelic.NoticeError("String error message", errorAttributes);
+}
+```
+
+#### Pass an error message string without custom attributes [#string-no-attributes]
+
+```cs
+try
+{
+    string ImNotABool = "43";
+    bool.Parse(ImNotABool);
+}
+catch (Exception ex)
+{
+    NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null);
+}
+```
+
+#### Pass an error message string and mark it as expected [#string-no-attributes]
+
+```cs
+try
+{
+    string ImNotABool = "43";
+    bool.Parse(ImNotABool);
+}
+catch (Exception ex)
+{
+    NewRelic.Api.Agent.NewRelic.NoticeError("String error message", null, true);
+}
+```
+
+
+## IncrementCounter [#incrementcounter]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.IncrementCounter(string $metric_name)
+```
+
+Increment the counter for a custom metric by 1.
+
+### Requirements
+
+Compatible with all agent versions.
+
+Compatible with all app types.
+
+### Description
+
+Increment the counter for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) by 1. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
+
+<Callout variant="important">
+When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`). For more on naming, see [Collect custom metrics](/docs/apm/agents/manage-apm-agents/agent-data/collect-custom-metrics/).
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$metric_name`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The name of the metric to increment.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.NewRelic.IncrementCounter("Custom/ExampleMetric");
+```
+
+## RecordCustomEvent [#recordcustomevent]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.RecordCustomEvent(string eventType, IEnumerable<string, object> attributeValues)
+```
+
+Records a custom event with the given name and attributes.
+
+### Requirements
+
+Agent version 4.6.29.0 or higher.
+
+Compatible with all app types.
+
+### Description
+
+Records a [custom event](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data#event-data) with the given name and attributes, which you can query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder). To verify if an event is being recorded correctly, look for the data in [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards).
+
+For related API calls, see the [.NET agent API guide](/docs/agents/net-agent/api-guides/guide-using-net-agent-api#custom-data).
+
+<Callout variant="important">
+* Sending a lot of events can increase the memory overhead of the agent.
+* Additionally, posts greater than 1MB (10^6 bytes) in size will not be recorded regardless of the maximum number of events.
+* Custom Events are limited to 64-attributes.
+* For more information about how custom attribute values are processed, see the [custom attributes](/docs/agents/net-agent/attributes/custom-attributes) guide.
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `eventType`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The name of the event type to record. Strings over 255 characters will result in the API call not being sent to New Relic. The name can only contain alphanumeric characters, underscores `_`, and colons `:`. For additional restrictions on event type names, see [Reserved words](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+    `attributeValues`
+
+        _IEnumerable&lt;string, object>_
+    </td>
+
+    <td>
+        Required. Specify key/value pairs of attributes to annotate the event.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+#### Record values [#record-strings]
+
+```cs
+var eventAttributes = new Dictionary<string, object>() 
+{
+    {"foo", "bar"},
+    {"alice", "bob"}, 
+    {"age", 32}, 
+    {"height", 21.3f}
+};
+
+NewRelic.Api.Agent.NewRelic.RecordCustomEvent("MyCustomEvent", eventAttributes);
+```
+
+## RecordMetric [#recordmetric]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.RecordMetric(string $metric_name, single $metric_value)
+```
+
+Records a custom metric with the given name.
+
+### Requirements
+
+Compatible with all agent versions.
+
+Compatible with all app types.
+
+### Description
+
+Records a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics) with the given name. To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`IncrementCounter()`](/docs/agents/net-agent/net-agent-api/incrementcounter-net-agent) and [`RecordResponseTimeMetric()`](/docs/agents/net-agent/net-agent-api/recordresponsetimemetric-net-agent).
+
+<Callout variant="important">
+When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$metric_name`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The name of the metric to record. Only the first 255 characters are retained.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$metric_value`
+
+        _single_
+    </td>
+
+    <td>
+        Required. The quantity to record for the metric.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+#### Record response time of a sleeping process [#record-stopwatch]
+
+```cs
+Stopwatch stopWatch = Stopwatch.StartNew();
+System.Threading.Thread.Sleep(5000);
+stopWatch.Stop();
+NewRelic.Api.Agent.NewRelic.RecordMetric("Custom/DEMO_Record_Metric", stopWatch.ElapsedMilliseconds);
+```
+
+
+## RecordResponseTimeMetric [#recordresponsetimemetric]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.RecordResponseTimeMetric(string $metric_name, Int64 $metric_value)
+```
+
+Records a custom metric with the given name and response time in milliseconds.
+
+### Requirements
+
+Compatible with all agent versions.
+
+Compatible with all app types.
+
+### Description
+
+Records the response time in milliseconds for a [custom metric](/docs/agents/manage-apm-agents/agent-metrics/custom-metrics). To view these custom metrics, use the [query builder](/docs/query-your-data/explore-query-data/query-builder/use-advanced-nrql-mode-specify-data) to search metrics and create customizable charts. See also [`IncrementCounter()`](/docs/agents/net-agent/net-agent-api/incrementcounter-net-agent) and [`RecordMetric()`](/docs/agents/net-agent/net-agent-api/recordmetric-net-agent).
+
+<Callout variant="important">
+When creating a custom metric, start the name with `Custom/` (for example, `Custom/MyMetric`).
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$metric_name`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The name of the response time metric to record. Only the first 255 characters are retained.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$metric_value`
+
+        _Int64_
+    </td>
+
+    <td>
+        Required. The response time to record in milliseconds.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+#### Record response time of a sleeping process [#record-stopwatch]
+
+```cs
+Stopwatch stopWatch = Stopwatch.StartNew();
+System.Threading.Thread.Sleep(5000);
+stopWatch.Stop();
+NewRelic.Api.Agent.NewRelic.RecordResponseTimeMetric("Custom/DEMO_Record_Response_Time_Metric", stopWatch.ElapsedMilliseconds);
+```
+
+
+## SetApplicationName [#setapplicationname]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetApplicationName(string $name[, string $name_2, string $name_3])
+```
+
+Set the app name for data rollup.
+
+### Requirements
+
+Agent version 5.0.136.0 or higher.
+
+Compatible with all app types.
+
+### Description
+
+Set the application name(s) reported to New Relic. For more information about application naming, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application). This method is intended to be called once, during startup of an application.
+
+<Callout variant="important">
+Updating the app name forces the agent to restart. The agent discards any unreported data associated with previous app names. Changing the app name multiple times during the lifecycle of an application is not recommended due to the associated data loss.
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$name`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The primary application name.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$name_2`
+
+        `$name_3`
+
+        _string_
+    </td>
+
+    <td>
+        Optional. Second and third names for app rollup. For more information, see [Use multiple names for an app](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app).
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetApplicationName("AppName1", "AppName2");
+```
+
+## SetErrorGroupCallback [#seterrorgroupcallback]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(Func<IReadOnlyDictionary<string,object>, string> errorGroupCallback);
+```
+Provide a callback method that takes an `IReadOnlyDictionary<string,object>` of attribute data, and returns an error group name.
+
+### Requirements [#requirements]
+
+This API call is compatible with:
+
+* Agent versions >= 10.9.0
+* All app types
+
+### Description [#description]
+
+Set a callback method that the agent will use to determine the error group name for error events and traces.  This name is used in the Errors Inbox to group errors into logical groups.
+
+The callback method must accept a single argument of type `IReadOnlyDictionary<string,object>`, and return a string (the error group name). The `IReadOnlyDictionary` is a collection of [attribute data](/docs/apm/agents/manage-apm-agents/agent-data/agent-attributes/) associated with each error event, including custom attributes.
+
+The exact list of attributes available for each error will vary depending on:
+
+* What application code generated the error
+* Agent configuration settings
+* Whether any custom attributes were added
+
+However, the following attributes should always exist:
+
+* `error.class`
+* `error.message`
+* `stack_trace`
+* `transactionName`
+* `request.uri`
+* `error.expected`
+
+An empty string may be returned for the error group name when the error can't be assigned to a logical error group.
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$callback`
+
+        _{'Func<IReadOnlyDictionary<string,object>,string>'}_
+        
+    </td>
+
+    <td>
+        The callback to determine the error group name based on attribute data.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+Group errors by error class name:
+
+```cs
+Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback = (attributes) => {
+    string errorGroupName = string.Empty;
+    if (attributes.TryGetValue("error.class", out var errorClass))
+    {
+        if (errorClass.ToString() == "System.ArgumentOutOfRangeException" || errorClass.ToString() == "System.ArgumentNullException")
+        {
+            errorGroupName = "ArgumentErrors";
+        }
+        else
+        {
+            errorGroupName = "OtherErrors";
+        }
+    }
+    return errorGroupName;
+};
+
+NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(errorGroupCallback);
+```
+
+Group errors by transaction name:
+
+```cs
+Func<IReadOnlyDictionary<string, object>, string> errorGroupCallback = (attributes) => {
+    string errorGroupName = string.Empty;
+    if (attributes.TryGetValue("transactionName", out var transactionName))
+    {
+    if (transactionName.ToString().IndexOf("WebTransaction/MVC/Home") != -1)
+    {
+    errorGroupName = "HomeControllerErrors";
+    }
+        else
+        {
+            errorGroupName = "OtherControllerErrors";
+        }
+    }
+    return errorGroupName;
+};
+
+NewRelic.Api.Agent.NewRelic.SetErrorGroupCallback(errorGroupCallback);
+```
+
+
+## SetTransactionName [#settransactionname]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetTransactionName(string $category, string $name)
+```
+
+Sets the name of the current transaction.
+
+### Requirements
+
+* Compatible with all agent versions.
+* Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+### Description
+
+Sets the name of the current transaction. Before you use this call, ensure you understand the implications of [metric grouping issues](/docs/agents/manage-apm-agents/troubleshooting/metric-grouping-issues).
+
+If you use this call multiple times within the same transaction, each call overwrites the previous call and the last call sets the name.
+
+<Callout variant="important">
+Do not use brackets `[suffix]` at the end of your transaction name. New Relic automatically strips brackets from the name. Instead, use parentheses `(suffix)` or other symbols if needed.
+</Callout>
+
+Unique values like URLs, page titles, hex values, session IDs, and uniquely identifiable values should not be used in naming your transactions. Instead, add that data to the transaction as a custom parameter with the [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) call.
+
+<Callout variant="important">
+Do not create more than 1000 unique transaction names (for example, avoid naming by URL if possible). This will make your charts less useful, and you may run into limits New Relic sets on the number of unique transaction names per account. It also can slow down the performance of your application.
+</Callout>
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$category`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The category of this transaction, which you can use to distinguish different types of transactions. Defaults to <DoNotTranslate>**`Custom`**</DoNotTranslate>. Only the first 255 characters are retained.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$name`
+
+        _string_
+    </td>
+
+    <td>
+        Required. The name of the transaction. Only the first 255 characters are retained.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetTransactionName("Other", "MyTransaction");
+```
+
+
+## SetTransactionUri [#settransactionuri]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetTransactionUri(Uri $uri)
+```
+
+Sets the URI of the current transaction.
+
+### Requirements
+
+* Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+* Agent version 6.16 or higher.
+
+<Callout variant="important">
+This method only works when used within a transaction created using the `Transaction` attribute with the `Web` property set to `true`. (See [Instrument using attributes](/docs/agents/net-agent/api-guides/net-agent-api-instrument-using-attributes).) It provides support for custom web-based frameworks that the agent does not automatically support.
+</Callout>
+
+### Description
+
+Sets the URI of the current transaction. The URI appears in the 'request.uri' [attribute](/docs/agents/net-agent/attributes/net-agent-attributes) of [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces) and [transaction events](/docs/using-new-relic/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data), and also can affect transaction naming.
+
+If you use this call multiple times within the same transaction, each call overwrites the previous call. The last call sets the URI.
+
+<DoNotTranslate>**Note**</DoNotTranslate>: as of agent version 8.18, the `request.uri` attribute's value is set to the value of the `Uri.AbsolutePath` property of the `System.Uri` object passed to the API.
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$uri`
+
+        _Uri_
+    </td>
+
+    <td>
+        The URI of this transaction.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+```cs
+var uri = new System.Uri("https://www.mydomain.com/path");
+NewRelic.Api.Agent.NewRelic.SetTransactionUri(uri);
+```
+
+
+## SetUserParameters [#setuserparameters]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetUserParameters(string $user_value, string $account_value, string $product_value)
+```
+
+Create user-related custom attributes. [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute) is more flexible.
+
+### Requirements
+
+* Compatible with all agent versions.
+* Must be called inside a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction).
+
+### Description
+
+<Callout variant="tip">
+This call only allows you to assign values to pre-existing keys. For a more flexible method to create key/value pairs, use [`AddCustomAttribute()`](/docs/agents/net-agent/net-agent-api/itransaction).
+</Callout>
+
+Define user-related [custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)to associate with a browser page view (user name, account name, and product name). The values are automatically associated with pre-existing keys (`user`, `account`, and `product`), then attached to the parent APM transaction. You can also [attach (or "forward") these attributes](/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#forwarding-attributes) to browser [PageView](/docs/agents/manage-apm-agents/agent-metrics/agent-attributes#destinations) events.
+
+### Parameters
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Parameter
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `$user_value`
+
+        _string_
+    </td>
+
+    <td>
+        Required (can be null). Specify a name or username to associate with this page view. This value is assigned to the `user` key.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$account_value`
+
+        _string_
+    </td>
+
+    <td>
+        Required (can be null). Specify the name of a user account to associate with this page view. This value is assigned to the `account` key.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `$product_value`
+
+        _string_
+    </td>
+
+    <td>
+        Required (can be null). Specify the name of a product to associate with this page view. This value is assigned to the `product` key.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+#### Record three user attributes [#report-three]
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetUserParameters("MyUserName", "MyAccountName", "MyProductName");
+```
+
+#### Record two user attributes and one empty attribute [#report-two]
+
+```cs
+NewRelic.Api.Agent.NewRelic.SetUserParameters("MyUserName", "", "MyProductName");
+```
+
+
+## StartAgent [#startagent]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.NewRelic.StartAgent()
+```
+
+Start the agent if it hasn't already started. Usually unnecessary.
+
+### Requirements
+
+* Agent version 5.0.136.0 or higher.
+* Compatible with all app types.
+
+### Description
+
+Starts the agent if it hasn't already been started. This call is usually unnecessary, since the agent starts automatically when it hits an instrumented method unless you disable [`autoStart`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-autoStart). If you use [`SetApplicationName()`](/docs/agents/net-agent/net-agent-api/setapplicationname-net-agent), ensure you set the app name <DoNotTranslate>**before**</DoNotTranslate> you start the agent.
+
+<Callout variant="tip">
+This method starts the agent asynchronously (meaning it won't block app startup) unless you enable [`syncStartup`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-syncStartup) or [`sendDataOnExit`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#service-sendDataOnExit).
+</Callout>
+
+### Examples
+
+```cs
+NewRelic.Api.Agent.NewRelic.StartAgent();
+```
+
+
+## TraceMetadata [#tracemetadata]
+
+### Syntax
+
+```cs
+NewRelic.Api.Agent.TraceMetadata;
+```
+
+Returns properties in the current execution environment used to support tracing.
+
+### Requirements
+
+* Agent version 8.19 or higher.
+* Compatible with all app types.
+* [Distributed tracing must be enabled](/docs/agents/net-agent/configuration/net-agent-configuration#distributed_tracing) to get meaningful values.
+
+### Description
+
+Provides access to the following properties:
+
+### Properties
+
+<table>
+<thead>
+    <tr>
+    <th width="25%">
+        Name
+    </th>
+
+    <th>
+        Description
+    </th>
+    </tr>
+</thead>
+
+<tbody>
+    <tr>
+    <td>
+        `TraceId`
+    </td>
+
+    <td>
+        Returns a string representing the currently executing trace. If the trace ID is not available, or distributed tracing is disabled, the value will be `string.Empty`.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `SpanId`
+    </td>
+
+    <td>
+        Returns a string representing the currently executing span. If the span ID is not available, or distributed tracing is disabled, the value will be `string.Empty`.
+    </td>
+    </tr>
+
+    <tr>
+    <td>
+        `IsSampled`
+    </td>
+
+    <td>
+        Returns `true` if the current trace is sampled for inclusion, `false` if it is sampled out.
+    </td>
+    </tr>
+</tbody>
+</table>
+
+### Examples
+
+```cs
+IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+TraceMetadata traceMetadata = agent.TraceMetadata;
+string traceId = traceMetadata.TraceId;
+string spanId = traceMetadata.SpanId;
+bool isSampled = traceMetadata.IsSampled;
+```


### PR DESCRIPTION
Test out version of the .NET agent API with all the docs in a single doc separated by h2s.