### PR TITLE
Fix example code in Python AWS lambda docs

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/enable-serverless-monitoring-aws-lambda-layerless.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/enable-serverless-monitoring-aws-lambda-layerless.mdx
@@ -215,7 +215,7 @@ If you're using a Lambda function without a layer, you'll need to instrument New
   >
     To instrument your Python Lambda:
 
-    1. Download our Python agent package as well as the Python lambda wrapper package and place them in the same directory as your function. To do this, use pip:
+    1. Download both the Python agent and Python lambda wrapper packages and place them in the same directory as your function code. To do this, use pip:
 
        ```bash
        pip install -t . newrelic newrelic-lambda
@@ -225,7 +225,8 @@ If you're using a Lambda function without a layer, you'll need to instrument New
          If you use Homebrew, you may get this error: `DistutilsOptionError: must supply either home or prefix/exec-prefix -- not both`. For details, see the [Homebrew GitHub post](https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md#note-on-pip-install---user).
        </Callout>
 
-    2. In your Lambda code, import the Python agent module and the Python lambda wrapper module. Next, decorate the handler function using the New Relic decorator. <DNT>**The New Relic package must be imported first in your code.**</DNT> Here's an example:
+    2. In your Lambda code, import both the Python agent module and the Python lambda wrapper module. 
+    3. Decorate the handler function using the New Relic decorator. The New Relic package must be imported first in your code. Here's an example:
 
       ```py
       import newrelic.agent

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/enable-serverless-monitoring-aws-lambda-layerless.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/enable-serverless-monitoring-aws-lambda-layerless.mdx
@@ -215,34 +215,37 @@ If you're using a Lambda function without a layer, you'll need to instrument New
   >
     To instrument your Python Lambda:
 
-    1. Download our Python agent package and place it in the same directory as your function. To do this, use pip:
+    1. Download our Python agent package as well as the Python lambda wrapper package and place them in the same directory as your function. To do this, use pip:
 
        ```bash
-       pip install -t . newrelic
+       pip install -t . newrelic newrelic-lambda
        ```
 
        <Callout variant="important">
          If you use Homebrew, you may get this error: `DistutilsOptionError: must supply either home or prefix/exec-prefix -- not both`. For details, see the [Homebrew GitHub post](https://github.com/Homebrew/brew/blob/master/docs/Homebrew-and-Python.md#note-on-pip-install---user).
        </Callout>
 
-    2. In your Lambda code, import the Python agent module and decorate the handler function using the New Relic decorator. <DNT>**The New Relic package must be imported first in your code.**</DNT> Here's an example:
+    2. In your Lambda code, import the Python agent module and the Python lambda wrapper module. Next, decorate the handler function using the New Relic decorator. <DNT>**The New Relic package must be imported first in your code.**</DNT> Here's an example:
 
-       ```py
-       import newrelic.agent
-       newrelic.agent.initialize()
-       @newrelic.agent.lambda_handler()
-       def handler(event, context):
-         ...
-       ```
+      ```py
+      import newrelic.agent
+      from newrelic_lambda.lambda_handler import lambda_handler
+
+      newrelic.agent.initialize()
+      
+      @lambda_handler()
+      def handler(event, context):
+        ...
+      ```
 
     3. Optional: You can also add [custom events](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#custom-event) to your Lambda using the [`record_custom_event` API](/docs/agents/python-agent/python-agent-api/record_custom_event). Here's an example:
 
-       ```py
-       @newrelic.agent.lambda_handler()
-       def handler(event, context):
-       newrelic.agent.record_custom_event('CustomEvent', {'foo': 'bar'})
-         ...
-       ```
+      ```py
+      @lambda_handler()
+      def handler(event, context):
+        newrelic.agent.record_custom_event('CustomEvent', {'foo': 'bar'})
+        ...
+      ```
 
     4. Zip your `lambda_function.py` and `newrelic/` folder together using these guidelines:
 


### PR DESCRIPTION
This PR fixes some example code in the Python section of the AWS lambda docs.  The original code example template has been deprecated (and non-functional) in 5+ years.