### PR TITLE
[NR-303342] Update manual install steps for Android plugin

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
@@ -51,7 +51,7 @@ To install the Android agent, you need to use our [guided install](https://onenr
 These procedures appear in our guided install. Keep in mind that even if you're updating your build files through the docs, you still need to add your app to New Relic and grab your generated app token from the guided install. You cannot capture data about your Android apps otherwise.
 
 
-## Resolve and apply the New Relic Android agent Gradle plugin
+## Resolve and apply the New Relic Android agent Gradle plugin [#resolve-apply-plugin]
 
 In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -99,7 +99,7 @@ If adding the New Relic Android agent to an older app, follow the instructions t
 6. View your app's data on New Relic by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app)**</DNT>.
 
 
-## Configure the Android agent for Gradle Plugin Portal [#plugin-portal]
+## Configure the Android agent for Gradle Plugin Portal [#configure-plugin-portal]
 
 Starting with agent version 7.6.0, the Android agent plugin is available on the [Gradle Plugin Portal](https://plugins.gradle.org/) as a community plugin. The Gradle plugin DSL simpifies adding plugin dependencies to apps. 
 
@@ -138,7 +138,7 @@ Starting with agent version 7.6.0, the Android agent plugin is available on the 
    </CollapserGroup>
 
 
-### Apply the plugin using the `plugins` DSL block [#plugin-dsl]
+### Apply the plugin using the `plugins` DSL block [#apply-plugin-dsl]
 
 The recommended approach for managing plugin dependencies in Gradle utilizes the `plugins` DSL block. This section details applying the fully qualified form of the plugin id (`com.newrelic.agent.android`) within this structure.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
@@ -50,48 +50,18 @@ To install the Android agent, you need to use our [guided install](https://onenr
 
 These procedures appear in our guided install. Keep in mind that even if you're updating your build files through the docs, you still need to add your app to New Relic and grab your generated app token from the guided install. You cannot capture data about your Android apps otherwise.
 
-1. Add the following code to your `build.gradle` files found in the Gradle & Android Studio tab. You need to update the top-level build snippet and each sub-module that you want to instrument.
 
-   <CollapserGroup>
-     <Collapser
-       id="project-level"
-       title="Project level `build.gradle` file:"
-     >
-       In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+## Resolve and apply the New Relic Android Agent Gradle plugin
+```In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.```
 
-       ```groovy
-       buildscript {
-         repositories {
-           mavenCentral()
-         }
+Starting with version 7.6.0, the New relic Android Gradle plugin is available on the [Gradle Plugin Portal](). This greatly simplifies the resolution and loading of community plugins.
 
-         dependencies {
-           classpath "com.newrelic.agent.android:agent-gradle-plugin:AGENT_VERSION"
-         }
-       }
-       ```
-     </Collapser>
+Newer apps should follow the instructions to [Apply the plugin using the plugins DSL block]](#plugin-dsl) to use agent plugin hosted on [Gradle Plugin Portal](https://plugins.gradle.org/). 
 
-     <Collapser
-       id="app-level"
-       title="App level `build.gradle` file:"
-     >
-       In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+If adding the New Relic Android agent to an older app, follow the instructions to [apply the plugin using the buildscript](#buildscript)
 
-       ```groovy
-       repositories {
-         mavenCentral()
-       }
+Gradle [guidance](https://docs.gradle.org/current/userguide/plugins.html#sec:binary_plugin_locations) on the various approaches to resolving plugins.
 
-       apply plugin: 'android'
-       apply plugin: 'newrelic'
-
-       dependencies {
-         implementation 'com.newrelic.agent.android:android-agent:AGENT_VERSION'
-       }
-       ```
-     </Collapser>
-   </CollapserGroup>
 
 2. Set app permissions. Ensure that your Android app requests `INTERNET` and `ACCESS_NETWORK_STATE` permissions by adding these lines to your `AndroidManifest.xml` file:
 
@@ -126,12 +96,94 @@ These procedures appear in our guided install. Keep in mind that even if you're 
 
 7. View your data for your Android app. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app)**</DNT>.
 
+
 ## Configure the Android agent for Gradle Plugin Portal [#plugin-portal]
 
-Because the Android agent isn't yet available as a community plugin, you need to provide the classpath through [MavenCentral](https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin) so the agent can instrument your Android app. If you've configured your app to look for plugins through Gradle Plugin Portal, you need to repeat this step in the `settings.gradle(.kts)` file.
+Starting with agent version 7.6.0, the Android agent plugin is available on the [Gradle Plugin Portal](https://plugins.gradle.org/) as a community plugin. The Gradle plugin DSL simpifies adding plugin dependencies to apps. 
 
-1. Add this snippet to your `settings.gradle(.kts)` file through `pluginManagement {}` block:
+   <CollapserGroup>
 
+     <Collapser
+       id="project-level"
+       title="Project level `build.gradle(.kts)`file:"
+     >
+       In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+
+       ```groovy
+       plugins {
+         // for binary Gradle plugins that need to be resolved
+         id("com.newrelic.agent.android") version "AGENT_VERSION" apply false
+       }
+       ```
+     </Collapser>
+
+     <Collapser
+       id="app-level"
+       title="App level `build.gradle(.kts)` file:"
+     >
+       In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+
+       ```groovy
+       plugins {
+         id 'com.newrelic.agent.android'
+       }
+
+       dependencies {
+         implementation 'com.newrelic.agent.android:android-agent:AGENT_VERSION'
+       }
+       ```
+     </Collapser>
+   </CollapserGroup>
+
+
+### Apply the plugin using the plugins DSL {} block [#plugin-dsl]
+
+The preferred and current approach to declaring plugin dependencies: apps must use the fully qualified form of the plugin id (`com.newrelic.agent.android`) in order to resolve the plugin.
+
+
+1. Declare the New Relic plugin to the top-level `build.gradle(.kts)` file using the Gradle Plugin Portal plugin ID:
+
+   ```groovy
+   plugins {
+     // for binary Gradle plugins that need to be resolved
+     id("com.newrelic.agent.android") version "AGENT_VERSION" apply false
+   }
+   ```
+
+2. Apply the plugin to the app-level build file, as well as any other sub-module to be instrumented:
+
+   ```groovy
+   plugins {
+     id("com.newrelic.agent.android")
+   }
+   ```
+
+
+Gradle provides guidance on [Applying plugins using the plugins{} block](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block).
+
+
+### Apply the plugin using the buildscript{} block [#buildscript]
+
+The New Relic Android Agent plugin is co-hosted on MavenCentral, but uses the legacy plugin ID ('newrelic'). Customers who prefer to use the legacy plugin ID must provide the classpath to [MavenCentral](https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin) to resolve the location of the plugin during builds. 
+
+
+To prefer MavenCentral over the Gradle Plugin Portal, you need to make the following changes to Gradle files:
+
+1. Add this snippet to your top-level `build.gradle(.kts)` file:
+   ```groovy
+   buildscript {
+     repositories {
+       mavenCentral()
+     }
+
+     // not required if plugin classpath in resolutionStrategy{} below
+     dependencies {
+       classpath "com.newrelic.agent.android:agent-gradle-plugin:AGENT_VERSION"
+     }
+   }
+   ```   
+
+2. Add this snippet to your `settings.gradle(.kts)` file through `pluginManagement {}` block:
    ```groovy
    pluginManagement {
      repositories {
@@ -139,41 +191,29 @@ Because the Android agent isn't yet available as a community plugin, you need to
      }
      resolutionStrategy {
        eachPlugin {
-         if (requested.id.id.startsWith("newrelic")) {
+         // not required if using `classpath dependency` above
+         if (requested.id.id.startsWith("newrelic") || requested.id.id.startsWith("com.newrelic.agent.android"))) {
            useModule("com.newrelic.agent.android:agent-gradle-plugin:${AGENT_VERSION}")
          }
        }
      }
-
-     // optional: define as a community plugin here or in root level build file
-
-     // for core Gradle plugins or plugins already available to the build script
      plugins {
-       id("newrelic") version "${AGENT_VERSION}"
+        id("newrelic") apply false
      }
    }
    ```
 
-2. Declare the New Relic plugin:
+3. Apply the plugin to the app-level build file, as well as any other submodule to be instrumented:
 
    ```groovy
    plugins {
-     // for binary Gradle plugins that need to be resolved
-     id("newrelic") version "AGENT_VERSION" apply false
-   }
-   ```
-
-3. Apply the plugin to the app-level build files:
-
-   ```groovy
-   plugins {
-     id("com.android.application")
-     id("org.jetbrains.kotlin.android")
      id("newrelic")
    }
    ```
 
+
 In the above snippets, `AGENT_VERSION` represents your agent version number. We strongly recommend you use the latest agent for set up.
+
 
 ## Android 4.x: Multidex support [#4x-multidex]
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
@@ -7,7 +7,7 @@ tags:
 translate:
   - jp
   - kr
-freshnessValidatedDate: 2024-11-30
+freshnessValidatedDate: 2024-08-21
 metaDescription: 'New accounts: Get Android app monitoring in New Relic at newrelic.com/signup. Existing accounts: Add mobile monitoring to your Android apps from the UI.'
 redirects:
   - /docs/mobile-apps/troubleshooting-eclipse-configurations
@@ -51,50 +51,52 @@ To install the Android agent, you need to use our [guided install](https://onenr
 These procedures appear in our guided install. Keep in mind that even if you're updating your build files through the docs, you still need to add your app to New Relic and grab your generated app token from the guided install. You cannot capture data about your Android apps otherwise.
 
 
-## Resolve and apply the New Relic Android Agent Gradle plugin
-```In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.```
+## Resolve and apply the New Relic Android agent Gradle plugin
+
+In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.```
 
 Starting with version 7.6.0, the New relic Android Gradle plugin is available on the [Gradle Plugin Portal](). This greatly simplifies the resolution and loading of community plugins.
 
-Newer apps should follow the instructions to [Apply the plugin using the plugins DSL block]](#plugin-dsl) to use agent plugin hosted on [Gradle Plugin Portal](https://plugins.gradle.org/). 
+Newer apps should follow the instructions to [Apply the plugin using the plugins DSL block](#plugin-dsl) to use agent plugin hosted on [Gradle Plugin Portal](https://plugins.gradle.org/). 
 
-If adding the New Relic Android agent to an older app, follow the instructions to [apply the plugin using the buildscript](#buildscript)
-
-Gradle [guidance](https://docs.gradle.org/current/userguide/plugins.html#sec:binary_plugin_locations) on the various approaches to resolving plugins.
+If adding the New Relic Android agent to an older app, follow the instructions to [apply the plugin using the buildscript](#buildscript). For guidance on different approaches to resolving plugins, see [Resolving plugins](https://docs.gradle.org/current/userguide/plugins.html#sec:binary_plugin_locations).
 
 
-2. Set app permissions. Ensure that your Android app requests `INTERNET` and `ACCESS_NETWORK_STATE` permissions by adding these lines to your `AndroidManifest.xml` file:
+1. Set app permissions. Update your `AndroidManifest.xml` file to allow your app to access the internet and check network state:
 
    ```xml
    <uses-permission android:name="android.permission.INTERNET" />
    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
    ```
 
-3. Start the Android agent. In your default Activity found in your manifest, import the `NewRelic` class:
+2. Start the Android agent. In your main Activity class (`onCreate` method), import the `NewRelic` class:
 
    ```java
    import com.newrelic.agent.android.NewRelic;
    ```
 
-   We don't support starting the <InlinePopover type="mobile"/> agent in other classes, as that can cause unexpected or unstable behavior.
+   <Callout variant="caution">
+    Starting the agent in other classes is not supported.
+   </Callout>
 
-4. After you've imported the `NewRelic` class, you need to add an additional snippet to the `onCreate()` method, which includes your app token, which is generated in the guided install. The snippet looks like this:
+3. Replace `GENERATED_TOKEN` with your actual app token (obtained during guided install) and add this code:
 
    ```java
    NewRelic.withApplicationToken("GENERATED_TOKEN").start(this.getApplicationContext());
    ```
 
-5. If you're using minification (for example, like with ProGuard or Dexguard), you need to add `newrelic.properties` file to your app-level directory (_projectname/app_). This step only applies to ProGuard and DexGuard users.
+4. (Optional) Configure for minification:
 
-   ```ini
-   com.newrelic.application_token=GENERATED_TOKEN
-   ```
+    1. If you use ProGuard or Dexguard for code shrinking, create a `newrelic.properties` file in your app-level directory (`_projectname/app_`). 
+    2. Add this line to the file, replacing `GENERATED_TOKEN` with your actual token:
+        ```ini
+        com.newrelic.application_token=GENERATED_TOKEN
+        ```
+    3. To finish set up for minification, follow the steps in [configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps).
 
-   To finish set up for minification, follow the steps in [configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps).
+5. Clean your project, then run your app in an emulator or device to generate traffic. Wait a few minutes as your agent captures that data.
 
-6. Clean your project, then run your app in an emulator or device to generate traffic. Wait a few minutes as your agent captures that data.
-
-7. View your data for your Android app. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app)**</DNT>.
+6. View your app's data on New Relic by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app)**</DNT>.
 
 
 ## Configure the Android agent for Gradle Plugin Portal [#plugin-portal]
@@ -105,7 +107,7 @@ Starting with agent version 7.6.0, the Android agent plugin is available on the 
 
      <Collapser
        id="project-level"
-       title="Project level `build.gradle(.kts)`file:"
+       title="Project-level build.gradle(.kts) file"
      >
        In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -119,7 +121,7 @@ Starting with agent version 7.6.0, the Android agent plugin is available on the 
 
      <Collapser
        id="app-level"
-       title="App level `build.gradle(.kts)` file:"
+       title="App-level build.gradle(.kts) file"
      >
        In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
@@ -136,9 +138,9 @@ Starting with agent version 7.6.0, the Android agent plugin is available on the 
    </CollapserGroup>
 
 
-### Apply the plugin using the plugins DSL {} block [#plugin-dsl]
+### Apply the plugin using the `plugins` DSL block [#plugin-dsl]
 
-The preferred and current approach to declaring plugin dependencies: apps must use the fully qualified form of the plugin id (`com.newrelic.agent.android`) in order to resolve the plugin.
+The recommended approach for managing plugin dependencies in Gradle utilizes the `plugins` DSL block. This section details applying the fully qualified form of the plugin id (`com.newrelic.agent.android`) within this structure.
 
 
 1. Declare the New Relic plugin to the top-level `build.gradle(.kts)` file using the Gradle Plugin Portal plugin ID:
@@ -150,7 +152,7 @@ The preferred and current approach to declaring plugin dependencies: apps must u
    }
    ```
 
-2. Apply the plugin to the app-level build file, as well as any other sub-module to be instrumented:
+2. Apply the plugin explicitly to the app-level build file (and any sub-modules intended for instrumentation) using the following syntax:
 
    ```groovy
    plugins {
@@ -159,13 +161,12 @@ The preferred and current approach to declaring plugin dependencies: apps must u
    ```
 
 
-Gradle provides guidance on [Applying plugins using the plugins{} block](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block).
+For detailed information on applying plugins within Gradle, refer to the [Gradle documentation](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block).
 
 
-### Apply the plugin using the buildscript{} block [#buildscript]
+### Apply the plugin using the `buildscript{}` block [#buildscript]
 
-The New Relic Android Agent plugin is co-hosted on MavenCentral, but uses the legacy plugin ID ('newrelic'). Customers who prefer to use the legacy plugin ID must provide the classpath to [MavenCentral](https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin) to resolve the location of the plugin during builds. 
-
+The New Relic Android agent plugin is co-hosted on MavenCentral, but uses the legacy plugin ID (`newrelic`). Customers who prefer to use the legacy plugin ID must provide the classpath to [MavenCentral](https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin) to resolve the location of the plugin during builds. 
 
 To prefer MavenCentral over the Gradle Plugin Portal, you need to make the following changes to Gradle files:
 
@@ -183,7 +184,7 @@ To prefer MavenCentral over the Gradle Plugin Portal, you need to make the follo
    }
    ```   
 
-2. Add this snippet to your `settings.gradle(.kts)` file through `pluginManagement {}` block:
+2. Add this snippet to your `settings.gradle(.kts)` file through the `pluginManagement {}` block:
    ```groovy
    pluginManagement {
      repositories {
@@ -203,7 +204,7 @@ To prefer MavenCentral over the Gradle Plugin Portal, you need to make the follo
    }
    ```
 
-3. Apply the plugin to the app-level build file, as well as any other submodule to be instrumented:
+3. Apply the plugin to the app-level build file, as well as any other sub-module to be instrumented:
 
    ```groovy
    plugins {

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
@@ -53,11 +53,11 @@ These procedures appear in our guided install. Keep in mind that even if you're 
 
 ## Resolve and apply the New Relic Android agent Gradle plugin
 
-In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.```
+In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
 
-Starting with version 7.6.0, the New relic Android Gradle plugin is available on the [Gradle Plugin Portal](). This greatly simplifies the resolution and loading of community plugins.
+Starting with version 7.6.0, the New relic Android Gradle plugin is available on the [Gradle Plugin Portal](https://plugins.gradle.org/). This greatly simplifies the resolution and loading of community plugins.
 
-Newer apps should follow the instructions to [Apply the plugin using the plugins DSL block](#plugin-dsl) to use agent plugin hosted on [Gradle Plugin Portal](https://plugins.gradle.org/). 
+Newer apps should follow the instructions to [Apply the plugin using the plugins DSL block](#plugin-dsl) to use agent plugin hosted on the Gradle Plugin Portal. 
 
 If adding the New Relic Android agent to an older app, follow the instructions to [apply the plugin using the buildscript](#buildscript). For guidance on different approaches to resolving plugins, see [Resolving plugins](https://docs.gradle.org/current/userguide/plugins.html#sec:binary_plugin_locations).
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-agent-gradle.mdx
@@ -38,183 +38,178 @@ redirects:
   - /docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-android-apps-gradle-android-studio
 ---
 
-To install the Android agent, you need to use our [guided install](https://onenr.io/0kjnEoryzRo). Setting up the Android agent requires an [application token](/docs/mobile-apps/viewing-your-application-token) that authenticates each mobile app you want to monitor. The app token is only available by going through the guided install.
-
-## Install the Android agent with guided install [#guided-install]
+To install the Android agent, we recommend you follow our guided install:
 
 1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > Integrations & Agents > Mobile > Android**</DNT>.
 2. Follow the guided install steps to set up your Android agent.
 3. Wait a few minutes, then view your data by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select your app)**</DNT>.
 
+
 ## Manually install the Android agent [#manual-install]
 
-These procedures appear in our guided install. Keep in mind that even if you're updating your build files through the docs, you still need to add your app to New Relic and grab your generated app token from the guided install. You cannot capture data about your Android apps otherwise.
+The steps below are outlined in our guided install. Note that even if you manually install the agent, you'll still need to create a New Relic app and obtain the generated application token. This token is essential for the agent to send data to New Relic.
 
+<Steps>
+<Step>
+Add the Android agent plugin to your project.
 
-## Resolve and apply the New Relic Android agent Gradle plugin [#resolve-apply-plugin]
+Regarding the location of the plugin, you have two options:
 
-In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
+* Recommended: Using the Gradle plugin DSL
+    * Starting with agent version 7.6.0, the Android agent plugin is available on the [Gradle Plugin Portal](https://plugins.gradle.org/) as a community plugin. The Gradle plugin DSL simpifies adding plugin dependencies to apps. The Gradle plugin DSL simplifies adding plugin dependencies to apps.
+    * This method involves adding the agent plugin dependency to your project's plugins DSL block.
+* Legacy Plugin ID (`newrelic`)
+    * For older projects or specific use cases, you can use the legacy plugin ID.
+    * This method involves adding the agent as a dependency to your project's build script, specifying the MavenCentral repository.
 
-Starting with version 7.6.0, the New relic Android Gradle plugin is available on the [Gradle Plugin Portal](https://plugins.gradle.org/). This greatly simplifies the resolution and loading of community plugins.
+Follow the detailed steps below for your chosen installation method.
 
-Newer apps should follow the instructions to [Apply the plugin using the plugins DSL block](#plugin-dsl) to use agent plugin hosted on the Gradle Plugin Portal. 
-
-If adding the New Relic Android agent to an older app, follow the instructions to [apply the plugin using the buildscript](#buildscript). For guidance on different approaches to resolving plugins, see [Resolving plugins](https://docs.gradle.org/current/userguide/plugins.html#sec:binary_plugin_locations).
-
-
-1. Set app permissions. Update your `AndroidManifest.xml` file to allow your app to access the internet and check network state:
-
-   ```xml
-   <uses-permission android:name="android.permission.INTERNET" />
-   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-   ```
-
-2. Start the Android agent. In your main Activity class (`onCreate` method), import the `NewRelic` class:
-
-   ```java
-   import com.newrelic.agent.android.NewRelic;
-   ```
-
-   <Callout variant="caution">
-    Starting the agent in other classes is not supported.
-   </Callout>
-
-3. Replace `GENERATED_TOKEN` with your actual app token (obtained during guided install) and add this code:
-
-   ```java
-   NewRelic.withApplicationToken("GENERATED_TOKEN").start(this.getApplicationContext());
-   ```
-
-4. (Optional) Configure for minification:
-
-    1. If you use ProGuard or Dexguard for code shrinking, create a `newrelic.properties` file in your app-level directory (`_projectname/app_`). 
-    2. Add this line to the file, replacing `GENERATED_TOKEN` with your actual token:
-        ```ini
-        com.newrelic.application_token=GENERATED_TOKEN
-        ```
-    3. To finish set up for minification, follow the steps in [configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps).
-
-5. Clean your project, then run your app in an emulator or device to generate traffic. Wait a few minutes as your agent captures that data.
-
-6. View your app's data on New Relic by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app)**</DNT>.
-
-
-## Configure the Android agent for Gradle Plugin Portal [#configure-plugin-portal]
-
-Starting with agent version 7.6.0, the Android agent plugin is available on the [Gradle Plugin Portal](https://plugins.gradle.org/) as a community plugin. The Gradle plugin DSL simpifies adding plugin dependencies to apps. 
-
-   <CollapserGroup>
-
-     <Collapser
-       id="project-level"
-       title="Project-level build.gradle(.kts) file"
-     >
-       In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
-
-       ```groovy
-       plugins {
-         // for binary Gradle plugins that need to be resolved
-         id("com.newrelic.agent.android") version "AGENT_VERSION" apply false
-       }
-       ```
-     </Collapser>
-
-     <Collapser
-       id="app-level"
-       title="App-level build.gradle(.kts) file"
-     >
-       In this example, `AGENT_VERSION` represents your agent version number. See the [agent release notes](/docs/release-notes/mobile-release-notes/android-release-notes), and use the latest version.
-
-       ```groovy
-       plugins {
-         id 'com.newrelic.agent.android'
-       }
-
-       dependencies {
-         implementation 'com.newrelic.agent.android:android-agent:AGENT_VERSION'
-       }
-       ```
-     </Collapser>
-   </CollapserGroup>
-
-
-### Apply the plugin using the `plugins` DSL block [#apply-plugin-dsl]
-
-The recommended approach for managing plugin dependencies in Gradle utilizes the `plugins` DSL block. This section details applying the fully qualified form of the plugin id (`com.newrelic.agent.android`) within this structure.
-
+<CollapserGroup>
+<Collapser
+    id="DSL"
+    title="(Recommended) Apply the plugin using the plugins DSL block"
+>
+The recommended approach for managing plugin dependencies in Gradle utilizes the plugins DSL block. This section details applying the fully qualified form of the plugin ID (`com.newrelic.agent.android`) within this structure.
 
 1. Declare the New Relic plugin to the top-level `build.gradle(.kts)` file using the Gradle Plugin Portal plugin ID:
 
-   ```groovy
-   plugins {
-     // for binary Gradle plugins that need to be resolved
-     id("com.newrelic.agent.android") version "AGENT_VERSION" apply false
-   }
-   ```
+```groovy
+plugins {
+  // for binary Gradle plugins that need to be resolved
+  id("com.newrelic.agent.android") version "AGENT_VERSION" apply false
+}
+```
+
+Make sure to replace `AGENT_VERSION` with your agent version number. We strongly recommend you use the [latest version](/docs/release-notes/mobile-release-notes/android-release-notes/). 
 
 2. Apply the plugin explicitly to the app-level build file (and any sub-modules intended for instrumentation) using the following syntax:
 
-   ```groovy
-   plugins {
-     id("com.newrelic.agent.android")
-   }
-   ```
-
+```groovy
+plugins {
+  id("com.newrelic.agent.android")
+}
+```
 
 For detailed information on applying plugins within Gradle, refer to the [Gradle documentation](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block).
 
+</Collapser>
 
-### Apply the plugin using the `buildscript{}` block [#buildscript]
-
-The New Relic Android agent plugin is co-hosted on MavenCentral, but uses the legacy plugin ID (`newrelic`). Customers who prefer to use the legacy plugin ID must provide the classpath to [MavenCentral](https://mvnrepository.com/artifact/com.newrelic.agent.android/agent-gradle-plugin) to resolve the location of the plugin during builds. 
+<Collapser
+    id="buildscript"
+    title=" Apply the plugin using the buildscript{} block"
+>
+The Android agent plugin is available on MavenCentral and uses the legacy plugin ID `newrelic` for compatibility with older projects. If you choose to leverage this legacy ID for an existing app, you'll need to explicitly configure the classpath to MavenCentral. This ensures Gradle can locate the plugin during your build process. For further details on various methods for resolving plugins, refer to the [Gradle documentation](https://docs.gradle.org/current/userguide/plugins.html#sec:binary_plugin_locations).
 
 To prefer MavenCentral over the Gradle Plugin Portal, you need to make the following changes to Gradle files:
 
-1. Add this snippet to your top-level `build.gradle(.kts)` file:
-   ```groovy
-   buildscript {
-     repositories {
-       mavenCentral()
-     }
+1. Add this snippet to your top-level build.gradle(.kts) file:
 
-     // not required if plugin classpath in resolutionStrategy{} below
-     dependencies {
-       classpath "com.newrelic.agent.android:agent-gradle-plugin:AGENT_VERSION"
-     }
-   }
-   ```   
+```groovy
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  // not required if plugin classpath in resolutionStrategy{} below
+  dependencies {
+    classpath "com.newrelic.agent.android:agent-gradle-plugin:AGENT_VERSION"
+  }
+}
+```
 
 2. Add this snippet to your `settings.gradle(.kts)` file through the `pluginManagement {}` block:
-   ```groovy
-   pluginManagement {
-     repositories {
-       mavenCentral()  // adds repo for NewRelic artifacts
-     }
-     resolutionStrategy {
-       eachPlugin {
-         // not required if using `classpath dependency` above
-         if (requested.id.id.startsWith("newrelic") || requested.id.id.startsWith("com.newrelic.agent.android"))) {
-           useModule("com.newrelic.agent.android:agent-gradle-plugin:${AGENT_VERSION}")
-         }
-       }
-     }
-     plugins {
-        id("newrelic") apply false
-     }
-   }
-   ```
+
+```groovy
+pluginManagement {
+  repositories {
+    mavenCentral()  // adds repo for NewRelic artifacts
+  }
+  resolutionStrategy {
+    eachPlugin {
+      // not required if using `classpath dependency` above
+      if (requested.id.id.startsWith("newrelic") || requested.id.id.startsWith("com.newrelic.agent.android"))) {
+        useModule("com.newrelic.agent.android:agent-gradle-plugin:${AGENT_VERSION}")
+      }
+    }
+  }
+  plugins {
+     id("newrelic") apply false
+  }
+}
+```
+
+Make sure to replace `AGENT_VERSION` with your agent version number. We strongly recommend you use the [latest version](/docs/release-notes/mobile-release-notes/android-release-notes/).
 
 3. Apply the plugin to the app-level build file, as well as any other sub-module to be instrumented:
 
-   ```groovy
-   plugins {
-     id("newrelic")
-   }
-   ```
+```groovy
+plugins {
+  id("newrelic")
+}
+```
+</Collapser>
+</CollapserGroup>
 
+</Step>
 
-In the above snippets, `AGENT_VERSION` represents your agent version number. We strongly recommend you use the latest agent for set up.
+<Step>
+In your `AndroidManifest.xml` file, add the following permissions:
 
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+```
+</Step>
+
+<Step>
+In your main `Activity` class within the `onCreate` method, add this import statement:
+
+```java
+import com.newrelic.agent.android.NewRelic;
+```
+
+Note: You must add this import statement to the `Activity` class. We don’t support starting the agent in other classes.
+</Step>
+
+<Step>
+In the `onCreate` method, add the following line, making sure to replace `GENERATED_TOKEN` with your actual app token (created during the guided install):
+
+```java
+NewRelic.withApplicationToken("GENERATED_TOKEN").start(this.getApplicationContext());
+```
+
+</Step>
+
+<Step>
+(Optional) Additional configurations for Proguard/Dexguard
+
+If you use ProGuard or Dexguard for code shrinking, follow these steps:
+
+1. Create a `newrelic.properties` file in your app-level directory (ex: `/projectname/app/newrelic.properties`).
+2. In this new file, add the following line, replacing `GENERATED_TOKEN ` with your actual token:
+
+    ```java
+    com.newrelic.application_token=GENERATED_TOKEN 
+    ```
+3. Follow the steps decribed on [Configure ProGuard or DexGuard for Android apps](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-proguard-or-dexguard-android-apps/).
+</Step>
+
+<Step>
+Clean your project, then run your app in an emulator or device to generate traffic. Wait a few minutes as your agent captures that data.
+</Step>
+
+<Step>
+View your app's data on New Relic by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile > (select an app)**</DNT>.
+</Step>
+</Steps>
+
+## What's next?
+
+Congratulations! You've successfully installed the Android agent. You have a few options for next steps:
+
+* Configure agent behavior during Gradle builds with the [New Relic Gradle plugin](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-new-relic-gradle-plugin).
+* [Upgrade the Android agent SDK](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrading-new-relic-mobiles-android-sdk) to keep your Android agent up to date.
+* Having problems with your Android installation? Follow the [troubleshooting procedures](/docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android).
 
 ## Android 4.x: Multidex support [#4x-multidex]
 
@@ -222,7 +217,7 @@ Mobile monitoring for Android versions older than Android 5.0 (API level 21) use
 
 <Collapser
   id="error"
-  title="Troubleshoot `java.lang.NoClassDefFoundError`"
+  title="Troubleshoot the java.lang.NoClassDefFoundError error"
 >
   When building each DEX file for a multidex app, the build tools perform complex decision making to determine which classes are needed in the primary DEX file so that your app can start successfully. If, during start up, the required classes aren't available in the primary DEX file, your app will crash with the error `java.lang.NoClassDefFoundError`.
 
@@ -253,11 +248,3 @@ Mobile monitoring for Android versions older than Android 5.0 (API level 21) use
 
   For more information, see the [Android Developers documentation](https://developer.android.com/studio/build/multidex.html#keep) on declaring classes required in the primary DEX file.
 </Collapser>
-
-## What's next?
-
-Congratulations! You've successfully installed the Android agent. You have a few options for next steps:
-
-* Configure agent behavior during Gradle builds with the [New Relic Gradle plugin](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/configure-new-relic-gradle-plugin).
-* [Upgrade the Android agent SDK](/docs/mobile-monitoring/new-relic-mobile-android/install-configure/upgrading-new-relic-mobiles-android-sdk) to keep your Android agent up to date.
-* Having problems with your Android installation? Follow the [troubleshooting procedures](/docs/mobile-monitoring/new-relic-mobile-android/troubleshoot/no-data-appears-android).


### PR DESCRIPTION
The Android agent's Gradle plugin is now deployed to the Gradle Plugin Portal as well as MavenCentral().

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

> What problems does this PR solve?
This PR updates manual instructions for applying the New Relic Android Agent Gradle plugin to a customer's app. Starting with version 7.6.0, Android agent releases will also deploy to the Gradle Plugin Portal. This is the default artifact repository for community Gradle plugins. 

Edits to the docs are intended to update instructions on resolving and applying our plugin. We now document the current approach favored by Google and Gradle. 

> Add any context that will help us review your changes such as testing notes,

I have proposed a slight restructuring of the install steps that require changing configuration (Gradle) files. There is still some duplication.

This PR does not yet include comparable changes to the UI guided installation screens. Will need @newrelic/docs-team assistance. 

> If your issue relates to an existing GitHub issue, please link to it.