### PR TITLE
chore(PHP): Adds note for API call

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3020,7 +3020,7 @@ The values of these settings are used to control various tracer features.
 
     Set this to `true` to assign the highest priority to errors identified through the [`newrelic_notice_error()`](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) API function.
 
-    NOTE: Any uncaught errors will be assigned an even higher priority so these will take precendence over errors reported through the [`newrelic_notice_error()`](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) API function.
+    Note: Any uncaught errors will be assigned an even higher priority so these will take precendence over errors reported through the [`newrelic_notice_error()`](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) API function.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3019,6 +3019,8 @@ The values of these settings are used to control various tracer features.
     </table>
 
     Set this to `true` to assign the highest priority to errors identified through the [`newrelic_notice_error()`](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) API function.
+
+    NOTE: Any uncaught errors will be assigned an even higher priority so these will take precendence over errors reported through the [`newrelic_notice_error()`](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) API function.
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
I am a PHP team engineer.

This update is based on customer feedback.  The INI option `newrelic.error_collector.prioritze_api_errors` is intended to cause errors reported through the `newrelic_notice_error()` API to take precedence over other error types which occur.  However, if an uncaught error error also occurs it will have the highest priority.  This can be confusing if notice'd errors are not showing up and this setting is set to `true`.

I made it a "NOTE:" but perhaps a different formatting (callout?) would be better and I leave this to your discretion.