### PR TITLE
chore: Fixed a default value and description for `strip_exception_messages`

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3499,7 +3499,7 @@ The Node.js agent variables that control error message redaction appear in the `
           </th>
 
           <td>
-            `true`
+            `false`
           </td>
         </tr>
 
@@ -3515,7 +3515,7 @@ The Node.js agent variables that control error message redaction appear in the `
       </tbody>
     </table>
 
-    When `false`, the agent will redact the messages of captured errors.
+    When `true`, the agent will redact the messages of captured errors.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
A TAM pointed out that this was confusing. After digging, I found out the default value should be `false` and the description should state when `true`, it will redact error messages.
