### PR TITLE
fix: broken in page link

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -33,7 +33,7 @@ If you have support for slow transaction traces and have added `'request.paramet
   If grouping your requests under the generic name, then `/*` is sufficient, and you do not need to customize your configuration file or API calls.
 </Callout>
 
-## Requirements
+## Requirements [#requirements]
 
 New Relic uses request names to group requests for many charts and tables. The value of these visualizations will drop as the number of different request names increases.
 
@@ -450,7 +450,7 @@ Use these API calls to record additional events:
   </Collapser>
 </CollapserGroup>
 
-## Transaction handle methods
+## Transaction handle methods [#transaction-handle-methods]
 
 This section details the methods provided by the `TransactionHandle` class instance that can be obtained through `newrelic.getTransaction()`.
 
@@ -1148,7 +1148,7 @@ Here is the structure for rules in New Relic's Node.js agent.
     NEW_RELIC_NAMING_RULES='{"pattern":"^t","name":"u"},{"pattern":"^u","name":"t"}'
     ```
 
-    ## Optional rules attributes
+    ## Optional rules attributes [#optional-rules-attribute]
 
     Additional optional attributes are available:
 
@@ -1215,7 +1215,7 @@ Here is the structure for rules in New Relic's Node.js agent.
       </tbody>
     </table>
 
-    ## Testing your naming rules
+    ## Testing your naming rules [#testing-naming-rules]
 
     The Node.js agent comes with a command-line tool for testing naming rules. For more information, run the following command in terminal window in a directory where your app is installed:
 

--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -1148,7 +1148,7 @@ Here is the structure for rules in New Relic's Node.js agent.
     NEW_RELIC_NAMING_RULES='{"pattern":"^t","name":"u"},{"pattern":"^u","name":"t"}'
     ```
 
-    ### Optional rules attributes
+    ## Optional rules attributes
 
     Additional optional attributes are available:
 
@@ -1192,8 +1192,8 @@ Here is the structure for rules in New Relic's Node.js agent.
 
             When set to `true`, all matches of the pattern will be replaced. Otherwise, only the first match will be replaced. Using the `g` flag with regular expression literal will have the same effect. For example:
 
-            ```
-            pattern: '[0-9]+',
+            ```js
+            pattern:     '[0-9]+',
             replace_all: true
             ```
 
@@ -1215,7 +1215,7 @@ Here is the structure for rules in New Relic's Node.js agent.
       </tbody>
     </table>
 
-    ### Testing your naming rules
+    ## Testing your naming rules
 
     The Node.js agent comes with a command-line tool for testing naming rules. For more information, run the following command in terminal window in a directory where your app is installed:
 
@@ -1223,7 +1223,7 @@ Here is the structure for rules in New Relic's Node.js agent.
     node node_modules/.bin/newrelic-naming-rules
     ```
 
-    ### Naming rule examples [#examples-rules]
+    ## Naming rule examples [#examples-rules]
 
     Here are some examples of naming rules and the results.
 
@@ -1232,9 +1232,9 @@ Here is the structure for rules in New Relic's Node.js agent.
         id="naming-full-url"
         title="Match full URL"
       >
-        ```
-        pattern: "^/items/[0-9]+$",
-        name: "/items/:id"
+        ```js
+        pattern: '^/items/[0-9]+$',
+        name:    '/items/:id'
         ```
 
         will result in:
@@ -1249,9 +1249,9 @@ Here is the structure for rules in New Relic's Node.js agent.
         id="first-match-url"
         title="Replace first match in URL"
       >
-        ```
-        pattern: "[0-9]+",
-        name: ":id"
+        ```js
+        pattern: '[0-9]+',
+        name:    ':id'
         ```
 
         will result in:
@@ -1267,9 +1267,9 @@ Here is the structure for rules in New Relic's Node.js agent.
         id="replace-urls"
         title="Replace all matches in any URL"
       >
-        ```
-        pattern: "[0-9]+",
-        name: ":id",
+        ```js
+        pattern:     '[0-9]+',
+        name:        ':id',
         replace_all: true
         ```
 
@@ -1286,9 +1286,9 @@ Here is the structure for rules in New Relic's Node.js agent.
       >
         Using regular expression match group references:
 
-        ```
+        ```js
         pattern: '^/(items|orders)/[0-9]+$',
-        name: '/\\1/:id'
+        name:    '/\\1/:id'
         ```
 
         will result in:


### PR DESCRIPTION
There is an in-page link rendering as plain text:

<img width="527" alt="image" src="https://github.com/user-attachments/assets/58fe8374-633b-439f-abb0-7a1e5a4cec72">

I didn't see a syntax issue causing this, but noticed it was the only in-page link in this doc that was broken and the only one on a `###` header, the rest were on `##` headers. So I'm trying to see if this fixes it.

 I also formatting some code blocks that I find tough to read