### PR TITLE
Tweak OpenTelemetry Resource page tilte and meta description

### DIFF
--- a/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'OpenTelemetry resources: Best practices'
+title: 'OpenTelemetry resources in New Relic'
 tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
-metaDescription: Here are some tips for working with OpenTelemetry resources and New Relic.
+metaDescription: Details on how New Relic works with OpenTelemetry resources
 freshnessValidatedDate: 2024-05-08
 ---
 


### PR DESCRIPTION
This aligns the naming with Log, Metric, and Trace sibling pages.