### PR TITLE
fix(dotnet): Corrects an error in the TraceMetadata code sample.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -2612,7 +2612,7 @@ To use the .NET agent API, make sure you have the [latest .NET agent release](/d
 
     ```cs
     IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
-    TraceMetadata traceMetadata = agent.TraceMetadata;
+    ITraceMetadata traceMetadata = agent.TraceMetadata;
     string traceId = traceMetadata.TraceId;
     string spanId = traceMetadata.SpanId;
     bool isSampled = traceMetadata.IsSampled;


### PR DESCRIPTION
Fixes a minor error in the code sample for the `TraceMetadata` property in the .NET agent API.