### PR TITLE
Java agent: Change category to "Related integrations"

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -283,7 +283,7 @@ pages:
                 path: /docs/apm/agents/java-agent/troubleshooting/application-server-jmx-setup
               - title: Java agent identified with security vulnerabilities
                 path: /docs/apm/agents/java-agent/troubleshooting/java-agent-identified-with-security-vulnerabilities
-          - title: Third-party integrations
+          - title: Related integrations
             path: /docs/apm/agents/java-agent/third-party-integrations
             pages:
               - title: Dropwizard integration


### PR DESCRIPTION
The category "Third-party integrations" was too narrow since not all of these use the Java agent.

