### PR TITLE
feat: update pageaction apis that mention limit

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -49,8 +49,12 @@ Reports a browser PageAction event along with a name and optional attributes.
 
 This API call sends a browser [`PageAction` event](/docs/insights/explore-data/custom-events/insert-browser-custom-events-attributes-insights-javascript-api) with your user-defined name and optional attributes to [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards), along with [several default attributes](/attribute-dictionary/?event=PageAction). This is useful to track any event that is not already tracked automatically by the browser agent, such as clicking a <DNT>**Subscribe**</DNT> button or accessing a tutorial.
 
-* `PageAction` events are sent every 30 seconds, with a maximum of 120 events per 30-second harvest cycle, per browser.
-* After the 120-event limit is reached, additional events are not captured for that harvest cycle.
+* `PageAction` events are sent every 30 seconds.
+* If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
+
+<Callout variant="important">
+  In earlier agent versions, events were dropped after 120 were observed. The event limit was increased from 120 to 1,000 in version [1.264.0](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.264.0/) and are no longer dropped.
+</Callout>
 
 ## Parameters
 

--- a/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -76,11 +76,11 @@ In order to report `PageAction` events, verify these prerequisites:
 
     <tr>
       <td>
-        Max events per cycle
+        Events per cycle
       </td>
 
       <td>
-        `PageAction` events are reported every 30 seconds, with a maximum of 120 events per 30-second harvest cycle, per browser. After the 120-event limit is reached, additional events are not captured for that cycle.
+        `PageAction` events are sent every 30 seconds. If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
       </td>
     </tr>
 


### PR DESCRIPTION
This PR adjusts the page action docs that mention a 120 event limit, which was changed in the latest browser agent release.