### PR TITLE
Ruby: automatic custom method tracers

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -189,7 +189,7 @@ Along with method-level tracing, you can instrument non-web transactions, such a
 
 With New Relic Ruby agent v9.14.0 and higher, method tracers can be applied automatically by the agent for any Ruby method defined in the agent's configuration (set via the YAML configuration file or environment variables).
 
-The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods that the agent can automatically add custom instrumentation to. This doesn't require any code modifications of the classes that define the methods.
+The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods for which the agent will try to add a tracer. This doesn't require any code modifications of the classes that define the methods.
 
 The list should be an array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings.
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -171,8 +171,8 @@ To instrument a class method, add the method tracer in the class singleton:
 ```rb
 class Controller
   include NewRelic::Agent::Instrumentation::ControllerInstrumentation
-  
-  class << self 
+
+  class << self
     def transaction
       # execute a transaction
     end
@@ -184,6 +184,56 @@ end
 ## Instrumenting non-web transactions [#non-web-transactions]
 
 Along with method-level tracing, you can instrument non-web transactions, such as background tasks, with the same level of transaction and error detail as web transactions. For more information, see [Monitoring Ruby background processes and daemons](/docs/ruby/monitoring-ruby-background-processes-and-daemons).
+
+## Applying method tracers automatically via config
+
+With New Relic Ruby agent v9.14.0 and above, method tracers can be applied automatically by the agent for any Ruby method defined in the agent's configuration (set via the YAML configuration file or environment variables).
+
+The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods for the agent to automatically add custom instrumentation for without requiring any code modifications to be made to the classes that define the methods.
+
+The list should be an array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings.
+
+Use fully qualified class names (using the `::` delimiter) that include any module or class namespacing.
+
+Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
+
+```
+module MyCompany
+  class Image
+    def render_png
+      # code to render a PNG
+    end
+  end
+
+  class User
+    def self.notify
+      # code to notify users
+    end
+  end
+end
+```
+
+Given that source code, the `newrelic.yml` config file might request instrumentation for both of these methods like so:
+
+```
+automatic_custom_instrumentation_method_list:
+  - MyCompany::Image#render_png
+  - MyCompany::User.notify
+```
+
+That configuration example uses YAML array syntax to specify both methods. Alternatively, a comma-delimited string can be used instead:
+
+```
+automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
+```
+
+Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, this comma-delimited string format should be used:
+
+```
+export NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png, MyCompany::User.notify'
+```
+
+The YAML entry or environment variable configuration is all that is needed. With this approach, there is no need to add any of the `require`, `include`, or `add_method_tracer` lines of code to the application.
 
 ## Advanced custom instrumentation [#advanced-tracing]
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -189,7 +189,7 @@ Along with method-level tracing, you can instrument non-web transactions, such a
 
 With New Relic Ruby agent v9.14.0 and higher, method tracers can be applied automatically by the agent for any Ruby method defined in the agent's configuration (set via the YAML configuration file or environment variables).
 
-The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods that the agent can automatically add custom instrumentation to. This doesn't require any code modifications to the classes that define the methods.
+The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods that the agent can automatically add custom instrumentation to. This doesn't require any code modifications of the classes that define the methods.
 
 The list should be an array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings.
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -221,7 +221,7 @@ automatic_custom_instrumentation_method_list:
   - MyCompany::User.notify
 ```
 
-That configuration example uses YAML array syntax to specify both methods. Alternatively, you can use a comma-delimited string instead:
+That configuration example uses YAML array syntax to specify both methods. Alternatively, you can use a comma-delimited string:
 
 ```
 automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -187,9 +187,9 @@ Along with method-level tracing, you can instrument non-web transactions, such a
 
 ## Applying method tracers automatically via config
 
-With New Relic Ruby agent v9.14.0 and above, method tracers can be applied automatically by the agent for any Ruby method defined in the agent's configuration (set via the YAML configuration file or environment variables).
+With New Relic Ruby agent v9.14.0 and higher, method tracers can be applied automatically by the agent for any Ruby method defined in the agent's configuration (set via the YAML configuration file or environment variables).
 
-The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods for the agent to automatically add custom instrumentation for without requiring any code modifications to be made to the classes that define the methods.
+The `:automatic_custom_instrumentation_method_list` configuration parameter can be used to define a list of fully qualified (namespaced) Ruby methods that the agent can automatically add custom instrumentation to. This doesn't require any code modifications to the classes that define the methods.
 
 The list should be an array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings.
 
@@ -221,13 +221,13 @@ automatic_custom_instrumentation_method_list:
   - MyCompany::User.notify
 ```
 
-That configuration example uses YAML array syntax to specify both methods. Alternatively, a comma-delimited string can be used instead:
+That configuration example uses YAML array syntax to specify both methods. Alternatively, you can use a comma-delimited string instead:
 
 ```
 automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
 ```
 
-Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, this comma-delimited string format should be used:
+Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, use this comma-delimited string format:
 
 ```
 export NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png, MyCompany::User.notify'


### PR DESCRIPTION
Update the Ruby APM agent specific custom method tracer documentation to reference the new agent v9.14.0+ support for applying custom method tracers automatically based on configuration.

NOTE:
* I'm on the Ruby APM agent dev team
* This PR should not be merged until Ruby agent version 9.14.0 has been released