### PR TITLE
Add `NewRelic.Labels` to the list of .NET agent configuration options that can be set in app settings

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3769,6 +3769,17 @@ For ASP.NET and .NET Framework console apps you can also configure the following
   </Collapser>
 
   <Collapser
+    id="app-cfg-labels"
+    title="Labels"
+  >
+    ```xml
+    <appSettings>
+      <add key="NewRelic.Labels" value="key1:value1;key2:value2" />
+    </appSettings>
+    ```
+  </Collapser>
+
+  <Collapser
     id="app-cfg-location"
     title="Change newrelic.config location"
   >
@@ -3828,6 +3839,17 @@ For .NET Core apps, you can configure the following settings in `appsettings.jso
     ```json
     {
       "NewRelic.LicenseKey": "YOUR_LICENSE_KEY"
+    }
+    ```
+  </Collapser>
+
+  <Collapser
+    id="appsettings-json-labels"
+    title="Labels"
+  >
+    ```json
+    {
+      "NewRelic.Labels": "key1:value1;key2:value2"
     }
     ```
   </Collapser>


### PR DESCRIPTION
This has been an oversight in our docs for a while.  The .NET agent has a limited set of configuration options that can be set via standard Microsoft application configuration files (e.g. `appsetttings.json`).  One of the things that can be set is the `labels` setting, with an appsettings key of `NewRelic.Labels`.  This PR updates the docs to show that labels can be configured this way.