### PR TITLE
Docs: Added tip about monitoring multiple SNMP trap versions on one host

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -495,7 +495,9 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
 
 In some circumstances, it's beneficial to isolate the collection of SNMP trap messages into a dedicated container. This is helpful to control scale in large environments as well as creating a distributed monitoring footprint with lower risk of full outages if a container fails. This process is not supported with the Linux service installation.
 
-Note: You cannot monitor both `v2c` and `v3` traps with the same container. If you want to monitor both trap versions, you will need to launch a secondary dedicated container and configure your trap messages to be sent on a non-default port. For example, if you have `v2c` traps already set up on port `162` you would need to configure your `v3` traps to be sent over another port such as `163`. Once complete you will need to change the Docker container's arguments slightly, from `-p 162:1620/udp` to `-p $src:1620/udp` where `$src` is the port your `v3` traps are arriving on.
+Note: You cannot monitor both `v2c` and `v3` traps with the same container. If you want to monitor both trap versions, you'll need to launch a secondary dedicated container and configure your trap messages to be sent on a non-default port. For example, if you have `v2c` traps already set up on port `162`:
+1. Configure your `v3` traps to be sent over another port such as `163`. 
+2. Change the Docker container's arguments slightly, from `-p 162:1620/udp` to `-p $src:1620/udp` where `$src` is the port your `v3` traps are arriving on.
 
 <Collapser id="trap-container-setup" title="Manual container setup for SNMP traps">
 

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -495,6 +495,8 @@ Our network monitoring container supports all major versions of SNMP (v1, v2c, a
 
 In some circumstances, it's beneficial to isolate the collection of SNMP trap messages into a dedicated container. This is helpful to control scale in large environments as well as creating a distributed monitoring footprint with lower risk of full outages if a container fails. This process is not supported with the Linux service installation.
 
+Note: You cannot monitor both `v2c` and `v3` traps with the same container. If you want to monitor both trap versions, you will need to launch a secondary dedicated container and configure your trap messages to be sent on a non-default port. For example, if you have `v2c` traps already set up on port `162` you would need to configure your `v3` traps to be sent over another port such as `163`. Once complete you will need to change the Docker container's arguments slightly, from `-p 162:1620/udp` to `-p $src:1620/udp` where `$src` is the port your `v3` traps are arriving on.
+
 <Collapser id="trap-container-setup" title="Manual container setup for SNMP traps">
 
     <Tabs>


### PR DESCRIPTION
Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Documentation updated to include information on running multiple trap containers on the same host.