### PR TITLE
chore: Update .NET Lambda layerless approach to not require the layer.

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-layerless.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-layerless.mdx
@@ -324,14 +324,14 @@ Manual instrumentation:
     
     To instrument your .NET Lambda:
 
-    1. Add the [NewRelic.Agent nuget package](https://www.nuget.org/packages/NewRelic.Agent) to your AWS Lambda project. For more information see our [installation guide](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/).
-    2. Add the [required environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-linux) to your project.  `NEW_RELIC_LICENSE_KEY` is not required since the agent will not attempt to contact or send data directly to New Relic.
+    1. Add the [NewRelic.Agent nuget package](https://www.nuget.org/packages/NewRelic.Agent) to your AWS Lambda project. For more information, see our [installation guide](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/).
+    2. Add the [required environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-linux) to your project. `NEW_RELIC_LICENSE_KEY` isn't required since the agent won't attempt to contact or send data directly to New Relic.
     3. Set the optional environment variables:
       - `NEW_RELIC_APP_NAME`
     4. Publish the project to your AWS Lambda account.
     5. [Configure](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking/) either the New Relic Lambda Extension or the `newrelic-log-ingestion` lambda.
     6. Optional: To configure logging, use the [`NEWRELIC_LOG_CONSOLE` and `NEWRELIC_LOG_LEVEL` environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#log) in the AWS Console.
-    7. Invoke the Lambda at least once and check for errors and that the data is visible in the New Relic UI.
+    7. Invoke the Lambda at least once to check for errors and ensure the data is visible in the New Relic UI.
 
   </Collapser>
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-layerless.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/enable-serverless-monitoring-aws-lambda-layerless.mdx
@@ -320,33 +320,18 @@ Manual instrumentation:
     id="dotnet"
     title=".NET"
   >
+    In most cases, the .NET Agent will automatically instrument your AWS Lambda function and switch into a "serverless mode" that will disable sending data directly to New Relic as well some other features.  You must either use the New Relic Lambda Extension or the `newrelic-log-ingestion` lambda method to send data to New Relic.
+    
     To instrument your .NET Lambda:
 
-    1. Navigate to the **Lambda** service section in the AWS web console. From there, find the Lambda function you would like to connect to New Relic.
-    2. In the default **Code** tab, scroll down to the **Layers** section and click on the **Add a layer** button.
-    3. Go to [New Relic's list of layers](https://layers.newrelic-external.com/) and use the drop-down list to select the AWS region where your Lambda function is hosted. From there, locate the ARN for the `NewRelicLambdaExtension` layer that matches your architecture. There should be two options: X86 and ARM64. Use the **Copy to clipboard** button or manually copy the ARN string.
-    4. In the **Specify an ARN** section of the AWS console form, paste in the New Relic Lambda layer ARN.
-    5. On the AWS console form, click the **Add** button to add the layer to your Lambda function.
-
-    6. Include the .NET agent with your lambda function by adding the [.NET Agent nuget package](https://www.nuget.org/packages/NewRelic.Agent) to your project.
-
-    7. Set the [required Linux environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-core-env-variables) for the agent using the AWS Lambda console. The base path should be the `newrelic` directory under your application's directory.
-
-    8. Set the require New Relic environment variables if they are not already configured:
-      - `NEW_RELIC_ACCOUNT_ID`
-      - `NEW_RELIC_LICENSE_KEY`
-
-    9. Set the optional environment variables:
+    1. Add the [NewRelic.Agent nuget package](https://www.nuget.org/packages/NewRelic.Agent) to your AWS Lambda project. For more information see our [installation guide](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/).
+    2. Add the [required environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-linux) to your project.  `NEW_RELIC_LICENSE_KEY` is not required since the agent will not attempt to contact or send data directly to New Relic.
+    3. Set the optional environment variables:
       - `NEW_RELIC_APP_NAME`
-
-    10. Publish the project to your AWS Lambda account.
-
-    11. Optional: To configure logging, use the [`NEWRELIC_LOG_CONSOLE` and `NEWRELIC_LOG_LEVEL` environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#log) in the AWS Console.
-
-    12. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
-
-       The New Relic decorator gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next, [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
-
+    4. Publish the project to your AWS Lambda account.
+    5. [Configure](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/account-linking/) either the New Relic Lambda Extension or the `newrelic-log-ingestion` lambda.
+    6. Optional: To configure logging, use the [`NEWRELIC_LOG_CONSOLE` and `NEWRELIC_LOG_LEVEL` environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#log) in the AWS Console.
+    7. Invoke the Lambda at least once and check for errors and that the data is visible in the New Relic UI.
 
   </Collapser>
 


### PR DESCRIPTION
## Give us some context

Update .NET Lambda layerless approach to not require the layer. Original updated focused on using the layer only.  This new approach does not.

Closes newrelic/newrelic-dotnet-agent#2585

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.