### PR TITLE
docs: Correct wording on MacOS agent update steps

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
@@ -144,7 +144,7 @@ If you used the default installation process, use your package manager to update
          brew services stop newrelic-infra-agent
        ```
 
-    2. Uninstall the agent:
+    2. Update the agent:
        ```
          brew upgrade newrelic-infra-agent
        ```


### PR DESCRIPTION
Noticed that the "update" guide for MacOS incorrectly said `Uninstall the agent` as one of the steps, when in fact the step was to upgrade the agent.