### PR TITLE
Remove references to "planning for paid consumption" from Session Replay

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay.mdx
@@ -45,7 +45,7 @@ By default, browser event data is stored 8 days, but actual data retention depen
 
 For more details on session replay, see the following sections:
 
-* [Data consumption](#view-consumption): View data consumption and plan for transitioning to paid consumption.
+* [Data consumption](#data-consumption): View or project data consumption.
 * [User privacy and security concerns](#data-security): Learn how we protect your user data and meet privacy requirements.
 * [Session replay and your app's performance](#app-performance): Learn how session replay minimizes impact on your app's performance.
 
@@ -389,8 +389,6 @@ Here's an example mutation and variables to create a new browser application wit
 </table>
 
 ## Data consumption [#data-consumption]
-
-### Plan for paid consumption [#plan-for-paid-consumption]
 
 Session replay follows the same consumption pricing as your other browser bytes. The amount of bytes produced depends on the count, length, and user-activity levels of sessions, as well as the complexity of your site's DOM.
 


### PR DESCRIPTION
Session Replay has been GA since 5/15 so I removed references from the transition from LP to GA.

-Removed "Plan for paid consumption" heading
-The #view-consumption anchor link was broken. Updated to the correct #data-consumption

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.