### PR TITLE
NR-307785 Update docs with latest bug fix if log message is empty

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -151,6 +151,13 @@ If you're not using a supported framework, you may instead use the agent's log f
        This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
        ```
 
+       If the log message is empty or blank, output message will also be empty. Example:
+
+       ```
+        NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
+        ```
+       Output log message will be just empty string.
+
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
 
        We recommend this option over manually using one of our log enrichers.

--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -156,7 +156,7 @@ If you're not using a supported framework, you may instead use the agent's log f
        ```
         NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
         ```
-       Output log message will be just empty string.
+       The output log message will be an empty string.
 
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -147,7 +147,8 @@ The other option is to have the agent decorate log records with a token containi
          ```
            NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
          ```
-         Output log message will be just empty string.
+         The output log message will be an empty string.
+
 
     5. To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-php.mdx
@@ -11,7 +11,7 @@ redirects:
   - /docs/logs/enable-log-monitoring-new-relic/logs-context-php/configure-logs-context-php
   - /docs/logs/enable-log-management-new-relic/logs-context-php
   - /docs/logs/enable-log-management-new-relic/logs-context-php/configure-logs-context-php
-  - /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-php 
+  - /docs/logs/enable-log-management-new-relic/configure-logs-context/configure-logs-context-php
 freshnessValidatedDate: never
 ---
 
@@ -134,7 +134,7 @@ The other option is to have the agent decorate log records with a token containi
           $logfmt = "%channel%.%level_name%: %message% %extra.NR-LINKING%\n";
           $formatter = new LineFormatter($logfmt);
           $handler->setFormatter($formatter);
-          $logger->pushHandler($handler); 
+          $logger->pushHandler($handler);
           ```
 
           Our decorator adds five attributes to every log `message` (plain text): `entity.guid`, `entity.name`, `hostname`, `trace.id`, and  `span.id`. Example:
@@ -142,6 +142,12 @@ The other option is to have the agent decorate log records with a token containi
           ```
           This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
           ```
+          If the log message is empty or blank, output message will also be empty. Example:
+
+         ```
+           NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
+         ```
+         Output log message will be just empty string.
 
     5. To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-python.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-python.mdx
@@ -117,6 +117,13 @@ You have three options to configure APM logs in context to send your app's logs 
        This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
        ```
 
+       If the log message is empty or blank, output message will also be empty. Example:
+
+       ```
+       NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
+       ```
+       Output log message will be just empty string.
+
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
 
        We recommend this option over the manual decorating formatter, `NewRelicContextFormatter`.

--- a/src/content/docs/logs/logs-context/configure-logs-context-python.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-python.mdx
@@ -122,7 +122,7 @@ You have three options to configure APM logs in context to send your app's logs 
        ```
        NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
        ```
-       Output log message will be just empty string.
+       The output log message will be an empty string.
 
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
 

--- a/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
@@ -120,6 +120,12 @@ You have three options to configure <InlinePopover type="apm"/> logs in context 
        This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
        ```
 
+       If the log message is empty or blank, output message will also be empty. Example:
+
+       ```
+       NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
+       ```
+       Output log message will be just empty string.
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
 
        We recommend this option over the manual decorating formatter, `NewRelic::Agent::Logging::DecoratingFormatter`.

--- a/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-ruby.mdx
@@ -125,7 +125,8 @@ You have three options to configure <InlinePopover type="apm"/> logs in context 
        ```
        NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
        ```
-       Output log message will be just empty string.
+       The output log message will be an empty string.
+       
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
 
        We recommend this option over the manual decorating formatter, `NewRelic::Agent::Logging::DecoratingFormatter`.

--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -140,8 +140,8 @@ If you prefer to use your own log forwarder, rather than having the Java agent f
       enabled: true
       forwarding:
         enabled: true
-        max_samples_stored: 10000 
-      local_decorating: 
+        max_samples_stored: 10000
+      local_decorating:
         enabled: false
     ```
 
@@ -183,7 +183,7 @@ If you prefer to use your own log forwarder, rather than having the Java agent f
       forwarding:
         enabled: true
         max_samples_stored: 10000
-      local_decorating: 
+      local_decorating:
         enabled: false
     ```
 
@@ -231,7 +231,7 @@ If you prefer to use your own log forwarder, rather than having the Java agent f
     ```yml
     application_logging:
       enabled: true
-      local_decorating: 
+      local_decorating:
         enabled: true
       forwarding:
         enabled: false
@@ -259,6 +259,12 @@ If you prefer to use your own log forwarder, rather than having the Java agent f
     This is my log message. NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|
     ```
 
