### PR TITLE
Python release notes v9.10.0

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -51,7 +51,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       </td>
 
       <td>
-        Python (CPython/PyPy) versions supported: 2.7, 3.7, 3.8, 3.9, 3.10, 3.11, and 3.12.
+        Python (CPython/PyPy) versions supported: 3.7, 3.8, 3.9, 3.10, 3.11, and 3.12.
 
         <DoNotTranslate>**Recommendation:**</DoNotTranslate> Use Python version 3.7 or higher with our agent.
 
@@ -171,8 +171,7 @@ The following are proposed time ranges. The actual release date may vary.
       </th>
 
       <th>
-        Initial release date of Python agent
-                                with support
+        Initial release date of Python agent with support
       </th>
     </tr>
   </thead>
@@ -226,11 +225,15 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        TBD
+        April 1, 2024 (see note below)
       </td>
     </tr>
   </tbody>
 </table>
+
+<Callout variant="note">
+  Python 2.7 is no longer officially supported in subsequent framework work or maintenance, but the date that Python 2.7 will be removed from the agent is TBD.
+</Callout>
 
 ## Connect the agent to other capabilities [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
@@ -604,7 +604,7 @@ Timing of message broker transactions is provided for the following modules.
 
 Timing of external web service requests is carried out via the following modules.
 
-* [aiobotocore](https://github.com/aio-libs/aiobotocore)
+* [aiobotocore](https://aiobotocore.readthedocs.io/en/stable/)
 * [aiohttp](http://aiohttp.readthedocs.io)
 * [botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/index.html)
 * [dropbox](https://www.dropbox.com/developers/start/setup#python)

--- a/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
@@ -604,6 +604,7 @@ Timing of message broker transactions is provided for the following modules.
 
 Timing of external web service requests is carried out via the following modules.
 
+* [aiobotocore](https://github.com/aio-libs/aiobotocore)
 * [aiohttp](http://aiohttp.readthedocs.io)
 * [botocore](https://botocore.amazonaws.com/v1/documentation/api/latest/index.html)
 * [dropbox](https://www.dropbox.com/developers/start/setup#python)
@@ -619,3 +620,17 @@ Timing of external web service requests is carried out via the following modules
 * [urllib2](http://docs.python.org/library/urllib2.html)
 * [urllib3](https://urllib3.readthedocs.org/en/latest/)
 * [xmlrpclib](http://docs.python.org/library/xmlrpclib.html)
+
+## Machine learning models and LLMs
+
+* [Scikit Learn](https://pypi.org/project/scikit-learn/)
+* [OpenAI](https://pypi.org/project/openai/)
+* [LangChain](https://pypi.org/project/langchain/)
+* [Amazon Bedrock](https://aws.amazon.com/bedrock/)
+  * [Amazon Titan](https://aws.amazon.com/bedrock/titan/)
+  * [Cohere Command and Embed](https://aws.amazon.com/bedrock/cohere-command-embed/)
+  * [AI21 Labs Jurassic](https://aws.amazon.com/bedrock/jurassic/)
+  * [Anthropic's Claude](https://aws.amazon.com/bedrock/claude/)
+  * [Meta Llama2](https://aws.amazon.com/bedrock/llama/)
+  * [Meta Llama3](https://aws.amazon.com/bedrock/llama/)
+  * [Mistral AI](https://aws.amazon.com/bedrock/mistral/)

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91000.mdx
@@ -1,0 +1,43 @@
+---
+subject: Python agent
+releaseDate: '2024-05-23'
+version: 9.10.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for AIOBotocore', 'Add support for Meta Llama3', 'Add support for Mistral AI']
+bugs: ['Fix OpenAI error parsing', 'Record loguru timing in milliseconds']
+security: []
+---
+
+## Notes
+
+This release of the Python agent adds instrumentation for [AIOBotocore](https://pypi.org/project/aiobotocore/), support for Meta Llama3 and Mistral AI in Amazon Bedrock, fixes an issue with error parsing within [OpenAI](https://pypi.org/project/openai/), and updates [Loguru](https://pypi.org/project/loguru/)'s instrumentation to use milliseconds instead of seconds.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## New features
+
+* **Add [AIOBotocore](https://pypi.org/project/aiobotocore/) instrumentation**
+
+    * Add instrumentation for AIOBotocore.  Supports proxy mode in addition to standard operation.
+
+* **Add new Amazon Bedrock models**
+
+    * Add instrumentation for the following Amazon Bedrock models:
+        * Meta Llama3
+        * Mistral AI
+
+## Bug fixes
+
+* **Fix [OpenAI](https://pypi.org/project/openai/) error parsing**
+
+    * Previously, if an error in OpenAI was encountered, the Python Agent would attempt to override the default `error.message` within `notice_error()` with the one used in OpenAI.  However, if there was no `message` attribute in the error, the Python Agent would crash.  Now it defaults to the original methodology of error handling by the Python Agent.
+
+* **Record timing in [Loguru](https://pypi.org/project/loguru/) in milliseconds**
+
+    * Timing in Loguru is recorded as an integer and if that value was less than 1 second, it would record it as 0s.  This changes the units to be in milliseconds instead.  Thanks, (@julia-tadej-wwtech)[https://github.com/julia-tadej-wttech] for the contribution!
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91000.mdx
@@ -10,7 +10,7 @@ security: []
 
 ## Notes
 
-This release of the Python agent adds instrumentation for [AIOBotocore](https://pypi.org/project/aiobotocore/), support for Meta Llama3 and Mistral AI in Amazon Bedrock, fixes an issue with error parsing within [OpenAI](https://pypi.org/project/openai/), and updates [Loguru](https://pypi.org/project/loguru/)'s instrumentation to use milliseconds instead of seconds.
+This release of the Python agent adds instrumentation for [AIOBotocore](https://pypi.org/project/aiobotocore/), support for Meta Llama3 and Mistral AI in Amazon Bedrock, fixes an error parsing issue in [OpenAI](https://pypi.org/project/openai/), and updates [Loguru](https://pypi.org/project/loguru/)'s instrumentation to use milliseconds instead of seconds.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91000.mdx
@@ -10,7 +10,11 @@ security: []
 
 ## Notes
 
-This release of the Python agent adds instrumentation for [AIOBotocore](https://pypi.org/project/aiobotocore/), support for Meta Llama3 and Mistral AI in Amazon Bedrock, fixes an error parsing issue in [OpenAI](https://pypi.org/project/openai/), and updates [Loguru](https://pypi.org/project/loguru/)'s instrumentation to use milliseconds instead of seconds.
+This release of the Python agent:
+* Adds instrumentation for [AIOBotocore](https://pypi.org/project/aiobotocore/)
+* Adds support for Meta Llama3 and Mistral AI in Amazon Bedrock
+* Fixes an error parsing issue in [OpenAI](https://pypi.org/project/openai/)
+* Updates [Loguru](https://pypi.org/project/loguru/)'s instrumentation to use milliseconds instead of seconds
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 


### PR DESCRIPTION
This PR adds notes for the Python v9.10.0 release, updates the supportability text for Python 2.7, and updates the instrumented frameworks for the Python Agent.