### PR TITLE
fix(Docs): Wanted to avoid using EOL in titles

### DIFF
--- a/src/content/eol/2024/08/eol-08-01-24.md
+++ b/src/content/eol/2024/08/eol-08-01-24.md
@@ -1,5 +1,5 @@
 ---
-title: "EOL for Google Core Web Vital FID metric"
+title: "End of life for Google Core Web Vital FID metric"
 summary: "On September 9, 2024, Google is deprecating the FID metric, in favor of Interaction to Next Paint (“INP”)."
 publishDate: '2024-08-01'
 eolEffectiveDate: '2024-09-09'


### PR DESCRIPTION
A minor fix that explodes the EOL acronym in the title