### PR TITLE
feat: Mark Entity as reserved event

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -180,7 +180,7 @@ Avoid using the following reserved words as names for events and attributes. Oth
       <td>
         For your `eventType` value, avoid using:
 
-        * `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` (such as `Metric2` or `Metric1Minute`).
+        * `Entity`, `EntityUpdate`, `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` or `Entity[0-9]` (such as `Metric2`, `Metric1Minute`, `Entity1HOUR`).
         * `Public_` and strings prefixed with `Public_`.
 
         These event types are reserved for use by New Relic. Events passed in with these `eventType` values will be dropped.

--- a/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -180,7 +180,7 @@ Avoid using the following reserved words as names for events and attributes. Oth
       <td>
         For your `eventType` value, avoid using:
 
-        * `Entity`, `EntityUpdate`, `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` or `Entity[0-9]` (such as `Metric2`, `Metric1Minute`, `Entity1HOUR`).
+        * `Entity`, `EntityUpdate`, `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` or `Entity[0-9]` (such as `Metric2`, `Metric1Minute`, or `Entity1HOUR`).
         * `Public_` and strings prefixed with `Public_`.
 
         These event types are reserved for use by New Relic. Events passed in with these `eventType` values will be dropped.

--- a/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -180,7 +180,8 @@ Avoid using the following reserved words as names for events and attributes. Oth
       <td>
         For your `eventType` value, avoid using:
 
-        * `Entity`, `EntityUpdate`, `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` or `Entity[0-9]` (such as `Metric2`, `Metric1Minute`, or `Entity1HOUR`).
+        * `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` (such as `Metric2` or `Metric1Minute`).
+        * `Entity`, `EntityUpdate`, and strings prefixed with `Entity[0-9]` (such as `Entity2` or `Entity1HOUR`).
         * `Public_` and strings prefixed with `Public_`.
 
         These event types are reserved for use by New Relic. Events passed in with these `eventType` values will be dropped.


### PR DESCRIPTION
We are making Entity a reseved event name. This change is to update documentation to reflect this change.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

We have some upcoming changes that require us to reserve the Entity event name. This change is to update our public documentation to reflect this so we don't have conflicts down the road.