### PR TITLE
Ignore sdk components in translation

### DIFF
--- a/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
+++ b/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
@@ -21,6 +21,7 @@ excludePath:
     - src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
     - src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
     - src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+    - src/content/docs/new-relic-solutions/build-nr-ui/sdk-component
 
   ko-KR:
     - src/announcements
@@ -44,6 +45,7 @@ excludePath:
     - src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
     - src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
     - src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+    - src/content/docs/new-relic-solutions/build-nr-ui/sdk-component
 
   es-LA:
     - src/announcements
@@ -67,6 +69,7 @@ excludePath:
     - src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
     - src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
     - src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+    - src/content/docs/new-relic-solutions/build-nr-ui/sdk-component
 
   pt-BR:
     - src/announcements
@@ -90,6 +93,7 @@ excludePath:
     - src/content/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy.mdx
     - src/content/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy.mdx
     - src/content/docs/apm/agents/net-agent/getting-started/net-agent-eol-policy.mdx
+    - src/content/docs/new-relic-solutions/build-nr-ui/sdk-component
 
 excludeType:
   ja-JP:


### PR DESCRIPTION
Adds the sdk component doc folder to the i18n exclusions list