### PR TITLE
fix(Mobile monitoring): Fixed duplicated TabsPageItems and anchor links

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-handled-exceptions.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-handled-exceptions.mdx
@@ -41,9 +41,9 @@ freshnessValidatedDate: 2023-07-20
 
   <TabsPages>
     <TabsPageItem id="android">
-      ## Syntax [#syntax]
+      ## Syntax [#android-syntax]
 
-      ### Java [#java]
+      ### Java [#android-syntax-java]
 
 ```java
       NewRelic.recordHandledException(Exception $exceptionToHandle)
@@ -55,7 +55,7 @@ freshnessValidatedDate: 2023-07-20
       NewRelic.recordHandledException(Throwable $throwableToHandle, Map of String, Object $exceptionAttributes)
 ```
 
-      ### Kotlin [#kotlin]
+      ### Kotlin [#android-syntax-kotlin]
 
 ```kotlin
       NewRelic.recordHandledException(
@@ -72,7 +72,7 @@ freshnessValidatedDate: 2023-07-20
       )
 ```
 
-      ## Description [#description]
+      ## Description [#android-description]
 
       Records a handled exception or other throwable type. Optionally takes map with additional attributes showing context.
 
@@ -80,7 +80,7 @@ freshnessValidatedDate: 2023-07-20
 
       In addition to associated custom attributes, the events will also have associated [session attributes](/docs/insights/insights-data-sources/default-attributes/mobile-default-attributes-insights). You can view event data in the mobile monitoring UI in the [Crash event trail](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail), or via NRQL.
 
-      ## Parameters [#parameters]
+      ## Parameters [#android-parameters]
 
       <table>
         <thead>
@@ -130,15 +130,15 @@ freshnessValidatedDate: 2023-07-20
         </tbody>
       </table>
 
-      ## Return values [#return-values]
+      ## Return values [#android-return-values]
 
       Returns `true` if recorded successfully, or `false` if not.
 
-      ## Examples [#examples]
+      ## Examples [#android-examples]
 
       Here's an example of recording a `ClassCastException` from within an on-click listener:
 
-      ### Java [#java]
+      ### Java [#android-examples-java]
 
 ```java
       public class MainActivity extends Activity {
@@ -159,7 +159,7 @@ freshnessValidatedDate: 2023-07-20
       }
 ```
 
-      ### Kotlin [#kotlin]
+      ### Kotlin [#android-examples-kotlin]
 
 ```kotlin
 
@@ -182,7 +182,7 @@ freshnessValidatedDate: 2023-07-20
     </TabsPageItem>
 
     <TabsPageItem id="ios">
-      ## Syntax [#syntax]
+      ## Syntax [#ios-syntax]
 
       ### Objective-c
 
@@ -190,7 +190,7 @@ freshnessValidatedDate: 2023-07-20
       recordHandledException:(NSException* __nonnull)exception withAttributes:(NSDictionary* __nullable)attributes;
 ```
 
-      ## Description [#description]
+      ## Description [#ios-description]
 
       Records a handled exception (Objective-c only). Optionally takes a map with additional attributes showing context.
 
@@ -199,10 +199,10 @@ freshnessValidatedDate: 2023-07-20
       This API takes an instance of an `NSException` and an optional `NSDictionary` attribute dictionary, then creates a `recordHandledException` event. You can view event data in the [Crash event trail UI](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/mobile-crash-event-trail), and query them with NRQL.
 
       <Callout variant="important">
-        This function should not be used with Swift code. Please use [recordError](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-errors/) to track handled errors in Swift code.
+        This function should not be used with Swift code. Please use [`recordError`](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-errors/) to track handled errors in Swift code.
       </Callout>
 
-      ## Parameters [#parameters]
+      ## Parameters [#ios-parameters]
 
       <table>
         <thead>
@@ -252,11 +252,11 @@ freshnessValidatedDate: 2023-07-20
         </tbody>
       </table>
 
-      ## Return values [#return-values]
+      ## Return values [#ios-return-values]
 
       Returns `true` if the event is recorded successfully, or `false` if not.
 
-      ## Examples [#examples]
+      ## Examples [#ios-examples]
 
       Here's an example of a simple handled exception:
 
