### PR TITLE
Refactor links

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
@@ -180,7 +180,7 @@ These queries apply for some older New Relic organizations that have only two us
 
     ### Count of full platform users and basic users
 
-    The [](/docs/accounts/accounts-billing/new-relic-one-pricing-users/pricing-billing#billing-usage-ui) shows the count of full platform users and basic users. The query used is:
+    The [How New Relic pricing works](/docs/accounts/accounts-billing/new-relic-one-pricing-users/pricing-billing#billing-usage-ui) shows the count of full platform users and basic users. The query used is:
 
     ```sql
     FROM NrUsage SELECT max(usage) SINCE 10 days ago

--- a/src/content/docs/accounts/original-accounts-billing/original-users-roles/user-migration.mdx
+++ b/src/content/docs/accounts/original-accounts-billing/original-users-roles/user-migration.mdx
@@ -238,7 +238,7 @@ User assets that are migrated include:
 * Weekly email settings
 * Email opt in/out preferences
 * User-specific [user keys](/docs/apis/intro-apis/new-relic-api-keys/#user-api-key)
-* New Relic apps [NerdStorage data](https://developer.newrelic.com/explore-docs/nerdstorage)
+* New Relic apps [NerdStorage data](/docs/new-relic-solutions/build-nr-ui/nerdstorage)
 
 If a user has access to several organizations that use New Relic (for example, if that user is a contractor), their original user model record won't be fully deleted until all those organizations migrate their users. Such a user will have both an original user record and one or more new user records, and if that's the case, that is displayed upon login (see [the login screenshot in Page 1 section](#page1)).
 

--- a/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph.mdx
@@ -244,7 +244,7 @@ Here are all our available NerdGraph docs:
       </td>
 
       <td>
-        [Build a New Relic app](https://developer.newrelic.com/explore-docs/query-and-store-data)
+        [Build a New Relic app](/docs/new-relic-solutions/build-nr-ui/query-and-store-data)
       </td>
     </tr>
 

--- a/src/content/docs/apis/nerdgraph/get-started/nerdgraph-explorer.mdx
+++ b/src/content/docs/apis/nerdgraph/get-started/nerdgraph-explorer.mdx
@@ -120,7 +120,7 @@ If you're new to GraphQL, get acquainted with the GraphQL API via the NerdGraph 
     Let's say that you've built a NerdGraph query you're happy with and you want to test it elsewhere. To capture code-ready queries and mutations:
 
     1. Select the <DNT>**Tools**</DNT> menu.
-    2. Copy the query as a curl call or as a [New Relic CLI](https://developer.newrelic.com/explore-docs/newrelic-cli) command.
+    2. Copy the query as a curl call or as a [New Relic CLI](/docs/new-relic-solutions/build-nr-ui/newrelic-cli) command.
 
     <img
       title="NerdGraph tools menu"

--- a/src/content/docs/new-relic-solutions/build-nr-ui/build-ab-app/first-chart.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/build-ab-app/first-chart.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
   Each lesson in the course builds upon the last, so make sure you've completed the last lesson, Add chart components to your A/B test application, before starting this one.
 </Callout>
 
-In this course, you're building an A/B test application for the New Relic platform. Previously, you learned about the New Relic One SDK and its component library. Now, It's time for you to start building your application focusing first on chart components.
+In this course, you're building an A/B test application for the New Relic platform. Previously, you learned about the New Relic One SDK](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk) and its component library. Now, It's time for you to start building your application focusing first on chart components.
 
 There are several charts you need to create, which may seem overwhelming at first, but take it one step at a time. The topmost chart, and the first you'll create, is a line chart that shows the number of users who sign up for your newsletter and what version of your website they were shown.
 

--- a/src/content/docs/new-relic-solutions/build-nr-ui/custom-visualizations/build-visualization.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/custom-visualizations/build-visualization.mdx
@@ -206,7 +206,7 @@ const ErrorState = () => (
 </Steps>
 
 <Callout variant="tip">
-  If you receive a `RequestError` for a self-signed certificate when you run `nr1 create`, you may need to add a certificate to Node's certificate chain. Read more about this and other advanced configurations in Enable advanced configurations for your Nerdpack.
+  If you receive a `RequestError` for a self-signed certificate when you run `nr1 create`, you may need to add a certificate to Node's certificate chain. Read more about this and other advanced configurations in [Enable advanced configurations for your Nerdpack](/docs/new-relic-solutions/new-relic-one/build-nr-apps/advanced-config).
 </Callout>
 
 As a result, you have a new `visualizations/my-awesome-visualization` directory in `my-awesome-nerdpack`:

--- a/src/content/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure.mdx
@@ -120,7 +120,7 @@ The launcher icon that appears on the **Apps** page in New Relic when an applica
 
 Launchers have their own file structure. Note that:
 
-* A launcher is not required; as an alternative to using a launcher, you can associate your application with a monitored entity.
+* A launcher is not required; as an alternative to using a launcher, you can [associate your application with a monitored entity](/docs/new-relic-solutions/tutorials/attach-nerdlet-entity).
 
 * An application can have more than one launcher, which might be desired for an application with multiple Nerdlets.
 

--- a/src/content/docs/new-relic-solutions/build-nr-ui/nerdstorage.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/nerdstorage.mdx
@@ -9,7 +9,7 @@ metaDescription: 'Learn about NerdStorage components'
 freshnessValidatedDate: 2024-04-29
 ---
 
-To help you build a New Relic application, we provide you with the New Relic One SDK. On this page, you'll learn how to use NerdStorage SDK components.
+To help you build a New Relic application, we provide you with the New Relic One SDK](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk). On this page, you'll learn how to use NerdStorage SDK components.
 
 ## Use NerdStorage in your apps [#nerdstorage]
 

--- a/src/content/docs/new-relic-solutions/build-nr-ui/nerdstoragevault.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/nerdstoragevault.mdx
@@ -10,11 +10,11 @@ metaDescription: 'Learn about NerdStorageVault usage'
 freshnessValidatedDate: 2024-04-29
 ---
 
-To help you build a New Relic application, we provide you with the New Relic One SDK. On this page, you'll learn how to use NerdStorageVault to store data in an encrypted storage solution.
+To help you build a New Relic application, we provide you with the [New Relic One SDK](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk). On this page, you'll learn how to use `NerdStorageVault` to store data in an encrypted storage solution.
 
-## Using NerdStorageVault in your apps [#using]
+## Using `NerdStorageVault` in your apps [#using]
 
-Use NerdStorageVault to store and retrieve sensitive secrets data such as:
+Use `NerdStorageVault` to store and retrieve sensitive secrets data such as:
 
 * personal access tokens
 * license keys
@@ -22,27 +22,27 @@ Use NerdStorageVault to store and retrieve sensitive secrets data such as:
 * other third party secrets
 
 <Callout variant="tip">
-  NerdStorageVault is encrypted with AES-256 encryption.
+  `NerdStorageVault` is encrypted with AES-256 encryption.
 </Callout>
 
 ## Usage considerations [#usage]
 
 * This storage is unique per Nerdpack, and can't be shared with any other Nerdpack.
-* NerdStorageVault can currently only be used within the context of a Nerdpack.
-* You cannot make a direct query or mutation to NerdStorageVault.
+* `NerdStorageVault` can currently only be used within the context of a Nerdpack.
+* You cannot make a direct query or mutation to `NerdStorageVault`.
 * You can explore the fields and response types via the [NerdGraph API explorer](https://api.newrelic.com/graphiql).
 * The only supported scope is ACTOR, or data that relates to a particular user.
 
 ## Component library [#component]
 
-Currently NerdStorageVault is available in the alpha release of [Nr1 Community component library](https://www.npmjs.com/package/@newrelic/nr1-community/v/1.3.0-alpha.5) and is not available in the Nr1 core components library. Open source components can be use to augment Nr1 core components for additional functionality.
+Currently `NerdStorageVault` is available in the alpha release of [Nr1 Community component library](https://www.npmjs.com/package/@newrelic/nr1-community/v/1.3.0-alpha.5) and is not available in the Nr1 core components library. Open source components can be use to augment Nr1 core components for additional functionality.
 
 ## NerdGraph queries [#nerdgraph]
 
-Below are examples of the queries used by the components to interact with NerdStorageVault.
+Below are examples of the queries used by the components to interact with `NerdStorageVault`.
 
 <Callout variant="tip">
-  NerdStorageVault can currently only be used within the context of a Nerdpack.
+  `NerdStorageVault` can currently only be used within the context of a Nerdpack.
 </Callout>
 
 ### Write [#write]
@@ -115,7 +115,7 @@ query {
 * A secret value is limited to 5000 characters.
 * A key value is limited to 64 characters.
 
-### Permissions for working with NerdStorageVault [#permissions]
+### Permissions for working with `NerdStorageVault` [#permissions]
 
-In order to persist changes to NerdStorageVault, such as writing, deleting,
+In order to persist changes to `NerdStorageVault`, such as writing, deleting,
 and fetching data, you must have a [user role with permission to persist changes](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model).

--- a/src/content/docs/new-relic-solutions/build-nr-ui/nr1-cli/nr1-common.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/nr1-cli/nr1-common.mdx
@@ -136,7 +136,7 @@ By default, the command displays the autocomplete instructions for `zsh`. If you
 
 Creates a new component from our template, either a Nerdpack, Nerdlet, launcher, or catalog. The CLI will walk you through this process.
 
-To learn more about Nerdpacks and their file structure, see [Nerdpack file structure](/explore-docs/nerdpack-file-structure). For more on how to set up your Nerdpacks, see our [Nerdpack CLI commands](/explore-docs/nr1-nerdpack).
+To learn more about Nerdpacks and their file structure, see [Nerdpack file structure](/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure). For more on how to set up your Nerdpacks, see our [Nerdpack CLI commands](/docs/new-relic-solutions/build-nr-ui/nr1-cli/nr1-nerdpack).
 
 ### Usage
 

--- a/src/content/docs/new-relic-solutions/build-nr-ui/query-and-store-data.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/query-and-store-data.mdx
@@ -8,7 +8,7 @@ metaDescription: 'Reference for query components using NerdGraph'
 freshnessValidatedDate: 2024-04-29
 ---
 
-To help you build a New Relic application, we provide you with the New Relic One SDK. Here you can learn how to use the SDK query components, which allow you to make queries and mutations via [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/), our GraphQL endpoint.
+To help you build a [New Relic application](/docs/new-relic-solutions/tutorials/build-hello-world-app), we provide you with the [New Relic One SDK](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk). Here you can learn how to use the SDK query components, which allow you to make queries and mutations via [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/), our GraphQL endpoint.
 
 <Callout variant="tip">
   Query-related React components can be identified by the `Query` suffix. Mutation-related components can be identified by the `Mutation` prefix.
@@ -87,6 +87,6 @@ Similarly, a mutation can happen either way; either declaratively or imperativel
 
 * `NERD_GRAPH`: Returns the format in which it arrives from NerdGraph.
 * `RAW`: The format exposed by default in Insights and dashboards when being plotted as JSON. This format is useful if you have a pre-existing script in this format that you're willing to migrate to or incorporate with.
-* `CHART`: The format used by the charting engine that we also expose.
+* `CHART`: The format used by the charting engine that we also expose. You can find a more detailed explanation of how to manipulate this format in the [guide to chart components](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk), and some examples.
 
 If you're willing to push data, we currently don't expose `NrqlMutation`. To do that, see the [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api/) for how to add custom events.

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
@@ -28,33 +28,33 @@ You can find the SDK components in the Node module package named `nr1`, which yo
 
 The **UI components** category of the SDK contains React UI components, including:
 
-* **Text components**: These components provide basic font and heading elements. These include `HeadingText` and `BlockText`.
+* **Text components**: These components provide basic font and heading elements. These include [`HeadingText`](/docs/new-relic-solutions/build-nr-ui/sdk-component/text/HeadingText/) and [`BlockText`](/docs/new-relic-solutions/build-nr-ui/sdk-component/text/BlockText/).
 
 * **Layout components**: These components give you control over the layout, and help you build complex layout designs without having to deal with the CSS. Layout components include:
 
-  * `Grid` and `GridItem`: For organizing more complex, larger scale page content in rows, and columns.
+  * [`Grid`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/Grid/) and [`GridItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/GridItem/): For organizing more complex, larger scale page content in rows, and columns.
 
-  * `Stack` and `StackItem`: For organizing simpler, smaller scale page content, in column or row.
+  * [`Stack`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/Stack/) and [`StackItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/StackItem/): For organizing simpler, smaller scale page content, in column or row.
 
-  * `Tabs` and `TabsItem`: Group various related pieces of content into separate hideable sections.
+  * [`Tabs`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/Tabs/) and [`TabsItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/TabsItem/): Group various related pieces of content into separate hideable sections.
 
-  * `List` and `ListItem`: For providing a basic skeleton of virtualized lists.
+  * [`List`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/List/) and [`ListItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/ListItem/): For providing a basic skeleton of virtualized lists.
 
-  * `Card`, `CardHeader`, and `CardBody`: Used to group similar concepts and tasks together.
+  * [`Card`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/ListItem/), [`CardHeader`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/CardHeader/), and [`CardBody`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/CardBody/): Used to group similar concepts and tasks together.
 
-* **Form components**: These components provide the basic building blocks to interact with the UI. These include [`Button`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/button), [`TextField`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/TextField), [`Dropdown`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdown), [`DropdownItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/DropdownItem), [`Checkbox`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/checkbox), [`RadioGroup`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/RadioGroup), and [`Radio`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio).
+* **Form components**: These components provide the basic building blocks to interact with the UI. These include [`Button`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/button), [`TextField`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/TextField/), [`Dropdown`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/DropdownItem/), [`DropdownItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/DropdownItem), [`Checkbox`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/checkbox), [`RadioGroup`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/RadioGroup/), and [`Radio`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio).
 
-* **Feedback components**: Use these components to provide feedback to users about actions they have taken. These include: `Spinner` and `Toast`.
+* **Feedback components**: Use these components to provide feedback to users about actions they have taken. These include: [`Spinner`](/docs/new-relic-solutions/build-nr-ui/sdk-component/feedback/Spinner/) and [`Toast`](/docs/new-relic-solutions/build-nr-ui/sdk-component/feedback/Toast/).
 
-* **Overlaid components**: Use these components to display contextual information and options in the form of an additional child view that appears above other content on screen when an action or event is triggered. They can either require user interaction (like modals), or be augmenting (like a tooltip). These include: `Modal` and `Tooltip`.
+* **Overlaid components**: Use these components to display contextual information and options in the form of an additional child view that appears above other content on screen when an action or event is triggered. They can either require user interaction (like modals), or be augmenting (like a tooltip). These include: [`Modal`](/docs/new-relic-solutions/build-nr-ui/sdk-component/overlays/Modal/) and [`Tooltip`](/docs/new-relic-solutions/build-nr-ui/sdk-component/overlays/Tooltip/).
 
 <Callout variant="important">
-  Components suffixed with `Item` can only operate as direct children of that name without the suffix. For example: `GridItem` should only be found as a child of `Grid`.
+  Components suffixed with `Item` can only operate as direct children of that name without the suffix. For example: [`GridItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/GridItem/) should only be found as a child of [`Grid`](/docs/new-relic-solutions/build-nr-ui/sdk-component/structure/Grid/).
 </Callout>
 
 ### Chart components [#chart-components]
 
-The **Charts** category of the SDK contains components representing different types of charts. The `ChartGroup` component helps a group of related charts share data and be aligned.
+The **Charts** category of the SDK contains components representing different types of charts. The [`ChartGroup`](/docs/new-relic-solutions/build-nr-ui/build-ab-app/chart-group) component helps a group of related charts share data and be aligned.
 
 Some chart components can perform [NRQL queries](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) on their own; some accept a customized set of data.
 
@@ -62,7 +62,7 @@ Some chart components can perform [NRQL queries](/docs/nrql/get-started/introduc
 
 The **Query components** category contains components for fetching and storing New Relic data.
 
-The main way to fetch data is with NerdGraph, our GraphQL endpoint. This can be queried using `NerdGraphQuery`. To simplify use of NerdGraph queries, we provide some components with pre-defined queries. See our docs about [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for more info.
+The main way to fetch data is with NerdGraph, our GraphQL endpoint. This can be queried using [`NerdGraphQuery`](/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/NerdGraphQuery/). To simplify use of NerdGraph queries, we provide some components with pre-defined queries. See our docs about [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for more info.
 
 We also provide storage for storing small data sets, such as configuration settings data, or user-specific data. For more on this, see [NerdStorage](/docs/new-relic-solutions/build-nr-ui/nerdstorage).
 
@@ -70,7 +70,7 @@ We also provide storage for storing small data sets, such as configuration setti
 
 The Platform API components of the SDK enable your application to interact with different parts of the New Relic platform, by reading and writing state from and to the URL, setting the configuration, etc. They are divided into these categories:
 
-* `PlatformStateContext`: Provides read access to the platform URL state variables. For example `timeRange` in the [time picker](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker).
-* `navigation`: An object that allows programmatic manipulation of the navigation in New Relic. Example: opening a new Nerdlet.
-* `NerdletStateContext`: Provides read access to the Nerdlet URL state variables. For example an `entityGuid` in the [entity explorer](/docs/new-relic-solutions/new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/).
-* `nerdlet`: allows you to configure your Nerdlet and write to your Nerdlet's URL state.
+* [`PlatformStateContext`](/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/PlatformStateContext/): Provides read access to the platform URL state variables. For example `timeRange` in the [time picker](/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/#dash-time-picker).
+* [`navigation`](/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/navigation/): An object that allows programmatic manipulation of the navigation in New Relic. Example: opening a new Nerdlet.
+* [`NerdletStateContext`](/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/NerdletStateContext/): Provides read access to the Nerdlet URL state variables. For example an `entityGuid` in the [entity explorer](/docs/new-relic-solutions/new-relic-one/core-concepts/new-relic-explorer-view-performance-across-apps-services-hosts/).
+* [`nerdlet`](/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/nerdlet/): Allows you to configure your Nerdlet and write to your Nerdlet's URL state.

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
@@ -62,7 +62,7 @@ Some chart components can perform [NRQL queries](/docs/nrql/get-started/introduc
 
 The **Query components** category contains components for fetching and storing New Relic data.
 
-The main way to fetch data is with NerdGraph, our GraphQL endpoint. This can be queried using `NerdGraphQuery`. To simplify use of NerdGraph queries, we provide some components with pre-defined queries. See our docs about [NerdGraph](/collect-data/get-started-nerdgraph-api-explorer) for more info.
+The main way to fetch data is with NerdGraph, our GraphQL endpoint. This can be queried using `NerdGraphQuery`. To simplify use of NerdGraph queries, we provide some components with pre-defined queries. See our docs about [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) for more info.
 
 We also provide storage for storing small data sets, such as configuration settings data, or user-specific data. For more on this, see [NerdStorage](/docs/new-relic-solutions/build-nr-ui/nerdstorage).
 

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
@@ -42,7 +42,7 @@ The **UI components** category of the SDK contains React UI components, includin
 
   * `Card`, `CardHeader`, and `CardBody`: Used to group similar concepts and tasks together.
 
-* **Form components**: These components provide the basic building blocks to interact with the UI. These include [`Button`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/button), [`TextField`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/text-field), [`Dropdown`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdown), [`DropdownItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdown-item), [`Checkbox`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/checkbox), [`RadioGroup`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio-group), and [`Radio`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio).
+* **Form components**: These components provide the basic building blocks to interact with the UI. These include [`Button`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/button), [`TextField`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/textfield), [`Dropdown`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdown), [`DropdownItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdownitem), [`Checkbox`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/checkbox), [`RadioGroup`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radiogroup), and [`Radio`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio).
 
 * **Feedback components**: Use these components to provide feedback to users about actions they have taken. These include: `Spinner` and `Toast`.
 

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk.mdx
@@ -42,7 +42,7 @@ The **UI components** category of the SDK contains React UI components, includin
 
   * `Card`, `CardHeader`, and `CardBody`: Used to group similar concepts and tasks together.
 
-* **Form components**: These components provide the basic building blocks to interact with the UI. These include [`Button`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/button), [`TextField`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/textfield), [`Dropdown`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdown), [`DropdownItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdownitem), [`Checkbox`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/checkbox), [`RadioGroup`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radiogroup), and [`Radio`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio).
+* **Form components**: These components provide the basic building blocks to interact with the UI. These include [`Button`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/button), [`TextField`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/TextField), [`Dropdown`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/dropdown), [`DropdownItem`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/DropdownItem), [`Checkbox`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/checkbox), [`RadioGroup`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/RadioGroup), and [`Radio`](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/radio).
 
 * **Feedback components**: Use these components to provide feedback to users about actions they have taken. These include: `Spinner` and `Toast`.
 

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -317,7 +317,7 @@ Whether you're considering New Relic or you're already using our capabilities, t
     id="cli"
     title="command line interface (CLI)"
   >
-    Our [command line interface](https://developer.newrelic.com/explore-docs/newrelic-cli) (CLI) is a tool that lets you manage New Relic, including managing and controlling your use of New Relic at scale.
+    Our [command line interface](/docs/new-relic-solutions/build-nr-ui/newrelic-cli) (CLI) is a tool that lets you manage New Relic, including managing and controlling your use of New Relic at scale.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/new-relic-solutions/new-relic-one/build-nr-apps/serve.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/build-nr-apps/serve.mdx
@@ -104,7 +104,7 @@ So, if you don't find your Nerdpack in New Relic, you're using the correct query
 
 ## Further reading
 
-Read the [`nr1 nerdpack:serve`](/explore-docs/nr1-nerdpack#nr1-nerdpackserve) documentation to learn more. Or, view the `nr1` help page:
+Read the [`nr1 nerdpack:serve`](/docs/new-relic-solutions/build-nr-ui/nr1-cli/nr1-nerdpack/#nr1-nerdpackserve) documentation to learn more. Or, view the `nr1` help page:
 
 ```shell
 nr1 nerdpack:serve --help

--- a/src/content/docs/new-relic-solutions/new-relic-one/build-nr-apps/set-up-dev-env.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/build-nr-apps/set-up-dev-env.mdx
@@ -31,7 +31,7 @@ To start building, you must have:
 
 ### A note on support
 
-Building a New Relic application is the same as building any JavaScript/React application. We offer support to help with our building tools ([our CLI](/explore-docs/nr1-cli) and [SDK library](/explore-docs/intro-to-sdk)). However, we don't offer support for basic JavaScript or React coding questions or issues.
+Building a New Relic application is the same as building any JavaScript/React application. We offer support to help with our building tools ([our CLI](https://one.newrelic.com/launcher/developer-center.launcher?pane=eyJuZXJkbGV0SWQiOiJkZXZlbG9wZXItY2VudGVyLmRldmVsb3Blci1jZW50ZXIifQ==) and [SDK library](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk). However, we don't offer support for basic JavaScript or React coding questions or issues.
 
 For common questions and answers about building, see the [Explorers Hub page on building on New Relic](https://discuss.newrelic.com/c/build-on-new-relic).
 
@@ -63,7 +63,7 @@ For common questions and answers about building, see the [Explorers Hub page on 
     If you want to learn more about building applications, try these step-by-step guides:
 
     * [Build a "Hello, World!" application](/docs/new-relic-solutions/tutorials/build-hello-world-app) shows how to create a little application, publish it to New Relic, and share it with others by subscribing accounts to it.
-    * [Map pageviews by region](/build-apps/map-pageviews-by-region) takes you through the steps to create one of our popular open source apps. You learn to add a custom query to an app and view it in a table, then add that data to a map.
+    * [Map pageviews by region](/docs/new-relic-solutions/tutorials/map-pageviews-region/) takes you through the steps to create one of our popular open source apps. You learn to add a custom query to an app and view it in a table, then add that data to a map.
   </Step>
 </Steps>
 

--- a/src/content/docs/new-relic-solutions/tutorials/build-hello-world-app.mdx
+++ b/src/content/docs/new-relic-solutions/tutorials/build-hello-world-app.mdx
@@ -34,7 +34,7 @@ Finally, make sure your `nr1` is up-to-date:
 nr1 update
 ```
 
-For additional details about setting up your environment, see [Set up your development environment](https://developer.newrelic.com/build-apps/set-up-dev-env/) and [Enable advanced configurations for your Nerdpack](https://developer.newrelic.com/build-apps/advanced-config).
+For additional details about setting up your environment, see [Set up your development environment](https://developer.newrelic.com/build-apps/set-up-dev-env/) and [Enable advanced configurations for your Nerdpack](/docs/new-relic-solutions/new-relic-one/build-nr-apps/advanced-config).
 
 <Callout variant="tip">
   If you use VSCode, we have an [extension](https://marketplace.visualstudio.com/items?itemName=new-relic.nr1) and an [extension pack](https://marketplace.visualstudio.com/items?itemName=new-relic.new-relic-extension-pack) you can use to build your app.
@@ -66,7 +66,7 @@ my-awesome-nerdpack/
 The _launchers_ and _nerdlets_ directories contain the logic of your application. It's in these directories that you update most of your code. The _nr1.json_ files throughout the Nerdpack hold metadata about your Nerdpack, Nerdlets, and launchers.
 
 <Callout variant="tip">
-  Read [our documentation](https://developer.newrelic.com/explore-docs/nerdpack-file-structure/) to learn more about the Nerdpack file structure.
+  Read [our documentation](/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure/) to learn more about the Nerdpack file structure.
 </Callout>
 
 <Steps>

--- a/src/content/docs/new-relic-solutions/tutorials/build-react-hooks-app.mdx
+++ b/src/content/docs/new-relic-solutions/tutorials/build-react-hooks-app.mdx
@@ -72,7 +72,7 @@ my-awesome-nerdpack/
 The _launchers_ and _nerdlets_ directories contain the logic of your application. It's in these directories that you update most of your code. The _nr1.json_ files throughout the Nerdpack hold metadata about your Nerdpack, Nerdlets, and launchers.
 
 <Callout variant="tip">
-  Read [our documentation](https://developer.newrelic.com/explore-docs/nerdpack-file-structure/) to learn more about the Nerdpack file structure.
+  Read [our documentation](/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure/) to learn more about the Nerdpack file structure.
 </Callout>
 
 <Steps>

--- a/src/content/docs/new-relic-solutions/tutorials/customize-nerdpacks.mdx
+++ b/src/content/docs/new-relic-solutions/tutorials/customize-nerdpacks.mdx
@@ -146,11 +146,11 @@ Tweak the **Circular progress bar** visualization to use straight edges and cust
   <Step>
     In your local Nerdpack, open `nr1-victory-visualizations/visualizations/circular-progress-bar/nr1.json`.
 
-    `nr1.json` is the **Circular progress bar** visualization's [metadata file](/explore-docs/custom-viz/configuration-options/). Use this file to add a configurable `colorScale` option, which corresponds to the `colorScale` field on `VictoryPie`.
+    `nr1.json` is the **Circular progress bar** visualization's [metadata file](/docs/new-relic-solutions/build-nr-ui/custom-visualizations/configuration-options). Use this file to add a configurable `colorScale` option, which corresponds to the `colorScale` field on `VictoryPie`.
   </Step>
 
   <Step>
-    Add a [`collection`](/explore-docs/custom-viz/configuration-options/#collection) of [`string`](/explore-docs/custom-viz/configuration-options/#string) fields for you to customize your chart's colors:
+    Add a [`collection`](/docs/new-relic-solutions/build-nr-ui/custom-visualizations/configuration-options/#collection) of [`string`](/docs/new-relic-solutions/build-nr-ui/custom-visualizations/configuration-options/#string) fields for you to customize your chart's colors:
 
     ```json fileName=nr1.json
     {

--- a/src/content/docs/new-relic-solutions/tutorials/map-pageviews-region.mdx
+++ b/src/content/docs/new-relic-solutions/tutorials/map-pageviews-region.mdx
@@ -30,7 +30,7 @@ To add your data to a world map in the second half of the guide:
 The following are some terms used in this guide:
 
 * New Relic application: The finished product where data is rendered in New Relic. This might look like a series of interactive charts or a map of the world.
-* Nerdpack: New Relic's standard collection of JavaScript, JSON, CSS, and other files that control the functionality and look of your application. For more information, see [Nerdpack file structure](/explore-docs/nerdpack-file-structure).
+* Nerdpack: New Relic's standard collection of JavaScript, JSON, CSS, and other files that control the functionality and look of your application. For more information, see [Nerdpack file structure](/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure).
 * Launcher: The button in New Relic that launches your application.
 * Nerdlets: New Relic React components used to build your application. The three default files are `index.js`, `nr1.json`, and `styles.scss`, but you can customize and add your own.
 
@@ -104,7 +104,7 @@ The following are some terms used in this guide:
     ### Review your app files and view your app locally [#review-files]
 
     1. Navigate to your `pageviews-app` to see how it's structured.
-       It contains a launcher folder, where you can customize the description and icon that will be displayed on the app's launcher in New Relic. It also contains `nerdlets`, which each contain three default files: `index.js`, `nr1.json`, and `styles.scss`. You'll edit some of these files as part of this guide. For more information, see [Nerdpack file structure](/explore-docs/nerdpack-file-structure).
+       It contains a launcher folder, where you can customize the description and icon that will be displayed on the app's launcher in New Relic. It also contains `nerdlets`, which each contain three default files: `index.js`, `nr1.json`, and `styles.scss`. You'll edit some of these files as part of this guide. For more information, see [Nerdpack file structure](/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure).
 
     2. Now in your browser, open `https://one.newrelic.com/?nerdpacks=local`, and then click **Apps** to see the `pageview-apps` Nerdpack that you served up.
 
@@ -242,7 +242,7 @@ Once you confirm that data is getting to New Relic from your app, you can start 
   <Step>
     ### Import the `TextField` component [#import-textfield]
 
-    Like you did with the `TableChart` component, you need to import a [`TextField` component](/client-side-sdk/index.html#components/TextField) from New Relic.
+    Like you did with the `TableChart` component, you need to import a [`TextField` component](/docs/new-relic-solutions/build-nr-ui/sdk-component/controls/TextField/) from New Relic.
 
     ```jsx fileName=pageview-app-nerdlet/index.js
     import React from 'react';

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/use-your-charts.mdx
@@ -291,7 +291,7 @@ Most charts have various options, including a chart-embed option, getting a char
 
 ## Use open-source charting library [#victory-charts]
 
-You can use [Nerdpacks](https://developer.newrelic.com/explore-docs/custom-viz/) to create your own custom visualizations. We've also teamed up with Formidable so you can use an open-source charting library, and quickly add unique "victory charts" to your dashboards. To learn about these [custom visualization Nerdpacks](https://developer.newrelic.com/build-apps/customize-nerdpack/), watch this short video (approx. 4 minutes).
+You can use [Nerdpacks](/docs/new-relic-solutions/build-nr-ui/nerdpack-file-structure/) to create your own custom visualizations. We've also teamed up with Formidable so you can use an open-source charting library, and quickly add unique "victory charts" to your dashboards. To learn about these [custom visualization Nerdpacks](/docs/new-relic-solutions/tutorials/customize-nerdpacks), watch this short video (approx. 4 minutes).
 
 <Video
   id="WgHPo1lyf0Q"

--- a/src/content/whats-new/2020/10/store-data-encrypted-storage-solution-nerdstoragevault.md
+++ b/src/content/whats-new/2020/10/store-data-encrypted-storage-solution-nerdstoragevault.md
@@ -16,4 +16,4 @@ NerdStorageVault provides you with a secure and encrypted storage location where
 
 ![break down of NerdGraph mutation](/images/nerdgraph-mutation.webp 'nerdgraph-mutation.webp')
 
-NerdStorageVault is currently only available in the alpha release of the [nr1-community](https://www.npmjs.com/package/@newrelic/nr1-community/v/1.3.0-alpha.5) component library and is not available in the [New Relic One core components](https://developer.newrelic.com/explore-docs/intro-to-sdk) library. The feature uses AES-256 encryption.
+NerdStorageVault is currently only available in the alpha release of the [nr1-community](https://www.npmjs.com/package/@newrelic/nr1-community/v/1.3.0-alpha.5) component library and is not available in the [New Relic One core components](/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk/) library. The feature uses AES-256 encryption.


### PR DESCRIPTION
these links were ported over from the developer site and didn't get updated 

page: `/docs/new-relic-solutions/build-nr-ui/sdk-component/intro-to-sdk`
fixes: links for text field, dropdown item, radio group, and nerdgraph