### PR TITLE
Fix: Documentation about using environment variables to obfuscate sensitive values

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
+++ b/src/content/docs/infrastructure/host-integrations/installation/secrets-management.mdx
@@ -63,7 +63,7 @@ integrations:
 
 ## Using environment variables [#using-variables]
 
-Environment variables can be used into the `variables` section with the `{{MY_ENV_VAR}}` notation. When doing so, environment variables are expanded and their value is replaced at runtime.
+Environment variables can be used into the `variables` section with the `{{ MY_ENV_VAR }}` notation. When doing so, environment variables are expanded and their value is replaced at runtime.
 
 Use this method to avoid having sensitive values such as tokens or obfuscation keys included in the configuration file.
 
@@ -733,8 +733,8 @@ It's recommended to use environment variables for the obfuscation arguments as s
 variables:
   creds:
     obfuscated:
-      key: {{OBFUSCATION_KEY}}
-      secret: {{OBFUSCATION_TEXT}}
+      key: {{ OBFUSCATION_KEY }}
+      secret: {{ OBFUSCATION_TEXT }}
 integrations:
   - name: nri-nginx
     env:


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Adds missing whitespaces between the curly brackets and the environment variable name. Without them, these are interpreted literally.
* Add any context that will help us review your changes such as testing notes,
In the tests that fixed an issue with variable passthrough, they do have whitespaces https://github.com/newrelic/nri-kubernetes/blob/main/charts/newrelic-infrastructure/tests/configmap_integrations_test.yaml#L231