### PR TITLE
Add bash script to check for BUILD_LANG var

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
   "scripts": {
     "add-files-to-translate": "node scripts/actions/add-files-to-translation-queue.js",
     "build:production": "ENVIRONMENT=production yarn run build",
-    "build": "node scripts/createNetlifyRedirects.mjs & NODE_OPTIONS='--max-old-space-size=5120' gatsby build --prefix-paths",
+    "build": "scripts/build.sh",
     "check-for-outdated-translations": "node scripts/actions/check-for-outdated-translations.js",
     "clean": "gatsby clean",
     "convert-to-webp": "node scripts/convertPNGs.mjs",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -z "${BUILD_LANG}" ]]; then
+  echo "BUILD_LANG env var required 🥸 set BUILD_LANG=en for a default build"
+  exit 1
+else 
+ exec node scripts/createNetlifyRedirects.mjs & NODE_OPTIONS='--max-old-space-size=5120' gatsby build --prefix-paths
+fi


### PR DESCRIPTION
You can't do a full build without the var but we don't have it set since it depends on the site in netlify. This way we get a little reminder locally