### PR TITLE
chore(ruby-agent): Add version tracking to errors

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -176,7 +176,7 @@ Because the API is intended to be called every time a new user ID has entered sc
 
 [Errors inbox](https://docs.newrelic.com/docs/errors-inbox/version-tracking/) will automatically track which versions of your software are producing errors. Any version data will also display in [CodeStream](/docs/codestream/how-use-codestream/performance-monitoring/#buildsha).
 
-Setting one of the following environment variables will help you identify which versions of your software produce errors.
+Set one of the following environment variables to help identify which versions of your software produce errors.
 
 * `NEW_RELIC_METADATA_SERVICE_VERSION` adds the attribute `tags.service.version` on error event data containing the version of your code that's deployed, often a semantic version such as `1.2.3`, but not always.
 * `NEW_RELIC_METADATA_RELEASE_TAG` adds the attribute `tags.releaseTag` on event data containing the release tag (such as `v0.1.209` or `release-209`).

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/sending-handled-errors-new-relic.mdx
@@ -100,7 +100,7 @@ The `exception` is the exception to be recorded, or an error message. If needed,
 </table>
 
 
-## Error fingerprinting: dynamically apply an error group to each noticed error [#error-fingerprinting]
+## Error fingerprinting: Dynamically apply an error group to each noticed error [#error-fingerprinting]
 
 Are your error occurrences grouped poorly? Set your own error fingerprint via a callback function.
 
@@ -162,7 +162,7 @@ The callback proc is expected to receive exactly one input argument, a hash. The
 
 The callback proc is expected to return a string representing the desired error group name if one can be determined. If the proc returns a `nil` or empty string (`''`), then the error will receive server-side grouping logic.
 
-## User tracking: associating a user ID with each transaction and error [#user-tracking]
+## User tracking: Associating a user ID with each transaction and error [#user-tracking]
 
 You can now see the number of users impacted by an error group.
 
@@ -171,3 +171,13 @@ Transactions and errors can be associated with a user ID if one is known to the 
 This API call requires a single argument of a string representing a unique identifier for an end user. This string can be a UUID, a database id, or similar. The API call should be made at least once per transaction to inform the New Relic Ruby agent of what user ID to associate the transaction with. Then in turn, when the agent notices errors during the lifespan of the transaction, the errors will bear an `enduser.id` agent attribute that holds the user ID value.
 
 Because the API is intended to be called every time a new user ID has entered scope, it will ideally be called via middleware that is aware of user session creation. Once the New Relic Ruby agent has been made aware of the user ID, it will supply the `enduser.id` agent attribute on the current transaction as well as on any errors noticed during the current transaction's lifespan.
+
+## Version tracking: Use metadata to see what version produced an error [#version-tracking]
+
+[Errors inbox](https://docs.newrelic.com/docs/errors-inbox/version-tracking/) will automatically track which versions of your software are producing errors. Any version data will also display in [CodeStream](/docs/codestream/how-use-codestream/performance-monitoring/#buildsha).
+
+Setting one of the following environment variables will help you identify which versions of your software produce errors.
+
+* `NEW_RELIC_METADATA_SERVICE_VERSION` adds the attribute `tags.service.version` on error event data containing the version of your code that's deployed, often a semantic version such as `1.2.3`, but not always.
+* `NEW_RELIC_METADATA_RELEASE_TAG` adds the attribute `tags.releaseTag` on event data containing the release tag (such as `v0.1.209` or `release-209`).
+* `NEW_RELIC_METADATA_COMMIT` adds the attribute `tags.commit` on event data containing the commit sha. You can use the entire sha or just the first seven characters (for example, `734713b`).


### PR DESCRIPTION
The Errors Inbox documentation about config options related to setting version tracking data is not currently part of the Ruby agent config doc (see https://github.com/newrelic/newrelic-ruby-agent/issues/2704).

While that's being worked on, add the content to this errors doc to help users find it.

cc @meda123 