### PR TITLE
Update monitor-your-php-app.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/monitor-your-php-app.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/monitor-your-php-app.mdx
@@ -51,13 +51,6 @@ We have a few paths to install the PHP agent, depending on what you're monitorin
   </Collapser>
 
   <Collapser
-    id="lambda"
-    title="App deployed with AWS Lambda"
-  >
-    If your app is deployed with AWS Lambda, follow our [self-guided steps](https://one.newrelic.com/marketplace?state=3daeff79-c8e3-4375-f0e0-57d417ec07ab) to instrument your app with the PHP agent.
-  </Collapser>
-
-  <Collapser
     id="hosting-providers"
     title="App hosted on AWS, Heroku, Magento, or other hosting providers"
   >


### PR DESCRIPTION
Confirmed with ENG that the PHP agent doesn't support running in AWS Lambda, and this links to an option in our Guided Install that doesn't exist.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.