### PR TITLE
.NET agent: add latest tested version of Microsoft.Data.SqlClient to compatibility and support docs

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -478,7 +478,7 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 
 <DoNotTranslate>**Microsoft.Data.SqlClient**</DoNotTranslate>
 * Minimum supported version: 1.0.19239.1
-* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0
+* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0, 5.2.1
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -548,7 +548,7 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 
 <DoNotTranslate>**Microsoft.Data.SqlClient**</DoNotTranslate>
 * Minimum supported version: 1.0.19239.1
-* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0
+* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0, 5.2.1
 
 <DoNotTranslate>**System.Data**</DoNotTranslate>
 * Minimum supported version: .NET Framework 4.6.2


### PR DESCRIPTION
The .NET agent team has tested a new version of a supported library and are adding it to our compatibility and support docs.