### PR TITLE
fix: transaction_tracer.transaction_threshold config

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -2253,11 +2253,9 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    Threshold of web transaction response time in seconds beyond which a [transaction](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction) is eligible for [transaction tracing](/docs/apm/transactions/transaction-traces/transaction-traces). The default value is `apdex_f`; this sets the trace threshold to four times your application's [Apdex T](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#apdex_t). You can also enter a specific time value in milliseconds.
+    Sets the time, in seconds, for a [transaction trace](/docs/apm/transactions/transaction-traces/transaction-traces) will be considered slow. The default value is `apdex_f`; this sets the trace threshold to four times your application's [Apdex T](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#apdex_t). If a number is provided, it is set in seconds.
 
-    <DoNotTranslate>**Example: Threshold set to `apdex_f`**</DoNotTranslate>
-
-    The default `apdex_t` is 100 milliseconds. If your transaction threshold is set to `apdex_f`, a "slow" transaction is 400 milliseconds.
+    The default `apdex_t` is 500 milliseconds. If your transaction threshold is set to `apdex_f`, a "slow" transaction is 2 seconds.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
The details of this config were incorrect. After discussing with the node team I'm attempting to update it using their [recently updated internal documentation](https://github.com/newrelic/node-newrelic/blob/b1b5e3e54074cc8b535927f4edad07925618260c/lib/config/default.js#L521-L528).  

This PR is waiting on review from the Node team.

One point needs clarifying before approval. The internal docs state:
> When a transaction exceeds this threshold, a transaction trace will be recorded

Discussing this with the engineers my understanding was this did not determine if a transaction trace was recorded, only if it would be considered 'slow'.