### PR TITLE
chore(Net agent): Removed ids from nested collapsers

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -287,7 +287,7 @@ The following list contains the different calls you can make with the API, inclu
 
     <CollapserGroup>
       <Collapser
-        id="with-aspx"
+        id=""
         title="With ASPX"
       >
         ```aspnet
@@ -312,7 +312,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="with-razor"
+        id=""
         title="With Razor"
       >
         ```cshtml
@@ -339,7 +339,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="with-blazor"
+        id=""
         title="With Blazor"
       >
         <Callout variant="important">
@@ -595,7 +595,7 @@ The following list contains the different calls you can make with the API, inclu
 
     <CollapserGroup>
       <Collapser
-        id="AcceptDistributedTraceHeaders"
+        id=""
         title="AcceptDistributedTraceHeaders"
       >
         ### Syntax
@@ -685,7 +685,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="InsertDistributedTraceHeaders"
+        id=""
         title="InsertDistributedTraceHeaders"
       >
         ### Syntax
@@ -758,7 +758,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="AcceptDistributedTracePayload"
+        id=""
         title="AcceptDistributedTracePayload (obsolete)"
       >
         <Callout variant="caution">
@@ -839,7 +839,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="CreateDistributedTracePayload"
+        id=""
         title="CreateDistributedTracePayload (obsolete)"
       >
         <Callout variant="caution">
@@ -873,7 +873,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="AddCustomAttribute"
+        id=""
         title="AddCustomAttribute"
       >
         ### Syntax
@@ -1046,7 +1046,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="CurrentSpan"
+        id=""
         title="CurrentSpan"
       >
         Provides access to the currently executing [span](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ISpan), making span-specific methods available within the New Relic API.
@@ -1061,7 +1061,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="SetUserId"
+        id=""
         title="SetUserId"
       >
         ### Syntax
@@ -1115,7 +1115,7 @@ The following list contains the different calls you can make with the API, inclu
         ```
       </Collapser>
       <Collapser
-        id="RecordDatastoreSegment"
+        id=""
         title="RecordDatastoreSegment"
       >
         ### Syntax
@@ -1302,7 +1302,7 @@ The following list contains the different calls you can make with the API, inclu
 
     <CollapserGroup>
       <Collapser
-        id="ISpanAddCustomAttribute"
+        id=""
         title="AddCustomAttribute"
       >
         Adds contextual information about your application to the current span in the form of [attributes](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute).
@@ -1477,7 +1477,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="setname"
+        id=""
         title="SetName"
       >
         Changes the name of the current segment/span that will be reported to New Relic. For segments/spans resulting from custom instrumentation, the metric name reported to New Relic will be altered as well.
@@ -1697,7 +1697,7 @@ The following list contains the different calls you can make with the API, inclu
 
     <CollapserGroup>
       <Collapser
-        id="exception-overload"
+        id=""
         title="NoticeError(Exception)"
       >
         ```cs
@@ -1734,7 +1734,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="exception-idictionary-overload"
+        id=""
         title="NoticeError(Exception, IDictionary)"
       >
         ```cs
@@ -1783,7 +1783,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="NoticeError(String, IDictionary)"
+        id=""
         title="string-idictionary-overload"
       >
         ```cs
@@ -1833,7 +1833,7 @@ The following list contains the different calls you can make with the API, inclu
       </Collapser>
 
       <Collapser
-        id="string-idictionary-bool-overload"
+        id=""
         title="NoticeError(String, IDictionary, bool)"
       >
         ```cs


### PR DESCRIPTION
Per a request in the help-documentation channel (10/25/2024) and following Liz advice, I've removed the ids from the nested collapsers on the [.NET agent API](https://docs.newrelic.com/docs/apm/agents/net-agent/net-agent-api/net-agent-api) doc.