### PR TITLE
chore(PHP): Corrects Dockerfile example

### DIFF
--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -92,8 +92,6 @@ To set up the PHP agent and daemon in the same Docker container:
         && NR_INSTALL_USE_CP_NOT_LN=1 NR_INSTALL_SILENT=0 ./*/newrelic-install install \
         # Configure the agent to use license key from NEW_RELIC_LICENSE_KEY env var:
         && sed -ie 's/[ ;]*newrelic.license[[:space:]]=.*/newrelic.license=${NEW_RELIC_LICENSE_KEY}/' $(php-config --ini-dir)/newrelic.ini \
-        # Configure the agent to send telemetry to collector defined by NEW_RELIC_HOST env var:
-        && sed -ie 's/[ ;]*newrelic.daemon.collector_host[[:space:]]=.*/newrelic.daemon.collector_host=${NEW_RELIC_HOST}/' $(php-config --ini-dir)/newrelic.ini \
         # Configure the agent to use app name from NEW_RELIC_APP_NAME env var:
         && sed -ie 's/[ ;]*newrelic.appname[[:space:]]=.*/newrelic.appname=${NEW_RELIC_APP_NAME}/' $(php-config --ini-dir)/newrelic.ini \
         # Cleanup temporary files:

--- a/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
+++ b/src/content/docs/apm/agents/php-agent/advanced-installation/docker-other-container-environments-install-php-agent.mdx
@@ -82,7 +82,7 @@ To set up the PHP agent and daemon in the same Docker container:
     RUN \
         cd /tmp \
         # Discover the latest released version:
-        && export NEW_RELIC_AGENT_VERSION=$(curl -s https://download.newrelic.com/php_agent/release/ | grep --only-match '[1-9][0-9]\?\(\.[0-9]\+\)\{3\}' | head -n1) \
+        && export NEW_RELIC_AGENT_VERSION=$(curl -s https://download.newrelic.com/php_agent/release/ | grep -o '[1-9][0-9]\?\(\.[0-9]\+\)\{3\}' | head -n1) \
         # Discover libc provider
         && export NR_INSTALL_PLATFORM=$(ldd --version 2>&1 | grep -q musl && echo "linux-musl" || echo "linux") \
         # Download the discovered version:


### PR DESCRIPTION
PHP team member here.

These instructions were recently modified and we have determined that this change needs to be made to be sure the instructions work on the Alpine Linux platform, which does not use GNU `grep` and requires using a different form of the `--only-match` option .  The change is compatible with GNU `grep` systems as well as these will accept the `-o` short form of the option.

Additionally, the `newrelic.daemon.collector_host` option was included in the original documentation.  After review we have determined this option should not be changed generally and so it was removed from the example.