### PR TITLE
fix: correct addToTrace documentation

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/addtotrace.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/addtotrace.mdx
@@ -81,9 +81,7 @@ Note that the number of events shared this way is limited by the Browser agent h
         Required. Supply a JavaScript object with these required and optional name/value pairs:
 
         * Required name/value pairs: `name`, `start`
-        * Optional name/value pairs: `end`, `origin`, `type`
-
-          If you are sending the same event object to New Relic as a [`PageAction`](/docs/insights/explore-data/attributes/browser-default-attributes-insights#pageaction-list), omit the `TYPE` attribute. (`type` is a string to describe what type of event you are marking inside of a session trace.) If included, it will override the event type and cause the `PageAction` event to be sent incorrectly. Instead, use the `name` attribute for event information.
+        * Optional name/value pairs: `end`, `origin`
       </td>
     </tr>
   </tbody>
@@ -101,8 +99,6 @@ var obj = {
   end: 1417044274252,
   // Time in ms since epoch. Defaults to same as start resulting in trace object with a duration of zero.
   origin: 'Origin of event',
-  // Defaults to empty string
-  type: 'What type of event was this'
   // Defaults to empty string
 };
 ```


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Fixing the `addToTrace` browser agent API documentation to remove reference to the `type` field. This field is not used in the agent. The documentation is misleading to customers that may think they can define a value for the `type` field. In reality the agent always set's the `type` field to a value of `api`.

https://new-relic.atlassian.net/browse/NR-302664