### PR TITLE
Removing inaccurate datacenter note

### DIFF
--- a/src/content/docs/alerts/overview.mdx
+++ b/src/content/docs/alerts/overview.mdx
@@ -222,10 +222,6 @@ This diagram shows how alerts work: you create an alert policy that includes an 
   </tbody>
 </table>
 
-## Note about EU/US data centers [#eu-datacenter]
-
-New Relic's alerts service is performed in the United States. By using New Relic alerts, you agree that New Relic may move your data to, and process your data in, the US region. This applies whether you store your data in New Relic's US region data center or in our [EU region data center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/).
-
 Ready to try New Relic for yourself? [Sign up for your free New Relic account](https://newrelic.com/signup) and follow our [quick launch guide](/docs/new-relic-solutions/get-started/intro-new-relic/#get-started) so you can start maximizing your data today! If you need any help, check out our [tutorial series](/docs/tutorial-create-alerts/create-new-relic-alerts/) on creating alerts to get started.
 
 <Callout variant="tip">


### PR DESCRIPTION
The note was never completely accurate.  With recent changes, no data crosses the US/EU boundary for Alerts so it's not accurate at all.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.