### PR TITLE
Python release v9.11.0 -- PLEASE MERGE Friday June 14 AM

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -5340,7 +5340,7 @@ Here are assorted other settings available via the agent configuration file.
       </tbody>
     </table>
 
-    If this setting is enabled, the agent will send detailed troubleshooting messages from its startup scripts directly to your console (standard output). This can be helpful for debugging crashes in the `newrelic-admin` startup script, the alternative `bootstrap/sitecustomize.py` startup script, or the startup sequence of the Kubernetes Agents Operator.
+    If this setting is enabled, the agent will send detailed troubleshooting messages from its startup scripts directly to your console (STDOUT). This can be helpful for debugging crashes in the `newrelic-admin` startup script, the alternative `bootstrap/sitecustomize.py` startup script, or the startup sequence of the Kubernetes Agents Operator.
 
     <Callout variant="caution">
         This environment variable setting has no corresponding config file setting, as the code related to it runs before the config file is read. For comprehensive debug logging after the agent has started, set [log level](#log_level) to `debug`.

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -5284,6 +5284,7 @@ Here are assorted other settings available via the agent configuration file.
     </table>
 
     If this setting is enabled, it will capture package and version information on startup of the agent that is displayed in the APM environment tab.
+
     <Callout variant="tip">
         In applications that have a large number of packages, having this setting enabled may cause a CPU spike as it captures all the package and version information. It is recommended in those cases to disable this setting.
     </Callout>
@@ -5339,7 +5340,8 @@ Here are assorted other settings available via the agent configuration file.
       </tbody>
     </table>
 
-    If this setting is enabled, the agent will output debug level logging from agent bootstrap scripts directly to STDOUT. This can be helpful for debugging crashes in the `newrelic-admin` startup script, the alternative `bootstrap/sitecustomize.py` startup script, or the startup sequence of the Kubernetes Agents Operator.
+    If this setting is enabled, the agent will send detailed troubleshooting messages from its startup scripts directly to your console (standard output). This can be helpful for debugging crashes in the `newrelic-admin` startup script, the alternative `bootstrap/sitecustomize.py` startup script, or the startup sequence of the Kubernetes Agents Operator.
+
     <Callout variant="caution">
         This environment variable setting has no corresponding config file setting, as the code related to it runs before the config file is read. For comprehensive debug logging after the agent has started, set [log level](#log_level) to `debug`.
     </Callout>

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -5291,6 +5291,110 @@ Here are assorted other settings available via the agent configuration file.
         Disabling this setting will disable the ability to detect vulnerabilities in outdated packages.
     </Callout>
   </Collapser>
+
+<Collapser
+    id="NEW_RELIC_STARTUP_DEBUG"
+    title="NEW_RELIC_STARTUP_DEBUG"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            false
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Environment variable
+          </td>
+        </tr>
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_STARTUP_DEBUG`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If this setting is enabled, the agent will output debug level logging from agent bootstrap scripts directly to STDOUT. This can be helpful for debugging crashes in the `newrelic-admin` startup script, the alternative `bootstrap/sitecustomize.py` startup script, or the startup sequence of the Kubernetes Agents Operator.
+    <Callout variant="caution">
+        This environment variable setting has no corresponding config file setting, as the code related to it runs before the config file is read. For comprehensive debug logging after the agent has started, set [log level](#log_level) to `debug`.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="k8s_operator.enabled"
+    title="k8s_operator.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            false
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_K8S_OPERATOR_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    
+    This is an informational setting used to report when the agent is injected into a Kubernetes cluster. This setting does **not** enable/disable this function of the agent.
+  </Collapser>
+
 </CollapserGroup>
 
 ## Heroku

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -5392,7 +5392,10 @@ Here are assorted other settings available via the agent configuration file.
       </tbody>
     </table>
     
-    This is an informational setting used to report when the agent is injected into a Kubernetes cluster. This setting does **not** enable/disable this function of the agent.
+    This is an informational setting used to report when the agent is injected into a Kubernetes cluster.
+    <Callout variant="caution">
+        This setting does **not** enable/disable this function of the agent.
+    </Callout>
   </Collapser>
 
 </CollapserGroup>

--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -59,7 +59,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
         * Python version 3.4 is supported only by Python agent versions 4.20.0.120 or lower.
         * Python version 3.5 is supported only by Python agent versions 5.24.0.153 or lower.
         * Python version 3.6 is supported only by Python agent versions 7.16.0.178 or lower.
-        * For Python version 2.7 follow our [end of life (EOL) support](#version) requirements.
+        * For Python version 2.7 follow our [end of life (EOL) support](#python-version) requirements.
       </td>
     </tr>
 
@@ -153,7 +153,7 @@ New Relic recommends that you upgrade the agent regularly and at a minimum every
 
 ## Python version support [#python-version]
 
-The agent in general will support all released and active [Python branches](https://devguide.python.org/#status-of-python-branches). However, to keep up with upcoming changes, the agent will also follow this Python version support schedule. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
+The agent in general will support all released and active [Python branches](https://devguide.python.org/versions/#versions). However, to keep up with upcoming changes, the agent will also follow this Python version support schedule. The version support policy does not replace our [general end-of-life (EOL) policy](/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy).
 
 ### Support for new Python releases [#support-new]
 

--- a/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/instrumented-python-packages.mdx
@@ -405,6 +405,24 @@ Python agent [version 2.72.0.52 or higher](/docs/release-notes/agent-release-not
       </td>
 
       <td>
+        [psycopg](https://pypi.python.org/pypi/psycopg)
+      </td>
+
+      <td>
+        3.0
+      </td>
+
+      <td>
+        9.11.0
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [PostgreSQL](https://www.postgresql.org/)
+      </td>
+
+      <td>
         [psycopg2](https://pypi.python.org/pypi/psycopg2)
       </td>
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
@@ -1,0 +1,59 @@
+---
+subject: Python agent
+releaseDate: '2024-06-13'
+version: 9.11.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add agent_language to lambda metadata', 'Optimize plugins list capturing', 'Add support for injecting the agent into Kubernetes', 'Add support for psycopg3']
+bugs: ['Fix Large Language Model event duration units', 'Fix crash when using OpenAI's with_raw_response', 'Fix crash when using OpenAI's with_streaming_response', 'Fix a crash in ASGI when the Content-Length header is missing']
+security: []
+---
+
+## Notes
+
+This release of the Python agent adds agent_language to lambda metadata, support for injecting the agent into k8s, support for [psycopg3](https://pypi.org/project/psycopg/), optimizes plugins list capturing, fixes the Large Language Model event duration units, a crash in ASGI when the Content-Length header is missing, a crash when using [OpenAI](https://pypi.org/project/openai)'s with_raw_response and with_streaming_response.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## New features
+
+* **Add `agent_language` to lambda metadata**
+
+    * Add `agent_language` to collected lambda metadata.
+
+* **Optimize plugins list capturing**
+
+    * Skip checking for a package version on newrelic hooks that we know do not have versions.
+
+* **Add support for injecting the agent into Kubernetes**
+
+    * Updates the bootstrap sitecustomize file to support injecting the agent into a Kubernetes cluster.
+    * A full product for agent injection in Kubernetes will be coming soon in public preview.
+    * A new informational only setting called `k8s_operator.enabled` (with `NEW_RELIC_K8S_OPERATOR_ENABLED` as an environment variable) was added, which is used to report when the agent is injected into a Kubernetes cluster. This setting does **not** enable/disable this function of the agent.
+
+* **Add support for [psycopg3](https://pypi.org/project/psycopg/)**
+
+    * New instrumentation for psycopg3 has b
+
+## Bug fixes
+
+* **Fix Large Language Model event duration units**
+
+    * Previously, durations on LLM events were recorded in seconds which did not match some of the other language agents. This has been changed to be milliseconds.
+
+* **Fix crash when using [OpenAI](https://pypi.org/project/openai)'s `.with_raw_response.`**
+
+    * Previously, an exception would be raised inside the instrumentation when `.with_raw_response.` was used. This no longer happens, the instrumentation successfuly records LLM data when `.with_raw_response.` is used.
+
+* **Fix crash when using [OpenAI](https://pypi.org/project/openai)'s `.with_streaming_response.`**
+
+    * Previously, an exception would be raised inside the instrumentation when `.with_streaming_response.` was used. This no longer happens, the instrumentation is just skipped.
+
+* **Fix a crash in ASGI when the Content-Length header is missing**
+
+    * Previously, an exception would be raised inside the instrumentation that injects the browser agent when an ASGI response was missing the Content-Length header. This issue has been fixed.
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
@@ -3,14 +3,14 @@ subject: Python agent
 releaseDate: '2024-06-13'
 version: 9.11.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Add agent_language to lambda metadata', 'Optimize plugins list capturing', 'Add support for injecting the agent into Kubernetes', 'Add support for psycopg3']
+features: ['Add agent_language to lambda metadata', 'Optimize plugins list capturing', 'Add support for injecting the agent into Kubernetes', 'Add support for psycopg 3.0+']
 bugs: ['Fix Large Language Model event duration units', 'Fix crash when using OpenAI's with_raw_response', 'Fix crash when using OpenAI's with_streaming_response', 'Fix a crash in ASGI when the Content-Length header is missing']
 security: []
 ---
 
 ## Notes
 
-This release of the Python agent adds agent_language to lambda metadata, support for injecting the agent into k8s, support for [psycopg3](https://pypi.org/project/psycopg/), optimizes plugins list capturing, fixes the Large Language Model event duration units, a crash in ASGI when the Content-Length header is missing, a crash when using [OpenAI](https://pypi.org/project/openai)'s with_raw_response and with_streaming_response.
+This release of the Python agent adds agent_language to lambda metadata, support for injecting the agent into Kubernetes, support for [psycopg 3.0+](https://pypi.org/project/psycopg/), optimizes plugins list capturing, fixes the Large Language Model event duration units, a crash in ASGI when the Content-Length header is missing, a crash when using [OpenAI](https://pypi.org/project/openai)'s `.with_raw_response.` and `.with_streaming_response.`.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 
@@ -30,9 +30,9 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
     * A full product for agent injection in Kubernetes will be coming soon in public preview.
     * A new informational only setting called `k8s_operator.enabled` (with `NEW_RELIC_K8S_OPERATOR_ENABLED` as an environment variable) was added, which is used to report when the agent is injected into a Kubernetes cluster. This setting does **not** enable/disable this function of the agent.
 
-* **Add support for [psycopg3](https://pypi.org/project/psycopg/)**
+* **Add support for [psycopg 3.0+](https://pypi.org/project/psycopg/)**
 
-    * New instrumentation for psycopg3 has b
+    * New instrumentation for psycopg 3.0+ has been added, providing database tracing for both the `Connection` and `AsyncConnection` classes.
 
 ## Bug fixes
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
@@ -4,7 +4,7 @@ releaseDate: '2024-06-13'
 version: 9.11.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['Add agent_language to lambda metadata', 'Optimize plugins list capturing', 'Add support for injecting the agent into Kubernetes', 'Add support for psycopg 3.0+']
-bugs: ['Fix Large Language Model event duration units', 'Fix crash when using OpenAIs with_raw_response', 'Fix crash when using OpenAIs with_streaming_response', 'Fix a crash in ASGI when the Content-Length header is missing']
+bugs: ['Fix Large Language Model event duration units', 'Fix crash when using OpenAI with_raw_response', 'Fix crash when using OpenAI with_streaming_response', 'Fix a crash in ASGI when the Content-Length header is missing']
 security: []
 ---
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-91100.mdx
@@ -1,10 +1,10 @@
 ---
-subject: Python agent
+subject: 'Python agent'
 releaseDate: '2024-06-13'
 version: 9.11.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
 features: ['Add agent_language to lambda metadata', 'Optimize plugins list capturing', 'Add support for injecting the agent into Kubernetes', 'Add support for psycopg 3.0+']
-bugs: ['Fix Large Language Model event duration units', 'Fix crash when using OpenAI's with_raw_response', 'Fix crash when using OpenAI's with_streaming_response', 'Fix a crash in ASGI when the Content-Length header is missing']
+bugs: ['Fix Large Language Model event duration units', 'Fix crash when using OpenAIs with_raw_response', 'Fix crash when using OpenAIs with_streaming_response', 'Fix a crash in ASGI when the Content-Length header is missing']
 security: []
 ---
 


### PR DESCRIPTION
## Update docs for Python agent release v9.11.0

* Document new configuration settings.
* Add release notes for v9.11.0.
* Fix broken link in Python2.7 EOL notice.