### PR TITLE
fix intermittent webdriver failures

### DIFF
--- a/scripts/actions/webdriver-mobile.mjs
+++ b/scripts/actions/webdriver-mobile.mjs
@@ -77,15 +77,14 @@ const navTest = async () => {
     '//header//button[contains(@aria-label, "Mobile")]'
   );
   console.log('\nOpening mobile Nav menu');
-  await hamburgerButton.click();
-  await driver.sleep(SLEEP_TIME);
-  // nav on mobile is a new list, the desktop nav comes first in the DOM but is hidden
-  let [_desktopRN, releaseNotes] = await waitForXPath(releaseNotesXPath);
-  while (releaseNotes == null) {
-    const result = await waitForXPath(releaseNotesXPath);
-    _desktopRN = result[0];
-    releaseNotes = result[1];
-  }
+  let _desktopRN;
+  let releaseNotes;
+  do {
+    await hamburgerButton.click();
+    await driver.sleep(SLEEP_TIME);
+    // nav on mobile is a new list, the desktop nav comes first in the DOM but is hidden
+    [_desktopRN, releaseNotes] = await waitForXPath(releaseNotesXPath);
+  } while (releaseNotes == null);
   const [_desktopINN, initialNextNode] = await waitForXPath(nextNodeXPath);
   await driver.executeScript('arguments[0].scrollIntoView()', releaseNotes);
   console.log('\nClicking Release Notes div');

--- a/scripts/actions/webdriver-mobile.mjs
+++ b/scripts/actions/webdriver-mobile.mjs
@@ -20,7 +20,7 @@ options.addArguments('disable-dev-shm-usage');
 options.addArguments('--headless=new');
 
 const TIMEOUT = 30000;
-const SLEEP_TIME = 5000;
+const SLEEP_TIME = 2000;
 
 const waitForXPath = (xpath, timeout = TIMEOUT) =>
   driver.wait(until.elementsLocated(By.xpath(xpath)), timeout);

--- a/scripts/actions/webdriver-mobile.mjs
+++ b/scripts/actions/webdriver-mobile.mjs
@@ -17,7 +17,7 @@ const options = new Options().setMobileEmulation({
 // options required for github action to run chromedriver properly
 options.addArguments('no-sandbox');
 options.addArguments('disable-dev-shm-usage');
-options.addArguments('headless');
+options.addArguments('--headless=new');
 
 const TIMEOUT = 30000;
 const SLEEP_TIME = 5000;

--- a/scripts/actions/webdriver-mobile.mjs
+++ b/scripts/actions/webdriver-mobile.mjs
@@ -80,7 +80,12 @@ const navTest = async () => {
   await hamburgerButton.click();
   await driver.sleep(SLEEP_TIME);
   // nav on mobile is a new list, the desktop nav comes first in the DOM but is hidden
-  const [_desktopRN, releaseNotes] = await waitForXPath(releaseNotesXPath);
+  let [_desktopRN, releaseNotes] = await waitForXPath(releaseNotesXPath);
+  while (releaseNotes == null) {
+    const result = await waitForXPath(releaseNotesXPath);
+    _desktopRN = result[0];
+    releaseNotes = result[1];
+  }
   const [_desktopINN, initialNextNode] = await waitForXPath(nextNodeXPath);
   await driver.executeScript('arguments[0].scrollIntoView()', releaseNotes);
   console.log('\nClicking Release Notes div');

--- a/scripts/actions/webdriver-mobile.mjs
+++ b/scripts/actions/webdriver-mobile.mjs
@@ -79,12 +79,15 @@ const navTest = async () => {
   console.log('\nOpening mobile Nav menu');
   let _desktopRN;
   let releaseNotes;
+  const MAX_TRIES = 3;
+  let tries = 0;
   do {
     await hamburgerButton.click();
     await driver.sleep(SLEEP_TIME);
     // nav on mobile is a new list, the desktop nav comes first in the DOM but is hidden
     [_desktopRN, releaseNotes] = await waitForXPath(releaseNotesXPath);
-  } while (releaseNotes == null);
+    tries += 1;
+  } while (releaseNotes == null && tries < MAX_TRIES);
   const [_desktopINN, initialNextNode] = await waitForXPath(nextNodeXPath);
   await driver.executeScript('arguments[0].scrollIntoView()', releaseNotes);
   console.log('\nClicking Release Notes div');


### PR DESCRIPTION
this adds a loop to redo the XPath selector for the release notes div if it comes back null. it also updates the headless argument per [this article](https://www.selenium.dev/blog/2023/headless-is-going-away/) and lowers the sleep time since it doesn't seem to need to be so long