### PR TITLE
Update opentelemetry-errors-inbox-page.mdx

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-errors-inbox-page.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-errors-inbox-page.mdx
@@ -38,7 +38,8 @@ The value of the error group message is determined in the following order:
 * `otel.status_description`
 * `rpc.grpc.status_code`
 * `http.status_code`
-* `undefined` if all three above are not present
+* `http.response.status_code`
+* `undefined` if all four above are not present
 
 Troubleshooting: In the event your inbox is too noisy, check out [these tips](/docs/errors-inbox/errors-inbox/#similar-events). If on the other hand, you’re not seeing errors data in Errors inbox, check out the [requirements](/docs/errors-inbox/errors-inbox#requirements) to get started.
 


### PR DESCRIPTION
add new field `http.response.status_code` being used for the error group message

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.