### PR TITLE
NR 298654 - The Infrastructure Agent now supports Ubuntu 24.04 and SUSE 15.5(x86_64).

### DIFF
--- a/src/content/docs/release-notes/logs-release-notes/logs-24-08-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-24-08-12.mdx
@@ -10,7 +10,7 @@ The Infrastructure Agent now supports Ubuntu 24.04 and SUSE 15.5(x86_64). This e
 
 ### Changed
 
-When users attempt to install the Infrastructure Agent from Add Integrations in New Relic, the installation process now correctly includes the necessary definitions for Ubuntu 24.04 and SUSE 15.5. Previously, Fluent Bit was not installed even though the installation of the Infrastructure Agent appeared to be successful.This issue has now been resolved, ensuring Fluent Bit is correctly installed on these platforms. This guarantees that logs are properly forwarded to New Relic, maintaining seamless log monitoring and analysis. To see all supported OS distributions for the Infrastructure Agent, please refer to [infrastructure agent's log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/).
+When users attempt to install the Infrastructure Agent from Add Integrations in New Relic, the installation process now correctly includes the necessary definitions for Ubuntu 24.04 and SUSE 15.5 (x86_64). Previously, logs-integration support was not available for these platforms. This issue has now been resolved, ensuring Fluent Bit is correctly installed on these platforms. This guarantees that logs are properly forwarded to New Relic, maintaining seamless log monitoring and analysis. To see all supported OS distributions for the Infrastructure Agent, please refer to [infrastructure agent's log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/).
 
 ### Notes
 

--- a/src/content/docs/release-notes/logs-release-notes/logs-24-08-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-24-08-12.mdx
@@ -1,0 +1,17 @@
+---
+subject: Logs
+releaseDate: '2024-08-12'
+version: '240812'
+---
+
+### Support for Ubuntu 24.04 and SUSE 15.5(x86_64) 
+
+The Infrastructure Agent now supports Ubuntu 24.04 and SUSE 15.5(x86_64). This enhancement ensures broader compatibility and better performance on these platforms.
+
+### Changed
+
+When users attempt to install the Infrastructure Agent from Add Integrations in New Relic, the installation process now correctly includes the necessary definitions for Ubuntu 24.04 and SUSE 15.5. Previously, Fluent Bit was not installed even though the installation of the Infrastructure Agent or Agent Control appeared to be successful. This issue has now been resolved, ensuring Fluent Bit is correctly installed on these platforms. To see all supported OS distributions for the Infrastructure Agent, please refer to [infrastructure agent's log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/).
+
+### Notes
+
+To stay up to date the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).

--- a/src/content/docs/release-notes/logs-release-notes/logs-24-08-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-24-08-12.mdx
@@ -10,7 +10,7 @@ The Infrastructure Agent now supports Ubuntu 24.04 and SUSE 15.5(x86_64). This e
 
 ### Changed
 
-When users attempt to install the Infrastructure Agent from Add Integrations in New Relic, the installation process now correctly includes the necessary definitions for Ubuntu 24.04 and SUSE 15.5. Previously, Fluent Bit was not installed even though the installation of the Infrastructure Agent or Agent Control appeared to be successful. This issue has now been resolved, ensuring Fluent Bit is correctly installed on these platforms. To see all supported OS distributions for the Infrastructure Agent, please refer to [infrastructure agent's log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/).
+When users attempt to install the Infrastructure Agent from Add Integrations in New Relic, the installation process now correctly includes the necessary definitions for Ubuntu 24.04 and SUSE 15.5. Previously, Fluent Bit was not installed even though the installation of the Infrastructure Agent appeared to be successful.This issue has now been resolved, ensuring Fluent Bit is correctly installed on these platforms. This guarantees that logs are properly forwarded to New Relic, maintaining seamless log monitoring and analysis. To see all supported OS distributions for the Infrastructure Agent, please refer to [infrastructure agent's log forwarder](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/).
 
 ### Notes
 


### PR DESCRIPTION
- The release notes have been updated to mention the included support for Ubuntu 24.04 and SUSE 15.5(x86_64).
- Refer to the recently merged PR - [https://github.com/newrelic/open-install-library/pull/1098](https://github.com/newrelic/docs-website/pull/url) for more details.