@@ -282,18 +282,18 @@ freshnessValidatedDate: 2023-07-20
 ```
     </TabsPageItem>
 
-    <TabsPageItem id="android">
-      ## Syntax [#syntax]
+    <TabsPageItem id="maui">
+      ## Syntax [#maui-syntax]
 
 ```csharp
       recordError(error, StackTrace.current, attributes: attributes);
 ```
 
-      ## Description [#description]
+      ## Description [#maui-description]
 
       Manually record non-fatal exceptions.
 
-      ## Parameters [#parameters]
+      ## Parameters [#maui-parameters]
 
       <table>
         <thead>
@@ -329,11 +329,11 @@ freshnessValidatedDate: 2023-07-20
         </tbody>
       </table>
 
-      ## Return values [#return-values]
+      ## Return values [#maui-return-values]
 
       Returns `true` if the event is recorded successfully, or `false` if not.
 
-      ## Example [#example]
+      ## Example [#maui-example]
 
 ```dart
       try {
@@ -345,18 +345,18 @@ freshnessValidatedDate: 2023-07-20
 ```
     </TabsPageItem>
 
-    <TabsPageItem id="maui">
-      ## Syntax [#syntax]
+    <TabsPageItem id="unity">
+      ## Syntax [#unity-syntax]
 
 ```csharp
       RecordException(System.Exception exception) : void;
 ```
 
-      ## Description [#description]
+      ## Description [#unity-description]
 
       Records a handled exception. Optionally takes map with additional attributes showing context.
 
-      ## Parameters [#parameters]
+      ## Parameters [#unity-parameters]
 
       <table>
         <thead>
@@ -392,11 +392,11 @@ freshnessValidatedDate: 2023-07-20
         </tbody>
       </table>
 
-      ## Return values [#return-values]
+      ## Return values [#unity-return-values]
 
       Returns `true` if the event is recorded successfully, or `false` if not.
 
-      ## Example [#example]
+      ## Example [#unity-example]
 
 ```csharp
           try {
@@ -407,18 +407,18 @@ freshnessValidatedDate: 2023-07-20
 ```
     </TabsPageItem>
 
-    <TabsPageItem id="unity">
-      ## Syntax [#syntax]
+    <TabsPageItem id="xamarin">
+      ## Syntax [#xamarin-syntax]
 
 ```csharp
       RecordException(System.Exception exception) : void;
 ```
 
-      ## Description [#description]
+      ## Description [#xamarin-description]
 
       Manually record any handled exceptions.
 
-      ## Parameters [#parameters]
+      ## Parameters [#xamarin-parameters]
 
       <table>
         <thead>
@@ -454,79 +454,17 @@ freshnessValidatedDate: 2023-07-20
         </tbody>
       </table>
 
-      ## Return values [#return-values]
+      ## Return values [#xamarin-return-values]
 
       Returns `true` if the event is recorded successfully, or `false` if not.
 
-      ## Example [#example]
+      ## Example [#xamarin-example]
 
 ```csharp
           try {
             some_code_that_throws_error();
           } catch (Exception ex) {
             NewRelicAgent.RecordException(e);
-          }
-```
-    </TabsPageItem>
-
-    <TabsPageItem id="xamarin">
-      ## Syntax [#syntax]
-
-```csharp
-      RecordException(System.Exception exception) : void;
-```
-
-      ## Description [#description]
-
-      Manually record any handled exceptions.
-
-      ## Parameters [#parameters]
-
-      <table>
-        <thead>
-          <tr>
-            <th width="30%">
-              Parameter
-            </th>
-
-            <th width={200}>
-              Type
-            </th>
-
-            <th>
-              Description
-            </th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr>
-            <td>
-              `exception`
-            </td>
-
-            <td>
-              `Exception`
-            </td>
-
-            <td>
-              Required. The exception to be recorded.
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-      ## Return values [#return-values]
-
-      Returns `true` if the event is recorded successfully, or `false` if not.
-
-      ## Example [#example]
-
-```csharp
-          try {
-            some_code_that_throws_error();
-          } catch (Exception ex) {
-            CrossNewRelicClient.Current.RecordException(ex);
           }
 ```
     </TabsPageItem>


### PR DESCRIPTION
Per a request in the help-documentation channel (10/25/2024), fixed duplicated `TabsPageItems` and anchor links on the [Record handled exception](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-handled-exceptions) doc.