### PR TITLE
infra-agent: EOL updates - Debian 10

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -92,7 +92,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Version 8 or higher
+        CentOS Stream 8 or higher
       </td>
     </tr>
 
@@ -102,7 +102,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Version 10 ("Buster") or higher
+        Version 11 ("bullseye") or higher
       </td>
     </tr>
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/linux-installation/install-infrastructure-monitoring-agent-linux.mdx
@@ -189,12 +189,6 @@ To install infrastructure in Linux, follow these instructions:
        id="debian-repository"
        title={<><img src={osDebian} title="Debian.png" alt="Debian.png" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Debian</>}
      >
-       <DNT>**Debian 10 ("Buster")**</DNT>
-
-       ```bash
-       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt buster main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-       ```
-
        <DNT>**Debian 11 ("Bullseye")**</DNT>
 
        ```bash
@@ -212,12 +206,6 @@ To install infrastructure in Linux, follow these instructions:
        id="ubuntu-repository"
        title={<><img src={osUbuntu} title="ubuntu icon" alt="ubuntu icon" style={{ height: '32px', width: '32px', verticalAlign: 'middle' }}/> Ubuntu</>}
      >
-       <DNT>**Ubuntu 16.04 LTS (Xenial Xerus)**</DNT>
-
-       ```bash
-       echo "deb https://download.newrelic.com/infrastructure_agent/linux/apt xenial main" | sudo tee -a /etc/apt/sources.list.d/newrelic-infra.list
-       ```
-
        <DNT>**Ubuntu 18.04 LTS (Bionic Beaver)**</DNT>
 
        ```bash


### PR DESCRIPTION
## Give us some context

* Debian 10 reached EOL 30th June, 2024.
* Removing old references to Ubuntu in manual install.
* CentOS should be referenced as CentOS Stream. 