### PR TITLE
(NR-274256) Add non-ingest endpoints to privatelink docs

### DIFF
--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -267,8 +267,9 @@ These are the New Relic endpoint services available via AWS PrivateLink:
         </tbody>
       </table>
       <Callout variant="important">
-        Review the following constraints when configuring the `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
-        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+ The endpoint services for `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com`, and `synthetics-horde.nr-data.net` do not have associated DNS private names.
+        * To configure access to these services, create a PrivateLink connection to each service endpoint.
+        * For each hostname listed above, create a corresponding Private Hosted Zone (PHZ).
       </Callout>
 
     </TabsPageItem>

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -751,8 +751,9 @@ These are the New Relic endpoint services available via AWS PrivateLink:
         </tbody>
       </table>
       <Callout variant="important">
-        Review the following constraints when configuring the `api.eu.newrelic.com`, `identity-api.eu.newrelic.com`, `infrastructure-command-api.eu.newrelic.com` or `synthetics-horde.eu01.nr-data.net` hostnames:
-        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+The endpoint services for `api.eu.newrelic.com`, `identity-api.eu.newrelic.com`, `infrastructure-command-api.eu.newrelic.com`, and `synthetics-horde.eu01.nr-data.net` do not have associated DNS private names.
+        * To configure access to these services, create a PrivateLink connection to each service endpoint.
+        * For each hostname listed above, create a corresponding Private Hosted Zone (PHZ).
       </Callout>
 
     </TabsPageItem>

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -591,8 +591,9 @@ These are the New Relic endpoint services available via AWS PrivateLink:
         </tbody>
       </table>
       <Callout variant="important">
-        Review the following constraints when configuring the `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
-        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+        The endpoint services for `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com`, and `synthetics-horde.nr-data.net` do not have associated DNS private names.
+        * To configure access to these services, create a PrivateLink connection to each service endpoint.
+        * For each hostname listed above, create a corresponding Private Hosted Zone (PHZ).
       </Callout>
 
     </TabsPageItem>

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -215,6 +215,19 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.us-east-1.vpce-svc-007e743510dc46024`
           </td>
         </tr>
+        <tr>
+          <td>
+
+          </td>
+          <td>
+            `identity-api.newrelic.com`
+            `infrastructure-command-api.newrelic.com`
+          </td>
+
+          <td>
+            `com.amazonaws.vpce.us-east-1.vpce-svc-05adda8aa9c23eaa3`
+          </td>
+        </tr>
 
         <tr>
           <td>
@@ -227,9 +240,36 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.us-east-1.vpce-svc-07d529b1d0f6d417d`
           </td>
         </tr>
+        <tr>
+          <td>
+            New Relic REST API
+          </td>
+          <td>
+            `api.newrelic.com`
+          </td>
+          <td>
+            `com.amazonaws.vpce.us-east-1.vpce-svc-05adda8aa9c23eaa3`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Synthetics job manager
+          </td>
+          <td>
+            `synthetics-horde.nr-data.net`
+          </td>
+          <td>
+            `com.amazonaws.vpce.us-east-1.vpce-svc-05adda8aa9c23eaa3`
+          </td>
+        </tr>
 
         </tbody>
       </table>
+      <Callout variant="important">
+        Review the following constraints when configuring the `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
+        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+      </Callout>
 
     </TabsPageItem>
     <TabsPageItem id="us-endpoints-use2">
@@ -391,7 +431,6 @@ These are the New Relic endpoint services available via AWS PrivateLink:
 
       <Callout variant="important">
         Review the following constraints when configuring the `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
-        - These are only exposed in the `us-east-2` (Ohio) region.
         - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
       </Callout>
 
