### PR TITLE
chore: add language identifiers, minor fixes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -442,8 +442,7 @@ module.exports = {
             'md',
             'java',
             'razor',
-            'hcl',
-            'profile'
+            'hcl'
           ],
         },
         newrelic: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -442,8 +442,8 @@ module.exports = {
             'md',
             'java',
             'razor',
-            'hcl'
-          ],
+            'hcl',
+            'profile'          ],
         },
         newrelic: {
           config: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -443,7 +443,8 @@ module.exports = {
             'java',
             'razor',
             'hcl',
-            'profile'          ],
+            'profile'
+          ],
         },
         newrelic: {
           config: {

--- a/src/content/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/get-started/integrations-managed-policies.mdx
@@ -46,7 +46,8 @@ A user different than `root` can be used in the managed policy.
     id="cloud-formation-template"
     title="CloudFormation template"
   >
-    ```
+
+    ```yml
     AWSTemplateFormatVersion: 2010-09-09
     Outputs:
       NewRelicRoleArn:

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
@@ -57,7 +57,7 @@ These procedures appear in our guided install. Keep in mind that even if you're 
       id="project-level"
       title="Project level `build.gradle` file:"
     >
-      In this example, `<AGENT_VERSION>` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+      In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
       ```groovy
       buildscript {
@@ -66,7 +66,7 @@ These procedures appear in our guided install. Keep in mind that even if you're 
         }
 
         dependencies {
-          classpath "com.newrelic.agent.android:agent-gradle-plugin:<AGENT_VERSION>"
+          classpath "com.newrelic.agent.android:agent-gradle-plugin:AGENT_VERSION"
         }
       }
       ```
@@ -76,7 +76,7 @@ These procedures appear in our guided install. Keep in mind that even if you're 
       id="app-level"
       title="App level `build.gradle` file:"
     >
-      In this example, `<AGENT_VERSION>` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+      In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
       ```groovy
       repositories {
@@ -87,7 +87,7 @@ These procedures appear in our guided install. Keep in mind that even if you're 
       apply plugin: 'newrelic'
 
       dependencies {
-        implementation 'com.newrelic.agent.android:android-agent:<AGENT_VERSION>'
+        implementation 'com.newrelic.agent.android:android-agent:AGENT_VERSION'
       }
       ```
     </Collapser>
@@ -102,7 +102,7 @@ These procedures appear in our guided install. Keep in mind that even if you're 
 
 3. Start the Android agent. In your default Activity found in your manifest, import the `NewRelic` class:
 
-  ```
+  ```java
   import com.newrelic.agent.android.NewRelic;
   ```
 
@@ -111,13 +111,13 @@ These procedures appear in our guided install. Keep in mind that even if you're 
 4. After you've imported the `NewRelic` class, you need to add an additional snippet to the `onCreate()` method, which includes your app token, which is generated in the guided install. The snippet looks like this:
 
   ```java
-  NewRelic.withApplicationToken("<GENERATED_TOKEN>").start(this.getApplicationContext());
+  NewRelic.withApplicationToken("GENERATED_TOKEN").start(this.getApplicationContext());
   ```
 
-5. If you're using minification (for example, like with ProGuard or Dexguard), you need to add `newrelic.properties` file to your app-level directory (projectname/app). This step only applies to ProGuard and DexGuard users. 
+5. If you're using minification (for example, like with ProGuard or Dexguard), you need to add `newrelic.properties` file to your app-level directory (_projectname/app_). This step only applies to ProGuard and DexGuard users. 
 
-  ```
-  com.newrelic.application_token=<GENERATED_TOKEN>
+  ```ini
+  com.newrelic.application_token=GENERATED_TOKEN
   ```
 
   To finish set up for minification, follow the steps in [configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps).
@@ -132,7 +132,7 @@ Because the Android agent isn't yet available as a community plugin, you need to
 
 1. Add this snippet to your `settings.gradle(.kts)` file through `pluginManagement {}` block:
 
-    ```
+    ```groovy
     pluginManagement {
       repositories {
         mavenCentral()  // adds repo for NewRelic artifacts
@@ -149,31 +149,31 @@ Because the Android agent isn't yet available as a community plugin, you need to
     
       // for core Gradle plugins or plugins already available to the build script
       plugins {
-        id("newrelic") version "${<AGENT_VERSION>}"
+        id("newrelic") version "${AGENT_VERSION}"
       }
     }
     ```
 
 2. Declare the New Relic plugin:
 
-    ```
+    ```groovy
     plugins {
       // for binary Gradle plugins that need to be resolved
-      id("newrelic") version "<AGENT_VERSION>" apply false
+      id("newrelic") version "AGENT_VERSION" apply false
     }
     ```
 
 3. Apply the plugin to the app-level build files:
 
-    ```
+    ```groovy
     plugins {
-        id("com.android.application")
-        id("org.jetbrains.kotlin.android")
-        id("newrelic")
+      id("com.android.application")
+      id("org.jetbrains.kotlin.android")
+      id("newrelic")
     }
     ```
 
-In the above snippets, `<AGENT_VERSION>` represents your agent version number. We strongly recommend you use the latest agent for set up. 
+In the above snippets, `AGENT_VERSION` represents your agent version number. We strongly recommend you use the latest agent for set up. 
 
 ## Android 4.x: Multidex support [#4x-multidex]
 
@@ -189,7 +189,7 @@ If you see the `java.lang.NoClassDefFoundError` error, then you must [manually s
 
 1. Create a `proguard.multidex.config` file within the `/app` folder of your project. Update `mypackage` to reflect your package name.
 
-    ```
+    ```profile
     ####################
     # keep class names #
     ####################
@@ -201,12 +201,12 @@ If you see the `java.lang.NoClassDefFoundError` error, then you must [manually s
 
 2. Merge the following code into the app-level `build.gradle` file:
 
-    ```
+    ```groovy
     android {
-        defaultConfig{
-            …
-            multiDexKeepProguard file("proguard.multidex.config")
-        }
+      defaultConfig{
+        …
+        multiDexKeepProguard file("proguard.multidex.config")
+      }
     }
     ```
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-unity/monitor-your-unity-application.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-unity/monitor-your-unity-application.mdx
@@ -117,16 +117,18 @@ To enable New Relic to authenticate your Unity app's data, follow these steps:
 
 To configure your Android app you need to customize your Gradle templates. If you're using Unity 2019 or later, complete the following steps:
 
-1. Include the New Relic Maven repository URL in the Gradle build settings. To do this, open your `mainTemplate.gradle` file. This file is usually located in the `Assets/Plugins/Android folder`. Now, open the New Relic Maven URL like this:
+1. Include the New Relic Maven repository URL in the Gradle build settings. To do this, open your `mainTemplate.gradle` file. This file is usually located in the `Assets/Plugins/Android` folder. Now, open the New Relic Maven URL like this:
 
     ```groovy
     allprojects {
-    buildscript {
-        repositories {<DoNotTranslate>**ARTIFACTORYREPOSITORY**</DoNotTranslate>
-            google()
-            jcenter()
-            mavenCentral()
+      buildscript {
+        repositories {
+          ARTIFACTORY_REPOSITORY
+          google()
+          jcenter()
+          mavenCentral()
         }
+      }
     }
     ```
 
@@ -134,13 +136,17 @@ To configure your Android app you need to customize your Gradle templates. If yo
 
     ```groovy
     dependencies {
-        // If you are changing the Android Gradle Plugin version, make sure it is compatible with the Gradle version preinstalled with Unity.
-        // See which Gradle version is preinstalled with Unity here: https://docs.unity3d.com/Manual/android-gradle-overview.html
-        // See the official Gradle and Android Gradle Plugin compatibility table here: https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
-        // To specify a custom Gradle version in Unity, go to "Preferences > External Tools", uncheck "Gradle Installed with Unity (recommended)", and specify a path to a custom Gradle version.
-        classpath 'com.newrelic.agent.android:agent-gradle-plugin:7.2.0'
-        <DoNotTranslate>**BUILD_SCRIPT_DEPS**</DoNotTranslate>
-        }
+      // If you are changing the Android Gradle Plugin version, 
+      // make sure it is compatible with the Gradle version preinstalled with Unity.
+      // See which Gradle version is preinstalled with Unity here:
+      //    https://docs.unity3d.com/Manual/android-gradle-overview.html
+      // See the official Gradle and Android Gradle Plugin compatibility table here: 
+      //    https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+      // To specify a custom Gradle version in Unity, go to "Preferences > External Tools", 
+      // uncheck "Gradle Installed with Unity (recommended)", 
+      // and specify a path to a custom Gradle version.
+      classpath 'com.newrelic.agent.android:agent-gradle-plugin:7.2.0'
+      BUILD_SCRIPT_DEPS
     }
     ```
 
@@ -148,12 +154,17 @@ To configure your Android app you need to customize your Gradle templates. If yo
 
     ```groovy
     dependencies {
-        // If you are changing the Android Gradle Plugin version, make sure it is compatible with the Gradle version preinstalled with Unity.
-        // See which Gradle version is preinstalled with Unity here: https://docs.unity3d.com/Manual/android-gradle-overview.html
-        // See official Gradle and Android Gradle Plugin compatibility table here: https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
-        // To specify a custom Gradle version in Unity, go to "Preferences > External Tools", uncheck "Gradle Installed with Unity (recommended)", and specify a path to a custom Gradle version.
-        classpath 'com.newrelic.agent.android:agent-gradle-plugin:6.11.0'
-        <DoNotTranslate>**BUILD_SCRIPT_DEPS**</DoNotTranslate>
+      // If you are changing the Android Gradle Plugin version, 
+      // make sure it is compatible with the Gradle version preinstalled with Unity.
+      // See which Gradle version is preinstalled with Unity here:
+      //    https://docs.unity3d.com/Manual/android-gradle-overview.html
+      // See official Gradle and Android Gradle Plugin compatibility table here: 
+      //    https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+      // To specify a custom Gradle version in Unity, go to "Preferences > External Tools", 
+      // uncheck "Gradle Installed with Unity (recommended)", 
+      // and specify a path to a custom Gradle version.
+      classpath 'com.newrelic.agent.android:agent-gradle-plugin:6.11.0'
+      BUILD_SCRIPT_DEPS
     }
     ```
 
@@ -348,7 +359,7 @@ SELECT * FROM MobileHandledException SINCE 24 hours ago
 New Relic stores your Unity logs as custom events. You can query these logs and build dashboards for them using this NRQL query:
 
 ```sql
- SELECT * FROM `Mobile Unity Logs` SINCE 30 MINUTES AGO
+SELECT * FROM `Mobile Unity Logs` SINCE 30 MINUTES AGO
 ```
 
 For more information on NRQL queries, see [Introduction to NRQL](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language/#where).

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-metrics.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-metrics.mdx
@@ -57,15 +57,15 @@ NewRelic.setUserId(string $userId)
 
 ```kotlin
 NewRelic.recordMetric(
-            name: String,
-            category: String,
-            count: Int,
-            totalValue: Double,
-            exclusiveValue: Double,
-            countUnit: MetricUnit,
-            valueUnit: MetricUnit
-        )
-   NewRelic.recordMetric(name: String?, category: String?, value: Double = 1.0)
+        name: String,
+        category: String,
+        count: Int,
+        totalValue: Double,
+        exclusiveValue: Double,
+        countUnit: MetricUnit,
+        valueUnit: MetricUnit
+    )
+NewRelic.recordMetric(name: String?, category: String?, value: Double = 1.0)
 ```
 
 ## Description [#description]
@@ -76,7 +76,7 @@ To get the most out of your metrics, follow these guidelines to create clear, co
 
 * Use case and whitespace characters appropriate for display in the user interface. Metric names are rendered as-is.
 * Capitalize the metric name.
-* Avoid using the characters `/ ] [ | *` when naming metrics.
+* Avoid using the characters `/` `]` `[` `|` `*` when naming metrics.
 * Avoid multi-byte characters.
 
 The `category` is also required; it is displayed in the UI and is useful for organizing custom metrics if you have many of them. It can be a custom category or it can be a predefined category using the [`MetricCategory` enum](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/work-android-sdk-api#cat).
@@ -228,8 +228,8 @@ NewRelic.recordMetric("Login Auth Metric", "Network", 1.0);
 ### Kotlin [#kotlin]
 
 ```kotlin
-    NewRelic.recordMetric("Custom Metric Name","MyCategory", 1.0)
-    NewRelic.recordMetric("Login Auth Metric", "Network", 1.0)
+NewRelic.recordMetric("Custom Metric Name","MyCategory", 1.0)
+NewRelic.recordMetric("Login Auth Metric", "Network", 1.0)
 ```
 
 Here's an example of creating a custom metric for agent start:
@@ -271,7 +271,7 @@ NewRelic.recordMetric("Agent start", "Lifecycle", 5, 10.11, 1.23, MetricUnit.OPE
 ### Kotlin [#kotlin]
 
 ```kotlin
-    NewRelic.recordMetric("Agent start", "Lifecycle", 5, 10.11, 1.23, MetricUnit.OPERATIONS, MetricUnit.SECONDS)
+NewRelic.recordMetric("Agent start", "Lifecycle", 5, 10.11, 1.23, MetricUnit.OPERATIONS, MetricUnit.SECONDS)
 ```
 
         </TabsPageItem>
@@ -282,7 +282,7 @@ NewRelic.recordMetric("Agent start", "Lifecycle", 5, 10.11, 1.23, MetricUnit.OPE
 ### Objective-c [#objc]
 
 ```objectivec
-NewRelic recordMetricWithName:(NSString *)name  category:(NSString *)category  value:(NSNumber *)value];
+[NewRelic recordMetricWithName:(NSString *)name  category:(NSString *)category  value:(NSNumber *)value];
 ```
 
 ### Swift [#swift]
@@ -301,7 +301,7 @@ To get the most out of your metrics, follow these guidelines to create clear, co
 
 * Use case and whitespace characters appropriate for display in the user interface. Metric names are rendered as-is.
 * Capitalize the metric name.
-* Avoid using the characters `/ ] [ | *` when naming metrics.
+* Avoid using the characters `/` `]` `[` `|` `*` when naming metrics.
 * Avoid multi-byte characters.
 
 The `category` is also required; it is displayed in the UI and is useful for organizing custom metrics if you have many of them. It can be a custom category or it can be a predefined category using the `MetricCategory` enum.
@@ -504,22 +504,22 @@ Supported measurements for `countUnit` and `valueUnit` are:
 ## Example [#example]
 
 ```typescript
-    NewRelicCapacitorPlugin.recordMetric({
-      name: "CapacitorMetricName",
-      category: "CapacitorMetricCategory",
-    });
-    NewRelicCapacitorPlugin.recordMetric({
-      name: "CapacitorMetricName2",
-      category: "CapacitorMetricCategory2",
-      value: 25,
-    });
-    NewRelicCapacitorPlugin.recordMetric({
-      name: "CapacitorMetricName3",
-      category: "CapacitorMetricCategory3",
-      value: 30,
-      countUnit: NREnums.MetricUnit.SECONDS,
-      valueUnit: NREnums.MetricUnit.OPERATIONS,
-    });
+NewRelicCapacitorPlugin.recordMetric({
+  name: "CapacitorMetricName",
+  category: "CapacitorMetricCategory",
+});
+NewRelicCapacitorPlugin.recordMetric({
+  name: "CapacitorMetricName2",
+  category: "CapacitorMetricCategory2",
+  value: 25,
+});
+NewRelicCapacitorPlugin.recordMetric({
+  name: "CapacitorMetricName3",
+  category: "CapacitorMetricCategory3",
+  value: 30,
+  countUnit: NREnums.MetricUnit.SECONDS,
+  valueUnit: NREnums.MetricUnit.OPERATIONS,
+});
 ```
 
         </TabsPageItem>
@@ -635,11 +635,11 @@ Supported measurements for `countUnit` and `valueUnit` are:
 
 ## Example [#example]
 
-  ```js
-    NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory');
-    NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory', 12);
-    NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory', 13, 'PERCENT', 'SECONDS');
-  ```
+```js
+NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory');
+NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory', 12);
+NewRelic.recordMetric('CordovaCustomMetricName', 'CordovaCustomMetricCategory', 13, 'PERCENT', 'SECONDS');
+```
 
         </TabsPageItem>
 
@@ -756,9 +756,9 @@ Supported measurements for `countUnit` and `valueUnit` are:
 </table>
 ## Example [#example]
 
-``` C#
-    CrossNewRelic.Current.RecordMetric("Agent start", "Lifecycle");
-    CrossNewRelic.Current.RecordMetric("Login Auth Metric", "Network", 78.9);
+```csharp
+CrossNewRelic.Current.RecordMetric("Agent start", "Lifecycle");
+CrossNewRelic.Current.RecordMetric("Login Auth Metric", "Network", 78.9);
 ```
         </TabsPageItem>
         <TabsPageItem id="flutter">
@@ -873,10 +873,10 @@ Supported measurements for `countUnit` and `valueUnit` are:
 
 ## Example [#example]
 
-  ```dart
+```dart
 NewrelicMobile.instance.recordMetric("testMetric", "Test Champ",value: 12.0);
-       NewrelicMobile.instance.recordMetric("testMetric1", "TestChamp12",value: 10,valueUnit: MetricUnit.BYTES,countUnit: MetricUnit.PERCENT);
-  ```
+NewrelicMobile.instance.recordMetric("testMetric1", "TestChamp12",value: 10,valueUnit: MetricUnit.BYTES,countUnit: MetricUnit.PERCENT);
+```
 
                     </TabsPageItem>
         <TabsPageItem id="react">
@@ -991,11 +991,11 @@ Supported measurements for `countUnit` and `valueUnit` are:
 
 ## Example [#example]
 
- ```js
-    NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory');
-    NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 12);
-    NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 13, NewRelic.MetricUnit.PERCENT, NewRelic.MetricUnit.SECONDS);
-  ```
+```js
+NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory');
+NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 12);
+NewRelic.recordMetric('RNCustomMetricName', 'RNCustomMetricCategory', 13, NewRelic.MetricUnit.PERCENT, NewRelic.MetricUnit.SECONDS);
+```
 
         </TabsPageItem>
   <TabsPageItem id="unity">
@@ -1113,10 +1113,10 @@ Supported measurements for `countUnit` and `valueUnit` are:
 
 ## Example [#example]
 
-``` csharp
-        NewRelicAgent.RecordMetricWithName('UnityCustomMetricName', 'UnityCustomMetricCategory');
-        NewRelicAgent.RecordMetricWithName('UnityCustomMetricName', 'UnityCustomMetricCategory', 12);
-        NewRelicAgent.RecordMetricWithName('UnityCustomMetricName', 'UnityCustomMetricCategory', 13, NewRelicAgent.MetricUnit.PERCENT, NewRelicAgent.MetricUnit.SECONDS);
+```csharp
+NewRelicAgent.RecordMetricWithName('UnityCustomMetricName', 'UnityCustomMetricCategory');
+NewRelicAgent.RecordMetricWithName('UnityCustomMetricName', 'UnityCustomMetricCategory', 12);
+NewRelicAgent.RecordMetricWithName('UnityCustomMetricName', 'UnityCustomMetricCategory', 13, NewRelicAgent.MetricUnit.PERCENT, NewRelicAgent.MetricUnit.SECONDS);
 ```
 
         </TabsPageItem>
@@ -1235,10 +1235,10 @@ Supported measurements for `countUnit` and `valueUnit` are:
 
 ## Example [#example]
 
-``` csharp
-    CrossNewRelicClient.Current.RecordMetric("Agent start", "Lifecycle");
-    CrossNewRelicClient.Current.RecordMetric("Login Auth Metric", "Network", 78.9);
-    CrossNewRelicClient.Current.RecordMetric("Request Metric", "Network", 20, MetricUnit.SECONDS, MetricUnit.OPERATIONS);
+```csharp
+CrossNewRelicClient.Current.RecordMetric("Agent start", "Lifecycle");
+CrossNewRelicClient.Current.RecordMetric("Login Auth Metric", "Network", 78.9);
+CrossNewRelicClient.Current.RecordMetric("Request Metric", "Network", 20, MetricUnit.SECONDS, MetricUnit.OPERATIONS);
 ```
 
         </TabsPageItem>

--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/micrometer/micrometer-metrics-registry.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/micrometer/micrometer-metrics-registry.mdx
@@ -39,7 +39,7 @@ These are generalized steps to set up Micrometer metrics forwarding. You may wan
 
 Add OpenTelemetry Micrometer instrumentation to the alpha modules section of your `build.gradle` file:
 
-    ```java
+    ```groovy
     //Alpha modules
     implementation 'io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5'
     ```
@@ -51,37 +51,36 @@ Add OpenTelemetry Micrometer instrumentation to the alpha modules section of you
         
 In the `dependencies` section, add the OpenTelemetry SDK and OTLP exporter:
 
-    ```java
+    ```groovy
     dependencies {
-        implementation 'io.opentelemetry:opentelemetry-sdk'
-        implementation 'io.opentelemetry:opentelemetry-exporters-otlp'
+      implementation 'io.opentelemetry:opentelemetry-sdk'
+      implementation 'io.opentelemetry:opentelemetry-exporters-otlp'
     }
     ```
     
-
-An example file with alpha modules and dependencies added might look something like this:
-
-```java
-plugins {
-    id 'java-library'
-    id 'org.springframework.boot'
-}
-
-bootRun {
-    mainClass.set 'io.opentelemetry.example.micrometer.Application'
-}
-
-dependencies {
-    implementation platform("io.opentelemetry:opentelemetry-bom-alpha:<JAVA_OTEL_VERSION>")
-    implementation 'io.opentelemetry:opentelemetry-sdk'
-    implementation 'io.opentelemetry:opentelemetry-exporters-otlp'
-
-    implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:<OTEL_JAVA_)INSTRUMENTATION_VERSION>")
-    implementation 'io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5'
-}
-```
-
-Keep in mind you will need to update the snippet with correct versioning. 
+    An example file with alpha modules and dependencies added might look something like this:
+    
+    ```groovy
+    plugins {
+      id 'java-library'
+      id 'org.springframework.boot'
+    }
+    
+    bootRun {
+      mainClass.set 'io.opentelemetry.example.micrometer.Application'
+    }
+    
+    dependencies {
+      implementation platform("io.opentelemetry:opentelemetry-bom-alpha:JAVA_OTEL_VERSION")
+      implementation 'io.opentelemetry:opentelemetry-sdk'
+      implementation 'io.opentelemetry:opentelemetry-exporters-otlp'
+  
+      implementation platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:OTEL_JAVA_INSTRUMENTATION_VERSION")
+      implementation 'io.opentelemetry.instrumentation:opentelemetry-micrometer-1.5'
+    }
+    ```
+    
+    Keep in mind you will need to update the snippet with correct versioning. 
 
     </Step>
     <Step>
@@ -94,50 +93,52 @@ This snippet updates your code so OpenTelemetry can detect Micrometer data, then
 
 ```java
 public OpenTelemetry openTelemetry() {
-    return OpenTelemetrySdk.builder()
-        .setMeterProvider(
-            SdkMeterProvider.builder()
-                .setResource(
-                    Resource.getDefault().toBuilder()
-                        .put("service.name", "micrometer-shim")
-                        // Include instrumentation.provider=micrometer to enable micrometer metrics
-                        // experience in New Relic
-                        .put("instrumentation.provider", "micrometer")
-                        .build())
-                .registerMetricReader(
-                    PeriodicMetricReader.builder(
-                            OtlpHttpMetricExporter.builder()
-                                .setEndpoint("https://otlp.nr-data.net")
-                                .addHeader(
-                                    "api-key",
-                                    Optional.ofNullable(System.getenv("NEW_RELIC_LICENSE_KEY"))
-                                        .filter(str -> !str.isEmpty() && !str.isBlank())
-                                        .orElseThrow())
-                                // IMPORTANT: New Relic exports data using delta temporality 
-                                // rather than cumulative temporality
-                                .setAggregationTemporalitySelector(
-                                    AggregationTemporalitySelector.deltaPreferred())
-                                // Use exponential histogram aggregation for histogram instruments
-                                // to
-                                // produce better data and compression
-                                .setDefaultAggregationSelector(
-                                    DefaultAggregationSelector.getDefault()
-                                        .with(
-                                            InstrumentType.HISTOGRAM,
-                                            Aggregation.base2ExponentialBucketHistogram()))
-                                .build())
-                        // Match default micrometer collection interval of 60 seconds
-                        .setInterval(Duration.ofSeconds(60))
-                        .build())
-                .build())
-        .build();
-    }
+  return OpenTelemetrySdk.builder()
+    .setMeterProvider(
+      SdkMeterProvider.builder()
+        .setResource(
+          Resource.getDefault()
+            .toBuilder()
+            .put("service.name", "micrometer-shim")
+            // Include instrumentation.provider=micrometer to enable
+            // micrometer metrics experience in New Relic
+            .put("instrumentation.provider", "micrometer")
+            .build())
+        .registerMetricReader(
+          PeriodicMetricReader.builder(
+            OtlpHttpMetricExporter.builder()
+              .setEndpoint("https://otlp.nr-data.net")
+              .addHeader("api-key",
+                Optional
+                  .ofNullable(System.getenv("NEW_RELIC_LICENSE_KEY"))
+                  .filter(str -> !str.isEmpty() && !str.isBlank())
+                  .orElseThrow())
+              // IMPORTANT: New Relic exports data using delta
+              // temporality rather than cumulative temporality
+              .setAggregationTemporalitySelector(
+                AggregationTemporalitySelector
+                  .deltaPreferred())
+              // Use exponential histogram aggregation for
+              // histogram instruments to produce better data
+              // and compression
+              .setDefaultAggregationSelector(
+                DefaultAggregationSelector.getDefault().with(
+                  InstrumentType.HISTOGRAM,
+                  Aggregation.base2ExponentialBucketHistogram()))
+              .build())
+          // Match default micrometer collection interval of 60
+          // seconds
+          .setInterval(Duration.ofSeconds(60))
+          .build())
+        .build())
+    .build();
+}
 ```
     
         
     </Step>
 
-        <Step>
+    <Step>
 
 ### Find your data in New Relic 
 


### PR DESCRIPTION
Groovy (`.gradle` files) is similar to Java, has has some differences, so updated the language

Java in other docs tends to use 2 space indentation. 

These docs used both `<NEW_RELIC_LICENSE_KEY>` and `NEW_RELIC_LICENSE_KEY` style for the placeholders , so I removed the `<>`to make them more consistent

also added the `profile` identifier for prism for `.pro` files 

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.