### PR TITLE
chore(apm/php): cleanup compatibility requirements table

### DIFF
--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -27,7 +27,7 @@ The PHP agent requires two components to work: the PHP agent (one for each appli
 
 ## Install agent and daemon in different containers [#install-diff-containers]
 
-Installing the agent and daemon in different containers is supported on PHP agnet versions 9.2 and higher.
+Installing the agent and daemon in different containers is supported starting with New Relic PHP agnet release 9.2.0.
 
 To see an example application, go to [New Relic's Support Forum](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). If you're using short-lived application containers, we recommend you use a separate container for the PHP agent's daemon.
 
@@ -53,8 +53,8 @@ The `--address` argument sets a port for the daemon to accept connections. The `
 
 To set up the PHP agent container for Docker:
 
-1. Make sure a PHP installation is available in the container. For example, use a published Docker image like `php:7.1`.
-2. To install the agent, download the PHP agent package from New Relic's [tar file download site](/docs/agents/php-agent/installation/php-agent-installation-tar-file), and run the `newrelic-install` script with the `install` argument.
+1. Make sure a PHP installation is available in the container. For example, use a [Docker "Official Image"](https://github.com/docker-library/official-images#what-are-official-images) for [`php`](https://hub.docker.com/_/php/) like `php:fpm` or `php:cli`.
+2. To install the agent, download the PHP agent package from New Relic's [download site](https://download.newrelic.com/php_agent/release/), and run the `newrelic-install` script with the `install` argument.
 3. In the `newrelic.ini` file, set the application name and <InlinePopover type="licenseKey" /> with the `newrelic.appname` and `newrelic.license` entries .
 4. Point the agent to the daemon by setting the `newrelic.daemon.address` option in the `newrelic.ini` file. Make sure the value for this option is `HOST:PORT`, where `HOST` is the name or IP address of the host where the daemon is running, and `PORT` is the port number where the daemon is listening
 
@@ -66,8 +66,8 @@ To set up the PHP agent container for Docker:
 
 To set up the PHP agent and daemon in the same Docker container:
 
-1. Make sure a PHP installation is available in the container. For example: you might use a published Docker image like `php:7.1`.
-2. To install the agent, download the PHP agent package from New Relic's [tar file download site](/docs/agents/php-agent/installation/php-agent-installation-tar-file) and run the `newrelic-install` script with the `install` argument.
+1. Make sure a PHP installation is available in the container. For example, use a [Docker "Official Image"](https://github.com/docker-library/official-images#what-are-official-images) for [`php`](https://hub.docker.com/_/php/) like `php:fpm` or `php:cli`.
+2. To install the agent, download the PHP agent package from New Relic's [download site](https://download.newrelic.com/php_agent/release/) and run the `newrelic-install` script with the `install` argument.
 3. Set the application name and <InlinePopover type="licenseKey" /> via the `newrelic.license` and `newrelic.appname` entries in the `newrelic.ini` file.
 
 <CollapserGroup>
@@ -76,27 +76,34 @@ To set up the PHP agent and daemon in the same Docker container:
     title="Dockerfile example"
   >
     ```dockerfile
-    FROM php:7.1
+    FROM php:fpm
 
+    # Install the latest New Relic PHP Agent
     RUN \
-      curl -L PHP_AGENT_URL | tar -C /tmp -zx && \
-      export NR_INSTALL_USE_CP_NOT_LN=1 && \
-      export NR_INSTALL_SILENT=1 && \
-      /tmp/newrelic-php5-*/newrelic-install install && \
-      rm -rf /tmp/newrelic-php5-* /tmp/nrinstall* && \
-      sed -i \
-          -e 's/"REPLACE_WITH_REAL_KEY"/"YOUR_LICENSE_KEY"/' \
-          -e 's/newrelic.appname = "PHP Application"/newrelic.appname = "YOUR_APPLICATION_NAME"/' \
-          -e 's/;newrelic.daemon.app_connect_timeout =.*/newrelic.daemon.app_connect_timeout=15s/' \
-          -e 's/;newrelic.daemon.start_timeout =.*/newrelic.daemon.start_timeout=5s/' \
-          /usr/local/etc/php/conf.d/newrelic.ini
+        cd /tmp \
+        # Discover the latest released version:
+        && export NEW_RELIC_AGENT_VERSION=$(curl -s https://download.newrelic.com/php_agent/release/ | grep --only-match '[1-9][0-9]\?\(\.[0-9]\+\)\{3\}' | head -n1) \
+        # Discover libc provider
+        && export NR_INSTALL_PLATFORM=$(ldd --version 2>&1 | grep -q musl && echo "linux-musl" || echo "linux") \
+        # Download the discovered version:
+        && curl -o newrelic-php-agent.tar.gz https://download.newrelic.com/php_agent/release/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-${NR_INSTALL_PLATFORM}.tar.gz \
+        # Install the downloaded agent:
+        && tar xzf newrelic-php-agent.tar.gz \
+        && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=0 ./*/newrelic-install install \
+        # Configure the agent to use license key from NEW_RELIC_LICENSE_KEY env var:
+        && sed -ie 's/[ ;]*newrelic.license[[:space:]]=.*/newrelic.license=${NEW_RELIC_LICENSE_KEY}/' $(php-config --ini-dir)/newrelic.ini \
+        # Configure the agent to send telemetry to collector defined by NEW_RELIC_HOST env var:
+        && sed -ie 's/[ ;]*newrelic.daemon.collector_host[[:space:]]=.*/newrelic.daemon.collector_host=${NEW_RELIC_HOST}/' $(php-config --ini-dir)/newrelic.ini \
+        # Configure the agent to use app name from NEW_RELIC_APP_NAME env var:
+        && sed -ie 's/[ ;]*newrelic.appname[[:space:]]=.*/newrelic.appname=${NEW_RELIC_APP_NAME}/' $(php-config --ini-dir)/newrelic.ini \
+        # Cleanup temporary files:
+        && rm newrelic-php-agent.tar.gz && rm -rf newrelic-php5-*-linux
     ```
 
-    You must edit three parts of this example Dockerfile:
+    You must set two environment variables when starting the container from the image built using the above `Dockerfile`:
 
-    * `PHP_AGENT_URL`: The download URL for your PHP agent version. To find the most recent version of the agent, go to <DNT>**[download.newrelic.com/php_agent/release/](https://download.newrelic.com/php_agent/release/)**</DNT>.
-    * `YOUR_LICENSE_KEY`: Replace this with your <InlinePopover type="licenseKey" />. Note that `"REPLACE_WITH_REAL_KEY"` is an actual string in the default <DNT>**newrelic.ini**</DNT> file for the PHP agent. Don't edit that string. The `sed` command replaces that default string with the actual 40-character key, in quotes.
-    * `YOUR_APPLICATION_NAME`: Replace with the your application name, in quotes.
+    * `NEW_RELIC_LICENSE_KEY`: set this to your <InlinePopover type="licenseKey" />.
+    * `NEW_RELIC_APP_NAME`: set this to your application name
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -27,7 +27,7 @@ The PHP agent requires two components to work: the PHP agent (one for each appli
 
 ## Install agent and daemon in different containers [#install-diff-containers]
 
-Installing the agent and daemon in different containers is supported starting with New Relic PHP agnet release 9.2.0.
+Installing the agent and daemon in different containers is supported starting with New Relic PHP agent release 9.2.0.
 
 To see an example application, go to [New Relic's Support Forum](https://discuss.newrelic.com/t/relic-solution-php-agent-and-daemon-containers/84841). If you're using short-lived application containers, we recommend you use a separate container for the PHP agent's daemon.
 

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent
   - /docs/install-php-agent-docker
   - /docs/agents/php-agent/advanced-installation/install-php-agent-docker
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 You can install the PHP agent on a Docker container or other container to monitor one or more of your PHP applications. This is supported for containers that meet the standard [PHP agent compatibility and requirements](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements).

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -98,7 +98,7 @@ When vendors announce end-of-life (such as on [Ubuntu's End of Standard Support 
 This is why we recommend always using the latest version of the OS that is officially supported by the vendor.
 The latest versions of our agent may work on OS versions that are past End of Life, but we no longer test or officially support the PHP agent with older versions.
 
-Based on the information above the PHP agent supports the operating systems listed in the table below. 
+Based on the information above the PHP agent can be installed on operating systems using install methods listed in the table below.
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -98,7 +98,7 @@ When vendors announce end-of-life (such as on [Ubuntu's End of Standard Support 
 This is why we recommend always using the latest version of the OS that is officially supported by the vendor.
 The latest versions of our agent may work on OS versions that are past End of Life, but we no longer test or officially support the PHP agent with older versions.
 
-The PHP agent supports the operating systems listed in the table below. 
+Based on the information above the PHP agent supports the operating systems listed in the table below. 
 
 <table>
   <thead>
@@ -108,67 +108,114 @@ The PHP agent supports the operating systems listed in the table below.
       </th>
 
       <th>
-        Supported vendors
+        Release
       </th>
 
-          <th>
-        Compatibility notes
+      <th>
+        CPU Architecture
+      </th>
+
+      <th>
+        Install method
       </th>
     </tr>
   </thead>
 
   <tbody>
     <tr>
-      <td>
-        Linux (x86_64)
-      </td>
+      <td>Alpine Linux</td>
+      <td>3.15, 3.16, 3.17, 3.18, 3.19, 3.20</td>
+      <td>x86_64, aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
 
-      <td>
+    <tr>
+      <td rowspan=3>Amazon Linux</td>
+      <td rowspan=2>2</td>
+      <td>x86_64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
+    </tr>
 
-        * <DNT>Alpine</DNT>
+    <tr>
+      <td>aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
 
-        * <DNT>Amazon Linux </DNT>
+    <tr>
+      <td>2023</td>
+      <td>x86_64, aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
 
-        * <DNT>Red Hat Enterprise Linux</DNT> (RHEL)
+    <tr>
+      <td rowspan=2>CentOS Linux</td>
+      <td rowspan=2>7</td>
+      <td>x86_64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
+    </tr>
 
-        * <DNT>CentOS</DNT>
+    <tr>
+      <td>aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
 
-        * <DNT>Debian</DNT>
+    <tr>
+      <td rowspan=2>CentOS Stream</td>
+      <td rowspan=2>8, 9</td>
+      <td>x86_64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
+    </tr>
 
-        * <DNT>Ubuntu</DNT>
+    <tr>
+      <td>aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
 
-        * Any other Linux distribution with:
+    <tr>
+      <td rowspan=2>RedHat Enterprise Linux</td>
+      <td rowspan=2>7, 8, 9</td>
+      <td>x86_64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
+    </tr>
 
+    <tr>
+      <td>aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
+
+    <tr>
+      <td rowspan=2>Debian</td>
+      <td rowspan=2>10, 11, 12</td>
+      <td>x86_64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [DEB](/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian)</td>
+    </tr>
+
+    <tr>
+      <td>aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
+
+    <tr>
+      <td rowspan=2>Ubuntu</td>
+      <td rowspan=2>20, 22, 24</td>
+      <td>x86_64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [DEB](/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian)</td>
+    </tr>
+
+    <tr>
+      <td>aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
+    </tr>
+
+    <tr>
+      <td>Any Linux distribution with:
           * Kernel version with [long term support](https://kernel.org/)
           * glibc [currently maintained branch](https://sourceware.org/glibc/wiki/Release) with [NPTL](https://en.wikipedia.org/wiki/Native_POSIX_Thread_Library)
           * musl libc [stable series](https://musl.libc.org/releases.html)
       </td>
-
-      <td>
-
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Linux (ARM64)
-      </td>
-
-      <td>
-        * Amazon Linux
-        * CentOS
-        * Alpine
-        * Debian
-      </td>
-
-      <td>
-
-        * ARM64 is only supported with PHP versions 8.0+.
-        * PHP agent 10.10.0 and higher provides support for ARM64 by including binaries in a tarball distribution.
-        * PHP agent 9.18.1 - 10.9.0 source distribution provides ARM64 support ONLY on Amazon Linux 2 (including AWS Graviton 2) and Centos 8.
-
-        For more information on ARM64 support and installation, please see [the ARM64 installation info](/docs/apm/agents/php-agent/installation/php-agent-installation-arm64).
-      </td>
+      <td>N/A</td>
+      <td>x86_64, aarch64</td>
+      <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -86,10 +86,10 @@ Your New Relic <InlinePopover type="licenseKey" /> is a 40-character hexadecimal
 
 ## Processors [#processor]
 
-The following processors are supported:
+The following processor architectures are supported:
 
-* Intel (and compatible) platforms
-* ARM64
+* x86_64 (also known as amd64)
+* aarch64 (also known as ARM64)
 
 ## Operating systems [#operating-systems]
 

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -130,8 +130,8 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan=3>Amazon Linux</td>
-      <td rowspan=2>2</td>
+      <td rowspan="3">Amazon Linux</td>
+      <td rowspan="2">2</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
@@ -148,8 +148,8 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan=2>CentOS Linux</td>
-      <td rowspan=2>7</td>
+      <td rowspan="2">CentOS Linux</td>
+      <td rowspan="2">7</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
@@ -160,8 +160,8 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan=2>CentOS Stream</td>
-      <td rowspan=2>8, 9</td>
+      <td rowspan="2">CentOS Stream</td>
+      <td rowspan="2">8, 9</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
@@ -172,8 +172,8 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan=2>RedHat Enterprise Linux</td>
-      <td rowspan=2>7, 8, 9</td>
+      <td rowspan="2">RedHat Enterprise Linux</td>
+      <td rowspan="2">7, 8, 9</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
@@ -184,8 +184,8 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan=2>Debian</td>
-      <td rowspan=2>10, 11, 12</td>
+      <td rowspan="2">Debian</td>
+      <td rowspan="2">10, 11, 12</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [DEB](/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian)</td>
     </tr>
@@ -196,8 +196,8 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan=2>Ubuntu</td>
-      <td rowspan=2>20, 22, 24</td>
+      <td rowspan="2">Ubuntu</td>
+      <td rowspan="2">20, 22, 24</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [DEB](/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian)</td>
     </tr>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -9,7 +9,7 @@ translate:
 metaDescription: A summary of the New Relic PHP agent's system requirements and the supported PHP frameworks and libraries.
 redirects:
   - /docs/agents/php-agent/getting-started/php-agent-compatibility-requirements
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 Before you [install the PHP agent](/docs/apm/agents/php-agent/installation), make sure your system meets the version requirements listed below.

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -103,7 +103,7 @@ Based on the information above the PHP agent supports the operating systems list
 <table>
   <thead>
     <tr>
-      <th width={250}>
+      <th width={350}>
         Operating system
       </th>
 
@@ -130,79 +130,92 @@ Based on the information above the PHP agent supports the operating systems list
     </tr>
 
     <tr>
-      <td rowspan="3">Amazon Linux</td>
-      <td rowspan="2">2</td>
+      <td>Amazon Linux</td>
+      <td>2</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
 
     <tr>
+      <td>Amazon Linux</td>
+      <td>2</td>
       <td>aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
 
     <tr>
+      <td>Amazon Linux</td>
       <td>2023</td>
       <td>x86_64, aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
 
     <tr>
-      <td rowspan="2">CentOS Linux</td>
-      <td rowspan="2">7</td>
+      <td>CentOS Linux</td>
+      <td>7</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
 
     <tr>
+      <td>CentOS Linux</td>
+      <td>7</td>
       <td>aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
 
     <tr>
-      <td rowspan="2">CentOS Stream</td>
-      <td rowspan="2">8, 9</td>
+      <td>CentOS Stream</td>
+      <td>8, 9</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
 
     <tr>
+      <td>CentOS Stream</td>
+      <td>8, 9</td>
       <td>aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
 
     <tr>
-      <td rowspan="2">RedHat Enterprise Linux</td>
-      <td rowspan="2">7, 8, 9</td>
+      <td>RedHat Enterprise Linux</td>
+      <td>7, 8, 9</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [RPM](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos)</td>
     </tr>
 
     <tr>
+      <td>RedHat Enterprise Linux</td>
+      <td>7, 8, 9</td>
       <td>aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
 
     <tr>
-      <td rowspan="2">Debian</td>
-      <td rowspan="2">10, 11, 12</td>
+      <td>Debian</td>
+      <td>10, 11, 12</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [DEB](/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian)</td>
     </tr>
 
     <tr>
+      <td>Debian</td>
+      <td>10, 11, 12</td>
       <td>aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>
 
     <tr>
-      <td rowspan="2">Ubuntu</td>
-      <td rowspan="2">20, 22, 24</td>
+      <td>Ubuntu</td>
+      <td>20, 22, 24</td>
       <td>x86_64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file), [DEB](/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian)</td>
     </tr>
 
     <tr>
+      <td>Ubuntu</td>
+      <td>20, 22, 24</td>
       <td>aarch64</td>
       <td>[tar file](/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file)</td>
     </tr>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -98,7 +98,7 @@ When vendors announce end-of-life (such as on [Ubuntu's End of Standard Support 
 This is why we recommend always using the latest version of the OS that is officially supported by the vendor.
 The latest versions of our agent may work on OS versions that are past End of Life, but we no longer test or officially support the PHP agent with older versions.
 
-Based on the information above the PHP agent can be installed on operating systems using install methods listed in the table below.
+Based on the information above the PHP agent, can be installed on operating systems using the install methods listed in the table below.
 
 <table>
   <thead>
@@ -112,7 +112,7 @@ Based on the information above the PHP agent can be installed on operating syste
       </th>
 
       <th>
-        CPU Architecture
+        CPU architecture
       </th>
 
       <th>

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-arm64.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-arm64.mdx
@@ -8,7 +8,7 @@ tags:
 metaDescription: "To install or update your New Relic PHP agent on ARM64, start here."
 redirects:
   - /docs/php/php-agent-installation-arm64
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 Starting with the New Relic PHP Agent release 10.10.0 [tar file](/docs/php/php-agent-installation-tar-files) contains aarch64 binaries for PHPs 8.0+.

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-arm64.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-arm64.mdx
@@ -1,5 +1,5 @@
 ---
-title: "PHP agent installation: ARM64"
+title: "PHP agent installation: aarch64 (ARM64)"
 tags:
   - Agents
   - PHP agent
@@ -11,80 +11,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-<Callout variant="important">
-  If you're compiling from source, ARM64 is only supported with New Relic PHP agent release 9.18.1 through release 10.9.0.
-  ARM64 binaries are ONLY provided starting with the New Relic PHP Agent release 10.10.0 or later.
-</Callout>
-
-## Tarball installation
-To install or update the New Relic PHP agent on ARM64 with the New Relic PHP Agent release 10.10.0 or later, please follow the instructions for installing from a tarball found in our [docs](/docs/apm/agents/php-agent/installation/php-agent-installation-overview/#install-tar) for installation instructions. 
-
-## Build from source
-To install or update the New Relic PHP agent on ARM64 with the New Relic PHP Agent release 9.18.0 - 10.9.0, you must install New Relic's PHP agent source for ARM64 platforms <DNT>**[github.com/newrelic/newrelic-php-agent](https://github.com/newrelic/newrelic-php-agent)**</DNT>.
-
-Building the New Relic PHP Agent for ARM64 from source is only supported for Amazon Linux 2 and CentOS Linux 8 (including use with <DNT>**[AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/)**</DNT>)
-
-### Install dependencies
-
-1. Run the appropriate code:
-
-   For Amazon Linux 2:
-
-   ```bash
-   sudo yum update -y
-   sudo yum install -y git 
-   sudo yum install -y amazon-linux-extras
-   sudo amazon-linux-extras install -y epel
-   sudo amazon-linux-extras install -y golang1.11
-   sudo yum -y groupinstall "Development Tools"
-   sudo yum -y install \
-      libcurl-devel \
-      openssl-devel openssl-static \
-      pcre-devel pcre-static \
-      zlib-devel zlib-static
-   sudo amazon-linux-extras install -y  php8.0
-   sudo yum install -y php-devel
-   ```
-
-   For CentOS 8 <DNT>**Ensure you have PHP 8.0 or 8.1 installed**</DNT>
-
-   ```bash
-   sudo yum update -y
-   sudo yum -y install epel-release
-   sudo yum -y groupinstall "Development Tools"
-   sudo yum -y install dnf-plugins-core
-   sudo yum config-manager --set-enabled powertools
-   sudo yum -y install  libcurl-devel php-devel openssl-devel pcre-devel pcre-static zlib-devel zlib-static golang
-   ```
-
-### Clone the agent [#clone]
-
-<Callout variant="important">
-  ARM64 is only supported from release 9.18.1 or later.
-</Callout>
-
-Clone from <DNT>**[github.com/newrelic/newrelic-php-agent](https://github.com/newrelic/newrelic-php-agent)**</DNT>. Here, you can also suggest a change and learn how to [contribute](https://github.com/newrelic/newrelic-php-agent/issues) to our PHP agent open source repository.
-
-### Build [#install]
-
-<Callout variant="tip">
-  The file <DNT>**[docs/development.md](https://github.com/newrelic/newrelic-php-agent/blob/main/docs/development.md)**</DNT> in the newrelic-php-agent repository has an in-depth guide for installation.
-</Callout>
-
-Run the following from the top of the cloned repository:
-
-1. `make all OPTIMIZE=1`
-2. `sudo make agent-install`
-3. `sudo mkdir /var/log/newrelic`
-4. `sudo chmod 777 /var/log/newrelic`
-5. `sudo cp bin/daemon /usr/bin/newrelic-daemon`
-
-### Configure the agent [#configure]
-
-1. Copy `agent/scripts/newrelic.ini.template` file to the same directory as `php.ini`. (Run `php --ini` to get its file path.)
-2. Once you've created `newrelic.ini` and put it in the correct location, edit the file to add the following:
-
-   * Add a valid <InlinePopover type="licenseKey" /> to the line `newrelic.license = "INSERT_YOUR_LICENSE_KEY"`.
-   * Change the application name that's shown in <DNT>**[one.newrelic.com](https://one.newrelic.com/all-capabilities)**</DNT> on the line `newrelic.appname = "PHP Application"` (optional).
+Starting with the New Relic PHP Agent release 10.10.0 [tar file](/docs/php/php-agent-installation-tar-files) contains aarch64 binaries for PHPs 8.0+.
+Please follow [these instructions](/docs/php/php-agent-installation-tar-files) to install or update the New Relic PHP agent on any supported operating system running on aarch64 CPU.
 
 <InstallFeedback />

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/php/php-agent-installation-redhat-and-centos
   - /docs/agents/php-agent/installation/php-agent-installation-redhat-and-centos
   - /docs/agents/php-agent/installation/php-agent-installation-redhat-centos
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 Our PHP agent auto-instruments your code so you can start monitoring applications. Follow this procedure to install New Relic's PHP agent for APM using Amazon Linux 2, RedHat, or CentOS on x86_64 architecture. For installation on aarch64 architecture, please use [tar file](/docs/php/php-agent-installation-tar-files) method. <DNT>**Exception:**</DNT> If you have an earlier version installed, [upgrade the agent](/docs/agents/php-agent/installation/upgrading-php-agent) instead.

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'PHP agent installation: Amazon Linux, RedHat, CentOS'
+title: 'PHP agent installation: Amazon Linux 2, RedHat, CentOS (x86_64)'
 tags:
   - Agents
   - PHP agent
   - Installation
 translate:
   - jp
-metaDescription: 'How to install New Relic''s PHP agent for application performance monitoring with Amazon Linux 2, RedHat, or CentOS.'
+metaDescription: 'How to install New Relic''s PHP agent for application performance monitoring with Amazon Linux 2, RedHat, or CentOS on x86_64 architecture.'
 redirects:
   - /docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
   - /docs/php/php-agent-installation-redhat-and-centos
@@ -15,7 +15,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-Our PHP agent auto-instruments your code so you can start monitoring applications. Follow this procedure to install New Relic's PHP agent for APM using Amazon Linux 2, RedHat, or CentOS. <DNT>**Exception:**</DNT> If you have an earlier version installed, [upgrade the agent](/docs/agents/php-agent/installation/upgrading-php-agent) instead.
+Our PHP agent auto-instruments your code so you can start monitoring applications. Follow this procedure to install New Relic's PHP agent for APM using Amazon Linux 2, RedHat, or CentOS on x86_64 architecture. For installation on aarch64 architecture, please use [tar file](/docs/php/php-agent-installation-tar-files) method. <DNT>**Exception:**</DNT> If you have an earlier version installed, [upgrade the agent](/docs/agents/php-agent/installation/upgrading-php-agent) instead.
 
 ## Install the agent [#install]
 
@@ -29,14 +29,6 @@ Even though the package name for New Relic's PHP agent refers to PHP 5, the pack
        id="tell-rpm"
        title={<>Tell the package manager (<InlineCode>rpm</InlineCode>) about the New Relic repository</>}
      >
-       For <DNT>**32-bit**</DNT> systems, run:
-
-       ```bash
-       sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/i386/newrelic-repo-5-3.noarch.rpm
-       ```
-
-       For <DNT>**64-bit**</DNT> systems, run:
-
        ```bash
        sudo rpm -Uvh http://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
        ```
@@ -46,22 +38,6 @@ Even though the package name for New Relic's PHP agent refers to PHP 5, the pack
        id="download-rpm"
        title="Download the rpm file from New Relic"
      >
-       For <DNT>**32-bit**</DNT> systems, download these three files from the [32-bit packages](https://download.newrelic.com/pub/newrelic/el5/i386/) (replacing `X.X.X.X` with the most recent [PHP agent version number](/docs/release-notes/agent-release-notes/php-release-notes)):
-
-       * ```
-         newrelic-php5-common-X.X.X.X-1.noarch.rpm
-         ```
-
-       * ```
-         newrelic-daemon-X.X.X.X-1.i386.rpm
-         ```
-
-       * ```
-           newrelic-php5-X.X.X.X-1.i386.rpm
-         ```
-
-         For <DNT>**64-bit**</DNT> systems, download these three files from the [64-bit packages](https://download.newrelic.com/pub/newrelic/el5/x86_64/) (replacing `X.X.X.X` with the most recent [PHP agent version number](/docs/release-notes/agent-release-notes/php-release-notes)):
-
        * ```
          newrelic-php5-common-X.X.X.X-1.noarch.rpm
          ```
@@ -90,19 +66,8 @@ Even though the package name for New Relic's PHP agent refers to PHP 5, the pack
      </Collapser>
 
      <Collapser
-       id="manager-32-bit-rpm"
-       title="32-bit rpm"
-     >
-       Replace `X.X.X.X` with the most recent [PHP agent version number](/docs/release-notes/agent-release-notes/php-release-notes) when you run this command:
-
-       ```bash
-       rpm -i newrelic-php5-common-X.X.X.X-1.noarch.rpm newrelic-daemon-X.X.X.X-1.i386.rpm newrelic-php5-X.X.X.X-1.i386.rpm
-       ```
-     </Collapser>
-
-     <Collapser
-       id="manager-64-bit-rpm"
-       title="64-bit rpm"
+       id="manager-rpm"
+       title="rpm"
      >
        Replace `X.X.X.X` with the most recent [PHP agent version number](/docs/release-notes/agent-release-notes/php-release-notes) when you run this command:
 

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'PHP agent installation: Tar file'
+title: 'PHP agent installation: Tar file (x86_64, aarch64)'
 tags:
   - Agents
   - PHP agent
@@ -12,16 +12,16 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-You can install New Relic's PHP agent from compressed tar files on any supported platform. However, for Redhat or CentOS it is more common to use the [RPM package](/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos/). For Ubuntu or Debian it is more common to use the [Debian package](/docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian).
+You can install New Relic's PHP agent from compressed tar files on any supported operating system on any supported processor architecture. However, for Redhat or CentOS on x86_64 it is more common to use the [RPM package](/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos/). For Ubuntu or Debian on x86_64 it is more common to use the [Debian package](/docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian).
 
 ## Download the tar distribution [#download]
 
 Unlike other installation options, tar archives do not require any special repository setup. All you need to do is download the archive and follow these instructions.
 
-Download the appropriate tar distribution file from <DNT>**[download.newrelic.com/php_agent/release/](https://download.newrelic.com/php_agent/release/)**</DNT>. For example:
+Download the appropriate tar distribution file from <DNT>**[download.newrelic.com/php_agent/release/](https://download.newrelic.com/php_agent/release/)**</DNT>:
 
-* For FreeBSD, download `newrelic-php5-X.X.X.X-freebsd.tar.gz`.
-* For Alpine Linux, download `newrelic-php5-X.X.X.X-linux-musl.tar.gz`.
+* For Linux with GNU libc (most Linux distributions), download `newrelic-php5-X.X.X.X-linux.tar.gz`.
+* For Linux with musl libc (Alpine Linux), download `newrelic-php5-X.X.X.X-linux-musl.tar.gz`.
 
 <Callout variant="tip">
   The package name for the PHP agent is `newrelic-php5`. Although the package name references PHP 5, this package works for all [supported PHP versions](/docs/agents/php-agent/getting-started/php-agent-compatibility-requirements#php-release).

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-tar-file.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/agents/php-agent/installation/php-agent-installation-tar-file
   - /docs/php/php-agent-installation-tar-files
   - /docs/php/php-agent-installation-tar-file
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 You can install New Relic's PHP agent from compressed tar files on any supported operating system on any supported processor architecture. However, for Redhat or CentOS on x86_64 it is more common to use the [RPM package](/docs/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos/). For Ubuntu or Debian on x86_64 it is more common to use the [Debian package](/docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian).

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'PHP agent installation: Ubuntu and Debian'
+title: 'PHP agent installation: Ubuntu and Debian (x86_64)'
 tags:
   - Agents
   - PHP agent
   - Installation
-metaDescription: 'Ubuntu and Debian users: To install, upgrade, or uninstall your New Relic PHP agent, start here.'
+metaDescription: 'Ubuntu and Debian on x86_64 architecture users: To install, upgrade, or uninstall your New Relic PHP agent, start here.'
 redirects:
   - /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
   - /docs/php/php-agent-installation-ubuntu-and-debian
@@ -12,7 +12,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-Our [PHP agent](/docs/agents/php-agent/getting-started/new-relic-php#configuration) auto-instruments your code so you can start monitoring applications. These are the standard procedures to install our PHP agent on Ubuntu or Debian. (This is not the same as the Ubuntu and Debian procedures for the [infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#apt-based).) For other situations, see the [PHP agent procedures for non-standard PHP installations](/docs/php/php-agent-installation-non-standard-php).
+Our [PHP agent](/docs/agents/php-agent/getting-started/new-relic-php#configuration) auto-instruments your code so you can start monitoring applications. These are the standard procedures to install our PHP agent on Ubuntu or Debian on x86_64 architecture. (This is not the same as the Ubuntu and Debian procedures for the [infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#apt-based).) For installation on aarch64 architecture, please use [tar file](/docs/php/php-agent-installation-tar-files) method. For other situations, see the [PHP agent procedures for non-standard PHP installations](/docs/php/php-agent-installation-non-standard-php).
 
 ## PHP versions [#php7]
 
@@ -112,10 +112,7 @@ To install the PHP agent manually using `dpkg`:
   <Step>
     ### Copy the URL for the package download [#copy-package]
 
-        Navigate to the appropriate URL for your architecture, and copy the full URL for the latest `newrelic-daemon`, `newrelic-php5-common`, and `newrelic-php5` packages:
-
-        * [32-bit architecture](https://download.newrelic.com/debian/dists/newrelic/non-free/binary-i386/)
-        * [64-bit architecture](https://download.newrelic.com/debian/dists/newrelic/non-free/binary-amd64/)
+        Copy the full URL for the latest `newrelic-daemon`, `newrelic-php5-common`, and `newrelic-php5` packages from [New Relic's repository](https://apt.newrelic.com/debian/dists/newrelic/non-free/binary-amd64/)
   </Step>
   <Step>
     ### Download the package [#download-package]
@@ -129,15 +126,7 @@ To install the PHP agent manually using `dpkg`:
   <Step>
     ### Install the PHP agent [#manual-install]
 
-        Run the appropriate command as root, replacing `X.X.X.X` with the current version:
-
-        <DNT>**32-bit:**</DNT>
-
-        ```bash
-        dpkg -i newrelic-php5-common_X.X.X.X_all.deb newrelic-daemon_X.X.X.X_i386.deb newrelic-php5_X.X.X.X_i386.deb
-        ```
-
-        <DNT>**64-bit:**</DNT>
+        Run the install command as root, replacing `X.X.X.X` with the current version:
 
         ```bash
         dpkg -i newrelic-php5-common_X.X.X.X_all.deb newrelic-daemon_X.X.X.X_amd64.deb newrelic-php5_X.X.X.X_amd64.deb

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/agents/php-agent/installation/php-agent-installation-ubuntu-debian
   - /docs/php/php-agent-installation-ubuntu-and-debian
   - /docs/agents/php-agent/installation/php-agent-installation-ubuntu-and-debian
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 Our [PHP agent](/docs/agents/php-agent/getting-started/new-relic-php#configuration) auto-instruments your code so you can start monitoring applications. These are the standard procedures to install our PHP agent on Ubuntu or Debian on x86_64 architecture. (This is not the same as the Ubuntu and Debian procedures for the [infrastructure agent](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux#apt-based).) For installation on aarch64 architecture, please use [tar file](/docs/php/php-agent-installation-tar-files) method. For other situations, see the [PHP agent procedures for non-standard PHP installations](/docs/php/php-agent-installation-non-standard-php).

--- a/src/content/docs/apm/agents/php-agent/installation/update-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/update-php-agent.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/agents/php-agent/maintenance/maintenance
   - /docs/agents/php-agent/installation/upgrading-php-agent
   - /docs/agents/php-agent/installation/upgrade-php-agent
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-31
 ---
 
 To take full advantage of New Relic's latest features, enhancements, and important security patches, we recommend you update your PHP agent to the latest version. For additional information about specific agent updates, refer to the [PHP agent release notes](/docs/release-notes/agent-release-notes/php-release-notes).

--- a/src/content/docs/apm/agents/php-agent/installation/update-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/update-php-agent.mdx
@@ -122,7 +122,7 @@ To update the PHP agent:
 
            <tr>
              <td>
-               <DNT>**64-bit dpkg**</DNT>
+               <DNT>**dpkg**</DNT>
              </td>
 
              <td>

--- a/src/content/docs/apm/agents/php-agent/installation/update-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/update-php-agent.mdx
@@ -18,8 +18,8 @@ To take full advantage of New Relic's latest features, enhancements, and importa
 
 This document explains how to update the agent for:
 
-* RedHat and CentOS
-* Ubuntu and Debian
+* RedHat and CentOS on x86_64
+* Ubuntu and Debian on x86_64
 
 To update via <DNT>**tar archive**</DNT>, follow the [tar archive installation procedures](/docs/agents/php-agent/installation/php-agent-installation-tar-file). (Procedures to install and update with the tar archive are the same.)
 
@@ -72,21 +72,7 @@ To update the PHP agent:
 
            <tr>
              <td>
-               <DNT>**32-bit rpm**</DNT>
-             </td>
-
-             <td>
-               Download the newest version of the `.rpm` files from the [New Relic downloads page](https://download.newrelic.com/pub/newrelic/el5/i386/), and run the following command. Make sure to replace `X.X.X.X` with the latest [New Relic for PHP version number](/docs/releases/php).
-
-               ```bash
-               rpm -i newrelic-php5-common-X.X.X.X-1.noarch.rpm newrelic-daemon-X.X.X.X-1.i386.rpm newrelic-php5-X.X.X.X-1.i386.rpm
-               ```
-             </td>
-           </tr>
-
-           <tr>
-             <td>
-               <DNT>**64-bit rpm**</DNT>
+               <DNT>**rpm**</DNT>
              </td>
 
              <td>
@@ -130,20 +116,6 @@ To update the PHP agent:
                ```bash
                apt-get update
                apt-get install newrelic-php5
-               ```
-             </td>
-           </tr>
-
-           <tr>
-             <td>
-               <DNT>**32-bit dpkg**</DNT>
-             </td>
-
-             <td>
-               Download the newest version of the `.deb` files from the [New Relic downloads page](https://download.newrelic.com/debian/dists/newrelic/non-free/binary-i386/), and run the following command. Make sure to replace `X.X.X.X` with the latest [New Relic for PHP version number](/docs/releases/php).
-
-               ```bash
-               dpkg -i newrelic-php5-common_X.X.X.X_all.deb newrelic-daemon_X.X.X.X_i386.deb newrelic-php5_X.X.X.X_i386.deb
                ```
              </td>
            </tr>

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -569,13 +569,13 @@ pages:
             pages:
               - title: Installation overview
                 path: /docs/apm/agents/php-agent/installation/php-agent-installation-overview
-              - title: 'AWS Linux, RedHat, CentOS'
+              - title: 'AWS Linux 2, RedHat, CentOS (x86_64)'
                 path: /docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos
               - title: ARM64
                 path: /docs/apm/agents/php-agent/installation/php-agent-installation-arm64
-              - title: Ubuntu and Debian
+              - title: Ubuntu and Debian (x86_64)
                 path: /docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian
-              - title: Tar archive
+              - title: Tar archive (x86_64, aarch64)
                 path: /docs/apm/agents/php-agent/installation/php-agent-installation-tar-file
               - title: Install agent on shared hosting service
                 path: /docs/apm/agents/php-agent/installation/install-php-agent-shared-hosting-service


### PR DESCRIPTION
Cleanup PHP Agent's documentation to make it less confusing for customers and support:
* refactor operating systems compatibility and requirements into table with links to install methods
* cleanup processors compatibility and requirements by using industry standard acronyms
* cleanup install instructions for Red Hat like distributions and make it clear that package install method is available only for x86_64 cpu.
* cleanup install instructions for Debian like distributions and make it clear that package install method is available only for x86_64 cpu.
* cleanup tar file install instructions and make it clear that this method works for any supported operating system on any supported cpu architecture
* cleanup agent's update instructions
* cleanup aarch64 instructions by removing no longer supported 'build from source' and redirecting to tar file install instructions
* cleanup `Dockerfile` example by modernizing it and making it work on any Docker "official image" for `php`.