### PR TITLE
Update microsoft-sql-server-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/microsoft-sql/microsoft-sql-server-integration.mdx
@@ -111,10 +111,10 @@ To install the Microsoft SQL Server integration, follow the instructions for you
 
 ## Enable your Microsoft SQL Server [#enable-microsoft-sql-server]
 
-For the Microsoft SQL Server to be monitored, you need a user with `CONNECT`, `VIEW SERVER STATE`, and read access permissions.
+For the Microsoft SQL Server to be monitored, you need a user with `CONNECT`, `VIEW SERVER STATE`, and `VIEW ANY DEFINITION` access permissions.
 
 <Callout variant="tip">
-  Check the Microsoft documentation for details on [creating logins](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-login-transact-sql?view=sql-server-2017) and [users](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-user-transact-sql?view=sql-server-2017) in Microsoft SQL Server.
+  Check the Microsoft documentation for details on [creating logins](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-login-transact-sql?view=sql-server-2017) and [users](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-user-transact-sql?view=sql-server-2017) in Microsoft SQL Server. There is also documentation for [server scope permissions](https://learn.microsoft.com/en-us/sql/t-sql/statements/grant-server-permissions-transact-sql?view=sql-server-ver16#remarks) (the newrelic user will use 3), and on [database roles](https://learn.microsoft.com/en-us/sql/relational-databases/security/authentication-access/database-level-roles?view=sql-server-ver16#fixed-database-roles) (the newrelic user will not get any, and remain only `public`).
 </Callout>
 
 Create a new login and grant the necessary permissions:
@@ -125,7 +125,7 @@ Create a new login and grant the necessary permissions:
     title="For SQL Users"
   >
 
-   1. Create a new login and grant `CONNECT` and `VIEW` permissions:
+   1. Create a new login and grant `CONNECT`, `VIEW SERVER` and `VIEW ANY DEFINITION` permissions:
 
     ```sql
     USE master;
@@ -135,7 +135,7 @@ Create a new login and grant the necessary permissions:
       GRANT VIEW ANY DEFINITION TO newrelic;
     ```
 
-    2. Use the following statements to grant `READ` access privileges to the user:
+    2. Use the following statements to grant `public` DB access privileges to the user:
 
     ```sql
     DECLARE @name SYSNAME
@@ -169,7 +169,7 @@ Create a new login and grant the necessary permissions:
   >
 
 
-    1. Create a new login and grant `CONNECT` and `VIEW` permissions:
+    1. Create a new login and grant `CONNECT`, `VIEW` and `VIEW ANY DEFINITION` permissions:
 
     ```sql
     USE master;
@@ -179,7 +179,7 @@ Create a new login and grant the necessary permissions:
       GRANT VIEW ANY DEFINITION TO [Domain\User];
     ```
 
-    2. Use the following statements to grant `READ` access privileges to the user:
+    2. Use the following statements to grant `public` DB access privileges to the user:
 
     ```sql
     DECLARE @name SYSNAME


### PR DESCRIPTION
fix: clarify the SQL permissions of the newrelic user that our script grants, and provide appropriate links to Microsoft's documentation. This improvement was done after a customer was stuck, as their security department complained the ambiguity.