@@ -500,6 +539,19 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.us-west-2.vpce-svc-006678e8c6f037152`
           </td>
         </tr>
+        <tr>
+          <td>
+
+          </td>
+          <td>
+            `identity-api.newrelic.com`
+            `infrastructure-command-api.newrelic.com`
+          </td>
+
+          <td>
+            `com.amazonaws.vpce.us-west-2.vpce-svc-0e8e1c3c0fd16ff9c`
+          </td>
+        </tr>
 
         <tr>
           <td>
@@ -512,9 +564,36 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.us-west-2.vpce-svc-06192ca8948a1e41c`
           </td>
         </tr>
+        <tr>
+          <td>
+            New Relic REST API
+          </td>
+          <td>
+            `api.newrelic.com`
+          </td>
+          <td>
+            `com.amazonaws.vpce.us-west-2.vpce-svc-0e8e1c3c0fd16ff9c`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Synthetics job manager
+          </td>
+          <td>
+            `synthetics-horde.nr-data.net`
+          </td>
+          <td>
+            `com.amazonaws.vpce.us-west-2.vpce-svc-0e8e1c3c0fd16ff9c`
+          </td>
+        </tr>
 
         </tbody>
       </table>
+      <Callout variant="important">
+        Review the following constraints when configuring the `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
+        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+      </Callout>
 
     </TabsPageItem>
     <TabsPageItem id="eu-endpoints">
@@ -619,6 +698,19 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.eu-central-1.vpce-svc-06d5b2d7e79ddd78e`
             </td>
           </tr>
+          <tr>
+            <td>
+
+            </td>
+            <td>
+              `identity-api.eu.newrelic.com`
+              `infrastructure-command-api.eu.newrelic.com`
+            </td>
+
+            <td>
+              `com.amazonaws.vpce.eu-central-1.vpce-svc-0779388869aeac607`
+            </td>
+          </tr>
 
           <tr>
             <td>
@@ -631,9 +723,36 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             `com.amazonaws.vpce.eu-central-1.vpce-svc-04308d96cf1012913`
             </td>
           </tr>
+          <tr>
+            <td>
+              New Relic REST API
+            </td>
+            <td>
+              `api.eu.newrelic.com`
+            </td>
+            <td>
+              `com.amazonaws.vpce.eu-central-1.vpce-svc-0779388869aeac607`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              Synthetics job manager
+            </td>
+            <td>
+              `synthetics-horde.eu01.nr-data.net`
+            </td>
+            <td>
+              `com.amazonaws.vpce.eu-central-1.vpce-svc-0779388869aeac607`
+            </td>
+          </tr>
 
         </tbody>
       </table>
+      <Callout variant="important">
+        Review the following constraints when configuring the `api.eu.newrelic.com`, `identity-api.eu.newrelic.com`, `infrastructure-command-api.eu.newrelic.com` or `synthetics-horde.eu01.nr-data.net` hostnames:
+        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+      </Callout>
 
     </TabsPageItem>
   </TabsPages>

--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -431,8 +431,9 @@ These are the New Relic endpoint services available via AWS PrivateLink:
       </table>
 
       <Callout variant="important">
-        Review the following constraints when configuring the `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com` or `synthetics-horde.nr-data.net` hostnames:
-        - The endpoint service does not have an associated DNS private name. Create a PrivateLink connected to this service endpoint, and create the Private Hosted Zone (PHZ) for each hostname.
+        The endpoint services for `api.newrelic.com`, `identity-api.newrelic.com`, `infrastructure-command-api.newrelic.com`, and `synthetics-horde.nr-data.net` do not have associated DNS private names.
+        * To configure access to these services, create a PrivateLink connection to each service endpoint.
+        * For each hostname listed above, create a corresponding Private Hosted Zone (PHZ).
       </Callout>
 
     </TabsPageItem>


### PR DESCRIPTION
The neteng team spun up some non-ingest privatelink endpoint services in us-east-1, us-west-2 and eu-central-1. This commit adds them to our docs.

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
We were missing privatelink endpoints for some non-ingest services. Since they are now up we can add them to docs.