### PR TITLE
Logs: Add video and remove tab reference

### DIFF
--- a/src/content/docs/logs/ui-data/query-time-parsing.mdx
+++ b/src/content/docs/logs/ui-data/query-time-parsing.mdx
@@ -45,6 +45,10 @@ import logsParsingAttributesView from 'images/logs_screenshot-crop_parsing-attri
 
 Are you looking for a quick way to visually extract attributes from your logs after they've been ingested into New Relic? Query time parsing lets you parse your logs directly in the UI without needing to write complex regular expressions or Grok patterns. You can use query time parsing to temporarily extract values from your logs and quickly perform a query on these variables. The results are shown instantly since parsing is performed at query time. 
 
+To get started, watch this five-minute video or see the tips below:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/tvK6MlkvD6Y?si=Vj4zadiAH1OG_wMy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## How query time parsing differs from ingest parsing [#differences]
 
 While both types of parsing make it easier for you to query logs, they have some significant differences:
@@ -159,7 +163,7 @@ Here's a guide to creating query time parsing rules. The example shows how to ex
         #### Select attribute value to parse [#select-attribute]
         You can start creating a query time parsing rule by selecting an attribute value to parse.  
 
-            1. In the log table or in the **Formatted** tab of the log details view, highlight an anchor string that contains the values you want to extract. In this case, you'd highlight `level=info msg="Running script"`. It looks like this in the logs table:
+            1. In the log table or in the **Log details** view, highlight an anchor string that contains the values you want to extract. In this case, you'd highlight `level=info msg="Running script"`. It looks like this in the logs table:
                 <img
                     title="Screenshot showing a highlighted section of a log"
                     alt="Screenshot showing a highlighted section of a log"


### PR DESCRIPTION
We received a new video that explains this feature. Also, we need to remove the reference to the "Formatted" tab.