### PR TITLE
fix(Synthetics): Minor style guide edit

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/set-proxy-settings-properties-scripted-monitors.mdx
@@ -15,7 +15,7 @@ Read on to learn about synthetic monitoring's proxy settings and properties.
 ## Proxy settings API for scripted monitors [#proxy-api]
 
 <Callout variant="important">
-  Proxy usage for Firefox requires version 3.0.7 or newer of the [synthetics-node-browser-runtime image](/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/).
+  Proxy usage for Firefox requires version 3.0.7 or higher of the [synthetics-node-browser-runtime image](/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/).
 </Callout>
 
 The global object `$network` allows you to control the network configuration used by your synthetic scripted monitors. The following are applicable for both [scripted browsers](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers) and [API tests](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-api-tests), unless otherwise stated.


### PR DESCRIPTION
@jeff-colucci Based on style guide, we use "higher or lower" and not "newer or older" when referring to versions.

