### PR TITLE
chore(apm/php): update steps to verify apt repo signature

### DIFF
--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -39,7 +39,7 @@ This is the recommended method for New Relic installation and maintenance.
 
         This command adds `deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`. It creates the file if it does not exist.
 
-    2. Execute the following to register New Relic as an authenticated source where apt-get will look for new packages. To get the New Relic public apt-key from global key servers, you need execute this command as root:
+    2. Trust the New Relic GPG key:
 
         ```bash
         wget -O- https://download.newrelic.com/548C16BF.gpg | sudo gpg --dearmor -o /usr/share/keyrings/download.newrelic.com-newrelic.gpg

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -85,7 +85,7 @@ This is the recommended method for New Relic installation and maintenance.
   <Step>
     ### Configure your application name and New Relic license key [#license-key]
 
-        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [insert your license key and application name by using `debconf`](#preseeding).
+        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [preconfigure your license key and application name by using `debconf`](#preseeding).
   </Step>
   <Step>
     ### Restart your web server or FastCGI Process Manager (FPM) [#fpm]

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -160,7 +160,7 @@ To install the PHP agent manually using `dpkg`:
 
 <InstallFeedback />
 
-## Headless: Insert license key and app name [#preseeding]
+## Headless: Preconfigure license key and app name [#preseeding]
 
 For headless installations, you need to take steps to insert your <InlinePopover type="licenseKey" /> and [application name](/docs/site/naming-your-application). You must use the default php5 packages provided by your distribution. To insert the license key and application name, set values in your `debconf` database by using [`debconf-set-selections`](http://manpages.ubuntu.com/manpages/trusty/en/man1/debconf-set-selections.1.html).
 

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -32,7 +32,7 @@ This is the recommended method for New Relic installation and maintenance.
 
     Complete these two tasks:
 
-    1. Add `http://apt.newrelic.com/debian/` apt repository to `sources.list` (only required once per system):
+    1. Add `http://apt.newrelic.com/debian/` apt repository to `sources.list`:
         ```bash
         echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
         ```

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -149,7 +149,7 @@ To install the PHP agent manually using `dpkg`:
   <Step>
     ### Configure your application name and New Relic license key [#configure-key]
 
