### PR TITLE
fix: z index to prevent see through of modal, correct string variable

### DIFF
--- a/src/components/FeedbackModal/FeedbackModal.js
+++ b/src/components/FeedbackModal/FeedbackModal.js
@@ -164,6 +164,7 @@ const FeedbackModal = ({ onClose }) => {
             node.style.position = 'fixed';
             node.style.bottom = '2rem';
             node.style.right = '1.5rem';
+            node.style.zIndex = 10;
           }
         }}
       >
@@ -242,7 +243,7 @@ const SuprQ = ({ onSubmit }) => {
               [questionId]: response,
             }))
           }
-          statement={t(`surveyModal.suprQ.${questionId}`)}
+          statement={t(`strings.surveyModal.suprQ.${questionId}`)}
         />
       ))}
       <Steps>


### PR DESCRIPTION
- Adds the correct location to the translation object.
- z-index needed to ensure text wasn't floating above the modal at all.

QA showing the desired view and testing i18n:
<img width="1374" alt="Screenshot 2024-06-05 at 10 19 23 AM" src="https://github.com/newrelic/docs-website/assets/26727669/f2d1e1bc-c544-4c0c-8c35-303ae7e2085d">
<img width="1381" alt="Screenshot 2024-06-05 at 10 19 47 AM" src="https://github.com/newrelic/docs-website/assets/26727669/95898077-a0f7-451a-91bc-cfb42161b00e">
