### PR TITLE
fix: small typos on markdown links

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -547,7 +547,7 @@ If your organization uses a firewall that restricts outbound traffic, follow the
 
     <tr>
       <td>
-        `[www.google.com](http://www.google.com)`
+        `www.google.com`
       </td>
 
       <td>
@@ -557,7 +557,7 @@ If your organization uses a firewall that restricts outbound traffic, follow the
 
     <tr>
       <td>
-        `[www.gstatic.com](http://www.gstatic.com)`
+        `www.gstatic.com`
       </td>
 
       <td>


### PR DESCRIPTION
small typo changes to remove HTML tagging on links that are not needed in the doc ([current doc](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#user-facing-domains)) is showing the plain text with tags right now; this cleans that up:

```plain
[www.google.com](http://www.google.com) ==> www.google.com

[www.gstatic.com](http://www.gstatic.com) ==> www.gstatic.com
```