### PR TITLE
feat(Networks): Added a new row for APM in the table

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -72,8 +72,7 @@ For more detail on specific agents and integrations, and about ports, keep readi
   <tbody>
     <tr>
       <td>
-        APM agent ingest  
-
+        [APM agent](/docs/apm/new-relic-apm/getting-started/introduction-apm/) ingest
       </td>
 
       <td>
@@ -85,6 +84,21 @@ For more detail on specific agents and integrations, and about ports, keep readi
         `collector.eu01.nr-data.net`
       </td>
     </tr>
+
+    <tr>
+      <td>
+        APM agent ingest, when you forward logs through our APM agents
+      </td>
+
+      <td>
+        `log-api.newrelic.com`
+      </td>
+
+      <td>
+        `collector.eu.newrelic.com` <br/>
+        `collector.eu01.nr-data.net`
+      </td>
+    </tr>    
   </tbody>
 
   <thead>


### PR DESCRIPTION
Per hero channel request (09-19-2024), added a new row for APM agent ingest in the table included in the [New Relic telemetry endpoints](http://localhost:8000/docs/new-relic-solutions/get-started/networks/#new-relic-endpoints) section.