### PR TITLE
chore: Removed a deprecated package from intro and linked to our example applications and next.js and apollo server packages

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -64,40 +64,18 @@ After installing the Node.js agent, extend your instrumentation:
         * Implement [Node.js custom instrumentation](/docs/agents/nodejs-agent/supported-features/nodejs-custom-instrumentation).
         * [Collect custom metrics via an API call](/docs/agents/nodejs-agent/supported-features/nodejs-custom-metrics).
         * Use our [Node.js agent API](/docs/agents/nodejs-agent/supported-features/nodejs-agent-api) to control, customize, or extend the agent's functionality.
+        * Browse our [example applications](https://github.com/newrelic/newrelic-node-examples) to see various out of the box and custom instrumentation in action.
       </td>
     </tr>
 
     <tr>
       <td>
-        Open source telemetry
+        Extend Instrumentation
       </td>
-
+        The Node.js agent auto-instruments many different [3rd party packages](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#instrumented-modules).  However there are two other modules that are needed if you want telemetry for [Apollo Server](https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/abfb3ede982169c4e1b1bcf9974ff3f6b01c68ea/README.md), and [Next.js](https://github.com/newrelic/newrelic-node-nextjs/blob/ea20b76a13c84f4f3c48e9544e18e568b8e41c33/README.md)
       <td>
-        * To create your own integrations, use our [Node.js Telemetry SDK](/docs/data-ingest-apis/get-data-new-relic/new-relic-sdks/telemetry-sdks-send-custom-telemetry-data-new-relic).
-        * To gain visibility into your GraphQL payloads, use our [Apollo Server plugin](/docs/agents/nodejs-agent/supported-features/apollo-server-plugin-nodejs).
       </td>
     </tr>
-
-    <tr>
-      <td>
-        Logs in context
-      </td>
-
-      <td>
-        * To enrich [Winston](https://github.com/winstonjs/winston) or [Pino](https://github.com/pinojs/pino) log data, use our [automatic logs in context](/docs/logs/logs-context/configure-logs-context-nodejs) solution for Node.js.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Traces
-      </td>
-
-      <td>
-        * Enable [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing).
-      </td>
-    </tr>
-
     <tr>
       <td>
         VM measurements

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs.mdx
@@ -72,7 +72,7 @@ After installing the Node.js agent, extend your instrumentation:
       <td>
         Extend Instrumentation
       </td>
-        The Node.js agent auto-instruments many different [3rd party packages](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#instrumented-modules).  However there are two other modules that are needed if you want telemetry for [Apollo Server](https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/abfb3ede982169c4e1b1bcf9974ff3f6b01c68ea/README.md), and [Next.js](https://github.com/newrelic/newrelic-node-nextjs/blob/ea20b76a13c84f4f3c48e9544e18e568b8e41c33/README.md)
+        The Node.js agent auto-instruments many different [3rd party packages](/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#instrumented-modules). However there are two other modules that are needed if you want telemetry for [Apollo Server](https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/abfb3ede982169c4e1b1bcf9974ff3f6b01c68ea/README.md) and [Next.js](https://github.com/newrelic/newrelic-node-nextjs/blob/ea20b76a13c84f4f3c48e9544e18e568b8e41c33/README.md).
       <td>
       </td>
     </tr>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
 * Our team maintains [example apps](https://github.com/newrelic/newrelic-node-examples) so you can see both stock and custom instrumentaiton in action.  We have some direct links to examples but I thought it'd be good to link this on the intro page.  Same goes for our apollo server plugin and next.js instrumentation.  We get common questions around support for these and since they don't ship with our node agent, people sometimes don't know they exist.  There are links throughout the Node.js section of docs linking these but not in the intro page.
