### PR TITLE
fix(data-apis): Restore the table for data plus comparisons

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -66,6 +66,426 @@ If you're in an organization that has more than one account in it, users can man
 
 If your user can't perform either of these two tasks after referencing the above details, contact support or your account team if you have one.
 
+## Default retention periods [#retention-periods]
+
+The best way to understand your New Relic data retention is to go to the <DoNotTranslate>**Data retention**</DoNotTranslate> UI page. We recommend this because your organization may have edited your settings and so they might not be the default settings shown below. 
+
+This table shows the default [namespace](/docs/glossary/glossary) retention settings.
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Data source
+      </th>
+
+      <th>
+        Namespace
+      </th>
+
+      <th style={{ width: "210px" }}>
+        Retention for [Original Data option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-prices) (days)
+      </th>
+      <th style={{ width: "210px" }}>
+        Retention for [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-prices) (days)
+      </th>
+
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        APM
+      </td>
+
+      <td>
+        APM
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        APM
+      </td>
+
+      <td>
+        APM errors 
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98 
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        APM
+      </td>
+
+      <td>
+        APM error stack traces
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        8
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Browser
+      </td>
+
+      <td>
+        All ([learn more](#browser-namespaces))
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Custom events
+      </td>
+
+      <td>
+        Custom events
+      </td>
+
+      <td>
+        30
+      </td>
+      <td>
+        120
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Logging
+      </td>
+
+      <td>
+        Logging
+      </td>
+
+      <td>
+        30
+      </td>
+      <td>
+        120
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Infrastructure
+      </td>
+
+      <td>
+        Infrastructure processes ([learn more](#infrastructure-data))
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Infrastructure
+      </td>
+
+      <td>
+        Infrastructure integrations ([learn more](#infrastructure-data))
+      </td>
+
+      <td>
+        395 (13 months)
+      </td>
+      <td>
+        485 (16 months)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Marker ([change tracking](/docs/change-tracking/change-tracking-introduction))
+      </td>
+
+      <td>
+        Marker
+      </td>
+
+      <td>
+        395 (13 months)
+      </td>
+      <td>
+        485 (16 months)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Mobile
+      </td>
+
+      <td>
+        Mobile crash event trails (breadcrumb)
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Mobile
+      </td>
+
+      <td>
+        Mobile exception
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Mobile
+      </td>
+
+      <td>
+        Mobile general
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Mobile
+      </td>
+
+      <td>
+        Mobile error
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Mobile
+      </td>
+
+      <td>
+        Mobile crash
+      </td>
+
+      <td>
+        90
+      </td>
+      <td>
+        180
+      </td>      
+    </tr>
+
+    <tr>
+      <td>
+        Mobile
+      </td>
+
+      <td>
+        Mobile session
+      </td>
+
+      <td>
+        90
+      </td>
+      <td>
+        180
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        Network
+      </td>
+
+      <td>
+        Flows (cloud & on-premises)
+      </td>
+
+      <td>
+        30
+      </td>
+      <td>
+        120
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        Network
+      </td>
+
+      <td>
+        SNMP ([see metrics](#dimensional-metrics))
+      </td>
+
+      <td>
+        395
+      </td>
+      <td>
+        485
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        Network
+      </td>
+
+      <td>
+        Syslog
+      </td>
+
+      <td>
+        30
+      </td>
+      <td>
+        120
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        Serverless
+      </td>
+
+      <td>
+        Lambda
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Serverless
+      </td>
+
+      <td>
+        Lambda custom
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Serverless
+      </td>
+
+      <td>
+        Lambda spans
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>
+    </tr>    
+    
+    <tr>
+      <td>
+    Synthetic monitoring (not editable)
+      </td>
+
+      <td>
+        Synthetic data (not editable)
+      </td>
+
+      <td>
+        395 (13 months)
+      </td>
+      <td>
+        395 (13 months)
+      </td>
+    </tr>
+    
+    <tr>
+      <td>
+        Traces
+      </td>
+
+      <td>
+        Distributed traces
+      </td>
+
+      <td>
+        8
+      </td>
+      <td>
+        98
+      </td>      
+    </tr>
+  </tbody>
+</table>
+
 ## Retention details for assorted data types [#data-details]
 
 In this section are details about a few different types of data, including some data types that have retention settings that can't be changed. 


### PR DESCRIPTION
Restore the comparison table for retention periods. We had removed this during a revamp of this page. In consultation with an SME, we removed it, thinking the Data Plus page was sufficient. Alas, we received feedback from the field that there isn't a 1:1 relationship between the content we removed and the data plus page. So, we are restoring it.