### PR TITLE
iOS agent 7.5.1 release notes: [Release asap on 8-21-2024]

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-751.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-751.mdx
@@ -1,0 +1,16 @@
+---
+subject: iOS agent
+releaseDate: '2024-08-21'
+version: 7.5.1
+downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.5.1.zip'
+---
+
+## Fixed in this release
+
+* Added watchOS as a compatible environment for the iOS agent. Fixed to work with SPM and Cocoapods. For more information on using the agent in a watchOS project visit our documentation.
+* [Starting the New Relic agent to your watchOS project](/docs/mobile-monitoring/new-relic-mobile-ios/watchOS/instrument-watchos)
+
+## Support statement
+
+* As of iOS agent version 7.4.1, the iOS agent will consolidate previously separate XCFramework and tvOS agents into a singular iOS agent.
+* As of this release, the oldest supported version of the [XCFramework](/docs/release-notes/mobile-release-notes/ios-release-notes/xcframework-agent-736) is 7.3.6.


### PR DESCRIPTION
New Relic iOS agent 7.5.1 release notes.