### PR TITLE
.NET agent: update compatibility and support docs

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -537,7 +537,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 <DNT>**Elastic.Clients.Elasticsearch**</DNT>
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2
+* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2, 8.14.5
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -714,7 +714,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 <DNT>**Elastic.Clients.Elasticsearch**</DNT>
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2
+* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2, 8.14.5
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 


### PR DESCRIPTION
Adds a new version of Elastic.Clients.Elasticsearch to verified compatible versions for the .NET agent.
