### PR TITLE
fix: bat -> batch

### DIFF
--- a/src/content/docs/apm/agents/java-agent/additional-installation/include-java-agent-jvm-argument.mdx
+++ b/src/content/docs/apm/agents/java-agent/additional-installation/include-java-agent-jvm-argument.mdx
@@ -173,13 +173,13 @@ To pass the `-javaagent` argument on JBoss:
           <td>
             In `bin/standalone.bat`, before the line:
 
-            ```bat
+            ```batch
             set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
             ```
 
             Add:
 
-            ```bat
+            ```batch
             set "JAVA_OPTS=-javaagent:C:/full/path/to/newrelic.jar %JAVA_OPTS%"
             ```
           </td>
@@ -207,13 +207,13 @@ To pass the `-javaagent` argument on JBoss:
           <td>
             In `bin/run.bat`, before the line:
 
-            ```bat
+            ```batch
             set JBOSS_CLASSPATH=%RUN_CLASSPATH%
             ```
 
             Add:
 
-            ```bat
+            ```batch
             set "JAVA_OPTS=-javaagent:C:/full/path/to/newrelic.jar %JAVA_OPTS%"
             ```
           </td>
@@ -330,11 +330,11 @@ To pass the `-javaagent` argument on Play:
 <DoNotTranslate>**Java 8**</DoNotTranslate>
 
 * Option 1: Add the `javaagent` argument via the `jvmargs` property in server's `resin.properties` file:
-  ```
+  ```properties
   jvm_args  : -javaagent:/full/path/to/newrelic.jar
   ```
 * Option 2: Specify the `-javaagent` argument by adding it to the `<jvm-args>` section in your `conf/resin.conf` or `conf/resin.xml` file:
-  ```
+  ```xml
   <jvm-arg>-javaagent:/full/path/to/newrelic.jar</jvm-arg>
   ```
 
@@ -345,13 +345,13 @@ The module system introduced in Java 9 can lead to the exception `NoClassDefFoun
 Resin can be run on Java 9 or higher, with the Java agent using one of the following options:
 
 * Option 1: Add the `javaagent` argument via the `jvmargs` property in server's `resin.properties` file:
-  ```
+  ```properties
   jvm_args  : -javaagent:/full/path/to/newrelic.jar
   ```
   The Resin server can then be run with `./bin/resin.sh start`.
 
 * Option 2: Run resin jar with the `-javaagent` property on the command line:
-  ```
+  ```sh
   java -javaagent:/path/to/newrelic.jar -jar lib/resin.jar start
   ```
 
@@ -437,7 +437,7 @@ To pass the `-javaagent` argument on Tomcat:
   >
     Create a `CATALINA_BASE/bin/setenv.bat` script if one doesn't already exist. Configure your `setenv.bat` script to use the New Relic agent using the `CATALINA_OPTS` environment variable:
 
-    ```bat
+    ```batch
     SET "CATALINA_OPTS=%CATALINA_OPTS% -javaagent:/full/path/to/newrelic.jar"
     ```
   </Collapser>
@@ -467,7 +467,7 @@ To pass the `-javaagent` argument on Tomcat:
 
     If you use `catalina.bat` to launch Tomcat, set the `JAVA_OPTS` variable near the top of the file:
 
-    ```bat
+    ```batch
     SET JAVA_OPTS=%JAVA_OPTS% -javaagent:/full/path/to/newrelic.jar
     ```
   </Collapser>
@@ -522,7 +522,7 @@ To pass the `-javaagent` argument on WebLogic:
     1. Edit your `startWebLogic.bat` file, located in the domain's `bin` directory.
     2. Near the beginning of the file, add:
 
-       ```bat
+       ```batch
        set JAVA_OPTIONS=%JAVA_OPTIONS% -javaagent:"C:\full\path\to\newrelic.jar"
        ```
   </Collapser>
