### PR TITLE
fix: Create PR instead of committing to develop

### DIFF
--- a/.github/workflows/update-whats-new-ids.yml
+++ b/.github/workflows/update-whats-new-ids.yml
@@ -43,10 +43,16 @@ jobs:
           git diff-index --quiet HEAD ./src/data/whats-new-ids.json || git commit -m 'chore(whats-new-ids): updated ids'
           echo "commit=true" >> $GITHUB_OUTPUT
 
-        # Push directly to the `develop` branch so we get the changes included in the release PR
-      - name: Push Commit
+      - name: Create Pull Request
+        id: create-pr
         if: steps.commit-changes.outputs.commit == 'true'
-        uses: ad-m/github-push-action@v0.8.0
+        uses: peter-evans/create-pull-request@v5
         with:
-          github_token: ${{ secrets.DOCS_ENG_BOT_TOKEN }}
-          branch: develop
+          token: ${{ secrets.DOCS_ENG_BOT_TOKEN }}
+          title: Updated whats new ids
+          body: ''
+          branch: whats-new-id
+          branch-suffix: short-commit-hash
+          base: develop
+          delete-branch: true
+          team-reviewers: DOCS


### PR DESCRIPTION
we now have organization enforced branch protection which doesn't allow pushing directly to default branches, even by admins or those with permission. this updates the whats new action to make a PR with new IDs