### PR TITLE
chore: Remove section on errors-inbox discussions

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -154,7 +154,6 @@ To learn more about specific permissions, select a category below, or try search
     title="Errors inbox"
   >
     * <DNT>**Attribute analysis**</DNT>: relates to the [attributes tab](/docs/errors-inbox/errors-inbox/#attributes).
-    * <DNT>**Discussions**</DNT>: relates to [errors inbox discussions](/docs/errors-inbox/errors-inbox/#discussions).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/errors-inbox/errors-inbox.mdx
+++ b/src/content/docs/errors-inbox/errors-inbox.mdx
@@ -199,66 +199,44 @@ In the left-hand panel, you can find details for an **aggregation of all occurre
 
 In the right-hand panel, you can find details for a single occurrence of that error:
 
-<CollapserGroup>
-  <Collapser
-    className="freq-link"
-    id="occurrences-tab"
-    title="Occurrences tab"
-  >
-    The <DNT>**Occurrences**</DNT> dropdown includes details like:
+* Number and frequency of errors
 
-    * Number and frequency of errors
+* Related accounts
 
-    * Related accounts
+* Stack traces
 
-    * Stack traces
+* Distributed tracking
 
-    * Distributed tracking
+* [Logs in context]\(/docs/logs/logs-context/logs-in-context
 
-    * [Logs in context]\(/docs/logs/logs-context/logs-in-context
+* A list of error attributes
 
-    * A list of error attributes
+  From the detailed view, you can cycle through specific errors using the toggle in the upper right to navigate between the first instance of the error, the last, or any instance between.
 
-      From the detailed view, you can cycle through specific errors using the toggle in the upper right to navigate between the first instance of the error, the last, or any instance between.
+  If you've set up [distributed tracing](/docs/distributed-tracing/concepts/quick-start/), and if there are sampled traces related to errors, you'll see options to view trace details. This is a quick way to view trace information without going to the main distributed tracing page:
 
-      If you've set up [distributed tracing](/docs/distributed-tracing/concepts/quick-start/), and if there are sampled traces related to errors, you'll see options to view trace details. This is a quick way to view trace information without going to the main distributed tracing page:
+* In the left pane labeled <DNT>**Distributed traces**</DNT>, you can expand the heading to show a list of all traces associated with errors in this error group. Alternatively, you can click <DNT>**Explore all**</DNT> to open a list of all the traces.
 
-    * In the left pane labeled <DNT>**Distributed traces**</DNT>, you can expand the heading to show a list of all traces associated with errors in this error group. Alternatively, you can click <DNT>**Explore all**</DNT> to open a list of all the traces.
+  <img
+    width="50%"
+    style={{ align: "left" }}
+    title="Screenshot showing how to expand the list of traces"
+    alt="Screenshot showing how to expand the list of traces"
+    src="/images/errors-inbox_screenshot-crop_list-of-traces.webp"
+  />
 
-      <img
-        width="50%"
-        style={{ align: "left" }}
-        title="Screenshot showing how to expand the list of traces"
-        alt="Screenshot showing how to expand the list of traces"
-        src="/images/errors-inbox_screenshot-crop_list-of-traces.webp"
-      />
+* In <DNT>**Distributed trace**</DNT>, you'll see the trace that's associated with the error occurrence displayed on this page. To see the trace's spans in a waterfall view:
 
-    * In <DNT>**Distributed trace**</DNT>, you'll see the trace that's associated with the error occurrence displayed on this page. To see the trace's spans in a waterfall view:
+  * Click directly on the trace name, or click the icon with an arrow on the right. This pens up the waterfall focus view that highlights trace spans with errors.
 
-      * Click directly on the trace name, or click the icon with an arrow on the right. This pens up the waterfall focus view that highlights trace spans with errors.
-
-        <img
-          width="70%"
-          style={{ align: "left" }}
-          title="Screenshot showing the trace related to your error"
-          alt="Screenshot showing the trace related to your error"
-          src="/images/errors-inbox_screenshot-crop_trace-for-error.webp"
-        />
-      * Click <DNT>**Explore**</DNT> to open an unfiltered waterfall where you can click through all the spans.
-  </Collapser>
-
-  <Collapser
-    className="freq-link"
-    id="discussions"
-    title="Discussions tab"
-  >
-    The <DNT>**Discussions**</DNT> tab provides room for detailed and organized collaboration. This is key to looping in collaborators and ensuring the entire team has the same context regardless of where they sit. Discussions includes:
-
-    * <DNT>**Threaded conversations**</DNT>: Reply directly to top level comments to tie replies to specific posts.
-    * <DNT>**Comment deletion**</DNT>: Delete comments. The content of the post will be removed unless it is the parent of a thread, in which case the box will remain with the message `Comment deleted by user.`
-    * <DNT>**Markdown support**</DNT>: Add styling and links to your comments in Markdown.
-  </Collapser>
-</CollapserGroup>
+    <img
+      width="70%"
+      style={{ align: "left" }}
+      title="Screenshot showing the trace related to your error"
+      alt="Screenshot showing the trace related to your error"
+      src="/images/errors-inbox_screenshot-crop_trace-for-error.webp"
+    />
+  * Click <DNT>**Explore**</DNT> to open an unfiltered waterfall where you can click through all the spans.
 
 ## Assign errors [#assign-errors]
 

--- a/src/i18n/content/es/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/i18n/content/es/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -153,7 +153,6 @@ Para obtener más información sobre permisos específicos, seleccione una categ
     title="Errors Inbox"
   >
     * <DNT>**Attribute analysis**</DNT>: se relaciona con la [pestaña de atributos](/docs/errors-inbox/errors-inbox/#attributes).
-    * <DNT>**Discussions**</DNT>: se relaciona con [las discusionesErrors Inbox ](/docs/errors-inbox/errors-inbox/#discussions).
   </Collapser>
 
   <Collapser

--- a/src/i18n/content/jp/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/i18n/content/jp/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -153,7 +153,6 @@ UI に移動して、事前に構築された各ロールの権限を表示で�
     title="エラーの受信トレイ"
   >
     * <DNT>**Attribute analysis**</DNT>:[属性タブ](/docs/errors-inbox/errors-inbox/#attributes)に関連します。
-    * <DNT>**Discussions**</DNT>: [Errors Inboxのディスカッション](/docs/errors-inbox/errors-inbox/#discussions)に関連します。
   </Collapser>
 
   <Collapser

--- a/src/i18n/content/kr/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/i18n/content/kr/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -153,7 +153,6 @@ UI로 이동하여 사전 구축된 각 역할에 대한 권한을 볼 수 있�
     title="오류 받은편지함"
   >
     * <DNT>**Attribute analysis**</DNT>: [속성 탭](/docs/errors-inbox/errors-inbox/#attributes) 과 관련이 있습니다.
-    * <DNT>**Discussions**</DNT>: [투명한스 인박스(errors inbox) 토론](/docs/errors-inbox/errors-inbox/#discussions) 과 관련이 있습니다.
   </Collapser>
 
   <Collapser

--- a/src/i18n/content/pt/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/i18n/content/pt/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -153,7 +153,6 @@ Para saber mais sobre permissões específicas, selecione uma categoria abaixo o
     title="Errors Inbox"
   >
     * <DNT>**Attribute analysis**</DNT>: refere-se à [aba atributo](/docs/errors-inbox/errors-inbox/#attributes).
-    * <DNT>**Discussions**</DNT>: refere-se às [discussõesErrors Inbox ](/docs/errors-inbox/errors-inbox/#discussions).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Removing references to the errors inbox discussions tab and any references to it elsewhere in the docs. This feature has been replaced by the Collaboration feature: https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/ui-data/collaborate/collaborate-with-teammates/