### PR TITLE
chore(ruby-agent): Add a section about turning off the agent 

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts.mdx
@@ -12,12 +12,12 @@ redirects:
   - /docs/ruby/force-the-ruby-agent-to-start
   - /docs/ruby/forcing-the-ruby-agent-to-start
   - /docs/agents/ruby-agent/troubleshooting/controlling-when-ruby-agent-starts
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-06-07
 ---
 
 ## Problem
 
-The Ruby agent is not properly starting or is not reporting data to New Relic.
+The Ruby agent isn't starting or isn't reporting data to New Relic.
 
 ## Solution
 
@@ -126,5 +126,47 @@ To solve this problem:
           </tr>
         </tbody>
       </table>
+  </Collapser>
+</CollapserGroup>
+
+## Problem
+
+The Ruby agent is starting in contexts I don't want it to start.
+
+
+## Solution
+
+<CollapserGroup>
+  <Collapser
+    id="configure-where-the-agent-starts"
+    title="Customize your configuration to control when the agent starts"
+  >
+    The Ruby agent makes some assumptions about the contexts most customers want the agent to automatically start.
+
+    There are three configuration options available to customize this behavior:
+
+    * [`autostart.denylisted_constants`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_constants)
+      Most of the constants on this list are Rails commands that perform operations that rarely benefit from monitoring.
+
+      The list doesn't include `Rails::Command::RakeCommand`, which powers commands like [`rails db:*`](https://guides.rubyonrails.org/command_line.html#bin-rails-db) as well as `rails solid_queue:start`, and other Rails commands related to Rake tasks.
+
+    * [`autostart.denylisted_executables`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_executables)
+      This configuration controls executables, like `rspec` and `irb`.
+
+    * [`autostart.denylisted_rake_tasks`](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#autostart-denylisted_rake_tasks)
+      Prior to Rails 5.1, `rake` was used instead of `thor` for many commands, such as `db:migrate`. The default values for this configuration lists many commands from that time. You can also add your own `rake` commands to this list.
+  </Collapser>
+
+  <Collapser
+    id="manually-start-and-stop-the-agent"
+    title="Manually start and stop the agent"
+  >
+    The [`NewRelic::Agent.manual_start`](https://rubydoc.info/gems/newrelic_rpm/NewRelic/Agent#manual_start-instance_method) API can be used to start the agent in specific contexts. If you set `:agent_enabled` to `false` in your configuration file or set the environment variable `NEW_RELIC_AGENT_ENABLED=false`, you can still manually start the agent using this API.
+
+    ```ruby
+      NewRelic::Agent.manual_start(agent_enabled: true)
+    ```
+
+    If you want to stop the agent before the process ends, you can call [`NewRelic::Agent.shutdown`](https://rubydoc.info/gems/newrelic_rpm/NewRelic/Agent#shutdown-instance_method).
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/control-when-ruby-agent-starts.mdx
@@ -131,7 +131,7 @@ To solve this problem:
 
 ## Problem
 
-The Ruby agent is starting in contexts I don't want it to start.
+The Ruby agent starts in contexts where I don't want it to start.
 
 
 ## Solution


### PR DESCRIPTION
We want to document that `Rails::Command::RakeCommand` may not be desired in all contexts. Adding a section about turning off the agent in certain contexts to this existing page seemed like a good place to do that.

However, it does provide a lot of duplication with the existing content. There may be a better way to achieve this goal.