### PR TITLE
Update requirements-infrastructure-agent.mdx

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -92,7 +92,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Version 7 or higher
+        Version 8 or higher
       </td>
     </tr>
 
@@ -132,7 +132,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Version 7 or higher
+        Version 8 or higher
       </td>
     </tr>
 


### PR DESCRIPTION
Official Support for CentOS 7 and RHEL 7 ended on June 30.

Ver 7 was removed from Infrastructure Agent Requirements and the minimum version is now 8 or higher.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.