### PR TITLE
chore: Adds Drupal 11.x to PHP compatibility

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -465,7 +465,7 @@ The following frameworks are supported:
         Drupal
       </td>
       <td>
-        7.x, 8.x, 9.x, 10.x
+        7.x, 8.x, 9.x, 10.x, 11.x
       </td>
       <td>
         [Drupal specific functionality](/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality)<br></br>


### PR DESCRIPTION
The PHP agent team has announced support for Drupal 11.x and this PR adds it to the compatibility page.