### PR TITLE
fix: wrap `\\` in backticks

### DIFF
--- a/src/content/docs/nrql/nrql-tutorials/introduction-nrql-tutorial.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/introduction-nrql-tutorial.mdx
@@ -230,7 +230,7 @@ Ready to get started? Let's go!
   </Step>
 
   <Step>
-    You can also specify time ranges relative to when you make queries by using keywords like `day`, `week`, `hour`, `minute`, or their plural equivalents. You can also use logical expressions like `SINCE` today or `SINCE` this week.
+    You can also specify time ranges relative to when you make queries by using keywords like `day`, `week`, `hour`, `minute`, or their plural equivalents. You can also use logical expressions like `SINCE today` or `SINCE this week`.
 
     <SideBySide>
       <Side>
@@ -330,7 +330,7 @@ Ready to get started? Let's go!
       src="/images/queries-nrql_screenshot-crop-tutorial-14.webp"
     />
 
-    Now you've reached new levels of data visualization, breaking out from summarized numbers to line charts of data trends over time. As you can see, using `TIMESERIES` offers full control over visualizations, granularity, and averaging data over specified windows. It's time for the next step: using the 'Where' clause.  
+    Now you've reached new levels of data visualization, breaking out from summarized numbers to line charts of data trends over time. As you can see, using `TIMESERIES` offers full control over visualizations, granularity, and averaging data over specified windows. It's time for the next step: using the `WHERE` clause.  
 
   </Step>
 </Steps>

--- a/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-dashboarding.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-dashboarding.mdx
@@ -15,7 +15,7 @@ We hope seeing example queries and explanations in the context of your own data 
 
 You'll learn how to advance your dashboarding by using faceting by case, advanced aggregation functions, the `EXTRAPOLATE` keyword, filtering aggregation functions, and overriding values. Specifically, you'll learn how to use:
 
-* Advanced aggregation functions like `filter()`, `apdex()`, `rate()funnel()`, `histogram()`.
+* Advanced aggregation functions like `filter()`, `apdex()`, `rate()`, `funnel()`, `histogram()`.
 * The `EXTRAPOLATE` clauses.
 * `FACET CASES()`, including how to use attribute and group matching values.
 * `filter()` to combine Event Types.
@@ -221,14 +221,14 @@ When you include `EXTRAPOLATE` in a query, we calculate the ratio between the re
 
 Homogenous data like throughput gets the most out of the `EXTRAPOLATE` function. It has less effect when attempting to extrapolate a count of distinct things (like `uniqueCount()` or `uniques()`). So, `EXTRAPOLATE` only works with NRQL queries that use one of the following aggregator functions:
 
-* apdex
-* average
-* count
-* histogram
-* sum
-* percentage
-* rate
-* stddev
+* `apdex`
+* `average`
+* `count`
+* `histogram`
+* `sum`
+* `percentage`
+* `rate`
+* `stddev`
 
 With `EXTRAPOLATE` finished, let's move on to using facet cases.
 
@@ -301,7 +301,7 @@ With `EXTRAPOLATE` finished, let's move on to using facet cases.
     To make this even more useful, the `eventType()` function tells you which event type the record comes from. You can use this to control your data output. In this example, you can see the total number of `Transaction` and `PageView` events combined, as well as the totals for only `Transaction` and `PageView`.
 
     ```sql
-    SELECT count(*) as 'Combined Events', filter(count(*), WHERE eventType() = 'PageView') as 'Page Views', filter(count(*), WHERE eventType()='Transaction') as 'Transactions' 
+    SELECT count(*) AS 'Combined Events', filter(count(*), WHERE eventType() = 'PageView') AS 'Page Views', filter(count(*), WHERE eventType()='Transaction') AS 'Transactions' 
     FROM Transaction, PageView 
     SINCE 1 day ago
     ```
@@ -317,7 +317,7 @@ With `EXTRAPOLATE` finished, let's move on to using facet cases.
     Let's look at this in more detail: `count(*)` shows the total number of both `Transaction` and `PageView` events. However, you can use the aggregator function `filter()` you recently learned about to do something unique. The query has `WHERE eventType()='PageView'`, which invokes the filter function to observe the event type as part of the total result set. It then filters to display only those specific events. You can even add `TIMESERIES` to visualize 2 directly comparable data points on a line graph.
 
     ```sql
-    SELECT count(*) as 'Combined Events', filter(count(*), WHERE eventType() = 'PageView') as 'Page Views', filter(count(*), WHERE eventType()='Transaction') as 'Transactions'
+    SELECT count(*) AS 'Combined Events', filter(count(*), WHERE eventType() = 'PageView') AS 'Page Views', filter(count(*), WHERE eventType()='Transaction') AS 'Transactions'
     FROM Transaction
     SINCE 1 day ago 
     TIMESERIES max

--- a/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-functions.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-functions.mdx
@@ -220,7 +220,7 @@ Discovering events and attributes can help answer questions about your available
     FACET name
     ```
 
-    The regular expression engine uses RE2 syntax. If you need to delete characters, you may need to use the double backslashing escape sequences. (e.g. \\).
+    The regular expression engine uses RE2 syntax. If you need to delete characters, you may need to use the double backslashing escape sequences. (e.g. `\\`).
 
     Remember that `RLIKE` has inherently more complexity and less performance than `LIKE`. Only use it when `LIKE` and other filtering functionality fails to fit your needs.
   </Step>

--- a/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-process-your-data.mdx
+++ b/src/content/docs/nrql/nrql-tutorials/nrql-tutorial-process-your-data.mdx
@@ -31,7 +31,7 @@ Let's get started!
 
 <Steps>
   <Step>
-    After completing the first [first NRQL tutorial](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-tutorial/), you've used `count()`, `average()`, `sum()`, `max()` and `min()` to transform your data in meaningful ways. But what if you want to find and count unique values? To find the number of unique values recorded for an attribute over a specified time range, you can use the `uniqueCount() function`. You only need to provide the attribute we want to inspect as an argument. For instance, here is a query to display all the unique public API calls:
+    After completing the first [first NRQL tutorial](/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-tutorial/), you've used `count()`, `average()`, `sum()`, `max()` and `min()` to transform your data in meaningful ways. But what if you want to find and count unique values? To find the number of unique values recorded for an attribute over a specified time range, you can use the `uniqueCount()` function. You only need to provide the attribute we want to inspect as an argument. For instance, here is a query to display all the unique public API calls:
 
     <SideBySide>
       <Side>
@@ -441,7 +441,7 @@ You can now control your data and manipulate it to do what you need, allowing yo
   </Step>
 
   <Step>
-    Sometimes you might receive an event time in epoch (unix) time. Conveniently, you can use epoch timestamps with`SINCE` and `UNTIL` clauses so you don't have to manually translate these values into another date format.
+    Sometimes you might receive an event time in epoch (unix) time. Conveniently, you can use epoch timestamps with `SINCE` and `UNTIL` clauses so you don't have to manually translate these values into another date format.
 
     ```sql
     SELECT average(duration) 


### PR DESCRIPTION
The backslash is an escape char, so having two in a row in plain text only renders one of the two, you need to wrap it in backticks, or do 4 in a row to render two as intended.

How this renders now:
<img width="846" alt="image" src="https://github.com/user-attachments/assets/5c7da3ee-ec24-4f48-821b-2e39c68d4b7f">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.