### PR TITLE
Create migration guide for the Rest API v2

### DIFF
--- a/src/content/docs/apis/rest-api-v2/migrate-to-nrql.mdx
+++ b/src/content/docs/apis/rest-api-v2/migrate-to-nrql.mdx
@@ -32,7 +32,7 @@ SELECT uniques(metricTimesliceName) FROM Metric WHERE realAgentId = '$AGENT_ID' 
 
 ## Get your app's metric timeslice data values
 
-The REST API v2 accepted a list of metric names and a list of values to fetch metric timeslice data.
+The REST API v2 accepts a list of metric names and a list of values to fetch metric timeslice data.
 
 The metric names are the same, you can filter them with the `metricTimesliceName` field in your NRQL query.
 
@@ -135,7 +135,7 @@ If you want to get the same results as the UI, you should query the events direc
 
 ### Timeseries and summaries
 
-By default,the REST API returns a series of metric data values based. To obtain the average of these values, you would include `&summarize=true` in your API call.
+By default, the REST API returns a series of metric data values based. To obtain the average of these values, you would include `&summarize=true` in your API call.
 
 In NRQL, that's the opposite. You get a summary by default, and you can get the timeseries by adding `TIMESERIES` to your query.
 

--- a/src/content/docs/apis/rest-api-v2/migrate-to-nrql.mdx
+++ b/src/content/docs/apis/rest-api-v2/migrate-to-nrql.mdx
@@ -1,0 +1,156 @@
+---
+title: Migrate to NRQL
+tags:
+  - APIs
+  - REST API v2
+  - NRQL
+translate:
+  - jp
+metaDescription: 'How to migrate your REST API v2 queries to NRQL queries.'
+freshnessValidatedDate: never
+---
+
+## List metric names for your app
+
+To view the metric names available for your application:
+
+```nrql
+SELECT uniques(metricTimesliceName) FROM Metric WHERE appId = '$APP_ID' AND newrelic.timeslice.value IS NOT NULL SINCE 30 MINUTES AGO LIMIT MAX
+```
+
+You can also filter using the application name:
+
+```nrql
+SELECT uniques(metricTimesliceName) FROM Metric WHERE appName = '$APP_NAME' AND newrelic.timeslice.value IS NOT NULL SINCE 30 MINUTES AGO LIMIT MAX
+```
+
+Or using a specific agent (host):
+
+```nrql
+SELECT uniques(metricTimesliceName) FROM Metric WHERE realAgentId = '$AGENT_ID' AND newrelic.timeslice.value IS NOT NULL SINCE 30 MINUTES AGO LIMIT MAX
+```
+
+## Get your app's metric timeslice data values
+
+The REST API v2 accepted a list of metric names and a list of values to fetch metric timeslice data.
+
+The metric names are the same, you can filter them with the `metricTimesliceName` field in your NRQL query.
+
+Each API value can be mapped to a NRQL function, you can refer to the table below.
+
+Example, for the following API request:
+
+```bash
+curl -X GET "https://api.newrelic.com/v2/applications/${APP_ID}/metrics/data.json" \
+     -H "X-Api-Key:${API_KEY}" -i \
+     -d 'names[]=HttpDispatcher&values[]=average_call_time&values[]=call_count'
+```
+
+You would use the following query:
+
+```nrql
+SELECT COUNT(newrelic.timeslice.value) AS call_count, average(newrelic.timeslice.value) * 1000 AS average_call_time
+FROM Metric
+WHERE appId = $APP_ID AND metricTimesliceName = 'HttpDispatcher'
+```
+
+| Value (RPM)                | NRQL Function                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------- |
+| average_response_time      | average(newrelic.timeslice.value) \* 1000                                                         |
+| calls_per_minute           | rate(count(newrelic.timeslice.value), 1 minute)                                                   |
+| call_count                 | count(newrelic.timeslice.value)                                                                   |
+| min_response_time          | min(newrelic.timeslice.value) \* 1000                                                             |
+| max_response_time          | max(newrelic.timeslice.value) \* 1000                                                             |
+| average_exclusive_time     | average(newrelic.timeslice.value['totalExclusive'] / newrelic.timeslice.value['count']) \* 1000   |
+| average_value              | average(newrelic.timeslice.value)                                                                 |
+| total_call_time_per_minute | rate(sum(newrelic.timeslice.value), 1 minute)                                                     |
+| requests_per_minute        | rate(count(newrelic.timeslice.value), 1 minute)                                                   |
+| standard_deviation         | stddev(newrelic.timeslice.value) \* 1000                                                          |
+| average_time               | average(newrelic.timeslice.value) \* 1000                                                         |
+| count                      | count(newrelic.timeslice.value)                                                                   |
+| used_bytes_by_host         | average(newrelic.timeslice.value) \* 1024 \* 1024                                                 |
+| used_mb_by_host            | average(newrelic.timeslice.value)                                                                 |
+| total_used_mb              | sum(newrelic.timeslice.value)                                                                     |
+| average_call_time          | average(newrelic.timeslice.value) \* 1000                                                         |
+| total_value                | sum(newrelic.timeslice.value)                                                                     |
+| min_value                  | min(newrelic.timeslice.value)                                                                     |
+| max_value                  | max(newrelic.timeslice.value)                                                                     |
+| rate                       | rate(sum(newrelic.timeslice.value), 1 second)                                                     |
+| throughput                 | rate(count(newrelic.timeslice.value), 1 second)                                                   |
+| as_percentage              | average(newrelic.timeslice.value) \* 100                                                          |
+| errors_per_minute          | rate(count(newrelic.timeslice.value), 1 minute)                                                   |
+| error_count                | count(newrelic.timeslice.value)                                                                   |
+| total_time                 | sum(newrelic.timeslice.value) \* 1000                                                             |
+| sessions_active            | average(newrelic.timeslice.value)                                                                 |
+| total_visits               | sum(newrelic.timeslice.value)                                                                     |
+| percent                    | average(newrelic.timeslice.value) \* 100                                                          |
+| percent (`CPU/User Time`)  | 100 \* sum(newrelic.timeslice.value) / `$TIME_WINDOW_IN_SECONDS`                                  |
+| time_percentage            | 100 \* sum(newrelic.timeslice.value) / `$TIME_WINDOW_IN_SECONDS`                                  |
+| utilization                | 100 \* sum(newrelic.timeslice.value) / `$TIME_WINDOW_IN_SECONDS`                                  |
+| visits_percentage          | 100 \* sum(newrelic.timeslice.value) / `$TIME_WINDOW_IN_SECONDS`                                  |
+
+If the function includes `$TIME_WINDOW_IN_SECONDS`, it means that you need to replace it with the time window you want to query.
+
+Example, if you query a 30 minutes time window, you would replace `$TIME_WINDOW_IN_SECONDS` with `1800`.
+
+### Apdex metrics
+
+| Value (RPM)   | NRQL Function                                                                      |
+| ------------- | ---------------------------------------------------------------------------------- |
+| score         | apdex(newrelic.timeslice.value)                                                    |
+| s             | apdex(newrelic.timeslice.value) or count(newrelic.timeslice.value)                 |
+| t             | apdex(newrelic.timeslice.value) or sum(newrelic.timeslice.value)                   |
+| f             | apdex(newrelic.timeslice.value) or sum(newrelic.timeslice.value['totalExclusive']) |
+| count         | apdex(newrelic.timeslice.value)                                                    |
+| value         | apdex(newrelic.timeslice.value)                                                    |
+| threshold     | max(newrelic.timeslice.value)                                                      |
+| threshold_min | min(newrelic.timeslice.value)                                                      |
+
+### EndUser & Mobile metrics
+
+These metrics will return the same result as what you would get from the REST API v2, but some results may differ from what you see on the New Relic UI.
+This is because the UI uses events instead of timeslice data.
+If you want to get the same results as the UI, you should query the events directly.
+
+| Value (RPM)                   | NRQL Function                                                                                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| average_response_time         | sum(newrelic.timeslice.value) / count(newrelic.timeslice.value) \* 1000                                                                                                  |
+| error_percentage              | (filter(count(newrelic.timeslice.value), WHERE metricTimesliceName = 'EndUser/errors') / filter(count(newrelic.timeslice.value), WHERE metricTimesliceName = 'Browser')) |
+| average_fe_response_time      | sum(newrelic.timeslice.value['totalExclusive']) / count(newrelic.timeslice.value) \* 1000                                                                                |
+| average_be_response_time      | 1000 \* (sum(newrelic.timeslice.value) - sum(newrelic.timeslice.value['totalExclusive'])) / count(newrelic.timeslice.value)                                              |
+| average_network_time          | (sum(newrelic.timeslice.value) - sum(newrelic.timeslice.value['totalExclusive']) - sum(newrelic.timeslice.value['sumOfSquares'])) / count(newrelic.timeslice.value)      |
+| total_network_time            | (sum(newrelic.timeslice.value) - sum(newrelic.timeslice.value['totalExclusive']) - sum(newrelic.timeslice.value['sumOfSquares']))                                        |
+| network_time_percentage       | (sum(newrelic.timeslice.value) - sum(newrelic.timeslice.value['totalExclusive']) - sum(newrelic.timeslice.value['sumOfSquares'])) / `$TIME_WINDOW_IN_SECONDS`            |
+| total_fe_time                 | sum(newrelic.timeslice.value['totalExclusive'])                                                                                                                          |
+| fe_time_percentage            | 100 \* sum(newrelic.timeslice.value['totalExclusive']) / `$TIME_WINDOW_IN_SECONDS`                                                                                       |
+| average_dom_content_load_time | average(newrelic.timeslice.value) \* 1000                                                                                                                                |
+| average_queue_time            | average(newrelic.timeslice.value['totalExclusive']) \* 1000                                                                                                              |
+| total_queue_time              | sum(newrelic.timeslice.value['totalExclusive']) \* 1000                                                                                                                  |
+| total_dom_content_time        | sum(newrelic.timeslice.value) \* 1000                                                                                                                                    |
+| total_app_time                | sum(newrelic.timeslice.value['sumOfSquares'])                                                                                                                            |
+| average_app_time              | sum(newrelic.timeslice.value['sumOfSquares']) / count(newrelic.timeslice.value)                                                                                          |
+| average_sent_bytes            | sum(newrelic.timeslice.value['totalExclusive']) \* 1000                                                                                                                  |
+| average_received_bytes        | 1000 \* sum(newrelic.timeslice.value) / count(newrelic.timeslice.value)                                                                                                  |
+| launch_count                  | count(newrelic.timeslice.value)                                                                                                                                          |
+
+### Timeseries and summaries
+
+By default,the REST API returns a series of metric data values based. To obtain the average of these values, you would include `&summarize=true` in your API call.
+
+In NRQL, that's the opposite. You get a summary by default, and you can get the timeseries by adding `TIMESERIES` to your query.
+
+Another difference is that the default time window of the REST API is 30 minutes, while in NRQL, it is 1 hour.
+
+## Query multiple metrics
+
+You can still query multiple metrics at once with NRQL, here's an example:
+
+```nrql
+SELECT
+    FILTER(1000 * AVERAGE(newrelic.timeslice.value), WHERE metricTimesliceName = 'HttpDispatcher') as average_response_time,
+    FILTER(count(newrelic.timeslice.value), WHERE metricTimesliceName = 'Errors/all') as error_count,
+    FILTER(average(newrelic.timeslice.value), WHERE metricTimesliceName = 'Memory/Heap/Max') as used_mb_by_host
+FROM Metric
+WHERE appName = '$APP_NAME'
+SINCE 1 day ago
+```

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -307,6 +307,8 @@ pages:
                     path: /docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls
                   - title: 500 error when starting the API Explorer
                     path: /docs/apis/rest-api-v2/troubleshooting/500-error-when-starting-api-explorer
