### PR TITLE
chore(php):Update OS support statement in php-agent-compatibility-requirements.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -94,7 +94,7 @@ The following processors are supported:
 
 ## Operating systems [#operating-systems]
 
-When vendors announce end-of-life (such as on [Ubuntu's End of Standard Support page](https://wiki.ubuntu.com/Releases)), we will continue to support those latest versions for one year. However, if the PHP version you're using is no longer officially supported, then support could end sooner than one year. 
+When vendors announce end-of-life (such as on [Ubuntu's End of Standard Support page](https://wiki.ubuntu.com/Releases)), we will continue to support those latest versions for one year after the vendor end-of-life date. However, if the PHP version you're using is no longer officially supported, then support could end sooner than one year. 
 
 This is why we recommend always using the latest version of the OS that is officially supported by the vendor.
 The latest versions of our agent may work on OS versions that are past End of Life, but we no longer test or officially support the PHP agent with older versions.
@@ -126,22 +126,23 @@ The PHP agent supports the operating systems listed in the table below.
 
       <td>
 
-        * Alpine 3.12 and higher
+        * Alpine
 
-        * Amazon Linux 2
+        * Amazon Linux 
 
-        * Red Hat Enterprise Linux (RHEL) 7 and higher
+        * Red Hat Enterprise Linux (RHEL)
 
-        * CentOS 7 and higher
+        * CentOS
 
-        * Debian 9.0 ("stretch") and higher
+        * Debian
 
-        * Ubuntu LTS 18.04 ("Bionic Beaver") and higher, or Ubuntu non-LTS 21.04 ("Hirsute Hippo") and higher
+        * Ubuntu
 
         * Any other Linux distribution with:
 
-          * Kernel version 4.9 (long term) and higher
-          * glibc 2.17 or higher with [NPTL](https://en.wikipedia.org/wiki/Native_POSIX_Thread_Library) support or musl libc version 1.1.24 and higher
+          * Kernel version with [long term support](https://kernel.org/)
+          * glibc [currently maintained branch](https://sourceware.org/glibc/wiki/Release) with [NPTL](https://en.wikipedia.org/wiki/Native_POSIX_Thread_Library)
+          * musl libc [stable series](https://musl.libc.org/releases.html)
       </td>
 
       <td>
@@ -155,10 +156,10 @@ The PHP agent supports the operating systems listed in the table below.
       </td>
 
       <td>
-        * Amazon Linux 2 (including AWS Graviton 2)
-        * CentOS 8
-        * Alpine 3.16 or later
-        * Debian 11 or later
+        * Amazon Linux
+        * CentOS
+        * Alpine
+        * Debian
       </td>
 
       <td>


### PR DESCRIPTION
The EOL + 1year support statement for OSs is sufficient and we no longer need to call out specific version numbers.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.