### PR TITLE
Add custom instrumentation link to .NET datastore instrumentation info

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -1555,6 +1555,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 </tbody>
                 </table>
+
+                If your datastore is not listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
             </Collapser>
 
             <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -591,7 +591,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
             Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
 
-            If your datastore is not listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
+            If your datastore isn't listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
         </Collapser>
 
         <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -1556,7 +1556,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </tbody>
                 </table>
 
-                If your datastore is not listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
+                If your datastore isn't listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
             </Collapser>
 
             <Collapser

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -590,6 +590,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             The .NET agent does not directly monitor datastore processes. Also, the .NET SQL parameter capture in a query trace does not list parameters for a parameterized query or a stored procedure.
 
             Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
+
+            If your datastore is not listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
         </Collapser>
 
         <Collapser


### PR DESCRIPTION
Adds a link in the .NET Agent requirements that offers a workaround if your chosen datastore is not supported.