### PR TITLE
Update network-syslog-monitoring.mdx

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-syslog-monitoring.mdx
@@ -42,7 +42,6 @@ Before you can start, you'll need to [sign up for a New Relic account](https://n
       * SSH access to the host
       * Access to install/remove applications and services
       * One of these supported operating systems:
-          * CentOS 7
           * CentOS 8
           * Debian 12 (Bookworm)
           * Debian 11 (Bullseye)


### PR DESCRIPTION
Official support for CentOS 7 and RHEL 7 ended on June 30.

CentOS 7 has been removed from the prerequisites for hosting Linux.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.