### PR TITLE
Update Documentation to reflect the inability to rotate a REST API key.

### DIFF
--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -445,9 +445,9 @@ We also have several older or less common API key type. To rotate these keys:
         title="Rotate REST API key"
     >
 
-      This is an older key that is not recommended for use by customers, but is still supported by New Relic. We now recommend using the user key instead of the REST API key.
+      This is an older key that is deprecated, but is still supported by New Relic. We now recommend using the user key instead of the REST API key.
 
-      To rotate this key:
+      You cannot rotate this key, you can only delete it.
 
       1. Log in to New Relic on an account with admin permissions.
 
@@ -460,7 +460,7 @@ We also have several older or less common API key type. To rotate these keys:
               src={apisAndDataLocateRestKey}
           />
 
-      4. Click <DNT>**Regenerate REST API**</DNT> and confirm to replace the existing API key.
+      4. Click <DNT>**Delete REST API**</DNT>.
 
     </Collapser>
     <Collapser

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -445,7 +445,7 @@ We also have several older or less common API key type. To rotate these keys:
         title="Rotate REST API key"
     >
 
-      This is an older key that is deprecated, but is still supported by New Relic. We now recommend using the user key instead of the REST API key.
+      This is an older key that's deprecated but still supported by New Relic. We now recommend using the user key instead of the REST API key.
 
       You can't rotate this key, but you can delete it.
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -447,7 +447,7 @@ We also have several older or less common API key type. To rotate these keys:
 
       This is an older key that is deprecated, but is still supported by New Relic. We now recommend using the user key instead of the REST API key.
 
-      You cannot rotate this key, you can only delete it.
+      You can't rotate this key, but you can delete it.
 
       1. Log in to New Relic on an account with admin permissions.
 

--- a/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
+++ b/src/content/docs/apis/intro-apis/new-relic-api-keys.mdx
@@ -460,7 +460,7 @@ We also have several older or less common API key type. To rotate these keys:
               src={apisAndDataLocateRestKey}
           />
 
-      4. Click <DNT>**Delete REST API**</DNT>.
+      4. Click <DNT>**Delete REST API Key**</DNT>.
 
     </Collapser>
     <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

You cannot rotate a REST API Key. These keys are deprecated and users should use a user API key instead.