### PR TITLE
fix release note text overflowing the right side

### DIFF
--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -105,6 +105,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
       </PageTitle>
       <Layout.Content
         css={css`
+          overflow-wrap: anywhere;
           & img {
             max-height: 460px;
           }


### PR DESCRIPTION
before:
<img width="1728" alt="Screenshot 2024-05-30 at 2 41 24 PM" src="https://github.com/newrelic/docs-website/assets/14365008/33cb6cdf-b19f-4b86-94bc-820e698c0a4f">

after:
<img width="1728" alt="Screenshot 2024-05-30 at 2 40 52 PM" src="https://github.com/newrelic/docs-website/assets/14365008/f56c9988-e253-461d-96eb-83f826860d57">

[preview link](https://deploy-preview-17493--docs-website-netlify.netlify.app/docs/release-notes/agent-release-notes/ruby-release-notes/)