### PR TITLE
update: remove unsupported .NET Core versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -49,10 +49,12 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     * [.NET Core version 3.1](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/) on December 13, 2022
     * [.NET version 5](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/) on May 10, 2022
 
-    The official product lifecycle start and end dates can be found in the [Microsoft documentation](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). Our .NET agent support of these framework versions end with the latest 9.x New Relic .NET agent. Starting from the New Relic .NET agent version 10.0, we will target .NET Core 3.1 onwards.
+    The official product lifecycle start and end dates can be found in the [Microsoft documentation](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). 
+
+    Our .NET agent support of Core version below 3.1 ended with our support of 9.x New Relic .NET agent. Starting from the New Relic .NET agent version 10.0, we will target .NET Core 3.1 onwards.
   </Callout>
 
-    The .NET agent supports .NET Core versions 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, 7.0, and 8.0.
+    The .NET agent supports .NET Core version 3.1, and .NET 5.0, 6.0, 7.0, and 8.0.
 
     <table style={{ width: "500px" }}>
       <thead>
@@ -68,46 +70,6 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
       </thead>
 
       <tbody>
-        <tr>
-          <td>
-            .NET Core 2.0
-          </td>
-
-          <td>
-            8.19.353.0 up to 9.9.0
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            .NET Core 2.1
-          </td>
-
-          <td>
-            8.19.353.0 up to 9.9.0
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            .NET Core 2.2
-          </td>
-
-          <td>
-            8.19.353.0 up to 9.9.0
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            .NET Core 3.0
-          </td>
-
-          <td>
-            8.21.34.0 up to 9.9.0
-          </td>
-        </tr>
-
         <tr>
           <td>
             .NET Core 3.1
@@ -159,8 +121,6 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     <Callout variant="important">
       On Linux ARM64 platforms, the .NET agent <DoNotTranslate>**only**</DoNotTranslate> supports versions of .NET 5.0 or higher.
     </Callout>
-
-    The agent is **not** compatible with .NET Core versions 1.0 or 1.1. For .NET Core 2.1 or higher applications with tiered compilation enabled, the agent will disable tiered compilation. .NET Core 2.1 support requires .NET Core runtime 2.1.3 and .NET Core SDK 2.1.401 or higher due to [a bug in the .NET Core profiling API](https://github.com/dotnet/coreclr/issues/18448).
   </Collapser>
 
   <Collapser
@@ -168,25 +128,9 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 2.0, 2.1, 2.2, 3.0, 3.1, and .NET 5.0, 6.0, 7.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, see the above section of our documentation, <DoNotTranslate>**[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**</DoNotTranslate>.
+    The .NET agent only supports applications targeting .NET Core 3.1, and .NET 5.0, 6.0, 7.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, see the above section of our documentation, <DoNotTranslate>**[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**</DoNotTranslate>.
 
     Supported:
-
-    ```xml
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    ```
-
-    ```xml
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    ```
-
-    ```xml
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-    ```
-
-    ```xml
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    ```
 
     ```xml
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -48,13 +48,14 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     * [.NET Core version 3.0](https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/) on March 3, 2020
     * [.NET Core version 3.1](https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/) on December 13, 2022
     * [.NET version 5](https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/) on May 10, 2022
+    * [.NET version 7](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) on May 24, 2024.
 
     The official product lifecycle start and end dates can be found in the [Microsoft documentation](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). 
 
     Our .NET agent support of Core version below 3.1 ended with our support of 9.x New Relic .NET agent. Starting from the New Relic .NET agent version 10.0, we will target .NET Core 3.1 onwards.
   </Callout>
 
-    The .NET agent supports .NET Core version 3.1, and .NET 5.0, 6.0, 7.0, and 8.0.
+    The .NET agent supports .NET Core version 3.1, and .NET 5.0, 6.0, and 8.0.
 
     <table style={{ width: "500px" }}>
       <thead>
@@ -128,7 +129,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
     id="target-framework"
     title="Target framework version"
   >
-    The .NET agent only supports applications targeting .NET Core 3.1, and .NET 5.0, 6.0, 7.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, see the above section of our documentation, <DoNotTranslate>**[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**</DoNotTranslate>.
+    The .NET agent only supports applications targeting .NET Core 3.1, and .NET 5.0, 6.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core. For information about which agent version to use for your application's targeted version of .NET Core, see the above section of our documentation, <DoNotTranslate>**[Microsoft .NET Core version](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core/#net-version)**</DoNotTranslate>.
 
     Supported:
 


### PR DESCRIPTION
We dropped support of agent v9 last week and all versions of .NET Core below 3.1. I've requested the .NET team review this for mistakes

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.