### PR TITLE
Add alternate privatelink endpoint for infra in the EU

### DIFF
--- a/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
+++ b/src/content/docs/data-apis/custom-data/aws-privatelink.mdx
@@ -776,11 +776,11 @@ These are the New Relic endpoint services available via AWS PrivateLink:
             </td>
 
             <td>
-              `infra-api.eu01.nr-data.net`
+              `infra-api.eu01.nr-data.net` and `infra-api.eu.newrelic.com`
             </td>
 
             <td>
-              `com.amazonaws.vpce.eu-central-1.vpce-svc-06d5b2d7e79ddd78e`
+              `com.amazonaws.vpce.eu-central-1.vpce-svc-06d5b2d7e79ddd78e` and `com.amazonaws.vpce.eu-central-1.vpce-svc-02fc7dd8d7be95a32`, respectively
             </td>
           </tr>
 


### PR DESCRIPTION
There are two supported endpoints for infra in the EU, and only one was included in the public docs previously. This commit adds the second endpoint.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.