### PR TITLE
fix(whats-new): Fix ignore language for NRVM

### DIFF
--- a/src/content/whats-new/2024/05/whats-new-05-13-nrvm-change-status-to-ignore.md
+++ b/src/content/whats-new/2024/05/whats-new-05-13-nrvm-change-status-to-ignore.md
@@ -1,7 +1,7 @@
 ---
 title: 'Manage vulnerabilities with new “Ignored” feature'
 summary: 'Remove noncritical vulnerabilities from Vulnerability Management default views.'
-releaseDate: '2023-05-13'
+releaseDate: '2024-06-04'
 learnMoreLink: 'https://docs.newrelic.com/docs/vulnerability-management/change-vulnerability-status/' 
 getStartedLink: 'https://docs.newrelic.com/docs/vulnerability-management'
 ---

--- a/src/content/whats-new/2024/05/whats-new-05-13-nrvm-change-status-to-ignore.md
+++ b/src/content/whats-new/2024/05/whats-new-05-13-nrvm-change-status-to-ignore.md
@@ -1,20 +1,20 @@
 ---
-title: 'Manage vulnerabilies in VM with new “Ignored” vulnerability feature'
-summary: 'NRVM users can remove noncritical vulnerabilies from default views, thereby reducing the volume of vulnerabilies that require attention, by assigning individual entities the Ignored status.'
+title: 'Manage vulnerabilities with new “Ignored” feature'
+summary: 'Remove noncritical vulnerabilities from Vulnerability Management default views.'
 releaseDate: '2023-05-13'
 learnMoreLink: 'https://docs.newrelic.com/docs/vulnerability-management/change-vulnerability-status/' 
 getStartedLink: 'https://docs.newrelic.com/docs/vulnerability-management'
 ---
 
-Vulnerability Management users who want to remove noncritical vulnerabilies from views, thereby reducing the volume of vulnerabilies that require user attention, cafeatn manage vulnerabilities by assigning individual entities the **Ignored** status so specific vulnerabilities no longer appear in default views.
+Vulnerability Management now allows you to remove noncritical vulnerabilities from views by assigning individual entities the **Ignored** status so specific vulnerabilities no longer appear in default views. This can reduce the volume of vulnerabilities that require your attention.
 
-VM helps DevSecOp users claim back their time spent triaging and remediating noncritical vulnerabilies by providing industry leading prioritization capabilities and the ability to customize vulnerability notifications so users can focus on those risks that matter. 
+If you're in DevSecOp, this option let's you claim back time spent triaging and remediating noncritical vulnerabilities by providing industry-leading prioritization capabilities and the ability to customize vulnerability notifications so you can focus on those risks that matter. 
 
-The **Ignored** status capability allows users to assign individual entities the **Ignored** status so their vulnerabilities no longer appear in VM default views, removing those items from triaging and remediation workflows which improves user productivity and reduces toil.
+The **Ignored** status capability allows you to assign individual entities the **Ignored** status so their vulnerabilities no longer appear in Vulnerability Management default views, removing those items from triaging and remediation workflows which improves user productivity and reduces toil.
 
 Key Capabilities:
-* **Ignore specific or groups of entities** VM users can ignore vulnerabilities for a specific entity, or ignore a vulnerability across multiple instances. Once the status of an instance is set to **Ignored**, this instance will be excluded from the summary tiles and vulnerability list by default.
-* **Audit documentation** When choosing to ignore a vulnerability, users are prompted to explain the rationale behind the decision for audit and compliance purposes.
-* **Summary Reporting** Ignored vulnerabilities can be viewed with the filter bar for summary reporting and audit checks.
-Configure time settings. The Ignored status duration can be set for a specific time period or manually removed.
-* **Manage vulnerability status** Changing the status from **Ignored** to **Affected** reintroduces the vulnerability back into default views and counts on this entity, but other instances of this vulnerability on other entities will still remain ignored.
+* **Ignore specific or groups of entities**: Vulnerability Management users can ignore vulnerabilities for a specific entity or ignore a vulnerability across multiple instances. Once the status of an instance is set to **Ignored**, this instance will be excluded from the summary tiles and vulnerability list by default.
+* **Audit documentation**: When choosing to ignore a vulnerability, users are prompted to explain the rationale behind the decision for audit and compliance purposes.
+* **Summary Reporting**: Ignored vulnerabilities can be viewed with the filter bar for summary reporting and audit checks.
+* **Configure time settings**: The **Ignored** status duration can be set for a specific time period or manually removed.
+* **Manage vulnerability status**: Changing the status from **Ignored** to **Affected** reintroduces the vulnerability back into default views and counts on this entity, but other instances of this vulnerability on other entities will still remain ignored.

--- a/src/content/whats-new/2024/05/whats-new-05-13-nrvm-change-status-to-ignore.md
+++ b/src/content/whats-new/2024/05/whats-new-05-13-nrvm-change-status-to-ignore.md
@@ -1,20 +1,20 @@
 ---
