### PR TITLE
NR-307459 Added a section about watchOS compatibility

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements.mdx
@@ -148,6 +148,10 @@ Make sure your iOS app meets these requirements:
 
 The iOS agent can monitor tvOS apps. For details, see [tvOS compatibility](/docs/mobile-monitoring/new-relic-mobile-ios/tvos/new-relic-tvos-compatibility-requirements).
 
+## watchOS [#watchos]
+
+The iOS agent can monitor watchOS apps. For details, see [watchOS compatibility](/docs/mobile-monitoring/new-relic-mobile-ios/watchOS/instrument-watchos).
+
 ## Testing is not supported [#testing]
 
 Our agents are designed and tested to work in a normal app lifecycle. New Relic does not support running any testing environment on applications with the agent. Testing can cause conflicts and unpredictable behavior.


### PR DESCRIPTION
Added a small section to the iOS agent compatibility page linking to the watchOS doc. https://new-relic.atlassian.net/browse/NR-307459