### PR TITLE
chore(dotnet): Add Amazon SQS support and compatibility statement

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -695,6 +695,24 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </td>
         </tr>
 
+        <tr>
+          <td>
+            Amazon Simple Queue Service (AWSSDK.SQS) (agent versions 10.27.0 and newer)
+          </td>
+
+          <td>
+            * Message send and receive, and queue purge.
+
+            * The following methods are instrumented:
+              * `AmazonSQSClient.SendMessageAsync`
+              * `AmazonSQSClient.SendMessageBatchAsync`
+              * `AmazonSQSClient.ReceiveMessageAsync`
+              * `AmazonSQSClient.PurgeQueueAsync`
+	
+            * Minimum supported version: 3.3.0
+            * Verified compatible versions: 3.3.0, 3.5.0, 3.7.0, 3.7.301.24
+          </td>
+        </tr>
       </tbody>
     </table>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -714,7 +714,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
               * `AmazonSQSClient.PurgeQueueAsync`
 	
             * Minimum supported version: 3.3.0
-            * Verified compatible versions: 3.3.0, 3.5.0, 3.7.0, 3.7.301.24
+            * Latest verified compatible version: 3.7.301.32
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -704,9 +704,13 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             * Message send and receive, and queue purge.
 
             * The following methods are instrumented:
+              * `AmazonSQSClient.SendMessage`
               * `AmazonSQSClient.SendMessageAsync`
+              * `AmazonSQSClient.SendMessageBatch`
               * `AmazonSQSClient.SendMessageBatchAsync`
+              * `AmazonSQSClient.ReceiveMessage`
               * `AmazonSQSClient.ReceiveMessageAsync`
+              * `AmazonSQSClient.PurgeQueue`
               * `AmazonSQSClient.PurgeQueueAsync`
 	
             * Minimum supported version: 3.3.0

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -1034,7 +1034,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
               * `AmazonSQSClient.PurgeQueueAsync`
 	
             * Minimum supported version: 3.3.0
-            * Verified compatible versions: 3.3.0, 3.5.0, 3.7.0, 3.7.301.24
+            * Latest verified compatible version: 3.7.301.32
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -1024,9 +1024,13 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             * Message send and receive, and queue purge.
 
             * The following methods are instrumented:
+              * `AmazonSQSClient.SendMessage`
               * `AmazonSQSClient.SendMessageAsync`
+              * `AmazonSQSClient.SendMessageBatch`
               * `AmazonSQSClient.SendMessageBatchAsync`
+              * `AmazonSQSClient.ReceiveMessage`
               * `AmazonSQSClient.ReceiveMessageAsync`
+              * `AmazonSQSClient.PurgeQueue`
               * `AmazonSQSClient.PurgeQueueAsync`
 	
             * Minimum supported version: 3.3.0

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -1015,6 +1015,24 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </td>
         </tr>
 
+        <tr>
+          <td>
+            Amazon Simple Queue Service (AWSSDK.SQS) (agent versions 10.27.0 and newer)
+          </td>
+
+          <td>
+            * Message send and receive, and queue purge.
+
+            * The following methods are instrumented:
+              * `AmazonSQSClient.SendMessageAsync`
+              * `AmazonSQSClient.SendMessageBatchAsync`
+              * `AmazonSQSClient.ReceiveMessageAsync`
+              * `AmazonSQSClient.PurgeQueueAsync`
+	
+            * Minimum supported version: 3.3.0
+            * Verified compatible versions: 3.3.0, 3.5.0, 3.7.0, 3.7.301.24
+          </td>
+        </tr>
       </tbody>
     </table>
 </Collapser>


### PR DESCRIPTION
Updates the .NET Core and .NET Framework compatibility docs to include Amazon SQS as a support messaging framework.