### PR TITLE
Frontmatter style guide fixes

### DIFF
--- a/src/content/docs/style-guide/formatting/hyperlinks.mdx
+++ b/src/content/docs/style-guide/formatting/hyperlinks.mdx
@@ -1,9 +1,5 @@
 ---
 title: Link guidelines
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/nronly/hyperlinks
   - /docs/new-relic-only/style-guide/writing-guidelines/hyperlinks

--- a/src/content/docs/style-guide/formatting/hyperlinks.mdx
+++ b/src/content/docs/style-guide/formatting/hyperlinks.mdx
@@ -1,6 +1,5 @@
 ---
 title: Link guidelines
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/images/image-annotations.mdx
+++ b/src/content/docs/style-guide/images/image-annotations.mdx
@@ -1,6 +1,5 @@
 ---
 title: Best practices for using image annotations
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/images/image-annotations.mdx
+++ b/src/content/docs/style-guide/images/image-annotations.mdx
@@ -1,9 +1,5 @@
 ---
 title: Best practices for using image annotations
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 ---
 
 

--- a/src/content/docs/style-guide/images/screenshots-images.mdx
+++ b/src/content/docs/style-guide/images/screenshots-images.mdx
@@ -1,9 +1,5 @@
 ---
 title: Screenshots and images
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/style-guide/writing-guidelines/screenshots-images
 ---

--- a/src/content/docs/style-guide/images/screenshots-images.mdx
+++ b/src/content/docs/style-guide/images/screenshots-images.mdx
@@ -1,6 +1,5 @@
 ---
 title: Screenshots and images
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/structure/levels-headings.mdx
+++ b/src/content/docs/style-guide/structure/levels-headings.mdx
@@ -1,6 +1,5 @@
 ---
 title: Levels of headings
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/structure/levels-headings.mdx
+++ b/src/content/docs/style-guide/structure/levels-headings.mdx
@@ -1,9 +1,5 @@
 ---
 title: Levels of headings
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/nronly/levels-of-headings
   - /docs/new-relic-only/style-guide/writing-guidelines/levels-headings

--- a/src/content/docs/style-guide/word-choice/nerdgraph-doc-guidelines.mdx
+++ b/src/content/docs/style-guide/word-choice/nerdgraph-doc-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 title: How to write NerdGraph docs
-contentType: page
 template: basicDoc
 ---
 

--- a/src/content/docs/style-guide/word-choice/nerdgraph-doc-guidelines.mdx
+++ b/src/content/docs/style-guide/word-choice/nerdgraph-doc-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 title: How to write NerdGraph docs
-template: basicDoc
 ---
 
 This resource contains style guide recommendations and guidelines for writing about New Relic's NerdGraph API.

--- a/src/content/docs/style-guide/word-choice/pricing-language-guidelines.mdx
+++ b/src/content/docs/style-guide/word-choice/pricing-language-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Pricing/billing-related guidelines'
-contentType: page
 template: basicDoc
 redirects: 
     - /docs/style-guide/writing-guidelines/pricing-language-guidelines

--- a/src/content/docs/style-guide/word-choice/pricing-language-guidelines.mdx
+++ b/src/content/docs/style-guide/word-choice/pricing-language-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Pricing/billing-related guidelines'
-template: basicDoc
 redirects: 
     - /docs/style-guide/writing-guidelines/pricing-language-guidelines
 ---

--- a/src/content/docs/style-guide/word-choice/user-related-language-guidelines.mdx
+++ b/src/content/docs/style-guide/word-choice/user-related-language-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Users/roles-related language guidelines'
-contentType: page
 template: basicDoc
 redirects:
       - /docs/style-guide/writing-guidelines/user-related-language-guidelines

--- a/src/content/docs/style-guide/word-choice/user-related-language-guidelines.mdx
+++ b/src/content/docs/style-guide/word-choice/user-related-language-guidelines.mdx
@@ -1,6 +1,5 @@
 ---
 title: 'Users/roles-related language guidelines'
-template: basicDoc
 redirects:
       - /docs/style-guide/writing-guidelines/user-related-language-guidelines
 ---

--- a/src/content/docs/style-guide/writing-docs/article-templates/agent-release-notes-template-123.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/agent-release-notes-template-123.mdx
@@ -3,7 +3,6 @@ subject: Agent release notes template
 releaseDate: '2021-01-31'
 version: 1.2.3
 downloadLink: 'https://example.com'
