### PR TITLE
Fixed mismatched header and rows in lookups API example

### DIFF
--- a/src/content/docs/apis/lookups-service-api/lookups-service-api.mdx
+++ b/src/content/docs/apis/lookups-service-api/lookups-service-api.mdx
@@ -478,7 +478,7 @@ The data you send in your request body can either be `multipart/form-data` or `a
         {
             "table": {
                 "headers": [
-                "id", "name", "text", "intvalue", "floatvalue", "boolvalue"
+                "id", "name", "intvalue", "floatvalue", "boolvalue"
                 ],
                 "rows": [
                     ["1", "abc", 27, 2.7, true],

--- a/src/i18n/content/es/docs/apis/lookups-service-api/lookups-service-api.mdx
+++ b/src/i18n/content/es/docs/apis/lookups-service-api/lookups-service-api.mdx
@@ -496,7 +496,7 @@ Los datos que envía en el cuerpo de su solicitud pueden ser `multipart/form-dat
     {
            "table": {
                "headers": [
-               "id", "name", "text", "intvalue", "floatvalue", "boolvalue"
+               "id", "name", "intvalue", "floatvalue", "boolvalue"
                ],
                "rows": [
                    ["1", "abc", 27, 2.7, true],

--- a/src/i18n/content/jp/docs/apis/lookups-service-api/lookups-service-api.mdx
+++ b/src/i18n/content/jp/docs/apis/lookups-service-api/lookups-service-api.mdx
@@ -496,7 +496,7 @@ HTTPヘッダーを作成する際には、以下のガイドラインを参考�
     {
            "table": {
                "headers": [
-               "id", "name", "text", "intvalue", "floatvalue", "boolvalue"
+               "id", "name", "intvalue", "floatvalue", "boolvalue"
                ],
                "rows": [
                    ["1", "abc", 27, 2.7, true],

--- a/src/i18n/content/kr/docs/apis/lookups-service-api/lookups-service-api.mdx
+++ b/src/i18n/content/kr/docs/apis/lookups-service-api/lookups-service-api.mdx
@@ -496,7 +496,7 @@ HTTP 헤더를 생성할 때 다음 지침을 사용하십시오.
     {
            "table": {
                "headers": [
-               "id", "name", "text", "intvalue", "floatvalue", "boolvalue"
+               "id", "name", "intvalue", "floatvalue", "boolvalue"
                ],
                "rows": [
                    ["1", "abc", 27, 2.7, true],

--- a/src/i18n/content/pt/docs/apis/lookups-service-api/lookups-service-api.mdx
+++ b/src/i18n/content/pt/docs/apis/lookups-service-api/lookups-service-api.mdx
@@ -496,7 +496,7 @@ Os dados que você envia no corpo da sua solicitação podem ser `multipart/form
     {
            "table": {
                "headers": [
-               "id", "name", "text", "intvalue", "floatvalue", "boolvalue"
+               "id", "name", "intvalue", "floatvalue", "boolvalue"
                ],
                "rows": [
                    ["1", "abc", 27, 2.7, true],


### PR DESCRIPTION
Fixed mismatched header and rows in lookups API example. Header has 6 values but rows only have 5 values. I removed the "text" in the header.