### PR TITLE
Remove 'plan for paid consumption' banner and section from session tr…

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-traces-explore-webpages-life-cycle.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-traces-explore-webpages-life-cycle.mdx
@@ -32,10 +32,6 @@ import browserMonthlySessionTraceConsumptionQuery from 'images/browser_screensho
 
 import browserDailySessionTraceConsumptionQuery from 'images/browser_screenshot-full_daily-session-trace-consumption-query.webp'
 
-<Callout variant="important">
-Session trace data will be billable starting June 10, 2024. See [Data consumption](#plan-for-paid-consumption) for details.
-</Callout>
-
 <DoNotTranslate>**Session traces**</DoNotTranslate> provides a detailed timeline of the load and interaction events during a webpage's full life cycle up to ten minutes. Select the session URL or session trace ID, you can use the detailed waterfall visualization and heat map overview to examine metrics and identify problems related to:
 
 * Page load timing
@@ -320,36 +316,6 @@ The following table describes each segment of the session trace, with a link to 
 Session traces help you identify callbacks in your JavaScript code that execute slowly and block the execution of subsequent calls on the browser's main thread. These calls should execute quickly in order to allow the browser to quickly repaint the page in response to user actions.
 
 Session traces highlight any callbacks longer than 33ms. If called in rapid succession (such as inside a `requestAnimationFrame` loop), callbacks longer than 33ms reduce the frame rate below 30 frames per second. This speed seems sluggish to users.
-
-## Plan for paid consumption [#plan-for-paid-consumption]
-
-Starting June 10, 2024, session trace data will contribute to your overall monthly data consumption. This means it will be charged per your existing order. This change reflects the storage upgrade to the New Relic database (NRDB) which enables [customization of your sampling rate](#configure-sampling-rates), extended data retention, and improved performance.
-
-In the [query builder](https://one.newrelic.com/data-exploration/query-builder), run the query below to view your current monthly consumption of session trace data. Note: If you run it from a [parent account](/docs/accounts/original-accounts-billing/original-users-roles/parent-child-account-structure/#hierarchy), the results will reflect consumption of all child accounts.
-
-```sql
-FROM NrConsumption SELECT rate(sum(consumption), 1 month) as monthly_SessionTrace_GBs WHERE usageMetric = 'UnbilledBrowserEventsBytes' SINCE '2024-04-25'
-```
-
-<img
-  title="Monthly session trace consumption query"
-  alt="A screenshot of monthly session trace consumption"
-  src={browserMonthlySessionTraceConsumptionQuery}
-/>
-
-For a more granular view, run the following query to view your daily consumption for a single child account (if applicable):
-
-```sql
-FROM NrConsumption SELECT sum(consumption) as SessionTraceGBs WHERE usageMetric = 'UnbilledBrowserEventsBytes' FACET consumingAccountId, consumingAccountName SINCE '2024-04-25' TIMESERIES 1 day
-```
-
-<img
-  title="Daily session trace consumption query"
-  alt="A screenshot of daily session trace consumption"
-  src={browserDailySessionTraceConsumptionQuery}
-/>
-
-You can decrease your consumption of session trace data by [adjusting your sampling rates](#configure-sampling-rates) or disabling session tracing.
 
 ## Disable session tracing [#disable-tracing]
 


### PR DESCRIPTION
…aces

Session Traces became billable on June 10th so these sections are no longer relevant.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.