### PR TITLE
Update log-event-data.mdx

### DIFF
--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -103,9 +103,9 @@ Some specific attributes have additional restrictions:
 
     <tr>
       <td>
-        <span class="nowrap">`instrumentation.name`</span>
-        <span class="nowrap">`instrumentation.provider`</span>
-        <span class="nowrap">`instrumentation.version`</span>
+        <span class="children-nowrap">`instrumentation.name`</span>
+        <span class="children-nowrap">`instrumentation.provider`</span>
+        <span class="children-nowrap">`instrumentation.version`</span>
       </td>
 
       <td>

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -100,5 +100,19 @@ Some specific attributes have additional restrictions:
         Payloads with timestamps older than 48 hours may be dropped.
       </td>
     </tr>
+
+    <tr>
+      <td>
+        `instrumentation.name`
+        `instrumentation.provider`
+        `instrumentation.version`
+      </td>
+
+      <td>
+        These attributes are reserved for our mobile and browser integrations.
+
+        If you use any of these integrations then you should not rely on or make use of these instrumentation attributes.
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -110,8 +110,9 @@ Some specific attributes have additional restrictions:
 
       <td>
         These attributes are reserved for our mobile and browser integrations.
-
-        If you use any of these integrations then you should not rely on or make use of these instrumentation attributes.
+        <Callout variant="important">
+        If you use any of these integrations, then you should not rely on or make use of these instrumentation attributes.
+        </Callout>
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -77,9 +77,9 @@ Some specific attributes have additional restrictions:
 
     <tr>
       <td>
-        `entity.guid`
-        `entity.name`
-        `entity.type`
+        <span class="children-nowrap">`entity.guid`</span>
+        <span class="children-nowrap">`entity.name`</span>
+        <span class="children-nowrap">`entity.type`</span>
       </td>
 
       <td>
@@ -91,7 +91,7 @@ Some specific attributes have additional restrictions:
 
     <tr>
       <td>
-        `timestamp`
+        <span class="children-nowrap">`timestamp`</span>
       </td>
 
       <td>

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -103,9 +103,9 @@ Some specific attributes have additional restrictions:
 
     <tr>
       <td>
-        `instrumentation.name`
-        `instrumentation.provider`
-        `instrumentation.version`
+        <span class="nowrap">`instrumentation.name`</span>
+        <span class="nowrap">`instrumentation.provider`</span>
+        <span class="nowrap">`instrumentation.version`</span>
       </td>
 
       <td>

--- a/src/content/docs/logs/log-api/log-event-data.mdx
+++ b/src/content/docs/logs/log-api/log-event-data.mdx
@@ -91,7 +91,7 @@ Some specific attributes have additional restrictions:
 
     <tr>
       <td>
-        <span class="children-nowrap">`timestamp`</span>
+        `timestamp`
       </td>
 
       <td>


### PR DESCRIPTION
Browser and mobile integrations are using `instrumentation.{name,provider,version}` for their own purposes. Customers using this integration should not use them or expect them to be stored with logs.

NR-304043