@@ -649,13 +649,13 @@ To pass the `-javaagent` argument on Wildfly (if using Wildfly 11 or higher, see
           <td>
             In `bin/standalone.bat`, find this line:
 
-            ```bat
+            ```batch
             rem Setup JBoss specific properties
             ```
 
             Then add:
 
-            ```bat
+            ```batch
             set "JAVA_OPTS=-javaagent:C:/full/path/to/newrelic.jar %JAVA_OPTS%"
             ```
           </td>

--- a/src/i18n/content/es/docs/apm/agents/java-agent/additional-installation/include-java-agent-jvm-argument.mdx
+++ b/src/i18n/content/es/docs/apm/agents/java-agent/additional-installation/include-java-agent-jvm-argument.mdx
@@ -175,13 +175,13 @@ Para pasar el argumento `-javaagent` en JBoss:
           <td>
             En `bin/standalone.bat`, antes de la línea:
 
-            ```bat
+            ```batch
             set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
             ```
 
             Agregar:
 
-            ```bat
+            ```batch
             set "JAVA_OPTS=-javaagent:C:/full/path/to/newrelic.jar %JAVA_OPTS%"
             ```
           </td>
@@ -209,13 +209,13 @@ Para pasar el argumento `-javaagent` en JBoss:
           <td>
             En `bin/run.bat`, antes de la línea:
 
-            ```bat
+            ```batch
             set JBOSS_CLASSPATH=%RUN_CLASSPATH%
             ```
 
             Agregar:
 
-            ```bat
+            ```batch
             set "JAVA_OPTS=-javaagent:C:/full/path/to/newrelic.jar %JAVA_OPTS%"
             ```
           </td>
@@ -339,13 +339,13 @@ Para pasar el argumento `-javaagent` en Play:
 
 * Opción 1: agregue el argumento `javaagent` a través de la propiedad `jvmargs` en el archivo `resin.properties` del servidor:
 
-  ```
-  jvm_args  : -javaagent:/full/path/to/newrelic.jar
+  ```properties
+  jvm_args : -javaagent:/full/path/to/newrelic.jar
   ```
 
 * Opción 2: especifique el argumento `-javaagent` agregándolo a la sección `<jvm-args>` de su archivo `conf/resin.conf` o `conf/resin.xml` :
 
-  ```
+  ```xml
   <jvm-arg>-javaagent:/full/path/to/newrelic.jar</jvm-arg>
   ```
 
@@ -359,15 +359,15 @@ Resin se puede ejecutar en Java 9 o superior, con el agente de Java usando una d
 
 * Opción 1: agregue el argumento `javaagent` a través de la propiedad `jvmargs` en el archivo `resin.properties` del servidor:
 
-  ```
-  jvm_args  : -javaagent:/full/path/to/newrelic.jar
+  ```properties
+  jvm_args : -javaagent:/full/path/to/newrelic.jar
   ```
 
   Luego, el servidor Resin se puede ejecutar con `./bin/resin.sh start`.
 
 * Opción 2: ejecutar resin jar con la propiedad `-javaagent` en la línea de comando:
 
-  ```
+  ```sh
   java -javaagent:/path/to/newrelic.jar -jar lib/resin.jar start
   ```
 
@@ -452,7 +452,7 @@ Para pasar el argumento `-javaagent` en Tomcat:
   >
     Cree un script `CATALINA_BASE/bin/setenv.bat` si aún no existe ninguno. Configure su script `setenv.bat` para usar el agente New Relic usando la variable de entorno `CATALINA_OPTS`:
 
-    ```bat
+    ```batch
     SET "CATALINA_OPTS=%CATALINA_OPTS% -javaagent:/full/path/to/newrelic.jar"
     ```
   </Collapser>
@@ -482,7 +482,7 @@ Para pasar el argumento `-javaagent` en Tomcat:
 
     Si usa `catalina.bat` para iniciar Tomcat, configure la variable `JAVA_OPTS` cerca de la parte superior del archivo:
 
-    ```bat
+    ```batch
     SET JAVA_OPTS=%JAVA_OPTS% -javaagent:/full/path/to/newrelic.jar
     ```
   </Collapser>
@@ -541,7 +541,7 @@ Para pasar el argumento `-javaagent` en WebLogic:
 
     2. Cerca del comienzo del archivo, agregue:
 
-       ```bat
+       ```batch
        set JAVA_OPTIONS=%JAVA_OPTIONS% -javaagent:"C:\full\path\to\newrelic.jar"
        ```
   </Collapser>
@@ -677,13 +677,13 @@ Para pasar el argumento `-javaagent` en Wildfly (si usa Wildfly 11 o superior, c
           <td>
             En `bin/standalone.bat`, busque esta línea:
 
-            ```bat
+            ```batch
             rem Setup JBoss specific properties
             ```
 
             Luego añade:
 
-            ```bat
+            ```batch
             set "JAVA_OPTS=-javaagent:C:/full/path/to/newrelic.jar %JAVA_OPTS%"
             ```
           </td>


### PR DESCRIPTION
Prisma supports `batch` but not the shorthand `bat`

- https://prismjs.com/#supported-languages

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.