### PR TITLE
Add a callout that links to k8s agents operator docs -- MERGE on FRIDAY w/ rest of Kubernetes doc changes

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
@@ -14,6 +14,10 @@ Want to learn more before you get started? [Introduction to APM](/docs/apm/new-r
 
 ## What do you want to monitor? [#what]
 
+<Callout variant="important">
+Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+</Callout>
+
 We have a few paths to install the Node.js agent, depending on what you're monitoring.
 
 <CollapserGroup>

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
@@ -15,7 +15,7 @@ Want to learn more before you get started? [Introduction to APM](/docs/apm/new-r
 ## What do you want to monitor? [#what]
 
 <Callout variant="tip">
-Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
+Is your application running on a Kubernetes cluster? Try out our installation method using the [Kubernetes agents operator](/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/).
 </Callout>
 
 We have a few paths to install the Node.js agent, depending on what you're monitoring.

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/monitor-your-nodejs-app.mdx
@@ -14,8 +14,8 @@ Want to learn more before you get started? [Introduction to APM](/docs/apm/new-r
 
 ## What do you want to monitor? [#what]
 
-<Callout variant="important">
-Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+<Callout variant="tip">
+Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
 </Callout>
 
 We have a few paths to install the Node.js agent, depending on what you're monitoring.

--- a/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
@@ -28,8 +28,8 @@ Our Ruby agent auto-instruments your code so you can start monitoring applicatio
   Add Ruby data
 </ButtonLink>
 
-<Callout variant="important">
-Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+<Callout variant="tip">
+Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
 </Callout>
 
 ## Install the gem [#Installing_the_Gem]

--- a/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
@@ -29,7 +29,7 @@ Our Ruby agent auto-instruments your code so you can start monitoring applicatio
 </ButtonLink>
 
 <Callout variant="tip">
-Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
+Is your application running on a Kubernetes cluster? Try out our installation method using the [Kubernetes agents operator](/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/).
 </Callout>
 
 ## Install the gem [#Installing_the_Gem]

--- a/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent.mdx
@@ -28,6 +28,10 @@ Our Ruby agent auto-instruments your code so you can start monitoring applicatio
   Add Ruby data
 </ButtonLink>
 
+<Callout variant="important">
+Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+</Callout>
+
 ## Install the gem [#Installing_the_Gem]
 
 <Callout variant="important">

--- a/src/install/dotnet/intro.mdx
+++ b/src/install/dotnet/intro.mdx
@@ -20,5 +20,5 @@ Okay, let's get started installing the .NET agent.
 ## Install the .NET agent [#install]
 
 <Callout variant="tip">
-Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
+Is your application running on a Kubernetes cluster? Try out our installation method using the [Kubernetes agents operator](/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/).
 </Callout>

--- a/src/install/dotnet/intro.mdx
+++ b/src/install/dotnet/intro.mdx
@@ -19,6 +19,6 @@ Okay, let's get started installing the .NET agent.
 
 ## Install the .NET agent [#install]
 
-<Callout variant="important">
-Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+<Callout variant="tip">
+Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
 </Callout>

--- a/src/install/dotnet/intro.mdx
+++ b/src/install/dotnet/intro.mdx
@@ -18,3 +18,7 @@ If you haven't already, you'll need to [sign up for New Relic](https://newrelic.
 Okay, let's get started installing the .NET agent.
 
 ## Install the .NET agent [#install]
+
+<Callout variant="important">
+Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+</Callout>

--- a/src/install/java/intro.mdx
+++ b/src/install/java/intro.mdx
@@ -16,6 +16,6 @@ New Relic supports the most popular Java app servers, frameworks, virtual machin
 To get the most out of this page, select your app deployment and framework. You need a [New Relic account](https://newrelic.com/signup) to finish the installation process. Want more context? See our [intro to APM](/docs/apm/new-relic-apm/getting-started/introduction-apm), or learn how to solve your app's performance issues with our [My app is slow tutorial](/docs/journey-app-slow/root-causes/). 
 
 
-<Callout variant="important">
-Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+<Callout variant="tip">
+Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
 </Callout>

--- a/src/install/java/intro.mdx
+++ b/src/install/java/intro.mdx
@@ -17,5 +17,5 @@ To get the most out of this page, select your app deployment and framework. You 
 
 
 <Callout variant="tip">
-Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
+Is your application running on a Kubernetes cluster? Try out our installation method using the [Kubernetes agents operator](/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/).
 </Callout>

--- a/src/install/java/intro.mdx
+++ b/src/install/java/intro.mdx
@@ -14,3 +14,8 @@ New Relic supports the most popular Java app servers, frameworks, virtual machin
 />
 
 To get the most out of this page, select your app deployment and framework. You need a [New Relic account](https://newrelic.com/signup) to finish the installation process. Want more context? See our [intro to APM](/docs/apm/new-relic-apm/getting-started/introduction-apm), or learn how to solve your app's performance issues with our [My app is slow tutorial](/docs/journey-app-slow/root-causes/). 
+
+
+<Callout variant="important">
+Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+</Callout>

--- a/src/install/python/python-agent-intro.mdx
+++ b/src/install/python/python-agent-intro.mdx
@@ -21,6 +21,10 @@ Use the New Relic Python agent to solve your app's performance issues with our [
 
 ## Start our interactive instructions
 
+<Callout variant="important">
+Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+</Callout>
+
 This page is interactive, which means we'll ask you some questions about your environment so we can give you specific steps to install the Python agent. Here's what we want to know:
 
 1. Do you have a web app or a non-web app?

--- a/src/install/python/python-agent-intro.mdx
+++ b/src/install/python/python-agent-intro.mdx
@@ -21,8 +21,8 @@ Use the New Relic Python agent to solve your app's performance issues with our [
 
 ## Start our interactive instructions
 
-<Callout variant="important">
-Is your application running in a Kubernetes cluster? Try out our new installation method using our [Kubernetes Agents Operator](kubernetes-agents-operator).
+<Callout variant="tip">
+Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
 </Callout>
 
 This page is interactive, which means we'll ask you some questions about your environment so we can give you specific steps to install the Python agent. Here's what we want to know:

--- a/src/install/python/python-agent-intro.mdx
+++ b/src/install/python/python-agent-intro.mdx
@@ -22,7 +22,7 @@ Use the New Relic Python agent to solve your app's performance issues with our [
 ## Start our interactive instructions
 
 <Callout variant="tip">
-Is your application running in a Kubernetes cluster? Try out our new installation method using the [Kubernetes Agents Operator](kubernetes-agents-operator).
+Is your application running in a Kubernetes cluster? Try out our installation method using the [Kubernetes agents operator](/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator/).
 </Callout>
 
 This page is interactive, which means we'll ask you some questions about your environment so we can give you specific steps to install the Python agent. Here's what we want to know:


### PR DESCRIPTION
## Link each agent's installation page to the k8s agents operator installation page

* Add a callout into each agent's installation documentation that links to the common kubernetes agents operator installation documentation. Link TBD.