### PR TITLE
Homepage: Remove "other capabilities" section

### DIFF
--- a/src/i18n/translations/en/translation.json
+++ b/src/i18n/translations/en/translation.json
@@ -164,6 +164,12 @@
               "icon": "nr-network-monitoring"
             },
             {
+              "title": "OpenTelemetry",
+              "text": "Instrument your service with OpenTelemetry and gain platform-agnostic observability.",
+              "to": "https://docs.newrelic.com/docs/opentelemetry/opentelemetry-introduction/",
+              "icon": "logo-opentelemetry"
+            },
+            {
               "title": "Serverless function monitoring",
               "text": "Monitor your serverless AWS Lambda functions using both CloudWatch data and code-level instrumentation.",
               "to": "https://docs.newrelic.com/docs/serverless-function-monitoring/overview/",
@@ -174,6 +180,12 @@
               "text": "Simulate end-user activity and API calls from locations around the world, so you can find problems before your users do.",
               "to": "https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/getting-started/get-started-synthetic-monitoring/",
               "icon": "nr-synthetics"
+            },
+            {
+              "title": "Website performance monitoring",
+              "text": "Keep your websites fast and error-free, improve your customer experience, and your conversion rates.",
+              "to": "https://docs.newrelic.com/docs/website-performance-monitoring/increase-user-engagement/",
+              "icon": "nr-dashboard"
             }
           ]
         },
@@ -199,10 +211,22 @@
               "icon": "nr-dashboard"
             },
             {
+              "title": "CodeStream",
+              "text": "Bring performance monitoring into your IDE to improve your software before you commit it to production.",
+              "to": "https://docs.newrelic.com/docs/codestream/start-here/what-is-codestream/",
+              "icon": "nr-notes-edit"
+            },
+            {
               "title": "Distributed tracing",
               "text": "See how data flows across your system and pinpoint where things are getting slowed down. Find, fix, and optimize system and application performance.",
               "to": "https://docs.newrelic.com/docs/distributed-tracing/concepts/introduction-distributed-tracing/",
               "icon": "nr-service-map"
+            },
+            {
+              "title": "Errors inbox",
+              "text": "Find, share, and fix software development errors in one place.",
+              "to": "https://docs.newrelic.com/docs/tutorial-error-tracking/respond-outages/",
+              "icon": "nr-inbox"
             },
             {
               "title": "NRQL",
@@ -219,20 +243,8 @@
           ]
         },
         "s4": {
-          "sectionTitle": "Other capabilities",
+          "sectionTitle": "Security",
           "tiles": [
-            {
-              "title": "CodeStream",
-              "text": "Bring performance monitoring into your IDE to improve your software before you commit it to production.",
-              "to": "https://docs.newrelic.com/docs/codestream/start-here/what-is-codestream/",
-              "icon": "nr-notes-edit"
-            },
-            {
-              "title": "Errors inbox",
-              "text": "Find, share, and fix software development errors in one place.",
-              "to": "https://docs.newrelic.com/docs/tutorial-error-tracking/respond-outages/",
-              "icon": "nr-inbox"
-            },
             {
               "title": "Interactive Application Security Testing (IAST)",
               "text": "Find, verify, and fix high-risk vulnerabilities throughout your software development lifecycle. Fully integrated with vulnerability management.",
@@ -240,28 +252,10 @@
               "icon": "nr-iast"
             },
             {
-                "title": "OpenTelemetry",
-                "text": "Instrument your service with OpenTelemetry and gain platform-agnostic observability.",
-                "to": "https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-introduction/",
-                "icon": "logo-opentelemetry"
-              },
-            {
-              "title": "Other integrations",
-              "text": "Integrate technologies you rely on, like: Terraform, Jenkins, Atlassian Jira, and more.",
-              "to": "https://docs.newrelic.com/docs/more-integrations/best-practices-integration/",
-              "icon": "nr-needs-instrumentation"
-            },
-            {
               "title": "Vulnerability management",
               "text": "Audit your applications, entities, and software libraries for security vulnerabilities and take action to remediate and reduce risk.",
               "to": "https://docs.newrelic.com/docs/vulnerability-management/overview/",
               "icon": "nr-vulnerability"
-            },
-            {
-              "title": "Website performance monitoring",
-              "text": "Keep your websites fast and error-free, improve your customer experience, and your conversion rates.",
-              "to": "https://docs.newrelic.com/docs/website-performance-monitoring/increase-user-engagement/",
-              "icon": "nr-dashboard"
             }
           ]
         },


### PR DESCRIPTION
This is for NR-283782. Here's what I did:

Heading: Other Capabilities > Deleted

Tile: CodeStream > Moved to Data Insights

Tile: Errors inbox > Moved to Data Insights

Tile: IAST > Moved to new Security section

Tile: Vulnerability Management > Moved to new Security section

Tile: Website Performance Monitoring > Moved to Monitor Your Data

Tile: OpenTelemetry > Moved to Monitor Your Data

Tile: Other integraitons > Deleted this grab bag tile