### PR TITLE
update mobile webdriver test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.5.6",
+    "@newrelic/gatsby-theme-newrelic": "9.6.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/scripts/actions/webdriver-mobile.mjs
+++ b/scripts/actions/webdriver-mobile.mjs
@@ -44,8 +44,8 @@ const main = async () => {
   // and the current homepage does not have the hamburger menu for `navTest`
   await driver.get(testUrl);
   await tileTest();
-  await navTest();
   await driver.get(testUrl + 'docs/mdx-test-page/');
+  await navTest();
   await collapserTest();
   await searchTest();
 
@@ -91,6 +91,11 @@ const navTest = async () => {
     afterNextNode,
     'clicking Release Notes in the nav did not expand the Release Notes section'
   );
+  const [navCloseButton] = await waitForXPath(
+    '//div[@id="portal"]//button[@aria-label="Close"]'
+  );
+  await navCloseButton.click();
+  await driver.sleep(1000);
 };
 
 const searchTest = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,10 +3629,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.5.6":
-  version "9.5.6"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.5.6.tgz#9a72bd30524845eab5ce2b5f6938036c5ad4e3ae"
-  integrity sha512-oVglC8G/Q/suEi6gWjVWQhY+Yqb6azJAqUwh9+hpA0IzMysuxc3bPd4CDRUY6Ppkb50XkLThxI9dusQqKdWFFQ==
+"@newrelic/gatsby-theme-newrelic@9.6.0":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.6.0.tgz#d3aae9b9230bc8ccf46ed1177023537c9f2eb700"
+  integrity sha512-S0bz5ifmSzEu2KLIhcbot7nRpNOQdPBs6NlGdvQGZkoFGQIudoRk6XpLTOK3eN//a1AO1Uyuh6t8FN2aJxSHWg==
   dependencies:
     "@segment/analytics-next" "1.63.0"
     "@wry/equality" "^0.4.0"


### PR DESCRIPTION
the nav is no longer on the homepage, so this changes the test to check the nav on the MDX kitchen sink page instead. it also updates `@newrelic/gatsby-theme-newrelic` so we can look for the close button using its aria-label