### PR TITLE
Docs: add in release notes for the iOS mobile app version 6.6.0

### DIFF
--- a/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/mobile-app-licenses/ios-application-licenses.mdx
@@ -61,6 +61,20 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
+        [antlr4](https://github.com/antlr/antlr4)
+      </td>
+
+      <td>
+        [BSD-3-CLAUSE](https://github.com/antlr/antlr4/blob/dev/LICENSE.txt)
+      </td>
+
+      <td>
+        Copyright © 2012-2022 The ANTLR Project. All rights reserved.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         [CDMarkdownKit](https://github.com/chrisdhaan/CDMarkdownKit.git)
       </td>
 
@@ -79,7 +93,7 @@ We love open-source software, and use the following in the New Relic iOS app. Th
       </td>
 
       <td>
-        [APACHE-2.0](https://github.com/danielgindi/Charts/blob/master/LICENSE)
+        [APACHE-2.0](https://github.com/ChartsOrg/Charts/blob/master/LICENSE)
       </td>
 
       <td>
@@ -131,20 +145,6 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
     <tr>
       <td>
-        login_manager_sdk
-      </td>
-
-      <td>
-        [New Relic License](https://newrelic.com/terms)
-      </td>
-
-      <td>
-        Copyright © 2010-2023 New Relic, Inc. All rights reserved.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         metric_metadata
       </td>
 
@@ -168,20 +168,6 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
       <td>
         Copyright © 2010-2023 New Relic, Inc. All rights reserved.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        [NavigationBackport](https://github.com/johnpatrickmorgan/NavigationBackport)
-      </td>
-
-      <td>
-        [MIT](https://github.com/johnpatrickmorgan/NavigationBackport/blob/main/LICENSE)
-      </td>
-
-      <td>
-        Copyright © 2022 johnpatrickmorgan {'<johnpatrickmorganuk@gmail.com>'}
       </td>
     </tr>
 
@@ -238,6 +224,20 @@ We love open-source software, and use the following in the New Relic iOS app. Th
 
       <td>
         Copyright © 2019 Timber Software
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [ViewInspector](https://github.com/nalexn/ViewInspector)
+      </td>
+
+      <td>
+        [MIT](https://github.com/nalexn/ViewInspector/blob/0.10.0/LICENSE)
+      </td>
+
+      <td>
+        Copyright © 2019 Alexey
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6060.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6060.mdx
@@ -1,0 +1,14 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2024-07-08'
+version: 6.6.0
+downloadLink: 'https://apps.apple.com/app/id594038638'
+---
+
+This release includes support for Teams if your organization is opted in. 
+
+### New features
+
+* Added support for thresholds in table visualizations
+* Enabled cross account toggling in explorer views
+* Fixes issue where users would encounter a blank screen on iOS 18


### PR DESCRIPTION
* Adds in latest iOS mobile app release notes
* Updates licenses to reflect the latest iOS mobile app