### PR TITLE
fix(Log management): renew supported debian version list

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -74,7 +74,7 @@ How you forward your logs depends on how you installed the infrastructure agent,
 * Amazon Linux 2 and 2023 (ARM64 not supported for 2023)
 * CentOS version 8 and 9 Stream (Rocky Linux and AlmaLinux are also supported)
 * RedHat version 8 and 9
-* Debian version 9 (Strech), 10 (Buster) and 11 (Bullseye).
+* Debian version 11 (Bullseye) and 12 (Bookworm).
 * SUSE Linux Enterprise Server (SLES) version 12 and 15 (ARM64 not supported).
 * Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x (LTS versions).
     * Ubuntu 24.04.x LTS is not supported yet.


### PR DESCRIPTION
* What problems does this PR solve?
  *  Fix a gap in the description of supported debian versions between two documents that [infrastructure agent](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) and its [built-in log forwarding](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/) feature (this doc).

* Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.
  * Remove version 9 (Stretch) and 10 (Buster) from list, since these are [officially deprecated](https://endoflife.date/debian) and are no longer on the [infrastructure agent compatibility list](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/)
  * Add version 12 (Bookworm) to list. infra and log are working fine and also I confirmed logging team supports it.