### PR TITLE
feat: change page_action refs to generic_events as per new browser agent version change

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -28,17 +28,17 @@ Reports a browser PageAction event along with a name and optional attributes.
 ## Requirements
 
 * Browser Pro or Pro+SPA agent (v593 or higher)
-* If you're using npm to install the browser agent, you must enable the `page_action` feature when instantiating the `BrowserAgent` class. In the `features` array, add the following:
+* If you're using npm to install the browser agent, you must enable the `generic_events` feature when instantiating the `BrowserAgent` class. In the `features` array, add the following:
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action';
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events';
 
   const options = {
     info: { ... },
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
     ]
   }
   ```

--- a/src/content/docs/browser/new-relic-browser/browser-apis/finished.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/finished.mdx
@@ -26,10 +26,10 @@ Records an additional time point as "finished" in a session trace, and sends the
 ## Requirements
 
 * Browser Pro, Pro+SPA, or Lite agent (v593 or higher)
-* If you're using npm to install the browser agent, you must enable the `page_action` and/or `session_trace` feature when instantiating the `BrowserAgent` class. In the `features` array, add the following:
+* If you're using npm to install the browser agent, you must enable the `generic_events` and/or `session_trace` feature when instantiating the `BrowserAgent` class. In the `features` array, add the following:
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action'
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events'
   import { SessionTrace } from '@newrelic/browser-agent/features/session_trace';
 
   const options = {
@@ -37,7 +37,7 @@ Records an additional time point as "finished" in a session trace, and sends the
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
       SessionTrace
     ]
   }

--- a/src/content/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -38,7 +38,7 @@ See [Feature names](#feature-names) for a list of feature names which can be sta
 * ajax
 * jserrors
 * metrics
-* page_action
+* generic_events
 * page_view_event
 * page_view_timing
 * session_replay
@@ -63,7 +63,7 @@ NREUM.init = {
   ajax: {autoStart: false},
   jserrors: {autoStart: false},
   metrics: {autoStart: false},
-  page_action: {autoStart: false},
+  generic_events: {autoStart: false},
   page_view_event: {autoStart: false},
   page_view_timing: {autoStart: false},
   session_replay: {autoStart: false},

--- a/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -23,17 +23,17 @@ Informa un evento PageAction browser junto con un nombre y un atributo opcional.
 
 * Browser Pro o agente Pro+SPA (v593 o superior)
 
-* Si está utilizando npm para instalar el agente del navegador, debe habilitar la característica `page_action` al crear una instancia de la clase `BrowserAgent` . En la matriz `features` , agregue lo siguiente:
+* Si está utilizando npm para instalar el agente del navegador, debe habilitar la característica `generic_events` al crear una instancia de la clase `BrowserAgent` . En la matriz `features` , agregue lo siguiente:
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action';
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events';
 
   const options = {
     info: { ... },
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
     ]
   }
   ```

--- a/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/finished.mdx
+++ b/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/finished.mdx
@@ -23,10 +23,10 @@ Registra un punto de tiempo adicional como "terminado" en un rastreo de sesión 
 
 * Browser Pro, Pro+SPA o Lite agente (v593 o superior)
 
