### PR TITLE
Update compatibility-requirements-java-agent.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -260,6 +260,9 @@ The agent automatically instruments these frameworks and libraries:
     * Derby 10.11.1.1 to latest
     * Generic JDBC (any JDBC compliant driver)
     * H2 1.0.57 to latest
+    * HikariCP 2.4.0 to latest
+      * Available in agent version 8.13.0 and later
+      * Replaces the HikariCP incubator module. Please remove the HikariCP incubator jar (hikaricp-2.4.0.jar) from the agent's extensions folder if in use.
     * HSQL 1.7.2.2 to latest
     * INet Oracle Driver (Oranxo) 3.06, 3.14
     * INet MERLIA 7.0.3, 8.04.03, and 8.06


### PR DESCRIPTION
Add HikariCP 2.4.0 as a newly supported datastore type instrumentation.
