### PR TITLE
fix(infra-agent): Note about APM inventory data not being collected on the agent

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure.mdx
+++ b/src/content/docs/infrastructure/infrastructure-ui-pages/infrastructure-inventory-page-search-your-entire-infrastructure.mdx
@@ -179,7 +179,8 @@ Inventory is collected from the infrastructure agent's built-in data collectors,
           </td>
 
           <td>
-            APM language agent metadata
+            APM language agent metadata.
+            APM metadata is created in the ingest pipeline when infrastructure and APM agents are running on the same host
           </td>
         </tr>
 
@@ -459,7 +460,8 @@ Inventory is collected from the infrastructure agent's built-in data collectors,
           </td>
 
           <td>
-            APM language agent metadata
+            APM language agent metadata.
+            APM metadata is created in the ingest pipeline when infrastructure and APM agents are running on the same host
           </td>
         </tr>
 


### PR DESCRIPTION
## Give us some context

* Adding a note based on customer feedback: inventory data for APM is not actually collected by the infrastructure agent but added in the backend once the same host is running both the infrastructure agent and APM agents. 