### PR TITLE
Remove notifications

### DIFF
--- a/src/content/docs/codestream/codestream-settings/account-settings.mdx
+++ b/src/content/docs/codestream/codestream-settings/account-settings.mdx
@@ -1,7 +1,7 @@
 ---
 title: CodeStream settings
 metaDescription: "An overview of CodeStream settings."
-freshnessValidatedDate: 2024-04-10
+freshnessValidatedDate: 2024-06-06
 ---
 
 CodeStream account settings let you make changes to your personal account.
@@ -9,7 +9,3 @@ CodeStream account settings let you make changes to your personal account.
 ## Account settings [#account-settings]
 
 The <DoNotTranslate>**Account**</DoNotTranslate> menu is located under the username menu at the top of the CodeStream pane, and you'll find options for viewing your profile and changing your CodeStream username. Note that if you have a profile photo associated with your New Relic email address on Gravatar it will automatically be used in CodeStream.
-
-## Notifications [#notifications]
-
-Transactions that are exhibiting [anomalous performance](/docs/codestream/observability/transactions) will trigger a toast notification in your IDE. If you have multiple repositories open in your IDE and/or multiple services associated with those repositories, you'll only get notified about the first transaction with anomalous performance. Note that desktop notifications in the IDE are only available if you’re using VS Code or a JetBrains IDE.


### PR DESCRIPTION
Remove reference to toast notifications. This section will come back in a month or so when we introduce email notifications.