### PR TITLE
.NET agent: update serverless docs with .NET support

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own.mdx
@@ -95,7 +95,7 @@ In the long term, it's usually less work to integrate New Relic into your existi
     title="Serverless Framework"
   >
     Serverless Framework is a popular development and deployment tool for serverless applications. It's written in Node.js,
-    and for AWS, acts mostly as a higher-level abstraction on top of CloudFormation templates. It works well for Node, Python, Ruby and Java functions.
+    and for AWS, acts mostly as a higher-level abstraction on top of CloudFormation templates. It works well for Node, Python, Ruby, Java, and .NET functions.
 
     New Relic offers a [Serverless Framework Plugin](https://github.com/newrelic/serverless-newrelic-lambda-layers) to
     simplify instrumentation of your Serverless Framework application.

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/compatibility-requirements-aws-lambda-monitoring.mdx
@@ -21,7 +21,7 @@ Before [enabling serverless monitoring](/docs/serverless-function-monitoring/aws
 
 AWS has older runtimes for these languages as well, but AWS has not [chosen to support](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) the latest Lambda APIs with those older runtimes. Integration for older runtimes requires a different strategy, but is possible.
 
-Python, Ruby and Node.js are by far the most popular languages in the Lambda ecosystem. The [New Relic Lambda Layers](https://layers.newrelic-external.com/) for Node.js, Ruby and Python include the very latest New Relic agent version, and provide rich instrumentation with minimal configuration, right out of the box.
+Python, Ruby and Node.js are by far the most popular languages in the Lambda ecosystem. The [New Relic Lambda Layers](https://layers.newrelic-external.com/) for Node.js, Ruby, Python and .NET include the very latest New Relic agent version, and provide rich instrumentation with minimal configuration, right out of the box.
 
 Similarly, Go uses the New Relic Go agent. New Relic recommends keeping the agent module up to date. Support is limited for agent versions older than 3.16.0.
 


### PR DESCRIPTION
The .NET agent recently added Lambda support to the agent and some associated serverless tooling.  This PR updates some serverless documentation to show .NET support where appropriate.