### PR TITLE
chore: Update .NET compatibility docs to clarify native images aren't supported

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -341,7 +341,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
   </Collapser>
 </CollapserGroup>
 
- Automatic instrumentation [#instrumented-features]
+ ##Automatic instrumentation [#instrumented-features]
 
 If your application is hosted in ASP.NET Core, the agent automatically creates and instruments transactions. The .NET agent will automatically instrument your application after install. If your app is not automatically instrumented, or if you want to add instrumentation, use [custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation).
 
@@ -848,6 +848,7 @@ The following features are not available for the .NET agent:
 
 * The .NET agent does not support [trim self-contained deployments and executables](https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-self-contained), because the compiler can potentially trim assemblies that the agent depends on.
 * [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing) is not supported on Alpine Linux due to a [GRPC compatibility issue](https://github.com/grpc/grpc/issues/21446). See [this agent issue](https://github.com/newrelic/newrelic-dotnet-agent/issues/289) for more information.
+* The .NET agent does not support [Native Ahead of Time (AOT) deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows) for .NET applications because just-in-time (JIT) compilation is required for the agent to function properly. 
 
 ## Connect the agent to other New Relic products [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -341,7 +341,7 @@ Before you install the New Relic .NET agent on Windows or Linux, make sure your 
   </Collapser>
 </CollapserGroup>
 
- ##Automatic instrumentation [#instrumented-features]
+ ## Automatic instrumentation [#instrumented-features]
 
 If your application is hosted in ASP.NET Core, the agent automatically creates and instruments transactions. The .NET agent will automatically instrument your application after install. If your app is not automatically instrumented, or if you want to add instrumentation, use [custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation).
 
@@ -848,7 +848,7 @@ The following features are not available for the .NET agent:
 
 * The .NET agent does not support [trim self-contained deployments and executables](https://docs.microsoft.com/en-us/dotnet/core/deploying/trim-self-contained), because the compiler can potentially trim assemblies that the agent depends on.
 * [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing) is not supported on Alpine Linux due to a [GRPC compatibility issue](https://github.com/grpc/grpc/issues/21446). See [this agent issue](https://github.com/newrelic/newrelic-dotnet-agent/issues/289) for more information.
-* The .NET agent does not support [Native Ahead of Time (AOT) deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows) for .NET applications because just-in-time (JIT) compilation is required for the agent to function properly. 
+* The .NET agent doesn't support [Native Ahead of Time (AOT) deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows) for .NET applications because just-in-time (JIT) compilation is required for the agent to function properly. 
 
 ## Connect the agent to other New Relic products [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -1128,6 +1128,9 @@ If data appears, you've instrumented your app correctly.
   </Collapser>
 </CollapserGroup>
 
+## Unavailable features [#unavailable-features]
+* The .NET agent does not support native images created with [Native Image Generator (NGEN)](https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator) because just-in-time (JIT) compilation is required for the agent to function properly.
+
 ## Connect the agent to other New Relic products [#digital-intelligence-platform]
 
 In addition to [APM](/docs/apm/new-relic-apm/getting-started/introduction-apm/), the agent integrates with other New Relic products to give you end-to-end visibility:

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -238,6 +238,8 @@ Before you [install New Relic's .NET agent](/docs/apm/agents/net-agent/getting-s
 </Collapser>
 </CollapserGroup>
 
+Keep in mind that just-in-time (JIT) compilation is a requirement for .NET agent functionality. Native images created with [Native Image Generator (NGEN)](https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator) aren't supported by the .NET agent.
+
 ## Automatic instrumentation [#instrumented-features]
 
 If your application is hosted in ASP.NET or another [fully supported framework](#app-frameworks), the .NET agent will automatically instrument your application after install. If your app isn't automatically instrumented, or if you want to add instrumentation, use [custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation/).
@@ -1127,9 +1129,6 @@ If data appears, you've instrumented your app correctly.
     </table>
   </Collapser>
 </CollapserGroup>
-
-## Unavailable features [#unavailable-features]
-* The .NET agent does not support native images created with [Native Image Generator (NGEN)](https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator) because just-in-time (JIT) compilation is required for the agent to function properly.
 
 ## Connect the agent to other New Relic products [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -238,8 +238,6 @@ Before you [install New Relic's .NET agent](/docs/apm/agents/net-agent/getting-s
 </Collapser>
 </CollapserGroup>
 
-Keep in mind that just-in-time (JIT) compilation is a requirement for .NET agent functionality. Native images created with [Native Image Generator (NGEN)](https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator) aren't supported by the .NET agent.
-
 ## Automatic instrumentation [#instrumented-features]
 
 If your application is hosted in ASP.NET or another [fully supported framework](#app-frameworks), the .NET agent will automatically instrument your application after install. If your app isn't automatically instrumented, or if you want to add instrumentation, use [custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation/).
@@ -1129,6 +1127,10 @@ If data appears, you've instrumented your app correctly.
     </table>
   </Collapser>
 </CollapserGroup>
+
+## Unavailable features [#unavailable-features]
+
+Just-in-time (JIT) compilation is a requirement for .NET agent functionality, so native images created with [Native Image Generator (NGEN)](https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator) aren't supported by the .NET agent.
 
 ## Connect the agent to other New Relic products [#digital-intelligence-platform]
 


### PR DESCRIPTION
Minor update to .NET agent compatibility docs to clarify that native images aren't supported.