### PR TITLE
docs(infra-agent): removing misleading note for Win 2012

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -30,7 +30,7 @@ The infrastructure agent supports these processor architectures:
 
 ## Operating systems [#os]
 
-The infrastructure agent supports these operating systems up to their manufacturer's end-of-life. The agent might still be compatible with older versions, please refer to step by step instructions for each operating system if guided installation is not longer available for specific operating system versions.
+The infrastructure agent supports these operating systems up to their manufacturer's end-of-life. The agent might still be compatible with older versions, but please refer to the step-by-step instructions for each operating system if the guided installation is no longer available for a specific operating system version.
 
 <table>
   <thead>

--- a/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent.mdx
@@ -30,7 +30,7 @@ The infrastructure agent supports these processor architectures:
 
 ## Operating systems [#os]
 
-The infrastructure agent supports these operating systems up to their manufacturer's end-of-life.
+The infrastructure agent supports these operating systems up to their manufacturer's end-of-life. The agent might still be compatible with older versions, please refer to step by step instructions for each operating system if guided installation is not longer available for specific operating system versions.
 
 <table>
   <thead>
@@ -160,10 +160,6 @@ The infrastructure agent supports these operating systems up to their manufactur
     </tr>
   </tbody>
 </table>
-
-<Callout variant="important">
-  Infrastructure agent running on Windows 2012 is version 1.37.1 and lower.
-</Callout>
 
 You can also monitor Amazon BottleRocket workloads:
 


### PR DESCRIPTION
## Give us some context
* Remove a misleading note for Windows 2012
* Compatibility explanation for older versions (not officially supported past EOL but agent might still be compatible)