-title: 'Manage alerts in VM with new “Ignored” alert feature'
-summary: 'NRVM users can remove noncritical alerts from default views, thereby reducing the volume of alerts that require attention, by assigning individual entities the Ignored status.'
+title: 'Manage vulnerabilies in VM with new “Ignored” vulnerability feature'
+summary: 'NRVM users can remove noncritical vulnerabilies from default views, thereby reducing the volume of vulnerabilies that require attention, by assigning individual entities the Ignored status.'
 releaseDate: '2023-05-13'
 learnMoreLink: 'https://docs.newrelic.com/docs/vulnerability-management/change-vulnerability-status/' 
 getStartedLink: 'https://docs.newrelic.com/docs/vulnerability-management'
 ---
 
-Vulnerability Management users who want to remove noncritical alerts from views, thereby reducing the volume of alerts that require user attention, cafeatn manage vulnerabilities by assigning individual entities the **Ignored** status so specific vulnerabilities no longer appear in default views.
+Vulnerability Management users who want to remove noncritical vulnerabilies from views, thereby reducing the volume of vulnerabilies that require user attention, cafeatn manage vulnerabilities by assigning individual entities the **Ignored** status so specific vulnerabilities no longer appear in default views.
 
-VM helps DevSecOp users claim back their time spent triaging and remediating noncritical alerts by providing industry leading prioritization capabilities and the ability to customize alert notifications so users can focus on those risks that matter. 
+VM helps DevSecOp users claim back their time spent triaging and remediating noncritical vulnerabilies by providing industry leading prioritization capabilities and the ability to customize vulnerability notifications so users can focus on those risks that matter. 
 
-The **Ignored** alert capability allows users to assign individual entities the **Ignored** status so their vulnerabilities no longer appear in VM default views, removing those items from triaging and remediation workflows which improves user productivity and reduces toil.
+The **Ignored** status capability allows users to assign individual entities the **Ignored** status so their vulnerabilities no longer appear in VM default views, removing those items from triaging and remediation workflows which improves user productivity and reduces toil.
 
 Key Capabilities:
 * **Ignore specific or groups of entities** VM users can ignore vulnerabilities for a specific entity, or ignore a vulnerability across multiple instances. Once the status of an instance is set to **Ignored**, this instance will be excluded from the summary tiles and vulnerability list by default.
 * **Audit documentation** When choosing to ignore a vulnerability, users are prompted to explain the rationale behind the decision for audit and compliance purposes.
 * **Summary Reporting** Ignored vulnerabilities can be viewed with the filter bar for summary reporting and audit checks.
 Configure time settings. The Ignored status duration can be set for a specific time period or manually removed.
-* **Manage alert status** Changing the status from **Ignored** to **Affected** reintroduces the vulnerability back into default views and counts on this entity, but other instances of this vulnerability on other entities will still remain ignored.
+* **Manage vulnerability status** Changing the status from **Ignored** to **Affected** reintroduces the vulnerability back into default views and counts on this entity, but other instances of this vulnerability on other entities will still remain ignored.

--- a/src/content/whats-new/2024/06/whats-new-05-13-nrvm-change-status-to-ignore.md
+++ b/src/content/whats-new/2024/06/whats-new-05-13-nrvm-change-status-to-ignore.md
@@ -1,7 +1,7 @@
 ---
 title: 'Manage vulnerabilities with new “Ignored” feature'
 summary: 'Remove noncritical vulnerabilities from Vulnerability Management default views.'
-releaseDate: '2024-06-04'
+releaseDate: '2024-06-05'
 learnMoreLink: 'https://docs.newrelic.com/docs/vulnerability-management/change-vulnerability-status/' 
 getStartedLink: 'https://docs.newrelic.com/docs/vulnerability-management'
 ---
@@ -9,8 +9,6 @@ getStartedLink: 'https://docs.newrelic.com/docs/vulnerability-management'
 Vulnerability Management now allows you to remove noncritical vulnerabilities from views by assigning individual entities the **Ignored** status so specific vulnerabilities no longer appear in default views. This can reduce the volume of vulnerabilities that require your attention.
 
 If you're in DevSecOp, this option let's you claim back time spent triaging and remediating noncritical vulnerabilities by providing industry-leading prioritization capabilities and the ability to customize vulnerability notifications so you can focus on those risks that matter. 
-
-The **Ignored** status capability allows you to assign individual entities the **Ignored** status so their vulnerabilities no longer appear in Vulnerability Management default views, removing those items from triaging and remediation workflows which improves user productivity and reduces toil.
 
 Key Capabilities:
 * **Ignore specific or groups of entities**: Vulnerability Management users can ignore vulnerabilities for a specific entity or ignore a vulnerability across multiple instances. Once the status of an instance is set to **Ignored**, this instance will be excluded from the summary tiles and vulnerability list by default.


### PR DESCRIPTION
## Give us some context

* Removes the usage of 'alerts' from the what's new message
* Vulnerabilities are not 'alerts'
* 'Alerts' term is used in other products and has a different set of implications when used. We have changed locations where we use the word  'alert' to 'vulnerability' in the what's new post.