### PR TITLE
NerdGraph Default Timeout rate-limits-nrql-queries.mdx

### DIFF
--- a/src/content/docs/nrql/using-nrql/rate-limits-nrql-queries.mdx
+++ b/src/content/docs/nrql/using-nrql/rate-limits-nrql-queries.mdx
@@ -35,6 +35,8 @@ The query duration limit is how long a NRQL query can run before it stops runnin
   * 10 minutes (using the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder) or [NerdGraph](/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial))
   * 2 minutes in other UI locations aside from the query builder
 
+The default timeout for querying with NerdGraph is 5 seconds. 
+
 ### Limits on number of queries [#query-count-limits]
 
 This limit only applies for NRQL queries run via our APIs, and doesn't apply to queries run from the UI. 


### PR DESCRIPTION
Adding NerdGraph's default timeout of 5 seconds to the query limits document, as this isn't recorded elsewhere (except in async queries document briefly).

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.