### PR TITLE
Update manage-synthetics-monitors-rest-api.mdx

### DIFF
--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -21,7 +21,11 @@ Use the synthetics REST API to create and manage [synthetic monitors](/docs/synt
 ## Before you start [#before-you-start]
 
 <Callout variant="important">
-  On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. On June 30, 2024, we will block the creation of new monitors using legacy synthetics runtime versions. The Synthetics REST API only supports monitor creation using legacy synthetics runtime versions. Please use [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/) to manage your synthetic monitors using our latest runtimes to avoid degradation.
+  The Synthetics REST API only supports monitor creation using legacy synthetics runtime versions. Please use [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/) to manage your synthetic monitors using our latest runtimes.
+</Callout>
+
+<Callout variant="important">
+  On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. On June 30, 2024, we will block the creation of new monitors using legacy synthetics runtime versions. 
 </Callout>
 
 Our synthetics REST API is one way to manage your synthetic monitors via API but the recommended way is using [our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial).


### PR DESCRIPTION
Reconfigured the callouts at the top of the page to first identify that this API only functions for legacy runtimes.

And added a second callout which identifies the EOL dates and link regarding the above mentioned legacy runtimes.

Reason for proposing: we still get customers using the REST API because it seems familiar, but they don't get errors from the API highlighting its limitations. It may help deflect support inquiries if we more clearly state that the API should no longer be part of a contemporary workflow.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.