### PR TITLE
(PLANNED FOR 8/5) Release go 3.34.0

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
@@ -40,7 +40,7 @@ Got lots of Go logs? Check out our [tutorial on how to optimize and manage them]
   <tbody>
     <tr>
       <td>
-        [log](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/logWriter)
+        [Standard Library Log](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/logWriter)
       </td>
       <td>
         No

--- a/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
@@ -22,6 +22,65 @@ With our Go language <InlinePopover type="apm" /> agent, you can get <DNT>**logs
 Got lots of Go logs? Check out our [tutorial on how to optimize and manage them](/docs/tutorial-large-logs/get-started-managing-large-logs/). 
 </Callout>
 
+## Supported Logging Libraries
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Library
+      </th>
+
+      <th>
+        Supports Attribute Collection
+      </th>
+
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        [log](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/logWriter)
+      </td>
+      <td>
+        No
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [slog](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrslog)
+      </td>
+      <td>
+        Yes
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [Logrus](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrlogrus)
+      </td>
+      <td>
+        Yes
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [Zap](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrzap)
+      </td>
+      <td>
+        Yes
+      </td>
+    </tr>
+    <tr>
+      <td>
+        [ZeroLog](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/zerologWriter)
+      </td>
+      <td>
+        Coming Soon
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Configuring logs in context in the agent  [#automatic]
 
 Modifications to the Go agent's config options are needed in order to use the following logs in context features.

--- a/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-go.mdx
@@ -22,7 +22,7 @@ With our Go language <InlinePopover type="apm" /> agent, you can get <DNT>**logs
 Got lots of Go logs? Check out our [tutorial on how to optimize and manage them](/docs/tutorial-large-logs/get-started-managing-large-logs/). 
 </Callout>
 
-## Supported Logging Libraries
+## Supported logging libraries [#supported-libraries]
 
 <table>
   <thead>
@@ -32,7 +32,7 @@ Got lots of Go logs? Check out our [tutorial on how to optimize and manage them]
       </th>
 
       <th>
-        Supports Attribute Collection
+        Supports attribute collection?
       </th>
 
     </tr>
@@ -48,7 +48,7 @@ Got lots of Go logs? Check out our [tutorial on how to optimize and manage them]
     </tr>
     <tr>
       <td>
-        [slog](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrslog)
+        [Slog](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/nrslog)
       </td>
       <td>
         Yes
@@ -75,7 +75,7 @@ Got lots of Go logs? Check out our [tutorial on how to optimize and manage them]
         [ZeroLog](https://github.com/newrelic/go-agent/tree/master/v3/integrations/logcontext-v2/zerologWriter)
       </td>
       <td>
-        Coming Soon
+        Coming soon
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-34-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-34-0.mdx
@@ -14,14 +14,14 @@ We recommend updating to the latest agent version as soon as it's available. If 
 
 ## 3.34.0
 ### Added
-  - logcontext-v2/nrlogrus can now collect user attributes
-  - logcontext-v2/nrslog can now collect user attributes
-  - use slog to manage Go agent logs with the new nrslog library
-  - use zerolog go manage Go agent logs with the new nrzerolog library
-  - support for `RegisterTLSConfig` in nrmysql
+  - `logcontext-v2/nrlogrus` can now collect user attributes
+  - `logcontext-v2/nrslog` can now collect user attributes
+  - Use `slog` to manage Go agent logs with the new `nrslog` library
+  - Use `zerolog` go manage Go agent logs with the new `nrzerolog` library
+  - Support for `RegisterTLSConfig` in `nrmysql`
 ### Fixed
-  - logcontext-v2/nrlogrus will still print user logs without isses if the Go agent has already been shut down.
-  - switched protobuff to google.golang.org/protobuff in modfile
+  - `logcontext-v2/nrlogrus` will still print user logs without issues if the Go agent has already been shut down
+  - Switched `protobuff` to `google.golang.org/protobuff` in `modfile`
 
 ### Support statement
 We use the latest version of the Go language. At a minimum, you should use no version of Go older than what's supported by the Go team themselves.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-34-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-34-0.mdx
@@ -1,0 +1,28 @@
+---
+subject: Go agent
+releaseDate: '2024-08-01'
+version: 3.34.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.34.0'
+features: ["Configure the agnet to write logs using Zerolog", "Configure the agnet to write logs using log/slog","Collect user attributes in Logrus using nrlogrus","Collect user attributes in Slog using nrslog","Added support for the RegisterTLSConfig method in nrmysql"]
+bugs: ["Fixed a bug where nrlogurs would not print any logs if the agnet was shut down","Switched protobuff to google.golang.org/protobuff in the go agent"]    
+security: []
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+## 3.34.0
+### Added
+  - logcontext-v2/nrlogrus can now collect user attributes
+  - logcontext-v2/nrslog can now collect user attributes
+  - use slog to manage Go agent logs with the new nrslog library
+  - use zerolog go manage Go agent logs with the new nrzerolog library
+  - support for `RegisterTLSConfig` in nrmysql
+### Fixed
+  - logcontext-v2/nrlogrus will still print user logs without isses if the Go agent has already been shut down.
+  - switched protobuff to google.golang.org/protobuff in modfile
+
+### Support statement
+We use the latest version of the Go language. At a minimum, you should use no version of Go older than what's supported by the Go team themselves.
+See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.


### PR DESCRIPTION
Prepares the Go agent docs for the 3.34.0 release.

Release planned for tomorrow 4PM EST.