### PR TITLE
fix: yaml indentation

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration-new.mdx
@@ -119,10 +119,10 @@ To install the integration, follow the instructions for your environment:
 5. To enable automatic Mongodb error log parsing and forwarding, create a YAML file with the following content in `/etc/newrelic-infra/logging.d/mongodb-log.yml`. No need to restart the agent.
     ```yaml
     logs:
-    - name: "mongodblog"
-      file: /var/log/mongodb/mongodb.log
-      attributes:
-        logtype: mongodb
+      - name: "mongodblog"
+        file: /var/log/mongodb/mongodb.log
+        attributes:
+          logtype: mongodb
     ```
 </Collapser>
 
@@ -133,12 +133,12 @@ To install the integration, follow the instructions for your environment:
     1. Download the `nri-mongodb3` [MSI installer](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-ibmmq/nri-mongodb3-amd64.msi).
     2. To install from the Windows command prompt, run:
 
-        ```
+        ```shell
         msiexec.exe /qn /i <PATH_TO_YOUR_nri-mongodb3-amd64.msi>
         ```
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
-        ```
+        ```shell
         copy mongodb3-config.yml.sample mongodb3-config.yml
         ```
     4. Edit the `mongodb3-config.yml` file as described in the [configuration settings](#config).
@@ -181,7 +181,7 @@ The attribute `mongodb_cluster_name` to all the MongoDB metrics is needed by the
 
 For example, the following Prometheus agent configuration adds to all the Prometheus metrics matching `mongodb_.*` the label `mongodb_cluster_name=cluster-name-example`.
 
-```
+```yml
 # (...)
 newrelic_remote_write:
   extra_write_relabel_configs:
@@ -193,7 +193,7 @@ newrelic_remote_write:
 
 If you are using multiple `percona/mongodb_exporter` pods to serve metrics from multiple MongoDB clusters, you can label each with a separate `mongodb_cluster_name` using a configuration like this:
 
-```
+```yml
 # (...)
 newrelic_remote_write:
   extra_write_relabel_configs:
@@ -230,43 +230,43 @@ On the other hand, in a Prometheus server, you can add custom attributes to all 
     Execute the [mongodb-exporter](https://hub.docker.com/r/percona/mongodb_exporter/tags), which is the same that the integration packs, along with [nri-prometheus](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#OpenMetrics). You may use the `docker-compose` example below as base for your setup:
 
     ```yaml
-      version: "3.8"
-      services:
+    version: "3.8"
+    services:
 
-        exporter:
-          image: percona/mongodb_exporter:2.37.0
-          command: --mongodb.uri="<YOUR-MONGODB-URI>" --collect-all --discovering-mode
-          ports:
-            - 9216:9216
-          links:
-            - mongo
+      exporter:
+        image: percona/mongodb_exporter:2.37.0
+        command: --mongodb.uri="<YOUR-MONGODB-URI>" --collect-all --discovering-mode
+        ports:
+          - 9216:9216
+        links:
+          - mongo
 
-        nri-prometheus:
-          image: newrelic/nri-prometheus
-          environment:
-            LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
-          volumes:
-            - "./config.yaml:/config.yaml"
-          links:
-            - exporter
+      nri-prometheus:
+        image: newrelic/nri-prometheus
+        environment:
+          LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY}
+        volumes:
+          - "./config.yaml:/config.yaml"
+        links:
+          - exporter
     ```
 
     Where, `config.yaml` is the nri-prometheus configuration file. Check [the corresponding docs](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/#OpenMetrics) for additional details.
 
     ```yaml
-      cluster_name: YOUR-CLUSTER-NAME
+    cluster_name: YOUR-CLUSTER-NAME
 
-      transformations: # The attribute `mongodb_cluster_name` to all the MongoDB metrics is needed by the MongoDB dashboard.
-        - {"add_attributes":[{"prefix":"mongodb_","attributes":{"mongodb_cluster_name": "YOUR-CLUSTER-NAME" }}]}
+    transformations: # The attribute `mongodb_cluster_name` to all the MongoDB metrics is needed by the MongoDB dashboard.
+      - {"add_attributes":[{"prefix":"mongodb_","attributes":{"mongodb_cluster_name": "YOUR-CLUSTER-NAME" }}]}
 
-      targets:
-        - urls:
-          - http://exporter:9216
+    targets:
+      - urls:
+        - http://exporter:9216
     ```
 
     Assuming that the docker-compose file is in the same folder that `config.yaml` and `${NEW_RELIC_LICENSE_KEY}` environment variable contains your license key, you can run it as follows:
 
-    ```
+    ```shell
     NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY} docker-compose up -d
     ```
   </Collapser>
@@ -293,21 +293,21 @@ Follow the next steps depending on your environment:
 
     1. In the MongoDB shell switch to the admin database.
 
-        ```
+        ```shell
         use admin
         ```
 
     2. Use the following command to create a new user, and assign `clusterMonitor` and `readAnyDatabase` roles to the user (adjust the username and password as required).
 
-        ```
-        db.createUser(
-          {
-            user: "username",
-            pwd:  "password",
-            roles: [ { role: "clusterMonitor", db: "admin" },
-                     { role: 'readAnyDatabase', db: 'admin' } ]
-          }
-        )
+        ```js
+        db.createUser({
+          user: "username",
+          pwd: "password",
+          roles: [
+            { role: "clusterMonitor", db: "admin" },
+            { role: "readAnyDatabase", db: "admin" },
+          ],
+        });
         ```
 
     3. Edit the YAML configuration file `mongodb3-config.yml` and inform the required parameters `mongodb_cluster_name` and `mongodb_uri`. Change other [configuration options](#instance-settings) if required.
@@ -321,7 +321,7 @@ Follow the next steps depending on your environment:
   >
     1. Using the Atlas CLI run the following command to create a new user, and assign `clusterMonitor` and `readAnyDatabase` roles to the user (Adjust the username and password as required).
 
-        ```
+        ```shell
         atlas dbuser create -u username -p password --role clusterMonitor,readAnyDatabase
         ```
 
@@ -356,7 +356,7 @@ The following configuration options are available:
   <tbody>
   <tr>
     <td>
-      <DoNotTranslate>**mongodb_cluster_name**</DoNotTranslate>
+      `mongodb_cluster_name`
     </td>
     <td>
       User-defined name to uniquely identify the cluster being monitored. <DoNotTranslate>**Required**</DoNotTranslate>
@@ -367,7 +367,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**mongodb_uri**</DoNotTranslate>
+      `mongodb_uri`
     </td>
     <td>
       MongoDB connection URI. <DoNotTranslate>**Required**</DoNotTranslate>
@@ -378,7 +378,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**mongodb_direct_connect**</DoNotTranslate>
+      `mongodb_direct_connect`
     </td>
     <td>
       Whether or not a direct connect should be made. Direct connections are not valid if multiple hosts are specified or an SRV URI is used, for example for mongoDB Atlas.
@@ -386,12 +386,12 @@ The following configuration options are available:
       Notice that direct connect should also be set to false if `loadBalanced=true` is specified either in the connection string or in the DNS entry as it happens in case of Serverless Atlas Deployments.
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**collection_filters**</DoNotTranslate>
+      `collection_filters`
     </td>
     <td>
       List of comma separated databases.collections. If empty, defaults to all databases and collections
@@ -402,7 +402,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**index_filters**</DoNotTranslate>
+      `index_filters`
     </td>
     <td>
       List of comma separated databases.collections to retrieve index stats. If empty, defaults to all indexes
@@ -413,73 +413,73 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**database_stats**</DoNotTranslate>
+      `database_stats`
     </td>
     <td>
       Enable/Disable collection of Database metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**collection_stats**</DoNotTranslate>
+      `collection_stats`
     </td>
     <td>
       Enable/Disable collection of Collections metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**index_stats**</DoNotTranslate>
+      `index_stats`
     </td>
     <td>
       Enable/Disable collection of Index metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**replicaset_stats**</DoNotTranslate>
+      `replicaset_stats`
     </td>
     <td>
       Enable/Disable collection of Replica Set metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**top_stats**</DoNotTranslate>
+      `top_stats`
     </td>
     <td>
       Enable/Disable collection of Top Admin metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**diagnostic_stats**</DoNotTranslate>
+      `diagnostic_stats`
     </td>
     <td>
       Enable/Disable collection of Diagnostic metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**exporter_port**</DoNotTranslate>
+      `exporter_port`
     </td>
     <td>
       Port to expose scrape endpoint on, If this is not provided a random port will be used to launch the exporter
@@ -490,13 +490,13 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**scrape_timeout**</DoNotTranslate>
+      `scrape_timeout`
     </td>
     <td>
       Time until a scrape request times out
     </td>
     <td>
-      5s
+      `5s`
     </td>
   </tr>
   </tbody>
@@ -647,7 +647,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   <tbody>
   <tr>
     <td>
-      <DoNotTranslate>**assert_type**</DoNotTranslate>
+      `assert_type`
     </td>
     <td>
       Type of assertion as per [official list](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#asserts).
@@ -655,7 +655,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**cl_id**</DoNotTranslate>
+      `cl_id`
     </td>
     <td>
       Cluster ID.
@@ -663,7 +663,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**cl_role**</DoNotTranslate>
+      `cl_role`
     </td>
     <td>
       Cluster Role which can have the following values:
@@ -674,7 +674,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**collection**</DoNotTranslate>
+      `collection`
     </td>
     <td>
       Collection name.
@@ -682,7 +682,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**concern_type**</DoNotTranslate>
+      `concern_type`
     </td>
     <td>
       Concern level for read query operations (available, linearizable, ...). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#opreadconcerncounters).
@@ -690,7 +690,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**conn_type**</DoNotTranslate>
+      `conn_type`
     </td>
     <td>
       Type or state of database connections (active, available, total, ...). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#connections).
@@ -698,7 +698,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**count_type**</DoNotTranslate>
+      `count_type`
     </td>
     <td>
       Count Type for database global lock state (readers,writers, total). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#globallock).
@@ -706,7 +706,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**csr_type**</DoNotTranslate>
+      `csr_type`
     </td>
     <td>
       Cursor Type for data open cursors (pinned, noTimeout, total, ...). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#mongodb-serverstatus-serverstatus.metrics.cursor.open).
@@ -714,7 +714,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**database**</DoNotTranslate>
+      `database`
     </td>
     <td>
       Database name.
@@ -722,7 +722,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**doc_op_type**</DoNotTranslate>
+      `doc_op_type`
     </td>
     <td>
       Operation Type for document access (inserted, deleted, returned, updated). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#mongodb-serverstatus-serverstatus.metrics.document).
@@ -730,7 +730,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**key_name**</DoNotTranslate>
+      `key_name`
     </td>
     <td>
       Index key name.
@@ -738,7 +738,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**legacy_op_type**</DoNotTranslate>
+      `legacy_op_type`
     </td>
     <td>
       Operation type for opcounters (delete, getmore, insert, ...). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#opcounters).
@@ -746,7 +746,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**lock_mode**</DoNotTranslate>
+      `lock_mode`
     </td>
     <td>
       Mode for data locks (R, W, r, and w). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#mongodb-serverstatus-serverstatus.locks).
@@ -754,7 +754,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**member_idx**</DoNotTranslate>
+      `member_idx`
     </td>
     <td>
       Member name. Normally IP address or DNS name and Port of the member instance.
@@ -762,7 +762,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**member_state**</DoNotTranslate>
+      `member_state`
     </td>
     <td>
       Member state in string format from the [official status codes](https://www.mongodb.com/docs/manual/reference/replica-states/).
@@ -770,7 +770,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**mongodb_cluster_name**</DoNotTranslate>
+      `mongodb_cluster_name`
     </td>
     <td>
       Cluster name set in your [configuration file](#instance-settings). Note that this dimension applies to all metrics.
@@ -778,7 +778,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**op_type**</DoNotTranslate>
+      `op_type`
     </td>
     <td>
       Operation Type for latency (reads, writes, commands). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#oplatencies).
@@ -786,7 +786,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**perf_bucket**</DoNotTranslate>
+      `perf_bucket`
     </td>
     <td>
       Latency buckets WiredTiger read/write performance metrics (bucket1, bucket2, ...). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#wiredtiger).
@@ -794,7 +794,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**resource**</DoNotTranslate>
+      `resource`
     </td>
     <td>
       Resource or type for data locks (Global, Mutex, ParallelBatchWriterMode, ...). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#mongodb-serverstatus-serverstatus.locks).
@@ -802,7 +802,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**rs_nm**</DoNotTranslate>
+      `rs_nm`
     </td>
     <td>
       Replicaset name.
@@ -810,7 +810,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**rs_state**</DoNotTranslate>
+      `rs_state`
     </td>
     <td>
       Replicaset status. An integer representing the replica status following the [official status codes](https://www.mongodb.com/docs/manual/reference/replica-states/).
@@ -818,7 +818,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
   </tr>
   <tr>
     <td>
-      <DoNotTranslate>**txn_rw**</DoNotTranslate>
+      `txn_rw`
     </td>
     <td>
       Concurrent transactions type for WiredTiger storage engine (write, read). [More info](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#mongodb-serverstatus-serverstatus.wiredTiger.concurrentTransactions).
@@ -831,7 +831,7 @@ The following dimensions are attached to the metrics collected. See the metrics 
 
 These are the 3 [entities](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/) created: `MONGODB_INSTANCE`, `MONGODB_DATABASE`, and `MONGODB_COLLECTION`.
 
-The following dimensional metrics are captured scraping the exporter and linked to the entity <DoNotTranslate>**MONGODB_INSTANCE**</DoNotTranslate>:
+The following dimensional metrics are captured scraping the exporter and linked to the entity `MONGODB_INSTANCE`:
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/mongodb/mongodb-monitoring-integration.mdx
@@ -57,12 +57,12 @@ If you want to install our legacy MongoDB integration, follow the instructions f
     1. Install [the infrastructure agent](/docs/integrations/host-integrations/installation/install-infrastructure-host-integrations/#install), and replace the `INTEGRATION_FILE_NAME` variable with `nri-mongodb`.
     2. Change directory to the integrations folder:
 
-       ```
+       ```shell
        cd /etc/newrelic-infra/integrations.d
        ```
     3. Copy of the sample configuration file:
 
-       ```
+       ```shell
        sudo cp mongodb-config.yml.sample mongodb-config.yml
        ```
     4. Edit the `mongodb-config.yml` file as described in the [configuration settings](#config).
@@ -70,7 +70,7 @@ If you want to install our legacy MongoDB integration, follow the instructions f
 
        <DoNotTranslate>**Example:**</DoNotTranslate>
 
-       ```
+       ```shell
        sudo cp /etc/newrelic-infra/logging.d/mongodb-log.yml.example /etc/newrelic-infra/logging.d/mongodb-log.yml
        ```
   </Collapser>
@@ -84,12 +84,12 @@ If you want to install our legacy MongoDB integration, follow the instructions f
        [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mongodb/nri-mongodb-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-mongodb/nri-mongodb-amd64.msi)
     2. To install from the Windows command prompt, run:
 
-       ```
+       ```shell
        msiexec.exe /qn /i PATH\TO\nri-mongodb-amd64.msi
        ```
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
-       ```
+       ```shell
        cp mongodb-config.yml.sample mongodb-config.yml
        ```
     4. Edit the `mongodb-config.yml` configuration file using the [configuration settings](#config).
@@ -119,29 +119,28 @@ See the MongoDB documentation for details on [creating users](https://docs.mongo
 
 2. Use the following command to create the `listCollections` role.
 
-   ```
-   db.createRole({
-       role: "listCollections",
-       privileges: [{
-           resource: {db:"",collection:""},
-           actions: ["listCollections"]
-       }],
-       roles: []
-   })
-   ```
+  ```js
+  db.createRole({
+    role: "listCollections",
+    privileges: [
+      {
+        resource: { db: "", collection: "" },
+        actions: ["listCollections"],
+      },
+    ],
+    roles: [],
+  })
+  ```
 
 3. Use the following commands to create a new user, and assign `clusterMonitor` and `listCollections` roles to the user.
 
-   ```
-   db.createUser({
-       user: "username",
-       pwd: "password",
-       roles: [
-           "clusterMonitor",
-           "listCollections"
-       ]
-   })
-   ```
+  ```js
+  db.createUser({
+    user: "username",
+    pwd: "password",
+    roles: ["clusterMonitor", "listCollections"],
+  })
+  ```
 
 <InstallFeedback />
 
@@ -199,7 +198,7 @@ The values for these settings can be defined in several ways:
   <tbody>
     <tr>
       <td>
-        <DoNotTranslate>**MONGODB_CLUSTER_NAME**</DoNotTranslate>
+        `MONGODB_CLUSTER_NAME`
       </td>
 
       <td>
@@ -217,7 +216,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**HOST**</DoNotTranslate>
+        `HOST`
       </td>
 
       <td>
@@ -235,11 +234,11 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**PORT**</DoNotTranslate>
+        `PORT`
       </td>
 
       <td>
-        Port on which MongoDB is listening. Default is 27017.
+        Port on which MongoDB is listening. Default is `27017`.
       </td>
 
       <td>
@@ -253,7 +252,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**USERNAME**</DoNotTranslate>
+        `USERNAME`
       </td>
 
       <td>
@@ -271,7 +270,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**PASSWORD**</DoNotTranslate>
+        `PASSWORD`
       </td>
 
       <td>
@@ -289,7 +288,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**AUTH_SOURCE**</DoNotTranslate>
+        `AUTH_SOURCE`
       </td>
 
       <td>
@@ -307,7 +306,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**SSL**</DoNotTranslate>
+        `SSL`
       </td>
 
       <td>
@@ -325,7 +324,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**SSL_CA_CERTS**</DoNotTranslate>
+        `SSL_CA_CERTS`
       </td>
 
       <td>
@@ -343,7 +342,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**SSL_INSECURE_SKIP_VERIFY**</DoNotTranslate>
+        `SSL_INSECURE_SKIP_VERIFY`
       </td>
 
       <td>
@@ -361,7 +360,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**PEM_KEY_FILE**</DoNotTranslate>
+        `PEM_KEY_FILE`
       </td>
 
       <td>
@@ -379,7 +378,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**PASSPHRASE**</DoNotTranslate>
+        `PASSPHRASE`
       </td>
 
       <td>
@@ -397,11 +396,11 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**CONCURRENT_COLLECTIONS**</DoNotTranslate>
+        `CONCURRENT_COLLECTIONS`
       </td>
 
       <td>
-        Number of entities to collect metrics for concurrently. Default is 50.
+        Number of entities to collect metrics for concurrently. Default is `50`.
       </td>
 
       <td>
@@ -415,7 +414,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**FILTERS**</DoNotTranslate>
+        `FILTERS`
       </td>
 
       <td>
@@ -433,7 +432,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**METRICS**</DoNotTranslate>
+        `METRICS`
       </td>
 
       <td>
@@ -449,7 +448,7 @@ The values for these settings can be defined in several ways:
 
     <tr>
       <td>
-        <DoNotTranslate>**INVENTORY**</DoNotTranslate>
+        `INVENTORY`
       </td>
 
       <td>
@@ -467,7 +466,7 @@ You can further decorate your metrics using labels. Labels allow you to add key/
 
 Our default sample config file includes examples of labels; however, as they are not mandatory, you can remove, modify, or add new ones of your choice.
 
-```
+```yml
  labels:
    env: production
    role: load_balancer
@@ -482,7 +481,7 @@ Our default sample config file includes examples of labels; however, as they are
   >
     This is the basic configuration used to collect metrics and inventory from your localhost:
 
-    ```
+    ```yml
     integrations:
       - name: nri-mongodb
         env:
@@ -504,7 +503,7 @@ Our default sample config file includes examples of labels; however, as they are
   >
     This configuration collects metrics every 15 seconds and inventory every 60 seconds:
 
-    ```
+    ```yml
     integrations:
       - name: nri-mongodb
         env:
@@ -539,7 +538,7 @@ Our default sample config file includes examples of labels; however, as they are
   >
     In this configuration we're using the environment variable `MONGODB_HOST` to populate the HOST setting of the integration:
 
-    ```
+    ```yml
     integrations:
       - name: nri-mongodb
         env:
@@ -566,7 +565,7 @@ Our default sample config file includes examples of labels; however, as they are
     * `db2` database metrics and metrics for `collection1` and `collection2`
     * `db3` database metrics and no collection metrics. Use an empty array `[]` if you want to skip collection metrics
 
-      ```
+      ```yml
       integrations:
         - name: nri-mongodb
           env:
@@ -590,7 +589,7 @@ Our default sample config file includes examples of labels; however, as they are
   >
     In this configuration we're monitoring multiple MongoDB servers from the same integration. For the first instance (`HOST: 1st_mongodb_host`) we're collecting metrics and inventory while for the second instance (`HOST: 2nd_mongodb_host`) we'll only collect metrics.
 
-    ```
+    ```yml
     integrations:
       - name: nri-mongodb
         env:

--- a/src/install/ibm-mq/whatsNext.mdx
+++ b/src/install/ibm-mq/whatsNext.mdx
@@ -31,7 +31,7 @@ The following configuration options are available:
   <tbody>
   <tr>
     <td>
-      **hostname**
+      `hostname`
     </td>
     <td>
       Hostname of the IBM MQ service
@@ -42,7 +42,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **port**
+      `port`
     </td>
     <td>
       Port of the IBM MQ service
@@ -53,7 +53,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **queue_manager**
+      `queue_manager`
     </td>
     <td>
       Queue Manager name
@@ -64,7 +64,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **channel**
+      `channel`
     </td>
     <td>
       Channel name used to connect to the queue manager. Typically you can use `SYSTEM.DEF.SVRCONN`
@@ -75,7 +75,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **username**
+      `username`
     </td>
     <td>
       Username to authenticate to IBM MQ service. If the password is not specified, user/password authentication is disabled and the username should not be specified in the configuration.
@@ -87,7 +87,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **password**
+      `password`
     </td>
     <td>
       Password to authenticate to IBM MQ service
@@ -98,21 +98,10 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **monitored_queues**
+      `monitored_queues`
     </td>
     <td>
-      Queues to monitor (wildcards and ! to exclude are accepted)
-    </td>
-    <td>
-      N/A
-    </td>
-  </tr>
-  <tr>
-    <td>
-      **monitored_channels**
-    </td>
-    <td>
-      Channels to monitor (wildcards and ! to exclude are accepted)
+      Queues to monitor (wildcards and `!` to exclude are accepted)
     </td>
     <td>
       N/A
@@ -120,21 +109,10 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **monitored_topics**
+      `monitored_channels`
     </td>
     <td>
-      Topics to monitor (wildcards and ! to exclude are accepted)
-    </td>
-    <td>
-      N/A
-    </td>
-  </tr>
-  <tr>
-    <td>
-      **monitored_subscriptions**
-    </td>
-    <td>
-      Subscriptions to monitor (wildcards and ! to exclude are accepted)
+      Channels to monitor (wildcards and `!` to exclude are accepted)
     </td>
     <td>
       N/A
@@ -142,33 +120,55 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **exporter_port**
+      `monitored_topics`
+    </td>
+    <td>
+      Topics to monitor (wildcards and `!` to exclude are accepted)
+    </td>
+    <td>
+      N/A
+    </td>
+  </tr>
+  <tr>
+    <td>
+      `monitored_subscriptions`
+    </td>
+    <td>
+      Subscriptions to monitor (wildcards and `!` to exclude are accepted)
+    </td>
+    <td>
+      N/A
+    </td>
+  </tr>
+  <tr>
+    <td>
+      `exporter_port`
     </td>
     <td>
       Port to expose scrape endpoint on, If this is not provided a random port will be used to launch the exporter
     </td>
     <td>
-      random-port
+      `random-port`
     </td>
   </tr>
   <tr>
     <td>
-      **scrape_timeout**
+      `scrape_timeout`
     </td>
     <td>
       Time until a scrape request times out
     </td>
     <td>
-      5s
+      `5s`
     </td>
   </tr>
   <tr>
     <td>
-      **mqsslkeyr**
+      `mqsslkeyr`
     </td>
     <td>
       Needed to configure TLS
-      MQSSLKEYR specifies the location of the keystore that holds the digital certificate belonging to the user or to the server.
+      `MQSSLKEYR` specifies the location of the keystore that holds the digital certificate belonging to the user or to the server.
       It should be specified without the extension to point to both `key.kdb` and `key.sth`.
     </td>
     <td>
@@ -177,11 +177,11 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **ccdt_url**
+      `ccdt_url`
     </td>
     <td>
       Needed to configure TLS
-      Path to the ccdt file. Two different environment variable will be set automatically: MQCCDTURL and IBMMQ_CONNECTION_CCDTURL.
+      Path to the ccdt file. Two different environment variable will be set automatically: `MQCCDTURL` and `IBMMQ_CONNECTION_CCDTURL`.
     </td>
     <td>
       N/A
@@ -189,10 +189,10 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **home**
+      `home`
     </td>
     <td>
-      IBMMQ Client needs permissions to write in a directory specified in the HOME environment variable.
+      IBMMQ Client needs permissions to write in a directory specified in the `HOME` environment variable.
     </td>
     <td>
       N/A
@@ -200,10 +200,10 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **ld_library_path**
+      `ld_library_path`
     </td>
     <td>
-      LD_LIBRARY_PATH environment variable for the IBMMQ Client used by the exporter.
+      `LD_LIBRARY_PATH` environment variable for the IBMMQ Client used by the exporter.
     </td>
     <td>
       N/A
@@ -230,19 +230,19 @@ The following configuration options are available:
 
             ```yml
             integrations:
-            - name: nri-ibmmq
+              - name: nri-ibmmq
                 config:
-                hostname: localhost
-                port: 1414
-                queue_manager: QM1
-                channel: SYSTEM.DEF.SVRCONN
-                username: your_mq_user
-                password: your_mq_password
-                monitored_queues: '!SYSTEM.*,*'
-                monitored_channels: '*'
-                monitored_topics: '*'
-                monitored_subscriptions: '*'
-                exporter_port: 9157
+                  hostname: localhost
+                  port: 1414
+                  queue_manager: QM1
+                  channel: SYSTEM.DEF.SVRCONN
+                  username: your_mq_user
+                  password: your_mq_password
+                  monitored_queues: '!SYSTEM.*,*'
+                  monitored_channels: '*'
+                  monitored_topics: '*'
+                  monitored_subscriptions: '*'
+                  exporter_port: 9157
             ```
         </TabsPageItem>
         <TabsPageItem id="different">
@@ -251,30 +251,30 @@ The following configuration options are available:
 
             ```yml
             integrations:
-            - name: nri-ibmmq
+              - name: nri-ibmmq
                 config:
-                hostname: host1
-                port: 1414
-                queue_manager: QM1
-                channel: SYSTEM.DEF.SVRCONN
-                username: your_mq_user
-                password: your_mq_password
-                monitored_queues: '!SYSTEM.*,*'
-                monitored_channels: '*'
-                monitored_topics: '*'
-                monitored_subscriptions: '*'
-            - name: nri-ibmmq
+                  hostname: host1
+                  port: 1414
+                  queue_manager: QM1
+                  channel: SYSTEM.DEF.SVRCONN
+                  username: your_mq_user
+                  password: your_mq_password
+                  monitored_queues: '!SYSTEM.*,*'
+                  monitored_channels: '*'
+                  monitored_topics: '*'
+                  monitored_subscriptions: '*'
+              - name: nri-ibmmq
                 config:
-                hostname: host2
-                port: 1414
-                queue_manager: QM1
-                channel: SYSTEM.DEF.SVRCONN
-                username: your_mq_user
-                password: your_mq_password
-                monitored_queues: '!SYSTEM.*,*'
-                monitored_channels: '*'
-                monitored_topics: '*'
-                monitored_subscriptions: '*'
+                  hostname: host2
+                  port: 1414
+                  queue_manager: QM1
+                  channel: SYSTEM.DEF.SVRCONN
+                  username: your_mq_user
+                  password: your_mq_password
+                  monitored_queues: '!SYSTEM.*,*'
+                  monitored_channels: '*'
+                  monitored_topics: '*'
+                  monitored_subscriptions: '*'
             ```
         </TabsPageItem>
         <TabsPageItem id="passwordless">
@@ -286,17 +286,17 @@ The following configuration options are available:
 
                 ```yml
                 integrations:
-                - name: nri-ibmmq
+                  - name: nri-ibmmq
                     config:
-                    hostname: localhost
-                    port: 1414
-                    queue_manager: QM1
-                    channel: SYSTEM.DEF.SVRCONN
-                    monitored_queues: '!SYSTEM.*,*'
-                    monitored_channels: '*'
-                    monitored_topics: '*'
-                    monitored_subscriptions: '*'
-                    exporter_port: 9157
+                      hostname: localhost
+                      port: 1414
+                      queue_manager: QM1
+                      channel: SYSTEM.DEF.SVRCONN
+                      monitored_queues: '!SYSTEM.*,*'
+                      monitored_channels: '*'
+                      monitored_topics: '*'
+                      monitored_subscriptions: '*'
+                      exporter_port: 9157
                 ```
         </TabsPageItem>
         <TabsPageItem id="filters">
@@ -304,19 +304,19 @@ The following configuration options are available:
 
                 ```yml
                 integrations:
-                - name: nri-ibmmq
+                  - name: nri-ibmmq
                     config:
-                    hostname: localhost
-                    port: 1414
-                    queue_manager: QM1
-                    channel: SYSTEM.DEF.SVRCONN
-                    username: your_mq_user
-                    password: your_mq_password
-                    monitored_queues: 'DEV.QUEUE*,!DEV.QUEUE.1'
-                    monitored_channels: '*'
-                    monitored_topics: '*'
-                    monitored_subscriptions: '*'
-                    exporter_port: 9157
+                      hostname: localhost
+                      port: 1414
+                      queue_manager: QM1
+                      channel: SYSTEM.DEF.SVRCONN
+                      username: your_mq_user
+                      password: your_mq_password
+                      monitored_queues: 'DEV.QUEUE*,!DEV.QUEUE.1'
+                      monitored_channels: '*'
+                      monitored_topics: '*'
+                      monitored_subscriptions: '*'
+                      exporter_port: 9157
                 ```
         </TabsPageItem>
         <TabsPageItem id="mtls">
@@ -327,22 +327,22 @@ The following configuration options are available:
 
                 ```yml
                 integrations:
-                - name: nri-ibmmq
+                  - name: nri-ibmmq
                     config:
-                    queue_manager: QM1
-                    channel: SYSTEM.DEF.SVRCONN
-                    username: your_mq_user
-                    password: your_mq_password
-                    monitored_queues: 'DEV.QUEUE*,!DEV.QUEUE.1'
-                    monitored_channels: '*'
-                    monitored_topics: '*'
-                    monitored_subscriptions: '*'
-                    exporter_port: 9157
+                      queue_manager: QM1
+                      channel: SYSTEM.DEF.SVRCONN
+                      username: your_mq_user
+                      password: your_mq_password
+                      monitored_queues: 'DEV.QUEUE*,!DEV.QUEUE.1'
+                      monitored_channels: '*'
+                      monitored_topics: '*'
+                      monitored_subscriptions: '*'
+                      exporter_port: 9157
 
-                    # Configuring mTLS
-                    mqsslkeyr: "/key"
-                    ccdt_url: "file:///ccdt.json"
-                    home: /tmp
+                      # Configuring mTLS
+                      mqsslkeyr: "/key"
+                      ccdt_url: "file:///ccdt.json"
+                      home: /tmp
                 ```
         </TabsPageItem>
     </TabsPages>

--- a/src/install/jmx/linux/install-linux.mdx
+++ b/src/install/jmx/linux/install-linux.mdx
@@ -25,16 +25,16 @@ headingText: Configure the JMX integration
 
     ```yml
       integrations:
-      - name: nri-jmx
-        env:
-          COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
-          JMX_HOST: jmx-host.localnet
-          JMX_PASS: admin
-          JMX_PORT: 9999
-          JMX_USER: admin
-        interval: 15s
-        labels:
-          env: production
+        - name: nri-jmx
+          env:
+            COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
+            JMX_HOST: jmx-host.localnet
+            JMX_PASS: admin
+            JMX_PORT: 9999
+            JMX_USER: admin
+          interval: 15s
+          labels:
+            env: production
     ```
 
 5. <DoNotTranslate>**Optional**</DoNotTranslate>: If you're interested in monitoring Tomcat, use this sample metrics file:

--- a/src/install/jmx/windows/install-windows.mdx
+++ b/src/install/jmx/windows/install-windows.mdx
@@ -21,14 +21,14 @@ headingText: Install the JMX monitoring integration
 
     ```yml
       integrations:
-      - name: nri-jmx
-        env:
-          COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
-          JMX_HOST: jmx-host.localnet
-          JMX_PASS: admin
-          JMX_PORT: 9999
-          JMX_USER: admin
-        interval: 15s
-        labels:
-          env: production
+        - name: nri-jmx
+          env:
+            COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
+            JMX_HOST: jmx-host.localnet
+            JMX_PASS: admin
+            JMX_PORT: 9999
+            JMX_USER: admin
+          interval: 15s
+          labels:
+            env: production
     ```

--- a/src/install/kafka/default-configuration.mdx
+++ b/src/install/kafka/default-configuration.mdx
@@ -17,7 +17,7 @@ sudo cp nri-kafka-config.yml.sample kafka-config.yml
 
 3. Edit the `kafka-config.yml` file. The following example collects metrics and inventory discovered from two JMX hosts. 
 
-```
+```yml
 integrations:
   - name: nri-kafka
     env:

--- a/src/install/kafka/default-install-linux.mdx
+++ b/src/install/kafka/default-install-linux.mdx
@@ -17,22 +17,22 @@ headingText: Configure the Kafka integration
 
 3. Edit the `kafka-config.yml` file. The following example collects metrics and inventory discovered from two JMX hosts. 
 
-    ```
+    ```yml
     integrations:
-    - name: nri-kafka
+      - name: nri-kafka
         env:
-        CLUSTER_NAME: testcluster1
-        KAFKA_VERSION: "1.0.0"
-        AUTODISCOVER_STRATEGY: zookeeper
-        ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
-        ZOOKEEPER_PATH: "/kafka-root"
-        DEFAULT_JMX_USER: username
-        DEFAULT_JMX_PASSWORD: password
-        TOPIC_MODE: all
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: all
         interval: 15s
         labels:
-        env: production
-        role: kafka
+          env: production
+          role: kafka
         inventory_source: config/kafka
     ```
 

--- a/src/install/kafka/linux/install-apt.mdx
+++ b/src/install/kafka/linux/install-apt.mdx
@@ -5,10 +5,10 @@ headingText: Download using APT
 
 1. Run the following commands:
 
-    ```yml
+    ```shell
     sudo apt-get update
     ```
 
-    ```yml
+    ```shell
     sudo apt-get install nri-kafka
     ```

--- a/src/install/kafka/linux/install-linux-boot.mdx
+++ b/src/install/kafka/linux/install-linux-boot.mdx
@@ -17,28 +17,28 @@ headingText: Configure the Kafka integration
 
 3. Edit the `kafka-config.yml` file to configure the integration. The following example collects metrics and inventory discovered by the bootstrap broker. 
 
-    ```
+    ```yml
     integrations:
-    - name: nri-kafka
+      - name: nri-kafka
         env:
-        CLUSTER_NAME: testcluster1
-        AUTODISCOVER_STRATEGY: bootstrap
-        BOOTSTRAP_BROKER_HOST: localhost
-        BOOTSTRAP_BROKER_KAFKA_PORT: 9092
-        BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT
-        BOOTSTRAP_BROKER_JMX_PORT: 9999  # This same port will be used to connect to all discover broker JMX
-        BOOTSTRAP_BROKER_JMX_USER: admin
-        BOOTSTRAP_BROKER_JMX_PASSWORD: password
+          CLUSTER_NAME: testcluster1
+          AUTODISCOVER_STRATEGY: bootstrap
+          BOOTSTRAP_BROKER_HOST: localhost
+          BOOTSTRAP_BROKER_KAFKA_PORT: 9092
+          BOOTSTRAP_BROKER_KAFKA_PROTOCOL: PLAINTEXT
+          BOOTSTRAP_BROKER_JMX_PORT: 9999  # This same port will be used to connect to all discover broker JMX
+          BOOTSTRAP_BROKER_JMX_USER: admin
+          BOOTSTRAP_BROKER_JMX_PASSWORD: password
 
-        LOCAL_ONLY_COLLECTION: false
-
-        COLLECT_BROKER_TOPIC_DATA: true
-        TOPIC_MODE: "all"
-        COLLECT_TOPIC_SIZE: false
+          LOCAL_ONLY_COLLECTION: false
+  
+          COLLECT_BROKER_TOPIC_DATA: true
+          TOPIC_MODE: "all"
+          COLLECT_TOPIC_SIZE: false
         interval: 15s
         labels:
-        env: production
-        role: kafka
+          env: production
+          role: kafka
         inventory_source: config/kafka
     ```
 

--- a/src/install/kafka/linux/install-linux-zoo.mdx
+++ b/src/install/kafka/linux/install-linux-zoo.mdx
@@ -17,22 +17,22 @@ headingText: Configure the Kafka integration
 
 3. Edit the `kafka-config.yml` file to configure the integration. The following example collects metrics and inventory discovered from two JMX hosts. 
 
-    ```
+    ```yml
     integrations:
-    - name: nri-kafka
+      - name: nri-kafka
         env:
-        CLUSTER_NAME: testcluster1
-        KAFKA_VERSION: "1.0.0"
-        AUTODISCOVER_STRATEGY: zookeeper
-        ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
-        ZOOKEEPER_PATH: "/kafka-root"
-        DEFAULT_JMX_USER: username
-        DEFAULT_JMX_PASSWORD: password
-        TOPIC_MODE: all
+          CLUSTER_NAME: testcluster1
+          KAFKA_VERSION: "1.0.0"
+          AUTODISCOVER_STRATEGY: zookeeper
+          ZOOKEEPER_HOSTS: '[{"host": "localhost", "port": 2181}, {"host": "localhost2", "port": 2181}]'
+          ZOOKEEPER_PATH: "/kafka-root"
+          DEFAULT_JMX_USER: username
+          DEFAULT_JMX_PASSWORD: password
+          TOPIC_MODE: all
         interval: 15s
         labels:
-        env: production
-        role: kafka
+          env: production
+          role: kafka
         inventory_source: config/kafka
     ```
 

--- a/src/install/kafka/linux/install-yum.mdx
+++ b/src/install/kafka/linux/install-yum.mdx
@@ -5,10 +5,10 @@ headingText: Download using Yum
 
 1. Run the following commands: 
 
-    ```
+    ```shell
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
     ```
 
-    ```
+    ```shell
     sudo yum install nri-kafka
     ```

--- a/src/install/kafka/linux/install-zypper.mdx
+++ b/src/install/kafka/linux/install-zypper.mdx
@@ -5,10 +5,10 @@ headingText: Download using Zypper
 
 1. From the command line, run:
 
-    ```
+    ```shell
     sudo zypper -n ref -r newrelic-infra
     ```
 
-    ```
+    ```shell
     sudo zypper -n install nri-kafka
     ```

--- a/src/install/kafka/whatsNext.mdx
+++ b/src/install/kafka/whatsNext.mdx
@@ -40,7 +40,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
   <tbody>
     <tr>
       <td>
-        **CLUSTER_NAME**
+        `CLUSTER_NAME`
       </td>
 
       <td>
@@ -58,7 +58,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **KAFKA_VERSION**
+        `KAFKA_VERSION`
       </td>
 
       <td>
@@ -70,7 +70,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        1.0.0
+        `1.0.0`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -84,7 +84,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **AUTODISCOVER_STRATEGY**
+        `AUTODISCOVER_STRATEGY`
       </td>
 
       <td>
@@ -92,7 +92,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        zookeeper
+        `zookeeper`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -106,7 +106,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **METRICS**
+        `METRICS`
       </td>
 
       <td>
@@ -114,7 +114,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -126,7 +126,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **INVENTORY**
+        `INVENTORY`
       </td>
 
       <td>
@@ -134,7 +134,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -170,7 +170,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
   <tbody>
     <tr>
       <td>
-        **ZOOKEEPER_HOSTS**
+        `ZOOKEEPER_HOSTS`
       </td>
 
       <td>
@@ -180,7 +180,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
       </td>
 
       <td>
-        \[]
+        `[]`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -194,7 +194,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
 
     <tr>
       <td>
-        **ZOOKEEPER_AUTH_SCHEME**
+        `ZOOKEEPER_AUTH_SCHEME`
       </td>
 
       <td>
@@ -217,7 +217,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
 
     <tr>
       <td>
-        **ZOOKEEPER_AUTH_SECRET**
+        `ZOOKEEPER_AUTH_SECRET`
       </td>
 
       <td>
@@ -241,7 +241,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
 
     <tr>
       <td>
-        **ZOOKEEPER_PATH**
+        `ZOOKEEPER_PATH`
       </td>
 
       <td>
@@ -250,7 +250,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
       </td>
 
       <td>
-        N/A
+        `/`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -264,7 +264,7 @@ These are only relevant when the `autodiscover_strategy` option is set to `zooke
 
     <tr>
       <td>
-        **PREFERRED_LISTENER**
+        `PREFERRED_LISTENER`
       </td>
 
       <td>
@@ -313,7 +313,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
   <tbody>
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_HOST**
+        `BOOTSTRAP_BROKER_HOST`
       </td>
 
       <td>
@@ -337,7 +337,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_KAFKA_PORT**
+        `BOOTSTRAP_BROKER_KAFKA_PORT`
       </td>
 
       <td>
@@ -355,7 +355,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_KAFKA_PROTOCOL**
+        `BOOTSTRAP_BROKER_KAFKA_PROTOCOL`
       </td>
 
       <td>
@@ -365,7 +365,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
       </td>
 
       <td>
-        PLAINTEXT
+        `PLAINTEXT`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -375,7 +375,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_JMX_PORT**
+        `BOOTSTRAP_BROKER_JMX_PORT`
       </td>
 
       <td>
@@ -399,7 +399,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_JMX_USER**
+        `BOOTSTRAP_BROKER_JMX_USER`
       </td>
 
       <td>
@@ -421,7 +421,7 @@ These are only relevant when the `autodiscover_strategy` option is set to`bootst
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_JMX_PASSWORD**
+        `BOOTSTRAP_BROKER_JMX_PASSWORD`
       </td>
 
       <td>
@@ -467,7 +467,7 @@ These options apply to all JMX connections on the instance.
   <tbody>
     <tr>
       <td>
-        **KEY_STORE**
+        `KEY_STORE`
       </td>
 
       <td>
@@ -489,7 +489,7 @@ These options apply to all JMX connections on the instance.
 
     <tr>
       <td>
-        **KEY_STORE_PASSWORD**
+        `KEY_STORE_PASSWORD`
       </td>
 
       <td>
@@ -511,7 +511,7 @@ These options apply to all JMX connections on the instance.
 
     <tr>
       <td>
-        **TRUST_STORE**
+        `TRUST_STORE`
       </td>
 
       <td>
@@ -534,7 +534,7 @@ These options apply to all JMX connections on the instance.
 
     <tr>
       <td>
-        **TRUST_STORE_PASSWORD**
+        `TRUST_STORE_PASSWORD`
       </td>
 
       <td>
@@ -556,7 +556,7 @@ These options apply to all JMX connections on the instance.
 
     <tr>
       <td>
-        **DEFAULT_JMX_USER**
+        `DEFAULT_JMX_USER`
       </td>
 
       <td>
@@ -579,7 +579,7 @@ These options apply to all JMX connections on the instance.
 
     <tr>
       <td>
-        **DEFAULT_JMX_PASSWORD**
+        `DEFAULT_JMX_PASSWORD`
       </td>
 
       <td>
@@ -602,7 +602,7 @@ These options apply to all JMX connections on the instance.
 
     <tr>
       <td>
-        **TIMEOUT**
+        `TIMEOUT`
       </td>
 
       <td>
@@ -610,7 +610,7 @@ These options apply to all JMX connections on the instance.
       </td>
 
       <td>
-        10000
+        `10000`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -648,7 +648,7 @@ You need these options if the broker protocol is `SSL` or `SASL_SSL`.
   <tbody>
     <tr>
       <td>
-        **TLS_CA_FILE**
+        `TLS_CA_FILE`
       </td>
 
       <td>
@@ -670,7 +670,7 @@ You need these options if the broker protocol is `SSL` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TLS_CERT_FILE**
+        `TLS_CERT_FILE`
       </td>
 
       <td>
@@ -692,7 +692,7 @@ You need these options if the broker protocol is `SSL` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TLS_KEY_FILE**
+        `TLS_KEY_FILE`
       </td>
 
       <td>
@@ -714,7 +714,7 @@ You need these options if the broker protocol is `SSL` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TLS_INSECURE_SKIP_VERIFY**
+        `TLS_INSECURE_SKIP_VERIFY`
       </td>
 
       <td>
@@ -722,7 +722,7 @@ You need these options if the broker protocol is `SSL` or `SASL_SSL`.
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -760,7 +760,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
   <tbody>
     <tr>
       <td>
-        **SASL_MECHANISM**
+        `SASL_MECHANISM`
       </td>
 
       <td>
@@ -782,7 +782,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_USERNAME**
+        `SASL_USERNAME`
       </td>
 
       <td>
@@ -804,7 +804,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_PASSWORD**
+        `SASL_PASSWORD`
       </td>
 
       <td>
@@ -826,7 +826,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_GSSAPI_REALM**
+        `SASL_GSSAPI_REALM`
       </td>
 
       <td>
@@ -848,7 +848,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_GSSAPI_SERVICE_NAME**
+        `SASL_GSSAPI_SERVICE_NAME`
       </td>
 
       <td>
@@ -870,7 +870,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_GSSAPI_USERNAME**
+        `SASL_GSSAPI_USERNAME`
       </td>
 
       <td>
@@ -892,7 +892,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_GSSAPI_KEY_TAB_PATH**
+        `SASL_GSSAPI_KEY_TAB_PATH`
       </td>
 
       <td>
@@ -914,7 +914,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_GSSAPI_KERBEROS_CONFIG_PATH**
+        `SASL_GSSAPI_KERBEROS_CONFIG_PATH`
       </td>
 
       <td>
@@ -922,7 +922,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        /etc/krb5.conf
+        `/etc/krb5.conf`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -936,7 +936,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **SASL_GSSAPI_DISABLE_FAST_NEGOTIATION**
+        `SASL_GSSAPI_DISABLE_FAST_NEGOTIATION`
       </td>
 
       <td>
@@ -944,7 +944,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -980,7 +980,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
   <tbody>
     <tr>
       <td>
-        **LOCAL_ONLY_COLLECTION**
+        `LOCAL_ONLY_COLLECTION`
       </td>
 
       <td>
@@ -988,11 +988,11 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
         **You must set environments that use discovery (such as Kubernetes) to true, otherwise it will discover brokers twice:**
 
-        **Note that activating this flag will skip KafkaTopicSample collection**
+        **Note that activating this flag will skip `KafkaTopicSample` collection**
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1006,7 +1006,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TOPIC_MODE**
+        `TOPIC_MODE`
       </td>
 
       <td>
@@ -1015,7 +1015,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        none
+        `none`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1029,7 +1029,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TOPIC_LIST**
+        `TOPIC_LIST`
       </td>
 
       <td>
@@ -1038,7 +1038,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        \[]
+        `[]`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1052,7 +1052,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TOPIC_REGEX**
+        `TOPIC_REGEX`
       </td>
 
       <td>
@@ -1071,7 +1071,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **TOPIC_BUCKET**
+        `TOPIC_BUCKET`
       </td>
 
       <td>
@@ -1079,7 +1079,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        1/1
+        `1/1`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1089,7 +1089,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **COLLECT_TOPIC_SIZE**
+        `COLLECT_TOPIC_SIZE`
       </td>
 
       <td>
@@ -1099,7 +1099,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1109,7 +1109,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
 
     <tr>
       <td>
-        **COLLECT_TOPIC_OFFSET**
+        `COLLECT_TOPIC_OFFSET`
       </td>
 
       <td>
@@ -1119,7 +1119,7 @@ You need these options if the broker protocol is `SASL_PLAINTEXT` or `SASL_SSL`.
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1157,7 +1157,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
   <tbody>
     <tr>
       <td>
-        **CLUSTER_NAME**
+        `CLUSTER_NAME`
       </td>
 
       <td>
@@ -1175,7 +1175,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **PRODUCERS**
+        `PRODUCERS`
       </td>
 
       <td>
@@ -1183,7 +1183,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
         `name` is the producer’s name as it appears in Kafka. If it isn't set, metrics from all producers in the `host:port` will be gathered.
         `host`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
         It's also possible to set the value `default` to let the `name` undefined and use the default values for `host`, `port`, `username` and `password`.
-        Required to produce KafkaProducerSample.
+        Required to produce `KafkaProducerSample`.
 
         **Examples:**
 
@@ -1194,7 +1194,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        \[]
+        `[]`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1204,7 +1204,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **CONSUMERS**
+        `CONSUMERS`
       </td>
 
       <td>
@@ -1212,7 +1212,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
         `name` is the consumer’s name as it appears in Kafka. If it is not set, metrics from all consumers in the `host:port` will be gathered.
         `host`, `port`, `username`, and `password` are the optional JMX settings and use the default if unspecified.
         It is also possible to set the value `default` to let the `name` undefined and use the default values for `host`, `port`, `username` and `password`.
-        Required to produce KafkaConsumerSample.
+        Required to produce `KafkaConsumerSample`.
 
         **Examples:**
 
@@ -1223,7 +1223,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        \[]
+        `[]`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1237,7 +1237,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **DEFAULT_JMX_HOST**
+        `DEFAULT_JMX_HOST`
       </td>
 
       <td>
@@ -1246,7 +1246,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        localhost
+        `localhost`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1260,7 +1260,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **DEFAULT_JMX_PORT**
+        `DEFAULT_JMX_PORT`
       </td>
 
       <td>
@@ -1269,7 +1269,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        9999
+        `9999`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1283,16 +1283,16 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **DEFAULT_JMX_USER**
+        `DEFAULT_JMX_USER`
       </td>
 
       <td>
-        The default user that is connecting to the JMX host to collect metrics. Ifif you omit the username field from a producer or consumer configuration,
+        The default user that is connecting to the JMX host to collect metrics. If you omit the username field from a producer or consumer configuration,
         this value will be used.
       </td>
 
       <td>
-        admin
+        `admin`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1306,7 +1306,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **DEFAULT_JMX_PASSWORD**
+        `DEFAULT_JMX_PASSWORD`
       </td>
 
       <td>
@@ -1314,7 +1314,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        admin
+        `admin`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1328,7 +1328,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **METRICS**
+        `METRICS`
       </td>
 
       <td>
@@ -1336,7 +1336,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -1348,7 +1348,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
 
     <tr>
       <td>
-        **INVENTORY**
+        `INVENTORY`
       </td>
 
       <td>
@@ -1356,7 +1356,7 @@ The Kafka integration collects both Metrics(<strong>M</strong>) and Inventory(<s
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -1392,7 +1392,7 @@ These options apply to all JMX connections on the instance:
   <tbody>
     <tr>
       <td>
-        **KEY_STORE**
+        `KEY_STORE`
       </td>
 
       <td>
@@ -1414,7 +1414,7 @@ These options apply to all JMX connections on the instance:
 
     <tr>
       <td>
-        **KEY_STORE_PASSWORD**
+        `KEY_STORE_PASSWORD`
       </td>
 
       <td>
@@ -1436,7 +1436,7 @@ These options apply to all JMX connections on the instance:
 
     <tr>
       <td>
-        **TRUST_STORE**
+        `TRUST_STORE`
       </td>
 
       <td>
@@ -1459,7 +1459,7 @@ These options apply to all JMX connections on the instance:
 
     <tr>
       <td>
-        **TRUST_STORE_PASSWORD**
+        `TRUST_STORE_PASSWORD`
       </td>
 
       <td>
@@ -1481,7 +1481,7 @@ These options apply to all JMX connections on the instance:
 
     <tr>
       <td>
-        **TIMEOUT**
+        `TIMEOUT`
       </td>
 
       <td>
@@ -1489,7 +1489,7 @@ These options apply to all JMX connections on the instance:
       </td>
 
       <td>
-        10000
+        `10000`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1527,7 +1527,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
   <tbody>
     <tr>
       <td>
-        **CLUSTER_NAME**
+        `CLUSTER_NAME`
       </td>
 
       <td>
@@ -1545,7 +1545,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **KAFKA_VERSION**
+        `KAFKA_VERSION`
       </td>
 
       <td>
@@ -1557,7 +1557,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        1.0.0
+        `1.0.0`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1571,7 +1571,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **AUTODISCOVER_STRATEGY**
+        `AUTODISCOVER_STRATEGY`
       </td>
 
       <td>
@@ -1579,7 +1579,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        zookeeper
+        `zookeeper`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1589,17 +1589,17 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **CONSUMER_OFFSET**
+        `CONSUMER_OFFSET`
       </td>
 
       <td>
-        Populate consumer offset data in KafkaOffsetSample if set to true.
+        Populate consumer offset data in `KafkaOffsetSample` if set to `true`.
 
-        **Note that this option will skip Broker/Consumer/Producer collection and only collect KafkaOffsetSample**
+        **Note that this option will skip Broker/Consumer/Producer collection and only collect `KafkaOffsetSample`**
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1609,13 +1609,13 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **CONSUMER_GROUP_REGEX**
+        `CONSUMER_GROUP_REGEX`
       </td>
 
       <td>
         Regex pattern that matches the consumer groups to collect offset statistics for. This is limited to collecting statistics for 300 consumer groups.
 
-        Note: This option must be set when CONSUMER_OFFSET is true.
+        Note: This option must be set when `CONSUMER_OFFSET` is `true`.
       </td>
 
       <td>
@@ -1629,15 +1629,15 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **INACTIVE_CONSUMER_GROUP_OFFSET**
+        `INACTIVE_CONSUMER_GROUP_OFFSET`
       </td>
 
       <td>
-        Collects offset metrics from consumer groups without any active consumer, it requires CONSUMER_OFFSET set to true.
+        Collects offset metrics from consumer groups without any active consumer, it requires `CONSUMER_OFFSET` set to `true`.
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1647,11 +1647,11 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **CONSUMER_GROUP_OFFSET_BY_TOPIC**
+        `CONSUMER_GROUP_OFFSET_BY_TOPIC`
       </td>
 
       <td>
-        Activates an extra metric aggregation for consumerGroup by topic. It requires CONSUMER_OFFSET set to true.
+        Activates an extra metric aggregation for consumerGroup by topic. It requires `CONSUMER_OFFSET` set to `true`.
       </td>
 
       <td>
@@ -1669,7 +1669,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **METRICS**
+        `METRICS`
       </td>
 
       <td>
@@ -1677,7 +1677,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -1689,7 +1689,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
 
     <tr>
       <td>
-        **INVENTORY**
+        `INVENTORY`
       </td>
 
       <td>
@@ -1697,7 +1697,7 @@ The Kafka integration collects both Metrics and Inventory information. Check the
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -1733,7 +1733,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
   <tbody>
     <tr>
       <td>
-        **ZOOKEEPER_HOSTS**
+        `ZOOKEEPER_HOSTS`
       </td>
 
       <td>
@@ -1743,7 +1743,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
       </td>
 
       <td>
-        \[]
+        `[]`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1757,7 +1757,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
 
     <tr>
       <td>
-        **ZOOKEEPER_AUTH_SCHEME**
+        `ZOOKEEPER_AUTH_SCHEME`
       </td>
 
       <td>
@@ -1780,7 +1780,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
 
     <tr>
       <td>
-        **ZOOKEEPER_AUTH_SECRET**
+        `ZOOKEEPER_AUTH_SECRET`
       </td>
 
       <td>
@@ -1804,7 +1804,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
 
     <tr>
       <td>
-        **ZOOKEEPER_PATH**
+        `ZOOKEEPER_PATH`
       </td>
 
       <td>
@@ -1813,7 +1813,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
       </td>
 
       <td>
-        N/A
+        `/`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1827,7 +1827,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `zookeep
 
     <tr>
       <td>
-        **PREFERRED_LISTENER**
+        `PREFERRED_LISTENER`
       </td>
 
       <td>
@@ -1876,7 +1876,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
   <tbody>
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_HOST**
+        `BOOTSTRAP_BROKER_HOST`
       </td>
 
       <td>
@@ -1900,7 +1900,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_KAFKA_PORT**
+        `BOOTSTRAP_BROKER_KAFKA_PORT`
       </td>
 
       <td>
@@ -1918,7 +1918,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_KAFKA_PROTOCOL**
+        `BOOTSTRAP_BROKER_KAFKA_PROTOCOL`
       </td>
 
       <td>
@@ -1928,7 +1928,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
       </td>
 
       <td>
-        PLAINTEXT
+        `PLAINTEXT`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -1938,7 +1938,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_JMX_PORT**
+        `BOOTSTRAP_BROKER_JMX_PORT`
       </td>
 
       <td>
@@ -1962,7 +1962,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_JMX_USER**
+        `BOOTSTRAP_BROKER_JMX_USER`
       </td>
 
       <td>
@@ -1984,7 +1984,7 @@ This is only relevant when the `autodiscover_strategy` option is set to `bootstr
 
     <tr>
       <td>
-        **BOOTSTRAP_BROKER_JMX_PASSWORD**
+        `BOOTSTRAP_BROKER_JMX_PASSWORD`
       </td>
 
       <td>
@@ -2030,7 +2030,7 @@ These apply to all JMX connections on an instance.
   <tbody>
     <tr>
       <td>
-        **KEY_STORE**
+        `KEY_STORE`
       </td>
 
       <td>
@@ -2052,7 +2052,7 @@ These apply to all JMX connections on an instance.
 
     <tr>
       <td>
-        **KEY_STORE_PASSWORD**
+        `KEY_STORE_PASSWORD`
       </td>
 
       <td>
@@ -2074,7 +2074,7 @@ These apply to all JMX connections on an instance.
 
     <tr>
       <td>
-        **TRUST_STORE**
+        `TRUST_STORE`
       </td>
 
       <td>
@@ -2097,7 +2097,7 @@ These apply to all JMX connections on an instance.
 
     <tr>
       <td>
-        **TRUST_STORE_PASSWORD**
+        `TRUST_STORE_PASSWORD`
       </td>
 
       <td>
@@ -2119,7 +2119,7 @@ These apply to all JMX connections on an instance.
 
     <tr>
       <td>
-        **DEFAULT_JMX_USER**
+        `DEFAULT_JMX_USER`
       </td>
 
       <td>
@@ -2142,7 +2142,7 @@ These apply to all JMX connections on an instance.
 
     <tr>
       <td>
-        **DEFAULT_JMX_PASSWORD**
+        `DEFAULT_JMX_PASSWORD`
       </td>
 
       <td>
@@ -2165,7 +2165,7 @@ These apply to all JMX connections on an instance.
 
     <tr>
       <td>
-        **TIMEOUT**
+        `TIMEOUT`
       </td>
 
       <td>
@@ -2263,7 +2263,7 @@ These apply to all JMX connections on an instance.
     id="zookeeper"
     title="Zookeper discovery"
   >
-    This configuration collects `Metrics` and `Inventory` including all topics discovering the brokers from two different JMX hosts :
+    This configuration collects `Metrics` and `Inventory` including all topics discovering the brokers from two different JMX hosts:
 
     ```yml
     integrations:
@@ -2289,7 +2289,7 @@ These apply to all JMX connections on an instance.
     id="zookeeper-ssl"
     title="Zookeper SSL discovery"
   >
-    This configuration collects Metrics and Inventory discovering the brokers from a JMX host with SSL :
+    This configuration collects Metrics and Inventory discovering the brokers from a JMX host with SSL:
 
     ```yml
     integrations:
@@ -2321,7 +2321,7 @@ These apply to all JMX connections on an instance.
     id="bootstrap"
     title="Bootstrap discovery"
   >
-    This configuration collects Metrics and Inventory including all topics discovering the brokers from one bootstrap broker :
+    This configuration collects Metrics and Inventory including all topics discovering the brokers from one bootstrap broker:
 
     ```yml
     integrations:
@@ -2353,7 +2353,7 @@ These apply to all JMX connections on an instance.
     id="bootstrap-tls"
     title="Bootstrap discovery TLS"
   >
-    This configuration collects only Metrics discovering the brokers from one bootstrap broker listening with TLS protocol :
+    This configuration collects only Metrics discovering the brokers from one bootstrap broker listening with TLS protocol:
 
     ```yml
     integrations:
@@ -2386,7 +2386,7 @@ These apply to all JMX connections on an instance.
     id="boostrap-kerberos"
     title="Bootstrap discovery kerberos auth"
   >
-    This configuration collects only Metrics discovering the brokers from one bootstrap broker in a Kerberos Auth Cluster :
+    This configuration collects only Metrics discovering the brokers from one bootstrap broker in a Kerberos Auth Cluster:
 
     ```yml
     integrations:

--- a/src/install/kafka/windows/install-msi.mdx
+++ b/src/install/kafka/windows/install-msi.mdx
@@ -5,6 +5,6 @@ headingText: Download using MSI
 
 1. Download the latest .MSI installer image for the desired integration [from our repository](https://download.newrelic.com/infrastructure_agent/windows/integrations/).
 2. In an admin account, run the install script using an absolute path.
-    ```
+    ```shell
     msiexec.exe /qn /i PATH\TO\nri-kafka.msi
     ```

--- a/src/install/kafka/windows/install-windows-boot.mdx
+++ b/src/install/kafka/windows/install-windows-boot.mdx
@@ -5,13 +5,13 @@ headingText: Configure the Kafka integration
 
 1. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
-```
+```shell
 copy kafka-config.yml.sample kafka-config.yml
 ```
 
 2. Edit the `kafka-config.yml` file to configure the integration. The following example collects metrics and inventory discovered by the bootstrap broker. 
 
-```
+```yml
 integrations:
   - name: nri-kafka
     env:

--- a/src/install/kafka/windows/install-windows-zoo.mdx
+++ b/src/install/kafka/windows/install-windows-zoo.mdx
@@ -5,13 +5,13 @@ headingText: Configure the Kafka integration
 
 1. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
-```
+```shell
 copy kafka-config.yml.sample kafka-config.yml
 ```
 
 2. Edit the `kafka-config.yml` file to configure the integration.  The following example collects metrics and inventory discovered from two JMX hosts. 
 
-```
+```yml
 integrations:
   - name: nri-kafka
     env:

--- a/src/install/memcached/default-install-linux.mdx
+++ b/src/install/memcached/default-install-linux.mdx
@@ -19,14 +19,14 @@ headingText: Configure the Memcached integration
 
     ```yml
     integrations:
-    - name: nri-memcached
+      - name: nri-memcached
         env:
-        PORT: "11211"
-        HOST: memcached_host
-
-        # ifauthentication is enabled.
-        USERNAME: cacheuser
-        PASSWORD: password
+          PORT: "11211"
+          HOST: memcached_host
+  
+          # ifauthentication is enabled.
+          USERNAME: cacheuser
+          PASSWORD: password
         interval: 15s
         inventory_source: config/memcached
     ```

--- a/src/install/memcached/whatsNext.mdx
+++ b/src/install/memcached/whatsNext.mdx
@@ -31,7 +31,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
   <tbody>
     <tr>
       <td>
-        <DoNotTranslate>**HOST**</DoNotTranslate>
+        `HOST`
       </td>
 
       <td>
@@ -39,7 +39,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
       </td>
 
       <td>
-        localhost
+        `localhost`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -53,7 +53,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
 
     <tr>
       <td>
-        <DoNotTranslate>**PORT**</DoNotTranslate>
+        `PORT`
       </td>
 
       <td>
@@ -61,7 +61,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
       </td>
 
       <td>
-        11211
+        `11211`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -75,7 +75,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
 
     <tr>
       <td>
-        <DoNotTranslate>**USERNAME**</DoNotTranslate>
+        `USERNAME`
       </td>
 
       <td>
@@ -97,7 +97,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
 
     <tr>
       <td>
-        <DoNotTranslate>**PASSWORD**</DoNotTranslate>
+        `PASSWORD`
       </td>
 
       <td>
@@ -119,7 +119,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
 
     <tr>
       <td>
-        <DoNotTranslate>**METRICS**</DoNotTranslate>
+        `METRICS`
       </td>
 
       <td>
@@ -127,7 +127,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -139,7 +139,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
 
     <tr>
       <td>
-        <DoNotTranslate>**INVENTORY**</DoNotTranslate>
+        `INVENTORY`
       </td>
 
       <td>
@@ -147,7 +147,7 @@ The Memcached integration collects both Metrics(<strong>M</strong>) and Inventor
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>

--- a/src/install/memcached/windows/install-msi.mdx
+++ b/src/install/memcached/windows/install-msi.mdx
@@ -5,6 +5,6 @@ headingText: Download using MSI
 
 1. Download the latest .MSI installer image for the desired integration [from our repository](https://download.newrelic.com/infrastructure_agent/windows/integrations/).
 2. In an admin account, run the install script using an absolute path.
-    ```
+    ```shell
     msiexec.exe /qn /i PATH\TO\nri-memcached.msi
     ```

--- a/src/install/memcached/windows/install-windows.mdx
+++ b/src/install/memcached/windows/install-windows.mdx
@@ -13,14 +13,14 @@ headingText: Configure the Memcached integration
 
     ```yml
     integrations:
-    - name: nri-memcached
+      - name: nri-memcached
         env:
-        PORT: "11211"
-        HOST: memcached_host
-
-        # ifauthentication is enabled.
-        USERNAME: cacheuser
-        PASSWORD: password
+          PORT: "11211"
+          HOST: memcached_host
+  
+          # ifauthentication is enabled.
+          USERNAME: cacheuser
+          PASSWORD: password
         interval: 15s
         inventory_source: config/memcached
     ```

--- a/src/install/microsoft-sql/whatsNext.mdx
+++ b/src/install/microsoft-sql/whatsNext.mdx
@@ -726,7 +726,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
   <tbody>
     <tr>
       <td>
-        <DoNotTranslate>**HOSTNAME**</DoNotTranslate>
+        `HOSTNAME`
       </td>
 
       <td>
@@ -734,7 +734,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        127.0.0.1
+        `127.0.0.1`
       </td>
 
       <td style={{ "text-align": "center" }}>
@@ -748,7 +748,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**PORT**</DoNotTranslate>
+        `PORT`
       </td>
 
       <td>
@@ -758,7 +758,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        1433
+        `1433`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -772,7 +772,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**INSTANCE**</DoNotTranslate>
+        `INSTANCE`
       </td>
 
       <td>
@@ -796,7 +796,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**USERNAME**</DoNotTranslate>
+        `USERNAME`
       </td>
 
       <td>
@@ -820,7 +820,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**PASSWORD**</DoNotTranslate>
+        `PASSWORD`
       </td>
 
       <td>
@@ -842,7 +842,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**EXTRA_CONNECTION_URL_ARGS**</DoNotTranslate>
+        `EXTRA_CONNECTION_URL_ARGS`
       </td>
 
       <td>
@@ -864,7 +864,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**ENABLE_SSL**</DoNotTranslate>
+        `ENABLE_SSL`
       </td>
 
       <td>
@@ -872,7 +872,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -886,7 +886,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**TRUST_SERVER_CERTIFICATE**</DoNotTranslate>
+        `TRUST_SERVER_CERTIFICATE`
       </td>
 
       <td>
@@ -894,7 +894,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -908,7 +908,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**CERTIFICATE_LOCATION**</DoNotTranslate>
+        `CERTIFICATE_LOCATION`
       </td>
 
       <td>
@@ -930,15 +930,15 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**TIMEOUT**</DoNotTranslate>
+        `TIMEOUT`
       </td>
 
       <td>
-        Timeout for queries, in seconds. Set 0 for no timeout.
+        Timeout for queries, in seconds. Set `0` for no timeout.
       </td>
 
       <td>
-        30
+        `30`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -952,7 +952,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**ENABLE_BUFFER_METRICS**</DoNotTranslate>
+        `ENABLE_BUFFER_METRICS`
       </td>
 
       <td>
@@ -961,7 +961,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        true
+        `true`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -975,7 +975,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**ENABLE_DATABASE_RESERVE_METRICS**</DoNotTranslate>
+        `ENABLE_DATABASE_RESERVE_METRICS`
       </td>
 
       <td>
@@ -984,7 +984,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        true
+        `true`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -998,7 +998,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**CUSTOM_METRICS_QUERY**</DoNotTranslate>
+        `CUSTOM_METRICS_QUERY`
       </td>
 
       <td>
@@ -1020,7 +1020,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**CUSTOM_METRICS_CONFIG**</DoNotTranslate>
+        `CUSTOM_METRICS_CONFIG`
       </td>
 
       <td>
@@ -1029,7 +1029,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}>
@@ -1043,7 +1043,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**METRICS**</DoNotTranslate>
+        `METRICS`
       </td>
 
       <td>
@@ -1051,7 +1051,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>
@@ -1063,7 +1063,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
 
     <tr>
       <td>
-        <DoNotTranslate>**INVENTORY**</DoNotTranslate>
+        `INVENTORY`
       </td>
 
       <td>
@@ -1071,7 +1071,7 @@ The Microsoft SQL Server integration collects both Metrics and Inventory informa
       </td>
 
       <td>
-        false
+        `false`
       </td>
 
       <td style={{ 'text-align': 'center' }}/>

--- a/src/install/mongodb/default-install-linux.mdx
+++ b/src/install/mongodb/default-install-linux.mdx
@@ -17,13 +17,13 @@ headingText: Configure the MongoDB integration
 
 3. Edit the `mongodb3-config.yml` file. The only two required fields are `mongodb_cluster_name` and `mongodb_uri`. This example config file collects all metrics:
 
-    ```
+    ```yml
     integrations:
-    - name: nri-mongodb3
+      - name: nri-mongodb3
         config:
-        mongodb_cluster_name: my_cluster
-        mongodb_uri: mongodb://username:password@localhost:27017
-        exporter_port: 9126
+          mongodb_cluster_name: my_cluster
+          mongodb_uri: mongodb://username:password@localhost:27017
+          exporter_port: 9126
     ```
 
 You can find all the config options at the bottom of this doc along with more complex config examples.

--- a/src/install/mongodb/host/atlas.mdx
+++ b/src/install/mongodb/host/atlas.mdx
@@ -6,7 +6,7 @@ headingText: Prepare Atlas
 
 Using the Atlas CLI run the following command to create a new user, and assign `clusterMonitor` and `readAnyDatabase` roles to the user (adjust the `username` and `password` as required):
 
-```
+```shell
 atlas dbuser create -u username -p password --role clusterMonitor,readAnyDatabase
 ```
 

--- a/src/install/mongodb/host/percona.mdx
+++ b/src/install/mongodb/host/percona.mdx
@@ -17,15 +17,15 @@ headingText: Prepare MongoDB or Percona
 
 2. Create a new user, and assign `clusterMonitor` and `readAnyDatabase` roles to the user (adjust the `username` and `password` as required).
 
-    ```
-    db.createUser(
-        {
-        user: "username",
-        pwd:  "password",
-        roles: [ { role: "clusterMonitor", db: "admin" },
-                    { role: 'readAnyDatabase', db: 'admin' } ]
-        }
-    )
+    ```js
+    db.createUser({
+      user: "username",
+      pwd:  "password",
+      roles: [ 
+        { role: "clusterMonitor", db: "admin" },
+        { role: "readAnyDatabase", db: "admin" }
+      ]
+    })
     ```
 
 For more information, check the [MongoDB Atlas documentation](https://docs.mongodb.com/manual/reference/method/db.createUser/index.html).

--- a/src/install/mongodb/linux/install-linux.mdx
+++ b/src/install/mongodb/linux/install-linux.mdx
@@ -19,11 +19,11 @@ headingText: Download the MongoDB integration
 
     ```yml
     integrations:
-    - name: nri-mongodb3
+      - name: nri-mongodb3
         config:
-        mongodb_cluster_name: my_cluster
-        mongodb_uri: mongodb://username:password@localhost:27017
-        exporter_port: 9126
+          mongodb_cluster_name: my_cluster
+          mongodb_uri: mongodb://username:password@localhost:27017
+          exporter_port: 9126
     ```
 
 You can find all the config options at the bottom of this doc along with more complex config examples.

--- a/src/install/mongodb/whatsNext.mdx
+++ b/src/install/mongodb/whatsNext.mdx
@@ -25,7 +25,7 @@ The following configuration options are available:
   <tbody>
   <tr>
     <td>
-      **mongodb_cluster_name**
+      `mongodb_cluster_name`
     </td>
     <td>
       User-defined name to uniquely identify the cluster being monitored. **Required**
@@ -36,7 +36,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **mongodb_uri**
+      `mongodb_uri`
     </td>
     <td>
       MongoDB connection URI. **Required**
@@ -47,7 +47,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **mongodb_direct_connect**
+      `mongodb_direct_connect`
     </td>
     <td>
       Whether or not a direct connect should be made. Direct connections are not valid if multiple hosts are specified or an SRV URI is used, for example for mongoDB Atlas.
@@ -60,7 +60,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **collection_filters**
+      `collection_filters`
     </td>
     <td>
       List of comma separated databases.collections. If empty, defaults to all databases and collections
@@ -71,7 +71,7 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **index_filters**
+      `index_filters`
     </td>
     <td>
       List of comma separated databases.collections to retrieve index stats. If empty, defaults to all indexes
@@ -82,73 +82,73 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **database_stats**
+      `database_stats`
     </td>
     <td>
       Enable/Disable collection of Database metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      **collection_stats**
+      `collection_stats`
     </td>
     <td>
       Enable/Disable collection of Collections metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      **index_stats**
+      `index_stats`
     </td>
     <td>
       Enable/Disable collection of Index metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      **replicaset_stats**
+      `replicaset_stats`
     </td>
     <td>
       Enable/Disable collection of Replica Set metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      **top_stats**
+      `top_stats`
     </td>
     <td>
       Enable/Disable collection of Top Admin metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      **diagnostic_stats**
+      `diagnostic_stats`
     </td>
     <td>
       Enable/Disable collection of Diagnostic metrics
     </td>
     <td>
-      true
+      `true`
     </td>
   </tr>
   <tr>
     <td>
-      **exporter_port**
+      `exporter_port`
     </td>
     <td>
       Port to expose scrape endpoint on, If this is not provided a random port will be used to launch the exporter
@@ -159,13 +159,13 @@ The following configuration options are available:
   </tr>
   <tr>
     <td>
-      **scrape_timeout**
+      `scrape_timeout`
     </td>
     <td>
       Time until a scrape request times out
     </td>
     <td>
-      5s
+      `5s`
     </td>
   </tr>
   </tbody>
@@ -175,7 +175,7 @@ The following configuration options are available:
 
 These are the 3 [entities](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/) created: `MONGODB_INSTANCE`, `MONGODB_DATABASE`, and `MONGODB_COLLECTION`.
 
-The following dimensional metrics are captured scraping the exporter and linked to the entity **MONGODB_INSTANCE**:
+The following dimensional metrics are captured scraping the exporter and linked to the entity `MONGODB_INSTANCE`
 
 <CollapserGroup>
   <Collapser

--- a/src/install/mongodb/windows/install-msi.mdx
+++ b/src/install/mongodb/windows/install-msi.mdx
@@ -5,6 +5,6 @@ headingText: Download using MSI
 
 1. Download the latest .MSI installer image for the desired integration [from our repository](https://download.newrelic.com/infrastructure_agent/windows/integrations/).
 2. In an admin account, run the install script using an absolute path.
-    ```
+    ```shell
     msiexec.exe /qn /i PATH\TO\mongodb3.msi
     ```

--- a/src/install/mongodb/windows/install-windows.mdx
+++ b/src/install/mongodb/windows/install-windows.mdx
@@ -13,11 +13,11 @@ headingText: Configure the MongoDB integration
 
     ```yml
     integrations:
-    - name: nri-mongodb3
+      - name: nri-mongodb3
         config:
-        mongodb_cluster_name: my_cluster
-        mongodb_uri: mongodb://username:password@localhost:27017
-        exporter_port: 9126
+          mongodb_cluster_name: my_cluster
+          mongodb_uri: mongodb://username:password@localhost:27017
+          exporter_port: 9126
     ```
 
 You can find all the config options at the bottom of this doc along with more complex config examples. 

--- a/src/install/nginx/default-configuration.mdx
+++ b/src/install/nginx/default-configuration.mdx
@@ -21,25 +21,25 @@ headingText: Configure the NGINX integration
     integrations:
       - name: nri-nginx
         env:
-        METRICS: "true"
-        STATUS_URL: http://127.0.0.1/status
-        STATUS_MODULE: discover
-        REMOTE_MONITORING: true
+          METRICS: "true"
+          STATUS_URL: http://127.0.0.1/status
+          STATUS_MODULE: discover
+          REMOTE_MONITORING: true
         interval: 30s
         labels:
-        env: production
-        role: load_balancer
+          env: production
+          role: load_balancer
     
       - name: nri-nginx
         env:
-        INVENTORY: "true"
-        STATUS_URL: http://127.0.0.1/status
-        CONFIG_PATH: /etc/nginx/nginx.conf
-        REMOTE_MONITORING: true
-        interval: 60s
+          INVENTORY: "true"
+          STATUS_URL: http://127.0.0.1/status
+          CONFIG_PATH: /etc/nginx/nginx.conf
+          REMOTE_MONITORING: true
+          interval: 60s
         labels:
-        env: production
-        role: load_balancer
+          env: production
+          role: load_balancer
         inventory_source: config/nginx
     ```
 

--- a/src/install/nginx/default-install-linux.mdx
+++ b/src/install/nginx/default-install-linux.mdx
@@ -21,25 +21,25 @@ headingText: Configure the NGINX integration
     integrations:
       - name: nri-nginx
         env:
-        METRICS: "true"
-        STATUS_URL: http://127.0.0.1/status
-        STATUS_MODULE: discover
-        REMOTE_MONITORING: true
+          METRICS: "true"
+          STATUS_URL: http://127.0.0.1/status
+          STATUS_MODULE: discover
+          REMOTE_MONITORING: true
         interval: 30s
         labels:
-        env: production
-        role: load_balancer
+          env: production
+          role: load_balancer
 
       - name: nri-nginx
         env:
-        INVENTORY: "true"
-        STATUS_URL: http://127.0.0.1/status
-        CONFIG_PATH: /etc/nginx/nginx.conf
-        REMOTE_MONITORING: true
+          INVENTORY: "true"
+          STATUS_URL: http://127.0.0.1/status
+          CONFIG_PATH: /etc/nginx/nginx.conf
+          REMOTE_MONITORING: true
         interval: 60s
         labels:
-        env: production
-        role: load_balancer
+          env: production
+          role: load_balancer
         inventory_source: config/nginx
     ```
 

--- a/src/install/nginx/windows/install-windows.mdx
+++ b/src/install/nginx/windows/install-windows.mdx
@@ -13,27 +13,27 @@ headingText: Configure the NGINX integration
 
     ```yml
     integrations:
-    - name: nri-nginx
+      - name: nri-nginx
         env:
-        METRICS: "true"
-        STATUS_URL: http://127.0.0.1/status
-        STATUS_MODULE: discover
-        REMOTE_MONITORING: true
+          METRICS: "true"
+          STATUS_URL: http://127.0.0.1/status
+          STATUS_MODULE: discover
+          REMOTE_MONITORING: true
         interval: 30s
         labels:
-        env: production
-        role: load_balancer
+          env: production
+          role: load_balancer
 
-    - name: nri-nginx
+      - name: nri-nginx
         env:
-        INVENTORY: "true"
-        STATUS_URL: http://127.0.0.1/status
-        CONFIG_PATH: /etc/nginx/nginx.conf
-        REMOTE_MONITORING: true
+          INVENTORY: "true"
+          STATUS_URL: http://127.0.0.1/status
+          CONFIG_PATH: /etc/nginx/nginx.conf
+          REMOTE_MONITORING: true
         interval: 60s
         labels:
-        env: production
-        role: load_balancer
+          env: production
+          role: load_balancer
         inventory_source: config/nginx
     ```
 


### PR DESCRIPTION
I just talked to @homelessbirds about this. The point of this PR is basically just that we have similar invalid yaml examples in a lot of different files. Example, this yml has indentation errors you can see if you throw it in a file:
```yml
integrations:
- name: nri-nginx
    env:
    METRICS: "true"
    STATUS_URL: http://127.0.0.1/status
    STATUS_MODULE: discover
    REMOTE_MONITORING: true
    interval: 30s
    labels:
    env: production
    role: load_balancer

- name: nri-nginx
    env:
    INVENTORY: "true"
    STATUS_URL: http://127.0.0.1/status
    CONFIG_PATH: /etc/nginx/nginx.conf
    REMOTE_MONITORING: true
    interval: 60s
    labels:
    env: production
    role: load_balancer
    inventory_source: config/nginx
```

change the indentation to this and it will run:

```yml
integrations:
  - name: nri-nginx
    env:
      METRICS: "true"
      STATUS_URL: http://127.0.0.1/status
      STATUS_MODULE: discover
      REMOTE_MONITORING: true
    interval: 30s
    labels:
      env: production
      role: load_balancer

  - name: nri-nginx
    env:
      INVENTORY: "true"
      STATUS_URL: http://127.0.0.1/status
      CONFIG_PATH: /etc/nginx/nginx.conf
      REMOTE_MONITORING: true
    interval: 60s
    labels:
      env: production
      role: load_balancer
    inventory_source: config/nginx
```

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.