### PR TITLE
Synthetics: add release notes for node-browser runtime 2.3.60 & sjm release-363

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-363.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-363.mdx
@@ -1,0 +1,8 @@
+---
+subject: Job Manager
+releaseDate: '2023-05-15'
+version: '257'
+---
+
+### Fixes
+* SJM will not attempt to run a job that does not have a script.

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-363.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-363.mdx
@@ -5,5 +5,5 @@ version: '363'
 ---
 
 ### Fixes
-* Adds null checks for har deserialization
-* Fixes issue with "usesCustomNodeModules" event attribute so it is no longer always false
+* Adds null checks for HAR deserialization
+* Fixes issue with `usesCustomNodeModules` event attribute so it is no longer always false

--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-363.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-363.mdx
@@ -1,8 +1,9 @@
 ---
 subject: Job Manager
-releaseDate: '2023-05-15'
-version: '257'
+releaseDate: '2024-04-10'
+version: '363'
 ---
 
 ### Fixes
-* SJM will not attempt to run a job that does not have a script.
+* Adds null checks for har deserialization
+* Fixes issue with "usesCustomNodeModules" event attribute so it is no longer always false

--- a/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-2.3.60.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-2.3.60.mdx
@@ -1,0 +1,14 @@
+---
+subject: Node browser runtime
+releaseDate: '2024-07-25'
+version: 2.3.60
+---
+
+### Features
+* Uses FIPs-compliant base images for the runtime
+
+### Fixes
+* Fixes step monitors failing when there are errors in the har
+
+### Security Patches
+* Upgrades various packages to mitigate CVE-2024-37890


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Adds release notes for new synthetics-node-browser-runtime release 2.3.60 & missed release notes for synthetics-job-manager release-363 (4/10/2024)
