### PR TITLE
Python Agent: Add callout for High Security Mode in affected settings

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -1424,7 +1424,7 @@ You must enable [distributed tracing](/docs/apm/agents/nodejs-agent/installation
     When set to `true`, enables AI monitoring.
 
     <Callout variant="important">
-      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
     </Collapser>
 
@@ -1675,7 +1675,7 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
     Most web frameworks (including Django) parameterize SQL queries so they do not actually contain the values used to fill out the query. If you use `raw` mode with one of these frameworks, the Python agent will only see the SQL prior to insertion of values. The parametrized SQL will look much like `obfuscated` mode.
   
     <Callout variant="important">
-      This setting is set to `obfuscated` when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
   
   </Collapser>
@@ -3092,7 +3092,7 @@ Here are custom events settings available via the agent configuration file.
     Allow recording of events to the Event API via [`record_custom_event()`](/docs/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api/).
 
     <Callout variant="important">
-      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
   
   </Collapser>
@@ -4157,7 +4157,7 @@ For some tips on configuring logs for the Python agent, see [Configure Python lo
     If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
 
     <Callout variant="important">
-      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
 
     <Callout variant="caution">
@@ -4667,7 +4667,7 @@ The following settings are available for configuration of machine learning data 
     Set to `true` to enable capturing of the raw inference value.
 
     <Callout variant="important">
-      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
 
   </Collapser>
@@ -4713,7 +4713,7 @@ The following settings are available for configuration of machine learning data 
     Allow recording of machine learning events to the Event API via [`record_ml_event()`](/docs/agents/python-agent/python-agent-api/recordmlevent-python-agent-api/).
   
     <Callout variant="important">
-      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
 
   </Collapser>
@@ -5064,7 +5064,7 @@ Here are assorted other settings available via the agent configuration file.
     If enabled, exception messages will be stripped from error traces before they are sent to the [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector), in order to prevent the inadvertent capture of sensitive information. This option is automatically enabled in high-security mode.
 
     <Callout variant="important">
-      This setting is enabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
     </Callout>
   
   </Collapser>

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -1422,7 +1422,12 @@ You must enable [distributed tracing](/docs/apm/agents/nodejs-agent/installation
     </table>
 
     When set to `true`, enables AI monitoring.
-        </Collapser>
+
+    <Callout variant="important">
+      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+    </Collapser>
+
     <Collapser
         id="ai-monitoring-streaming"
         title="ai_monitoring.streaming.enabled"
@@ -1668,6 +1673,11 @@ For more information about transaction traces, see [Transaction traces](/docs/tr
     When the transaction tracer is [enabled](#txn-tracer-enabled), the agent can record SQL statements. The recorder has three modes: `off` (sends no SQL), `raw` (sends the SQL statement in its original form), and `obfuscated` (strips out numeric and string literals).
 
     Most web frameworks (including Django) parameterize SQL queries so they do not actually contain the values used to fill out the query. If you use `raw` mode with one of these frameworks, the Python agent will only see the SQL prior to insertion of values. The parametrized SQL will look much like `obfuscated` mode.
+  
+    <Callout variant="important">
+      This setting is set to `obfuscated` when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  
   </Collapser>
 
   <Collapser
@@ -3080,6 +3090,11 @@ Here are custom events settings available via the agent configuration file.
     </table>
 
     Allow recording of events to the Event API via [`record_custom_event()`](/docs/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api/).
+
+    <Callout variant="important">
+      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  
   </Collapser>
 </CollapserGroup>
 
@@ -4141,6 +4156,10 @@ For some tips on configuring logs for the Python agent, see [Configure Python lo
 
     If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
 
+    <Callout variant="important">
+      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+
     <Callout variant="caution">
       If you are already sending your application's logs to New Relic using an existing log forwarding solution, be sure to disable that before enabling log forwarding in the agent, in order to prevent being billed for duplicate log data.
     </Callout>
@@ -4646,6 +4665,11 @@ The following settings are available for configuration of machine learning data 
     </table>
 
     Set to `true` to enable capturing of the raw inference value.
+
+    <Callout variant="important">
+      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+
   </Collapser>
 
   <Collapser
@@ -4687,6 +4711,11 @@ The following settings are available for configuration of machine learning data 
     </table>
 
     Allow recording of machine learning events to the Event API via [`record_ml_event()`](/docs/agents/python-agent/python-agent-api/recordmlevent-python-agent-api/).
+  
+    <Callout variant="important">
+      This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+
   </Collapser>
 </CollapserGroup>
 
@@ -5033,6 +5062,11 @@ Here are assorted other settings available via the agent configuration file.
     </table>
 
     If enabled, exception messages will be stripped from error traces before they are sent to the [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector), in order to prevent the inadvertent capture of sensitive information. This option is automatically enabled in high-security mode.
+
+    <Callout variant="important">
+      This setting is enabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api.mdx
@@ -336,7 +336,7 @@ These API calls allow you to collect performance data on your message-passing ar
 </table>
 
 <Callout variant="important">
-  The agent does not collect message queue parameters when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+  The agent does not collect message queue parameters when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
 </Callout>
 
 ## Implement distributed tracing [#distributed-tracing]

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/guide-using-python-agent-api.mdx
@@ -335,6 +335,10 @@ These API calls allow you to collect performance data on your message-passing ar
   </tbody>
 </table>
 
+<Callout variant="important">
+  The agent does not collect message queue parameters when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+</Callout>
+
 ## Implement distributed tracing [#distributed-tracing]
 
 These APIs require [distributed tracing to be enabled](/docs/enable-distributed-tracing).

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api.mdx
@@ -36,7 +36,7 @@ For custom machine learning events, see [the record_ml_event page](/docs/apm/age
 </Callout>
 
 <Callout variant="important">
-  This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+  This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
 </Callout>
 
 ## Parameters

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api.mdx
@@ -35,6 +35,10 @@ For custom machine learning events, see [the record_ml_event page](/docs/apm/age
   For limits and restrictions on `event_type` and `params`, see [Limits and restricted characters](/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes/#limits) and [Reserved words](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
+<Callout variant="important">
+  This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+</Callout>
+
 ## Parameters
 
 <table>

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api.mdx
@@ -121,7 +121,7 @@ This records a [log event](/docs/logs/logs-context/configure-logs-context-python
 </table>
 
 <Callout variant="important">
-  This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+  This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
 </Callout>
 
 ## Return values

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordlogevent-python-agent-api.mdx
@@ -120,6 +120,10 @@ This records a [log event](/docs/logs/logs-context/configure-logs-context-python
   </tbody>
 </table>
 
+<Callout variant="important">
+  This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+</Callout>
+
 ## Return values
 
 None.

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordmlevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordmlevent-python-agent-api.mdx
@@ -34,7 +34,7 @@ This records a machine learning [event](/docs/data-apis/understand-data/new-reli
 </Callout>
 
 <Callout variant="important">
-  This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+  This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
 </Callout>
 
 ## Parameters

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/recordmlevent-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/recordmlevent-python-agent-api.mdx
@@ -33,6 +33,10 @@ This records a machine learning [event](/docs/data-apis/understand-data/new-reli
   For limits and restrictions on `event_type` and `params`, see [Limits and restricted characters](/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes/#limits) and [Reserved words](/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data/#reserved-words).
 </Callout>
 
+<Callout variant="important">
+  This setting is disabled when [High Security Mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+</Callout>
+
 ## Parameters
 
 <table>


### PR DESCRIPTION
This PR adds a callout to each of the settings in the Python Agent that will be overridden when High Security Mode is enabled.  While there is a separate page for High Security Mode to explain this, having a separate callout box for each affected setting can be helpful for customers.