### PR TITLE
fix: codeblock not closed correctly

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/ray-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/ray-integration.mdx
@@ -70,10 +70,10 @@ To use the Ray integration, you need to first [install the infrastructure agent]
         targets:
           - description: Ray_Metrics
             urls: ["http://<YOUR_HOST_IP>:64747/metrics", "http://<YOUR_HOST_IP>:44217/metrics", "http://<YOUR_HOST_IP>:44227/metrics"]
-        #    tls_config:
-        #      ca_file_path: "/etc/etcd/etcd-client-ca.crt"
-        #      cert_file_path: "/etc/etcd/etcd-client.crt"
-        #      key_file_path: "/etc/etcd/etcd-client.key"
+            # tls_config:
+              # ca_file_path: "/etc/etcd/etcd-client-ca.crt"
+              # cert_file_path: "/etc/etcd/etcd-client.crt"
+              # key_file_path: "/etc/etcd/etcd-client.key"
         verbose: false
         # Defaults to false. This determines whether or not the integration should run in verbose mode.
         audit: false
@@ -122,7 +122,7 @@ Use the instructions in our [infrastructure agent docs](/docs/infrastructure/ins
 
     ```shell
     sudo systemctl restart newrelic-infra.service
-    ```  
+    ```
     </Step>
     <Step>
 ## View your Ray metrics in New Relic [#view-data]


### PR DESCRIPTION
Stray whitespace in after the triple backticks made the codeblock render incorrectly:

<img width="592" alt="image" src="https://github.com/user-attachments/assets/791bbe72-0af6-4a46-875e-c48447259507">
