### PR TITLE
fix: new link name from ISpan.AddCustomAttribute()

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -1144,21 +1144,21 @@ The following list contains the different calls you can make with the API, inclu
       <tbody>
         <tr>
           <td>
-            [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpanAddCustomAttribute)
+            `AddCustomAttribute`
           </td>
 
           <td>
-            Add contextual information from your application to the current span in form of attributes.
+            Add contextual information from your application to the current span in form of attributes (see below for more details).
           </td>
         </tr>
 
         <tr>
           <td>
-            [`SetName`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#setname)
+            `SetName`
           </td>
 
           <td>
-            Changes the name of the current span/segment/metrics that will be reported to New Relic.
+            Changes the name of the current span/segment/metrics that will be reported to New Relic (see below for more details).
           </td>
         </tr>
       </tbody>

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -512,72 +512,72 @@ The following list contains the different calls you can make with the API, inclu
 
       <tbody>
         <tr>
-          <td>
-            [`AcceptDistributedTraceHeaders`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AcceptDistributedTraceHeaders)
+          <td class="children-nowrap">
+            `AcceptDistributedTraceHeaders`
           </td>
 
           <td>
-            Accepts incoming trace context headers from another service.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            [`InsertDistributedTraceHeaders`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#InsertDistributedTraceHeaders)
-          </td>
-
-          <td>
-            Adds trace context headers to an outgoing request.
+            Accepts incoming trace context headers from another service (see below for more details).
           </td>
         </tr>
 
         <tr>
-          <td>
-            [`AcceptDistributedTracePayload` (obsolete)](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AcceptDistributedTraceHeaders)
+          <td class="children-nowrap">
+            InsertDistributedTraceHeaders
           </td>
 
           <td>
-            Accepts an incoming distributed trace payload from another service.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            [`CreateDistributedTracePayload` (obsolete)](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#CreateDistributedTracePayload)
-          </td>
-
-          <td>
-            Creates a distributed trace payload for inclusion in an outgoing request.
+            Adds trace context headers to an outgoing request (see below for more details).
           </td>
         </tr>
 
         <tr>
-          <td>
-            [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AddCustomAttribute)
+          <td class="children-nowrap">
+            `AcceptDistributedTracePayload` (obsolete)
           </td>
 
           <td>
-            Add contextual information from your application to the current transaction in form of attributes.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            [`CurrentSpan`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#CurrentSpan)
-          </td>
-
-          <td>
-            Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpan), which provides access to span-specific methods in the New Relic API.
+            Accepts an incoming distributed trace payload from another service (see below for more details).
           </td>
         </tr>
 
         <tr>
-          <td>
-            [`SetUserId`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#SetUserId)
+          <td class="children-nowrap">
+            `CreateDistributedTracePayload` (obsolete)
           </td>
 
           <td>
-            Associates a user ID to the current transaction.
+            Creates a distributed trace payload for inclusion in an outgoing request (see below for more details).
+          </td>
+        </tr>
+
+        <tr>
+          <td class="children-nowrap">
+            `AddCustomAttribute`
+          </td>
+
+          <td>
+            Add contextual information from your application to the current transaction in form of attributes (see below for more details).
+          </td>
+        </tr>
+
+        <tr>
+          <td class="children-nowrap">
+            `CurrentSpan`
+          </td>
+
+          <td>
+            Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpan), which provides access to span-specific methods in the New Relic API (see below for more details).
+          </td>
+        </tr>
+
+        <tr>
+          <td class="children-nowrap">
+            `SetUserId`
+          </td>
+
+          <td>
+            Associates a user ID to the current transaction (see below for more details).
           </td>
         </tr>
       </tbody>
@@ -1143,7 +1143,7 @@ The following list contains the different calls you can make with the API, inclu
 
       <tbody>
         <tr>
-          <td>
+          <td class="children-nowrap">
             `AddCustomAttribute`
           </td>
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -1144,7 +1144,7 @@ The following list contains the different calls you can make with the API, inclu
       <tbody>
         <tr>
           <td>
-            [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AddCustomAttribute)
+            [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpanAddCustomAttribute)
           </td>
 
           <td>
@@ -1166,7 +1166,7 @@ The following list contains the different calls you can make with the API, inclu
 
     <CollapserGroup>
       <Collapser
-        id="AddCustomAttribute"
+        id="ISpanAddCustomAttribute"
         title="AddCustomAttribute"
       >
         Adds contextual information about your application to the current span in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).

--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -254,7 +254,7 @@ This table includes general max limits that apply across all New Relic accounts.
       </td>
 
       <td>
-        See [Trace limits](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#trace-origin-sampling).
+        See [Trace limits](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/#trace-limits).
       </td>
     </tr>
 


### PR DESCRIPTION
There were two identical in-page link ids for `"AddCustomAttribute"`. These are linked a lot in the docs so I only changed this one so I don't have to update docs everywhere. With both having the same ID this in page link doesn't work.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.