### PR TITLE
feat(SyntheticsFirefox): Added proxy support

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
@@ -15,7 +15,7 @@ Read on to learn about synthetic monitoring's proxy settings and properties.
 ## Proxy settings API for scripted monitors [#proxy-api]
 
 <Callout variant="important">
-  Proxy usage is not supported yet for browser monitors using Firefox.
+  Proxy usage for Firefox requires version 3.0.7 or newer of the [synthetics-node-browser-runtime image](/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/).
 </Callout>
 
 The global object `$network` allows you to control the network configuration used by your synthetic scripted monitors. The following are applicable for both [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) and [API tests](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-api-tests), unless otherwise stated.


### PR DESCRIPTION
Proxy support is available for Firefox monitors using Synthetics Private Locations. This requires the customer to use version 3.0.7 of the synthetics-node-browser-runtime container image or newer. 