### PR TITLE
synthetics - remove invalid webelement methods

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
@@ -944,30 +944,6 @@ When a function such as [`$webDriver.findElement`](#webDriver-findElement) retur
       </td>
     </tr>
 
-    <tr id="webElement-getSize">
-      <td>
-        `getSize()`
-      </td>
-
-      <td>
-        Schedules a command to compute the size of this element's bounding box, in pixels.
-
-        Return value: promise
-      </td>
-    </tr>
-
-    <tr id="webElement-getLocation">
-      <td>
-        `getLocation()`
-      </td>
-
-      <td>
-        Schedules a command to compute the location of this element, in page space.
-
-        Return value: promise
-      </td>
-    </tr>
-
     <tr id="webElement-isEnabled">
       <td>
         `isEnabled()`


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Removes invalid methods from Synthetics Chrome 100+ documentation.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
The Selenium WebElements docs show these methods don't exist for the JavaScript API: https://www.selenium.dev/selenium/docs/api/javascript/WebElement.html