### PR TITLE
Logs not supported yet on ubuntun 24.04

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -162,8 +162,9 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x
-        Interim releases 20.10, 21.04.
+        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x*<br />
+        Interim releases 20.10, 21.04.<br />
+        <small>* Logs are not supported on supported on Ubuntu 24.04 yet.</small>
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -162,9 +162,9 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x*<br />
-        Interim releases 20.10, 21.04.<br />
-        <small>* Logs are not supported on supported on Ubuntu 24.04 yet.</small>
+        [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x
+        
+        Note: Logs are not yet supported on supported on Ubuntu 24.04.
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -163,7 +163,6 @@ The infrastructure agent supports these operating systems up to their manufactur
 
       <td>
         [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x
-        
         Note: Logs are not yet supported on supported on Ubuntu 24.04.
       </td>
     </tr>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -163,6 +163,7 @@ The infrastructure agent supports these operating systems up to their manufactur
 
       <td>
         [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x
+        Interim releases 20.10, 21.04.
         Note: Logs are not yet supported on supported on Ubuntu 24.04.
       </td>
     </tr>

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -62,7 +62,7 @@ How you forward your logs depends on how you installed the infrastructure agent,
 </Callout>
 
 <Callout variant="tip">
-  Got lots of logs? Check out our [tutorial on how to optimize and manage them](/docs/tutorial-large-logs/get-started-managing-large-logs/). 
+  Got lots of logs? Check out our [tutorial on how to optimize and manage them](/docs/tutorial-large-logs/get-started-managing-large-logs/).
 </Callout>
 
 ## System requirements [#system]
@@ -76,10 +76,11 @@ How you forward your logs depends on how you installed the infrastructure agent,
 * RedHat version 7, 8 and 9
 * Debian version 9 (Strech), 10 (Buster) and 11 (Bullseye).
 * SUSE Linux Enterprise Server (SLES) version 12 and 15 (ARM64 not supported).
-* Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x (LTS versions).
+* Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x (LTS versions<sup>*</sup>).
 * Windows Server 2012, 2016, 2019, and 2022, and their service packs.
 * Windows 10, Windows 11.
 
+* Ubuntu 24.04.x LTS is not supported yet.
 
 ## Automatically forward logs with guided install [#infra]
 
@@ -595,7 +596,7 @@ Although these configuration parameters aren't required, we still recommend you 
     title="max_line_kb"
   >
     Maximum size of log entries/lines in KB. If log entries exceed the limit, they are skipped. Default is `128`,the minimum allowed value is `33`.
-    
+
   </Collapser>
 
   <Collapser
@@ -1139,7 +1140,7 @@ The following instructions summarize how to increase these limits if you want to
     sudo apt install fluent-bit=2.2.2
     ```
   </Collapser>
-  <Collapser 
+  <Collapser
     className="freq-link"
     id="rollback-after-fluent-bit-2"
     title="Rollback to fluent-bit 1.x after infrastructure agent 1.42.0 on Linux"

--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -76,11 +76,10 @@ How you forward your logs depends on how you installed the infrastructure agent,
 * RedHat version 7, 8 and 9
 * Debian version 9 (Strech), 10 (Buster) and 11 (Bullseye).
 * SUSE Linux Enterprise Server (SLES) version 12 and 15 (ARM64 not supported).
-* Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x (LTS versions<sup>*</sup>).
+* Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x (LTS versions).
+    * Ubuntu 24.04.x LTS is not supported yet.
 * Windows Server 2012, 2016, 2019, and 2022, and their service packs.
 * Windows 10, Windows 11.
-
-* Ubuntu 24.04.x LTS is not supported yet.
 
 ## Automatically forward logs with guided install [#infra]
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1523.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1523.mdx
@@ -9,4 +9,5 @@ New Relic recommends that you upgrade the agent regularly and at a minimum every
 
 ## Changed
 * Add support for ubuntu 24.04 [854](https://github.com/newrelic/infrastructure-agent/pull/854)
+  * Logs are not supported yet for this ubuntu version
 * Bump nri-flex to v1.13.0 (https://github.com/newrelic/infrastructure-agent/pull/1860)


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

Infra agent nows support ubuntu 24.04 but logs are not supported there, this adds an extra note on the changelog and installation of infra-agent to let the user know.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

Fluent-bit (the forwarder logs using) didn't release an ubuntu 24.04 version yet.