### PR TITLE
chore: Remove note for ubuntu 24 in infra requirements

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -164,7 +164,6 @@ The infrastructure agent supports these operating systems up to their manufactur
       <td>
         [LTS](https://wiki.ubuntu.com/LTS) versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x
         Interim releases 20.10, 21.04.
-        Note: Logs are not yet supported on supported on Ubuntu 24.04.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->
## Give us some context

Removed `Note: Logs are not yet supported on Ubuntu 24.04.` from the requirements of Ubuntu category in the Infrastructure agent. Because the logs will now support Ubuntu 24.04.