### PR TITLE
Extend NR's EOL of FID to end of 2024

### DIFF
--- a/src/content/whats-new/2024/08/whats-new-8-01-eol-fid.md
+++ b/src/content/whats-new/2024/08/whats-new-8-01-eol-fid.md
@@ -5,6 +5,10 @@ releaseDate: '2024-08-01'
 learnMoreLink: 'https://forum.newrelic.com/s/hubtopic/aAXPh0000002q8z/upcoming-endoflife-google-core-web-vital-fid' 
 ---
 
+<Callout variant="important">
+  New Relic has extended support for FID until December 31, 2024 to allow more time to transition to INP. The New Relic Browser agent will continue to report FID after Google ends support for FID on September 9, 2024.
+</Callout>
+
 ## What you need to do
 
 On September 9, 2024, [Google is deprecating the FID metric](https://developers.google.com/search/blog/2023/05/introducing-inp), in favor of Interaction to Next Paint (“INP”). Since New Relic uses certain libraries and APIs that leverage the FID metric, you will need to take the actions below before September 9, 2024 to avoid inaccurate or unexpected behavior with dashboards, alerts, and service level reporting. 


### PR DESCRIPTION
The email notice went out late and there have been customer concerns (Verizon) about pulling support going into the holiday season, so NR will continue to report FID through the end of 2024 despite Google ending support for the metric on Sept 9, 2024.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.