### PR TITLE
chore(style guide): Delete docs library service info

### DIFF
--- a/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
@@ -55,7 +55,7 @@ Swiftype should reindex within a minute. Note that that record will be removed f
 You may want to manually remove an existing record from the index in these cases:
 
 * When you want to quickly remove a record for a page that was deleted with no redirects
-* If you notice that there is more than one record for a page that changed URLs recently (one for the old URL, one for the new one that was discovered outside of the redirect).
+* If you notice that there's more than one record for a page that changed URLs recently (one for the old URL, one for the new one that was discovered outside of the redirect).
 
 To manually remove a record from the index:
 

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
@@ -8,17 +8,9 @@ import styleguideNewRelicUiQuestionMark from 'images/style-guide_screenshot-crop
 import styleguideUiSearchString from 'images/style-guide_screenshot-crop_ui-search-string.webp'
 
 
-Swiftype is the elastic-based search engine that powers the search in `docs.newrelic.com` and the product UI.
+Swiftype is the elastic-based search engine that powers the search in `docs.newrelic.com`.
 
 As a technical writer at New Relic, you may need to log into Swiftype and do a variety of tasks to make sure your docs are recognized during internal searches.
-
-## Where are Swiftype results used? [#where-used]
-
-A growing number of sites and projects use our Swiftype engine to provide search results:
-
-* The New Relic help center
-* Support landing page
-* Most non-product New Relic sites (developer for related content, docs, storefront, etc.)
 
 ## Swiftype crawler info [#crawler-info]
 
@@ -30,7 +22,7 @@ The average re-index time for docs is four days.
 
 ## Manually add new page to Swiftype index [#manually-index]
 
-You may want to manually add a new page to the Swiftype index when the crawl is too slow and you want the page available right away. Keep in mind that updating the index may produce quick results for the docs site, you may experience a lag for the docs in the product UI.
+You may want to manually add a new page to the Swiftype index when the crawl is too slow and you want the page available right away. 
 
 To manually add a new page in Swiftype:
 
@@ -62,8 +54,8 @@ Swiftype should reindex within a minute. Note that that record will be removed f
 
 You may want to manually remove an existing record from the index in these cases:
 
-    * When you want to quickly remove a record for a page that was deleted with no redirects
-    * If you notice that there is more than one record for a page that changed URLs recently (one for the old URL, one for the new one that was discovered outside of the redirect).
+* When you want to quickly remove a record for a page that was deleted with no redirects
+* If you notice that there is more than one record for a page that changed URLs recently (one for the old URL, one for the new one that was discovered outside of the redirect).
 
 To manually remove a record from the index:
 
@@ -116,7 +108,6 @@ For more information, see the [official docs](https://swiftype.com/documentation
 
 We probably want to ensure that results are ranked and accurate for search terms that are:
 
-* Commonly pre-populated in the New Relic Help Center in the UI
 * Known to be really vague with noisy results (example: browser)
 * The most popular search terms on our site
 * Glossary terms
@@ -124,10 +115,6 @@ We probably want to ensure that results are ranked and accurate for search terms
 ## Best practice: URL changes [#url-changes]
 
 If a page that's already indexed has its URL changed, Swiftype will remove that record associated with the old URL. And, if a redirect exists to a new URL, Swiftype will create a new record for the page that's associated with the new URL. When that happens, result rankings for the old record are lost and must be re-added for the new record with the new URL.
-
-Note that this could impact search results in the New Relic product UI. If URL paths change for any pages, Swiftype will be behind what's in the product (storing the record for the old page at the old URL) until it recrawls and re-indexes. This process can take anywhere from days to more than a week.
-
-When this happens the body content in the product UI is empty. It's empty because the `docs-library-service` (which is the service behind the NerdGraph queries the nerdlet uses) will go query Swiftype. It uses the `url` in the Swiftype response for a record and go get the JSON for the given page at that URL slug. If the Swiftype index is behind, that URL won't exist when it requests it and thus the `body` will be null.
 
 Triggering a recrawl in Swiftype will eventually fix this, but it may take a long time. Alternatively you can delete specific results for old pages and manually tell it to index new ones. This _should_ be synced down to `docs-library-service` when it next goes to update its cache for a given search term.
 

--- a/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
+++ b/src/content/docs/style-guide/writing-docs/writer-workflow/swiftype-search.mdx
@@ -112,29 +112,6 @@ To add synonyms, go to **New Relic > Synonyms**.
 
 For more information, see the [official docs](https://swiftype.com/documentation/site-search/guides/synonyms).
 
-## Update search results for New Relic UI pages [#update-ui-search]
-
-The New Relic UI pages are indirectly linked to pages on our docs site. So, when a user clicks on the question mark icon in the upper-right corner of the UI, they are presented with a page from the docs site that corresponds to the UI nerdlet they are viewing. Also, they get various related results in the left pane in case the main page isn't quite what they want.
-
-Sometimes the main document that is displayed for a particular product UI page isn't what you want, but you can easily change this in Swiftype. The way you can change what's displayed for a UI page is by changing the Swiftype result rankings for the default search string for a nerdlet.
-
-1. Go to the page in the UI that needs a better help doc and click the question mark (?) icon in the upper-right corner: 
-    <img
-      title="Screenshot showing the UI question mark button"
-      alt="Screenshot showing the UI question mark button"
-      src={styleguideNewRelicUiQuestionMark}
-    />
-2. Copy the value of the search term that is automatically populated by that page in the search bar.
-    <img
-      title="Screenshot showing how to find the search string in the UI."
-      alt="Screenshot showing how to find the search string in the UI."
-      src={styleguideUiSearchString}
-    />
-3. Log into Swiftype.
-4. Go to **New Relic > Result Rankings**.
-5. Paste the search string from the UI into the **Search your engine** box, and then press ENTER.
-6. If you see the page you want in the list, drag it to the top of the list. Otherwise, click **Add a result** and insert the URL of the page you want.
-
 ## Best practice: Important search terms [#important-search-terms]
 
 We probably want to ensure that results are ranked and accurate for search terms that are:


### PR DESCRIPTION
We used to use Swiftype to automatically surface relevant docs in the UI based on your location, but we decomissioned that capability over a year ago.