-* Si está utilizando npm para instalar el agente del navegador, debe habilitar la característica `page_action` y/o `session_trace` al crear una instancia de la clase `BrowserAgent` . En la matriz `features` , agregue lo siguiente:
+* Si está utilizando npm para instalar el agente del navegador, debe habilitar la característica `generic_events` y/o `session_trace` al crear una instancia de la clase `BrowserAgent` . En la matriz `features` , agregue lo siguiente:
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action'
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events'
   import { SessionTrace } from '@newrelic/browser-agent/features/session_trace';
 
   const options = {

--- a/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -68,7 +68,7 @@ Al ejecutar esta función con un valor válido, el agente del navegador iniciar�
 * ajax
 * jserrors
 * métrica
-* page_action
+* generic_events
 * page_view_event
 * page_view_timing
 * session_replay
@@ -91,7 +91,7 @@ NREUM.init = {
   ajax: {autoStart: false},
   jserrors: {autoStart: false},
   metrics: {autoStart: false},
-  page_action: {autoStart: false},
+  generic_events: {autoStart: false},
   page_view_event: {autoStart: false},
   page_view_timing: {autoStart: false},
   session_replay: {autoStart: false},
@@ -100,13 +100,6 @@ NREUM.init = {
   // other configurations
   // ...
 }
-```
-
-### "Iniciando" una lista de características diferidas
-
-```js
-newrelic.start(['ajax', 'jserrors', 'page_action'])
-// ajax, jserrors, and page_action features will now start harvesting
 ```
 
 ### "Iniciando" todas las características diferidas

--- a/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -23,17 +23,17 @@ newrelic.addPageAction(string $name[, JSON object $attributes])
 
 * Browser Pro または Pro+SPA エージェント (v593 以降)
 
-* npm を使用してブラウザ エージェントをインストールしている場合は、 `BrowserAgent`クラスをインスタンス化するときに`page_action`機能を有効にする必要があります。`features`配列に以下を追加します。
+* npm を使用してブラウザ エージェントをインストールしている場合は、 `BrowserAgent`クラスをインスタンス化するときに`generic_events`機能を有効にする必要があります。`features`配列に以下を追加します。
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action';
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events';
 
   const options = {
     info: { ... },
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
     ]
   }
   ```

--- a/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/finished.mdx
+++ b/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/finished.mdx
@@ -23,10 +23,10 @@ newrelic.finished(time $time_stamp)
 
 * Browser Pro、Pro+SPA、または Lite エージェント (v593 以降)
 
-* npm を使用してブラウザ エージェントをインストールしている場合は、 `BrowserAgent`クラスをインスタンス化するときに、 `page_action`および/または`session_trace`機能を有効にする必要があります。`features`配列に以下を追加します。
+* npm を使用してブラウザ エージェントをインストールしている場合は、 `BrowserAgent`クラスをインスタンス化するときに、 `generic_events`および/または`session_trace`機能を有効にする必要があります。`features`配列に以下を追加します。
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action'
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events'
   import { SessionTrace } from '@newrelic/browser-agent/features/session_trace';
 
   const options = {
@@ -34,7 +34,7 @@ newrelic.finished(time $time_stamp)
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
       SessionTrace
     ]
   }

--- a/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -73,7 +73,7 @@ NREUM.init = {
   ajax: {autoStart: false},
   jserrors: {autoStart: false},
   metrics: {autoStart: false},
-  page_action: {autoStart: false},
+  generic_events: {autoStart: false},
   page_view_event: {autoStart: false},
   page_view_timing: {autoStart: false},
   session_replay: {autoStart: false},

--- a/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -23,17 +23,17 @@ newrelic.addPageAction(string $name[, JSON object $attributes])
 
 * Browser Pro 또는 Pro+SPA 에이전트(v593 이상)
 
-* npm을 사용하여 브라우저 에이전트를 설치하는 경우 `BrowserAgent` 클래스를 인스턴스화할 때 `page_action` 기능을 활성화해야 합니다. `features` 배열에 다음을 추가합니다.
+* npm을 사용하여 브라우저 에이전트를 설치하는 경우 `BrowserAgent` 클래스를 인스턴스화할 때 `generic_events` 기능을 활성화해야 합니다. `features` 배열에 다음을 추가합니다.
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action';
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events';
 
   const options = {
     info: { ... },
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
     ]
   }
   ```

--- a/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/finished.mdx
+++ b/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/finished.mdx
@@ -23,10 +23,10 @@ newrelic.finished(time $time_stamp)
 
 * Browser Pro, Pro+SPA 또는 Lite 에이전트(v593 이상)
 
-* npm을 사용하여 브라우저 에이전트를 설치하는 경우 `BrowserAgent` 클래스를 인스턴스화할 때 `page_action` 및/또는 `session_trace` 기능을 활성화해야 합니다. `features` 배열에 다음을 추가합니다.
+* npm을 사용하여 브라우저 에이전트를 설치하는 경우 `BrowserAgent` 클래스를 인스턴스화할 때 `generic_events` 및/또는 `session_trace` 기능을 활성화해야 합니다. `features` 배열에 다음을 추가합니다.
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action'
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events'
   import { SessionTrace } from '@newrelic/browser-agent/features/session_trace';
 
   const options = {
@@ -34,7 +34,7 @@ newrelic.finished(time $time_stamp)
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
       SessionTrace
     ]
   }

--- a/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -41,7 +41,7 @@ newrelic.start()
 
 * 측정항목
 
-* page_action
+* generic_events
 
 * page_view_event
 
@@ -73,7 +73,7 @@ NREUM.init = {
   ajax: {autoStart: false},
   jserrors: {autoStart: false},
   metrics: {autoStart: false},
-  page_action: {autoStart: false},
+  generic_events: {autoStart: false},
   page_view_event: {autoStart: false},
   page_view_timing: {autoStart: false},
   session_replay: {autoStart: false},

--- a/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -23,17 +23,17 @@ Relata um evento PageAction do browser junto com um nome e um atributo opcional.
 
 * Browser Pro ou agente Pro+SPA (v593 ou superior)
 
-* Se estiver usando o npm para instalar o agente browser, você deverá ativar o recurso `page_action` ao instanciar a classe `BrowserAgent` . Na matriz `features` , adicione o seguinte:
+* Se estiver usando o npm para instalar o agente browser, você deverá ativar o recurso `generic_events` ao instanciar a classe `BrowserAgent` . Na matriz `features` , adicione o seguinte:
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action';
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events';
 
   const options = {
     info: { ... },
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
     ]
   }
   ```

--- a/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/finished.mdx
+++ b/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/finished.mdx
@@ -23,10 +23,10 @@ Registra um ponto de tempo adicional como “terminado” em uma sessão de rast
 
 * Agente browser Pro, Pro+SPA ou Lite (v593 ou superior)
 
-* Se estiver usando o npm para instalar o agente browser, você deverá ativar o recurso `page_action` e/ou `session_trace` ao instanciar a classe `BrowserAgent` . Na matriz `features` , adicione o seguinte:
+* Se estiver usando o npm para instalar o agente browser, você deverá ativar o recurso `generic_events` e/ou `session_trace` ao instanciar a classe `BrowserAgent` . Na matriz `features` , adicione o seguinte:
 
   ```js
-  import { PageAction } from '@newrelic/browser-agent/features/page_action'
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events'
   import { SessionTrace } from '@newrelic/browser-agent/features/session_trace';
 
   const options = {
@@ -34,7 +34,7 @@ Registra um ponto de tempo adicional como “terminado” em uma sessão de rast
     loader_config: { ... },
     init: { ... },
     features: [
-      PageAction
+      GenericEvents
       SessionTrace
     ]
   }

--- a/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -41,7 +41,7 @@ Ao executar esta função com um valor válido, o agente browser iniciará o rec
 
 * métrica
 
-* page_action
+* generic_events
 
 * page_view_event
 
@@ -73,7 +73,7 @@ NREUM.init = {
   ajax: {autoStart: false},
   jserrors: {autoStart: false},
   metrics: {autoStart: false},
-  page_action: {autoStart: false},
+  generic_events: {autoStart: false},
   page_view_event: {autoStart: false},
   page_view_timing: {autoStart: false},
   session_replay: {autoStart: false},


### PR DESCRIPTION
The browser agent is updating to use the entry field `generic_events` instead of `page_action`.  This PR updates the refs that point at those entry points.  The `page_action` entry will continue to work in the agent for the foreseeable future, but the preferred method of implementation going forward should be `generic_events`.

Please reach out if we need to add more by way of callouts or other disclaimers.