### PR TITLE
Clarify and fix environment variables

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/introduction-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/introduction-lambda.mdx
@@ -235,6 +235,12 @@ When you instrument New Relic's Lambda layer with the CLI your environment varia
             <td>Your New Relic account ID or parent ID, if it exists</td>
         </tr>
         <tr>
+            <td>`NEW_RELIC_LAMBDA_HANDLER`</td>
+            <td></td>
+            <td></td>
+            <td>Used by our [handler wrapper](https://github.com/newrelic/newrelic-lambda-layers/blob/master/java/src/main/java/com/newrelic/java/HandlerWrapper.java) to find your function's actual handler.</td>
+        </tr>
+        <tr>
             <td>`NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`</td>
             <td>`false`</td>
             <td>`true`, `false`</td>
@@ -283,6 +289,12 @@ When you instrument New Relic's Lambda layer with the CLI your environment varia
             <td>Your New Relic account ID or parent ID, if it exists</td>
         </tr>
         <tr>
+            <td>`NEW_RELIC_LAMBDA_HANDLER`</td>
+            <td></td>
+            <td></td>
+            <td>Used by our [handler wrapper](https://github.com/newrelic/newrelic-lambda-layers/blob/master/nodejs/index.js) to find your function's actual handler. Not needed if using the [manual wrapping method](https://github.com/newrelic/newrelic-lambda-layers?tab=readme-ov-file#note-on-performance-for-es-module-functions).</td>
+        </tr>
+        <tr>
             <td>`NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`</td>
             <td>`false`</td>
             <td>`true`, `false`</td>
@@ -304,7 +316,7 @@ When you instrument New Relic's Lambda layer with the CLI your environment varia
             <td>`NEW_RELIC_LOG_ENABLED`</td>
             <td>`false`</td>
             <td>`true`,`false`</td>
-            <td>Outputs agent logs to CloudWatch</td>
+            <td>Enable or disable agent logging</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_LOG_LEVEL`</td>
@@ -368,6 +380,12 @@ You can find more environment variables in our [Node.js configuration documentat
             <td>`false`</td>
             <td>`true`, `false`</td>
             <td>Enable or disable distributed tracing (Java excluded)</td>
+        </tr>
+        <tr>
+            <td>`NEW_RELIC_LAMBDA_HANDLER`</td>
+            <td></td>
+            <td></td>
+            <td>Used by our [handler wrapper](https://github.com/newrelic/newrelic-lambda-layers/blob/master/python/newrelic_lambda_wrapper.py) to find your function's actual handler.</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_NO_CONFIG_FILE`</td>
@@ -441,13 +459,13 @@ You can find more environment variables in our [Python configuration documentati
             <td>`NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`</td>
             <td>`false`</td>
             <td>`true`, `false`</td>
-            <td>Enable or disable distributed tracing </td>
+            <td>Enable or disable distributed tracing</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_LAMBDA_HANDLER`</td>
             <td></td>
             <td></td>
-            <td>Set to your function's original Handler value</td>
+            <td>Used by our [handler wrapper](https://github.com/newrelic/newrelic-lambda-layers/blob/master/ruby/newrelic_lambda_wrapper.rb) to find your function's actual handler.</td>
         </tr>
     </tbody>
 </table>
@@ -466,7 +484,7 @@ You can find more environment variables in our [Python configuration documentati
         <tbody>
             <tr>
                 <td>`CORECLR_ENABLE_PROFILING`</td>
-                <td></td>
+                <td>`0`</td>
                 <td>`0`, `1`</td>
                 <td>Required: This must be set to `1` in order for the .NET agent to instrument your application.</td>
             </tr>
@@ -482,14 +500,24 @@ You can find more environment variables in our [Python configuration documentati
                 <td></td>
                 <td>`/opt/lib/newrelic-dotnet-agent`</td>
                 <td>Required: This must be set to `/opt/lib/newrelic-dotnet-agent` in order for the .NET agent to
-                    instrument your application.</td>
+                    instrument your application via our layer.</td>
             </tr>
             <tr>
                 <td>`CORECLR_PROFILER_PATH`</td>
                 <td></td>
                 <td>`/opt/lib/newrelic-dotnet-agent/libNewRelicProfiler.so`</td>
                 <td>Required: This must be set to `/opt/lib/newrelic-dotnet-agent/libNewRelicProfiler.so` in order for
-                    the .NET agent to instrument your application.</td>
+                    the .NET agent to instrument your application via our layer.</td>
+            </tr>
+            <tr>
+                <td>`NEW_RELIC_LAMBDA_HANDLER`</td>
+                <td>the runtime handler</td>
+                <td></td>
+                <td>Required if the runtime handler is not in the `assembly::class::method` format, where `assembly` is
+                    the name of the DLL file that contains your code, `class` is the complete name (including namespace)
+                    of the class that contains your handler method, and `method` is the name of the function handler
+                    method. Note that this environment variable has the same name as one used by our [handler wrappers](https://github.com/search?q=NEW_RELIC_LAMBDA_HANDLER+AND+%28path%3Anodejs%2Findex.js+OR+path%3Apython%2Fnewrelic_lambda_wrapper.py+OR+path%3Aruby%2Fnewrelic_lambda_wrapper.rb+OR+path%3A**%2Fjava%2FHandlerWrapper.java%29++owner%3Anewrelic+&type=code&ref=advsearch)
+                    for other agents, though the .NET agent does not need to utilize a handler wrapper.</td>
             </tr>
             <tr>
                 <td>`NEW_RELIC_APP_NAME`</td>
@@ -499,21 +527,27 @@ You can find more environment variables in our [Python configuration documentati
                     integration.</td>
             </tr>
             <tr>
+                <td>`NEW_RELIC_LOG_ENABLED`</td>
+                <td>`1`</td>
+                <td>`1`, `0`</td>
+                <td>Enable or disable agent logging</td>
+            </tr>
+            <tr>
+                <td>`NEW_RELIC_LOG_CONSOLE`</td>
+                <td>`0`</td>
+                <td>`1`, `0`</td>
+                <td>Must be set to `1` to output logs to CloudWatch</td>
+            </tr>
+            <tr>
                 <td>`NEW_RELIC_LOG_LEVEL`</td>
                 <td>`info`</td>
                 <td>`info`, `debug`, `finest`</td>
                 <td>Agent log level</td>
             </tr>
-            <tr>
-                <td>`NEWRELIC_LOG_CONSOLE`</td>
-                <td>`0`</td>
-                <td>`1`, `0`</td>
-                <td>Send log messages to the console</td>
-            </tr>
         </tbody>
     </table>
 
-    You can find more environment variables in our [.NET configuration documentation](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
+    You can find more environment variables in our [.NET configuration documentation](/docs/apm/agents/net-agent/configuration/net-agent-configuration/) and [layerless instrumentation](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/enable-serverless-monitoring-aws-lambda-layerless/#dotnet) method.
 
 </Collapser>
 
@@ -542,19 +576,13 @@ You can find more environment variables in our [Python configuration documentati
             <td>`NEW_RELIC_LICENSE_KEY`</td>
             <td></td>
             <td></td>
-            <td>Your New Relic ingest key. This overrides Secrets Manager</td>
+            <td>Your New Relic ingest key. This overrides Secrets Manager.</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_LICENSE_KEY_SECRET`</td>
             <td>`NEW_RELIC_LICENSE_KEY`</td>
             <td></td>
             <td>Custom secret name in AWS Secrets Manager</td>
-        </tr>
-        <tr>
-            <td>`NEW_RELIC_LAMBDA_HANDLER`</td>
-            <td></td>
-            <td></td>
-            <td>If you don't use New Relic's [manual wrapping method](https://github.com/newrelic/newrelic-lambda-layers?tab=readme-ov-file#note-on-performance-for-es-module-functions) this is your your function's handler.</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_DATA_COLLECTION_TIMEOUT`</td>
@@ -566,7 +594,7 @@ You can find more environment variables in our [Python configuration documentati
             <td>`NEW_RELIC_EXTENSION_LOGS_ENABLED`</td>
             <td>`true`</td>
             <td>`true`, `false`</td>
-            <td>Enable or disable `NR_EXT` log lines</td>
+            <td>Enable or disable `[NR_EXT]` log lines</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_EXTENSION_LOG_LEVEL`</td>
@@ -582,15 +610,15 @@ You can find more environment variables in our [Python configuration documentati
         </tr>
         <tr>
             <td>`NEW_RELIC_LOG_ENDPOINT`</td>
-            <td></td>
-            <td></td>
-            <td>Set to https://log-api.newrelic.com/log/v</td>
+            <td>`https://log-api.newrelic.com/log/v1`</td>
+            <td>`https://log-api.newrelic.com/log/v1`, `https://log-api.eu.newrelic.com/log/v1`</td>
+            <td>Logs endpoint</td>
         </tr>
         <tr>
             <td>`NEW_RELIC_TELEMETRY_ENDPOINT`</td>
-            <td>Set to [US endpoint](https://cloud-collector.newrelic.com/aws/lambda/v1)</td>
-            <td></td>
-            <td>Optional [EU endpoint](https://github.com/newrelic/newrelic-lambda-extension/blob/3c4218dd7727d0b0467f24f0902b616b7f4e46b7/telemetry/client.go#L24-L27)</td>
+            <td>`https://cloud-collector.newrelic.com/aws/lambda/v1`</td>
+            <td>`https://cloud-collector.newrelic.com/aws/lambda/v1`, `https://cloud-collector.eu01.nr-data.net/aws/lambda/v1`</td>
+            <td>Telemetry endpoint</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Add `NEW_RELIC_LAMBDA_HANDLER` to agents and remove from the extension since the extension only really checks to ensure it is set. The variable is actually used by our layers in the handler wrapper code.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.