### PR TITLE
fix method call to get commits

### DIFF
--- a/scripts/actions/github-release-notes.mjs
+++ b/scripts/actions/github-release-notes.mjs
@@ -15,9 +15,8 @@ if (!token) {
 
 const octokit = github.getOctokit(token);
 
-const { data } = await octokit.repos.compareCommits({
-  base: lastRelease,
-  head: 'develop',
+const { data } = await octokit.rest.repos.compareCommitsWithBasehead({
+  basehead: `${lastRelease}...develop`,
   owner: 'newrelic',
   repo: 'docs-website',
 });


### PR DESCRIPTION
it should've been `octokit.rest.repos.compareCommits` but also `compareCommits` is deprecated so i used `octokit.rest.repos.compareCommitsWithBasehead`