### PR TITLE
Data APIs: Fix spurious link

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/report-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-custom-event-data.mdx
@@ -47,7 +47,8 @@ The use cases for custom events vary widely. Basically they're used for any type
 
 ## Use custom events [#use-events]
 
-After [creating a custom event](/docs/data-apis/custom-data/custom-events/collect-custom-attributes/#enabling-custom), you can use it in a standard NRQL query the same way you would use [any other event](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions).
+After creating a [custom event](#ways), you can use it in a standard NRQL query the same way you would use [any other event](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions).
+
 ```sql
 SELECT *
 FROM YourCustomEvent


### PR DESCRIPTION
Jira NR-287391 noted that the link was to a doc about custom attributes--not events. I switched the link to a local anchor.