### PR TITLE
Update infrastructure-agent-configuration-settings.mdx

### DIFF
--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -3236,7 +3236,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
       </tbody>
     </table>
 
-    Use a list of custom attributes to annotate the data from this agent instance. Separate keys and values with colons `:`, as in `KEY: VALUE`, and separate each key-value pair with a line break. Keys can be any valid YAML except slashes `/`. Values can be any YAML string, including spaces. Starting the key with `label.` will make sure it remains as is, even if that host might run in different cloud environments, where the cloud tags or cloud labels might interact with it in the combined decoration of Tags. In contrast, custom_labels migth be prefixed with `gcp.` or `azure.` when running in those environments and when combining data from the infrastructure agent with cloud monitoring together.
+    Use a list of custom attributes to annotate the data from this agent instance. Separate keys and values with colons `:`, as in `KEY: VALUE`, and separate each key-value pair with a line break. Keys can be any valid YAML except slashes `/`. Values can be any YAML string, including spaces. Starting the key with `label.` will make sure it remains as is, even if that host might run in different cloud environments, where the cloud tags or cloud labels might interact with it in the combined decoration of tags. In contrast, `custom_labels` might be prefixed with `gcp.` or `azure.` when running in those environments and when combining data from the infrastructure agent with cloud monitoring together.
 
     Example as a YAML attribute:
 

--- a/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -3236,27 +3236,27 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
       </tbody>
     </table>
 
-    Use a list of custom attributes to annotate the data from this agent instance. Separate keys and values with colons `:`, as in `KEY: VALUE`, and separate each key-value pair with a line break. Keys can be any valid YAML except slashes `/`. Values can be any YAML string, including spaces.
+    Use a list of custom attributes to annotate the data from this agent instance. Separate keys and values with colons `:`, as in `KEY: VALUE`, and separate each key-value pair with a line break. Keys can be any valid YAML except slashes `/`. Values can be any YAML string, including spaces. Starting the key with `label.` will make sure it remains as is, even if that host might run in different cloud environments, where the cloud tags or cloud labels might interact with it in the combined decoration of Tags. In contrast, custom_labels migth be prefixed with `gcp.` or `azure.` when running in those environments and when combining data from the infrastructure agent with cloud monitoring together.
 
     Example as a YAML attribute:
 
     ```yml
     custom_attributes:
-      environment: production
-      service: login service
-      team: alpha-team
+      label.environment: production
+      label.service: login service
+      label.team: alpha-team
     ```
 
     Example as an environment variable:
 
     ```ini
-    NRIA_CUSTOM_ATTRIBUTES='{"customAttribute_1":"SOME_ATTRIBUTE","customAttribute_2": "SOME_ATTRIBUTE_2"}'
+    NRIA_CUSTOM_ATTRIBUTES='{"label.customAttribute_1":"SOME_ATTRIBUTE","label.customAttribute_2": "SOME_ATTRIBUTE_2"}'
     ```
 
     NRQL example filtering by custom attribute:
 
     ```sql
-    FROM SystemSample SELECT * WHERE environment = 'production'
+    FROM SystemSample SELECT * WHERE label.environment = 'production'
     ```
   </Collapser>
 


### PR DESCRIPTION
fix: explaining custom_attributes of the Infrastructure Agent better, along with the tip to prefix them with label.* so that these tags do not interact with Azure & GCP cloud monitoring

(Details are in NR-293494, NR-305957 and the linked page.)