### PR TITLE
Update custom event attribute naming syntax to include forward slash

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -97,8 +97,8 @@ When reporting custom events and attributes, follow these general requirements f
       </td>
 
       <td>
-        Event names can be a combination of alphanumeric characters, colons (`:`), and underscores (`_`). Attribute names can include those and also periods (`.`). 
-        
+        Event names can be a combination of alphanumeric characters, colons (`:`), and underscores (`_`). Attribute names can include those as well as periods (`.`) and forward slashes (`/`).
+
         We recommend starting names with a letter: if it starts with something else, you'll need to put backticks around the name when querying. For more on when backticks are required in a query, see [NRQL reference](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-how-nrql-works/#syntax).
 
         Do not use [words reserved for use by NRQL](#reserved-words).


### PR DESCRIPTION
Forward slashes are valid in custom event attributes, so let's include them in the documentation.