### PR TITLE
Update extension-additional-instrumentation-modules.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/instrumentation/extension-additional-instrumentation-modules.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/extension-additional-instrumentation-modules.mdx
@@ -263,44 +263,6 @@ These are the incubator modules that are currently available:
 
   <Collapser
     className="freq-link"
-    id="hikaricp-240"
-    title="HikariCP 2.4.0 or higher"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Download link
-          </th>
-
-          <td>
-            [Download the module](https://download.newrelic.com/newrelic/java-agent/extensions/hikaricp-2.4.0.jar)
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Java agent version
-          </th>
-
-          <td>
-            3.12.0 or higher
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    This instrumentation module samples HikariCP database connection pools and reports busy and idle counts in metrics that start with this:
-
-    ```
-    Custom/Database Connection/HikariCP/METRIC_NAME
-    ```
-
-    You can view the metrics with the [metric explorer](/docs/insights/use-insights-ui/explore-data/metric-explorer-search-chart-metrics-sent-new-relic-agents).
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
     id="ratpack-1-6-0"
     title="Ratpack 1.6.0 or higher"
   >


### PR DESCRIPTION
Remove the HikariCP module section since this has been moved into the agent as a proper module.

