### PR TITLE
fix(Troubleshooting): Broken link fix and additional upgrade example

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
@@ -579,7 +579,7 @@ These functions manage options for your browser instance, such as cookies, timeo
       <td>
         Schedules a command to add a cookie.
 
-        `spec` is a record object describing a browser cookie. For more information, see the [Selenium documentation](http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_Options.Cookie.html).
+        `spec` is a record object describing a browser cookie. For more information, see the [WebDriver documentation](https://www.w3.org/TR/webdriver1/#cookies).
 
         Return value: promise
       </td>

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-reference-monitor-versions-050.mdx
@@ -585,7 +585,7 @@ These functions manage options for your browser instance, such as cookies, timeo
       <td>
         Schedules a command to add a cookie.
 
-        `spec` is a record object describing a browser cookie. For more information, see the [Selenium documentation](http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_Options.Cookie.html).
+        `spec` is a record object describing a browser cookie. For more information, see the [WebDriver documentation](https://www.w3.org/TR/webdriver1/#cookies).
 
         Return value: promise
       </td>

--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
@@ -72,6 +72,28 @@ In the Node 10 or older runtimes you could use the option `jar: true` to store c
 
 In the Node 16 runtime you must create a cookie jar using the `tough-cookie` module and then refer to that cookie jar in your request instead. If you created a cookie jar named cookies, refer to it in your options as `cookieJar: cookies`
 
+## Scripted API: Form differences [#scripted-api-form]
+
+Due to differences between the `request` module that was used for the `$http` object in the Node 10 and older runtimes and the `got` module that is used for the `$http` object in the Node 16 runtime, you may encounter issues with requests using forms in API monitors. 
+
+If so, please use the `form-data` module to create and include your form with your request as shown in this partial example.
+
+```js
+const FormData = require('form-data');
+
+let form = new FormData();
+form.set('fieldName1','value1');
+form.set('fieldName2','value2');
+
+let req = {
+  headers: {
+    'Authorization': 'Bearer ' + token,
+    'Content-Type': 'multipart/form-data',
+  },
+  body: form
+}
+```
+
 ## UUID module version differences [#uuid-module-version]
 
 The Node 16 runtime includes a newer version of the `uuid` module that forces the use of updated `require` syntax. 

--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
@@ -74,7 +74,7 @@ In the Node 16 runtime you must create a cookie jar using the `tough-cookie` mod
 
 ## Scripted API: Form differences [#scripted-api-form]
 
-Due to differences between the `request` module that was used for the `$http` object in the Node 10 and older runtimes and the `got` module that is used for the `$http` object in the Node 16 runtime, you may encounter issues with requests using forms in API monitors. 
+Due to differences between the `request` module used for the `$http` object in Node 10 and older runtimes and the `got` module that's used for the `$http` object in the Node 16 runtime, you may encounter issues with requests using forms in API monitors. 
 
 If so, please use the `form-data` module to create and include your form with your request as shown in this partial example.
 


### PR DESCRIPTION
- Fixed a broken link on the scripted browser reference page to Selenium documentation
- Added an additional runtime upgrade troubleshooting example related to form usage. This is less common, but common enough that we should include it.