### PR TITLE
fix(Synthetics): Updated URLs for synthetic monitors

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
@@ -48,7 +48,7 @@ Before [using secure credentials](#ui-procedures), review these requirements and
       </td>
 
       <td>
-        The [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/) feature is available for synthetic scripted browsers and API test monitors and step monitors. See [Types of synthetic monitors](/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring/#types-of-synthetic-monitors) for more information.
+        The secure credentials feature is available for synthetic scripted browsers and API test monitors and step monitors. See [Types of synthetic monitors](/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring/#types-of-synthetic-monitors) for more information.
       </td>
     </tr>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
@@ -48,7 +48,7 @@ Before [using secure credentials](#ui-procedures), review these requirements and
       </td>
 
       <td>
-        The secure credentials feature is available only for [synthetic scripted browsers and API test monitors](/docs/synthetics/new-relic-synthetics/getting-started/types-synthetics-monitors).
+        The [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/) feature is available for synthetic scripted browsers and API test monitors and step monitors. See [Types of synthetic monitors](/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring/#types-of-synthetic-monitors) for more information.
       </td>
     </tr>
 


### PR DESCRIPTION
Updated URLs for synthetic monitors on the [Store secure credentials for scripted browsers and API tests](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests) page.

This is a request from this:  [https://github.com/newrelic/docs-website/issues/18985](https://github.com/newrelic/docs-website/issues/18985)