### PR TITLE
chore: Add limitations for .NET agent Lambda function support.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
@@ -155,7 +155,7 @@ Since the agent automatically instruments most lambda functions, you can use the
 Limitations:
 
 - Generic lambda Methods are not instrumented automatically. If your lambda method is a generic method, such as ``Task<TResponse> MyMethod<TRequest, TResponse>(TRequest, ILambdaContext)``, the .NET agent is currently not able to instrument that method.
-- AspNetCore lambda functions are currently not supported. AspNetCore lambda functions rely on a generic method that is registered as the lambda handler.
+- AspNetCore lambda functions are currently not supported. AspNetCore lambda functions rely on a generic method that's registered as the lambda handler.
 - The [Lambda Annotations Framework](https://aws.amazon.com/blogs/developer/net-lambda-annotations-framework/) is currently not supported.
 - [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for distributed tracing.
 - Outbound Distributed Tracing for different AWS SDK calls (such as SQS) are not supported.

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
@@ -152,6 +152,16 @@ In a Lambda function, the agent will switch into a "serverless mode" that will d
 
 Since the agent automatically instruments most lambda functions, you can use the [agent NuGet package](https://www.nuget.org/packages/NewRelic.Agent#readme-body-tab) to monitor your lambda functions. You need to manually configure environment variables for your chosen deployment method (see our [installation guide](/install/dotnet/?deployment=nuget#nuget-linux)). This still requires that you set up either the [New Relic Lambda Extension or CloudWatch integration](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/introduction-lambda/#how) to send your data to New Relic.
 
+Limitations:
+
+- Generic lambda Methods are not instrumented automatically. If your lambda method is a generic method, such as ``Task<TResponse> MyMethod<TRequest, TResponse>(TRequest, ILambdaContext)``, the .NET agent is currently not able to instrument that method.
+- AspNetCore lambda functions are currently not supported. AspNetCore lambda functions rely on a generic method that is registered as the lambda handler.
+- The [Lambda Annotations Framework](https://aws.amazon.com/blogs/developer/net-lambda-annotations-framework/) is currently not supported.
+- [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for Distributed Tracing.
+- Outbound Distributed Tracing for different AWS SDK calls (such as SQS) are not supported.
+- If your lambda function handler does not include an [ILambdaContext](https://docs.aws.amazon.com/lambda/latest/dg/csharp-context.html) parameter, the .NET agent will not be able to gather all of the expected information about your lambda function.
+- .NET lambda functions build with the [Native AOT deployment method](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows) are not supported.
+
 <Callout variant="important">
     **Serverless Framework Plugin**
     Support for .NET Lambda functions begins in v5.3.0 of the serverless plugin.  If you are running a version of the serverless plugin prior to v5.3.0, upgrading to v5.3.0 or later will automatically instrument your .NET Lambda functions.  You can [use the exclude statement](https://github.com/newrelic/serverless-newrelic-lambda-layers?tab=readme-ov-file#exclude-optional) in your serverless.yml to exclude functions from automatic instrumentation.

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
@@ -157,10 +157,10 @@ Limitations:
 - Generic lambda Methods are not instrumented automatically. If your lambda method is a generic method, such as ``Task<TResponse> MyMethod<TRequest, TResponse>(TRequest, ILambdaContext)``, the .NET agent is currently not able to instrument that method.
 - AspNetCore lambda functions are currently not supported. AspNetCore lambda functions rely on a generic method that is registered as the lambda handler.
 - The [Lambda Annotations Framework](https://aws.amazon.com/blogs/developer/net-lambda-annotations-framework/) is currently not supported.
-- [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for Distributed Tracing.
+- [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for distributed tracing.
 - Outbound Distributed Tracing for different AWS SDK calls (such as SQS) are not supported.
-- If your lambda function handler does not include an [ILambdaContext](https://docs.aws.amazon.com/lambda/latest/dg/csharp-context.html) parameter, the .NET agent will not be able to gather all of the expected information about your lambda function.
-- .NET lambda functions build with the [Native AOT deployment method](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows) are not supported.
+- If your Lambda function handler does not include an [`ILambdaContext`](https://docs.aws.amazon.com/lambda/latest/dg/csharp-context.html) parameter, the .NET agent will not be able to gather all of the expected information about your lambda function.
+- .NET Lambda functions build with the [Native AOT deployment method](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows) are not supported.
 
 <Callout variant="important">
     **Serverless Framework Plugin**

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
@@ -154,13 +154,13 @@ Since the agent automatically instruments most lambda functions, you can use the
 
 Limitations:
 
-- Generic lambda Methods are not instrumented automatically. If your lambda method is a generic method, such as ``Task<TResponse> MyMethod<TRequest, TResponse>(TRequest, ILambdaContext)``, the .NET agent is currently not able to instrument that method.
-- AspNetCore lambda functions are currently not supported. AspNetCore lambda functions rely on a generic method that's registered as the lambda handler.
-- The [Lambda Annotations Framework](https://aws.amazon.com/blogs/developer/net-lambda-annotations-framework/) is currently not supported.
-- [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for distributed tracing.
-- Outbound Distributed Tracing for different AWS SDK calls (such as SQS) are not supported.
-- If your Lambda function handler does not include an [`ILambdaContext`](https://docs.aws.amazon.com/lambda/latest/dg/csharp-context.html) parameter, the .NET agent will not be able to gather all of the expected information about your lambda function.
-- .NET Lambda functions build with the [Native AOT deployment method](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows) are not supported.
+* Generic lambda Methods are not instrumented automatically. If your lambda method is a generic method, such as `Task<TResponse> MyMethod<TRequest, TResponse>(TRequest, ILambdaContext)`, the .NET agent is currently not able to instrument that method.
+* AspNetCore lambda functions are currently not supported. AspNetCore lambda functions rely on a generic method that's registered as the lambda handler.
+* The [Lambda Annotations Framework](https://aws.amazon.com/blogs/developer/net-lambda-annotations-framework/) is currently not supported.
+* [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for distributed tracing.
+* Outbound distributed tracing for different AWS SDK calls (such as SQS) are not supported.
+* If your Lambda function handler does not include an [`ILambdaContext`](https://docs.aws.amazon.com/lambda/latest/dg/csharp-context.html) parameter, the .NET agent will not be able to gather all of the expected information about your Lambda function.
+* .NET Lambda functions built with the [Native AOT deployment method](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows) are not supported.
 
 <Callout variant="important">
     **Serverless Framework Plugin**


### PR DESCRIPTION
## Give us some context

We have been getting some questions about limitations to the .NET agent's support for lambda functions.  We had an internal docs with a list, but this really needs to be public.  These are in the approaches docs since it should be more discoverable.  I looked and didn't find any other suitable location for them, but please let me know if you have one!

* What problems does this PR solve?
 * Customer and support questions about what is not supported.

Relates to newrelic/newrelic-dotnet-agent#2654