### PR TITLE
fix(OHI Elastic): Fixed errors in the installation doc

### DIFF
--- a/src/install/elasticsearch/default-install-linux.mdx
+++ b/src/install/elasticsearch/default-install-linux.mdx
@@ -15,7 +15,7 @@ headingText: Configure the Elasticsearch integration
    sudo cp  elasticsearch-config.yml.sample  elasticsearch-config.yml
    ```
 
-3. Edit the ` elasticsearch-config.yml` file. This example config file collects all metrics and inventory from your localhost:
+3. Edit the `elasticsearch-config.yml` file. This example config file collects all metrics and inventory from your localhost:
 
    ```yml
    integrations:

--- a/src/install/elasticsearch/find-data.mdx
+++ b/src/install/elasticsearch/find-data.mdx
@@ -3,10 +3,15 @@ componentType: default
 headingText: Find and use data
 ---
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com) > Integrations & Agents** and type **Elasticsearch**.
-2. Under **Dashboards**, click **Elasticsearch overview dashboard**.
-3. In the popup window, select your account, and follow the instructions in the UI.
-4. Click **View dashboard**, and see your Elasticsearch data in New Relic.
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > Integrations & Agents**</DNT> and search <DNT>**Elasticsearch**</DNT>.
+
+2. Under <DNT>**Dashboards**</DNT>, click <DNT>**Elasticsearch monitoring**</DNT>.
+
+3. A popup window opens. Click <DNT>**Edit**</DNT> if you want to change the account.
+
+4. Click <DNT>**Setup Elasticsearch**</DNT> or <DNT>**Skip this step**</DNT> if you already setup this datasource.
+
+5. Click <DNT>**View dashboard**</DNT>, and see your Elasticsearch data in New Relic.
 
 <img
   title="Elasticsearch dashboard"

--- a/src/install/elasticsearch/linux/install-apt.mdx
+++ b/src/install/elasticsearch/linux/install-apt.mdx
@@ -3,7 +3,7 @@ componentType: default
 headingText: Download using APT
 ---
 
-1. From the command line, run these commands:
+From the command line, run these commands:
 
    ```shell
    sudo apt-get update
@@ -12,7 +12,3 @@ headingText: Download using APT
    ```shell
    sudo apt-get install nri-elasticsearch
    ```
-
-```
-
-```

--- a/src/install/elasticsearch/linux/install-linux.mdx
+++ b/src/install/elasticsearch/linux/install-linux.mdx
@@ -5,17 +5,17 @@ headingText: Configure the Elasticsearch integration
 
 1. Change directory to the integrations configuration folder by running:
 
-   ```shell
-   cd /etc/newrelic-infra/integrations.d
-   ```
+  ```shell
+  cd /etc/newrelic-infra/integrations.d
+  ```
 
 2. Copy the sample configuration file by running:
 
-```shell
-sudo cp  elasticsearch-config.yml.sample  elasticsearch-config.yml
-```
+  ```shell
+  sudo cp  elasticsearch-config.yml.sample  elasticsearch-config.yml
+  ```
 
-3. Edit the ` elasticsearch-config.yml` file. This example config file collects all metrics and inventory from your localhost:
+3. Edit the `elasticsearch-config.yml` file. This example config file collects all metrics and inventory from your localhost:
 
    ```yml
    integrations:

--- a/src/install/elasticsearch/linux/install-yum.mdx
+++ b/src/install/elasticsearch/linux/install-yum.mdx
@@ -3,7 +3,7 @@ componentType: default
 headingText: Download using Yum
 ---
 
-1. From the command line, run these commands:
+From the command line, run these commands:
 
    ```shell
    sudo yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'

--- a/src/install/elasticsearch/linux/install-zypper.mdx
+++ b/src/install/elasticsearch/linux/install-zypper.mdx
@@ -3,7 +3,7 @@ componentType: default
 headingText: Download using Zypper
 ---
 
-1. From the command line, run these commands:
+From the command line, run these commands:
 
    ```shell
    sudo zypper -n ref -r newrelic-infra

--- a/src/install/elasticsearch/whatsNext.mdx
+++ b/src/install/elasticsearch/whatsNext.mdx
@@ -171,7 +171,7 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
 
       <td>
         Hostname or IP of the Elasticsearch node from which to collect inventory
-        data. Should only be set if you do not wish to collect inventory data
+        data. Should only be set if you don't wish to collect inventory data
         against localhost.
       </td>
 
