### PR TITLE
NR-304043: The support of browser and mobile logs brings a new set of reserved attributes (`instrumentation.*`)

### DIFF
--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -103,7 +103,7 @@ Some specific attributes have additional restrictions:
       </td>
 
       <td>
-        These are reserved attribute names. If any is included, it will be dropped during ingest.
+        These are reserved attribute names. If any attribute name is included, it will be dropped during ingest.
       </td>
     </tr>
 

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -96,5 +96,16 @@ Some specific attributes have additional restrictions:
         Payloads with timestamps older than 48 hours may be dropped.
       </td>
     </tr>
+
+    <tr>
+      <td>
+        `instrumentation.*`
+      </td>
+
+      <td>
+        These are reserved attribute names. If any is included, it will be dropped during ingest.
+      </td>
+    </tr>
+
   </tbody>
 </table>

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -98,7 +98,7 @@ Some specific attributes have additional restrictions:
     </tr>
 
     <tr>
-      <td>
+      <td class="children-nowrap">
         `instrumentation.*`
       </td>
 


### PR DESCRIPTION
The support of browser and mobile logs brings a new set of reserved attributes (`instrumentation.*`)