### PR TITLE
remove hard-coded 'v' for docs release notes

### DIFF
--- a/plugins/gatsby-plugin-release-note-rss/gatsby-node.js
+++ b/plugins/gatsby-plugin-release-note-rss/gatsby-node.js
@@ -11,6 +11,7 @@ const removeExports = require('remark-mdx-remove-exports');
 const parseISO = preferDefault(require('date-fns/parseISO'));
 const jsxImagesToChildren = require('../utils/jsxImagesToChildren');
 const handlers = require('../utils/handlers');
+const { getTitle } = require('../../src/utils/releaseNotes');
 
 // NOTE: remove-imports and remove-exports are now depreciated
 const htmlGenerator = unified()
@@ -106,7 +107,7 @@ const getFeedItem = (node, siteMetadata, imageHashMap) => {
 
   return {
     guid: id,
-    title: `${subject} ${version}`,
+    title: getTitle(frontmatter),
     custom_elements: [
       { link },
       { pubDate },

--- a/plugins/gatsby-source-nav/gatsby-node.js
+++ b/plugins/gatsby-source-nav/gatsby-node.js
@@ -1,3 +1,4 @@
+const { getTitle } = require('../../src/utils/releaseNotes');
 const hasOwnProperty = (obj, key) =>
   Object.prototype.hasOwnProperty.call(obj, key);
 
@@ -169,17 +170,11 @@ const createReleaseNotesNav = async ({ createNodeId, nodeModel }) => {
     );
 
   const formatReleaseNotePosts = (posts) =>
-    posts.map((post) => {
-      const derivedTitle = post.frontmatter.version
-        ? `${post.frontmatter.subject} v${post.frontmatter.version}`
-        : post.frontmatter.subject;
-
-      return {
-        title: post.frontmatter.title ? post.frontmatter.title : derivedTitle,
-        url: post.fields.slug,
-        pages: [],
-      };
-    });
+    posts.map((post) => ({
+      title: getTitle(post.frontmatter),
+      url: post.fields.slug,
+      pages: [],
+    }));
 
   const filterBySubject = (subject, posts) =>
     posts.filter((post) => post.frontmatter.subject === subject);

--- a/src/content/docs/release-notes/docs-release-notes/docs-3-15-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-3-15-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-03-15'
-version: 'ersion: March 8–14, 2024'
+version: 'version: March 8–14, 2024'
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/docs-release-notes/docs-3-22-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-3-22-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-03-22'
-version: 'ersion: March 15–21, 2024'
+version: 'version: March 15–21, 2024'
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/docs-release-notes/docs-3-29-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-3-29-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-03-29'
-version: 'ersion: March 22–28, 2024'
+version: 'version: March 22–28, 2024'
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/docs-release-notes/docs-4-12-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-4-12-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-04-12'
-version: 'ersion: April 5–11, 2024'
+version: 'version: April 5–11, 2024'
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/docs-release-notes/docs-4-19-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-4-19-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-04-19'
-version: 'ersion: April 12–18, 2024'
+version: 'version: April 12–18, 2024'
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/docs-release-notes/docs-4-26-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-4-26-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-04-26'
-version: 'ersion: April 19–25, 2024'
+version: 'version: April 19–25, 2024'
 ---
 
 ### New docs

--- a/src/content/docs/release-notes/docs-release-notes/docs-4-5-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-4-5-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-04-05'
-version: 'ersion: March 29–April 4, 2024'
+version: 'version: March 29–April 4, 2024'
 ---
 
 <Callout variant="important">

--- a/src/content/docs/release-notes/docs-release-notes/docs-5-10-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-10-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-05-10'
-version: 'ersion: May 3-9, 2024'
+version: 'version: May 3-9, 2024'
 ---
 
 ### New docs

--- a/src/content/docs/release-notes/docs-release-notes/docs-5-17-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-17-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-05-17'
-version: 'ersion: May 10-16, 2024'
+version: 'version: May 10-16, 2024'
 ---
 
 ### New docs

--- a/src/content/docs/release-notes/docs-release-notes/docs-5-24-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-24-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-05-24'
-version: 'ersion: May 17-23, 2024'
+version: 'version: May 17-23, 2024'
 ---
 
 ### New docs

--- a/src/content/docs/release-notes/docs-release-notes/docs-5-3-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-3-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-05-03'
-version: 'ersion: April 26–May 2, 2024'
+version: 'version: April 26–May 2, 2024'
 ---
 
 ### New docs

--- a/src/content/docs/release-notes/docs-release-notes/docs-5-31-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-31-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-05-31'
-version: 'ersion: May 24-30, 2024'
+version: 'version: May 24-30, 2024'
 ---
 
 ### New docs

--- a/src/content/docs/release-notes/docs-release-notes/docs-6-7-2024.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-6-7-2024.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2024-06-07'
-version: 'ersion: May 31-June 6, 2024'
+version: 'version: May 31-June 6, 2024'
 ---
 
 ### New docs

--- a/src/templates/releaseNote.js
+++ b/src/templates/releaseNote.js
@@ -3,19 +3,13 @@ import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
 import { Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
+
 import PageTitle from '../components/PageTitle';
 import MDXContainer from '../components/MDXContainer';
 import SEO from '../components/SEO';
 import ErrorBoundary from '../components/ErrorBoundary';
 import { TYPES } from '../utils/constants';
-
-const getTitle = ({ title, version, subject }) => {
-  if (title) {
-    return title;
-  }
-
-  return version ? `${subject} v${version}` : subject;
-};
+import { getTitle } from '../utils/releaseNotes';
 
 const ReleaseNoteTemplate = ({ data, location, pageContext }) => {
   const {

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -8,6 +8,7 @@ import SEO from '../components/SEO';
 import { Button, Icon, Layout, Link } from '@newrelic/gatsby-theme-newrelic';
 import { TYPES } from '../utils/constants';
 import MDXContainer from '../components/MDXContainer';
+import { getTitle } from '../utils/releaseNotes';
 
 const sortByVersion = (
   { frontmatter: { version: versionA } },
@@ -137,9 +138,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
                           margin-bottom: 0.5rem;
                         `}
                       >
-                        {post.frontmatter.title
-                          ? post.frontmatter.title
-                          : `${subject} v${post.frontmatter.version}`}
+                        {getTitle(post.frontmatter)}
                       </Link>
                       <p
                         css={css`
@@ -243,6 +242,7 @@ export const pageQuery = graphql`
           slug
         }
         frontmatter {
+          subject
           title
           version
           releaseDate(formatString: "MMMM D, YYYY")

--- a/src/utils/releaseNotes.js
+++ b/src/utils/releaseNotes.js
@@ -2,7 +2,7 @@
  * given a release note's frontmatter,
  * return what the title of the release note should be.
  */
-export const getTitle = (frontmatter) => {
+const getTitle = (frontmatter) => {
   const { title, version, subject } = frontmatter;
 
   if (title) {
@@ -14,4 +14,8 @@ export const getTitle = (frontmatter) => {
   }
 
   return version ? `${subject} v${version}` : subject;
+};
+
+module.exports = {
+  getTitle,
 };

--- a/src/utils/releaseNotes.js
+++ b/src/utils/releaseNotes.js
@@ -1,0 +1,17 @@
+/**
+ * given a release note's frontmatter,
+ * return what the title of the release note should be.
+ */
+export const getTitle = (frontmatter) => {
+  const { title, version, subject } = frontmatter;
+
+  if (title) {
+    return title;
+  }
+
+  if (subject?.startsWith('Docs')) {
+    return `${subject} ${version}`;
+  }
+
+  return version ? `${subject} v${version}` : subject;
+};


### PR DESCRIPTION
this PR keeps the hard-coded 'v' for agent release notes and removes it for Docs release notes. it also updates the RSS feed generation code to be consistent with the release notes pages and the navigation