### PR TITLE
Add python agent release notes for 10.0.0 - PLEASE MERGE SEPTEMBER 27th 2024 AM

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -216,6 +216,19 @@ The following are proposed time ranges. The actual release date may vary.
   </thead>
 
   <tbody>
+    <tr>
+      <td>
+        3.7
+      </td>
+
+      <td>
+        June 27th, 2023
+      </td>
+
+      <td>
+        March 1st, 2025
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -59,7 +59,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
         * Python version 3.4 is supported only by Python agent versions 4.20.0.120 or lower.
         * Python version 3.5 is supported only by Python agent versions 5.24.0.153 or lower.
         * Python version 3.6 is supported only by Python agent versions 7.16.0.178 or lower.
-        * For Python version 2.7 follow our [end of life (EOL) support](#python-version) requirements.
+        * Python version 2.7 is supported only by Python agent versions 9.13.0 or lower.
       </td>
     </tr>
 
@@ -216,25 +216,8 @@ The following are proposed time ranges. The actual release date may vary.
   </thead>
 
   <tbody>
-    <tr>
-      <td>
-        2.7
-      </td>
-
-      <td>
-        January 1, 2020
-      </td>
-
-      <td>
-        April 1, 2024 (see note below)
-      </td>
-    </tr>
   </tbody>
 </table>
-
-<Callout variant="important">
-  Python 2.7 is no longer officially supported in subsequent framework work or maintenance, but the date that Python 2.7 will be removed from the agent is TBD.
-</Callout>
 
 ## Connect the agent to other capabilities [#digital-intelligence-platform]
 

--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -222,11 +222,11 @@ The following are proposed time ranges. The actual release date may vary.
       </td>
 
       <td>
-        June 27th, 2023
+        June 27, 2023
       </td>
 
       <td>
-        March 1st, 2025
+        March 1, 2025
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apm/agents/python-agent/hosting-services/install-python-agent-gae-flexible-environment.mdx
+++ b/src/content/docs/apm/agents/python-agent/hosting-services/install-python-agent-gae-flexible-environment.mdx
@@ -81,8 +81,8 @@ For more information about deploying and configuring your Node.js app in the GAE
     # Install the fortunes binary from the debian repositories.
     RUN apt-get update && apt-get install -y fortunes
 
-    # Optional: Change the -p argument to use Python 2.7.
-    RUN virtualenv /env -p python3.5
+    # Optional: Change the -p argument to use a particular version of Python.
+    RUN virtualenv /env -p python3.9
 
     # Set virtualenv environment variables. This is equivalent to running
     # source /env/bin/activate.

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
@@ -101,7 +101,7 @@ If you call `initialize` with no arguments, you must have already specified your
       </td>
 
       <td>
-        Optional. Sets the logging level. The agent uses [Python's logging module](https://docs.python.org/2.7/library/logging.html#logging-levels). Options are the same as for the [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) option in config file.
+        Optional. Sets the logging level. The agent uses [Python's logging module](https://docs.python.org/3.7/library/logging.html#logging-levels). Options are the same as for the [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) option in config file.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
@@ -1,18 +1,43 @@
 ---
 subject: 'Python agent'
-releaseDate: '2024-08-08'
+releaseDate: '2024-09-26'
 version: 10.0.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Remove Python2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChasimilarity search', 'Add environment variable for GC runtime metrics']
-bugs: ['Fix bug in graphql entity name detection', 'Fix issue in LangChain where a thread is started and the transaction context is lost', 'Fix parsing of request and response when running OpenAI via LangChain', 'Instrument new path to OpenAI chat class', 'Fix pyscopg v3 API incompatibilities']
+features: ['Remove Python 2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChasimilarity search', 'Add environment variable for GC runtime metrics']
+bugs: ['Fix bug in gRPC entity name detection', 'Fix issue in LangChain where a thread is started and the transaction context is lost', 'Fix parsing of request and response when running OpenAI via LangChain', 'Instrument new path to OpenAI chat class', 'Fix pyscopg v3 API incompatibilities', 'Remove versioned logic in loguru instrumentation']
 security: []
 ---
 
 ## Notes
 
-This release of the Python agent drops support for Python2.7, adds a Kafka server metric, capturing of memcache host and port, support for [kafka-python-ng](https://pypi.org/project/kafka-python-ng/), support for [uvicorn_worker](https://pypi.org/project/uvicorn-worker/), an environment variable for GC runtime metrics, and automatically detects the function signature in [LangChain](https://pypi.org/project/langchain/) `similarity_search`. It also fixes a bug in [graphql](https://pypi.org/project/graphql/) entity name detection, an issue in [LangChain](https://pypi.org/project/langchain/) where a thread is started and the transaction context is lost, parsing of the request and response when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/), [pyscopg](https://pypi.org/project/psycopg/) v3 API incompatibilities, and instruments a new path to the [OpenAI](https://pypi.org/project/openai/) chat class.
+This release of the Python agent drops support for Python 2.7 and adds the following:
+
+ * a Kafka server metric
+ * host and port attributes for memcache
+ * support for [kafka-python-ng](https://pypi.org/project/kafka-python-ng/)
+ * support for [uvicorn_worker](https://pypi.org/project/uvicorn-worker/)
+ * an environment variable for garbage collector (GC) runtime metrics
+ * automatic detection for the function signature in [LangChain](https://pypi.org/project/langchain/)'s similarity_search
+ * updated support for [OpenAI](https://pypi.org/project/openai/)'s chat class
+ * a fix for a bug in gRPC's entity name detection
+ * a fix for transaction context propagation loss in [LangChain](https://pypi.org/project/langchain/) in the case of a new thread
+ * parsing of the request and response when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/)
+ * a fix for [pyscopg](https://pypi.org/project/psycopg/) v3 API incompatibilities
+ * a fix that removes versioned logic in [loguru](https://pypi.org/project/loguru/) instrumentation
  
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## Deprecations
+
+* Remove Python 2.7 Support
+
+  * Removes compatibility with Python 2.7. Also removes support for the following libraries that were only supported on Python2.7:
+    * [umemcache](https://pypi.org/project/umemcache/)
+    * [oursql](https://pypi.org/project/oursql/)
+    * [pywapi](https://pypi.org/project/pywapi/)
+    * [Pylons](https://pypi.org/project/Pylons/)
+    * [web2py](https://pypi.org/project/web2py/)
+    * [weberror](https://pypi.org/project/WebError/)
 
 ## New features
 
@@ -20,9 +45,9 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
   * Adds a metric to capture the host and port information for Kafka entities on both consumers and producers. This metric allows the UI to link AWS information with AWS MSK entities in the service map.
 
-* Add capturing of memcache host and port
+* Add capturing of memcache `host` and `port`
 
-  * Adds capturing of host and port info on memcache libraries; bmemcached, aiomcache, and pymemcache. This allows the UI to link AWS information with AWS memcache entities in the service map.
+  * Adds capturing of `host` and `port` info on the following memcache libraries: [bmemcached](https://pypi.org/project/python-binary-memcached/), [aiomcache](https://pypi.org/project/aiomcache/), and [pymemcache](https://pypi.org/project/pymemcache/). This allows the UI to link AWS information with AWS memcache entities in the service map.
 
 * Add support for [kafka-python-ng](https://pypi.org/project/kafka-python-ng/)
 
@@ -36,21 +61,15 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
   * Automatically detect the function signature when wrapping `similarity_search`.
 
-* Add environment variable for GC runtime metrics
+* Add environment variable for garbage collector runtime metrics
 
-  * GC runtime metircs can now be enabled/disabled via the following environment variable: NEW_RELIC_GC_RUNTIME_METRICS_ENABLED. 
-
-## Deprecations
-
-* Remove Python2.7 Support
-
-  * Removes compatibility with Python2.7. Also removes instrumentations that were only supported on Python2.7.
+  * Garbage collector runtime metircs can now be enabled/disabled via the following environment variable: `NEW_RELIC_GC_RUNTIME_METRICS_ENABLED`. 
 
 ## Bug fixes
 
-* Fix bug in graphql entity name detection
+* Fix bug in gRPC entity name detection
 
-  * Previously, the graphql channel entity name would be missing the first couple characters. This bug has been fixed.
+  * Previously, the gRPC channel entity name was missing the first character(s) in specific cases. This bug has been fixed.
 
 * Fix issue in [LangChain](https://pypi.org/project/langchain/) where a thread is started and the transaction context is lost
 
@@ -62,12 +81,15 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 * Instrument new path to [OpenAI](https://pypi.org/project/openai/) chat class
 
-    * [OpenAI](https://pypi.org/project/openai/) moved the ChatCompletions class to a different path which prevented the instrumentation from being applied. This has been fixed.
+    * [OpenAI](https://pypi.org/project/openai/) moved the `ChatCompletions` class to a different path which prevented the instrumentation from being applied. This has been fixed.
 
 * Fix [pyscopg](https://pypi.org/project/psycopg/) v3 API incompatibilities
 
     * Expand DBAPI2 wrappers to allow arbitrary `kwargs` on `executemany()`. Upgrade [psycopg](https://pypi.org/project/psycopg/) v3 instrumentation to allow arbitrary `kwargs` on `executemany()`. Rename existing psycopg v3 wrapper arguments to match the upstream library's names for compatibility.
 
+* Remove versioned logic in loguru instrumentation
+
+    * Removed versioned logic in [loguru](https://pypi.org/project/loguru/) instrumentation to fix a bug that occurred when the version was undeterminable.
 
 ## Support statement
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
@@ -3,7 +3,7 @@ subject: 'Python agent'
 releaseDate: '2024-09-26'
 version: 10.0.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Remove Python 2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChasimilarity search', 'Add environment variable for GC runtime metrics']
+features: ['Remove Python 2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChain similarity search', 'Add environment variable for GC runtime metrics']
 bugs: ['Fix bug in gRPC entity name detection', 'Fix issue in LangChain where a thread is started and the transaction context is lost', 'Fix parsing of request and response when running OpenAI via LangChain', 'Instrument new path to OpenAI chat class', 'Fix pyscopg v3 API incompatibilities', 'Remove versioned logic in loguru instrumentation']
 security: []
 ---
@@ -17,7 +17,7 @@ This release of the Python agent drops support for Python 2.7 and adds the follo
  * support for [kafka-python-ng](https://pypi.org/project/kafka-python-ng/)
  * support for [uvicorn_worker](https://pypi.org/project/uvicorn-worker/)
  * an environment variable for garbage collector (GC) runtime metrics
- * automatic detection for the function signature in [LangChain](https://pypi.org/project/langchain/)'s similarity_search
+ * automatic detection for the function signature in [LangChain](https://pypi.org/project/langchain/)'s `similarity_search`
  * updated support for [OpenAI](https://pypi.org/project/openai/)'s chat class
  * a fix for a bug in gRPC's entity name detection
  * a fix for transaction context propagation loss in [LangChain](https://pypi.org/project/langchain/) in the case of a new thread
@@ -31,7 +31,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 * Remove Python 2.7 Support
 
-  * Removes compatibility with Python 2.7. Also removes support for the following libraries that were only supported on Python2.7:
+  * Removes compatibility with Python 2.7. Also removes support for the following libraries that were only supported on Python 2.7:
     * [umemcache](https://pypi.org/project/umemcache/)
     * [oursql](https://pypi.org/project/oursql/)
     * [pywapi](https://pypi.org/project/pywapi/)
@@ -63,7 +63,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 * Add environment variable for garbage collector runtime metrics
 
-  * Garbage collector runtime metircs can now be enabled/disabled via the following environment variable: `NEW_RELIC_GC_RUNTIME_METRICS_ENABLED`. 
+  * Garbage collector runtime metrics can now be enabled/disabled via the following environment variable: `NEW_RELIC_GC_RUNTIME_METRICS_ENABLED`. 
 
 ## Bug fixes
 
@@ -73,7 +73,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
 * Fix issue in [LangChain](https://pypi.org/project/langchain/) where a thread is started and the transaction context is lost
 
-  * Previously, when calling some chains like retreival chains, the transaction would be lost and instrumentation would be broken because a thread would be started by [LangChain](https://pypi.org/project/langchain/). This has been fixed so the transaction context is passed across threads and instrumentation still works for retreival chains.
+  * Previously, when LangChain called certain chains, such as retrieval chains, LangChain started a thread that caused the transaction to be lost, resulting in broken instrumentation. This has been fixed so the transaction context is passed across threads and instrumentation still works for retrieval chains.
 
 * Fix parsing of request and response when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/)
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
@@ -79,7 +79,7 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 
   * Previously, when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/) the request and response were a different format and were not being recorded. This issue has been fixed.
 
-* Instrument new path to [OpenAI](https://pypi.org/project/openai/) chat class
+* Instrument new path to [OpenAI](https://pypi.org/project/openai/) chat completions class
 
     * [OpenAI](https://pypi.org/project/openai/) moved the `ChatCompletions` class to a different path which prevented the instrumentation from being applied. This has been fixed.
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
@@ -1,0 +1,76 @@
+---
+subject: 'Python agent'
+releaseDate: '2024-08-08'
+version: 10.0.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Remove Python2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChasimilarity search', 'Add environment variable for GC runtime metrics']
+bugs: ['Fix bug in graphql entity name detection', 'Fix issue in LangChain where a thread is started and the transaction context is lost', 'Fix parsing of request and response when running OpenAI via LangChain', 'Instrument new path to OpenAI chat class', 'Fix pyscopg v3 API incompatibilities']
+security: []
+---
+
+## Notes
+
+This release of the Python agent drops support for Python2.7, adds a Kafka server metric, capturing of memcache host and port, support for [kafka-python-ng](https://pypi.org/project/kafka-python-ng/), support for [uvicorn_worker](https://pypi.org/project/uvicorn-worker/), an environment variable for GC runtime metrics, and automatically detects the function signature in [LangChain](https://pypi.org/project/langchain/) `similarity_search`. It also fixes a bug in [graphql](https://pypi.org/project/graphql/) entity name detection, an issue in [LangChain](https://pypi.org/project/langchain/) where a thread is started and the transaction context is lost, parsing of the request and response when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/), [pyscopg](https://pypi.org/project/psycopg/) v3 API incompatibilities, and instruments a new path to the [OpenAI](https://pypi.org/project/openai/) chat class.
+ 
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## New features
+
+* Add Kafka server metric
+
+  * Adds a metric to capture the host and port information for Kafka entities on both consumers and producers. This metric allows the UI to link AWS information with AWS MSK entities in the service map.
+
+* Add capturing of memcache host and port
+
+  * Adds capturing of host and port info on memcache libraries; bmemcached, aiomcache, and pymemcache. This allows the UI to link AWS information with AWS memcache entities in the service map.
+
+* Add support for [kafka-python-ng](https://pypi.org/project/kafka-python-ng/)
+
+  * [kafka-python](https://pypi.org/project/kafka-python/) has been released under a new name: [kafka-python-ng](https://pypi.org/project/kafka-python-ng/). This continues to support kafka-python under the new package name.
+
+* Add support for [uvicorn_worker](https://pypi.org/project/uvicorn-worker/)
+
+  * `uvicorn.workers` has been moved to a separate package called `uvicorn_worker`. This checks for both names of the module when reporting dispatcher information.
+
+* Automatically detect function signature in [LangChain](https://pypi.org/project/langchain/) `similarity_search`
+
+  * Automatically detect the function signature when wrapping `similarity_search`.
+
+* Add environment variable for GC runtime metrics
+
+  * GC runtime metircs can now be enabled/disabled via the following environment variable: NEW_RELIC_GC_RUNTIME_METRICS_ENABLED. 
+
+## Deprecations
+
+* Remove Python2.7 Support
+
+  * Removes compatibility with Python2.7. Also removes instrumentations that were only supported on Python2.7.
+
+## Bug fixes
+
+* Fix bug in graphql entity name detection
+
+  * Previously, the graphql channel entity name would be missing the first couple characters. This bug has been fixed.
+
+* Fix issue in [LangChain](https://pypi.org/project/langchain/) where a thread is started and the transaction context is lost
+
+  * Previously, when calling some chains like retreival chains, the transaction would be lost and instrumentation would be broken because a thread would be started by [LangChain](https://pypi.org/project/langchain/). This has been fixed so the transaction context is passed across threads and instrumentation still works for retreival chains.
+
+* Fix parsing of request and response when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/)
+
+  * Previously, when running [OpenAI](https://pypi.org/project/openai/) via [LangChain](https://pypi.org/project/langchain/) the request and response were a different format and were not being recorded. This issue has been fixed.
+
+* Instrument new path to [OpenAI](https://pypi.org/project/openai/) chat class
+
+    * [OpenAI](https://pypi.org/project/openai/) moved the ChatCompletions class to a different path which prevented the instrumentation from being applied. This has been fixed.
+
+* Fix [pyscopg](https://pypi.org/project/psycopg/) v3 API incompatibilities
+
+    * Expand DBAPI2 wrappers to allow arbitrary `kwargs` on `executemany()`. Upgrade [psycopg](https://pypi.org/project/psycopg/) v3 instrumentation to allow arbitrary `kwargs` on `executemany()`. Rename existing psycopg v3 wrapper arguments to match the upstream library's names for compatibility.
+
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100000.mdx
@@ -3,7 +3,7 @@ subject: 'Python agent'
 releaseDate: '2024-09-26'
 version: 10.0.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Remove Python 2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChain similarity search', 'Add environment variable for GC runtime metrics']
+features: ['Remove Python 2.7 support', 'Add Kafka server metric', 'Add capturing of memcache host and port', 'Add support for kafka-python-ng', 'Add support for uvicorn_workers', 'Automatically detect function signature in LangChain similarity search', 'Add environment variable for garbage collector runtime metrics']
 bugs: ['Fix bug in gRPC entity name detection', 'Fix issue in LangChain where a thread is started and the transaction context is lost', 'Fix parsing of request and response when running OpenAI via LangChain', 'Instrument new path to OpenAI chat class', 'Fix pyscopg v3 API incompatibilities', 'Remove versioned logic in loguru instrumentation']
 security: []
 ---


### PR DESCRIPTION
## Give us some context

* Add release notes for Python agent release 10.0.
* Update docs to remove Python 2.7 support.