### PR TITLE
fix(K8s): Modified the title of the installation doc

### DIFF
--- a/src/install/config/kubernetes.yaml
+++ b/src/install/config/kubernetes.yaml
@@ -1,6 +1,6 @@
 agentName: kubernetes
 agentType: integration
-title: 'Kubernetes monitoring integration'
+title: 'Install the Kubernetes integration'
 metaDescription: 'Install the Kubernetes integration'
 redirects:
   - /docs/integrations/kubernetes-integration/installation/kubernetes-integration-install-configure


### PR DESCRIPTION
Modified the title of the installation doc, from [Kubernetes monitoring integration](https://docs.newrelic.com/install/kubernetes/) to `Install the Kubernetes integration`.