### PR TITLE
fix (NRQL): Adjust consumption queries to include SINCE clause

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
@@ -116,7 +116,8 @@ This query shows the billable full platform users for the month. In other words,
 
 ```sql
 FROM NrMTDConsumption 
-SELECT latest(FullPlatformUsersBillable)
+SELECT latest(FullPlatformUsersBillable) 
+SINCE 3 hours ago 
 ```
 
 ### Month-to-date core users
@@ -126,6 +127,7 @@ This query shows the number of core users you'd be billed for if you were billed
 ```sql
 FROM NrMTDConsumption 
 SELECT latest(CoreUsersBillable)
+SINCE 3 hours ago 
 ```
 
 ### Estimated cost
@@ -135,6 +137,7 @@ Here's a query for getting the current month's cost for your full platform users
 ```sql
 FROM NrMTDConsumption 
 SELECT latest(FullPlatformUsersBillable) * YOUR_PER_FULL_PLATFORM_USER_COST
+SINCE 3 hours ago 
 ```
 
 ### User queries for organizations without core users [#queries-non-core]
@@ -205,6 +208,7 @@ These queries apply for some older New Relic organizations that have only two us
     ```sql
     FROM NrMTDConsumption 
     SELECT latest(FullPlatformUsersBillable) * YOUR_PER_FULL_PLATFORM_USER_COST
+    SINCE 3 hours ago 
     ```
 
     Here's an equivalent one for your core users:
@@ -212,6 +216,7 @@ These queries apply for some older New Relic organizations that have only two us
     ```sql
     FROM NrMTDConsumption 
     SELECT latest(CoreUsersBillable) * YOUR_PER_CORE_USER_COST
+    SINCE 3 hours ago 
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This came up as a suggestion from an SME.