### PR TITLE
fix(infra-agent): Explain status_server is enabled by default when using guided install (install recipe)

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -3280,7 +3280,7 @@ See our [github documentation](https://github.com/newrelic/infrastructure-agent/
   >
     <Callout variant="important">
       Requires infrastructure agent version 1.12.0 or higher.
-      Accounts created before July 20, 2020 and/or infrastructure agents installed using the new Guided Install have this variable enabled by default.
+      Accounts created before July 20, 2020 and/or infrastructure agents installed using the new guided install have this variable enabled by default.
     </Callout>
 
     Enables the sending of [process metrics](/attribute-dictionary/?event=ProcessSample) to New Relic.
@@ -5954,7 +5954,7 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
 about the agent/host entity. Therefore, it may take several requests to until the agent provides entity data. 
 
   <Callout variant="important">
-    This setting is enabled by default when you use Guided Install. It helps confirm that the agent installation was successful.
+    This setting is enabled by default when you use the guided install. It helps confirm that the agent installation was successful.
   </Callout>
 
     <table>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -5953,6 +5953,10 @@ If you are having problems with proxy configuration, see [Proxy troubleshooting]
     Returns information about the agent/host entity. A response status code *204* ("No Content") will be returned when the agent still has no information
 about the agent/host entity. Therefore, it may take several requests to until the agent provides entity data. 
 
+  <Callout variant="important">
+    This setting is enabled by default when you use Guided Install. It helps confirm that the agent installation was successful.
+  </Callout>
+
     <table>
       <thead>
         <tr>


### PR DESCRIPTION
## Give us some context

* Customer feedback requesting better explanation on why this setting is enabled by default in some scenarios.