### PR TITLE
chore: Updated release date for Node 16, and removed unused `@newrelic/next`

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -205,7 +205,7 @@ The following are proposed time ranges for EOL on older Node.js versions. We wil
       </td>
 
       <td>
-        TBD
+        As of July 31, 2024, we have discontinued support for Node.js 16 with v12 of the Node.js agent.
       </td>
     </tr>
     <tr>

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
@@ -33,9 +33,9 @@ node -r newrelic server.js
 ```
 
 <Callout variant="important">
-  For a Next.js app use our standalone [`@newrelic/next` agent](https://github.com/newrelic/newrelic-node-nextjs) instead of the `newrelic` agent, for example:
+  For a Next.js app load our agent via `NODE_OPTIONS`, for example:
   ```shell
-  node -r @newrelic/next server.js
+  NODE_OPTIONS='-r newrelic' next start
   ```
 </Callout>
 

--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
@@ -33,7 +33,7 @@ node -r newrelic server.js
 ```
 
 <Callout variant="important">
-  For a Next.js app load our agent via `NODE_OPTIONS`, for example:
+  For a Next.js app, load our agent via `NODE_OPTIONS`, such as:
   ```shell
   NODE_OPTIONS='-r newrelic' next start
   ```

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker.mdx
@@ -31,7 +31,6 @@ With just a few additions your existing Dockerfile can be used with our Node.js 
 
 2. Depending on how your container is setup, you can edit the `ENTRYPOINT` to include `newrelic` module first with Node.js `-r`/`--require` flag by running `node -r newrelic YOUR_PROGRAM.js`. If you can't control how your program runs, you can load the `newrelic` module before any other module in your program by adding `require('newrelic')`.
 
-  For Next.js use `@newrelic/next` instead of `newrelic`.
    <Callout variant="tip">
      If you have an npm script to run your program such as `npm start`, you can programmatically modify this script by running `npm pkg set scripts.start="node -r newrelic your-program.js"`.
    </Callout>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -60,7 +60,7 @@ To install the Node.js agent:
 3. Use the command `npm install newrelic` for each application you want to monitor. If your app is using [one of these Apollo Server modules](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) install our Apollo plugin with `npm install @newrelic/apollo-server-plugin`. [More details about using `@newrelic/apollo-server-plugin` can be found here](https://github.com/newrelic/newrelic-node-apollo-server-plugin/tree/main#readme).
 
   <Callout variant="important">
-    If you're using Next.js, here is an [example Next.js app](https://github.com/newrelic/newrelic-node-nextjs#example-project)
+    If you're using Next.js, see [this example of a Next.js app](https://github.com/newrelic/newrelic-node-nextjs#example-project)
   </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -60,7 +60,7 @@ To install the Node.js agent:
 3. Use the command `npm install newrelic` for each application you want to monitor. If your app is using [one of these Apollo Server modules](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) install our Apollo plugin with `npm install @newrelic/apollo-server-plugin`. [More details about using `@newrelic/apollo-server-plugin` can be found here](https://github.com/newrelic/newrelic-node-apollo-server-plugin/tree/main#readme).
 
   <Callout variant="important">
-    If you're using Next.js use our standalone [`@newrelic/next` agent](https://github.com/newrelic/newrelic-node-nextjs) instead of the `newrelic` agent. [Here is an example Next.js app](https://github.com/newrelic/newrelic-node-nextjs#example-project)
+    If you're using Next.js, here is an [example Next.js app](https://github.com/newrelic/newrelic-node-nextjs#example-project)
   </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.
@@ -77,7 +77,10 @@ To install the Node.js agent:
   ```
 
   <Callout variant="important">
-    For Next.js use `-r @newrelic/next` instead of `-r newrelic`.
+    For a Next.js app load our agent via `NODE_OPTIONS`:
+    ```dockerfile
+    CMD ["NODE_OPTIONS='-r newrelic'", "next", "start"]
+    ```
 
     If you're using Nest.JS and the `nest start` command to start the application, modify its startup binary to load the New Relic agent: `nest start --exec 'node -r newrelic'`. [Here is an example Nest.js application](https://github.com/newrelic/newrelic-node-examples/tree/main/nestjs)
   </Callout>
@@ -86,16 +89,16 @@ To install the Node.js agent:
 
   <Callout variant="important">
     If you are unable to use the `-r` require flag you can also use `require('newrelic')` as the first line of your app's main module. <DNT>**Note**</DNT>   If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler `require('newrelic')` will cause instrumentation issues.
-  
+
   If neither of these options work for you, (e.g. asynchronously loading api keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentLoadedModule):
-    
+
     ```js
-    // module loaded before newrelic 
+    // module loaded before newrelic
     const expressModule = require('express');
-    
+
     // load the agent
     const newrelic = require('newrelic');
-  
+
     // instrument express after the agent has been loaded
     newrelic.instrumentLoadedModule(
       'express',    // the module's name, as a string


### PR DESCRIPTION
…

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
 We are about to release v12.0.0 of Node.js agent.  This a semver major that drops support for Node.js 16.  It also merges the standalone Next.js instrumentation (@newrelic/next) into the agent so I updated docs to reflect that as well.