### PR TITLE
fix(AWS): Fixed broken links

### DIFF
--- a/src/content/docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/product-based-pricing/overview-data-retention-components.mdx
@@ -412,7 +412,7 @@ Select a New Relic product to see details about its data retention:
     id="infra"
     title="Infrastructure"
   >
-    For organizations on our [original pricing model](/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing), [Infrastructure](/docs/infrastructure/new-relic-infrastructure/getting-started/welcome-new-relic-infrastructure) data retention policies depend on your Infrastructure [subscription level](https://newrelic.com/infrastructure/pricing) and your infrastructure [compute units pricing model](/docs/accounts-partnerships/accounts/account-billing-usage/compute-unit-pricing-host-pricing#compute-unit). The data retention rules apply the same way whether displaying that data in the UI or querying it.
+    For organizations on our [original pricing model](/docs/accounts/original-accounts-billing/product-pricing/product-based-pricing), [Infrastructure](/docs/infrastructure/new-relic-infrastructure/getting-started/welcome-new-relic-infrastructure) data retention policies depend on your Infrastructure [subscription level](https://newrelic.com/pricing) and your infrastructure [compute units pricing model](/docs/accounts-partnerships/accounts/account-billing-usage/compute-unit-pricing-host-pricing#compute-unit). The data retention rules apply the same way whether displaying that data in the UI or querying it.
 
     <Callout variant="tip">
       Infrastructure data retention policies are separate from your [Insights subscription](/docs/insights/use-insights-ui/manage-account-data/insights-data-retention). 
@@ -1101,7 +1101,7 @@ For organizations on our [original pricing model](/docs/accounts/original-accoun
     id="components-aggregate-metrics"
     title="Aggregate metric timeslice data: reported by APM, Browser, and Mobile"
   >
-    Aggregate [metric timeslice data](/docs/using-new-relic/data/understand-data/new-relic-data-types#timeslice-data) summarizes calls to specific methods in your application: how many times each one was called and response times. In the New Relic UI, you see the class and method names along with their aggregate numbers. Metric data aggregation depends on your [subscription level](http://newrelic.com/application-monitoring/pricing).
+    Aggregate [metric timeslice data](/docs/using-new-relic/data/understand-data/new-relic-data-types#timeslice-data) summarizes calls to specific methods in your application: how many times each one was called and response times. In the New Relic UI, you see the class and method names along with their aggregate numbers. Metric data aggregation depends on your [subscription level](https://newrelic.com/pricing).
 
     <table>
       <thead>

--- a/src/content/docs/apm/reports/api-examples-sla-reports.mdx
+++ b/src/content/docs/apm/reports/api-examples-sla-reports.mdx
@@ -18,7 +18,7 @@ freshnessValidatedDate: never
 New Relic stores SLA data forever for [eligible accounts](http://newrelic.com/application-monitoring/pricing), so you can use the [New Relic REST API](/docs/apm/apis/requirements/new-relic-rest-api-v2-getting-started) to generate service level agreement reports over any time period. For example, you can create SLA reports going back more than 12 days, weeks, or months.
 
 <Callout variant="tip">
-  Access to this feature depends on your [subscription level](https://newrelic.com/application-monitoring/features/edition).
+  Access to this feature depends on your [subscription level](https://newrelic.com/pricing).
 </Callout>
 
 ## Browser metrics for SLAs [#browser-metrics]

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-ec2-monitoring-integration.mdx
@@ -23,7 +23,7 @@ freshnessValidatedDate: never
 
 ## Features [#about]
 
-[Amazon's EC2](https://aws.amazon.com/ec2/) is a central part of Amazon's cloud-computing platform. All New Relic infrastructure monitoring users, regardless of [subscription level](https://newrelic.com/infrastructure/pricing), can use the New Relic infrastructure agent to get a comprehensive, real-time view of their host's performance and status. New Relic's EC2 integration uses the [`ec2Describe*` policy](/docs/infrastructure/infrastructure-integrations/getting-started/integrations-managed-policies) to add data about your EC2 instances to your standard infrastructure monitoring data. We also import [Amazon EC2 custom tags](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) and add it to your data.
+[Amazon's EC2](https://aws.amazon.com/ec2/) is a central part of Amazon's cloud-computing platform. All New Relic infrastructure monitoring users, regardless of https://newrelic.com/pricing), can use the New Relic infrastructure agent to get a comprehensive, real-time view of their host's performance and status. New Relic's EC2 integration uses the [`ec2Describe*` policy](/docs/infrastructure/infrastructure-integrations/getting-started/integrations-managed-policies) to add data about your EC2 instances to your standard infrastructure monitoring data. We also import [Amazon EC2 custom tags](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) and add it to your data.
 
 You can also create [custom attributes](/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#attributes) to be analyzed in New Relic.
 
@@ -91,7 +91,7 @@ This table describes the locations where you can find and use your EC2 data:
 
     <tr>
       <td>
-        [<DNT>**Processes**</DNT> page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-processes-page-inspect-process-performance)
+        [<DNT>**Processes**</DNT> page](/docs/infrastructure/infrastructure-ui-pages/infra-hosts-ui-page/#processes)
       </td>
 
       <td>
@@ -101,7 +101,7 @@ This table describes the locations where you can find and use your EC2 data:
 
     <tr>
       <td>
-        [<DNT>**Network**</DNT> page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-network-page-measure-compare-capacity)
+        [<DNT>**Network**</DNT> page](/docs/infrastructure/infrastructure-ui-pages/infra-hosts-ui-page/#network)
       </td>
 
       <td>
@@ -111,7 +111,7 @@ This table describes the locations where you can find and use your EC2 data:
 
     <tr>
       <td>
-        [<DNT>**Storage**</DNT> page](/docs/infrastructure/new-relic-infrastructure/infrastructure-ui-pages/infrastructure-storage-page-evaluate-disk-usage-efficiency)
+        [<DNT>**Storage**</DNT> page](/docs/infrastructure/infrastructure-ui-pages/infra-hosts-ui-page/#storage)
       </td>
 
       <td>


### PR DESCRIPTION
Fixed several broken links from AWS section.

This is a request from the #help-documentation channel (07-16-2024)