### PR TITLE
fix(Doc site): Replaced Ktranslate with KTranslate

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-health.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-health.mdx
@@ -111,7 +111,7 @@ Below are some common searches that can be used during troubleshooting to gather
       KTranslate>cisco-7513 There was an SNMP polling error with the CustomDeviceMetrics walking OID .1.3.6.1.2.1.4.31.1.1.21 after 0 retries: request timeout (after 0 retries).
       ```
     <Callout variant="tip">
-      Ktranslate has the following log severity levels: `Info`, `Warn`, and `Error`.
+      KTranslate has the following log severity levels: `Info`, `Warn`, and `Error`.
     </Callout> 
 
 </Collapser>

--- a/src/content/docs/network-performance-monitoring/troubleshooting/change-ktranslate-versions.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/change-ktranslate-versions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Managing Ktranslate container versions
+title: Managing KTranslate container versions
 tags:
   - Integrations
   - Network monitoring

--- a/src/content/docs/network-performance-monitoring/troubleshooting/ktranslate-cpu-usage.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/ktranslate-cpu-usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Understanding Ktranslate CPU usage
+title: Understanding KTranslate CPU usage
 tags:
   - Integrations
   - Network monitoring
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 You've ktranslate containers hitting 100% CPU utilization, or just generally it's higher than expected.
 
 <Callout variant="tip">
-  One detail to be careful about is that for ktranslate it's important to focus on the maximum CPU percent instead of the average. Ktranslate uses a high percentage of CPU near the beginning of a polling cycle and much less at the end of the cycle. When you look at the average usage you might see 60% and miss the fact that ktranslate is spending time close to 100%, which is a potential problem. You need to allocate enough resources so that the max CPU consumption doesn't hit 100%.
+  One detail to be careful about is that for ktranslate it's important to focus on the maximum CPU percent instead of the average. KTranslate uses a high percentage of CPU near the beginning of a polling cycle and much less at the end of the cycle. When you look at the average usage you might see 60% and miss the fact that ktranslate is spending time close to 100%, which is a potential problem. You need to allocate enough resources so that the max CPU consumption doesn't hit 100%.
 </Callout>
 
 ## Solution [#solution]

--- a/src/content/docs/network-performance-monitoring/troubleshooting/understanding-snmp-utilization-calculations.mdx
+++ b/src/content/docs/network-performance-monitoring/troubleshooting/understanding-snmp-utilization-calculations.mdx
@@ -92,7 +92,7 @@ You have questions about various results calculated by the `ktranslate` network 
 
     ### Source data
 
-    [Ktranslate](https://github.com/kentik/ktranslate/blob/72257357db05f36e05389b0a278b702a707a0941/pkg/formats/nrm/nrm.go#L581-L623), uses the value of either [ifHCInOctets](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.31.1.1.1.6) (receive) or [ifHCOutOctets](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.31.1.1.1.10) (transmit); replacing `ifSpeed` in the denominator with the value of [ifHighSpeed](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.31.1.1.1.15) as needed:
+    [KTranslate](https://github.com/kentik/ktranslate/blob/72257357db05f36e05389b0a278b702a707a0941/pkg/formats/nrm/nrm.go#L581-L623), uses the value of either [ifHCInOctets](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.31.1.1.1.6) (receive) or [ifHCOutOctets](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.31.1.1.1.10) (transmit); replacing `ifSpeed` in the denominator with the value of [ifHighSpeed](https://oid-rep.orange-labs.fr/get/1.3.6.1.2.1.31.1.1.1.15) as needed:
 
     <Callout variant="tip">
       A common reason for seeing inaccurate interface utilization percentages is the configured interface speed on the device doesn't reflect the real interface speed. For instance, a 1GB MPLS circuit on a 10GB interface would show percentages at only 10% of the real utilization. To resolve this, consult your vendor's documentation on setting the interface bandwidth.

--- a/src/nav/network-performance-monitoring.yml
+++ b/src/nav/network-performance-monitoring.yml
@@ -48,7 +48,7 @@ pages:
         path: /docs/network-performance-monitoring/troubleshooting/snmp-walk
       - title: Container is running but discovery job doesn't begin
         path: /docs/network-performance-monitoring/troubleshooting/chtimes-error
-      - title: Ktranslate CPU usage
+      - title: KTranslate CPU usage
         path: /docs/network-performance-monitoring/troubleshooting/ktranslate-cpu-usage
       - title: Managing container versions
         path: /docs/network-performance-monitoring/troubleshooting/change-ktranslate-versions


### PR DESCRIPTION
Replaced `Ktranslate` with `KTranslate`.