### PR TITLE
docs: Simplify .NET agent  install steps for YUM.

### DIFF
--- a/src/install/dotnet/installation/linuxInstall2.mdx
+++ b/src/install/dotnet/installation/linuxInstall2.mdx
@@ -59,28 +59,15 @@ To start installing the agent, choose your package manager:
   New Relic does not currently offer Linux RPM packages for ARM64. Instead, [leverage the tarball to install](#tarball) on these platforms.
 </Callout>
 
-1. Add New Relic's signing key to your system:
+1. Configure the New Relic YUM repository:
+
   ```bash
-  sudo wget https://download.newrelic.com/548C16BF.gpg -O /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
-  sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
+  sudo curl -o /etc/yum.repos.d/newrelic-dotnet-agent.repo https://download.newrelic.com/dot_net_agent/yum/newrelic-dotnet-agent.repo
   ```
-
-2. Configure the New Relic YUM repository:
-
-  ```bash
-  cat << REPO | sudo tee "/etc/yum.repos.d/newrelic-dotnet-agent.repo"
-  [newrelic-dotnet-agent-repo]
-  name=New Relic .NET Core packages for Enterprise Linux
-  baseurl=https://yum.newrelic.com/pub/newrelic/el7/\$basearch
-  enabled=1
-  gpgcheck=1
-  gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
-  REPO
-  ```
-3. Install the agent:
+2. Install the agent:
 
   ```bash
-  sudo yum install newrelic-dotnet-agent
+  sudo yum install newrelic-dotnet-agent -y
   ```
     </TabsPageItem>
     <TabsPageItem id="rpm">


### PR DESCRIPTION
Minor change to the install steps for the .NET agent when using the YUM package manager. This change removes some unnecessarily manual tasks, replacing them with a single command that the user can run.