### PR TITLE
chore: Correct URLs for some references to the .NET agent samples repo.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -26,7 +26,7 @@ Before installing the agent using NuGet, understand these important points:
   The agent's `logs` folder gets created as a subfolder of the `newrelic` folder in your application's build/publish output directory.  The `logs` folder gets created with default permissions, meaning that it may not be writable by the agent if your app is run by a different user than the user who built/published the app.  Make sure that the user your app runs as can write to the `logs` folder.
 </Callout>
 
-Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
+Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
 
 1. Open your Visual Studio solution, or create a new one by selecting <DoNotTranslate>**File > New > Project**</DoNotTranslate>. For multi-project solutions, be sure to select the correct project (for example, a specific website project).
 2. Open the [Package Manager console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console) by selecting <DoNotTranslate>**Tools > Library Package Manager > Package Manager Console**</DoNotTranslate>. Set your project as the default project.

--- a/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
+++ b/src/content/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget.mdx
@@ -26,7 +26,7 @@ Before installing the agent using NuGet, understand these important points:
   The agent's `logs` folder gets created as a subfolder of the `newrelic` folder in your application's build/publish output directory.  The `logs` folder gets created with default permissions, meaning that it may not be writable by the agent if your app is run by a different user than the user who built/published the app.  Make sure that the user your app runs as can write to the `logs` folder.
 </Callout>
 
-Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
+Here's an example of using NuGet via Visual Studio to install the .NET agent: (You can also find a similar example in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
 
 1. Open your Visual Studio solution, or create a new one by selecting <DoNotTranslate>**File > New > Project**</DoNotTranslate>. For multi-project solutions, be sure to select the correct project (for example, a specific website project).
 2. Open the [Package Manager console](https://docs.microsoft.com/en-us/nuget/tools/package-manager-console) by selecting <DoNotTranslate>**Tools > Library Package Manager > Package Manager Console**</DoNotTranslate>. Set your project as the default project.

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -13,7 +13,7 @@ Some notes about how to implement your Docker file:
 * The .NET agent must be installed and enabled at runtime.
 * For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`. We'll use `newrelic-dotnet-agent` in this doc.
 
-Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
+Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
 
 ### Example Linux Dockerfile
 

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -13,7 +13,7 @@ Some notes about how to implement your Docker file:
 * The .NET agent must be installed and enabled at runtime.
 * For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`. We'll use `newrelic-dotnet-agent` in this doc.
 
-Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/elastic-beanstalk).
+Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET Agent Samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
 
 ### Example Linux Dockerfile
 


### PR DESCRIPTION
This PR updates two URLs that were incorrectly modified by the reviewer in #17431. We're using specific URLs on these pages to point to the examples relative to the docs page.