### PR TITLE
Add Browser Injection Instructions for Next.js

### DIFF
--- a/src/content/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring.mdx
@@ -20,6 +20,123 @@ You can review [compability and requirements for SPA monitoring here](/docs/brow
 
 When you set up your first monitored app in a New Relic account, you must agree to the Terms of Service. By agreeing to the terms, you authorize New Relic to collect hash fragments from URLs. You only need to select the checkbox option once for an account.
 
+## Inject the Browser Agent for Next.js
+
+### App Router (/app/layout.js)
+```js
+// This file defines the overall layout of all pages in the application.
+// The default function exported from this module must return a document with
+// `html` and `body` tags. A `head` tag will be ignored.
+
+import Script from 'next/script'
+import Link from 'next/link'
+import newrelic from 'newrelic'
+
+// Somehow, this ends up including our static stylesheet correctly.
+// See https://nextjs.org/docs/app/building-your-application/styling/css-modules#global-styles.
+import './style.css'
+
+export default async function RootLayout({ children }) {
+  if (newrelic.agent.collector.isConnected() === false) {
+    await new Promise((resolve) => {
+      newrelic.agent.on("connected", resolve)
+    })
+  }
+
+  const browserTimingHeader = newrelic.getBrowserTimingHeader({
+    hasToRemoveScriptWrapper: true,
+    allowTransactionlessInjection: true,
+  })
+
+  return (
+    <html>
+    <body>
+    <ul className="navbar">
+      <li><a href="/">Home</a></li>
+      <li><Link href="/users" key={"users"}>Users</Link></li>
+      <li><Link href="/about" key={"about"}>About</Link></li>
+    </ul>
+    {children}
+
+    <Script
+      // We have to set an id for inline scripts.
+      // See https://nextjs.org/docs/app/building-your-application/optimizing/scripts#inline-scripts
+      id="nr-browser-agent"
+      // By setting the strategy to "beforeInteractive" we guarantee that
+      // the script will be added to the document's `head` element.
+      strategy="beforeInteractive"
+      // The body of the script element comes from the async evaluation
+      // of `getInitialProps`. We use the special
+      // `dangerouslySetInnerHTML` to provide that element body. Since
+      // it requires an object with an `__html` property, we pass in an
+      // object literal.
+      dangerouslySetInnerHTML={{__html: browserTimingHeader}}
+    />
+    </body>
+    </html>
+  )
+}
+```
+
+### Pages Router (/pages/_document.jsx)
+```js
+// This file provides the overall layout of the site via the `render` method.
+
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+import newrelic from 'newrelic'
+
+// In order to inject the browser agent we need to perform an asynchronous
+// operation. To do that, we need to extend the `Document` object as
+// described in
+// https://nextjs.org/docs/pages/building-your-application/routing/custom-document#customizing-renderpage
+class RootDocument extends Document {
+  static async getInitialProps(context) {
+    const initialProps = await Document.getInitialProps(context)
+
+    if (newrelic.agent.collector.isConnected() === false) {
+      await new Promise((resolve) => {
+        newrelic.agent.on("connected", resolve)
+      })
+    }
+
+    const browserTimingHeader = newrelic.getBrowserTimingHeader({
+      hasToRemoveScriptWrapper: true,
+      allowTransactionlessInjection: true,
+    })
+
+    return {
+      ...initialProps,
+      browserTimingHeader,
+    }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <script
+            type="text/javascript"
+            // The body of the script element comes from the async evaluation
+            // of `getInitialProps`. We use the special
+            // `dangerouslySetInnerHTML` to provide that element body. Since
+            // it requires an object with an `__html` property, we pass in an
+            // object literal.
+            dangerouslySetInnerHTML={{ __html: this.props.browserTimingHeader }}
+          />
+          <link rel="stylesheet" href="/style.css" />
+        </Head>
+        <body>
+        <Main />
+        <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default RootDocument
+```
+
 ## Enable or disable SPA monitoring [#enable-spa]
 
 When you [enable browser monitoring](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#enable), SPA monitoring is included by default because it gives access to a range of our most recent features, including distributed tracing. Some older agent installations may need to be upgraded. Read more about [browser agent types](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types).

--- a/src/content/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring.mdx
@@ -22,7 +22,7 @@ When you set up your first monitored app in a New Relic account, you must agree 
 
 ## Inject the Browser Agent for Next.js
 
-### App Router (/app/layout.js)
+### App Router (app/layout.js)
 ```js
 // This file defines the overall layout of all pages in the application.
 // The default function exported from this module must return a document with
@@ -78,7 +78,7 @@ export default async function RootLayout({ children }) {
 }
 ```
 
-### Pages Router (/pages/_document.jsx)
+### Pages Router (pages/_document.jsx)
 ```js
 // This file provides the overall layout of the site via the `render` method.
 
@@ -136,6 +136,36 @@ class RootDocument extends Document {
 
 export default RootDocument
 ```
+
+## Next.js Server-side Rendering Instrumentation 
+Currently, server-side rendering for Next.js is not bundled with the agent, and must be installed as a standalone. The `newrelic/next` package is New Relic’s official Next.js framework instrumentation for use with the New Relic [Node.js agent](https://github.com/newrelic/node-newrelic).
+
+**Note:** The minimum supported Next.js version is 12.0.9. If you are using Next.js middleware the minimum supported version is 12.2.0.
+
+### Installation
+
+This package depends on the Node agent so you will get all the capabilities of the agent when loading this package.
+npm install @newrelic/next
+In package.json:
+
+```
+"start": "NODE_OPTIONS='-r @newrelic/next' next start
+```
+If you cannot control how your program is run, you can load the @newrelic/nextmodule before any other module in your program. However, we strongly suggest you avoid this method at all costs. We found bundling when running next build causes problems and also will make your bundle unnecessarily large.
+
+```
+require('@newrelic/next')
+/* ... the rest of the program ... */
+```
+### Custom Next.js servers
+
+If you are using next as a custom server, you're probably not running your application with the next CLI. In that scenario we recommend running the Next.js instrumentation as follows.
+
+```
+node -r @newrelic/next your-program.js
+```
+For more information, please see the agent [installation guide](https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent)
+
 
 ## Enable or disable SPA monitoring [#enable-spa]
 


### PR DESCRIPTION
Add installation instructions for Next.js. Injection for both the pages router and app router are included.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
The current documentation covering installation of the Browser Agent for SPAs does not work for Next.js applications. This PR adds instructions on how to inject the browser agent for both the pages router and app router implementations of Next.js. 

This PR is in draft because I'd like to discuss where to add documentation for instrumenting server-side rendering in Next.js which requires a [standalone module](https://github.com/newrelic/newrelic-node-nextjs?tab=readme-ov-file) that we maintain.