### PR TITLE
Rewrite data source examples for Python Agent

### DIFF
--- a/src/content/docs/apm/agents/python-agent/python-agent-api/datasourcegenerator-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/datasourcegenerator-python-agent-api.mdx
@@ -88,14 +88,29 @@ Returns a function.
 An example of using `data_source_generator` to wrap a function that returns metric values:
 
 ```py
+import newrelic.agent
 import psutil
 import os
- 
-@newrelic.agent.data_source_generator(name='Memory Usage')
+
+@newrelic.agent.data_source_generator(name='Memory_Usage')
 def memory_metrics():
     pid = os.getpid()
-    p = psutil.Process(os.getpid())
-    m = p.get_memory_info()
-    yield ('Custom/Memory/Physical', float(m.rss)/(1024*1024))
-    yield ('Custom/Memory/Virtual', float(m.vms)/(1024*1024))
+    p = psutil.Process(pid)
+    m = p.memory_info()
+    yield ('Custom/Memory/Physical', float(m.rss) / (1024 * 1024))
+    yield ('Custom/Memory/Virtual', float(m.vms) / (1024 * 1024))
+
+
+@newrelic.agent.background_task()
+def main():
+    # Example code, business as usual
+    print("Hello, world!")
+
+
+if __name__ == "__main__":
+    newrelic.agent.initialize(config_file="newrelic.ini")
+    app = newrelic.agent.register_application()
+    newrelic.agent.register_data_source(memory_metrics, app)
+    
+    main()
 ```

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/registerdatasource-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/registerdatasource-python-agent-api.mdx
@@ -146,40 +146,32 @@ None.
 
 ## Examples
 
-### Registering a data source [#register-example]
-
-Here's an example of some app code that generates custom metric data:
-
-```py
-@newrelic.agent.data_source_generator(name='External') 
-def services(): 
-    # code goes here
-    pass
-
-
-if __name__ == '__main__': 
-    application = nr.configure_newrelic() 
-    newrelic.agent.register_data_source(services, application)
-
-    while True: 
-        pass
-```
-
 ### Memory usage from data source [#data-source-memory]
 
 ```py
+import newrelic.agent
 import psutil
 import os
 
-
-@newrelic.agent.data_source_generator(name='Memory Usage')
+@newrelic.agent.data_source_generator(name='Memory_Usage')
 def memory_metrics():
     pid = os.getpid()
     p = psutil.Process(os.getpid())
-    m = p.get_memory_info()
+    m = p.memory_info()
     yield ('Custom/Memory/Physical', float(m.rss) / (1024 * 1024))
     yield ('Custom/Memory/Virtual', float(m.vms) / (1024 * 1024))
 
 
-newrelic.agent.register_data_source(memory_metrics)
+@newrelic.agent.background_task()
+def main():
+    # Example code, business as usual
+    print("Hello, world!")
+
+
+if __name__ == "__main__":
+    newrelic.agent.initialize(config_file="newrelic.ini")
+    app = newrelic.agent.register_application()
+    newrelic.agent.register_data_source(memory_metrics, app)
+    
+    main()
 ```


### PR DESCRIPTION
This PR updates the Python Agent's examples for the `data_source_generator` and `register_data_source` pages.