### PR TITLE
chore(dotnet): Reworks .NET agent compatibility docs

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core.mdx
@@ -398,7 +398,7 @@ If your application is hosted in ASP.NET Core, the agent automatically creates a
 The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
 * Minimum supported version: 3.17.0
-* Verified compatible versions: 3.17.0, 3.23.0
+* Latest verified compatible version: 3.23.0
           </td>
         </tr>
 
@@ -419,11 +419,11 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 
 <DNT>**System.Data.SqlClient**</DNT>
 * Minimum supported version: 4.4.0
-* Verified compatible versions: 4.4.0, 4.6.1, 4.7.0, 4.8.4, 4.8.5, 4.8.6
+* Latest verified compatible version: 4.8.6
 
 <DNT>**Microsoft.Data.SqlClient**</DNT>
 * Minimum supported version: 1.0.19239.1
-* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0, 5.2.1
+* Latest verified compatible version: 5.2.1
           </td>
         </tr>
 
@@ -443,7 +443,7 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 Use [Npgsql](https://www.nuget.org/packages/Npgsql/)
 
 * Minimum supported version: 4.0.0
-* Verified compatible versions: 4.0.13
+* Latest verified compatible version: 4.0.13
 
 Prior versions of Npgsql may also be instrumented, but duplicate and/or missing metrics are possible.
           </td>
@@ -464,7 +464,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1, 2.24.0, 2.25.0, 2.26.0
+Latest verified compatible version: 2.26.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * IMongoCollection.CountDocuments[Async]
@@ -494,11 +494,11 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
 
 <DNT>**MySql.Data**</DNT>
 * Minimum supported version: 6.10.7
-* Verified compatible versions: 6.10.7, 8.0.15, 8.0.30, 8.0.33, 8.1.0, 8.2.0, 8.3.0, 8.4.0
+* Latest verified compatible version: 8.4.0
 
 <DNT>**MySqlConnector**</DNT>
 * Minimum supported version: 1.0.1
-* Verified compatible versions: 1.0.1, 1.3.13, 2.1.2, 2.3.1, 2.3.3, 2.3.5, 2.3.6
+* Latest verified compatible version: 2.3.6
           </td>
         </tr>
 
@@ -516,7 +516,7 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
           <td>
 Minimum supported version: .0.488
 
-Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116, 2.7.4, 2.7.10, 2.7.17, 2.7.33
+Latest verified compatible version: 2.7.33
 		  </td>
         </tr>
 
@@ -537,18 +537,18 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 <DNT>**Elastic.Clients.Elasticsearch**</DNT>
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2, 8.14.5
+* Latest verified compatible version: 8.14.6
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 
 <DNT>**NEST**</DNT>
 * Minimum supported version: 7.0.0
-* Verified compatible versions: 7.0.0, 7.17.5
+* Latest verified compatible version: 7.17.5
 
 
 <DNT>**Elasticsearch.Net**</DNT>
 * Minimum supported version: 7.0.0
-* Verified compatible versions: 7.0.0, 7.17.5
+* Latest verified compatible version: 7.17.5
           </td>
         </tr>
 
@@ -639,7 +639,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
             * Minimum supported version: 1.4.0
 
-            * Verified compatible versions: 1.4.0, 2.2.0
+            * Latest verified compatible version: 2.2.0
           </td>
         </tr>
 
@@ -676,7 +676,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 	
 * Minimum supported version: 3.5.2
 
-* Verified compatible versions: 3.5.2, 3.6.9, 4.1.3, 5.1.0, 5.2.0, 6.0.0, 6.2.1, 6.4.0, 6.5.0, 6.6.0
+* Latest verified compatible version: 6.6.0
 
           </td>
         </tr>
@@ -691,7 +691,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             
             * Minimum supported version: 7.1.0
             
-            * Verified compatible versions: 7.1.0, 7.3.1, 8.1.1
+            * Latest verified compatible version: 8.1.1
           </td>
         </tr>
 
@@ -723,7 +723,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </th>
 
           <th>
-            Verified compatible versions
+            Latest verified compatible version
           </th>
         </tr>
       </thead>
@@ -740,7 +740,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            2.0.10, 2.0.12, 2.0.13, 2.0.14, 2.0.16
+            2.0.16
           </td>
 
         </tr>
@@ -756,7 +756,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            2.8.0, 2.10.0, 2.11.0, 3.0.1, 3.1.1
+            3.1.1
           </td>
         </tr>
 
@@ -771,7 +771,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            4.5.9, 4.7.15, 5.0.4, 5.2.0, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.3.2
+            5.3.2
           </td>
         </tr>
 
@@ -786,7 +786,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             10.0.0
           </td>
           <td>
-            3.0.0, 3.1.22, 6.0.0, 7.0.0, 8.0.0
+            8.0.0
           </td>
         </tr>
       </tbody>
@@ -816,7 +816,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
           </th>
 
           <th>
-            Verified compatible versions
+            Latest verified compatible version
           </th>
         </tr>
       </thead>
@@ -833,7 +833,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             10.23.0
           </td>
           <td>
-            3.7.200.0, 3.7.301.45
+            3.7.301.45
           </td>
 
         </tr>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework.mdx
@@ -482,7 +482,7 @@ The .NET agent doesn't directly monitor datastore processes. Also, by default th
 The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
 * Minimum supported version: 3.17.0
-* Verified compatible versions: 3.17.0, 3.23.0
+* Latest verified compatible version: 3.23.0
           </td>
         </tr>
 
@@ -497,7 +497,7 @@ The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cos
 Use [CouchbaseNetClient](https://www.nuget.org/packages/CouchbaseNetClient/).
 
 * Minimum supported version: 2.0.0
-* Verified compatible versions: 2.3.8
+* Latest verified compatible version: 2.3.8
 * Known incompatible versions: 2.4.0+
 
 With Couchbase, the following are not instrumented by default in favor of their multi-document counterparts:
@@ -542,15 +542,15 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
 
 <DNT>**System.Data.SqlClient**</DNT>
 * Minimum supported version: 4.4.0
-* Verified compatible versions: 4.4.0, 4.6.1, 4.7.0, 4.8.4, 4.8.5, 4.8.6
+* Latest verified compatible version: 4.8.6
 
 <DNT>**Microsoft.Data.SqlClient**</DNT>
 * Minimum supported version: 1.0.19239.1
-* Verified compatible versions: 1.0.19239.1, 2.1.5, 3.1.1, 4.1.1, 5.0.1, 5.1.1, 5.2.0, 5.2.1
+* Latest verified compatible version: 5.2.1
 
 <DNT>**System.Data**</DNT>
 * Minimum supported version: .NET Framework 4.6.2
-* Verified compatible versions: .NET Framework 4.6.2, 4.7.1, 4.8
+* Latest verified compatible version: 4.8
           </td>
         </tr>
 
@@ -569,7 +569,7 @@ Use SqlClient from [System.Data.SqlClient](https://www.nuget.org/packages/System
           <td>
 Minimum supported version: 1.10.0
 
-Verified compatible versions: 1.10.0
+Latest verified compatible version: 1.10.0
 
 Known incompatible versions: Instance details aren't available in lower version 2.
           </td>
@@ -589,7 +589,7 @@ Known incompatible versions: Instance details aren't available in lower version 
           <td>
 Minimum supported version: 2.3.0
 
-Verified compatible versions: 2.3.0, 2.8.1, 2.13.1, 2.14.1, 2.17.1, 2.19.0, 2.20.0, 2.21.0, 2.22.0, 2.23.0, 2.23.1. 2.24.0, 2.25.0, 2.26.0
+Latest verified compatible version: 2.26.0
 
 Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
 * `IMongoCollection.CountDocuments[Async]`
@@ -619,11 +619,11 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
 
 <DNT>**MySql.Data**</DNT>
 * Minimum supported version: 6.10.7
-* Verified compatible versions: 6.10.7, 8.0.15, 8.0.30, 8.0.33, 8.1.0, 8.2.0, 8.3.0, 8.4.0
+* Latest verified compatible version: 8.4.0
 
 <DNT>**MySqlConnector**</DNT>
 * Minimum supported version: 1.0.1
-* Verified compatible versions: 1.0.1, 1.3.13, 2.1.2, 2.3.1, 2.3.3, 2.3.5, 2.3.6
+* Latest verified compatible version: 2.3.6
           </td>
         </tr>
 
@@ -658,7 +658,7 @@ Use [MySql.Data](https://www.nuget.org/packages/MySql.Data/) or [MySQL Connector
 Use [Npgsql](https://www.nuget.org/packages/Npgsql/)
 
 * Minimum supported version: 4.0.0
-* Verified compatible versions: 4.0.5
+* Latest verified compatible version: 4.0.5
 
 Prior versions of Npgsql may also be instrumented, but duplicate and/or missing metrics are possible.
           </td>
@@ -675,7 +675,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
               name="fe-check"
             />
           </td>
-            * Verified compatible versions: 4.0.40
+            * Latest verified compatible version: 4.0.40
             * Known incompatible versions: 4.0.44 or higher
           <td/>
         </tr>
@@ -693,7 +693,7 @@ Prior versions of Npgsql may also be instrumented, but duplicate and/or missing 
           </td>
           <td>
             * Minimum supported version: 1.0.488
-            * Verified compatible versions: 1.0.488, 1.1.608, 1.2.6, 2.0.601, 2.1.58, 2.2.88, 2.6.66, 2.6.116, 2.7.4, 2.7.10, 2.7.17, 2.7.33
+            * Latest verified compatible version: 2.7.33
           </td>
         </tr>
 
@@ -714,18 +714,18 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 <DNT>**Elastic.Clients.Elasticsearch**</DNT>
 * Minimum supported version: 8.0.0
-* Verified compatible versions: 8.0.0, 8.1.0, 8.1.1, 8.9.1, 8.9.2, 8.9.3, 8.10.0, 8.11.0, 8.12.0, 8.12.1, 8.13.11, 8.13.12, 8.14.0, 8.14.2, 8.14.5
+* Latest verified compatible version: 8.14.6
 * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
 * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 
 <DNT>**NEST**</DNT>
 * Minimum supported version: 7.0.0
-* Verified compatible versions: 7.0.0, 7.17.5
+* Latest verified compatible version: 7.17.5
 
 
 <DNT>**Elasticsearch.Net**</DNT>
 * Minimum supported version: 7.0.0
-* Verified compatible versions: 7.0.0, 7.17.5
+* Latest verified compatible version: 7.17.5
           </td>
         </tr>
 
@@ -799,8 +799,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
       			Minimum supported version: 105.2.3
       			
-      			Verified compatible versions: 105.2.3, 106.0.0, 106.6.10, 106.11.0, 106.12.0, 106.13.0, 106.15.0, 
-      			107.3.0, 108.0.3, 109.0.1
+      			Latest verified compatible version: 111.4.0
       			
       			Known incompatible versions: 106.8.0, 106.9.0, 106.10.0, 106.10.1
           </td>
@@ -845,7 +844,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 
           <th>
-            Verified compatible versions
+            Latest verified compatible version
           </th>
         </tr>
       </thead>
@@ -862,7 +861,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            1.2.10, 2.0.5, 2.0.14, 2.0.16
+            2.0.16
           </td>
         </tr>
 
@@ -877,7 +876,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            1.5.14, 2.5.0, 2.10.0, 3.0.1, 3.1.1
+            3.1.1
           </td>
         </tr>
 
@@ -892,7 +891,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
             9.7.0
           </td>
           <td>
-            4.1.2, 4.3.11, 4.5.11, 5.2.0, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.2.6, 5.2.7, 5.2.8, 5.3.2
+            5.3.2
           </td>
         </tr>
 
@@ -950,7 +949,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
             * Minimum supported version: 1.4.0
 
-            * Verified compatible versions: 1.4.0, 2.2.0
+            * Latest verified compatible version: 2.2.0
           </td>
         </tr>
 
@@ -997,7 +996,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 	
 * Minimum supported version: 3.5.2
 
-* Verified compatible versions: 3.5.2, 5.1.0, 6.2.1, 3.6.9, 4.1.3, 5.2.0, 6.0.0, 6.2.1, 6.4.0, 6.5.0, 6.6.0
+* Latest verified compatible version: 6.6.0
           </td>
         </tr>
 
@@ -1011,7 +1010,7 @@ Use [Elastic.Clients.Elasticsearch](https://www.nuget.org/packages/Elastic.Clien
 
 * Minimum supported version: 7.1.0
 
-* Verified compatible versions: 7.1.0, 7.3.1, 8.1.1
+* Latest verified compatible version: 8.1.1
           </td>
         </tr>
 
@@ -1103,7 +1102,7 @@ If data appears, you've instrumented your app correctly.
           </th>
 
           <th>
-            Verified compatible versions
+            Latest verified compatible version
           </th>
         </tr>
       </thead>
@@ -1120,7 +1119,7 @@ If data appears, you've instrumented your app correctly.
             10.23.0
           </td>
           <td>
-            3.7.200.0, 3.7.301.45
+            3.7.301.45
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Reworks .NET agent compatibility docs to list a single "Latest verified compatible version" rather than an ever-growing list of "Verified compatible versions" - any versions with known incompatibilities are (already) called out specifically in the docs.