### PR TITLE
fix(Style guide): Updated the new image name convention

### DIFF
--- a/src/content/docs/style-guide/images/embed-images.mdx
+++ b/src/content/docs/style-guide/images/embed-images.mdx
@@ -113,16 +113,14 @@ To add or edit an image:
 Descriptive captions help the reader know why the image matters. If it's a screenshot, it's helpful to include the path in bold in addition to a description. For example:
 
 ```
----
-title: Abbreviated example file
----
-
-import nr1DashboardsImages from 'images/nr1-dashboards.webp'
-
-<img src={nr1DashboardsImages} alt="Dashboards in New Relic" title="Dashboards in New Relic" />
+<img
+    title="Screenshot showing the Overview dashboard"
+    alt="Screenshot showing the Overview dashboard"
+    src="/images/kubernetes_screenshot-full_cluster-dashboard-detail.webp"
+/>
 
 <figcaption>
-  **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Dashboards**: Quickly create information-dense custom views into the data that matters most to you with dashboards in New Relic.
+    Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Kubernetes**</DNT>. Select your cluster and click <DNT>**Overview Dashboard**</DNT> in the left navigation pane. It shows useful overview data about the status and performance of the cluster and its containerized workloads.
 </figcaption>
 ```
 

--- a/src/content/docs/style-guide/structure/side-by-side.mdx
+++ b/src/content/docs/style-guide/structure/side-by-side.mdx
@@ -21,7 +21,7 @@ Here's an example of the component:
     />
 
     <figcaption>
-      **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Network**
+      Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Network**
     </figcaption>
   </Side>
 
@@ -37,7 +37,7 @@ Here's a template of a `SideBySide` component:
 ```jsx
 <SideBySide>
     <Side>
-        <img alt="example" src={exampleImg} />
+        <img alt="Example" src="/images/example-image.webp" />
     </Side>
 
     <Side>


### PR DESCRIPTION
Updated the src attribute on these pages:

- [Embed images](https://docs.newrelic.com/docs/style-guide/images/embed-images/#labeling)
- [SideBySide](https://docs.newrelic.com/docs/style-guide/structure/side-by-side/)