### PR TITLE
Restore collector infra redirect links

### DIFF
--- a/src/content/docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro.mdx
+++ b/src/content/docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro.mdx
@@ -20,6 +20,17 @@ redirect:
   - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-squid
   - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-statsd
   - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-docker
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hcp-consul
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-hivemq
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-infra-hosts
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-k8s
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-kafka-confluentcloud
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-prometheus
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-redis
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-singlestore
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-squid
+  - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/collector-configuration-examples/opentelemetry-collector-statsd
 ---
 
 The [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) is a vendor-agnostic tool for receiving, processing, and exporting telemetry data. While collector requirements and configuration will vary, it comes with a variety of receivers and processors which make it popular for infrastructure monitoring. It's also common to use the collector for data processing, but this documentation focuses on infrastructure monitoring use cases. See [OpenTelemetry Collector for data processing](/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro) for more information.


### PR DESCRIPTION
Carry forward all the redirect links to the the collector infra page from before the recent consolidation into a single page, and relocation. Ensure that all the redirect links from the pages in this [directory](https://github.com/newrelic/docs-website/tree/3f96c21a5fae39cc75a84910abfc3fedfe6c8cd7/src/content/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/collector-infra-monitoring) exist.