+              - title: Migrate to NRQL
+                path: /docs/apis/rest-api-v2/migrate-to-nrql
           - title: Synthetics REST API
             path: /docs/apis/synthetics-rest-api/monitor-examples
             pages:

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -200,6 +200,8 @@ pages:
           - title: REST API v2
             path: /docs/apis/rest-api-v2
             pages:
+              - title: Migrate to NRQL
+                path: /docs/apis/rest-api-v2/migrate-to-nrql
               - title: Get started
                 path: /docs/apis/rest-api-v2/get-started
                 pages:
@@ -329,8 +331,6 @@ pages:
             pages:
               - title: Insights query API
                 path: /docs/apis/insights-apis/query-insights-event-data-api
-          - title: Migrate to NRQL
-            path: /docs/apis/rest-api-v2/migrate-to-nrql
           - title: NRQL Lookups API
             path: /docs/apis/lookups-service-api/lookups-service-api
           - title: "REST API v1 (EOL)"

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -307,8 +307,6 @@ pages:
                     path: /docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls
                   - title: 500 error when starting the API Explorer
                     path: /docs/apis/rest-api-v2/troubleshooting/500-error-when-starting-api-explorer
-              - title: Migrate to NRQL
-                path: /docs/apis/rest-api-v2/migrate-to-nrql
           - title: Synthetics REST API
             path: /docs/apis/synthetics-rest-api/monitor-examples
             pages:
@@ -331,6 +329,8 @@ pages:
             pages:
               - title: Insights query API
                 path: /docs/apis/insights-apis/query-insights-event-data-api
+          - title: Migrate to NRQL
+            path: /docs/apis/rest-api-v2/migrate-to-nrql
           - title: NRQL Lookups API
             path: /docs/apis/lookups-service-api/lookups-service-api
           - title: "REST API v1 (EOL)"


### PR DESCRIPTION
We plan to deprecate the REST API that returns metric data. The API calls can be replaced by NRQL queries, which are more flexible and are better supported/documented.
This new page aims to help the customers to migrate from the legacy API to NRQL.

Note:
- I was not able to see my new page when running the app locally, I don't know if I missed a step
- Let me know if the page is not in the right folder, tell me where I should put it
- Same for the page title/content