### PR TITLE
chore(docs): Update aws-firelens-plugin-log-forwarding.mdx to include…

### DIFF
--- a/src/content/docs/logs/forward-logs/aws-firelens-plugin-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/aws-firelens-plugin-log-forwarding.mdx
@@ -58,6 +58,16 @@ To forward your logs from FireLens to New Relic:
       <tbody>
         <tr>
           <td>
+            af-south-1
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.af-south-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             ap-northeast-1
           </td>
 
@@ -128,6 +138,16 @@ To forward your logs from FireLens to New Relic:
 
         <tr>
           <td>
+            ca-west-1
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.ca-west-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             eu-central-1
           </td>
 
@@ -138,11 +158,41 @@ To forward your logs from FireLens to New Relic:
 
         <tr>
           <td>
+            eu-central-2
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.eu-central-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             eu-north-1
           </td>
 
           <td>
             `533243300146.dkr.ecr.eu-north-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            eu-south-1
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.eu-south-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            eu-south-2
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.eu-south-2.amazonaws.com/newrelic/logging-firelens-fluentbit`
           </td>
         </tr>
 
@@ -173,6 +223,26 @@ To forward your logs from FireLens to New Relic:
 
           <td>
             `533243300146.dkr.ecr.eu-west-3.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            me-central-1
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.me-central-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            me-south-1
+          </td>
+
+          <td>
+            `533243300146.dkr.ecr.me-south-1.amazonaws.com/newrelic/logging-firelens-fluentbit`
           </td>
         </tr>
 


### PR DESCRIPTION
## Give us some context

* **What problems does this PR solve?**
Today, July 10th 2024, we have enabled the newrelic-fluent-bit-output Firelens Docker image replication to the new following AWS regions:
  - `af-south-1`: Africa (Cape Town)
  - `ca-west-1`: Canada (Calgary)
  - `eu-central-2`: Europe (Zurich)
  - `eu-south-1`: Europe (Milan)
  - `eu-south-2`: Europe (Spain)
  - `me-central-1`: Middle East (UAE)
  - `me-south-1`: Middle East (Bahrain)
This pull request updates our docs accordingly, where we list the supported regions and corresponding image repositories.

* **Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.**
The images have been republished as part of this PR: https://github.com/newrelic/newrelic-fluent-bit-output/pull/162