### PR TITLE
Rectify links for CloudWatch

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/instrument-your-own.mdx
@@ -31,7 +31,7 @@ New Relic offers several methods to instrument your AWS Lambda functions for com
 
 Regardless of the method you choose, the New Relic layer adds the New Relic agent to your functions. This agent automatically instruments your functions upon invocation, generating a payload, `NR_LAMBDA_MONITORING`,  that is sent to New Relic via the New Relic Lambda extension.
 
-Depending on your needs, you can choose to either bypass the extension and only see telemetry in CloudWatch, bypass CloudWatch, or use CloudWatch as a fallback. The [CloudWatch](#CloudWatch-only) section at end of this doc will guide you through each option.
+Depending on your needs, you can choose to either bypass the extension and only see telemetry in CloudWatch, bypass CloudWatch, or use CloudWatch as a fallback. The [CloudWatch](#CloudWatch) section at end of this doc will guide you through each option.
 
 <CollapserGroup>
   <Collapser
@@ -221,10 +221,10 @@ Depending on your needs, you can choose to either bypass the extension and only 
   </Collapser>
 
   <Collapser
-    id="fallback"
+    id="CloudWatch"
     title="CloudWatch only and CloudWatch fallback"
   >
-    You can choose to send data to CloudWatch only or as a fallback.To learn more, please see our [CloudWatch fallback documentation](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloudwatch-fallback).
+    You can choose to send data to CloudWatch only or as a fallback.To learn more, please see our [CloudWatch fallback documentation](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback).
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Navigation links in the page are incorrect. The PR rectifies the incorrect links. For example, 
Previously the link was - `/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloudwatch-fallback`
But the correct link is - `/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback` , this points to docs page [here](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback/).
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
NA
* If your issue relates to an existing GitHub issue, please link to it.
NA