### PR TITLE
docs: Update Elastic Beanstalk instructions for .NET agent

### DIFF
--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-on-aws-elastic-beanstalk.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-on-aws-elastic-beanstalk.mdx
@@ -59,23 +59,10 @@ To install the .NET agent for ASP.NET Core web applications deployed to AWS Elas
        title="Amazon Linux 2023"
      >
         ```
-        files:
-          # Create the dotnet agent YUM repo definition
-          "/etc/yum.repos.d/newrelic-dotnet-agent.repo":
-            owner: root
-            group: root
-            content: |
-              [newrelic-dotnet-agent-repo]
-              name=New Relic .NET Core packages for Enterprise Linux
-              baseurl=https://yum.newrelic.com/pub/newrelic/el7/$basearch
-              enabled=1
-              gpgcheck=1
-              gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
         commands: 
           install_dotnet_agent:
             command: |
-              sudo curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic https://download.newrelic.com/548C16BF.gpg
-              sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-NewRelic
+              sudo curl -o /etc/yum.repos.d/newrelic-dotnet-agent.repo https://download.newrelic.com/dot_net_agent/yum/newrelic-dotnet-agent.repo
               sudo yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-dotnet-agent-repo'
               # this command installs the latest version of the dotnet agent.
               sudo yum install newrelic-dotnet-agent -y
@@ -97,7 +84,7 @@ To install the .NET agent for ASP.NET Core web applications deployed to AWS Elas
      </Collapser>
    </CollapserGroup>
 
-   3. Deploy your application using the latest version of the [AWS Toolkit for Visual Studio](https://aws.amazon.com/visualstudio/). You can also use the [AWS CLI](https://docs.aws.amazon.com/cli/) to deploy the application.
+3. Deploy your application using the latest version of the [AWS Toolkit for Visual Studio](https://aws.amazon.com/visualstudio/). You can also use the [AWS CLI](https://docs.aws.amazon.com/cli/) to deploy the application.
 
 If your application is receiving traffic, data should appear within a few minutes. If it doesn't, see [No data appears](/docs/agents/net-agent/troubleshooting/no-data-appears-net).
 


### PR DESCRIPTION
Minor update to the AWS Elastic Beanstalk installation instructions for the .NET agent, brings the install steps in line with our [Linux / YUM instructions](https://docs.newrelic.com/install/dotnet/?deployment=linux&docker=noDocker#yum)