### PR TITLE
Revert "NR-304043: The support of browser and mobile logs brings a new set of reserved attributes (`instrumentation.*`)"

### DIFF
--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -100,16 +100,5 @@ Some specific attributes have additional restrictions:
         Payloads with timestamps older than 48 hours may be dropped.
       </td>
     </tr>
-
-    <tr>
-      <td class="children-nowrap">
-        `instrumentation.*`
-      </td>
-
-      <td>
-        These are reserved attribute names. If any attribute name is included, it will be dropped during ingest.
-      </td>
-    </tr>
-
   </tbody>
 </table>


### PR DESCRIPTION
Reverts newrelic/docs-website#18446

This was not meant to be merged yet, the exact wording is being discussed. Sorry!