### PR TITLE
fix: [NR-171881] Clearly indicate FedRAMP is not supported for AWS Kinesis Firehose

### DIFF
--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -19,6 +19,8 @@ If your log data is already being monitored by [Amazon CloudWatch Logs](https://
 
 Forwarding your CloudWatch Logs or other logs compatible with a Kinesis stream to New Relic will give you enhanced <InlinePopover type="logs"/> capabilities to collect, process, explore, query, and alert on your log data.
 
+You should not enable Log Streaming using Kinesis Data Firehose if you're a [FedRAMP customer](/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate), because AWS Kinesis Data Firehose integration is not currently FedRAMP authorized.
+
 ## Create the delivery stream for New Relic [#create-delivery-stream]
 
 To forward your logs from Kinesis Data Firehose to New Relic:

--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -20,7 +20,7 @@ If your log data is already being monitored by [Amazon CloudWatch Logs](https://
 Forwarding your CloudWatch Logs or other logs compatible with a Kinesis stream to New Relic will give you enhanced <InlinePopover type="logs"/> capabilities to collect, process, explore, query, and alert on your log data.
 
 <Callout variant="important">
-You should not enable Log Streaming using Kinesis Data Firehose if you're a [FedRAMP customer](/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate), because AWS Kinesis Data Firehose integration is not currently FedRAMP authorized.
+If you're a [FedRAMP customer](/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate), you should not enable log streaming using Kinesis Data Firehose because AWS Kinesis Data Firehose integration is not currently FedRAMP authorized.
 </Callout>
 
 ## Create the delivery stream for New Relic [#create-delivery-stream]

--- a/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
+++ b/src/content/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose.mdx
@@ -19,7 +19,9 @@ If your log data is already being monitored by [Amazon CloudWatch Logs](https://
 
 Forwarding your CloudWatch Logs or other logs compatible with a Kinesis stream to New Relic will give you enhanced <InlinePopover type="logs"/> capabilities to collect, process, explore, query, and alert on your log data.
 
+<Callout variant="important">
 You should not enable Log Streaming using Kinesis Data Firehose if you're a [FedRAMP customer](/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp-moderate), because AWS Kinesis Data Firehose integration is not currently FedRAMP authorized.
+</Callout>
 
 ## Create the delivery stream for New Relic [#create-delivery-stream]
 

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp.mdx
@@ -247,5 +247,19 @@ The following services are not FedRAMP-authorized:
         [AI Monitoring](/docs/ai-monitoring/compatibility-requirements-ai-monitoring/)
       </td>
     </tr>
+
+    <tr>
+      <td>
+        N/A
+      </td>
+
+      <td>
+        AWS
+      </td>
+
+      <td>
+        [Logs Streaming using Kinesis Data Firehose](/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose/)
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp.mdx
@@ -258,7 +258,7 @@ The following services are not FedRAMP-authorized:
       </td>
 
       <td>
-        [Logs Streaming using Kinesis Data Firehose](/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose/)
+        [Logs streaming using Kinesis Data Firehose](/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose/)
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Clearly indicate FedRAMP is not supported for AWS Kinesis Firehose

What problems does this PR solve? 
-> 
updates `stream-logs-using-kinesis-data-firehose.mdx` and `fedramp.mdx` to alert firehose integration to NR is not fedramp supported

Following are the changes made:
1. [FedRAMP doc](https://deploy-preview-18573--docs-website-netlify.netlify.app/docs/security/security-privacy/compliance/certificates-standards-regulations/fedramp/)
<img width="1043" alt="Screenshot 2024-09-09 at 6 59 30 PM" src="https://github.com/user-attachments/assets/8e47cc53-9b6c-41f0-ab1c-9988c7384ccd">

2. [Firehose doc](https://deploy-preview-18573--docs-website-netlify.netlify.app/docs/logs/forward-logs/stream-logs-using-kinesis-data-firehose/)
<img width="1067" alt="Screenshot 2024-09-09 at 6 59 37 PM" src="https://github.com/user-attachments/assets/6423f279-dfdf-4314-b82c-56c492a439fa">
