### PR TITLE
Update compatibility-requirements-java-agent.mdx

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -164,9 +164,7 @@ The agent automatically instruments these frameworks and libraries:
       * Scala 2.13: 3.2.x
     * CXF 2.1.3 to latest
     * Grails 1.3.7 to 2.3.x
-    * GraphQL 16.0 - 16.2
-    * GraphQL 17.0 to 20.x
-    * GraphQL 21.0 to latest
+    * GraphQL 16.0 - latest
     * Hibernate 3.3.0.CR1 to 6.0.0.Alpha2
     * Hystrix 1.3.15 to latest
     * Jakarta RESTful WS API 2.1.x to 3.1.x
@@ -333,7 +331,7 @@ The agent automatically instruments these frameworks and libraries:
   >
     * EJB Session Beans 3.0 or higher
     * JMX
-    * JSP (Java Server Pages) 2.0 to 3.0
+    * JSP (Java Server Pages) 2.0 to latest
     * [Scala](/docs/agents/java-agent/frameworks/scala-installation-java) 2.9.3 to latest
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
**Do not merge until go-ahead from java agent team**

This PR is an update to the compatibility docs to follow our upcoming release of Java Agent 8.13.0. 