### PR TITLE
Update use-nerdgraph-manage-license-keys-user-keys.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys.mdx
@@ -172,7 +172,7 @@ Single key example query:
 query {
   actor {
     apiAccess {
-      key(id: INGEST_KEY_ID, keyType: INGEST) {
+      key(id: "INGEST_KEY_ID", keyType: INGEST) {
         key
         name
         type


### PR DESCRIPTION
The INGEST_KEY_ID needs to be in double quotes to work correctly. Confirmed this syntax myself today.

<!-- Thanks for contributing to our docs! -->

## Give us some context

Fixed the syntax for using Nerdgraphql to decode ingest license keys. The Key Id needs to be in double quotes to have valid syntax and for the API to respond.