### PR TITLE
fix: Add callout about expensive stand alone LoS condition queries

### DIFF
--- a/src/content/docs/alerts/create-alert/create-alert-condition/create-nrql-alert-conditions.mdx
+++ b/src/content/docs/alerts/create-alert/create-alert-condition/create-nrql-alert-conditions.mdx
@@ -772,7 +772,7 @@ Loss of signal settings include a time duration and a few actions.
   * Do not open "lost signal" incidents on expected termination. When a signal is expected to terminate, you can choose not to open a new incident. This is useful when you know that a signal will be lost at a certain time, and you don't want to open a new incident for that signal loss. The GraphQL node name for this is [`ignoreOnExpectedTermination`](/docs/apis/nerdgraph/examples/nerdgraph-api-loss-signal-gap-filling/#loss-of-signal).
 
 <Callout variant="important">
-  In order to prevent a loss of signal incident from opening when "Do not open "lost signal" incident on expected termination", the tag `termination: expected` must be added to the entity. This tag tells us the signal was expected to terminate. See [how to add the tag directly to the entity](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-tags).
+  In order to prevent a loss of signal incident from opening when <DNT>**Do not open "lost signal" incident on expected termination**</DNT>, the tag `termination: expected` must be added to the entity. This tag tells us the signal was expected to terminate. See [how to add the tag directly to the entity](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-tags).
 </Callout>
 
 To create a NRQL alert configured with loss of signal detection in the UI:
@@ -782,11 +782,15 @@ To create a NRQL alert configured with loss of signal detection in the UI:
 3. Set the signal expiration duration time in minutes or seconds in the <DNT>**Consider the signal lost after**</DNT> field.
 4. Choose what you want to happen when the signal is lost. You can check any or all of the following options: <DNT>**Close all current open incidents**</DNT>, <DNT>**Open new "lost signal" incident**</DNT>, <DNT>**Do not open "lost signal" incident on expected termination**</DNT>. These control how loss of signal incidents will be handled for the condition.
 5. You can optionally add or remove static/anomaly numeric thresholds. A condition that has only a loss of signal threshold and no static/anomaly numeric thresholds is valid, and it's considered a "stand alone" loss of signal condition.
+  <Callout variant="caution">
+    When creating a stand alone loss of signal condition, consider the query used. Using complex queries could cost more than what is necessary to monitor a signal.
+  </Callout>
+
 6. Continue through the steps to save your condition.
-7. If you selected "<DNT>**Do not open "lost signal" incident on expected termination**</DNT>", you must add the `termination: expected` tag to the entity to prevent a loss of signal incident from opening. See [how to add the tag directly to the entity](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-tags).
+7. If you selected <DNT>**Do not open "lost signal" incident on expected termination**</DNT>, you must add the `termination: expected` tag to the entity to prevent a loss of signal incident from opening. See [how to add the tag directly to the entity](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/#add-tags).
 
 <Callout variant="tip">
-  You might be curious why you'd ever want to have both<DNT>Open new "lost signal" incident</DNT> and <DNT>Do not open "lost signal" incident on expected termination</DNT> set to true. Think of it like this: you always want to be notified when a signal is lost until the one time you know the signal is scheduled to stop and you don't want to be notified. In that case, you'd set both to true, and when you expect the signal to be lost, you'd add the `termination: expected` tag to the relevant entity.
+  You might be curious why you'd ever want to have both <DNT>**Open new "lost signal" incident**</DNT> and <DNT>**Do not open "lost signal" incident on expected termination**</DNT> set to true. Think of it like this: you always want to be notified when a signal is lost until the one time you know the signal is scheduled to stop and you don't want to be notified. In that case, you'd set both to true, and when you expect the signal to be lost, you'd add the `termination: expected` tag to the relevant entity.
 </Callout>
 
 Incidents open due to loss of signal close when:


### PR DESCRIPTION
Added a `Callout` regarding queries used for alert conditions that contain ONLY loss of signal thresholds that are more complex than needed to monitor that signal and therefore more expensive. We want to call this out in the docs so users can consider this when creating alert conditions.

Also made some minor punctuation/style changes for consistency within the section of the doc.
