### PR TITLE
fix(Get started): Fixed a typo

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/intro-new-relic.mdx
@@ -177,7 +177,7 @@ New Relic provides many ways to increase visibility. This allows you to monitor,
   <Side>
     The New Relic Kubernetes integration gives you complete observability into the health and performance of your clusters and the workloads running on them. It includes a set of components that collect telemetry data, which are metrics, logs, and events. These components are the Kubernetes events integration, the Prometheus agent, and the New Relic Logs plugin.
 
-    Learn more about Kubernetes [here](l/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
+    Learn more about Kubernetes [here](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration).
   </Side>
 </SideBySide>
 


### PR DESCRIPTION
Fixed a typo on the [Get started with New Relic](https://docs.newrelic.com/docs/new-relic-solutions/get-started/intro-new-relic) doc.