### PR TITLE
fix(infra-agent): centOS stream 8 reached EOL

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -92,7 +92,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        CentOS Stream 8 or higher
+        CentOS Stream 9 or higher
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

* Minor update: CentOS Stream 8 reached EOL so 9 or higher is recommended / officially supported.