### PR TITLE
Fix: Add browser endpoint to networks.mdx

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -159,7 +159,8 @@ For more detail on specific agents and integrations, and about ports, keep readi
       </td>
 
       <td>
-        `bam.nr-data.net`
+        `bam.nr-data.net` <br/>
+        `bam-cell.nr-data.net`
       </td>
 
       <td>
@@ -445,6 +446,7 @@ The telemetry endpoints in the table above are included below in easy-to-copy li
     * `aws-api.newrelic.com`
     * `cloud-collector.newrelic.com`
     * `bam.nr-data.net`
+    * `bam-cell.nr-data.net`
     * `csec.nr-data.net`
     * `insights-collector.newrelic.com`
     * `log-api.newrelic.com`


### PR DESCRIPTION
Added bam-cell.nr-data.net to the US Browser Endpoints.

This endpoint is provided in our CSP docs at https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#csp and should be listed in the network page.

