### PR TITLE
Node.js agent: Add link from Node docker to main Node instructions

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
@@ -13,6 +13,10 @@ freshnessValidatedDate: never
 
 You can use our Node.js agent to instrument Node.js applications deployed in Docker containers. This document explains how to build, configure, and deploy your Dockerized Node.js application that has been instrumented with New Relic.
 
+<Callout tip="variant">
+  If you need general help with the Node.js agent installation, see our [main installation instructions](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent).
+</Callout>
+
 ## Instrument your container [#instrument]
 
 With just a few additions your existing Dockerfile can be used with our Node.js agent. You'll configure the agent by running your new Docker image with environment variables set.


### PR DESCRIPTION
Jira NR-287339 said it would be helpful to have a link to the main Node.js instructions from the Docker instructions.