### PR TITLE
Translate install mdx

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -101,6 +101,21 @@ module.exports = {
     {
       resolve: 'gatsby-source-filesystem',
       options: {
+        name: 'translated-install-mdx',
+        path: `${__dirname}/src/i18n/install/`,
+        ignore: [`${__dirname}/src/i18n/install/config`],
+      },
+    },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'translated-install-config',
+        path: `${__dirname}/src/i18n/install/config`,
+      },
+    },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
         name: 'translated-nav',
         path: `${__dirname}/src/i18n/nav`,
       },

--- a/plugins/gatsby-source-install-config/gatsby-node.js
+++ b/plugins/gatsby-source-install-config/gatsby-node.js
@@ -1,5 +1,7 @@
 const { pick } = require('lodash');
 
+const locale = process.env.BUILD_LANG;
+
 exports.sourceNodes = ({
   actions,
   createNodeId,
@@ -8,7 +10,12 @@ exports.sourceNodes = ({
 }) => {
   const { createNode } = actions;
 
-  const configYamlNodes = getNodesByType('ConfigYaml');
+  const configYamlNodes =
+    locale === 'en'
+      ? getNodesByType('ConfigYaml')
+      : getNodesByType(
+          `${locale.charAt(0).toUpperCase() + locale.slice(1)}Yaml`
+        );
 
   configYamlNodes.forEach((configYamlNode) => {
     const {
@@ -138,7 +145,7 @@ exports.createResolvers = ({ createResolvers }) => {
         resolve: async (source, _args, context) => {
           const { nodeModel } = context;
 
-          const { entries: allMdx } = await nodeModel.findAll({
+          const { entries: allEnglishMdx } = await nodeModel.findAll({
             type: 'Mdx',
             query: {
               filter: {
@@ -149,6 +156,18 @@ exports.createResolvers = ({ createResolvers }) => {
             },
           });
 
+          const { entries: allTranslatedMdx } = await nodeModel.findAll({
+            type: 'Mdx',
+            query: {
+              filter: {
+                fileAbsolutePath: {
+                  regex: `/src/i18n/install/${locale}/${source.agentName.toLowerCase()}/`,
+                },
+              },
+            },
+          });
+
+          const allMdx = locale === 'en' ? allEnglishMdx : allTranslatedMdx;
           const mdxFiles = Array.from(allMdx);
 
           const steps = source.steps.map((step) =>

--- a/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
+++ b/scripts/actions/utils/docs-content-tools/i18n-exclusions.yml
@@ -12,7 +12,6 @@ excludePath:
     - src/content/docs/security/security-privacy/data-privacy
     - src/content/docs/security/security-privacy/compliance
     - scripts/actions/__tests__/kitchen-sink.mdx
-    - src/install
     - src/content/docs/mdx-test-page
     - src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
     - src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -37,7 +36,6 @@ excludePath:
     - src/content/docs/security/security-privacy/data-privacy
     - src/content/docs/security/security-privacy/compliance
     - scripts/actions/__tests__/kitchen-sink.mdx
-    - src/install
     - src/content/docs/mdx-test-page
     - src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
     - src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -62,7 +60,6 @@ excludePath:
     - src/content/docs/security/security-privacy/data-privacy
     - src/content/docs/security/security-privacy/compliance
     - scripts/actions/__tests__/kitchen-sink.mdx
-    - src/install
     - src/content/docs/mdx-test-page
     - src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
     - src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -87,7 +84,6 @@ excludePath:
     - src/content/docs/security/security-privacy/data-privacy
     - src/content/docs/security/security-privacy/compliance
     - scripts/actions/__tests__/kitchen-sink.mdx
-    - src/install
     - src/content/docs/mdx-test-page
     - src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
     - src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx
@@ -112,7 +108,6 @@ excludePath:
     - src/content/docs/security/security-privacy/data-privacy
     - src/content/docs/security/security-privacy/compliance
     - scripts/actions/__tests__/kitchen-sink.mdx
-    - src/install
     - src/content/docs/mdx-test-page
     - src/content/docs/apm/agents/go-agent/get-started/go-agent-eol-policy.mdx
     - src/content/docs/apm/agents/java-agent/getting-started/java-agent-eol-policy.mdx

--- a/scripts/actions/utils/handlers.mjs
+++ b/scripts/actions/utils/handlers.mjs
@@ -377,6 +377,10 @@ export default {
     serialize: (state, node) =>
       serializeComponent(state, node, { textAttributes: ['title'] }),
   },
+  WhatsNextTile: {
+    deserialize: deserializeComponent,
+    serialize: serializeComponent,
+  },
   thead: {
     deserialize: deserializeComponent,
     serialize: (state, node) =>


### PR DESCRIPTION
to test you'll need to edit the start script in the package.json and replace BUILD_LANG=en with BUILD_LANG=jp. then create a few folders resulting in these paths: `i18n/install/config/jp` and `i18n/install/jp`. copy the config yaml for java and plop it into `i18n/install/config/jp`. then copy an mdx file from the java mdx and put it in the `i18n/install/jp` folder. edit that file to look different in some way. finally in the i18n config yaml edit the step path that relates to that mdx file to match the i18n path, e.g. `src/i18n/install/jp/java/createDirectory.mdx`. run locally as normal and the install page should have picked up on the alternative mdx for the chosen step

- [ ] alternative mdx shows up when the BUILD_LANG is set to jp
- [ ] serializing and deserializing an install mdx page with a <WhatsNextTile> works appropriately