### PR TITLE
Update to aws-logs-ingestion Lambda function

### DIFF
--- a/src/content/docs/release-notes/logs-release-notes/logs-24-09-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-24-09-12.mdx
@@ -4,13 +4,13 @@ releaseDate: '2024-09-12'
 version: '240912'
 ---
 
-### Update to aws-log-ingestion Lambda Function
+### Update to AWS-log-ingestion Lambda function
 
-Users no longer need to manually enable logging for New Relic.The NRLoggingEnabled parameter is now set to true by default.
+Users no longer need to manually enable logging for New Relic. The `NRLoggingEnabled` parameter is now set to true by default.
 
 ### Changed
 
-The default value of the NRLoggingEnabled parameter for the New Relic Lambda function has been changed from false to true.Users were required to manually enable this parameter to forward logs to New Relic, adding an extra step to the setup process.This change simplifies the setup process and ensures logs are automatically sent to New Relic.
+The default value of the `NRLoggingEnabled` parameter for the New Relic Lambda function has been changed from `false` to `true`. Users were required to manually enable this parameter to forward logs to New Relic, adding an extra step to the setup process. This change simplifies the setup process and ensures logs are automatically sent to New Relic.
 
 ### Notes
 

--- a/src/content/docs/release-notes/logs-release-notes/logs-24-09-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-24-09-12.mdx
@@ -6,7 +6,7 @@ version: '240912'
 
 ### Update to AWS-log-ingestion Lambda function
 
-Users no longer need to manually enable logging for New Relic. The `NRLoggingEnabled` parameter is now set to true by default.
+Users no longer need to manually enable logging for New Relic. The `NRLoggingEnabled` parameter is now set to `true` by default.
 
 ### Changed
 

--- a/src/content/docs/release-notes/logs-release-notes/logs-24-09-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-24-09-12.mdx
@@ -1,0 +1,17 @@
+---
+subject: Logs
+releaseDate: '2024-09-12'
+version: '240912'
+---
+
+### Update to aws-log-ingestion Lambda Function
+
+Users no longer need to manually enable logging for New Relic.The NRLoggingEnabled parameter is now set to true by default.
+
+### Changed
+
+The default value of the NRLoggingEnabled parameter for the New Relic Lambda function has been changed from false to true.Users were required to manually enable this parameter to forward logs to New Relic, adding an extra step to the setup process.This change simplifies the setup process and ensures logs are automatically sent to New Relic.
+
+### Notes
+
+To stay up to date the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).

--- a/src/install/aws-logs/cloudwatch/basic-cloudwatch.mdx
+++ b/src/install/aws-logs/cloudwatch/basic-cloudwatch.mdx
@@ -59,7 +59,9 @@ Complete the following:
          </td>
 
          <td>
-           Determines if logs are forwarded to New Relic. **Required.** To turn on logging, set this to `true`.
+           Determines if logs are forwarded to New Relic. By default, this is set to `true`. **Required.**
+
+           Ensure this is set to `true` to turn on logging.
          </td>
        </tr>
 


### PR DESCRIPTION
We have updated the default value of the NRLoggingEnabled parameter for the New Relic Lambda function from false to true. This change has been released and is now live. The release notes have been updated to reflect this change.

