### PR TITLE
Accounts: Remove the reference to Google sheet

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/account-user-mgmt-tutorial.mdx
@@ -20,7 +20,6 @@ Before you start this tutorial, some things to understand:
   * [Organization and account concepts](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure#new-model)
   * [User management concepts](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts#understand-concepts)
 * This presents one recommended workflow but no particular order of steps is required. 
-* For an example spreadsheet showing how an organization might plan out their users' access, see the [group access planning spreadsheet](https://docs.google.com/spreadsheets/d/1FnguDXRUX9FGY14oV4Gx6O08v4vNC2Pv0GGCsU7Pxuw/edit?usp=sharing). 
 
 ## Overview [#overview]
 


### PR DESCRIPTION
We had a reference to a user planning Google Sheet that was not available to the public. Our SME said this was not a useful link, so I'm removing it.

Closes GitHub issue 16983