### PR TITLE
docs: update combining-npm-nerdgraph.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/combining-npm-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/combining-npm-nerdgraph.mdx
@@ -57,7 +57,7 @@ The `options` object in the previous snippet needs to be populated with configur
             guid
             name
             browserProperties {
-              jsConfigScript
+              jsConfig
             }
           }
         }


### PR DESCRIPTION
The GraphQL in the "Retrieve the configuration" section is incorrect.

It returns the config as a script, not an object, as shown in the example.

This PR updates the GraphQL to fix this.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
    * Fixes incorrect GraphQL
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
    * N/A
* If your issue relates to an existing GitHub issue, please link to it.
    * N/A