### PR TITLE
fix(infra-agent): Update supported OS

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -82,7 +82,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Docker 1.12 or higher
+        See [container monitoring requirements](docs/infrastructure/install-infrastructure-agent/linux-installation/container-instrumentation-infrastructure-monitoring/#requirements)
       </td>
     </tr>
 
@@ -92,7 +92,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Tested with versions 1.16 to 1.22
+        See [Kubernetes integration requirements](/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements/#compatibility)
       </td>
     </tr>
 
@@ -102,7 +102,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Version 8 or higher
+        Version 7 or higher
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

* Linux RedHat 7 still has extended support..
* Adding links to Docker (Container) and Kubernetes requirements to avoid data to be out of sync.