### PR TITLE
Add OpenTelemetry manage ingest volume page

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
@@ -24,6 +24,8 @@ OTLP is divided into trace, metric, and log signals, all of which include the co
 * [OpenTelemetry logs in New Relic](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/)
 * [OpenTelemetry resources in New Relic](/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources/)
 
+See  [manage OpenTelemetry data volume New Relic](/docs/opentelemetry/best-practices/opentelemetry-manage-ingest-volume/) for concepts contributing to data ingest volume and tools to manage it.
+
 All OTLP data is ingested into the [New Relic platform](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-platform/), which includes many powerful general purpose observability tools to help you identify and diagnose problems, including:
 
 * [Alerts](/docs/alerts-applied-intelligence/overview/): Get informed when a signal exceeds a threshold.

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
@@ -24,7 +24,7 @@ OTLP is divided into trace, metric, and log signals, all of which include the co
 * [OpenTelemetry logs in New Relic](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/)
 * [OpenTelemetry resources in New Relic](/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources/)
 
-See  [manage OpenTelemetry data volume New Relic](/docs/opentelemetry/best-practices/opentelemetry-manage-ingest-volume/) for concepts contributing to data ingest volume and tools to manage it.
+For details on OpenTelemetry data volume in New Relic and management tools, see  [Manage OpenTelemetry ingest volume](/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume/).
 
 All OTLP data is ingested into the [New Relic platform](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-platform/), which includes many powerful general purpose observability tools to help you identify and diagnose problems, including:
 

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
@@ -24,7 +24,7 @@ OTLP is divided into trace, metric, and log signals, all of which include the co
 * [OpenTelemetry logs in New Relic](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/)
 * [OpenTelemetry resources in New Relic](/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources/)
 
-For details on OpenTelemetry data volume in New Relic and management tools, see  [Manage OpenTelemetry ingest volume](/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume/).
+For details on OpenTelemetry data volume in New Relic and management tools, see  [Manage OpenTelemetry data ingest volume](/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume/).
 
 All OTLP data is ingested into the [New Relic platform](/docs/new-relic-solutions/new-relic-one/introduction-new-relic-platform/), which includes many powerful general purpose observability tools to help you identify and diagnose problems, including:
 

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume.mdx
@@ -1,11 +1,11 @@
 ---
-title: Manage OpenTelemetry Ingest Volume
+title: Manage OpenTelemetry data ingest volume
 tags:
   - Integrations
   - Open source telemetry integrations
   - OpenTelemetry
   - OTLP
-metaDescription: Manage OpenTelemetry Ingest Volume
+metaDescription: Optimize your OpenTelemetry data pipeline in New Relic. Discover key factors and tools for efficient management.
 freshnessValidatedDate: never
 redirects:
 ---
@@ -16,15 +16,14 @@ This page talks about a variety of concepts that contribute to data volume when 
 
 ## Key concepts: Resources [#concept-resources]
 
