### PR TITLE
Fix automation markers

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -269,8 +269,11 @@ granular information specific to your web apps and servers.  For unsupported
 frameworks or libraries, you'll need to instrument the agent yourself using the
 [Node.js agent API](https://newrelic.github.io/node-newrelic/API.html).
 
-**Note**: The latest supported version may not reflect the most recent supported
-version.
+
+<Callout variant="important">
+    The latest supported version may not be the latest supported version.
+</Callout>
+
 
 | Package name | Minimum supported version | Latest supported version | Introduced in* |
 | --- | --- | --- | --- |
@@ -342,7 +345,11 @@ Through the `@aws-sdk/client-bedrock-runtime` module, we support:
 | Meta Llama2          | ❌     | ✅    | -      |
 | Meta Llama3          | ❌     | ✅    | -      |
 
-Note: if a model supports streaming, we also instrument the streaming variant.
+
+<Callout variant="important">
+    If a model supports streaming, we also instrument the streaming variant.
+</Callout>
+
 
 ### Langchain
 
@@ -352,7 +359,7 @@ The following general features of Langchain are supported:
 | ------ | ------ | ----- | ------------ |
 | ✅      | ✅      | ✅     | ✅            |
 
-Models/providers are generally supported transitively by our instrumentation of the provider's module.
+Models and providers are generally supported transitively by our instrumentation of the provider's module.
 
 | Provider       | Supported | Transitively |
 | -------------- | --------- | ------------ |
@@ -396,9 +403,9 @@ The Node.js agent integrates with other features to give you observability acros
       <td>
         If you have version 11.13.0 of the Node.js agent, you can collect AI data from certain AI libraries and frameworks:
 
-        * [OpenAI Node.js API library](https://www.npmjs.com/package/openai/v/4.0.0-beta.4) versions 4.0.0 and above. If your model uses streaming, the Node.js agent supports versions 4.12.2 and above
-        * [AWS SDK for JavaScript BedrockRuntime Client](https://www.npmjs.com/package/@aws-sdk/client-bedrock-runtime) versions 3.474.0 and above
-        * [LangChain.js](https://www.npmjs.com/package/langchain/v/0.1.17) versions 0.1.17 and above
+        * [OpenAI Node.js API library](https://www.npmjs.com/package/openai/v/4.0.0-beta.4) versions 4.0.0 and higher. If your model uses streaming, the Node.js agent supports versions 4.12.2 and higher.
+        * [AWS SDK for JavaScript BedrockRuntime Client](https://www.npmjs.com/package/@aws-sdk/client-bedrock-runtime) versions 3.474.0 and higher.
+        * [LangChain.js](https://www.npmjs.com/package/langchain/v/0.1.17) versions 0.1.17 and higher.
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -259,9 +259,7 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
   </Collapser>
 </CollapserGroup>
 
-{
-  /* begin: compat-table */
-}
+{/* begin: compat-table */}
 
 ## Instrumented modules
 
@@ -370,9 +368,7 @@ Through the `openai` module, we support:
 | ----- | ---- | ----------- | ---------- | ----- | ------ |
 | ❌     | ✅    | ✅           | ✅          | ❌     | ❌      |
 
-{
-  /* end: compat-table */
-}
+{/* end: compat-table */}
 
 ## Connect the agent to other New Relic features [#digital-intelligence-platform]
 


### PR DESCRIPTION
In https://github.com/newrelic/docs-website/commit/23b82a175fcd78f2bb8695b6c3f23ebf991cd370 the markers we use for automating the updating of the compatibility matrix were mutated into a format that the automation tool does not recognize. Please do not change these markers.