### PR TITLE
Netlify CDN / image performance testing

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,7 +135,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 850,
-              linkImagesToOriginal: true,
+              linkImagesToOriginal: false,
               backgroundColor: 'transparent',
               disableBgImageOnAlpha: true,
             },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,7 +135,7 @@ module.exports = {
             resolve: 'gatsby-remark-images',
             options: {
               maxWidth: 850,
-              linkImagesToOriginal: false,
+              linkImagesToOriginal: true,
               backgroundColor: 'transparent',
               disableBgImageOnAlpha: true,
             },
@@ -226,7 +226,7 @@ module.exports = {
           },
           {
             resolve: require.resolve('./plugins/fix-remark-path-prefix-plugin'),
-          }
+          },
         ],
       },
     },
@@ -442,7 +442,7 @@ module.exports = {
             'md',
             'java',
             'razor',
-            'hcl'
+            'hcl',
           ],
         },
         newrelic: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,6 @@ for = "/*"
 Access-Control-Allow-Origin = "*"
 Referrer-Policy="no-referrer-when-downgrade"
 Content-Security-Policy="frame-ancestors *.newrelic.com"
+
+[build.environment]
+ NETLIFY_IMAGE_CDN = "true"

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   "scripts": {
     "add-files-to-translate": "node scripts/actions/add-files-to-translation-queue.js",
     "build:production": "ENVIRONMENT=production yarn run build",
-    "build": "node scripts/createNetlifyRedirects.mjs & NODE_OPTIONS='--max-old-space-size=5120' gatsby build --prefix-paths",
+    "build": "node scripts/createNetlifyRedirects.mjs & NODE_OPTIONS='--max-old-space-size=5120' NETLIFY_IMAGE_CDN=true gatsby build --prefix-paths",
     "check-for-outdated-translations": "node scripts/actions/check-for-outdated-translations.js",
     "clean": "gatsby clean",
     "convert-to-webp": "node scripts/convertPNGs.mjs",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   "scripts": {
     "add-files-to-translate": "node scripts/actions/add-files-to-translation-queue.js",
     "build:production": "ENVIRONMENT=production yarn run build",
-    "build": "node scripts/createNetlifyRedirects.mjs & NODE_OPTIONS='--max-old-space-size=5120' NETLIFY_IMAGE_CDN=true gatsby build --prefix-paths",
+    "build": "node scripts/createNetlifyRedirects.mjs & NODE_OPTIONS='--max-old-space-size=5120' gatsby build --prefix-paths",
     "check-for-outdated-translations": "node scripts/actions/check-for-outdated-translations.js",
     "clean": "gatsby clean",
     "convert-to-webp": "node scripts/convertPNGs.mjs",


### PR DESCRIPTION
Testing a deploy with just the CDN ENV variable to see if it affects how it references the images. I can't find any useful info on removing hashes from URI's in static assets.  - trying a [cache clear](https://app.netlify.com/sites/docs-website-netlify/deploys/667d8ce1343796256203d735) since this image related

just enabling this option and running a cache clear seemed to drastically improve lighthouse scores:
Some of these diferences could be related to the newrelic domain vs netlify tho

docs.newrelic.com vs build preview
<img width="2485" alt="Screenshot 2024-06-27 at 11 50 47 AM" src="https://github.com/newrelic/docs-website/assets/47728020/49c86d08-227a-4f28-9621-86e2f21ecc0d">
<img width="2485" alt="Screenshot 2024-06-27 at 11 51 01 AM" src="https://github.com/newrelic/docs-website/assets/47728020/a032b5b0-dc11-48de-81e5-724c867db23d">

things to note:
 - performance score almost doubled
- most of the top diagnostics numbers look to be reduced by about half. 


I think these changes might be worth pushing to prod and then we can at least test if changing images causes caching issues.

We have decided not to pursue the complex hashing issue at this time because that will become irrelevant after we move to s3.