### PR TITLE
fix: removing the ability to set replicaCount in helm chart, so updating docs to reflect

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
@@ -285,18 +285,6 @@ Environmental variables allow you to fine-tune the synthetics job manager config
 
         <tr>
           <td>
-            `replicaCount`
-          </td>
-
-          <td>
-            Number of replicas to maintain with your installation
-
-            Default: `1.`
-          </td>
-        </tr>
-
-        <tr>
-          <td>
             `imagePullSecrets`
           </td>
 


### PR DESCRIPTION
Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
We are removing the ability to configure `replicaCount` for the Synthetics Job Manager in helm charts, and so need to update the configuration docs here to reflect this change.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Helm chart PR: https://github.com/newrelic/helm-charts/pull/1467

* If your issue relates to an existing GitHub issue, please link to it.