### PR TITLE
Fixed typo in dashboards-charts-import-export-data.mdx

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
@@ -14,7 +14,7 @@ import dashboardsExportPdf from 'images/dashboards_screenshot-full_export-pdf.we
 
 import dashboardsExportCsv from 'images/dashboards_screenshot-crop_export-csv.webp'
 
-You can use [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) to visualalize and track your system's health, tackle issues, and plan any further steps. Learn to share all that information with your team, customers, or other stakeholders with various import and export options.
+You can use [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) to visualize and track your system's health, tackle issues, and plan any further steps. Learn to share all that information with your team, customers, or other stakeholders with various import and export options.
 
 ## Import a dashboard as JSON [#import-json]
 


### PR DESCRIPTION
There was an instance of the word visualize misspelled as "visualalize". This PR resolves that typo.