+    If the log message is empty or blank, output message will also be empty. Example:
+
+    ```
+    NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
+    ```
+    Output log message will be just empty string.
     Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
   </Collapser>
 </CollapserGroup>
@@ -508,7 +514,7 @@ If you need to use the manual process to set up logs in context for Java, follow
     5. Use `NewRelicAsyncAppender` to wrap any appenders that will target New Relic's log forwarder. For example:
 
        ```xml
-       <appender name="NewRelicFile" 
+       <appender name="NewRelicFile"
                  class="com.newrelic.logging.log4j1.NewRelicAsyncAppender">
          <appender-ref ref="TypicalFile" />
        </appender>
@@ -538,15 +544,15 @@ If you need to use the manual process to set up logs in context for Java, follow
          </appender>
 
            <!-- this appender was added -->
-         <appender name="NewRelicFile" 
+         <appender name="NewRelicFile"
                    class="com.newrelic.logging.log4j1.NewRelicAsyncAppender">
            <appender-ref ref="TypicalFile" />
          </appender>
 
          <appender name="TypicalConsole" class="org.apache.log4j.ConsoleAppender">
-           <layout class="org.apache.log4j.PatternLayout"> 
-             <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/> 
-           </layout> 
+           <layout class="org.apache.log4j.PatternLayout">
+             <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/>
+           </layout>
          </appender>
 
          <root>        ​
@@ -737,7 +743,7 @@ If you need to use the manual process to set up logs in context for Java, follow
          <root level="debug">
 
            <!-- changed the root logger -->
-           <appender-ref ref="ASYNC" /> 
+           <appender-ref ref="ASYNC" />
 
          </root>
        </configuration>
@@ -766,12 +772,12 @@ If you need to use the manual process to set up logs in context for Java, follow
 
          <!-- The required New Relic ASYNC appender wraps the FILE appender -->
          <appender name="ASYNC" class="com.newrelic.logging.logback.NewRelicAsyncAppender">
-           <appender-ref ref="FILE" /> 
+           <appender-ref ref="FILE" />
          </appender>
 
          <root level="debug">
            <!-- ASYNC is one of the main appenders -->
-           <appender-ref ref="ASYNC" /> 
+           <appender-ref ref="ASYNC" />
 
            <!-- Send every message to normal console logging, as well. -->
            <appender-ref ref="STDOUT" />

--- a/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/java-configure-logs-context-all.mdx
@@ -264,7 +264,8 @@ If you prefer to use your own log forwarder, rather than having the Java agent f
     ```
     NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
     ```
-    Output log message will be just empty string.
+    The output log message will be an empty string.
+    
     Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -285,7 +285,8 @@ You have three options to configure <InlinePopover type="apm"/> logs in context 
        ```
        NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
        ```
-       Output log message will be just empty string.
+       The output log message will be an empty string.
+       
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context. We recommend this option over the manual process to use a decorating formatter.
 
        <Callout variant="important">

--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -280,6 +280,12 @@ You have three options to configure <InlinePopover type="apm"/> logs in context 
          For JSON, the `NR-LINKING` data must be in the `message` property.
        </Callout>
 
+        If the log message is empty or blank, output message will also be empty. Example:
+
+       ```
+       NR-LINKING|{entity.guid}|{hostname}|{trace.id}|{span.id}|{entity.name}|.
+       ```
+       Output log message will be just empty string.
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context. We recommend this option over the manual process to use a decorating formatter.
 
        <Callout variant="important">
@@ -679,11 +685,11 @@ You can use our [Serilog](https://serilog.net/) extension to link to your log da
 
        loggerConfig
            .Enrich.WithThreadName()
-           .Enrich.WithThreadId()    
+           .Enrich.WithThreadId()
            .Enrich.WithNewRelicLogsInContext()
            .WriteTo.File( path: @"C:\logs\ExistingLoggingOutput.txt")
            .WriteTo.File(
-               formatter: new NewRelicFormatter(), 
+               formatter: new NewRelicFormatter(),
                path: @"C:\logs\SerilogExample.log.json");
 
        var log = loggerConfig.CreateLogger();


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
This PR fixes the issues when the log message is empty, customers were seeing our decorator values i.e NR-LINKING string which would be fixed by this PR and if the log message is empty they will see only empty message.
Related Jira ticket:- https://new-relic.atlassian.net/browse/NR-307785