### PR TITLE
Update flex-integration-tool-build-your-own-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration.mdx
@@ -3,6 +3,7 @@ title: 'New Relic Flex: Build your own integration'
 tags:
   - Instrument everything
   - Develop your own integrations
+  - nri-flex
 translate:
   - jp
 metaDescription: Use New Relic's Flex integration tool to create a lightweight custom integration that reports event and metric data to New Relic.


### PR DESCRIPTION
fix: adding nri-flex as a tag, hoping that this will make it easier to find this page when looking for this component with its full name
