### PR TITLE
Update php-agent-compatibility-requirements.mdx for Yii 1 & 2

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -549,7 +549,7 @@ The following frameworks are supported:
       <td>
         Yii
       </td>
-      <td>2.0</td>
+      <td>1.x, 2.x</td>
       <td></td>
     </tr>
 


### PR DESCRIPTION
Yii 1.x support is still there, so for completion and given that this version is still widely used, I've udpated the docs to reflect that.

See: https://github.com/newrelic/newrelic-php-agent/issues/821

Related to #16030