### PR TITLE
chore(apm/php): update Joomla compatibility

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -477,8 +477,8 @@ The following frameworks are supported:
       <td>
         Joomla
       </td>
-      <td><= 3.7</td>
-      <td>with Agent Version <= [10.22.0.12](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-22-0-12/)</td>
+      <td>&le; 3.7</td>
+      <td>with Agent Version &le; [10.22.0.12](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-22-0-12/)</td>
     </tr>
 
     <tr>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -477,8 +477,8 @@ The following frameworks are supported:
       <td>
         Joomla
       </td>
-      <td>3.x</td>
-      <td></td>
+      <td><= 3.7</td>
+      <td>with Agent Version <= [10.22.0.12](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-10-22-0-12/)</td>
     </tr>
 
     <tr>


### PR DESCRIPTION
Make the compatibility page accurate with respect to support for Joomla framework. PHP Agent only supports Joomla up to release 3.7, which is only compatible with PHPs < 7.2, and 10.22.0.12 is the last agent version supporting those PHPs.