### PR TITLE
fix: broken links

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -108,30 +108,29 @@ To delete a Heroku syslog drain token mapping via the UI:
 To delete a Heroku syslog drain token mapping via REST API: 
 
 1. Find or generate a <InlinePopover type="userKey" />.
-2. Run the command below to retrieve a list of Heroku drain token mappings from your New Relic account, making sure to update values for [YOUR_NR_LICENSE_KEY](/docs/apis/intro-apis/new-relic-api-keys/#license-key) and [YOUR_NR_ACCOUNT_ID](/docs/accounts/accounts-billing/account-structure/account-id):
+2. Run the command below to retrieve a list of Heroku drain token mappings from your New Relic account, making sure to update values for [`YOUR_NR_LICENSE_KEY`](/docs/apis/intro-apis/new-relic-api-keys/#license-key) and [`YOUR_NR_ACCOUNT_ID`](/docs/accounts/accounts-billing/account-structure/account-id):
 
+    ```shell
+    curl -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=YOUR_NR_ACCOUNT_ID
+    ```
 
-   ```shell
-   curl -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings?accountId=YOUR_NR_ACCOUNT_ID
-   ```
+    The formatted result looks something like this:
 
-The formatted result looks something like this:
+    ```json
+    [
+      {
+        "herokuMappingId": 1549,
+        "drainToken": "YOUR_DRAIN_TOKEN",
+        "nrApiInsertKey": "YOUR_DRAIN_TOKEN_NR_API_KEY",
+        "createdAt": "2022-05-13T07:47:23",
+        "createdBy": "YOUR_EMAIL_ADDRESS"
+      }
+    ]
+    ```
 
-   ```json
-   [
-     {
-       "herokuMappingId": 1549,
-       "drainToken": "YOUR_DRAIN_TOKEN",
-       "nrApiInsertKey": "YOUR_DRAIN_TOKEN_NR_API_KEY",
-       "createdAt": "2022-05-13T07:47:23",
-       "createdBy": "YOUR_EMAIL_ADDRESS"
-     }
-   ]
-   ```
+    You need the `herokuMappingId` for each drain token that you want to remove.
 
-   You need the `herokuMappingId` for each drain token that you want to remove.
-
- 3. To delete a drain token, run the command below. Make sure to update values for `YOUR_NR_LICENSE_KEY`(/docs/apis/intro-apis/new-relic-api-keys/#license-key),`YOUR_NR_ACCOUNT_ID`(/docs/accounts/accounts-billing/account-structure/account-id/), and the `herokuMappingId` you retrieved in the last step:
+ 3. To delete a drain token, run the command below. Make sure to update values for [`YOUR_NR_LICENSE_KEY`](/docs/apis/intro-apis/new-relic-api-keys/#license-key), [`YOUR_NR_ACCOUNT_ID`](/docs/accounts/accounts-billing/account-structure/account-id/), and the `herokuMappingId` you retrieved in the last step:
 
    ```shell
    curl -XDELETE -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=YOUR_NR_ACCOUNT_ID


### PR DESCRIPTION
Link urls were in the plain text of the doc, also the 1,2,3 list was rendering as 1,2,1, so I increased the indentation of #2's content to maintain the list structure

<img width="1280" alt="image" src="https://github.com/newrelic/docs-website/assets/48165493/2d6bb172-e2c7-4f69-8520-0ed74adc079c">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.