### PR TITLE
.NET Azure: Update Azure installation workflow to include containerized apps.

### DIFF
--- a/src/install/config/dotnet.yaml
+++ b/src/install/config/dotnet.yaml
@@ -81,17 +81,17 @@ appInfo:
       - value: 'windowsInstallNonIis'
         displayName: 'Windows, not using IIS'
       - value: 'azure'
-        displayName: 'Azure Web Apps'
+        displayName: 'Azure App Service (Web Apps)'
+      - value: 'nuget'
+        displayName: 'Nuget package'
+      - value: 'awselastic'
+        displayName: 'AWS Elastic Beanstalk'
       - value: 'azurecloudservices'
-        displayName: 'Azure Cloud Services' 
+        displayName: 'Azure Cloud Services (Legacy)' 
       - value: 'azureservicefabric'
         displayName: 'Azure Service Fabric'          
       - value: 'WCF'
         displayName: 'WCF'
-      - value: 'nuget'
-        displayName: 'Nuget package'  
-      - value: 'awselastic'
-        displayName: 'AWS Elastic Beanstalk'   
   - optionType: docker
     label: ''
     placeholder: 'Is your app in a Docker container?'
@@ -109,7 +109,11 @@ appInfo:
       - value: 'azurenugetframework'
         displayName: 'Use NuGet for .NET Framework'
       - value: 'azureframeworkcore'
-        displayName: 'Use NuGet for .NET Core'
+        displayName: 'Use NuGet for .NET Core (Windows and Linux)'
+      - value: 'azurelinuxcontainer'
+        displayName: 'Use a Linux Docker container'
+      - value: 'azurewindowscontainer'
+        displayName: 'Use a Windows Docker container'
       - value: 'azurelocalconfig'
         displayName: 'Place local newrelic.config file'        
       - value: 'azureappconfig'
@@ -393,6 +397,20 @@ steps:
           - optionType: azure
             options:
               - value: 'azurelocalconfig'
+  - filePath: 'src/install/dotnet/installation/azure-windows-container.mdx'
+    overrides:
+      - isConditionalStep: true
+        selectedOptions:
+          - optionType: azure
+            options:
+              - value: 'azurewindowscontainer'
+  - filePath: 'src/install/dotnet/installation/azure-linux-container.mdx'
+    overrides:
+      - isConditionalStep: true
+        selectedOptions:
+          - optionType: azure
+            options:
+              - value: 'azurelinuxcontainer'
   - filePath: 'src/install/dotnet/installation/windowsInstall.mdx'
     overrides:
       - isConditionalStep: true

--- a/src/install/config/dotnet.yaml
+++ b/src/install/config/dotnet.yaml
@@ -404,7 +404,21 @@ steps:
           - optionType: azure
             options:
               - value: 'azurewindowscontainer'
+  - filePath: 'src/install/dotnet/installation/azure-app-services.mdx'
+    overrides:
+      - isConditionalStep: true
+        selectedOptions:
+          - optionType: azure
+            options:
+              - value: 'azurewindowscontainer'
   - filePath: 'src/install/dotnet/installation/azure-linux-container.mdx'
+    overrides:
+      - isConditionalStep: true
+        selectedOptions:
+          - optionType: azure
+            options:
+              - value: 'azurelinuxcontainer'
+  - filePath: 'src/install/dotnet/installation/azure-app-services.mdx'
     overrides:
       - isConditionalStep: true
         selectedOptions:

--- a/src/install/config/dotnet.yaml
+++ b/src/install/config/dotnet.yaml
@@ -74,6 +74,8 @@ appInfo:
     label: ''
     placeholder: "Pick the option that best matches how you'll install the agent."
     options:
+      - value: 'nuget'
+        displayName: 'Nuget package'
       - value: 'linux'
         displayName: 'Linux'
       - value: 'windowsInstall'
@@ -82,8 +84,6 @@ appInfo:
         displayName: 'Windows, not using IIS'
       - value: 'azure'
         displayName: 'Azure App Service (Web Apps)'
-      - value: 'nuget'
-        displayName: 'Nuget package'
       - value: 'awselastic'
         displayName: 'AWS Elastic Beanstalk'
       - value: 'azurecloudservices'

