### PR TITLE
fix: `-XDELETE` -> `-X DELETE` typo in curl cmd

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -133,7 +133,7 @@ To delete a Heroku syslog drain token mapping via REST API:
  3. To delete a drain token, run the command below. Make sure to update values for [`YOUR_NR_LICENSE_KEY`](/docs/apis/intro-apis/new-relic-api-keys/#license-key), [`YOUR_NR_ACCOUNT_ID`](/docs/accounts/accounts-billing/account-structure/account-id/), and the `herokuMappingId` you retrieved in the last step:
 
    ```shell
-   curl -XDELETE -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=YOUR_NR_ACCOUNT_ID
+   curl -X DELETE -H 'api-key: YOUR_NR_LICENSE_KEY' https://log-syslog-configuration-api.service.newrelic.com/heroku-account-mappings/<herokuMappingId>?accountId=YOUR_NR_ACCOUNT_ID
    ```
    
 When you're done, the API returns an HTTP 204 response and the drain token mapping is deleted.


### PR DESCRIPTION
this curl flag `-X` flag is here:

- https://curl.se/docs/manpage.html#-X

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.