### PR TITLE
Add Python 3.12 to python agent compatibility docs.

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -51,7 +51,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       </td>
 
       <td>
-        Python (CPython/PyPy) versions supported: 2.7, 3.7, 3.8, 3.9, 3.10, and 3.11.
+        Python (CPython/PyPy) versions supported: 2.7, 3.7, 3.8, 3.9, 3.10, 3.11, and 3.12.
 
         <DoNotTranslate>**Recommendation:**</DoNotTranslate> Use Python version 3.7 or higher with our agent.
 
@@ -107,7 +107,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       </td>
 
       <td>
-        Web hosting mechanisms compliant with WSGI 1.0 (PEP 333). 
+        Web hosting mechanisms compliant with WSGI 1.0 (PEP 333).
         We support these hosting services:
         * [Google App Engine flexible environment](/docs/agents/python-agent/hosting-services/install-new-relic-python-agent-gae-flexible-environment).
         * [Heroku](/docs/apm/agents/python-agent/hosting-services/python-agent-heroku/)


### PR DESCRIPTION
The PR updates the Python Agent compatibility docs to include support for Python 3.12.