### PR TITLE
feat: add missing release notes

### DIFF
--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.263.0.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.263.0.mdx
@@ -1,0 +1,32 @@
+---
+subject: Browser agent
+releaseDate: "2024-07-25"
+version: 1.263.0
+features: ["Optimize bundle size with warning codes", "Shut down agent if improperly configured"]
+bugs: ["Prevent agent using invalid date header"]
+security: []
+---
+
+## v1.263.0
+
+### Features
+
+#### Optimize bundle size with warning codes
+Decrease bundle size by converting static strings to warning codes with an accompanying link to a web resource.
+
+#### Shut down agent if improperly configured
+Shut down initialization of the agent if improperly configured. Agents must be provided a valid licenseKey and applicationID at runtime.
+
+
+### Bug Fixes
+
+#### Prevent agent using invalid date header
+Shut down the agent when unable to read a correctly formatted date header for the page view event harvest. This prevents harvesting data with wildly inaccurate timestamps. This should only happen with third-party or non-agent code has tampered with the ajax response headers.
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/). Release dates are reflective of the original publish date of the agent version.
+
+New browser agent releases are rolled out to customers in small stages over a period of time. Because of this, the date the release becomes accessible to your account may not match the original publish date. Please see this [status dashboard](https://newrelic.github.io/newrelic-browser-agent-release/) for more information.
+
+Consistent with our [browser support policy](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types), v1.263.0 of the Browser agent was built for and tested against these browsers and version ranges: Chrome 116-126, Edge 116-126, Safari 16-17, and Firefox 117-127. For mobile devices, v1.263.0 was built and tested for Android OS 9-14 and iOS Safari 16-17.5.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.264.0.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.264.0.mdx
@@ -1,0 +1,27 @@
+---
+subject: Browser agent
+releaseDate: "2024-08-06"
+version: 1.264.0
+features: ["Create generic events feature with 1,000 event limit","Report Page Actions with Generic Events Feature"]
+bugs: []
+security: []
+---
+
+## v1.263.0
+
+### Features
+
+#### Create generic events feature with 1,000 event limit
+Create a feature that will normalize, aggregate and harvest all generic events.
+
+#### Report Page Actions with Generic Events Feature
+Report all customer PageAction data utilizing the new Generic Events feature.
+
+
+## Support statement
+
+New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/). Release dates are reflective of the original publish date of the agent version.
+
+New browser agent releases are rolled out to customers in small stages over a period of time. Because of this, the date the release becomes accessible to your account may not match the original publish date. Please see this [status dashboard](https://newrelic.github.io/newrelic-browser-agent-release/) for more information.
+
+Consistent with our [browser support policy](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types), v1.264.0 of the Browser agent was built for and tested against these browsers and version ranges: Chrome 116-126, Edge 116-126, Safari 16-17, and Firefox 117-127. For mobile devices, v1.264.0 was built and tested for Android OS 9-14 and iOS Safari 16-17.5.

--- a/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.264.0.mdx
+++ b/src/content/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.264.0.mdx
@@ -7,7 +7,7 @@ bugs: []
 security: []
 ---
 
-## v1.263.0
+## v1.264.0
 
 ### Features
 


### PR DESCRIPTION
The browser agent team's automation was discovered to have a bug that failed to post release notes for the previous two releases.  This PR adds those missing release notes.