### PR TITLE
fix(Browser): Swapped upgraded for updated

### DIFF
--- a/src/content/docs/browser/single-page-app-monitoring/get-started/browser-spa-v2.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/get-started/browser-spa-v2.mdx
@@ -15,7 +15,7 @@ For customers monitoring browser single page applications (SPA), we're excited t
 * Third-party library conflicts: Global wrapping, particularly around `Promises`, often disrupted code functionality due to conflicts with other libraries.
 * Performance bottlenecks: Conflicts with code using timers, RAF, and promise chaining led to performance issues, ranging from slowdowns to freezes.
 
-The upgraded SPA monitoring experience is designed to eliminate these problems and provide a significantly improved monitoring experience. Key changes include:
+The updated SPA monitoring experience is designed to eliminate these problems and provide a significantly improved monitoring experience. Key changes include:
 
 * Unwrapped execution: By not wrapping core globals, the new SPA experience unleashes execution speed boosts for your application.
 * Aligned with soft navigation heuristics: The new experience adopts Google Chrome's soft navigation, providing more accurate interaction tracking and improved alignment with browser behavior.


### PR DESCRIPTION
@ally-sassman We want to avoid "upgraded" because, according to our style guide, any upgrade incurs additional cost.

Also, would you please remove the (new) from the left nav for this doc? Thanks!