### PR TITLE
.NET agent: update verified compatible versions of MongoDB and Elasticsearch clients

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -464,7 +464,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1, 2.24.0
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1, 2.24.0, 2.25.0, 2.26.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * IMongoCollection.CountDocuments[Async]
@@ -537,7 +537,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 <DoNotTranslate>**Elastic.Clients.Elasticsearch**</DoNotTranslate>
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12
+* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -589,7 +589,7 @@ Known incompatible versions: Instance details aren't available in lower version 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1. 2.24.0
+Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1. 2.24.0, 2.25.0, 2.26.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * `IMongoCollection.CountDocuments[Async]`
@@ -714,7 +714,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 <DoNotTranslate>**Elastic.Clients.Elasticsearch**</DoNotTranslate>
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12
+* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 


### PR DESCRIPTION
The .NET agent has tested some newer versions of our auto-instrumented clients for MongoDB and Elasticsearch and want to update our compatibility and support docs.