### PR TITLE
fix(K8s): Fixed typo errors

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page.mdx
+++ b/src/content/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page.mdx
@@ -156,7 +156,7 @@ The [OpenTelemetry collector](/docs/opentelemetry/get-started/collector-processi
 
 2. Adjust the configuration of the collector to retrieve the appropriate Kubernetes metadata using this APM environment variable.
 
-As a result, all the APM metrics and entities will include Kubernetes metadata thanks to the K8sattributes processor. For more information, see how to [link your OpenTelemetry applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes/).
+As a result, all the APM metrics and entities will include Kubernetes metadata thanks to the `K8sattributes` processor. For more information, see how to [link your OpenTelemetry applications to Kubernetes](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes/).
 
 The following attributes are required in the APM service entity to display the Kubernetes summary page:
 
@@ -165,7 +165,7 @@ The following attributes are required in the APM service entity to display the K
 * `k8s.namespace.name`
 
 <Callout variant="caution">
-The Kubernetes summary page won't work properly if there is a mix of different instrumentation providers (newRelic and OpenTelemetry). For it to work properly, both Kubernetes and APM need to be monitored either exclusively through New Relic's proprietary agents or entirely through OpenTelemetry. 
+The Kubernetes summary page won't work properly if there is a mix of different instrumentation providers (New Relic and OpenTelemetry). For it to work properly, both Kubernetes and APM need to be monitored either exclusively through New Relic's proprietary agents or entirely through OpenTelemetry. 
 
 As of now, we don't support hybrid scenarios.
 </Callout>


### PR DESCRIPTION
Fixed 2 small typos on the [Kubernetes summary page](https://docs.newrelic.com/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page/) page.