### PR TITLE
feat(apm/php): add `newrelic.vulnerability_management.composer_api.enabled` description

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3934,6 +3934,114 @@ Setting one of the following tags will help you identify which versions of your 
 
 An upcoming release of errors inbox will automatically track which versions of your software are producing errors. Any version data will also be displayed in [CodeStream](/docs/codestream/how-use-codestream/performance-monitoring/#buildsha).
 
+## Vulnerability management settings [#inivar-vulnerability-management]
+
+This section lists the settings that affect the reporting of PHP packages.
+
+  <Collapser
+    id="inivar-package-detection"
+    title="newrelic.vulnerability_management.package_detection.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            PERDIR
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Notes:
+          </th>
+
+          <td>
+            Introduced in PHP agent version 10.17
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, the agent will send up package detection information that can be viewed on the environment page.
+  </Collapser>
+</CollapserGroup>
+
+<CollapserGroup>
+  <Collapser
+    id="inivar-package-detection-use-composer-api"
+    title="newrelic.vulnerability_management.composer_api.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            PERDIR
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+        <tr>
+          <th>
+            Notes:
+          </th>
+
+          <td>
+            Introduced in PHP agent version 11.2
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, the agent will try using Composer's runtime API for package detection.
+
+  </Collapser>
+
 ## Other .ini settings [#inivar-rare-settings]
 
 This section lists the remaining newrelic.ini settings.
@@ -4294,55 +4402,3 @@ This section lists the remaining newrelic.ini settings.
 
     Enables the detection of frameworks and libraries when preloading is enabled. Preloading was introduced in PHP version 7.4. `newrelic.preload_framework_library_detection` will only take effect when `opcache.preload` is set in the `php.ini` file.
   </Collapser>
-
-  <Collapser
-    id="inivar-package-detection"
-    title="newrelic.vulnerability_management.package_detection.enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Scope:
-          </th>
-
-          <td>
-            SYSTEM
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Type:
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default:
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Notes:
-          </th>
-
-          <td>
-            Introduced in PHP agent version 10.17
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    When set to `true`, the agent will send up package detection information that can be viewed on the environment page.
-  </Collapser>
-</CollapserGroup>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3938,6 +3938,7 @@ An upcoming release of errors inbox will automatically track which versions of y
 
 This section lists the settings that affect the reporting of PHP packages.
 
+<CollapserGroup>
   <Collapser
     id="inivar-package-detection"
     title="newrelic.vulnerability_management.package_detection.enabled"
@@ -3988,9 +3989,7 @@ This section lists the settings that affect the reporting of PHP packages.
 
     When set to `true`, the agent will send up package detection information that can be viewed on the environment page.
   </Collapser>
-</CollapserGroup>
 
-<CollapserGroup>
   <Collapser
     id="inivar-package-detection-use-composer-api"
     title="newrelic.vulnerability_management.composer_api.enabled"
@@ -4041,6 +4040,7 @@ This section lists the settings that affect the reporting of PHP packages.
     When set to `true`, the agent will try using [Composer's runtime API](https://getcomposer.org/doc/07-runtime.md) for package detection.
 
   </Collapser>
+</CollapserGroup>
 
 ## Other .ini settings [#inivar-rare-settings]
 
@@ -4402,3 +4402,4 @@ This section lists the remaining newrelic.ini settings.
 
     Enables the detection of frameworks and libraries when preloading is enabled. Preloading was introduced in PHP version 7.4. `newrelic.preload_framework_library_detection` will only take effect when `opcache.preload` is set in the `php.ini` file.
   </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -4038,7 +4038,7 @@ This section lists the settings that affect the reporting of PHP packages.
       </tbody>
     </table>
 
-    When set to `true`, the agent will try using Composer's runtime API for package detection.
+    When set to `true`, the agent will try using [Composer's runtime API](https://getcomposer.org/doc/07-runtime.md) for package detection.
 
   </Collapser>
 

--- a/src/content/docs/vulnerability-management/integrations/intro.mdx
+++ b/src/content/docs/vulnerability-management/integrations/intro.mdx
@@ -180,7 +180,7 @@ CVE detection coverage differs between agents:
     id="php-packages"
     title="PHP package support"
   >
-    Our New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) currently supports detecting CVEs related to packages from the following frameworks:
+    By default, New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) supports detecting CVEs in the core packages of the following frameworks:
 
     <table>
       <thead>
@@ -268,9 +268,10 @@ CVE detection coverage differs between agents:
       </tbody>
     </table>
 
-    We recommend using [officially supported versions](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) of PHP. Note, the PHP agent differs from other language agents as it's not aware of packages until they are used. If the version is not specified in the package's source code in an accessible way, the PHP agent is unable to provide version detection information for that package, and vulnerabilities will not be shown.
+    We recommend using [officially supported versions](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) of PHP.
+    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) can be configured to detect vulnerabilities in all your packages. This feature is disabled by default.
+    See [PHP Agent Configuration - Vulnerability management settings](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-vulnerability-management) for detailed information how to configure Vulnerability Management integration in New Relic PHP APM Agent.
 
-    To disable package detection for Vulnerability Management, you can find more information on the [configuration page](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-package-detection).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/vulnerability-management/integrations/intro.mdx
+++ b/src/content/docs/vulnerability-management/integrations/intro.mdx
@@ -268,9 +268,10 @@ CVE detection coverage differs between agents:
       </tbody>
     </table>
 
-    We recommend using [officially supported versions](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) of PHP.
-    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) can be configured to detect vulnerabilities in all your packages. This feature is disabled by default.
-    See [PHP Agent Configuration - Vulnerability management settings](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-vulnerability-management) for detailed information how to configure Vulnerability Management integration in New Relic PHP APM Agent.
+    We recommend you use [officially supported versions](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) of PHP.
+    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, you can configure the New Relic [PHP APM agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) to detect vulnerabilities in all your packages. This feature is disabled by default.
+    
+    See the Vulnerability Management settings in [PHP agent configuration](/docs/apm/agents/php-agent/configuration/php-agent-configuration/#inivar-vulnerability-management) for detailed information about how to configure the integration in the New Relic PHP APM agent.
 
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
New Relic PHP Agent v11.2 adds new configuration settings that enables use of [Composer's runtime API](https://getcomposer.org/doc/07-runtime.md) for package detection (vulnerability management php-agent integration). With added support for Composer's runtime API, PHP APM Agent can be configured to detect vulnerabilities in all packages managed by [Composer](https://getcomposer.org/). The section about Vulnerability Management PHP APM Agent integration needed an update to advertise this new feature.