### PR TITLE
docs: Update .NET agent install docs to reference the .NET agent samples repo

### DIFF
--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-on-aws-elastic-beanstalk.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-on-aws-elastic-beanstalk.mdx
@@ -19,7 +19,7 @@ Make sure you have a supported [Amazon Web Services account](http://aws.amazon.c
 
 ## Install the .NET agent
 
-To install the .NET agent for ASP.NET Core web applications deployed to AWS Elastic Beanstalk, follow these steps. You can also find working example projects for both Windows and Linux in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
+To install the .NET agent for ASP.NET Core web applications deployed to AWS Elastic Beanstalk, follow these steps. You can also find working example projects for both Windows and Linux in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
 
 1. Create a `.ebextensions` folder at the root of your application and create a file named `newrelic-dotnet-agent-install.config`. (The exact filename isn't important, but it must have a `.config` extension.) 
 

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-on-aws-elastic-beanstalk.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-on-aws-elastic-beanstalk.mdx
@@ -19,7 +19,7 @@ Make sure you have a supported [Amazon Web Services account](http://aws.amazon.c
 
 ## Install the .NET agent
 
-To install the .NET agent for ASP.NET Core web applications deployed to AWS Elastic Beanstalk:
+To install the .NET agent for ASP.NET Core web applications deployed to AWS Elastic Beanstalk, follow these steps. You can also find working example projects for both Windows and Linux in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
 
 1. Create a `.ebextensions` folder at the root of your application and create a file named `newrelic-dotnet-agent-install.config`. (The exact filename isn't important, but it must have a `.config` extension.) 
 

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -26,7 +26,7 @@ Before installing the agent using NuGet, understand these important points:
   The agent's `logs` folder gets created as a subfolder of the `newrelic` folder in your application's build/publish output directory.  The `logs` folder gets created with default permissions, meaning that it may not be writable by the agent if your app is run by a different user than the user who built/published the app.  Make sure that the user your app runs as can write to the `logs` folder.
 </Callout>
 
-Here's an example of using NuGet via Visual Studio to install the .NET agent:
+Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/console).)
 
 1. Open your Visual Studio solution, or create a new one by selecting <DoNotTranslate>**File > New > Project**</DoNotTranslate>. For multi-project solutions, be sure to select the correct project (for example, a specific website project).
 2. Open the [Package Manager console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console) by selecting <DoNotTranslate>**Tools > Library Package Manager > Package Manager Console**</DoNotTranslate>. Set your project as the default project.

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -26,7 +26,7 @@ Before installing the agent using NuGet, understand these important points:
   The agent's `logs` folder gets created as a subfolder of the `newrelic` folder in your application's build/publish output directory.  The `logs` folder gets created with default permissions, meaning that it may not be writable by the agent if your app is run by a different user than the user who built/published the app.  Make sure that the user your app runs as can write to the `logs` folder.
 </Callout>
 
-Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/console).)
+Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
 
 1. Open your Visual Studio solution, or create a new one by selecting <DoNotTranslate>**File > New > Project**</DoNotTranslate>. For multi-project solutions, be sure to select the correct project (for example, a specific website project).
 2. Open the [Package Manager console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console) by selecting <DoNotTranslate>**Tools > Library Package Manager > Package Manager Console**</DoNotTranslate>. Set your project as the default project.

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -13,7 +13,7 @@ Some notes about how to implement your Docker file:
 * The .NET agent must be installed and enabled at runtime.
 * For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`. We'll use `newrelic-dotnet-agent` in this doc.
 
-Here are example Docker files for Linux: 
+Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
 
 ### Example Linux Dockerfile
 

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -13,7 +13,7 @@ Some notes about how to implement your Docker file:
 * The .NET agent must be installed and enabled at runtime.
 * For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`. We'll use `newrelic-dotnet-agent` in this doc.
 
-Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
+Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
 
 ### Example Linux Dockerfile
 


### PR DESCRIPTION
Updates the .NET agent install docs in a few places to reference our recently-created code samples repository.