### PR TITLE
Add msg as a reserved attribute that is automatically mapped to the message attribute

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -775,6 +775,28 @@ We accept any valid JSON payload. The payload must encoded as <DoNotTranslate>**
             We will rewrite this string as the field `message` on ingest
           </td>
         </tr>
+
+        <tr>
+          <td>
+            `"msg"`
+          </td>
+
+          <td>
+            String
+          </td>
+
+          <td>
+            (any string)
+          </td>
+
+          <td>
+            No
+          </td>
+
+          <td>
+            We will rewrite this string as the field `message` on ingest
+          </td>
+        </tr>
       </tbody>
     </table>
   </Collapser>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems do this PR solve?
`msg` is not listed in the Log block table as a reserved attribute that is automatically mapped to the `message` attribute.

* Add any context that will help us review your changes, such as testing notes,
  links to related docs, screenshots, etc.

* If your issue relates to an existing GitHub issue, please link to it.
Infra-agent repo issue [#1780 fluent-bit config works as expected and yet it does not work in newrelic UI](https://github.com/newrelic/infrastructure-agent/issues/1780), reports a behaviour that is interpreted as a problem while it's the expected behaviour since the logs being forwarded to NR do contain the `msg` attribute. This documentation PR add and explicit mention/explanation about this behaviour.