### PR TITLE
add deprecation note

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
@@ -16,6 +16,10 @@ redirects:
 freshnessValidatedDate: never
 ---
 
+<Callout variant="important">
+  The createTracer browser API has been deprecated. The recommended way to trace the duration of a task is to capture a performance [mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and/or [measure](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).  Future browser agent versions will capture marks and measures automatically, at which point support for createTracer will cease.   
+</Callout>
+
 ## Syntax
 
 ```js

--- a/src/content/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
@@ -211,7 +211,7 @@ To track single page applications, use these SPA API methods:
       </td>
 
       <td>
-        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer)
+        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer) (deprecated)
       </td>
     </tr>
 

--- a/src/content/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
@@ -91,7 +91,7 @@ Select an event name in the following table to see its attributes.
       </td>
 
       <td>
-        `BrowserTiming` is a custom event that captures SPA timing data for browser interactions started using the custom [createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA API method. `BrowserTiming` contains many of the same attributes used by other events, especially `AjaxRequest`.
+        `BrowserTiming` is a custom event that captures SPA timing data for browser interactions started using the custom [createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA API method. `BrowserTiming` contains many of the same attributes used by other events, especially `AjaxRequest`. (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
+++ b/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
@@ -11,6 +11,10 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
+<Callout variant="important">
+  The createTracer browser API has been deprecated. The recommended way to trace the duration of a task is to capture a performance [mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and/or [measure](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).  Future browser agent versions will capture marks and measures automatically, at which point support for createTracer will cease.   
+</Callout>
+
 ## Sintaxis
 
 ```js

--- a/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
+++ b/src/i18n/content/es/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
@@ -187,7 +187,7 @@ Para realizar un seguimiento de una aplicación de una sola página, utilice est
       </td>
 
       <td>
-        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer)
+        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer) (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
+++ b/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
@@ -11,6 +11,10 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
+<Callout variant="important">
+  The createTracer browser API has been deprecated. The recommended way to trace the duration of a task is to capture a performance [mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and/or [measure](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).  Future browser agent versions will capture marks and measures automatically, at which point support for createTracer will cease.   
+</Callout>
+
 ## 構文
 
 ```js

--- a/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
+++ b/src/i18n/content/jp/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
@@ -207,7 +207,7 @@ browser APIすると、<InlinePopover type="browser"/> をカスタマイズお�
       </td>
 
       <td>
-        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer)
+        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer) (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/jp/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
+++ b/src/i18n/content/jp/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
@@ -81,7 +81,7 @@ translationType: human
       </td>
 
       <td>
-        `BrowserTiming` は、カスタム[createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA APIメソッドを使用して開始されたブラウザインタラクションのSPAタイミングデータをキャプチャするカスタムイベントです。`BrowserTiming`には、他のイベント（特に`AjaxRequest`）で使用されるものと同じ多くの属性が含まれています。
+        `BrowserTiming` は、カスタム[createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA APIメソッドを使用して開始されたブラウザインタラクションのSPAタイミングデータをキャプチャするカスタムイベントです。`BrowserTiming`には、他のイベント（特に`AjaxRequest`）で使用されるものと同じ多くの属性が含まれています。 (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
+++ b/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
@@ -11,6 +11,10 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
+<Callout variant="important">
+  The createTracer browser API has been deprecated. The recommended way to trace the duration of a task is to capture a performance [mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and/or [measure](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).  Future browser agent versions will capture marks and measures automatically, at which point support for createTracer will cease.   
+</Callout>
+
 ## 통사론
 
 ```js

--- a/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
+++ b/src/i18n/content/kr/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
@@ -207,7 +207,7 @@ translationType: machine
       </td>
 
       <td>
-        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer)
+        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer) (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/kr/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
+++ b/src/i18n/content/kr/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
@@ -81,7 +81,7 @@ translationType: machine
       </td>
 
       <td>
-        `BrowserTiming` 사용자 정의 [createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA API 메소드를 사용하여 시작된 브라우저 상호 작용에 대한 SPA 타이밍 데이터를 캡처하는 사용자 정의 이벤트입니다. `BrowserTiming` 에는 다른 이벤트, 특히 `AjaxRequest` 에서 사용하는 것과 동일한 속성이 많이 포함되어 있습니다.
+        `BrowserTiming` 사용자 정의 [createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA API 메소드를 사용하여 시작된 브라우저 상호 작용에 대한 SPA 타이밍 데이터를 캡처하는 사용자 정의 이벤트입니다. `BrowserTiming` 에는 다른 이벤트, 특히 `AjaxRequest` 에서 사용하는 것과 동일한 속성이 많이 포함되어 있습니다. (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
+++ b/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/createtracer.mdx
@@ -11,6 +11,10 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
+<Callout variant="important">
+  The createTracer browser API has been deprecated. The recommended way to trace the duration of a task is to capture a performance [mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and/or [measure](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure).  Future browser agent versions will capture marks and measures automatically, at which point support for createTracer will cease.   
+</Callout>
+
 ## Sintaxe
 
 ```js

--- a/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
+++ b/src/i18n/content/pt/docs/browser/new-relic-browser/browser-apis/using-browser-apis.mdx
@@ -207,7 +207,7 @@ Para rastrear aplicativos de página única, use estes métodos de API SPA:
       </td>
 
       <td>
-        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer)
+        [`newrelic.interaction().createTracer()`](/docs/browser/new-relic-browser/browser-apis/createtracer) (deprecated)
       </td>
     </tr>
 

--- a/src/i18n/content/pt/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
+++ b/src/i18n/content/pt/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
@@ -81,7 +81,7 @@ Selecione um nome de evento na tabela a seguir para ver seu atributo.
       </td>
 
       <td>
-        `BrowserTiming` é um evento personalizado que captura dados de tempo do SPA para interação do browser iniciada usando o método [createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA API personalizado. `BrowserTiming` contém muitos dos mesmos atributos usados por outros eventos, especialmente `AjaxRequest`.
+        `BrowserTiming` é um evento personalizado que captura dados de tempo do SPA para interação do browser iniciada usando o método [createTracer](/docs/browser/new-relic-browser/browser-agent-spa-api/createtracer-browser-spa-api) SPA API personalizado. `BrowserTiming` contém muitos dos mesmos atributos usados por outros eventos, especialmente `AjaxRequest`. (deprecated)
       </td>
     </tr>
 


### PR DESCRIPTION
This PR adds a deprecation warning to the docs tied to browser's createTracer method.