### PR TITLE
chore: add otel codeowners team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,5 +17,5 @@ yarn.lock @newrelic/docs-engineering
 
 /src/content/whats-new/ @john-withers @aalfano7
 
-#Otel files
+# Otel files
 /src/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/ @newrelic/opentelemetry-community

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,3 +16,6 @@ yarn.lock @newrelic/docs-engineering
 # Whats new files (pings individual project marketing managers)
 
 /src/content/whats-new/ @john-withers @aalfano7
+
+#Otel files
+/src/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/ @newrelic/opentelemetry-community


### PR DESCRIPTION
## Description

Adds the [Otel team](https://github.com/orgs/newrelic/teams/opentelemetry-community) as code owners / approvers of changes to Otel docs

Had to also add team to repo as collaborators

## Related
Closes NR-273107
