### PR TITLE
fix(Style Guide): Fixed error in the navigation file

### DIFF
--- a/src/nav/style-guide.yml
+++ b/src/nav/style-guide.yml
@@ -92,7 +92,7 @@ pages:
               - title: Edit the docs site structure and nav
                 path: /docs/style-guide/writing-docs/processes-procedures/understand-edit-docs-site-structure
               - title: Frontmatter and page templates
-                path: /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats/
+                path: /docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats
               - title: Create release notes
                 path: /docs/style-guide/writing-docs/processes-procedures/create-release-notes
               - title: Rename or redirect docs


### PR DESCRIPTION
Fixed the navigation file for the style guide. Removed the "/" at the end of a path. This is the file: [Frontmatter and page templates](https://docs.newrelic.com/docs/style-guide/writing-docs/processes-procedures/use-content-types-text-formats/).