-        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [insert your license key and application name by using `debconf`](#preseeding).
+        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [preconfigure your license key and application name by using `debconf`](#preseeding).
   </Step>
   <Step>
     ### Restart your web server or FastCGI Process Manager (FPM) [#restart-server]

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -30,7 +30,7 @@ This is the recommended method for New Relic installation and maintenance.
   <Step>
     ### Configure the New Relic apt repository [#configure-repo]
 
-    Complete these two tasks:
+    New Relic's apt repository configuration is only required once per system. To do so, complete these two tasks:
 
     1. Add `http://apt.newrelic.com/debian/` apt repository to `sources.list`:
         ```bash

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -214,7 +214,7 @@ These keys are located in the `newrelic-php5` package:
   </tbody>
 </table>
 
-For example, you can run these commands to insert your app name and license key:
+For example, you can run these commands to preconfigure your app name and license key:
 
 ```bash
 echo newrelic-php5 newrelic-php5/application-name string "My App Name" | debconf-set-selections

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -32,7 +32,7 @@ This is the recommended method for New Relic installation and maintenance.
 
     Complete these two tasks:
 
-    1. Add `http://apt.newrelic.com/debian/` apt repository to `sources.list` (This step is only required once per system):
+    1. Add `http://apt.newrelic.com/debian/` apt repository to `sources.list` (only required once per system):
         ```bash
         echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
         ```

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -49,10 +49,10 @@ This is the recommended method for New Relic installation and maintenance.
         <DNT>**Configure the New Relic apt repository.**</DNT>
 
         ```bash
-        echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
+        echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
         ```
 
-        This command adds `deb http://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`. It creates the file if it does not exist.
+        This command adds `deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`. It creates the file if it does not exist.
 
         This step is only required once per system.
       </td>
@@ -69,7 +69,7 @@ This is the recommended method for New Relic installation and maintenance.
         This step is required to register New Relic as an authenticated source where apt-get will look for new packages. To get the New Relic public apt-key from global key servers, run the following command as root:
 
         ```bash
-        wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
+        wget -O- https://download.newrelic.com/548C16BF.gpg | sudo gpg --dearmor -o /usr/share/keyrings/download.newrelic.com-newrelic.gpg
         ```
 
         If you do not run this command as root, you may see an error message about the public key.

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -162,7 +162,7 @@ To install the PHP agent manually using `dpkg`:
 
 ## Headless: Preconfigure license key and app name [#preseeding]
 
-For headless installations, you need to take steps to insert your <InlinePopover type="licenseKey" /> and [application name](/docs/site/naming-your-application). You must use the default php5 packages provided by your distribution. To insert the license key and application name, set values in your `debconf` database by using [`debconf-set-selections`](http://manpages.ubuntu.com/manpages/trusty/en/man1/debconf-set-selections.1.html).
+For headless installations, you need to take steps to preconfigure your <InlinePopover type="licenseKey" /> and [application name](/docs/site/naming-your-application). You must use the default php5 packages provided by your distribution. To preconfigure the license key and application name, set values in your `debconf` database by using [`debconf-set-selections`](https://manpages.debian.org/bookworm/debconf/debconf-set-selections.1.en.html).
 
 <Callout variant="important">
   These settings will be ignored if you are not using a packaged PHP. You will be prompted to run `newrelic-install`.

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -44,9 +44,7 @@ This is the recommended method for New Relic installation and maintenance.
         ```bash
         wget -O- https://download.newrelic.com/548C16BF.gpg | sudo gpg --dearmor -o /usr/share/keyrings/download.newrelic.com-newrelic.gpg
         ```
-        <Callout variant="tip">
-          If you don't run this command as root, you may see an error message about the public key.
-        </Callout>
+       This command installs New Relic's GPG key used by `apt` to verify signatures of packages in `http://apt.newrelic.com/debian/` apt repository added in previous step.
   </Step>
 
   <Step>

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -26,27 +26,9 @@ This is the recommended method for New Relic installation and maintenance.
   Run the commands in this procedure as root.
 </Callout>
 
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "75px" }}>
-        Step
-      </th>
-
-      <th>
-        Notes
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        <DNT>**1.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Configure the New Relic apt repository.**</DNT>
+<Steps>
+  <Step>
+    ### Configure the New Relic apt repository [#configure-repo]
 
         ```bash
         echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
@@ -55,16 +37,9 @@ This is the recommended method for New Relic installation and maintenance.
         This command adds `deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`. It creates the file if it does not exist.
 
         This step is only required once per system.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**2.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Trust the New Relic GPG key.**</DNT>
+  </Step>
+  <Step>
+    ### Trust the New Relic GPG key [#gpg-key]
 
         This step is required to register New Relic as an authenticated source where apt-get will look for new packages. To get the New Relic public apt-key from global key servers, run the following command as root:
 
@@ -73,48 +48,28 @@ This is the recommended method for New Relic installation and maintenance.
         ```
 
         If you do not run this command as root, you may see an error message about the public key.
-      </td>
-    </tr>
+  </Step>
 
-    <tr>
-      <td>
-        <DNT>**3.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Update the local package list.**</DNT>
+  <Step>
+    ### Update the local package list [#update-package-list]
 
         Execute the following command as root:
 
         ```bash
         sudo apt-get update
         ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**4.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Install the PHP agent.**</DNT>
+  </Step>
+  <Step>
+    ### Install the PHP agent [#install-php-agent]
 
         Execute the following command to install directly from the New Relic repositories:
 
         ```bash
         sudo apt-get install newrelic-php5
         ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**5.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Non-standard installations: Complete installation manually.**</DNT>
+  </Step>
+  <Step>
+    ### Non-standard installations: Complete installation manually [#manual-install]
 
         If you are not using the default Ubuntu or Debian PHP packages, the `newrelic-php5` package may be unable to configure PHP automatically. You may see this error:
 
@@ -127,34 +82,18 @@ This is the recommended method for New Relic installation and maintenance.
         ```bash
         sudo newrelic-install install
         ```
-      </td>
-    </tr>
+  </Step>
+  <Step>
+    ### Configure your application name and New Relic license key [#license-key]
 
-    <tr>
-      <td>
-        <DNT>**6.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Configure your application name and New Relic license key.**</DNT>
-
-        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [preseed your license key and application name by using `debconf`](#preseeding).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**7.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Restart your web server or FastCGI Process Manager (FPM).**</DNT>
+        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [insert your license key and application name by using `debconf`](#preseeding).
+  </Step>
+  <Step>
+    ### Restart your web server or FastCGI Process Manager (FPM) [#fpm]
 
         Generate traffic for your app, and wait a few minutes for your application to send data to New Relic. Then, [check your app's performance in the New Relic UI](/docs/apm/applications-menu/monitoring/apm-overview-page).
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </Step>
+</Steps>
 
 ## Optional: Unattended installation [#unattended]
 
@@ -172,58 +111,26 @@ DEBIAN_FRONTEND=noninteractive apt-get -y install newrelic-php5
 
 To install the PHP agent manually using `dpkg`:
 
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "75px" }}>
-        Step
-      </th>
-
-      <th>
-        Notes
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        <DNT>**1.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Copy the URL for the package download.**</DNT>
+<Steps>
+  <Step>
+    ### Copy the URL for the package download [#copy-package]
 
         Navigate to the appropriate URL for your architecture, and copy the full URL for the latest `newrelic-daemon`, `newrelic-php5-common`, and `newrelic-php5` packages:
 
         * [32-bit architecture](https://download.newrelic.com/debian/dists/newrelic/non-free/binary-i386/)
         * [64-bit architecture](https://download.newrelic.com/debian/dists/newrelic/non-free/binary-amd64/)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**2.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Download the package.**</DNT>
+  </Step>
+  <Step>
+    ### Download the package [#download-package]
 
         Run the following `wget` command, replacing `https://LINK_TO_PACKAGE` with the full URL of the package:
 
         ```bash
         wget -L https://LINK_TO_PACKAGE
         ```
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**3.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Install the PHP agent.**</DNT>
+  </Step>
+  <Step>
+    ### Install the PHP agent [#manual-install]
 
         Run the appropriate command as root, replacing `X.X.X.X` with the current version:
 
@@ -238,40 +145,24 @@ To install the PHP agent manually using `dpkg`:
         ```bash
         dpkg -i newrelic-php5-common_X.X.X.X_all.deb newrelic-daemon_X.X.X.X_amd64.deb newrelic-php5_X.X.X.X_amd64.deb
         ```
-      </td>
-    </tr>
+  </Step>
+  <Step>
+    ### Configure your application name and New Relic license key [#configure-key]
 
-    <tr>
-      <td>
-        <DNT>**4.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Configure your application name and New Relic license key.**</DNT>
-
-        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [preseed your license key and application name by using `debconf`](#preseeding).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        <DNT>**5.**</DNT>
-      </td>
-
-      <td>
-        <DNT>**Restart your web server or FastCGI Process Manager (FPM).**</DNT>
+        The installation process prompts for your application name and license key. Your <InlinePopover type="licenseKey" /> appears in the account information section of <DNT>**Account settings**</DNT>. For headless installations, you can also [insert your license key and application name by using `debconf`](#preseeding).
+  </Step>
+  <Step>
+    ### Restart your web server or FastCGI Process Manager (FPM) [#restart-server]
 
         Generate traffic for your app, and wait a few minutes for your application to send data to New Relic. Then, [check your app's performance in the New Relic UI](/docs/apm/applications-menu/monitoring/apm-overview-page).
-      </td>
-    </tr>
-  </tbody>
-</table>
+  </Step>
+</Steps>
 
 <InstallFeedback />
 
-## Headless: Preseed license key and app name [#preseeding]
+## Headless: Insert license key and app name [#preseeding]
 
-For headless installations, you can preseed your <InlinePopover type="licenseKey" /> and [application name](/docs/site/naming-your-application). You must use the default php5 packages provided by your distribution. To preseed, set values in your `debconf` database by using [`debconf-set-selections`](http://manpages.ubuntu.com/manpages/trusty/en/man1/debconf-set-selections.1.html).
+For headless installations, you need to take steps to insert your <InlinePopover type="licenseKey" /> and [application name](/docs/site/naming-your-application). You must use the default php5 packages provided by your distribution. To insert the license key and application name, set values in your `debconf` database by using [`debconf-set-selections`](http://manpages.ubuntu.com/manpages/trusty/en/man1/debconf-set-selections.1.html).
 
 <Callout variant="important">
   These settings will be ignored if you are not using a packaged PHP. You will be prompted to run `newrelic-install`.
@@ -323,7 +214,7 @@ These keys are located in the `newrelic-php5` package:
   </tbody>
 </table>
 
-For example, you can run these commands to preseed your app name and license key:
+For example, you can run these commands to insert your app name and license key:
 
 ```bash
 echo newrelic-php5 newrelic-php5/application-name string "My App Name" | debconf-set-selections

--- a/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
+++ b/src/content/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian.mdx
@@ -30,24 +30,23 @@ This is the recommended method for New Relic installation and maintenance.
   <Step>
     ### Configure the New Relic apt repository [#configure-repo]
 
+    Complete these two tasks:
+
+    1. Add `http://apt.newrelic.com/debian/` apt repository to `sources.list` (This step is only required once per system):
         ```bash
         echo 'deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
         ```
 
         This command adds `deb [signed-by=/usr/share/keyrings/download.newrelic.com-newrelic.gpg] http://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`. It creates the file if it does not exist.
 
-        This step is only required once per system.
-  </Step>
-  <Step>
-    ### Trust the New Relic GPG key [#gpg-key]
-
-        This step is required to register New Relic as an authenticated source where apt-get will look for new packages. To get the New Relic public apt-key from global key servers, run the following command as root:
+    2. Execute the following to register New Relic as an authenticated source where apt-get will look for new packages. To get the New Relic public apt-key from global key servers, you need execute this command as root:
 
         ```bash
         wget -O- https://download.newrelic.com/548C16BF.gpg | sudo gpg --dearmor -o /usr/share/keyrings/download.newrelic.com-newrelic.gpg
         ```
-
-        If you do not run this command as root, you may see an error message about the public key.
+        <Callout variant="tip">
+          If you don't run this command as root, you may see an error message about the public key.
+        </Callout>
   </Step>
 
   <Step>


### PR DESCRIPTION
apt-key is deprecated because it adds keys to a trusted shared keyring which in turns causes apt to use all of those keys when verifying signatures of packages from any repository.  This compromises trust in package signing.  The proper way is to specify which key should be used to verify packages from which repository.