### PR TITLE
No new legacy monitors

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -1020,7 +1020,6 @@ While you can't change the monitor type after creating it, you can update its se
     }
     ```
   </Collapser>
-</CollapserGroup>
 
 <Collapser
     id="downgrade-monitor-runtime"

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -424,6 +424,12 @@ Below are some sample requests to automate the creation of your synthetic monito
   Include the runtime object that includes `runtimeType`, `runtimeTypeVersion`, and `scriptLanguage` to use a newer runtime. Do not include the runtime object and these attributes to continue using a legacy runtime.
 </Callout>
 
+<Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
+  On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
+</Callout>
+
 <CollapserGroup>
   <Collapser
     id="create-ping"
@@ -1003,6 +1009,39 @@ While you can't change the monitor type after creating it, you can update its se
             runtimeType: "RUNTIME_TYPE", 
             runtimeTypeVersion: "RUNTIME_TYPE_VERSION", 
             scriptLanguage: "SCRIPT_LANGUAGE"
+            }
+          }
+        ) {
+        errors {
+          description
+          type
+        }
+      }
+    }
+    ```
+  </Collapser>
+</CollapserGroup>
+
+<Collapser
+    id="downgrade-monitor-runtime"
+    title="Downgrade a monitor's runtime"
+  >
+    You can use the below example to update a simple browser, scripted API, or scripted browser monitor to use a legacy runtime prior to the October 22, 2024 EOL. The following example downgrades a scripted browser monitor to the legacy runtime from the new runtime.
+
+    * To update a simple browser monitor using the below example, change the mutation to `syntheticsUpdateSimpleBrowserMonitor` instead of `syntheticsUpdateScriptBrowserMonitor`.
+    * To update a scripted API monitor using the below example, change the mutation to `syntheticsUpdateScriptApiMonitor` instead of `syntheticsUpdateScriptBrowserMonitor`.
+
+    Check out [optional-fields](#optional-fields) for additional details on runtime settings.
+
+    ```
+    mutation {
+      syntheticsUpdateScriptBrowserMonitor ( 
+        guid: "<ENTITY_GUID>", 
+        monitor: {
+          runtime: {
+            runtimeType: "", 
+            runtimeTypeVersion: "", 
+            scriptLanguage: ""
             }
           }
         ) {

--- a/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
+++ b/src/content/docs/apis/synthetics-rest-api/monitor-examples/manage-synthetics-monitors-rest-api.mdx
@@ -21,7 +21,7 @@ Use the synthetics REST API to create and manage [synthetic monitors](/docs/synt
 ## Before you start [#before-you-start]
 
 <Callout variant="important">
-  On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. On June 30, 2024, we will block the creation of new monitors using legacy synthetics runtime versions. The Synthetics REST API only supports monitor creation using legacy synthetics runtime versions. Please use [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/) to manage your synthetic monitors using our latest runtimes to avoid degradation.
+  On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. As of August 26, 2024, you can no longer create new monitors using legacy synthetics runtime versions. The Synthetics REST API only supports monitor creation using legacy synthetics runtime versions. Please use [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/) to manage your synthetic monitors using our latest runtimes to avoid degradation.
 </Callout>
 
 Our synthetics REST API is one way to manage your synthetic monitors via API but the recommended way is using [our NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial).
@@ -212,7 +212,7 @@ https://synthetics.eu.newrelic.com/synthetics/api
     title="Create a monitor"
   >
     <Callout variant="important">
-      On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. On June 30, 2024, we will block the creation of new monitors using legacy synthetics runtime versions. The Synthetics REST API only supports monitor creation using legacy synthetics runtime versions. Please use [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/) to manage your synthetic monitors using our latest runtimes to avoid degradation.
+      On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. As of August 26, 2024, you can no longer create new monitors using legacy synthetics runtime versions. The Synthetics REST API only supports monitor creation using legacy synthetics runtime versions. Please use [NerdGraph APIs](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial/) to manage your synthetic monitors using our latest runtimes to avoid degradation.
     </Callout>
 
     To add a new monitor to your Synthetics account, send a POST request to `$API_ENDPOINT/v3/monitors` with a JSON payload that describes the monitor.

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-configuration.mdx
@@ -13,6 +13,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and the legacy synthetics runtime versions it supports. Please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid degradation of your private location monitors.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-maintenance-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/containerized-private-minion-cpm-maintenance-monitoring.mdx
@@ -13,6 +13,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and the legacy synthetics runtime versions it supports. Please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid degradation of your private location monitors.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/install-containerized-private-minions-cpms.mdx
@@ -18,6 +18,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and the legacy synthetics runtime versions it supports. Please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid degradation of your private location monitors.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide.mdx
@@ -16,6 +16,8 @@ The synthetics job manager brings monitors on the newest runtime to your private
 If you're ready to install the job manager, you can check out our [install doc](/docs/synthetics/synthetic-monitoring/private-locations/install-job-manager) for installation procedures, or read through our [configuration doc](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration) for working with new or existing [private locations](/docs/synthetics/synthetic-monitoring/private-locations/private-locations-overview-monitor-internal-sites-add-new-locations).
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and the legacy synthetics runtime versions it supports. Please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid degradation of your private location monitors.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-04x-or-lower.mdx
@@ -15,6 +15,8 @@ freshnessValidatedDate: never
 This document is for synthetic monitor versions 0.4.x or lower. See also the documentation for [Synthetic monitor versions 0.5 or 0.6.0](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050) and [monitor version Chrome 100 and newer](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetic-scipted-browser-reference-monitor-versions-chrome100).
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
@@ -17,6 +17,8 @@ This document describes scripted browser functions available for synthetic monit
 For more on monitor versions and runtime differences, see [Runtime environments](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment).
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 
   The Chrome 100+ browser runtime provides backward compatible support for 0.5.0 and 0.6.0 browser runtime syntax.

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests-legacy.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests-legacy.mdx
@@ -10,6 +10,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
@@ -12,6 +12,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/manage-monitor-runtimes.mdx
@@ -14,6 +14,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 </Callout>
 
@@ -423,8 +425,9 @@ The browser runtime is used for these monitor types:
 ## Review legacy runtime dependencies [#dependencies]
 
 <Callout variant="important">
-  The containerized private minion (CPM) and legacy synthetics runtimes are [end of life on October 22, 2024](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm/).
-  Please complete your migration to [synthetics job manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/) and [new runtimes](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) prior to that date to avoid synthetic monitoring degradation from occuring.
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
+  The containerized private minion (CPM) and legacy synthetics runtimes are [end of life on October 22, 2024](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm/). Please complete your migration to [synthetics job manager](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/) and [new runtimes](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) prior to that date to avoid synthetic monitoring degradation from occuring.
 </Callout>
 
 The monitor version always matches its runtime version, and determines what features the monitor can execute. The section below lists runtimes with its available features.

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/new-runtime.mdx
@@ -22,6 +22,8 @@ Making the switch gives you these features:
 * Access to  our [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial) to automate the management of your synthetic monitors.
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui.mdx
@@ -13,6 +13,8 @@ Use the synthetics runtime upgrades UI if your monitors use legacy runtimes, inc
 The synthetics runtime upgrade UI is a central place to view all monitors that use legacy runtimes. It also allows you to update them to the newest runtimes.
 
 <Callout variant="important">
+  As of August 26, 2024, you can no longer create new monitors using legacy runtimes on public or private locations.
+  
   On October 22, 2024, we will [end of life](/whats-new/2024/04/whats-new-04-09-eol-synthetics-runtime-cpm) the containerized private minion (CPM) and legacy synthetics runtime versions. For public locations, use [the runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) to update your monitors to the newest runtimes. For private locations, please review our [recommended migration steps](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-transition-guide/#monitorMigration) to avoid monitor degradation.
 </Callout>
 


### PR DESCRIPTION
- Updated all EOL callouts to make it obvious that no new legacy runtime monitors can be created as of Monday
- Added an example NerdGraph mutation that allows you to downgrade the runtime of an existing monitor

It will still be possible to downgrade monitors to the legacy runtime AND edit legacy runtime monitors until the EOL on October 22, 2024.

While we will roll out the no new legacy monitors restriction on Monday, it should be safe to merge this in at any time. It does not have to wait until Monday. 