### PR TITLE
fix(on-host): Replace cp with copy for Windows instructions

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/couchbase-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/couchbase-monitoring-integration.mdx
@@ -105,7 +105,7 @@ To install the Couchbase integration, follow the instructions for your environme
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
        ```
-       cp couchbase-config.yml.sample couchbase-config.yml
+       copy couchbase-config.yml.sample couchbase-config.yml
        ```
     4. Edit the `couchbase-config.yml` file as described in the [configuration settings](#config).
   </Collapser>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/hashicorp-consul-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/hashicorp-consul-monitoring-integration.mdx
@@ -108,7 +108,7 @@ To install the HashiCorp Consul integration, follow the instructions for your en
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
        ```
-       cp consul-config.yml.sample consul-config.yml
+       copy consul-config.yml.sample consul-config.yml
        ```
     4. Edit the `consul-config.yml` file as described in the [configuration settings](#config).
   </Collapser>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/nagios-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/nagios-monitoring-integration.mdx
@@ -91,7 +91,7 @@ To install the Nagios integration:
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
        ```
-       cp nagios-config.yml.sample nagios-config.yml
+       copy nagios-config.yml.sample nagios-config.yml
        ```
     4. Edit the `nagios-config.yml` file as described in the [configuration settings](#config).
     5. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a `nagios-service-checks.yml` file that describes the service checks to be run by the integration.

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/varnish-cache-monitoring-integration.mdx
@@ -85,13 +85,13 @@ To install the Varnish Cache integration:
        [https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-varnish/nri-varnish-amd64.msi](https://download.newrelic.com/infrastructure_agent/windows/integrations/nri-varnish/nri-varnish-amd64.msi)
     2. To install from the Windows command prompt, run:
 
-       ```
+       ```shell
        msiexec.exe /qn /i PATH\TO\nri-varnish-amd64.msi
        ```
     3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
-       ```
-       cp varnish-config.yml.sample varnish-config.yml
+       ```shell
+       copy varnish-config.yml.sample varnish-config.yml
        ```
     4. Edit the `varnish-config.yml` file as described in the [configuration settings](#config).
   </Collapser>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
@@ -85,7 +85,7 @@ You must have <DNT>**version 1.12.1 or higher**</DNT> for our [infrastructure ag
     Restart your infrastructure agent:
 
     ```shell
-    sudo systemctl restart newrelic-infra.service
+   net stop newrelic-infra && net start newrelic-infra
     ```
 
     In a couple of minutes, your application will send metrics to [one.newrelic.com](https://one.newrelic.com).  

--- a/src/install/postgresql/windows/install-windows.mdx
+++ b/src/install/postgresql/windows/install-windows.mdx
@@ -14,7 +14,7 @@ headingText: Configure the PostgreSQL integration
 3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
    ```shell
-   cp postgresql-config.yml.sample postgresql-config.yml
+   copy postgresql-config.yml.sample postgresql-config.yml
    ```
 
 4. Edit the `postgresql-config.yml` file. This example config file collects all metrics:

--- a/src/install/rabbitmq/windows/install-windows.mdx
+++ b/src/install/rabbitmq/windows/install-windows.mdx
@@ -12,7 +12,7 @@ headingText: Install the RabbitMQ monitoring integration
 3. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
    ```shell
-   cp rabbitmq-config.yml.sample rabbitmq-config.yml
+   copy rabbitmq-config.yml.sample rabbitmq-config.yml
    ```
 4. Edit the `rabbitmq-config.yml` configuration file using the [configuration settings](#config).
 5. To enable automatic Rabbitmq error log parsing and forwarding, copy (or rename) the `rabbitmq-log-win.yml.example` file to `rabbitmq-log-win.yml`.


### PR DESCRIPTION
For NR-313160.

In Windows instructions, replace any occurrences of the `cp` command with `copy`.

Fix one instance where the Windows restart commands use Linux commands.