### PR TITLE
Adding Callout for file system restrictions in Synthetic scripts

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors.mdx
@@ -61,7 +61,7 @@ Scripted browsers emulate a custom user experience by scripting browsers that na
 
 6. Click <DNT>**Write script**</DNT> to add your script describing the actions you want the monitor to take. The monitor pre-fills the editor with an example script you can work from, or you can remove this and start from scratch.
 
-7. Click <DNT>**Validate**</DNT> if you want to test your script. This may take a few minutes depending on the script. 
+7. Click <DNT>**Validate**</DNT> if you want to test your script. This may take a few minutes depending on the script.
 
 8. Click <DNT>**Save monitor**</DNT>.
 
@@ -83,7 +83,7 @@ await $webDriver.get("https://my-website.com");
 await $webDriver.findElement($selenium.By.linkText("Configuration Panel"));
 ```
 
-You can also wrap each action in a `then(function(){})` call. But, in that case, the wrapped function must `return` each asynchronous function to ensure they complete before the script moves on: 
+You can also wrap each action in a `then(function(){})` call. But, in that case, the wrapped function must `return` each asynchronous function to ensure they complete before the script moves on:
 
 ```js
 $webDriver.get("https://my-website.com").then(function(){
@@ -395,3 +395,10 @@ await $webDriver.get('http://httpbin.org/user-agent');
 ## Import optional modules [#importing]
 
 You can also import many popular Node.js modules to enhance your test suite, automate the insertion of test data, and simplify complex functions. For more information, see [Importing Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules/).
+
+<Callout variant="important">
+  <DNT>**For Non-Legacy Runtimes**</DNT>
+    The script environment contains write protected directories. If your script requires storing files, prepend any of the following paths to the filename:
+    * `runtime/input-output/input/`
+    * `runtime/input-output/output/`
+</Callout>

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests.mdx
@@ -269,6 +269,12 @@ To make a POST request, use the [`$http.post`](https://github.com/request/reques
   </Collapser>
 </CollapserGroup>
 
+<Callout variant="important">
+  The script environment contains write protected directories. If your script requires storing files, prepend any of the following paths to the filename:
+  * `runtime/input-output/input/`
+  * `runtime/input-output/output/`
+</Callout>
+
 ## Validate results [#validating]
 
 To validate your results, import the `assert` module to define your test case. Call an `assert` method to validate your endpoint's response. If any `assert` functions fail, the entire monitor will be considered a failed check. This may trigger [alert notifications](/docs/synthetics/new-relic-synthetics/using-monitors/alerting-synthetics#alerts) and affect your metrics.


### PR DESCRIPTION
fix(synthetic-script-docs): Adding Callout for file system restrictions in Synthetic scripts

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

  * Adds clarification about acceptable file storage paths to customers using Synthetics script monitors

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.