### PR TITLE
Fix otel nav

### DIFF
--- a/src/nav/opentelemetry.yml
+++ b/src/nav/opentelemetry.yml
@@ -67,9 +67,3 @@ pages:
         path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-logs
       - title: Resources
         path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources
-      - title: Traces
-        path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-traces
-      - title: Create custom queries
-        path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/view-your-data/opentelemetry-data-explorer-query-builder
-      - title: Alerts
-        path: /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-alerts


### PR DESCRIPTION
Looks like something went wonky when merging #17503 and #17372. There are duplicate entries in the nav and some that don't belong. 

<img width="380" alt="Screenshot 2024-06-04 at 6 33 19 PM" src="https://github.com/newrelic/docs-website/assets/34418638/f90c0f98-dba6-4aff-9140-2eed756e0c53">
