### PR TITLE
Update configure-transaction-traces.mdx

### DIFF
--- a/src/content/docs/apm/transactions/transaction-traces/configure-transaction-traces.mdx
+++ b/src/content/docs/apm/transactions/transaction-traces/configure-transaction-traces.mdx
@@ -92,18 +92,7 @@ For more information, see [Collect custom attributes](/docs/agents/manage-apm-ag
 When you delete a transaction trace, it is deleted permanently.
 
 <CollapserGroup>
-  <Collapser
-    id="delete-trace"
-    title="Delete a single transaction trace"
-  >
-    To delete a transaction trace record permanently:
-
-    1. Go to <DoNotTranslate>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & services > (select an app) > Monitor > Transactions**</DoNotTranslate>.
-    2. Under <DoNotTranslate>**Transaction traces**</DoNotTranslate> click on the trace you want to delete.
-    3. On the details page, select <DoNotTranslate>**Delete this trace**</DoNotTranslate>.
-  </Collapser>
-
-  <Collapser
+ <Collapser
     id="delete-all"
     title="Delete all transaction traces"
   >


### PR DESCRIPTION
Previously, we have removed the feature to Delete a Transaction Trace. However, related documents still suggests we can delete a single transaction trace (Configure transaction traces ). Remove this section from the document.

Ticket link: https://new-relic.atlassian.net/browse/NR-276556

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
   Previously, in the transactions, we had a feature to delete a single transaction trace. Later, this feature was removed. However, this section in the docs still suggests we can delete a single transaction trace. Hence, removing this section.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.