### PR TITLE
The ServiceName is not exactly the same as the Windows UI.

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
@@ -222,15 +222,15 @@ The Windows services integration sends the following metadata to New Relic:
 * `display_name`: Name of the service as viewed in the services snap-in.
 * `process_id`: Process identifier of the service.
 * `run_as`: Account name under which a service runs. Depending on the service type, the format of the account name may be `DomainName\Username` or `Username@DomainName` (UPN). The value is taken from the `StartName` attribute of the `Win32_Service` class, which can be `NULL` (in that case, the label is reported as an empty string).
+
+  <Callout variant="important">
+    If the `StartName` attribute is `NULL`, the service is logged on under the `LocalSystem` account. For kernel or system-level drive, it runs with a default object name that the the I/O system creates based on the service name, for example, `DWDOM\Admin`.
+  </Callout>
+
 * `service_name`: Unique identifier of the service.
 
   <Callout variant="important">
-    If the `StartName` attribute is `NULL`, the service is logged on under the `LocalSystem` account. For kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, `DWDOM\Admin`.
-  </Callout>
-  </br>
-  </br>
-  <Callout variant="important">
-    `service_name` is converted to lowercase in accordance with label management best practices, and all spaces and periods are replaced with underscores. It is not exactly the same as the service name on the Windows UI.
+    The system converts `service_name` to lowercase per best practices. It replaces all spaces and periods with underscores. It isn't the the same as the service name on the Windows interface.
   </Callout>
 
 ## Source code [#open-source]

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/windows-services-integration.mdx
@@ -227,6 +227,11 @@ The Windows services integration sends the following metadata to New Relic:
   <Callout variant="important">
     If the `StartName` attribute is `NULL`, the service is logged on under the `LocalSystem` account. For kernel or system-level drive, it runs with a default object name created by the I/O system based on the service name, for example, `DWDOM\Admin`.
   </Callout>
+  </br>
+  </br>
+  <Callout variant="important">
+    `service_name` is converted to lowercase in accordance with label management best practices, and all spaces and periods are replaced with underscores. It is not exactly the same as the service name on the Windows UI.
+  </Callout>
 
 ## Source code [#open-source]
 


### PR DESCRIPTION
This article describes the specifications for how the ServiceName is converted by the Prometheus exporter. https://github.com/prometheus-community/windows_exporter/blob/master/internal/collector/smb/smb.go#L129-L135

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.