### PR TITLE
[chore] Update aws-privatelink.mdx

### DIFF
--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -88,7 +88,7 @@ New Relic exposes AWS PrivateLink endpoints for the following:
 
 An endpoint service is available only in the region where it was created ([see the Amazon docs](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html)), but it can be accessed from other regions using inter-region peering.
 
-This means that if your VPC is in `us-east-2`, the only thing you need to do is to create the necessary internal VPC endpoint, as described below. But if you're in another region, you'll need to also [set up a peering connection](#peering) after that step.
+This means that if your VPC is in the above supported regions (`us-east-1`, `us-east-2`, `us-west-2`, and `eu-central-1`) the only thing you need to do is to create the necessary internal VPC endpoint, as described below. But if you're in a region outside of the supported regions, you'll need to also [set up a peering connection](#peering) after that step.
 
 ## The endpoints [#endpoints]
 
@@ -755,7 +755,7 @@ Here's a screenshot of some sample settings:
 
 ## Set up a peering connection [#peering]
 
-This is required only if you're using a region other than `us-east-2` (Ohio).
+This is required only if you're using a region other than the current supported regions: `us-east-1` (Virginia), `us-east-2` (Ohio), `us-west-2` (Oregon), or `eu-central-1`.
 
 ### VPC peering [#vpc-peering]
 


### PR DESCRIPTION
Updated doc to show that we support regions other than us-east-2 making it more clear that VPC peering is not needed if you're in the current supported regions

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.