### PR TITLE
Update azure-log-forwarding.mdx with size constraint

### DIFF
--- a/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
@@ -192,7 +192,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
     id="large-files"
     title="Large Log Files"
   >
-    The Azure function invocation for forwarding our logs fails for files above a certain size (~105 MB). This is due to an out of memory error caused by the fact that the Azure Functions Node.js Binding [doesn't support streaming](https://github.com/Azure/azure-functions-host/issues/1361). This is a known issue and can't be mitigated, except by reducing the size of the logs you upload.
+    The Azure function invocation for forwarding our logs fails for files above a certain size (approximately 105 MB). This is due to an out of memory error caused by the fact that the Azure Functions Node.js Binding [doesn't support streaming](https://github.com/Azure/azure-functions-host/issues/1361). This is a known issue and can't be mitigated, except by reducing the size of the logs you upload.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
@@ -174,7 +174,27 @@ If you want to only query for logs coming from Azure, run the following query:
 SELECT * FROM Log where plugin.type='azure'
 ```
 
-If no data appears after you enable our log management capabilities, follow our [standard log troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).
+## Troubleshooting [#troubleshoot]
+
+If you encounter problems with configuring your log forwarder, try these troubleshooting tips.
+
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="log-data"
+    title="No log data"
+  >
+    If no data appears after you enable our log management capabilities, follow our [standard log troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="large-files"
+    title="Large Log Files"
+  >
+    For files above a certain size (~105 MB), the azure function invocation for forwarding our logs fails. This is due to an out of memory error caused by the fact that the Azure Functions Node.js Binding [does not support streaming](https://github.com/Azure/azure-functions-host/issues/1361). This is a known issue and cannot be mitigated except by reducing the size of the logs being uploaded.
+  </Collapser>
+</CollapserGroup>
 
 ## Security recommendations for your Azure resources [#azure-security-recommendations]
 

--- a/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
@@ -176,7 +176,7 @@ SELECT * FROM Log where plugin.type='azure'
 
 ## Troubleshooting [#troubleshoot]
 
-If you encounter problems with configuring your log forwarder, try these troubleshooting tips.
+If you encounter problems with configuring your log forwarder, try these troubleshooting tips:
 
 <CollapserGroup>
   <Collapser
@@ -192,7 +192,7 @@ If you encounter problems with configuring your log forwarder, try these trouble
     id="large-files"
     title="Large Log Files"
   >
-    For files above a certain size (~105 MB), the azure function invocation for forwarding our logs fails. This is due to an out of memory error caused by the fact that the Azure Functions Node.js Binding [does not support streaming](https://github.com/Azure/azure-functions-host/issues/1361). This is a known issue and cannot be mitigated except by reducing the size of the logs being uploaded.
+    The Azure function invocation for forwarding our logs fails for files above a certain size (~105 MB). This is due to an out of memory error caused by the fact that the Azure Functions Node.js Binding [doesn't support streaming](https://github.com/Azure/azure-functions-host/issues/1361). This is a known issue and can't be mitigated, except by reducing the size of the logs you upload.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
There is a size constraint on Azure Function uploads using the Node.js binding. This is a known issue on Azure's side. See here: https://github.com/Azure/azure-functions-host/issues/1361
This has caused a customer issue in the past and we're adding this section to make people aware of it.
