### PR TITLE
chore: Update .NET compatibility/support docs with latest tested versions of instrumented libraries

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -846,6 +846,20 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
                 </tr>
 
+                <tr>
+                <td>
+                  AWSSDK.SQS (Amazon Simple Queue Service) (agent versions 10.27.0 and newer)
+                </td>
+
+                <td>
+                  * Message send and receive
+                    
+                  * Minimum supported version: 3.7.0
+                    
+                  * Latest verified compatible version: 3.7.400.19
+                </td>
+                </tr>
+
             </tbody>
             </table>
 
@@ -1841,6 +1855,20 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       * Minimum supported version: 7.1.0
 
                       * Latest verified compatible version: 8.1.1
+                    </td>
+                    </tr>
+
+                    <tr>
+                    <td>
+                        AWSSDK.SQS (Amazon Simple Queue Service) (agent versions 10.27.0 and newer)
+                    </td>
+
+                    <td>
+                        * Message send and receive
+                    
+                        * Minimum supported version: 3.7.0
+                    
+                        * Latest verified compatible version: 3.7.400.19
                     </td>
                     </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -4,7 +4,7 @@ tags:
   - Agents
   - NET agent
   - Getting started
-metaDescription: "APM's .NET agent for .NET Framework applications: compatibility and requirement, and what frameworks are automatically instrumented."
+metaDescription: "APM's .NET agent for .NET applications: compatibility and requirements, and what frameworks are automatically instrumented."
 redirects:
   - /docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
   - /docs/agents/net-agent/getting-started/compatibility-requirements-net-agent
@@ -18,7 +18,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-New Relic's .NET agent supports both .NET Framework and .NET Core. This document describes compatibility and support for .NET Core applications. 
+New Relic's .NET agent supports both .NET Framework and .NET Core. This document describes compatibility and support for .NET runtimes, frameworks and libraries. 
 
 The agent includes built-in instrumentation for some of the most popular parts of the .NET ecosystem, including frameworks, databases, and message queuing systems. After you [download and install](/install/dotnet) the agent, it runs within the monitored process. The agent doesn't create a separate process or service.
 
@@ -525,9 +525,9 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     />
                 </td>
                 <td>
-            Minimum supported version: .0.488
+            Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.7.33
+            Latest verified compatible version: 2.8.16
                 </td>
                 </tr>
 
@@ -653,7 +653,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.23.0
                 </td>
                 <td>
-                    3.7.301.45
+                    3.7.403.4
                 </td>
 
                 </tr>
@@ -790,7 +790,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 1.4.0
 
-                    * Latest verified compatible version: 2.2.0
+                    * Latest verified compatible version: 2.5.3
                 </td>
                 </tr>
 
@@ -1454,7 +1454,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.7.33
+                        * Latest verified compatible version: 2.8.16
                     </td>
                     </tr>
 
@@ -1643,7 +1643,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.23.0
                     </td>
                     <td>
-                        3.7.301.45
+                        3.7.403.4
                     </td>
                     </tr>
                 </tbody>
@@ -1779,7 +1779,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 1.4.0
 
-                        * Latest verified compatible version: 2.2.0
+                        * Latest verified compatible version: 2.5.3
                     </td>
                     </tr>
 


### PR DESCRIPTION
This PR updates the latest versions of the .NET agent's instrumented libraries that we have tested and verified compatible.

This PR also adds a row for `AWSSDK.SQS` (Amazon Simple Queue Service) which we recently added instrumentation for in agent version 10.27.0.

This PR also fixes a few issues I found that were probably introduced by the merging of the .NET Core and .NET Framework versions of this doc into a single unified doc.