### PR TITLE
Add missing set user id API call for PHP

### DIFF
--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -131,6 +131,14 @@ You can use an agent method to identify an end user. See implementation details 
         </tr>
         <tr>
             <td>
+                PHP
+            </td>
+            <td>
+                [`newrelic_set_user_id(string $user_id)`](https://docs.newrelic.com/docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id/)
+            </td>
+        </tr>
+        <tr>
+            <td>
                 Python
             </td>
             <td>

--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -34,9 +34,9 @@ You can review how New Relic processes custom attributes by reading our doc abou
 
 The number of users impacted on an error group is recorded as a [Metric data type](/docs/data-apis/understand-data/metric-data/metric-data-type/) with the name `newrelic.error.group.userImpact`. You can use this metric with the following NRQL string:
 
-    ```sql
-    SELECT uniqueCount(newrelic.error.group.userImpact) FROM Metric WHERE metricName='newrelic.error.group.userImpact'
-    ```
+```sql
+SELECT uniqueCount(newrelic.error.group.userImpact) FROM Metric WHERE metricName='newrelic.error.group.userImpact'
+```
 
 The metric captures the approximate number of unique users in the time period selected. Additional attributes provided by the `userImpact` metric which can be used in a `FACET` clause are `error.group.guid`, `entity.guid`.
 

--- a/src/content/docs/errors-inbox/error-users-impacted.mdx
+++ b/src/content/docs/errors-inbox/error-users-impacted.mdx
@@ -35,7 +35,9 @@ You can review how New Relic processes custom attributes by reading our doc abou
 The number of users impacted on an error group is recorded as a [Metric data type](/docs/data-apis/understand-data/metric-data/metric-data-type/) with the name `newrelic.error.group.userImpact`. You can use this metric with the following NRQL string:
 
 ```sql
-SELECT uniqueCount(newrelic.error.group.userImpact) FROM Metric WHERE metricName='newrelic.error.group.userImpact'
+SELECT uniqueCount(newrelic.error.group.userImpact) 
+FROM Metric 
+WHERE metricName='newrelic.error.group.userImpact'
 ```
 
 The metric captures the approximate number of unique users in the time period selected. Additional attributes provided by the `userImpact` metric which can be used in a `FACET` clause are `error.group.guid`, `entity.guid`.
@@ -48,17 +50,21 @@ Creating this alert requires determining the [NRQL query](/docs/query-your-data/
 
 As an example, the following NRQL query measures the amount of unique users which have been impacted by an [error group](/docs/errors-inbox/errors-inbox/#groups) coming from a specific entity:
 
-    ```sql
-    SELECT uniqueCount(newrelic.error.group.userImpact) FROM Metric WHERE metricName='newrelic.error.group.userImpact' 
-    AND entity.guid='RXxCUk9XU9182nNEFQUExJQ0FLsU9OfDgzNzgwNw' FACET error.group.guid TIMESERIES
-    ```
+```sql
+SELECT uniqueCount(newrelic.error.group.userImpact) 
+FROM Metric 
+WHERE metricName='newrelic.error.group.userImpact' 
+AND entity.guid='RXxCUk9XU9182nNEFQUExJQ0FLsU9OfDgzNzgwNw' FACET error.group.guid TIMESERIES
+```
 
 Read more about using the [`uniqueCount()`](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/) function, [how to find the entity GUID](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/#find) for your entities.
 
 Similarly, the following NRQL query measures the total number of users impacted by errors from all entities under the account in the last hour:
 
-    ```sql
-    SELECT count(newrelic.error.group.userImpact) FROM Metric WHERE metricName='newrelic.error.group.userImpact' SINCE 1 hour ago TIMESERIES
+```sql
+SELECT count(newrelic.error.group.userImpact) 
+FROM Metric 
+WHERE metricName='newrelic.error.group.userImpact' SINCE 1 hour ago TIMESERIES
 ```
 
 Once you have decided on a NRQL query, it can be used to create a [NRQL alert condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions/#create).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
>* Doc page is missing the equivalent set user API call for PHP
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
>* https://docs.newrelic.com/docs/apm/agents/php-agent/php-agent-api/newrelic_set_user_id/