--- a/src/install/dotnet/installation/azure-linux-container.mdx
+++ b/src/install/dotnet/installation/azure-linux-container.mdx
@@ -1,0 +1,83 @@
+---
+componentType: default
+optionType: deployment
+headingText: Install in a Linux Docker container
+descriptionText: ""  
+---
+
+How you configure a containerized Web App to work with our .NET agent will depend on your setup. We'll give some example Docker files below but these are only examples. The Docker files are meant to accomplish the same things that our standard install procedures do.
+
+Some notes about how to implement your Docker file:
+
+* The .NET agent must be installed on the containers you want to monitor.
+* The .NET agent must be installed and enabled at runtime.
+* For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`. We'll use `newrelic-dotnet-agent` in this doc.
+
+Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
+
+### Example Linux dockerfile
+
+```dockerfile
+# Use the correct tagged version for your application's targeted runtime.  See https://hub.docker.com/_/microsoft-dotnet-aspnet/ 
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
+
+# Publish your application.
+COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
+
+# Install the agent
+RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
+&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& wget https://download.newrelic.com/548C16BF.gpg \
+&& apt-key add 548C16BF.gpg \
+&& apt-get update \
+&& apt-get install -y newrelic-dotnet-agent \
+&& rm -rf /var/lib/apt/lists/*
+
+# Enable the agent
+ENV CORECLR_ENABLE_PROFILING=1 \
+CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
+CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
+NEW_RELIC_LICENSE_KEY=INSERT_YOUR_LICENSE_KEY \
+NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
+
+WORKDIR /app
+
+ENTRYPOINT ["dotnet", "./YOUR_APP_NAME.dll"]
+```
+
+### Example Linux multi-stage dockerfile
+
+```dockerfile
+# This example uses .NET 6.0.  For other versions, see https://hub.docker.com/_/microsoft-dotnet-sdk/
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
+
+# Build your application
+WORKDIR /src
+RUN dotnet new mvc -o YOUR_APP_NAME
+RUN dotnet publish -c Release -o /app ./YOUR_APP_NAME
+
+# The runtime tag version should match the SDK tag version
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS final
+
+# Install the agent
+RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
+&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& wget https://download.newrelic.com/548C16BF.gpg \
+&& apt-key add 548C16BF.gpg \
+&& apt-get update \
+&& apt-get install -y newrelic-dotnet-agent
+
+# Enable the agent
+ENV CORECLR_ENABLE_PROFILING=1 \
+CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
+CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
+NEW_RELIC_LICENSE_KEY=INSERT_NEW_RELIC_LICENSE_KEY \
+NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
+
+WORKDIR /app
+COPY --from=base /app .
+
+ENTRYPOINT ["dotnet", "./INSERT_YOUR_APP_NAME.dll"]
+```

--- a/src/install/dotnet/installation/azure-linux-container.mdx
+++ b/src/install/dotnet/installation/azure-linux-container.mdx
@@ -12,6 +12,7 @@ Some notes about how to implement your Docker file:
 * The .NET agent must be installed on the containers you want to monitor.
 * The .NET agent must be installed and enabled at runtime.
 * For .NET agent versions 10.0.0 or higher, the name of the package is `newrelic-dotnet-agent`. For .NET agent versions 9.9.0 or lower, the name of the package is `newrelic-netcore20-agent`. We'll use `newrelic-dotnet-agent` in this doc.
+* The license key and application name are not set directly in these docker file examples. Instead, set these values in Azure as app settings.
 
 Here are example Docker files for Linux. Additional examples for multiple Linux distros can be found in our [.NET agent samples repository](https://github.com/newrelic/newrelic-dotnet-examples).
 
@@ -37,9 +38,7 @@ RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 ENV CORECLR_ENABLE_PROFILING=1 \
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
 CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
-CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
-NEW_RELIC_LICENSE_KEY=INSERT_YOUR_LICENSE_KEY \
-NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so
 
 WORKDIR /app
 
@@ -72,9 +71,7 @@ RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 ENV CORECLR_ENABLE_PROFILING=1 \
 CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
 CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
-CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
-NEW_RELIC_LICENSE_KEY=INSERT_NEW_RELIC_LICENSE_KEY \
-NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
+CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so
 
 WORKDIR /app
 COPY --from=base /app .

--- a/src/install/dotnet/installation/azure-linux-container.mdx
+++ b/src/install/dotnet/installation/azure-linux-container.mdx
@@ -20,7 +20,7 @@ Here are example Docker files for Linux. Additional examples for multiple Linux 
 
 ```dockerfile
 # Use the correct tagged version for your application's targeted runtime.  See https://hub.docker.com/_/microsoft-dotnet-aspnet/ 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 # Publish your application.
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
@@ -49,7 +49,7 @@ ENTRYPOINT ["dotnet", "./YOUR_APP_NAME.dll"]
 
 ```dockerfile
 # This example uses .NET 6.0.  For other versions, see https://hub.docker.com/_/microsoft-dotnet-sdk/
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 
 # Build your application
 WORKDIR /src
@@ -57,7 +57,7 @@ RUN dotnet new mvc -o YOUR_APP_NAME
 RUN dotnet publish -c Release -o /app ./YOUR_APP_NAME
 
 # The runtime tag version should match the SDK tag version
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \

--- a/src/install/dotnet/installation/azure-windows-container.mdx
+++ b/src/install/dotnet/installation/azure-windows-container.mdx
@@ -1,0 +1,83 @@
+---
+componentType: default
+optionType: deployment
+headingText: Install in a Windows Docker container
+descriptionText: ""  
+---
+
+How you configure Docker to work with our .NET agent will depend on your setup. We'll give some example Docker files below but these are only examples. The Docker files are meant to accomplish the same things that our standard install procedures do.
+
+Some notes about how to implement your Docker file:
+
+* The .NET agent must be installed on the containers you want to monitor.
+* The .NET agent must be installed and enabled at runtime.
+
+<Callout variant="important">
+  Note that Windows Nano Server images aren't supported.
+</Callout>
+
+### Example Windows dockerfile for .NET framework application using IIS [#example-windows-dockerfile-framework]
+
+<Callout variant="important">
+  For non-IIS hosted applications:
+
+  * The `INSTALLLEVEL=50` switch must be used to set the [required environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables).
+  * Enable the agent for your application using: [application config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#app-config), [app name in newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config), or [a local newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config-local).
+</Callout>
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/framework/aspnet
+
+# Publish your application.
+COPY YOUR_APP_TO_BE_PUBLISHED /inetpub/wwwroot
+
+# Download the New Relic .NET agent installer
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
+ Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
+ -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
+
+# Install the New Relic .NET agent
+RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn,\
+ NR_LICENSE_KEY=INSERT_YOUR_LICENSE_KEY
+
+# Remove the New Relic .NET agent installer
+RUN Remove-Item "NewRelicDotNetAgent_x64.msi"
+
+# Set your application name
+ENV NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
+```
+
+### Example Windows dockerfile for .NET Core application [#example-windows-dockerfile-net-core]
+
+```dockerfile
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+# Publish your application.
+COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
+
+# Download the New Relic .NET agent installer
+RUN powershell.exe [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
+ Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
+ -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
+
+# Install the New Relic .NET agent
+RUN powershell.exe Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn,\
+ NR_LICENSE_KEY=INSERT_YOUR_LICENSE_KEY
+
+# Remove the New Relic .NET agent installer
+RUN powershell.exe Remove-Item "NewRelicDotNetAgent_x64.msi"
+
+# Enable the agent
+ENV CORECLR_ENABLE_PROFILING=1
+
+# Set your application name
+ENV NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
+
+# windows/servercore images may not include the .NET Core SDK or runtime
+RUN dotnet sdk/runtime installer
+
+WORKDIR /app
+
+ENTRYPOINT ["dotnet", ".\\INSERT_YOUR_APP_NAME.dll"]
+```
+

--- a/src/install/dotnet/installation/azure-windows-container.mdx
+++ b/src/install/dotnet/installation/azure-windows-container.mdx
@@ -65,7 +65,7 @@ RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent
 # Remove the New Relic .NET agent installer
 RUN Remove-Item "NewRelicDotNetAgent_x64.msi"
 
-# [OPTIONAL ]Copy the newrelic.config file into the container
+# [OPTIONAL] Copy the newrelic.config file into the container
 # COPY path/to/newrelic.config /app
 
 ENTRYPOINT ["INSERT_YOUR_APP_NAME.exe"]

--- a/src/install/dotnet/installation/azure-windows-container.mdx
+++ b/src/install/dotnet/installation/azure-windows-container.mdx
@@ -19,13 +19,6 @@ Some notes about how to implement your Docker file:
 
 ### Example Windows dockerfile for .NET framework application using IIS [#example-windows-dockerfile-framework]
 
-<Callout variant="important">
-  For non-IIS hosted applications:
-
-  * The `INSTALLLEVEL=50` switch must be used to set the [required environment variables](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#net-framework-env-variables).
-  * Enable the agent for your application using: [application config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#app-config), [app name in newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config), or [a local newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config-local).
-</Callout>
-
 ```dockerfile
 FROM mcr.microsoft.com/dotnet/framework/aspnet
 
@@ -42,6 +35,40 @@ RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent
 
 # Remove the New Relic .NET agent installer
 RUN Remove-Item "NewRelicDotNetAgent_x64.msi"
+```
+
+### Example Windows dockerfile for .NET framework application not using IIS [#example-windows-dockerfile-framework-notiis]
+
+<Callout variant="important">
+  Enable the agent for your application using: 
+  * [application config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#app-config)
+  * [app name in newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config)
+  * [a local newrelic.config](/install/dotnet/?deployment=windowsInstallNonIis&docker=noDocker#newrelic-config-local)
+
+  For both newrelic.config options, the modified newrelic.config will need to be copied into the container in a separate COPY step.
+</Callout>
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/framework/aspnet
+
+# Publish your application.
+COPY YOUR_APP_TO_BE_PUBLISHED /app
+
+# Download the New Relic .NET agent installer
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
+ Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
+ -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
+
+# Install the New Relic .NET agent
+RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn, INSTALLLEVEL=50
+
+# Remove the New Relic .NET agent installer
+RUN Remove-Item "NewRelicDotNetAgent_x64.msi"
+
+# [OPTIONAL ]Copy the newrelic.config file into the container
+# COPY path/to/newrelic.config /app
+
+ENTRYPOINT ["INSERT_YOUR_APP_NAME.exe"]
 ```
 
 ### Example Windows dockerfile for .NET Core application [#example-windows-dockerfile-net-core]

--- a/src/install/dotnet/installation/azure-windows-container.mdx
+++ b/src/install/dotnet/installation/azure-windows-container.mdx
@@ -11,6 +11,7 @@ Some notes about how to implement your Docker file:
 
 * The .NET agent must be installed on the containers you want to monitor.
 * The .NET agent must be installed and enabled at runtime.
+* The license key and application name are not set directly in these docker file examples. Instead, set these values in Azure as app settings.
 
 <Callout variant="important">
   Note that Windows Nano Server images aren't supported.
@@ -37,14 +38,10 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
  -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
 
 # Install the New Relic .NET agent
-RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn,\
- NR_LICENSE_KEY=INSERT_YOUR_LICENSE_KEY
+RUN Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn
 
 # Remove the New Relic .NET agent installer
 RUN Remove-Item "NewRelicDotNetAgent_x64.msi"
-
-# Set your application name
-ENV NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
 ```
 
 ### Example Windows dockerfile for .NET Core application [#example-windows-dockerfile-net-core]
@@ -61,17 +58,13 @@ RUN powershell.exe [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityPr
  -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
 
 # Install the New Relic .NET agent
-RUN powershell.exe Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn,\
- NR_LICENSE_KEY=INSERT_YOUR_LICENSE_KEY
+RUN powershell.exe Start-Process -Wait -FilePath msiexec -ArgumentList /i, "NewRelicDotNetAgent_x64.msi", /qn
 
 # Remove the New Relic .NET agent installer
 RUN powershell.exe Remove-Item "NewRelicDotNetAgent_x64.msi"
 
 # Enable the agent
 ENV CORECLR_ENABLE_PROFILING=1
-
-# Set your application name
-ENV NEW_RELIC_APP_NAME=INSERT_YOUR_APP_NAME
 
 # windows/servercore images may not include the .NET Core SDK or runtime
 RUN dotnet sdk/runtime installer


### PR DESCRIPTION
## Give us some context

Updates the Azure installation workflow to include containerized apps.  Also changes some of the labels and names to better match modern App Service naming as well make things a bit clearer (I hope!).

* Adds install entries for Windows and Linux containers under Azure App Services
  * Includes modified dockerfiles that do not include app name or license key - these should be set in Azure
  * Includes a step after the dockerfiles covering how to set the license key and app name
* Renames a few buttons to make them a bit clearer
* Moves top level NuGet install button to be first for more visibility * 