### PR TITLE
fix: Update attribute dictionary update schedule to weekdays only

### DIFF
--- a/.github/workflows/update-attribute-dictionary-json.yml
+++ b/.github/workflows/update-attribute-dictionary-json.yml
@@ -3,8 +3,8 @@ name: Update Attribute Dictionary JSON
 on:
   workflow_dispatch:
   schedule:
-    # 12pm UTC every day (5a PDT)
-    - cron: '0 12 * * *'
+    # 12pm UTC (5a PDT) Monday - Friday
+    - cron: '0 12 * * 1-5'
 
 env:
   API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}


### PR DESCRIPTION
To help reduce the amount of redundant PR's that end up just being closed, changed `cron` schedule to just M - F