### PR TITLE
Adding .NET agent to AIM compatibility list

### DIFF
--- a/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
@@ -66,6 +66,14 @@ AI monitoring is compatible with these agent versions and AI libraries:
             * [OpenAI gem](https://github.com/alexrudall/ruby-openai) version 3.4.0 and above
             </td>
         </tr>
+        <tr>
+            <td>
+            [.NET version 10.23.0 and above](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#large-language-models)
+            </td>
+            <td>
+            * [AWS Bedrock](https://www.nuget.org/packages/AWSSDK.Bedrock/) version 3.7.200 and above
+            </td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
This was missed with the rest of the AIM documentation rollout.