### PR TITLE
Add new prohibited 'EntityRelationship' event type

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/data-requirements-limits-custom-event-data.mdx
@@ -12,7 +12,7 @@ redirects:
   - /docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements
   - /docs/insights/insights-data-sources/custom-data/data-requirements
   - /docs/insights/insights-data-sources/custom-data/insights-custom-data-requirements-limits
-  - /docs/insights/nrql-new-relic-query-language/nrql-resources/reserved-words/  
+  - /docs/insights/nrql-new-relic-query-language/nrql-resources/reserved-words/
   - /docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data
 freshnessValidatedDate: never
 ---
@@ -185,6 +185,7 @@ Avoid using the following reserved words as names for events and attributes. Oth
 
         * `Metric`, `MetricRaw`, and strings prefixed with `Metric[0-9]` (such as `Metric2` or `Metric1Minute`).
         * `Entity`, `EntityUpdate`, and strings prefixed with `Entity[0-9]` (such as `Entity2` or `Entity1HOUR`).
+        * `EntityRelationship`, `RelationshipUpdate`, and strings prefixed with `Relationship[0-9]` (such as `Relationship2` or `Relationship1HOUR`)
         * `Public_` and strings prefixed with `Public_`.
 
           These event types are reserved for use by New Relic. Events passed in with these `eventType` values will be dropped.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->
We recently added a new prohibited event type, and are updating the docs accordingly.
The event type that should be excluded is `EntityRelationship`, along with `RelationshipUpdate`, `Relationship[0-9]*`.

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.