### PR TITLE
Update chart-refresh-rates.mdx

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
@@ -6,7 +6,7 @@ redirects:
 freshnessValidatedDate: 2024-09-09
 ---
 
-The refresh rate of New Relic charts is the number of times per second that a chart is refreshed. You can select a default configuration, and you can also configure this refresh rate if your account is on the [New Relic Compute](https://newrelic.com/pricing/compute) consumption pricing plan.
+The refresh rate of New Relic charts is the number of times per second that a chart is refreshed. You can select a default configuration, and you can also configure this refresh rate if your account is on the [New Relic Compute](https://newrelic.com/pricing/compute) consumption pricing plan. See [How New Relic pricing works](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/) for more information.
 
 This configuration lets you decide how often you want to update your data. It also gives you control over your costs. See the [Overview of our pricing models](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models/#determine-pricing) to learn more.
 

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/chart-refresh-rates.mdx
@@ -6,7 +6,7 @@ redirects:
 freshnessValidatedDate: 2024-09-09
 ---
 
-The refresh rate of New Relic charts is the number of times per second that a chart is refreshed. You can select a default configuration, and you can also configure this refresh rate.
+The refresh rate of New Relic charts is the number of times per second that a chart is refreshed. You can select a default configuration, and you can also configure this refresh rate if your account is on the [New Relic Compute](https://newrelic.com/pricing/compute) consumption pricing plan.
 
 This configuration lets you decide how often you want to update your data. It also gives you control over your costs. See the [Overview of our pricing models](/docs/accounts/original-accounts-billing/original-product-based-pricing/overview-pricing-models/#determine-pricing) to learn more.
 


### PR DESCRIPTION
Refresh rate feature is only available for account on the New Relic Compute consumption plan

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The refresh rate feature on charts visualisation for these accounts on the New Relic compute consumption plan, we got some requests about this feature for account out of this plan and we saw the documentation was not explicitly saying this. So we believe now we will fix this confusion.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
I only changed the first part about the definition one the feature refresh rates and it's aligned with this communication https://docs.newrelic.com/whats-new/2024/09/whats-new-09-17-chart-refresh-rate/
* If your issue relates to an existing GitHub issue, please link to it.
Not in this case