### PR TITLE
fix(Whats new): Fixed a broken link

### DIFF
--- a/src/content/docs/logs/forward-logs/kong-gateway.mdx
+++ b/src/content/docs/logs/forward-logs/kong-gateway.mdx
@@ -31,7 +31,7 @@ To receive logs from Kong Gateway, you need to connect the Kong Gateway File Log
     <Step>
     ## Configure the File Log plugin [#install-config-filelog]
 
-    Once you've [installed the Kong Gateway File Log pluin](https://docs.konghq.com/hub/kong-inc/file-log/), you need to direct the plugin to send logs to `/dev/stdout`. Here is an example manifest for this configuration:
+    Once you've [installed the Kong Gateway File Log plugin](https://docs.konghq.com/hub/kong-inc/file-log/), you need to direct the plugin to send logs to `/dev/stdout`. Here is an example manifest for this configuration:
 
         ```yaml
         # file-log-plugin.yaml

--- a/src/content/whats-new/2024/10/whats-new-10-23-kogs-gateway-logs-integration.md
+++ b/src/content/whats-new/2024/10/whats-new-10-23-kogs-gateway-logs-integration.md
@@ -26,7 +26,7 @@ Follow these steps:
 
 **Step 1: Install the New Relic Kubernetes logging integration**
 
-  Before configuring the File Log plugin, ensure you have the New Relic Kubernetes logging integration installed. Follow the [instructions](https:/docs.newrelic.com/docs/logs/forward-logs/kubernetes-plugin-log-forwarding/) to set this up.
+  Before configuring the File Log plugin, ensure you have the New Relic Kubernetes logging integration installed. Follow the [instructions](https://docs.newrelic.com/docs/logs/forward-logs/kubernetes-plugin-log-forwarding) to set this up.
 
 **Step 2: Install and configure Kong File Log plugin**
 


### PR DESCRIPTION
Fixed a broken link on the [Forward logs from Kong Gateway to New Relic](https://docs.newrelic.com/whats-new/2024/10/whats-new-10-23-kogs-gateway-logs-integration/) doc.