### PR TITLE
chore: Clarify our cadence of dropping EOL versions of Node.js

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -136,7 +136,7 @@ The following are proposed time ranges. The actual release date may vary.
   </tbody>
 </table>
 
-The following are proposed time ranges for EOL on older Node.js versions. The actual release date may vary.
+The following are proposed time ranges for EOL on older Node.js versions. We will typically drop support 2-4 months after the [published EOL date from Node.js](https://nodejs.org/en/about/previous-releases).
 
 <table>
   <thead>
@@ -156,6 +156,58 @@ The following are proposed time ranges for EOL on older Node.js versions. The ac
   </thead>
 
   <tbody>
+    <tr>
+      <td>
+        22
+      </td>
+
+      <td>
+        April 2027
+      </td>
+
+      <td>
+        TBD
+      </td>
+    </tr>
+    <tr>
+      <td>
+        20
+      </td>
+
+      <td>
+        April 2026
+      </td>
+
+      <td>
+        TBD
+      </td>
+    </tr>
+    <tr>
+      <td>
+        18
+      </td>
+
+      <td>
+        April 2025
+      </td>
+
+      <td>
+        TBD
+      </td>
+    </tr>
+    <tr>
+      <td>
+        16
+      </td>
+
+      <td>
+        September 2023
+      </td>
+
+      <td>
+        TBD
+      </td>
+    </tr>
     <tr>
       <td>
         14


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Our docs call out that we only support LTS versions.  We also document EOL versions after we drop support. This PR adds upcoming EOL dates from the Node.js docs and clarifies we will drop 2-4 months after the date.
