### PR TITLE
Update forward-your-logs-using-infrastructure-agent.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -72,8 +72,8 @@ How you forward your logs depends on how you installed the infrastructure agent,
 * OpenSSL library 1.1.0 or higher
 * Built-in support for ARM64 architecture on Linux systems (for example, AWS Graviton architecture) added in infrastructure agent [1.20.6](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
 * Amazon Linux 2 and 2023 (ARM64 not supported for 2023)
-* CentOS version 7, 8 and 9 Stream (Rocky Linux and AlmaLinux are also supported)
-* RedHat version 7, 8 and 9
+* CentOS version 8 and 9 Stream (Rocky Linux and AlmaLinux are also supported)
+* RedHat version 8 and 9
 * Debian version 9 (Strech), 10 (Buster) and 11 (Bullseye).
 * SUSE Linux Enterprise Server (SLES) version 12 and 15 (ARM64 not supported).
 * Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x (LTS versions).


### PR DESCRIPTION
Official Support for CentOS 7 and RHEL 7 ended on June 30.

Ver 7 was removed from Infrastructure Agent Requirements and the minimum version is now 8 or higher.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.