### PR TITLE
Update find-data.mdx

### DIFF
--- a/src/install/apache-flink/find-data.mdx
+++ b/src/install/apache-flink/find-data.mdx
@@ -5,10 +5,7 @@ headingText: Find and use data
 
 Data from this integration can be found by going to: **[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Infrastructure > Third-party services > Apache Flink**. 
 
-Apache Flink data is attached to the `ApacheFlinkSample` [event type](/docs/using-new-relic/data/understand-data/new-relic-data-types#events-new-relic). You can [query this data](/docs/using-new-relic/data/understand-data/query-new-relic-data) for troubleshooting purposes or to create custom charts and dashboards.
-
-For more on how to find and use your data, see [Understand integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
-
+Apache Flink data is ingested as [Dimensional Metrics](/docs/data-apis/understand-data/new-relic-data-types/#dimensional-metrics). You can [query this data](/docs/using-new-relic/data/understand-data/query-new-relic-data) for troubleshooting purposes or to create custom charts and dashboards.
 
 You can use NRQL to [query your data](/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial/). For example, if you want to view the total number of completed checkpoints on New Relic's Query Builder, use this NRQL query:
 


### PR DESCRIPTION
fix: Flink does not create events, as it is ingested via Prometheus as Dimensional Metrics. The described ApacheFlinkSample does not exist - and this doc was corrected accordingly.

