### PR TITLE
fix: typo

### DIFF
--- a/src/content/docs/new-relic-solutions/build-nr-ui/custom-visualizations/build-visualization.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/custom-visualizations/build-visualization.mdx
@@ -188,7 +188,7 @@ const ErrorState = () => (
 
     ```bash
     nr1 update
-    ``` 
+    ```
     </Step>
     <Step>
     Create a visualization, called `my-awesome-visualization`, in a Nerdpack, called `my-awesome-nerdpack`:


### PR DESCRIPTION
I think that stray whitespace is causing the codeblock to not end where it should:

<img width="363" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/9998787e-fc83-4979-a9c3-fdb1d32d8f5a">