@@ -260,8 +260,7 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
       </td>
 
       <td>
-        A way to further specify which cluster we are gathering data for, example:
-        'staging'.
+        A way to further specify which cluster we're gathering data, for example: `staging'.
       </td>
 
       <td>
@@ -349,8 +348,7 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
       </td>
 
       <td>
-        Alternative server hostname that the integration will accept as valid for
-        the purposes of SSL negotiation.
+        Alternative server hostname that the integration will accept as valid for the purposes of SSL negotiation.
       </td>
 
       <td>
@@ -798,7 +796,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            Bytes available to this Java virtual machine on this file store, in bytes.
+            Bytes available to this Java virtual machine on this file store.
           </td>
         </tr>
 
@@ -808,7 +806,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The total bytes read from the file store, in bytes.
+            The total bytes read from the file store.
           </td>
         </tr>
 
@@ -818,7 +816,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The total bytes used for all I/O operations on the file store, in bytes.
+            The total bytes used for all I/O operations on the file store.
           </td>
         </tr>
 

--- a/src/install/elasticsearch/whatsNext.mdx
+++ b/src/install/elasticsearch/whatsNext.mdx
@@ -260,8 +260,7 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
       </td>
 
       <td>
-        A way to further specify which cluster we are gathering data, for example:
-        'staging'.
+        A way to further specify which cluster we are gathering data, for example, 'staging'.
       </td>
 
       <td>

--- a/src/install/elasticsearch/whatsNext.mdx
+++ b/src/install/elasticsearch/whatsNext.mdx
@@ -171,7 +171,7 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
 
       <td>
         Hostname or IP of the Elasticsearch node from which to collect inventory
-        data. Should only be set if you don't wish to collect inventory data
+        data. Should only be set if you do not wish to collect inventory data
         against localhost.
       </td>
 
@@ -260,7 +260,8 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
       </td>
 
       <td>
-        A way to further specify which cluster we're gathering data, for example: `staging'.
+        A way to further specify which cluster we are gathering data, for example:
+        'staging'.
       </td>
 
       <td>
@@ -348,7 +349,8 @@ The Elasticsearch integration collects both Metrics and Inventory information. I
       </td>
 
       <td>
-        Alternative server hostname that the integration will accept as valid for the purposes of SSL negotiation.
+        Alternative server hostname that the integration will accept as valid for
+        the purposes of SSL negotiation.
       </td>
 
       <td>
@@ -796,7 +798,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            Bytes available to this Java virtual machine on this file store.
+            Bytes available to this Java virtual machine on this file store, in bytes.
           </td>
         </tr>
 
@@ -806,7 +808,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The total bytes read from the file store.
+            The total bytes read from the file store, in bytes.
           </td>
         </tr>
 
@@ -816,7 +818,7 @@ The Elasticsearch integration collects the following metrics. Each metric name i
           </td>
 
           <td>
-            The total bytes used for all I/O operations on the file store.
+            The total bytes used for all I/O operations on the file store, in bytes.
           </td>
         </tr>
 

--- a/src/install/elasticsearch/windows/install-msi.mdx
+++ b/src/install/elasticsearch/windows/install-msi.mdx
@@ -4,7 +4,9 @@ headingText: Download using MSI
 ---
 
 1. Download the latest .MSI installer image for the desired integration [from our repository](https://download.newrelic.com/infrastructure_agent/windows/integrations/).
+
 2. In an admin account, run the install script using an absolute path.
-   ```
+
+   ```shell
    msiexec.exe /qn /i PATH\TO\nri-elasticsearch.msi
    ```

--- a/src/install/elasticsearch/windows/install-windows.mdx
+++ b/src/install/elasticsearch/windows/install-windows.mdx
@@ -9,9 +9,9 @@ headingText: Configure the Elasticsearch integration
    copy elasticsearch-config.yml.sample elasticsearch-config.yml
    ```
 
-2. Edit the ` elasticsearch-config.yml` file. This example config file collects all metrics and inventory from your localhost:
+2. Edit the `elasticsearch-config.yml` file. This example config file collects all metrics and inventory from your localhost:
 
-   ```
+   ```yml
    integrations:
    - name: nri-elasticsearch
        env:


### PR DESCRIPTION
Fixed errors in the [Elasticsearch monitoring integration](https://docs.newrelic.com/install/elastic/)