### PR TITLE
Add note about dropping redis<4 support

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-81000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-81000.mdx
@@ -10,14 +10,14 @@ security: []
 
 ## Notes
 
-This release of the Python agent drops support for redis 3 and below and adds support for [Google Cloud Firestore](https://pypi.org/project/google-cloud-firestore/), async [redis](https://pypi.org/project/redis/), and fixes a crash that occurs when wrapping generators.
+This release of the Python agent drops support for Redis v3 and below and adds support for [Google Cloud Firestore](https://pypi.org/project/google-cloud-firestore/), async [Redis](https://pypi.org/project/redis/), and fixes a crash that occurs when wrapping generators.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 
 ## Deprecations
 
-* **Drop support for redis 3 and below**
-  As of 8.10.0, [redis](https://pypi.org/project/redis/3.5.3/) 3 and below are no longer supported. Because redis 4 and above no longer support Python2.7, this means Python2.7 support has been dropped from redis as well.
+* **Drop support for Redis v3 and below**
+  As of v8.10.0, [Redis](https://pypi.org/project/redis/3.5.3/) v3 and below are outside New Relic's supportability window and therefore no longer supported. Because Redis v4 and above no longer support Python 2.7, this means Python 2.7 support has been dropped from Redis as well.
 
 ## Enhancements
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-81000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-81000.mdx
@@ -3,16 +3,21 @@ subject: Python agent
 releaseDate: '2023-08-10'
 version: 8.10.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Add support for firestore', 'Add support for Redis async', 'Add automatic wrapping for async generators']
+features: ['Add support for firestore', 'Add support for Redis async', 'Add automatic wrapping for async generators', 'Drop support for redis 3 and below']
 bugs: ['Fix crash on throw for wrapped generator']
 security: []
 ---
 
 ## Notes
 
-This release of the Python agent adds support for [Google Cloud Firestore](https://pypi.org/project/google-cloud-firestore/).
+This release of the Python agent drops support for redis 3 and below and adds support for [Google Cloud Firestore](https://pypi.org/project/google-cloud-firestore/), async [redis](https://pypi.org/project/redis/), and fixes a crash that occurs when wrapping generators.
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## Deprecations
+
+* **Drop support for redis 3 and below**
+  As of 8.10.0, [redis](https://pypi.org/project/redis/3.5.3/) 3 and below are no longer supported. Because redis 4 and above no longer support Python2.7, this means Python2.7 support has been dropped from redis as well.
 
 ## Enhancements
 


### PR DESCRIPTION
Add note about dropping redis<4 support into Python agent v8.10.0 release docs.
Fixes https://github.com/newrelic/newrelic-python-agent/issues/1236.