### PR TITLE
chore(dotnet): Correct release notes for .NET agent v10.30.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-30-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/net-release-notes/net-agent-10-30-0.mdx
@@ -11,7 +11,7 @@ security: []
 ### New features
 
 * Oracle instrumentation now supports latest version. ([#2721](https://github.com/newrelic/newrelic-dotnet-agent/issues/2721)) ([50cb663](https://github.com/newrelic/newrelic-dotnet-agent/commit/50cb663957ccfcfd55d104a7f54755100bfa46cc))
-* Preview support for instrumentation of "isolated" model Azure Functions. Instrumentation is disabled by default. Please reach out to your account team if you would like to try this new feature. ([d8a79e5](https://github.com/newrelic/newrelic-dotnet-agent/commit/d8a79e51683225e9b574efc8d1b154b2a4b9eadc))
+* Initial support for instrumentation of "isolated" model Azure Functions. Instrumentation is disabled by default. ([d8a79e5](https://github.com/newrelic/newrelic-dotnet-agent/commit/d8a79e51683225e9b574efc8d1b154b2a4b9eadc))
 
 ### Fixes
 


### PR DESCRIPTION
Makes a minor change to the .NET agent v10.30.0 release notes related to instrumentation of Azure functions.