### PR TITLE
Left navigation: Correct alphabetization

### DIFF
--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -33,10 +33,10 @@ pages:
     path: serverless-function-monitoring
   - title: Synthetic Monitoring
     path: synthetics
-  - title: Website performance monitoring
-    path: website-performance-monitoring
   - title: Video
     path: video
+  - title: Website performance monitoring
+    path: website-performance-monitoring
   - title: Data insights
   - title: Alerts and Applied Intelligence
     path: alerts-applied-intelligence

--- a/src/nav/root.yml
+++ b/src/nav/root.yml
@@ -55,10 +55,10 @@ pages:
   - title: Service Level Management
     path: service-level-management
   - title: Security 
-  - title: Vulnerability Management
-    path: vuln-management 
   - title: New Relic IAST
     path: iast 
+  - title: Vulnerability Management
+    path: vuln-management 
   - title: Latest updates
   - title: Release notes
     path: release-notes


### PR DESCRIPTION
In a previous PR, I removed OTHER CAPABILITIES, but I put the new Video category in the wrong spot. This PR fixes that.