-type: releaseNote
 redirects:
   - /docs/new-relic-only/style-guide/miscellaneous/release-notes-template-123
   - /docs/new-relic-only/advanced-style-guide/article-templates/release-notes-template-123

--- a/src/content/docs/style-guide/writing-docs/article-templates/apistyleguidelines-example-agent-api.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/apistyleguidelines-example-agent-api.mdx
@@ -1,6 +1,5 @@
 ---
 title: Agent API method pages
-type: apiDoc
 shortDescription: 'Briefly describe the call. Ideally, one line or less.'
 tags:
   - Tech writer style guide

--- a/src/content/docs/style-guide/writing-docs/article-templates/prometheus-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/prometheus-template.mdx
@@ -1,10 +1,5 @@
 ---
 title: 'Prometheus integration template'
-topics:
-  - New Relic only
-  - Basic style guide
-  - Writing guidelines
-  - Prometheus writing guidelines
 ---
 
 **This document is a template for a Prometheus integration document**: Please skim the entire template first to understand the expected structure for this type of doc. Delete all content up to **Introduction (this heading won't be visible)**.

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Tech writer tasks for What's New posts"
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-tech-writer-tasks.mdx
@@ -1,9 +1,5 @@
 ---
 title: "Tech writer tasks for What's New posts"
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 ---
 
 Technical writers play an important role in the publication of "What's new" posts. While our contributors follow [Instructions to create What's New posts](/docs/style-guide/writing-docs/article-templates/whats-new-template/), you will take some additional steps to help contributors finalize their work.

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-template.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Instructions to create What's New posts"
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-docs/article-templates/whats-new-template.mdx
+++ b/src/content/docs/style-guide/writing-docs/article-templates/whats-new-template.mdx
@@ -1,9 +1,5 @@
 ---
 title: "Instructions to create What's New posts"
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/style-guide/writing-docs/article-templates/whats-new-style-guidelines
 ---

--- a/src/content/docs/style-guide/writing-docs/docs-translation.mdx
+++ b/src/content/docs/style-guide/writing-docs/docs-translation.mdx
@@ -1,9 +1,5 @@
 ---
 title: Docs translation
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - >-
     /docs/new-relic-only/drupal-configuration/page-components/manage-translated-docs

--- a/src/content/docs/style-guide/writing-docs/docs-translation.mdx
+++ b/src/content/docs/style-guide/writing-docs/docs-translation.mdx
@@ -1,6 +1,5 @@
 ---
 title: Docs translation
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-docs/docs-translation.mdx
+++ b/src/content/docs/style-guide/writing-docs/docs-translation.mdx
@@ -18,14 +18,16 @@ New Relic documentation exists on these sites:
 * [**docs.newrelic.com**](https://docs.newrelic.com): English
 * [**docs.newrelic.com/jp/**](https://docs.newrelic.com/jp/): Japanese
 * [**docs.newrelic.com/kr/**](https://docs.newrelic.com/kr/): Korean
+* [**docs.newrelic.com/es/**](https://docs.newrelic.com/es/): Spanish
+* [**docs.newrelic.com/pt/**](https://docs.newrelic.com/pt/): Portuguese
 
 You can toggle between languages with a button in the top menu bar.
 
 ## View translation status [#translation-status]
 
-Every doc's frontmatter includes its translation status.
+Every doc's frontmatter includes its human translation status.
 
-If there is no `translate:` element in the frontmatter, the doc has not been translated into any other languages.
+If there is no `translate:` element in the frontmatter, the doc is not human-translated into any languages. It will still be automatically translated into all our machine-translated languages.
 
 If the `translate:` element has a language abbreviation, such as `jp`, then the doc has been translated, will be translated, or is under consideration for translation. For example:
 

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-preview-document.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-preview-document.mdx
@@ -1,10 +1,5 @@
 ---
 title: Create content for the preview docs site
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
-redirects:
 ---
 
 The preview docs site hosts docs for upcoming features that we share with customers. Unlike the public docs site, the preview docs site isn't publicly editable and doesn't appear in search engine results. Users can't navigate from one preview doc to another, because the site isn't indexed.

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-preview-document.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-preview-document.mdx
@@ -1,6 +1,5 @@
 ---
 title: Create content for the preview docs site
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-release-notes.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-release-notes.mdx
@@ -1,9 +1,5 @@
 ---
 title: Create release notes
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/new-relic-only/basic-style-guide/writing-guidelines/create-release-notes
   - /docs/style-guide/article-templates/create-release-notes

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/create-release-notes.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/create-release-notes.mdx
@@ -1,6 +1,5 @@
 ---
 title: Create release notes
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
@@ -160,7 +160,7 @@ The docs site doesn't have strict page templates—since we have a "docs as code
       <td>
         This format includes unique frontmatter fields. Release notes live in `/src/content/docs/release-notes/`, and they are generally authored by product teams rather than writers.
         
-        Users rely on release notes to keep up with smaller changes in the product, particularly for downloadble software like the agents. For more, see [Create release notes](/docs/style-guide/article-templates/create-release-notes/).
+        Users rely on release notes to keep up with smaller changes in the product, particularly for downloadable software like the agents. For more, see [Create release notes](/docs/style-guide/article-templates/create-release-notes/).
       </td>
     </tr>
 

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
@@ -12,11 +12,9 @@ redirects:
   - /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats/
 ---
 
-Our docs site is made up of different content types and templates. Most of the time, the default page content type and the basic template will have everything you'll need.
+The docs site doesn't have strict page templates—since we have a "docs as code" approach, writers can use a variety of components to structure docs however they think best. However, we do have several unique types of content that behave differently than our standard `.mdx` docs. This style guide page describes the standard frontmatter for docs, and also outlines the various types of content we maintain on the site. 
 
-Read on for more information about our page types.
-
-## Docs meta content (frontmatter) [#meta-fields]
+## Docs frontmatter and metadata [#meta-fields]
 
 The top of every doc begins with a set of metadata. Read on for more information about this metadata content:
 
@@ -40,7 +38,7 @@ The top of every doc begins with a set of metadata. Read on for more information
       </td>
 
       <td>
-        Whenever possible, provide an action-oriented or task-oriented title; for example, "AJAX page: Identify time-consuming calls." In general, use sentence case. Capitalize only the first word. Do not capitalize any other word in the title unless it's a proper noun, such as a specific product name, or it follows a colon (:).
+        Whenever possible, provide an action-oriented or task-oriented title; for example, "AJAX page: Identify time-consuming calls." In general, use sentence case. Capitalize only the first word. Do not capitalize any other word in the title unless it's a proper noun, such as a specific product name, or it follows a colon `:`.
 
         If you're looking for ideas on how to choose a title, browse the titles of similar docs.
 
@@ -50,57 +48,43 @@ The top of every doc begins with a set of metadata. Read on for more information
 
     <tr>
       <td>
-        type
+        `tags`
       </td>
 
       <td>
-        For the **basicDoc** template, use **page** or omit `type`. If omitted, the default `type` is `page` and the `basicDoc` template is used.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        template
-      </td>
-
-      <td>
-        The template determines the basic layout and style of a page. Use **basicDoc** for more pages.
+        Deprecated. Historically, tags were used to help search engines and AI find the right content. Modern engines are sophisticated enough to infer that context without tags, so this tag is no longer needed. 
       </td>
     </tr>
 
     <tr>
       <td>
-        tags
+        `metaDescription`
       </td>
 
       <td>
-        Keywords related to your doc. Through some technical wizardry, they generate **Related resources** links in the right nav area.
-
-        Start each topic with a `-` on a new line.
-
-        A topic can include multiple words separated by spaces.
+        A short description of the doc. Search engines rely on this field to understand what a doc is about, and they'll often show the meta description right in the search results. Should be under 160 characters. For more info on why meta descriptions matter to search, see [Control your snippets in search results](https://developers.google.com/search/docs/appearance/snippet) in Google's documentation.
       </td>
     </tr>
 
     <tr>
       <td>
-        japaneseVersion
+        `redirects`
       </td>
 
       <td>
-        The URL to the Japanese language version of the doc. Leave this blank if there isn't a Japanese version.
+        Redirects **to** this doc from old URLs. One redirect per line. Use a relative path and don't include a trailing slash `/`. 
       </td>
     </tr>
 
-        <tr>
+    <tr>
       <td>
-        freshnessValidatedDate
+        `freshnessValidatedDate`
       </td>
 
       <td>
-        The default is `never`.
-
-        When you make a significant update to a doc, add today's date in this format: `YYYY-MM-DD`.
+        The last time a writer made significant updates to this doc and verified its accuracy. 
+        
+        The default is `never`. When you make a significant update to a doc, add today's date in this format: `YYYY-MM-DD`.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
@@ -16,7 +16,7 @@ This style guide page describes the standard frontmatter for docs, and also outl
 
 ## Docs frontmatter and metadata [#meta-fields]
 
-The top of every doc begins with a set of metadata. Read on for more information about this metadata content:
+The top of every doc begins with a set of metadata. Read on For more about this metadata content:
 
 <table>
   <thead>
@@ -34,10 +34,12 @@ The top of every doc begins with a set of metadata. Read on for more information
   <tbody>
     <tr>
       <td>
-        Title
+        `title`
       </td>
 
       <td>
+        The primay title of the doc, which will show up at the top of the doc as an `<h1>` HTML header, in the browser page title, and in search engine meta fields.
+        
         Whenever possible, provide an action-oriented or task-oriented title; for example, "AJAX page: Identify time-consuming calls." In general, use sentence case. Capitalize only the first word. Do not capitalize any other word in the title unless it's a proper noun, such as a specific product name, or it follows a colon `:`.
 
         If you're looking for ideas on how to choose a title, browse the titles of similar docs.
@@ -58,11 +60,21 @@ The top of every doc begins with a set of metadata. Read on for more information
 
     <tr>
       <td>
+        `translate`
+      </td>
+
+      <td>
+        Indicates which languages this page is human-translated into. This field doesn't govern machine translation; generally speaking, all "standard" docs on the site are machine-translated into all languages. For more, see [Docs translation](/docs/style-guide/writing-docs/docs-translation/).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         `metaDescription`
       </td>
 
       <td>
-        A short description of the doc. Search engines rely on this field to understand what a doc is about, and they'll often show the meta description right in the search results. Should be under 160 characters. For more info on why meta descriptions matter to search, see [Control your snippets in search results](https://developers.google.com/search/docs/appearance/snippet) in Google's documentation.
+        A short description of the doc. Search engines rely on this field to understand what a doc is about, and they'll often show the meta description right in the search results. Should be under 160 characters. For more on why meta descriptions matter to search, see [Control your snippets in search results](https://developers.google.com/search/docs/appearance/snippet) in Google's documentation.
       </td>
     </tr>
 
@@ -124,7 +136,7 @@ The docs site doesn't have strict page templates—since we have a "docs as code
       </td>
 
       <td>
-        This format is for defining attributes and event types. These definitions live in their own GitHub Enterprise repo, then they're published to the docs site and NerdGraph via the data dictionary service. For more information, see [Work with attribute definition content type](/docs/style-guide/article-templates/attribute-definition-template).
+        This format is for defining attributes and event types. These definitions live in their own GitHub Enterprise repo, then they're published to the docs site and NerdGraph via the data dictionary service. For more, see [Work with attribute definition content type](/docs/style-guide/article-templates/attribute-definition-template).
       </td>
     </tr>
 
@@ -136,7 +148,7 @@ The docs site doesn't have strict page templates—since we have a "docs as code
       <td>
         This format is for interactive installation docs. Branching install docs consist of multiple components in individual `.mdx` files that live together in a subdirectory, with the logic that defines which pieces to show when defined in a separate `.yaml` file. Branching install content lives in the `/src/install/` subdirectory. 
         
-        For more information, see [Get started with the branched install component](/docs/style-guide/writing-docs/article-templates/intro-branch-install-doc/). 
+        For more, see [Get started with the branched install component](/docs/style-guide/writing-docs/article-templates/intro-branch-install-doc/). 
       </td>
     </tr>
 
@@ -148,7 +160,7 @@ The docs site doesn't have strict page templates—since we have a "docs as code
       <td>
         This format includes unique frontmatter fields. Release notes live in `/src/content/docs/release-notes/`, and they are generally authored by product teams rather than writers.
         
-        Users rely on release notes to keep up with smaller changes in the product, particularly for downloadble software like the agents. For more information, see [Create release notes](/docs/style-guide/article-templates/create-release-notes/).
+        Users rely on release notes to keep up with smaller changes in the product, particularly for downloadble software like the agents. For more, see [Create release notes](/docs/style-guide/article-templates/create-release-notes/).
       </td>
     </tr>
 
@@ -160,7 +172,7 @@ The docs site doesn't have strict page templates—since we have a "docs as code
       <td>
         This format includes unique frontmatter fields. What's New posts are created by PMM for larger announcements. Unlike most content, they live in `/src/content/whats-new/` rather than in the `/docs/` subdirectory.
         
-        They're available in the docs site, but they're also visible in the New Relic UI. For more information, see [What's New style guidelines](/docs/style-guide/article-templates/whats-new-style-guidelines/).
+        They're available in the docs site, but they're also visible in the New Relic UI. For more, see [What's New style guidelines](/docs/style-guide/article-templates/whats-new-style-guidelines/).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats/
 ---
 
-The docs site doesn't have strict page templates—since we have a "docs as code" approach, writers can use a variety of components to structure docs however they think best. However, we do have several unique types of content that behave differently than our standard `.mdx` docs. This style guide page describes the standard frontmatter for docs, and also outlines the various types of content we maintain on the site. 
+This style guide page describes the standard frontmatter for docs, and also outlines the various types of content we maintain on the site. 
 
 ## Docs frontmatter and metadata [#meta-fields]
 
@@ -90,13 +90,9 @@ The top of every doc begins with a set of metadata. Read on for more information
   </tbody>
 </table>
 
-## Document body [#body-field]
-
-The document body is where you edit the page content. Use the GitHub Markdown format when you write content.
-
 ## Page templates
 
-For most situations, use the **basicDoc** page template. Read on for information about our other page templates.
+The docs site doesn't have strict page templates—since we have a "docs as code" approach, writers can use a variety of components to structure docs however they think best. However, we do have several unique types of content that behave differently than our standard `.mdx` docs. 
 
 <table>
   <thead>
@@ -114,21 +110,11 @@ For most situations, use the **basicDoc** page template. Read on for information
   <tbody>
     <tr>
       <td>
-        Basic page
+        "Standard" docs
       </td>
 
       <td>
-        A standard HTML webpage without special fields. This content type is used for the majority of content on the site.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        API doc
-      </td>
-
-      <td>
-        This format is for API reference documentation. For more information, see [apiStyleGuidelines](/docs/style-guide/article-templates/apistyleguidelines-example-agent-api) (for style guidelines) and [Work with the API doc content type](/docs/style-guide/article-templates/api-tutorial-template) (for how to use and configure).
+        A standard `.mdx` file, living in the `/src/content/docs/` subdirectory. This content type is used for the majority of content on the site.
       </td>
     </tr>
 
@@ -138,17 +124,19 @@ For most situations, use the **basicDoc** page template. Read on for information
       </td>
 
       <td>
-        This format is for defining attributes and event types. These definitions are shared with the UI via the data dictionary service. For more information, see [Work with attribute definition content type](/docs/style-guide/article-templates/attribute-definition-template).
+        This format is for defining attributes and event types. These definitions live in their own GitHub Enterprise repo, then they're published to the docs site and NerdGraph via the data dictionary service. For more information, see [Work with attribute definition content type](/docs/style-guide/article-templates/attribute-definition-template).
       </td>
     </tr>
 
     <tr>
       <td>
-        Landing pages
+        Branching install docs
       </td>
 
       <td>
-        This format is for a more user-friendly and readable landing page, which replaces the standard taxonomy list views. For more information, see [Working with landing pages](/docs/style-guide/article-templates/landing-page-template).
+        This format is for interactive installation docs. Branching install docs consist of multiple components in individual `.mdx` files that live together in a subdirectory, with the logic that defines which pieces to show when defined in a separate `.yaml` file. Branching install content lives in the `/src/install/` subdirectory. 
+        
+        For more information, see [Get started with the branched install component](/docs/style-guide/writing-docs/article-templates/intro-branch-install-doc/). 
       </td>
     </tr>
 
@@ -158,7 +146,9 @@ For most situations, use the **basicDoc** page template. Read on for information
       </td>
 
       <td>
-        This format includes specific fields for release notes. Users rely on release notes to keep up with smaller changes in the product, particularly for downloadble software like the agents. For more information, see [Create release notes](/docs/style-guide/article-templates/create-release-notes/).
+        This format includes unique frontmatter fields. Release notes live in `/src/content/docs/release-notes/`, and they are generally authored by product teams rather than writers.
+        
+        Users rely on release notes to keep up with smaller changes in the product, particularly for downloadble software like the agents. For more information, see [Create release notes](/docs/style-guide/article-templates/create-release-notes/).
       </td>
     </tr>
 
@@ -168,17 +158,9 @@ For most situations, use the **basicDoc** page template. Read on for information
       </td>
 
       <td>
-        This format includes specific fields for product announcements. What's New posts are created by PMM for larger announcements. They're available in the docs site, but they're also visible in the New Relic UI. For more information, see [What's New style guidelines](/docs/style-guide/article-templates/whats-new-style-guidelines/).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Troubleshooting doc
-      </td>
-
-      <td>
-        This format is for troubleshooting docs in a Problem-Solution-Cause format. For more information, see [Troubleshooting docs guide](/docs/style-guide/article-templates/troubleshooting-docs-guide).
+        This format includes unique frontmatter fields. What's New posts are created by PMM for larger announcements. Unlike most content, they live in `/src/content/whats-new/` rather than in the `/docs/` subdirectory.
+        
+        They're available in the docs site, but they're also visible in the New Relic UI. For more information, see [What's New style guidelines](/docs/style-guide/article-templates/whats-new-style-guidelines/).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
@@ -4,19 +4,19 @@ tags:
   - Tech writer style guide
   - Processes and procedures
 redirects:
-  - /docs/new-relic-only/style-guide/processes-and-procedures/using-content-editors
-  - /docs/new-relic-only/style-guide/processes-procedures/using-content-editors
-  - /docs/new-relic-only/advanced-style-guide/processes-procedures/using-content-editors
-  - /docs/new-relic-only/tech-writer-style-guide/processes-procedures/using-content-editors
-  - /docs/style-guide/processes-procedures/use-content-types-text-formats
-  - /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats/
+    - /docs/new-relic-only/style-guide/processes-and-procedures/using-content-editors
+    - /docs/new-relic-only/style-guide/processes-procedures/using-content-editors
+    - /docs/new-relic-only/advanced-style-guide/processes-procedures/using-content-editors
+    - /docs/new-relic-only/tech-writer-style-guide/processes-procedures/using-content-editors
+    - /docs/style-guide/processes-procedures/use-content-types-text-formats
+    - /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats
 ---
 
 This style guide page describes the standard frontmatter for docs, and also outlines the various types of content we maintain on the site. 
 
 ## Docs frontmatter and metadata [#meta-fields]
 
-The top of every doc begins with a set of metadata. Read on For more about this metadata content:
+The top of every doc begins with a set of metadata. Read on for more about this metadata content:
 
 <table>
   <thead>

--- a/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
+++ b/src/content/docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use content types and text formats
+title: Frontmatter and page templates
 tags:
   - Tech writer style guide
   - Processes and procedures
@@ -9,6 +9,7 @@ redirects:
   - /docs/new-relic-only/advanced-style-guide/processes-procedures/using-content-editors
   - /docs/new-relic-only/tech-writer-style-guide/processes-procedures/using-content-editors
   - /docs/style-guide/processes-procedures/use-content-types-text-formats
+  - /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats/
 ---
 
 Our docs site is made up of different content types and templates. Most of the time, the default page content type and the basic template will have everything you'll need.

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/github-history.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/github-history.mdx
@@ -1,8 +1,5 @@
 ---
 title: GitHub history and deleted files
-topics:
-  - Tech writer style guide
-  - How to use GitHub
 redirects: 
   - /docs/style-guide/writer-workflow/github-intro
 ---

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/github-intro.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/github-intro.mdx
@@ -1,8 +1,5 @@
 ---
 title: Get around GitHub
-topics:
-  - Tech writer style guide
-  - How to use GitHub
 redirects:
   - /docs/style-guide/writer-workflow/github-intro
 ---

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/github-troubleshooting.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/github-troubleshooting.mdx
@@ -1,8 +1,5 @@
 ---
 title: GitHub troubleshooting
-topics:
-  - Tech writer style guide
-  - GitHub issues
 redirects: 
   - /docs/style-guide/writer-workflow/github-troubleshotting
 ---

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/onramps-style-guide.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/onramps-style-guide.mdx
@@ -1,6 +1,5 @@
 ---
 title: Onramps style guide
-template: basicDoc
 ---
 
 import apmApmSummaryOnrampsGif from 'images/apm_screenshot-full_apm-summary-onramps-gif.gif'

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/onramps-style-guide.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/onramps-style-guide.mdx
@@ -1,6 +1,5 @@
 ---
 title: Onramps style guide
-contentType: page
 template: basicDoc
 ---
 

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/peer-editor-workflow.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/peer-editor-workflow.mdx
@@ -1,8 +1,5 @@
 ---
 title: Peer editor workflow
-topics:
-  - Tech writer style guide
-  - Processes and procedures
 redirects: 
   - /docs/style-guide/writer-workflow/peer-editor-workflow
 ---

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/set-up-local.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/set-up-local.mdx
@@ -1,8 +1,5 @@
 ---
 title: Set up your local build environment
-topics:
-  - Tech writer style guide
-  - Processes and procedures
 ---
 
 Running the site locally makes testing and previewing large changes much easier. There are several things you need to do get this working. Fortunately, you only need to do this once.

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
@@ -1,8 +1,5 @@
 ---
 title: Swiftype search
-topics:
-  - Tech writer style guide
-  - Processes and procedures
 ---
 
 

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/tech-writer-workflow.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/tech-writer-workflow.mdx
@@ -1,8 +1,5 @@
 ---
 title: Tech writer workflow
-topics:
-  - Tech writer style guide
-  - Processes and procedures
 redirects: 
   - /docs/style-guide/writer-workflow/tech-writer-workflow
 ---

--- a/src/content/docs/style-guide/writing-strategies/contribute-to-site.mdx
+++ b/src/content/docs/style-guide/writing-strategies/contribute-to-site.mdx
@@ -1,6 +1,5 @@
 ---
 title: Contribute to the docs site 
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-strategies/contribute-to-site.mdx
+++ b/src/content/docs/style-guide/writing-strategies/contribute-to-site.mdx
@@ -1,9 +1,5 @@
 ---
 title: Contribute to the docs site 
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - >-
     /docs/new-relic-only/style-guide/processes-and-procedures/creating-and-editing-content

--- a/src/content/docs/style-guide/writing-strategies/five-questions-help-write-docs.mdx
+++ b/src/content/docs/style-guide/writing-strategies/five-questions-help-write-docs.mdx
@@ -1,6 +1,5 @@
 ---
 title: Five questions to help write docs
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-strategies/five-questions-help-write-docs.mdx
+++ b/src/content/docs/style-guide/writing-strategies/five-questions-help-write-docs.mdx
@@ -1,9 +1,5 @@
 ---
 title: Five questions to help write docs
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /5Qs
   - /docs/style-guide/writing-guidelines/five-questions-help-write-docs

--- a/src/content/docs/style-guide/writing-strategies/guidelines-documenting-ui.mdx
+++ b/src/content/docs/style-guide/writing-strategies/guidelines-documenting-ui.mdx
@@ -1,9 +1,5 @@
 ---
 title: Guidelines for documenting new UI components or pages, and avoiding overdocumentation
-topics:
-  - New Relic only
-  - Basic style guide
-  - Writing guidelines
 ---
 
 These are guidelines that will help us achieve more consistent and less redundant documentation when product teams add new UI pages or UI components. 

--- a/src/content/docs/style-guide/writing-strategies/how-to-write-intros.mdx
+++ b/src/content/docs/style-guide/writing-strategies/how-to-write-intros.mdx
@@ -1,9 +1,5 @@
 ---
 title: How to write introductions
-topics:
-  - New Relic only
-  - Basic style guide
-  - Writing guidelines
 ---
 
 Introductions are a lot like appetizers for a dinner party—they set the stage for the main course. If you put some extra work into the introduction, your readers will be ready for the main course.

--- a/src/content/docs/style-guide/writing-strategies/install-docs-guidance.mdx
+++ b/src/content/docs/style-guide/writing-strategies/install-docs-guidance.mdx
@@ -1,9 +1,5 @@
 ---
 title: How to document our install methods
-topics:
-  - New Relic only
-  - Basic style guide
-  - Writing guidelines
 ---
 
 Installing New Relic is a crucial piece in our customer's experience, whether it's installing APM agents, the infrastructure agent, sending logs to New Relic, or installing CodeStream, among other things.

--- a/src/content/docs/style-guide/writing-strategies/introduction-style-guide.mdx
+++ b/src/content/docs/style-guide/writing-strategies/introduction-style-guide.mdx
@@ -1,6 +1,5 @@
 ---
 title: Introduction to the style guide
-contentType: page
 template: basicDoc
 topics:
   - New Relic only

--- a/src/content/docs/style-guide/writing-strategies/introduction-style-guide.mdx
+++ b/src/content/docs/style-guide/writing-strategies/introduction-style-guide.mdx
@@ -1,10 +1,5 @@
 ---
 title: Introduction to the style guide
-template: basicDoc
-topics:
-  - New Relic only
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/nronly/writing-a-document
   - /docs/new-relic-only/style-guide/writing-guidelines/writing-document

--- a/src/content/docs/style-guide/writing-strategies/organize-doc.mdx
+++ b/src/content/docs/style-guide/writing-strategies/organize-doc.mdx
@@ -1,9 +1,5 @@
 ---
 title: Organize your page
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects:
   - /docs/style-guide/writing-guidelines/organize-doc
 ---

--- a/src/content/docs/style-guide/writing-strategies/organize-doc.mdx
+++ b/src/content/docs/style-guide/writing-strategies/organize-doc.mdx
@@ -1,6 +1,5 @@
 ---
 title: Organize your page
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic.mdx
+++ b/src/content/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic.mdx
@@ -1,9 +1,5 @@
 ---
 title: Voice strategies for docs that sound like us
-template: basicDoc
-topics:
-  - Basic style guide
-  - Writing guidelines
 redirects: 
   - /docs/style-guide/writing-guidelines/voice-strategies-docs-sound-new-relic
 ---

--- a/src/content/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic.mdx
+++ b/src/content/docs/style-guide/writing-strategies/voice-strategies-docs-sound-new-relic.mdx
@@ -1,6 +1,5 @@
 ---
 title: Voice strategies for docs that sound like us
-contentType: page
 template: basicDoc
 topics:
   - Basic style guide

--- a/src/content/docs/style-guide/writing-strategies/writing-inclusive-content.mdx
+++ b/src/content/docs/style-guide/writing-strategies/writing-inclusive-content.mdx
@@ -1,11 +1,5 @@
 ---
 title: Writing inclusive content
-
-template: basicDoc
-tags:
-  - gender
-  - racism
-  - addressing bias
 ---
 
 We choose words that help customers feel safe, supported, and informed about the health of their systems. A commitment to inclusive, bias-free language is an opportunity to extend that care, to be historically minded and compassionate in our word choice. This isn't an exhaustive list of do's and don'ts, but a starting point for content that embraces and empowers all users.  

--- a/src/content/docs/style-guide/writing-strategies/writing-inclusive-content.mdx
+++ b/src/content/docs/style-guide/writing-strategies/writing-inclusive-content.mdx
@@ -1,6 +1,6 @@
 ---
 title: Writing inclusive content
-contentType: page
+
 template: basicDoc
 tags:
   - gender

--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -100,7 +100,7 @@ pages:
               - title: Edit the docs site structure and nav
                 path: /docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure
               - title: Frontmatter and page templates
-                path: /docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templatess
+                path: /docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templates
               - title: Create release notes
                 path: /docs/style-guide/writing-docs/processes-procedures/create-release-notes
               - title: Rename or redirect docs

--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -100,7 +100,7 @@ pages:
               - title: Edit the docs site structure and nav
                 path: /docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure
               - title: Frontmatter and page templates
-                path: /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats
+                path: /docs/style-guide/writing-docs/processes-procedures/frontmatter-page-templatess
               - title: Create release notes
                 path: /docs/style-guide/writing-docs/processes-procedures/create-release-notes
               - title: Rename or redirect docs


### PR DESCRIPTION
* Clarifies what all the docs site frontmatter fields do
* Corrects a bunch of inaccuracy about old content types
* Adds definitions for new content types that weren't accurate
* Sweeps docs to remove a bunch of unused frontmatter fields to avoid future confusion

**Reviewer**: Please focus on the "Frontmatter and page templates" doc, the rest of this is just sweep work. I want to ensure the changed doc is helpful and accurate for writers