### PR TITLE
Add env var configs for ignored and expected status codes

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2321,7 +2321,7 @@ The `errorCollector` element supports the following elements and attributes:
     id="error-expectedStatusCodes"
     title="expectedStatusCodes"
   >
-    A comma separated list of status codes. The list may include integer ranges, using a single dash (-) and will be inclusive of both the starting and ending integer in the range.
+    A comma-separated list of status codes. The list may include integer ranges using a single dash (-), and will be inclusive of both the starting and ending integer in the range.
 
     This can also be configured via environment variable:
   

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2292,6 +2292,12 @@ The `errorCollector` element supports the following elements and attributes:
 
     Lists specific HTTP error codes to not report to New Relic. You can use standard integral HTTP error codes, such as just 401, or you may use Microsoft full status codes with decimal points, such as 401.4 or 403.18. The status codes should be equal to or greater than 400.
 
+    This can also be configured via environment variable, specifying multiple codes with a comma-separated list:
+  
+    ```ini
+    NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=<var>401, 403.18</var>
+    ```
+
     <Callout variant="tip">
       Custom errors reported with the agent's [`NoticeError()` API](/docs/agents/net-agent/net-agent-api/noticeerror-net-agent) are still reported to New Relic even if the associated transaction has an HTTP status code configured here.
     </Callout>
@@ -2316,6 +2322,12 @@ The `errorCollector` element supports the following elements and attributes:
     title="expectedStatusCodes"
   >
     A comma separated list of status codes. The list may include integer ranges, using a single dash (-) and will be inclusive of both the starting and ending integer in the range.
+
+    This can also be configured via environment variable:
+  
+    ```ini
+    NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES=<var>401, 501-503</var>
+    ```
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
This PR updates the .NET agent configuration to add environment variable configuration options for ignored and expected status codes.

This is associated with this PR in the .NET agent repo: https://github.com/newrelic/newrelic-dotnet-agent/pull/2487

This PR should not be merged until the feature is released with an upcoming agent release; the .NET agent team will change the title of this PR and change the status from Draft to Ready For Review when that happens.