### PR TITLE
chore: Updates PHP api docs for newrelic_notice_error()

### DIFF
--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
@@ -211,7 +211,7 @@ newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline)
       </td>
 
       <td>
-        Required. Provide an error message that will be meaningful to you when it displays in [error traces](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors#traces-table).  This can be used to include addition information you would like to see.
+        Required. Provide an error message that will be meaningful to you when it displays in [error traces](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors#traces-table).  This can be used to include additional information you would like to see.
       </td>
     </tr>
 

--- a/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
+++ b/src/content/docs/apm/agents/php-agent/php-agent-api/newrelic_notice_error.mdx
@@ -18,7 +18,8 @@ freshnessValidatedDate: never
 newrelic_notice_error(string $message)
 newrelic_notice_error(Throwable|Exception $e)
 newrelic_notice_error(string $errstr, Throwable|Exception $e)
-newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline, string $errcontext)
+newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline)  (PHP 8+)
+newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline, string $errcontext) (PHP 7)
 ```
 
 Use these calls to collect errors that the PHP agent does not collect automatically and to set the callback for your own error and exception handler.
@@ -79,15 +80,23 @@ To use your own handler, use these calls to make sure that the PHP agent notices
   >
     To [provide `newrelic_notice_error` as the callback](#custom-error-handler-5) for [`set_error_handler()`](https://secure.php.net/set_error_handler), use the following:
 
+    PHP 7.x
+
     ```php
     newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline, string $errcontext)
+    ```
+
+    PHP 8.x
+
+    ```php
+    newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline)
     ```
   </Collapser>
 </CollapserGroup>
 
 ## Parameters
 
-This function can handle a variable number of parameters. You can pass-in 1 or 5 parameters, depending on your use case.
+This function can handle a variable number of parameters. You can pass-in 1, 4 or 5 parameters, depending on your use case.
 
 ```php
 newrelic_notice_error(string $message)
@@ -156,8 +165,16 @@ newrelic_notice_error(Throwable|Exception $e)
   </tbody>
 </table>
 
+PHP 7.3
+
 ```php
 newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline, string $errcontext)
+```
+
+PHP 8.x
+
+```php
+newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline)
 ```
 
 <table width={800}>
@@ -194,7 +211,7 @@ newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline,
       </td>
 
       <td>
-        Required. Provide an error message that will be meaningful to you when it displays in [error traces](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors#traces-table).
+        Required. Provide an error message that will be meaningful to you when it displays in [error traces](/docs/apm/applications-menu/error-analytics/error-analytics-explore-events-behind-errors#traces-table).  This can be used to include addition information you would like to see.
       </td>
     </tr>
 
@@ -207,6 +224,8 @@ newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline,
 
       <td>
         Optional. The name of the file that the error occurred in.
+
+        NOTE: This parameter is ignored by the agent - the agent will provide a stack trace with this information.
       </td>
     </tr>
 
@@ -219,6 +238,8 @@ newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline,
 
       <td>
         Optional. The line number where the error occurred.
+
+        NOTE: This parameter is ignored by the agent - the agent will provide a stack trace with this information.
       </td>
     </tr>
 
@@ -231,6 +252,8 @@ newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline,
 
       <td>
         Optional. An array that points to the symbol table that was active when the error occurred.
+
+        NOTE: The agent ignores this parameter - and it is not supported with PHP 8+.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
I am a member of the PHP agent team - here is a docs update I'd appreciate having reviewed and formatted (if needed):

* What problems does this PR solve?
Based on customer feedback this PR includes some clarifications for the newrelic_notice_error() API call.