-[OTLP](https://opentelemetry.io/docs/specs/otlp/) (OpenTeLemetry Protocol) defines a similar hierarchical message structure across all signals, which avoid repetition at the protocol level by sharing information across records.
+[OTLP](https://opentelemetry.io/docs/specs/otlp/) defines a similar hierarchical message structure across all signals, which avoids repetition at the protocol level by sharing information across records.
 
 * Each export request contains many `Resource{SignalRecord}`s
 * Each `Resource{SignalRecord}` contains many `Scope{SignalRecord}`s
 * Each `Scope{SignalRecord}` contains many `{SignalRecord}`s
+* `{SignalRecord}` is `Span`, `Metric`, and `LogRecord`.
 
-Where `{SignalRecord}` is `Span`, `Metric`, and `LogRecord`.
-
-As discussed in the pages discussing ingestion of [Traces](/docs/opentelemetry/best-practices/opentelemetry-best-practices-traces/), [Metrics](/docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics/), and [Logs](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/) sent to the [New Relic OTLP Endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp/), this hierarchical structure is flattened during New Relic and each resource attribute is denormalized onto individual `Span`, `Metric`, and `Log` records.
+This hierarchical structure is flattened when sent to New Relic endpoint, and each resource attribute is denormalized onto individual `Span`, `Metric`, and `Log` records. (See [Traces](/docs/opentelemetry/best-practices/opentelemetry-best-practices-traces/), [Metrics](/docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics/), and [Logs](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/) pages for more information on how OpenTelemetry data is handled in New Relic.)
 
 Most OpenTelemetry language implementations provide packages with [resource detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment), which contribute resource attributes based on information detected in the environment. These attributes can be extremely useful, but may include more information than necessary.
 
@@ -34,7 +33,7 @@ See "SDK resource detectors", "Collector resource processor", and "Collector tra
 
 ### Sampling [#concept-sampling]
 
-[Sampling](https://opentelemetry.io/docs/concepts/sampling/) is the process of controlling which spans are exported to an observability backend. Trace data can provide highly valuable insights, but if unchecked, can quickly fill up hard drives (and bills!).
+[Sampling](https://opentelemetry.io/docs/concepts/sampling/) is the process of controlling which spans are exported to an observability backend. Trace data can provide highly valuable insights, but if unchecked can quickly fill up hard drives (and bills!).
 
 By default, OpenTelemetry SDKs use the [`ParentBased(root=AlwaysOn)`](https://opentelemetry.io/docs/specs/otel/trace/sdk/#parentbased) sampler. The `ParentBased` sampler delegates to different configurable samplers based on whether there is a parent span, whether that parent is local to the current process or remote, and whether that parent is sampled. The default `ParentBased(root=AlwaysOn)` sampler will sample a span if either of the following is true:
 
@@ -43,15 +42,15 @@ By default, OpenTelemetry SDKs use the [`ParentBased(root=AlwaysOn)`](https://op
 
 In other words, it will sample the span unless the parent is unsampled.
 
-This is a good default for the OpenTelemetry community since it allows users to install instrumentation and see trace data without first needing to be aware of the sampling concept. However, production deployments of OpenTelemetry should be cautious. Under this policy, **all spans** are sampled unless there is some upstream component or gateway making intelligent sampling decisions for downstream systems to conform to.
+This is a good default for the OpenTelemetry community since it allows users to install instrumentation and see trace data without first needing to be aware of the sampling concept. However, you should be cautious with production deployments of OpenTelemetry. Under this policy, _all spans_ are sampled unless there is some upstream component or gateway making intelligent sampling decisions for downstream systems to conform to.
 
 See "ParentBased(root=TraceIdRatioBased) sampler", "Collector filter processor", and "Collector tailsampling processor" in the [tool catalog](#tool-catalog) for alternatives.
 
 ### Span data [#concept-span-data]
 
-OpenTelemetry spans are composed of a variety of top level fields (name, kind, etc.), attributes, span events, and span links. The amount of data attached to spans directly corresponds to data volume in New Relic.
+OpenTelemetry spans are composed of a variety of top-level fields (name, kind, etc.), attributes, span events, and span links. The amount of data attached to spans directly corresponds to data volume in New Relic.
 
-Instrumentation libraries make decisions about what pieces of information to attach to spans, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/). When exceptions occur, the information is often attached to the span in the form of an [exception span event](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/). This event includes attributes representing the exception message, type, and stacktrace, which depending on the language and application, can consist of thousands of bytes. If exceptions occur frequently, stacktraces may produce high data volume in New Relic.
+Instrumentation libraries make decisions about what pieces of information to attach to spans, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/). When exceptions occur, the information is often attached to the span in the form of an [exception span event](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/). This event includes attributes representing the exception message, type, and stack trace, which, depending on the language and application, can consist of thousands of bytes. If exceptions occur frequently, stack traces may produce high data volume in New Relic.
 
 See "SDK Span limits", "Collector transform processor" in [tool catalog](#tool-catalog) for strategies for managing span data.
 
@@ -69,7 +68,7 @@ See "SDK disable Tracers, Meter, Loggers" in [tool catalog](#tool-catalog) for d
 
 Metrics aggregate individual measurements and export the aggregated state out of process. For push-based protocols like OTLP, exporting occurs on a configurable interval defaulting to `60s`. This interval directly corresponds to data volume in New Relic. Reduce the interval to `30s` and data volume should approximately double. Increase the interval to `120s` and the data volume should approximately cut in half.
 
-The `60s` default interval is a reasonable default, and balances the tradeoff between data volume and observability lag. Increase the interval too high, and delays in critical signals reaching New Relic dashboards and alerts can exacerbate issues.
+The `60s` default interval is a reasonable default, as it balances the tradeoff between data volume and observability lag. Increase the interval too high, and delays in critical signals reaching New Relic dashboards and alerts can exacerbate issues.
 
 See "SDK periodic exporting Metric Reader `exportIntervalMillis`" in [tool catalog](#tool-catalog) for details.
 
@@ -77,7 +76,7 @@ See "SDK periodic exporting Metric Reader `exportIntervalMillis`" in [tool catal
 
 The measurements that metrics aggregate are associated with a set of attributes. The number of distinct sets of attributes is called cardinality. Cardinality is important because it dictates how much application memory is required to maintain the aggregated state of the measurements, how much data is exported each collection interval, and the data volume in New Relic.
 
-If cardinality is too high, consider omitting attributes which contribute to it. If you control the instrumentation, this could mean recording fewer attributes with each measurement. However, often the instrumentation is not directly configurable.
+If cardinality is too high, consider omitting attributes which contribute to it. If you control the instrumentation, this could mean recording fewer attributes with each measurement. However, the instrumentation is often not directly configurable.
 
 See "SDK metric views" and "Collector metricstransform processor" in [tool catalog](#tool-catalog) for details on how to drop attributes from metrics.
 
@@ -87,13 +86,13 @@ In OpenTelemetry metrics, the concept of [aggregation temporality](https://opent
 
 While New Relic's [OTLP endpoint supports cumulative aggregation temporality](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality), the New Relic metrics architecture is a delta metrics system. Using the default cumulative setting will generally incur more memory usage from SDKs and result in high data ingest. Conversion from cumulative to delta aggregation is a stateful activity, since you need to hold on to the previous point of each time series in order to compute the difference. For this reason, it's best to configure aggregation temporality in the SDK, which saves application memory and avoids extra complexity downstream.
 
-See "SDK delta aggregation temporality" and "Collector cumulativetodelta processor" in [tool catalog](#tool-catalog) for details.
+See "SDK delta aggregation temporality" and [Collector cumulativetodelta processor](#collector-cumulativetodelta-processor) in [tool catalog](#tool-catalog) for details.
 
 ### Meters and Instruments [#concept-meters-instruments]
 
-An [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. Each instrumentation library has one (or more) unique scopes, and corresponding meter(s). And each meter has one or more instruments.
+An [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. Each instrumentation library has one (or more) unique scopes and corresponding meter(s), and each meter has one or more instruments.
 
-Meters or instruments which do not produce high-value metric data can be selectively disabled.
+Meters or instruments that don't provide valuable metric data can be selectively disabled.
 
 See "SDK disable Tracers, Meter, Loggers" and "SDK metric views" in [tool catalog](#tool-catalog) for details.
 
@@ -101,7 +100,7 @@ See "SDK disable Tracers, Meter, Loggers" and "SDK metric views" in [tool catalo
 
 ### LogRecord data [#concept-logrecord-data]
 
-OpenTelemetry log records are composed of a variety of top level fields (timestamp, severity, body, etc.) and attributes. The amount of data attached to log records directly corresponds to data volume in New Relic.
+OpenTelemetry log records are composed of a variety of top-level fields (timestamp, severity, body, etc.) and attributes. The amount of data attached to log records directly corresponds to data volume in New Relic.
 
 Instrumentation libraries (called [log appenders](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/#how-to-create-a-log4j-log-appender) in the OpenTelemetry log space since the OpenTelemetry log bridge API is meant for bridging logs from log APIs into OpenTelemetry) make decisions about what pieces of information to attach to log records, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/).
 
@@ -111,15 +110,13 @@ See "SDK LogRecord limits", "SDK configure log appenders", "Collector filter pro
 
 An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. For OpenTelemetry logging, each distinct logger (bridged by a log appender using the OpenTelemetry log bridge API) has a unique instrumentation scope.
 
-Loggers which do not produce high-value log data can be selectively disabled.
+Loggers that don't not produce high-value log data can be selectively disabled.
 
 See "SDK disable Tracers, Meter, Loggers" and "SDK configure log appenders" in [tool catalog](#tool-catalog) for details.
 
 ## Pipeline management tool catalog [#tool-catalog]
 
 The following table lists a variety of useful tools for managing your OpenTelemetry data pipeline. Note that OpenTelemetry is a highly extensible ecosystem. If these tools do not suffice, other tools may be available or you may be able to write custom extension logic for the language SDKs or collector to accomplish your goals.
-
-https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased
 
 <table>
   <thead>
@@ -222,9 +219,9 @@ https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased
     <tr>
       <td>[Collector transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)</td>
       <td>Collector</td>
-      <td>The collector transform processor allows you transform observability data using conditions to select data and statements to modify it. For example, you can remove resource attributes, truncate attributes, change top level fields for spans, metrics, and logs records, and much more.</td>
+      <td>The collector transform processor allows you transform observability data using conditions to select data and statements to modify it. For example, you can remove resource attributes, truncate attributes, change top-level fields for spans, metrics, and logs records, and much more.</td>
     </tr>
-    <tr>
+    <tr id="collector-cumulativetodelta-processor">
       <td>[Collector cumulativetodelta processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)</td>
       <td>Collector</td>
       <td>The collector cumulativetodelta processor allows you to transform metric aggregation temporality from cumulative to delta. This is useful to align your metrics with the [preferred aggregation temporality of New Relic's OTLP endpoint](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality). Note, translation from cumulative to delta aggregation is a stateful process, requiring the collector to store the last point of each timeseries in memory in order to compute and emit the difference. This requires careful planning of collector memory resources, and structuring the observability pipeline to ensure that all points of the same series arrive at the same collector instance.</td>

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume.mdx
@@ -27,7 +27,7 @@ This hierarchical structure is flattened when sent to New Relic endpoint, and ea
 
 Most OpenTelemetry language implementations provide packages with [resource detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment), which contribute resource attributes based on information detected in the environment. These attributes can be extremely useful, but may include more information than necessary.
 
-See "SDK resource detectors", "Collector resource processor", and "Collector transform processor" in the [tool catalog](#tool-catalog).
+See [SDK resource detectors](#sdk-resource-detectors), [Collector resource processor](#collector-resource-processor), and [Collector transform processor](#collector-transform-processor) in the [tool catalog](#tool-catalog).
 
 ## Key concepts: Traces [#concept-traces]
 
@@ -44,7 +44,7 @@ In other words, it will sample the span unless the parent is unsampled.
 
 This is a good default for the OpenTelemetry community since it allows users to install instrumentation and see trace data without first needing to be aware of the sampling concept. However, you should be cautious with production deployments of OpenTelemetry. Under this policy, _all spans_ are sampled unless there is some upstream component or gateway making intelligent sampling decisions for downstream systems to conform to.
 
-See "ParentBased(root=TraceIdRatioBased) sampler", "Collector filter processor", and "Collector tailsampling processor" in the [tool catalog](#tool-catalog) for alternatives.
+See [ParentBased(root=TraceIdRatioBased) sampler](#sdk-parentbased-traceidratiobased-sampler), [Collector filter processor](#collector-filter-processor), and [Collector tailsampling processor](#collector-tailsampling-processor) in the [tool catalog](#tool-catalog) for alternatives.
 
 ### Span data [#concept-span-data]
 
@@ -52,7 +52,7 @@ OpenTelemetry spans are composed of a variety of top-level fields (name, kind, e
 
 Instrumentation libraries make decisions about what pieces of information to attach to spans, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/). When exceptions occur, the information is often attached to the span in the form of an [exception span event](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/). This event includes attributes representing the exception message, type, and stack trace, which, depending on the language and application, can consist of thousands of bytes. If exceptions occur frequently, stack traces may produce high data volume in New Relic.
 
-See "SDK Span limits", "Collector transform processor" in [tool catalog](#tool-catalog) for strategies for managing span data.
+See [SDK Span limits](#sdk-span-limits), [Collector transform processor](#collector-transform-processor) in [tool catalog](#tool-catalog) for strategies for managing span data.
 
 ### Tracers [#concept-tracers]
 
@@ -60,7 +60,7 @@ An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#ins
 
 Tracers which do not produce high-value trace data can be selectively disabled without breaking traces.
 
-See "SDK disable Tracers, Meter, Loggers" in [tool catalog](#tool-catalog) for details.
+See [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers) in [tool catalog](#tool-catalog) for details.
 
 ## Key concepts: Metrics [#concept-metrics]
 
@@ -70,7 +70,7 @@ Metrics aggregate individual measurements and export the aggregated state out of
 
 The `60s` default interval is a reasonable default, as it balances the tradeoff between data volume and observability lag. Increase the interval too high, and delays in critical signals reaching New Relic dashboards and alerts can exacerbate issues.
 
-See "SDK periodic exporting Metric Reader `exportIntervalMillis`" in [tool catalog](#tool-catalog) for details.
+See [SDK periodic exporting Metric Reader `exportIntervalMillis`](#sdk-pmr-interval) in [tool catalog](#tool-catalog) for details.
 
 ### Cardinality [#concept-cardinality]
 
@@ -78,7 +78,7 @@ The measurements that metrics aggregate are associated with a set of attributes.
 
 If cardinality is too high, consider omitting attributes which contribute to it. If you control the instrumentation, this could mean recording fewer attributes with each measurement. However, the instrumentation is often not directly configurable.
 
-See "SDK metric views" and "Collector metricstransform processor" in [tool catalog](#tool-catalog) for details on how to drop attributes from metrics.
+See [SDK metric views](#sdk-metric-views) and [Collector metricstransform processor](#collector-metricstransform-processor) in [tool catalog](#tool-catalog) for details on how to drop attributes from metrics.
 
 ### Aggregation temporality [#concept-aggregation-temporality]
 
@@ -86,7 +86,7 @@ In OpenTelemetry metrics, the concept of [aggregation temporality](https://opent
 
 While New Relic's [OTLP endpoint supports cumulative aggregation temporality](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality), the New Relic metrics architecture is a delta metrics system. Using the default cumulative setting will generally incur more memory usage from SDKs and result in high data ingest. Conversion from cumulative to delta aggregation is a stateful activity, since you need to hold on to the previous point of each time series in order to compute the difference. For this reason, it's best to configure aggregation temporality in the SDK, which saves application memory and avoids extra complexity downstream.
 
-See "SDK delta aggregation temporality" and [Collector cumulativetodelta processor](#collector-cumulativetodelta-processor) in [tool catalog](#tool-catalog) for details.
+See [SDK delta aggregation temporality](#sdk-delta-temporality) and [Collector cumulativetodelta processor](#collector-cumulativetodelta-processor) in [tool catalog](#tool-catalog) for details.
 
 ### Meters and Instruments [#concept-meters-instruments]
 
@@ -94,7 +94,7 @@ An [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#in
 
 Meters or instruments that don't provide valuable metric data can be selectively disabled.
 
-See "SDK disable Tracers, Meter, Loggers" and "SDK metric views" in [tool catalog](#tool-catalog) for details.
+See [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers) and [SDK metric views](#sdk-metric-views) in [tool catalog](#tool-catalog) for details.
 
 ## Key concepts: Logs [#concept-logs]
 
@@ -104,15 +104,15 @@ OpenTelemetry log records are composed of a variety of top-level fields (timesta
 
 Instrumentation libraries (called [log appenders](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/#how-to-create-a-log4j-log-appender) in the OpenTelemetry log space since the OpenTelemetry log bridge API is meant for bridging logs from log APIs into OpenTelemetry) make decisions about what pieces of information to attach to log records, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/).
 
-See "SDK LogRecord limits", "SDK configure log appenders", "Collector filter processor", and "Collector transform processor" in [tool catalog](#tool-catalog) for strategies for managing log data.
+See [SDK LogRecord limits](#sdk-logrecord-limits), [SDK configure log appenders](#sdk-log-appenders), [Collector filter processor](#collector-filter-processor), and [Collector transform processor](#collector-transform-processor) in [tool catalog](#tool-catalog) for strategies for managing log data.
 
 ### Loggers [#concept-loggers]
 
 An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. For OpenTelemetry logging, each distinct logger (bridged by a log appender using the OpenTelemetry log bridge API) has a unique instrumentation scope.
 
-Loggers that don't not produce high-value log data can be selectively disabled.
+Loggers that don't produce high-value log data can be selectively disabled.
 
-See "SDK disable Tracers, Meter, Loggers" and "SDK configure log appenders" in [tool catalog](#tool-catalog) for details.
+See [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers) and [SDK configure log appenders](#sdk-log-appenders) in [tool catalog](#tool-catalog) for details.
 
 ## Pipeline management tool catalog [#tool-catalog]
 
@@ -127,12 +127,12 @@ The following table lists a variety of useful tools for managing your OpenTeleme
     </tr>
   </thead>
   <tbody>
-    <tr>
+    <tr id="sdk-resource-detectors">
       <td>[SDK resource detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment)</td>
       <td>SDK</td>
       <td>OpenTelemetry language SDKs package detectors to supply resource attributes based on the environment. Some set of these are often enabled by default with [zero-code instrumenation](https://opentelemetry.io/docs/zero-code/) options like the OpenTelemetry Java Agent. See [language docs](https://opentelemetry.io/docs/languages/) for details on how to enable / disable resource detectors.</td>
     </tr>
-    <tr>
+    <tr id="sdk-parentbased-traceidratiobased-sampler">
       <td>[SDK `ParentBased(root=TraceIdRatioBased) sampler`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)</td>
       <td>SDK</td>
       <td>The `ParentBased` sampler with the root set to the `TraceIdRatioBased` sampler is simple and reasonable alternative to the default `ParentBased` sampler with the root set to `AlwaysOn`. With the root set to `TraceIdRatioBased`, spans which represent new traces are sampled probabilistically, with child spans sampled according to the sampling decision of their parent (so long as other applications are configured with the same sampling policy). The sampler can be configured programmatically on the SDK `TracerProvider`, but it's common to use env vars:
@@ -143,7 +143,7 @@ The following table lists a variety of useful tools for managing your OpenTeleme
       Set the `TraceIdRatioBased` sampler to sample 25% of root spans.
       </td>
     </tr>
-    <tr>
+    <tr id="sdk-span-limits">
       <td>[SDK Span limits](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits)</td>
       <td>SDK</td>
       <td>The OpenTelemetry trace SDK allows span limits to be configured to specify the max length and quantity of attributes, the max number of span events, and the max number of span links. Span limits can be configured programmatically on the SDK `TracerProvider`, but it's common to use env vars:
@@ -153,7 +153,7 @@ The following table lists a variety of useful tools for managing your OpenTeleme
       ```
       Set the span limits to align with the New Relic OTLP endpoint's [attribute limits](docs/opentelemetry/best-practices/opentelemetry-otlp/#attribute-limits).</td>
     </tr>
-    <tr>
+    <tr id="sdk-logrecord-limits">
       <td>[SDK LogRecord limits](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#logrecord-limits)</td>
       <td>SDK</td>
       <td>The OpenTelemetry log SDK allows span limits to be configured to specify the max length and quantity of attributes. LogRecord limits can be configured programmatically on the SDK `LoggerProvider`, but it's common to use env vars:
@@ -163,12 +163,12 @@ The following table lists a variety of useful tools for managing your OpenTeleme
       ```
       Set the log record limits to align with the New Relic OTLP endpoint's [attribute limits](docs/opentelemetry/best-practices/opentelemetry-otlp/#attribute-limits).</td>
     </tr>
-    <tr>
+    <tr id="sdk-disable-tracers-meters-loggers">
       <td>SDK disable [Tracers](https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracerconfigurator), [Meters](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#meterconfigurator), [Loggers](https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerconfigurator)</td>
       <td>SDK</td>
       <td>The OpenTelemetry SDK defines `TracerConfigurator`, `MeterConfigurator`, and `LoggerConfigurator` to configure and disable Tracers, Meters, and Loggers respectively. This concept is currently under development and not available in all language implementations. See individual [language docs](https://opentelemetry.io/docs/languages/) and reach out to language maintainers to check the status.</td>
     </tr>
-    <tr>
+    <tr id="sdk-pmr-interval">
       <td>[SDK periodic exporting Metric Reader `exportIntervalMillis`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader)</td>
       <td>SDK</td>
       <td>The OpenTelemetry metric SDK allows the collection interval of the periodic exporting Metric reader to be configured. The interval can be configured programmatically, but it's common to use env vars:
@@ -177,12 +177,12 @@ The following table lists a variety of useful tools for managing your OpenTeleme
       ```
       Set the collection interval to be 60s (60k ms). This is the default, but can be adjusted to suit.</td>
     </tr>
-    <tr>
+    <tr id="sdk-metric-views">
       <td>[SDK metric views](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view)</td>
       <td>SDK</td>
       <td>The OpenTelemetry metric SDK allows `MeterProvider` to be configured with views to specify various options including the set of attribute keys to retain, the aggregation type, and dropping the metric. Generally, views are configured programmatically. See individual [language docs](https://opentelemetry.io/docs/languages/) to check for alternatives in your language. For example, OpenTelemetry Java has experimental support configuring views in a [YAML file](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/incubator#view-file-configuration).</td>
     </tr>
-    <tr>
+    <tr id="sdk-delta-temporality">
       <td>[SDK delta aggregation temporality](https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-configuration)</td>
       <td>SDK</td>
       <td>The OpenTelemetry metrics SDK allows aggregation temporality to be configured for the OTLP exporter. This temporality can be configured programatically, but it's common to use env vars:
@@ -191,32 +191,32 @@ The following table lists a variety of useful tools for managing your OpenTeleme
       ```
       Set the OTLP metric exporter aggregation temporality to be delta, aligning with the New Relic OTLP endpoint's [preference](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality).</td>
     </tr>
-    <tr>
+    <tr id="sdk-log-appenders">
       <td>[SDK configure log appenders](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/)</td>
       <td>SDK</td>
       <td>The OpenTelemetry log bridge API is designed for use by log appenders, which bridge logs from log APIs into OpenTelemetry. These log appenders may be automatically installed with [zero-code instrumenation](https://opentelemetry.io/docs/zero-code/) options like the OpenTelemetry Java Agent, or may require manual installation steps. They often have configuration options to specify which logs and what data is bridged into OpenTelemetry. Additionally, it's often possible to configure the log API being bridged to specify which logs (baesd on severity or logger name) should be passed to the log appender. See individual [language docs](https://opentelemetry.io/docs/languages/) for details.</td>
     </tr>
-    <tr>
+    <tr id="collector-filter-processor">
       <td>[Collector filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)</td>
       <td>Collector</td>
       <td>The collector filter processor can be used to filter out span, metric, and log records from your observability pipeline. For spans, it can function as a simple tail sampler, acting on completed spans but without access to the full trace (Note: this can result in broken traces). For metrics, it can be used to drop metrics or series which are not high value. For logs, it can be used to drop log records which are not high value (e.g. logs with fine grain severity or from noisy loggers).</td>
     </tr>
-    <tr>
+    <tr id="collector-tailsampling-processor">
       <td>[Collector tailsampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)</td>
       <td>Collector</td>
       <td>The collector tailsampling allows you to decide whether to sample based on completed traces. For example, you can emphasize retaining traces which have errors or which touch high interest areas of the system. The drawback is that tailsampling processor adds complexity to your observability pipeline since it requires that all spans of a trace be routed to the same collector instance, and that the collector hold spans in memory while waiting for the trace to complete. This requires careful planning when your observability pipeline reaches a scale which cannot be handled by a single collector instance.</td>
     </tr>
-    <tr>
+    <tr id="collector-resource-processor">
       <td>[Collector resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)</td>
       <td>Collector</td>
       <td>The collector resource processor allows you to write simple rules to manipulate resource attributes of spans, metrics, and logs. For example, you can delete attributes which are not high value.</td>
     </tr>
-    <tr>
+    <tr id="collector-metricstransform-processor">
       <td>[Collector metricstransform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)</td>
       <td>Collector</td>
       <td>The collector metric transform processor allows you to manipulate metric data. For example, you can delete series which are not high value, or merge timeseries to reduce cardinality (sometimes called spatial re-aggregation).</td>
     </tr>
-    <tr>
+    <tr id="collector-transform-processor">
       <td>[Collector transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)</td>
       <td>Collector</td>
       <td>The collector transform processor allows you transform observability data using conditions to select data and statements to modify it. For example, you can remove resource attributes, truncate attributes, change top-level fields for spans, metrics, and logs records, and much more.</td>

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume.mdx
@@ -6,7 +6,7 @@ tags:
   - OpenTelemetry
   - OTLP
 metaDescription: Optimize your OpenTelemetry data pipeline in New Relic. Discover key factors and tools for efficient management.
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-07-23
 redirects:
 ---
 
@@ -21,13 +21,19 @@ This page talks about a variety of concepts that contribute to data volume when 
 * Each export request contains many `Resource{SignalRecord}`s
 * Each `Resource{SignalRecord}` contains many `Scope{SignalRecord}`s
 * Each `Scope{SignalRecord}` contains many `{SignalRecord}`s
-* `{SignalRecord}` is `Span`, `Metric`, and `LogRecord`.
+* `{SignalRecord}` is `Span`, `Metric`, and `LogRecord`
 
-This hierarchical structure is flattened when sent to New Relic endpoint, and each resource attribute is denormalized onto individual `Span`, `Metric`, and `Log` records. (See [Traces](/docs/opentelemetry/best-practices/opentelemetry-best-practices-traces/), [Metrics](/docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics/), and [Logs](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/) pages for more information on how OpenTelemetry data is handled in New Relic.)
+This hierarchical structure is flattened when sent to New Relic endpoint, and each resource attribute is denormalized onto individual `Span`, `Metric`, and `Log` records. For more informaton on how OpenTelemetry data is handled in New Relic, see the following pages:
+    * [Traces](/docs/opentelemetry/best-practices/opentelemetry-best-practices-traces/)
+    * [Metrics](/docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics/)
+    * [Logs](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/)
 
 Most OpenTelemetry language implementations provide packages with [resource detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment), which contribute resource attributes based on information detected in the environment. These attributes can be extremely useful, but may include more information than necessary.
 
-See [SDK resource detectors](#sdk-resource-detectors), [Collector resource processor](#collector-resource-processor), and [Collector transform processor](#collector-transform-processor) in the [tool catalog](#tool-catalog).
+For more details, see the following:
+* [SDK resource detectors](#sdk-resource-detectors)
+* [Collector resource processor](#collector-resource-processor)
+* [Collector transform processor](#collector-transform-processor).
 
 ## Key concepts: Traces [#concept-traces]
 
@@ -44,7 +50,10 @@ In other words, it will sample the span unless the parent is unsampled.
 
 This is a good default for the OpenTelemetry community since it allows users to install instrumentation and see trace data without first needing to be aware of the sampling concept. However, you should be cautious with production deployments of OpenTelemetry. Under this policy, _all spans_ are sampled unless there is some upstream component or gateway making intelligent sampling decisions for downstream systems to conform to.
 
-See [ParentBased(root=TraceIdRatioBased) sampler](#sdk-parentbased-traceidratiobased-sampler), [Collector filter processor](#collector-filter-processor), and [Collector tailsampling processor](#collector-tailsampling-processor) in the [tool catalog](#tool-catalog) for alternatives.
+For alternatives, see the following:
+* [ParentBased(root=TraceIdRatioBased) sampler](#sdk-parentbased-traceidratiobased-sampler)
+* [Collector filter processor](#collector-filter-processor)
+* [Collector tailsampling processor](#collector-tailsampling-processor)
 
 ### Span data [#concept-span-data]
 
@@ -52,7 +61,9 @@ OpenTelemetry spans are composed of a variety of top-level fields (name, kind, e
 
 Instrumentation libraries make decisions about what pieces of information to attach to spans, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/). When exceptions occur, the information is often attached to the span in the form of an [exception span event](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/). This event includes attributes representing the exception message, type, and stack trace, which, depending on the language and application, can consist of thousands of bytes. If exceptions occur frequently, stack traces may produce high data volume in New Relic.
 
-See [SDK Span limits](#sdk-span-limits), [Collector transform processor](#collector-transform-processor) in [tool catalog](#tool-catalog) for strategies for managing span data.
+For strategies for managing span data, see the following:
+* [SDK Span limits](#sdk-span-limits)
+* [Collector transform processor](#collector-transform-processor)
 
 ### Tracers [#concept-tracers]
 
@@ -60,7 +71,7 @@ An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#ins
 
 Tracers which do not produce high-value trace data can be selectively disabled without breaking traces.
 
-See [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers) in [tool catalog](#tool-catalog) for details.
+For more details, see [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers).
 
 ## Key concepts: Metrics [#concept-metrics]
 
@@ -70,7 +81,7 @@ Metrics aggregate individual measurements and export the aggregated state out of
 
 The `60s` default interval is a reasonable default, as it balances the tradeoff between data volume and observability lag. Increase the interval too high, and delays in critical signals reaching New Relic dashboards and alerts can exacerbate issues.
 
-See [SDK periodic exporting Metric Reader `exportIntervalMillis`](#sdk-pmr-interval) in [tool catalog](#tool-catalog) for details.
+For more details, see [SDK periodic exporting Metric Reader `exportIntervalMillis`](#sdk-pmr-interval).
 
 ### Cardinality [#concept-cardinality]
 
@@ -78,7 +89,9 @@ The measurements that metrics aggregate are associated with a set of attributes.
 
 If cardinality is too high, consider omitting attributes which contribute to it. If you control the instrumentation, this could mean recording fewer attributes with each measurement. However, the instrumentation is often not directly configurable.
 
-See [SDK metric views](#sdk-metric-views) and [Collector metricstransform processor](#collector-metricstransform-processor) in [tool catalog](#tool-catalog) for details on how to drop attributes from metrics.
+For details on how to drop attributes from metrics, see the following:
+* [SDK metric views](#sdk-metric-views)
+* [Collector metricstransform processor](#collector-metricstransform-processor)
 
 ### Aggregation temporality [#concept-aggregation-temporality]
 
@@ -86,7 +99,9 @@ In OpenTelemetry metrics, the concept of [aggregation temporality](https://opent
 
 While New Relic's [OTLP endpoint supports cumulative aggregation temporality](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality), the New Relic metrics architecture is a delta metrics system. Using the default cumulative setting will generally incur more memory usage from SDKs and result in high data ingest. Conversion from cumulative to delta aggregation is a stateful activity, since you need to hold on to the previous point of each time series in order to compute the difference. For this reason, it's best to configure aggregation temporality in the SDK, which saves application memory and avoids extra complexity downstream.
 
-See [SDK delta aggregation temporality](#sdk-delta-temporality) and [Collector cumulativetodelta processor](#collector-cumulativetodelta-processor) in [tool catalog](#tool-catalog) for details.
+For more details, see the following:
+* [SDK delta aggregation temporality](#sdk-delta-temporality)
+* [Collector cumulativetodelta processor](#collector-cumulativetodelta-processor)
 
 ### Meters and Instruments [#concept-meters-instruments]
 
@@ -94,7 +109,9 @@ An [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#in
 
 Meters or instruments that don't provide valuable metric data can be selectively disabled.
 
-See [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers) and [SDK metric views](#sdk-metric-views) in [tool catalog](#tool-catalog) for details.
+For more details, see the following:
+* [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers)
+* [SDK metric views](#sdk-metric-views)
 
 ## Key concepts: Logs [#concept-logs]
 
@@ -104,7 +121,11 @@ OpenTelemetry log records are composed of a variety of top-level fields (timesta
 
 Instrumentation libraries (called [log appenders](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/#how-to-create-a-log4j-log-appender) in the OpenTelemetry log space since the OpenTelemetry log bridge API is meant for bridging logs from log APIs into OpenTelemetry) make decisions about what pieces of information to attach to log records, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/).
 
-See [SDK LogRecord limits](#sdk-logrecord-limits), [SDK configure log appenders](#sdk-log-appenders), [Collector filter processor](#collector-filter-processor), and [Collector transform processor](#collector-transform-processor) in [tool catalog](#tool-catalog) for strategies for managing log data.
+For strategies on managing log data, see the following:
+* [SDK LogRecord limits](#sdk-logrecord-limits)
+* [SDK configure log appenders](#sdk-log-appenders)
+* [Collector filter processor](#collector-filter-processor)
+* [Collector transform processor](#collector-transform-processor)
 
 ### Loggers [#concept-loggers]
 
@@ -112,7 +133,9 @@ An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#ins
 
 Loggers that don't produce high-value log data can be selectively disabled.
 
-See [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers) and [SDK configure log appenders](#sdk-log-appenders) in [tool catalog](#tool-catalog) for details.
+For more details, see the following:
+* [SDK disable Tracers, Meter, Loggers](#sdk-disable-tracers-meters-loggers)
+* [SDK configure log appenders](#sdk-log-appenders)
 
 ## Pipeline management tool catalog [#tool-catalog]
 
@@ -224,7 +247,7 @@ The following table lists a variety of useful tools for managing your OpenTeleme
     <tr id="collector-cumulativetodelta-processor">
       <td>[Collector cumulativetodelta processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)</td>
       <td>Collector</td>
-      <td>The collector cumulativetodelta processor allows you to transform metric aggregation temporality from cumulative to delta. This is useful to align your metrics with the [preferred aggregation temporality of New Relic's OTLP endpoint](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality). Note, translation from cumulative to delta aggregation is a stateful process, requiring the collector to store the last point of each timeseries in memory in order to compute and emit the difference. This requires careful planning of collector memory resources, and structuring the observability pipeline to ensure that all points of the same series arrive at the same collector instance.</td>
+      <td>The collector cumulativetodelta processor allows you to transform metric aggregation temporality from cumulative to delta. This is useful to align your metrics with the [preferred aggregation temporality of New Relic's OTLP endpoint](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality). Note that translation from cumulative to delta aggregation is a stateful process, requiring the collector to store the last point of each timeseries in memory in order to compute and emit the difference. This requires careful planning of collector memory resources and structuring the observability pipeline to ensure that all points of the same series arrive at the same collector instance.</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-ingest-volume.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-manage-ingest-volume.mdx
@@ -1,0 +1,233 @@
+---
+title: Manage OpenTelemetry Ingest Volume
+tags:
+  - Integrations
+  - Open source telemetry integrations
+  - OpenTelemetry
+  - OTLP
+metaDescription: Manage OpenTelemetry Ingest Volume
+freshnessValidatedDate: never
+redirects:
+---
+
+One of OpenTelemetry's core strengths is its rich set of tools providing unparalleled control over your telemetry data pipeline. This control complements New Relic's [consumption-based pricing](https://newrelic.com/pricing#pricing_plan-data) model.
+
+This page talks about a variety of concepts that contribute to data volume when using OpenTelemetry with New Relic, and tools / patterns available to manage your telemetry data pipeline. It's organized into sections talking about key concepts contributing to data volume for [resource](#concept-resources), [traces](#concept-traces), [metrics](#concept-metrics), and [logs](#concept-logs), followed by a [catalog of tools](#tool-catalog) available for helping manage volume.
+
+## Key concepts: Resources [#concept-resources]
+
+[OTLP](https://opentelemetry.io/docs/specs/otlp/) (OpenTeLemetry Protocol) defines a similar hierarchical message structure across all signals, which avoid repetition at the protocol level by sharing information across records.
+
+* Each export request contains many `Resource{SignalRecord}`s
+* Each `Resource{SignalRecord}` contains many `Scope{SignalRecord}`s
+* Each `Scope{SignalRecord}` contains many `{SignalRecord}`s
+
+Where `{SignalRecord}` is `Span`, `Metric`, and `LogRecord`.
+
+As discussed in the pages discussing ingestion of [Traces](/docs/opentelemetry/best-practices/opentelemetry-best-practices-traces/), [Metrics](/docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics/), and [Logs](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs/) sent to the [New Relic OTLP Endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp/), this hierarchical structure is flattened during New Relic and each resource attribute is denormalized onto individual `Span`, `Metric`, and `Log` records.
+
+Most OpenTelemetry language implementations provide packages with [resource detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment), which contribute resource attributes based on information detected in the environment. These attributes can be extremely useful, but may include more information than necessary.
+
+See "SDK resource detectors", "Collector resource processor", and "Collector transform processor" in the [tool catalog](#tool-catalog).
+
+## Key concepts: Traces [#concept-traces]
+
+### Sampling [#concept-sampling]
+
+[Sampling](https://opentelemetry.io/docs/concepts/sampling/) is the process of controlling which spans are exported to an observability backend. Trace data can provide highly valuable insights, but if unchecked, can quickly fill up hard drives (and bills!).
+
+By default, OpenTelemetry SDKs use the [`ParentBased(root=AlwaysOn)`](https://opentelemetry.io/docs/specs/otel/trace/sdk/#parentbased) sampler. The `ParentBased` sampler delegates to different configurable samplers based on whether there is a parent span, whether that parent is local to the current process or remote, and whether that parent is sampled. The default `ParentBased(root=AlwaysOn)` sampler will sample a span if either of the following is true:
+
+- There is no parent span (i.e. this span is the root)
+- The parent is sampled, regardless of whether the parent is local or remote
+
+In other words, it will sample the span unless the parent is unsampled.
+
+This is a good default for the OpenTelemetry community since it allows users to install instrumentation and see trace data without first needing to be aware of the sampling concept. However, production deployments of OpenTelemetry should be cautious. Under this policy, **all spans** are sampled unless there is some upstream component or gateway making intelligent sampling decisions for downstream systems to conform to.
+
+See "ParentBased(root=TraceIdRatioBased) sampler", "Collector filter processor", and "Collector tailsampling processor" in the [tool catalog](#tool-catalog) for alternatives.
+
+### Span data [#concept-span-data]
+
+OpenTelemetry spans are composed of a variety of top level fields (name, kind, etc.), attributes, span events, and span links. The amount of data attached to spans directly corresponds to data volume in New Relic.
+
+Instrumentation libraries make decisions about what pieces of information to attach to spans, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/). When exceptions occur, the information is often attached to the span in the form of an [exception span event](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/). This event includes attributes representing the exception message, type, and stacktrace, which depending on the language and application, can consist of thousands of bytes. If exceptions occur frequently, stacktraces may produce high data volume in New Relic.
+
+See "SDK Span limits", "Collector transform processor" in [tool catalog](#tool-catalog) for strategies for managing span data.
+
+### Tracers [#concept-tracers]
+
+An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. Each instrumentation library has one (or more) unique scopes, and corresponding tracer(s).
+
+Tracers which do not produce high-value trace data can be selectively disabled without breaking traces.
+
+See "SDK disable Tracers, Meter, Loggers" in [tool catalog](#tool-catalog) for details.
+
+## Key concepts: Metrics [#concept-metrics]
+
+### Collection interval [#concept-collection-interval]
+
+Metrics aggregate individual measurements and export the aggregated state out of process. For push-based protocols like OTLP, exporting occurs on a configurable interval defaulting to `60s`. This interval directly corresponds to data volume in New Relic. Reduce the interval to `30s` and data volume should approximately double. Increase the interval to `120s` and the data volume should approximately cut in half.
+
+The `60s` default interval is a reasonable default, and balances the tradeoff between data volume and observability lag. Increase the interval too high, and delays in critical signals reaching New Relic dashboards and alerts can exacerbate issues.
+
+See "SDK periodic exporting Metric Reader `exportIntervalMillis`" in [tool catalog](#tool-catalog) for details.
+
+### Cardinality [#concept-cardinality]
+
+The measurements that metrics aggregate are associated with a set of attributes. The number of distinct sets of attributes is called cardinality. Cardinality is important because it dictates how much application memory is required to maintain the aggregated state of the measurements, how much data is exported each collection interval, and the data volume in New Relic.
+
+If cardinality is too high, consider omitting attributes which contribute to it. If you control the instrumentation, this could mean recording fewer attributes with each measurement. However, often the instrumentation is not directly configurable.
+
+See "SDK metric views" and "Collector metricstransform processor" in [tool catalog](#tool-catalog) for details on how to drop attributes from metrics.
+
+### Aggregation temporality [#concept-aggregation-temporality]
+
+In OpenTelemetry metrics, the concept of [aggregation temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) defines whether or not the state of aggregated measurements resets after each collection. When aggregation temporality is cumulative, the aggregated state does not reset and metrics represent the cumulative values since application start. When aggregation temporality is delta, the aggregated state resets after each collection and metrics represent the difference since the previous collection.
+
+While New Relic's [OTLP endpoint supports cumulative aggregation temporality](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality), the New Relic metrics architecture is a delta metrics system. Using the default cumulative setting will generally incur more memory usage from SDKs and result in high data ingest. Conversion from cumulative to delta aggregation is a stateful activity, since you need to hold on to the previous point of each time series in order to compute the difference. For this reason, it's best to configure aggregation temporality in the SDK, which saves application memory and avoids extra complexity downstream.
+
+See "SDK delta aggregation temporality" and "Collector cumulativetodelta processor" in [tool catalog](#tool-catalog) for details.
+
+### Meters and Instruments [#concept-meters-instruments]
+
+An [instrumentation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. Each instrumentation library has one (or more) unique scopes, and corresponding meter(s). And each meter has one or more instruments.
+
+Meters or instruments which do not produce high-value metric data can be selectively disabled.
+
+See "SDK disable Tracers, Meter, Loggers" and "SDK metric views" in [tool catalog](#tool-catalog) for details.
+
+## Key concepts: Logs [#concept-logs]
+
+### LogRecord data [#concept-logrecord-data]
+
+OpenTelemetry log records are composed of a variety of top level fields (timestamp, severity, body, etc.) and attributes. The amount of data attached to log records directly corresponds to data volume in New Relic.
+
+Instrumentation libraries (called [log appenders](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/#how-to-create-a-log4j-log-appender) in the OpenTelemetry log space since the OpenTelemetry log bridge API is meant for bridging logs from log APIs into OpenTelemetry) make decisions about what pieces of information to attach to log records, often following the [semantic conventions](https://opentelemetry.io/docs/specs/semconv/).
+
+See "SDK LogRecord limits", "SDK configure log appenders", "Collector filter processor", and "Collector transform processor" in [tool catalog](#tool-catalog) for strategies for managing log data.
+
+### Loggers [#concept-loggers]
+
+An [instrumenation scope](https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope) is a logical unit of application code with telemetry associated with it. For OpenTelemetry logging, each distinct logger (bridged by a log appender using the OpenTelemetry log bridge API) has a unique instrumentation scope.
+
+Loggers which do not produce high-value log data can be selectively disabled.
+
+See "SDK disable Tracers, Meter, Loggers" and "SDK configure log appenders" in [tool catalog](#tool-catalog) for details.
+
+## Pipeline management tool catalog [#tool-catalog]
+
+The following table lists a variety of useful tools for managing your OpenTelemetry data pipeline. Note that OpenTelemetry is a highly extensible ecosystem. If these tools do not suffice, other tools may be available or you may be able to write custom extension logic for the language SDKs or collector to accomplish your goals.
+
+https://opentelemetry.io/docs/specs/otel/trace/sdk/#traceidratiobased
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Collector or SDK?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>[SDK resource detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/#detecting-resource-information-from-the-environment)</td>
+      <td>SDK</td>
+      <td>OpenTelemetry language SDKs package detectors to supply resource attributes based on the environment. Some set of these are often enabled by default with [zero-code instrumenation](https://opentelemetry.io/docs/zero-code/) options like the OpenTelemetry Java Agent. See [language docs](https://opentelemetry.io/docs/languages/) for details on how to enable / disable resource detectors.</td>
+    </tr>
+    <tr>
+      <td>[SDK `ParentBased(root=TraceIdRatioBased) sampler`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)</td>
+      <td>SDK</td>
+      <td>The `ParentBased` sampler with the root set to the `TraceIdRatioBased` sampler is simple and reasonable alternative to the default `ParentBased` sampler with the root set to `AlwaysOn`. With the root set to `TraceIdRatioBased`, spans which represent new traces are sampled probabilistically, with child spans sampled according to the sampling decision of their parent (so long as other applications are configured with the same sampling policy). The sampler can be configured programmatically on the SDK `TracerProvider`, but it's common to use env vars:
+      ```
+      export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+      export OTEL_TRACES_SAMPLER_ARG=0.25
+      ```
+      Set the `TraceIdRatioBased` sampler to sample 25% of root spans.
+      </td>
+    </tr>
+    <tr>
+      <td>[SDK Span limits](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry trace SDK allows span limits to be configured to specify the max length and quantity of attributes, the max number of span events, and the max number of span links. Span limits can be configured programmatically on the SDK `TracerProvider`, but it's common to use env vars:
+      ```
+      export OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
+      export OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT=64
+      ```
+      Set the span limits to align with the New Relic OTLP endpoint's [attribute limits](docs/opentelemetry/best-practices/opentelemetry-otlp/#attribute-limits).</td>
+    </tr>
+    <tr>
+      <td>[SDK LogRecord limits](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#logrecord-limits)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry log SDK allows span limits to be configured to specify the max length and quantity of attributes. LogRecord limits can be configured programmatically on the SDK `LoggerProvider`, but it's common to use env vars:
+      ```
+      export OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
+      export OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT=64
+      ```
+      Set the log record limits to align with the New Relic OTLP endpoint's [attribute limits](docs/opentelemetry/best-practices/opentelemetry-otlp/#attribute-limits).</td>
+    </tr>
+    <tr>
+      <td>SDK disable [Tracers](https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracerconfigurator), [Meters](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#meterconfigurator), [Loggers](https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerconfigurator)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry SDK defines `TracerConfigurator`, `MeterConfigurator`, and `LoggerConfigurator` to configure and disable Tracers, Meters, and Loggers respectively. This concept is currently under development and not available in all language implementations. See individual [language docs](https://opentelemetry.io/docs/languages/) and reach out to language maintainers to check the status.</td>
+    </tr>
+    <tr>
+      <td>[SDK periodic exporting Metric Reader `exportIntervalMillis`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry metric SDK allows the collection interval of the periodic exporting Metric reader to be configured. The interval can be configured programmatically, but it's common to use env vars:
+      ```
+      export OTEL_METRIC_EXPORT_INTERVAL=60000
+      ```
+      Set the collection interval to be 60s (60k ms). This is the default, but can be adjusted to suit.</td>
+    </tr>
+    <tr>
+      <td>[SDK metric views](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry metric SDK allows `MeterProvider` to be configured with views to specify various options including the set of attribute keys to retain, the aggregation type, and dropping the metric. Generally, views are configured programmatically. See individual [language docs](https://opentelemetry.io/docs/languages/) to check for alternatives in your language. For example, OpenTelemetry Java has experimental support configuring views in a [YAML file](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/incubator#view-file-configuration).</td>
+    </tr>
+    <tr>
+      <td>[SDK delta aggregation temporality](https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-configuration)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry metrics SDK allows aggregation temporality to be configured for the OTLP exporter. This temporality can be configured programatically, but it's common to use env vars:
+      ```
+      export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta
+      ```
+      Set the OTLP metric exporter aggregation temporality to be delta, aligning with the New Relic OTLP endpoint's [preference](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality).</td>
+    </tr>
+    <tr>
+      <td>[SDK configure log appenders](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/)</td>
+      <td>SDK</td>
+      <td>The OpenTelemetry log bridge API is designed for use by log appenders, which bridge logs from log APIs into OpenTelemetry. These log appenders may be automatically installed with [zero-code instrumenation](https://opentelemetry.io/docs/zero-code/) options like the OpenTelemetry Java Agent, or may require manual installation steps. They often have configuration options to specify which logs and what data is bridged into OpenTelemetry. Additionally, it's often possible to configure the log API being bridged to specify which logs (baesd on severity or logger name) should be passed to the log appender. See individual [language docs](https://opentelemetry.io/docs/languages/) for details.</td>
+    </tr>
+    <tr>
+      <td>[Collector filter processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor)</td>
+      <td>Collector</td>
+      <td>The collector filter processor can be used to filter out span, metric, and log records from your observability pipeline. For spans, it can function as a simple tail sampler, acting on completed spans but without access to the full trace (Note: this can result in broken traces). For metrics, it can be used to drop metrics or series which are not high value. For logs, it can be used to drop log records which are not high value (e.g. logs with fine grain severity or from noisy loggers).</td>
+    </tr>
+    <tr>
+      <td>[Collector tailsampling processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)</td>
+      <td>Collector</td>
+      <td>The collector tailsampling allows you to decide whether to sample based on completed traces. For example, you can emphasize retaining traces which have errors or which touch high interest areas of the system. The drawback is that tailsampling processor adds complexity to your observability pipeline since it requires that all spans of a trace be routed to the same collector instance, and that the collector hold spans in memory while waiting for the trace to complete. This requires careful planning when your observability pipeline reaches a scale which cannot be handled by a single collector instance.</td>
+    </tr>
+    <tr>
+      <td>[Collector resource processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourceprocessor)</td>
+      <td>Collector</td>
+      <td>The collector resource processor allows you to write simple rules to manipulate resource attributes of spans, metrics, and logs. For example, you can delete attributes which are not high value.</td>
+    </tr>
+    <tr>
+      <td>[Collector metricstransform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor)</td>
+      <td>Collector</td>
+      <td>The collector metric transform processor allows you to manipulate metric data. For example, you can delete series which are not high value, or merge timeseries to reduce cardinality (sometimes called spatial re-aggregation).</td>
+    </tr>
+    <tr>
+      <td>[Collector transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor)</td>
+      <td>Collector</td>
+      <td>The collector transform processor allows you transform observability data using conditions to select data and statements to modify it. For example, you can remove resource attributes, truncate attributes, change top level fields for spans, metrics, and logs records, and much more.</td>
+    </tr>
+    <tr>
+      <td>[Collector cumulativetodelta processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor)</td>
+      <td>Collector</td>
+      <td>The collector cumulativetodelta processor allows you to transform metric aggregation temporality from cumulative to delta. This is useful to align your metrics with the [preferred aggregation temporality of New Relic's OTLP endpoint](docs/opentelemetry/best-practices/opentelemetry-otlp/#metric-aggregation-temporality). Note, translation from cumulative to delta aggregation is a stateful process, requiring the collector to store the last point of each timeseries in memory in order to compute and emit the difference. This requires careful planning of collector memory resources, and structuring the observability pipeline to ensure that all points of the same series arrive at the same collector instance.</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/nav/opentelemetry.yml
+++ b/src/nav/opentelemetry.yml
@@ -2,36 +2,38 @@ title: OpenTelemetry
 path: /docs/opentelemetry
 pages:
   - title: Overview
-    path: /docs/opentelemetry/opentelemetry-introduction 
+    path: /docs/opentelemetry/opentelemetry-introduction
   - title: Get started
     pages:
       - title: Overview
-        path: /docs/opentelemetry/get-started/opentelemetry-get-started-intro 
+        path: /docs/opentelemetry/get-started/opentelemetry-get-started-intro
       - title: OpenTelemetry APM monitoring
         pages:
           - title: Overview
-            path: /docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-intro 
+            path: /docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-intro
           - title: OpenTelemetry APM UI
-            path: /docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui 
+            path: /docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui
       - title: Collector for infrastructure monitoring
-        path: /docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro 
+        path: /docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro
       - title: Collector for data processing
-        path: /docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro 
+        path: /docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro
   - title: OpenTelemetry data in New Relic
     pages:
       - title: Overview
-        path: /docs/opentelemetry/best-practices/opentelemetry-data-overview 
+        path: /docs/opentelemetry/best-practices/opentelemetry-data-overview
       - title: OTLP
         pages:
           - title: New Relic OTLP endpoint
-            path: /docs/opentelemetry/best-practices/opentelemetry-otlp 
+            path: /docs/opentelemetry/best-practices/opentelemetry-otlp
           - title: OTLP troubleshooting
-            path: /docs/opentelemetry/best-practices/opentelemetry-otlp-troubleshooting 
+            path: /docs/opentelemetry/best-practices/opentelemetry-otlp-troubleshooting
       - title: Traces
-        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-traces 
+        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-traces
       - title: Metrics
-        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics 
+        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-metrics
       - title: Logs
-        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-logs 
+        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-logs
       - title: Resources
-        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-resources 
+        path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-resources
+      - title: Manage Data Ingest Volume
+        path: /docs/opentelemetry/best-practices/opentelemetry-manage-ingest-volume

--- a/src/nav/opentelemetry.yml
+++ b/src/nav/opentelemetry.yml
@@ -35,5 +35,5 @@ pages:
         path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-logs
       - title: Resources
         path: /docs/opentelemetry/best-practices/opentelemetry-best-practices-resources
-      - title: Manage Data Ingest Volume
-        path: /docs/opentelemetry/best-practices/opentelemetry-manage-ingest-volume
+      - title: Manage data ingest volume
+        path: /docs/opentelemetry/best-practices/opentelemetry-manage-data-ingest-volume


### PR DESCRIPTION
Adds a new page to the OpenTelemetry docs hierarchy explaining concepts contributing to ingest volume when using OpenTelemetry with New Relic, and tools / strategies to manage it.

cc @alanwest @ally-sassman 