### PR TITLE
fix: add handler for `span`

### DIFF
--- a/scripts/actions/utils/handlers.mjs
+++ b/scripts/actions/utils/handlers.mjs
@@ -479,6 +479,10 @@ export default {
     deserialize: deserializeComponent,
     serialize: serializeComponent,
   },
+  span: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
   sup: {
     deserialize: deserializeComponent,
     serialize: serializeComponent,


### PR DESCRIPTION
Many `span` tags were added to use this new class in tables, and we did not have handlers set up for them causing i18n workflows to fail.
```html                      
 <td>
  <span class="children-nowrap">`http`</span>
 </td>
```