### PR TITLE
chore(Java): update Java agent's Kafka compatibility

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -223,12 +223,12 @@ The agent automatically instruments these frameworks and libraries:
     * Apache Httpclient from 3.1 to 5.x
     * java.net.HttpURLConnection
     * JMS from 1.1 to latest
-    * [Kafka Client Metrics](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 0.10.0.0 to latest (for metrics)
-    * [Kafka Client Spans](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 0.11.0.0 to latest (for distributed tracing)
-    * [Kafka Connect](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 1.0.0 to latest (for metrics)
-    * [Kafka Connect](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 2.0.0 to latest (for distributed tracing and transaction data)
-    * [Kafka Streams](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 1.0.0 to latest (for metrics)
-    * [Kafka Streams](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 2.0.0 to latest (for distributed tracing and transaction data)
+    * [Kafka Client Metrics](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 0.10.0.0 to 3.6.x (for metrics)
+    * [Kafka Client Spans](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 0.11.0.0 to 3.6.x (for distributed tracing)
+    * [Kafka Connect](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 1.0.0 to 3.6.x (for metrics)
+    * [Kafka Connect](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 2.0.0 to 3.6.x (for distributed tracing and transaction data)
+    * [Kafka Streams](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 1.0.0 to 3.6.x (for metrics)
+    * [Kafka Streams](/docs/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues) 2.0.0 to 3.6.x (for distributed tracing and transaction data)
     * OkHttp 3.6.0 to latest
     * Ning AsyncHttpClient 1.x
     * Play WS


### PR DESCRIPTION
## Give us some context

The Java agent is not compatible with the newest version of Kafka. Updating docs to reflect that.