### PR TITLE
Added nbaenam back to auto-assign list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -10,6 +10,7 @@ reviewers:
   - akristen
   - jeff-colucci
   - bradleycamacho
+  - nbaenam
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)


### PR DESCRIPTION
I wanted to get @nbaenam back on the auto-assign reviewer list