### PR TITLE
fix(Alerts): Fixed broken links

### DIFF
--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -151,7 +151,7 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
     <tr>
       <td>
-        [Targets (product entities)](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition) per condition
+        [Targets (product entities)](/docs/new-relic-solutions/get-started/glossary/#alert-target) per condition
       </td>
 
       <td>
@@ -192,7 +192,7 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
     <tr>
       <td>
-        [Custom incident descriptions](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-incident-descriptions)
+        [Custom incident descriptions](/docs/alerts/create-alert/condition-details/alert-custom-incident-descriptions)
       </td>
 
       n/a
@@ -309,11 +309,11 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        [Depends on channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#channel-types)
+        [Depends on channel](/docs/alerts/get-notified/intro-notifications/#channels)
       </td>
 
       <td>
-        [Depends on channel](/docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts#channel-types)
+        [Depends on channel](/docs/alerts/get-notified/intro-notifications/#channels)
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/alerts/create-alert/condition-details/alert-custom-incident-descriptions.mdx
+++ b/src/content/docs/alerts/create-alert/condition-details/alert-custom-incident-descriptions.mdx
@@ -10,6 +10,7 @@ redirects:
   - /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-violation-descriptions
   - /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-violation-descriptions/
   - /docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/advanced-techniques/alert-custom-incident-descriptions
+  - /docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/alert-custom-incident-descriptions
 freshnessValidatedDate: never
 ---
 

--- a/src/content/docs/alerts/create-alert/create-alert-condition/alert-conditions.mdx
+++ b/src/content/docs/alerts/create-alert/create-alert-condition/alert-conditions.mdx
@@ -15,6 +15,7 @@ redirects:
   - /docs/alerts/create-alert/create-alert-condition/update-or-disable-policies-conditions
   - /docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions
   - /docs/alerts/new-relic-alerts/configuring-alert-policies/define-alert-conditions
+  - /docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition
 freshnessValidatedDate: never
 ---
 

--- a/src/content/docs/alerts/create-alert/examples/define-custom-metrics-alert-condition.mdx
+++ b/src/content/docs/alerts/create-alert/examples/define-custom-metrics-alert-condition.mdx
@@ -25,7 +25,7 @@ To alert on custom metrics, follow standard procedures to [add a condition](/doc
 
 Use the policy's <DNT>**Thresholds**</DNT> section to define the custom metric values. These include:
 
-* The custom metric name for the selected product category and [targets](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition).
+* The custom metric name for the selected product category and [targets](/docs/new-relic-solutions/get-started/glossary/#alert-target).
 * Selected threshold value function of either average, minimum, maximum, total value per minute, or throughput.
 * Selected threshold level of either above, below, or equal to.
 * Critical and warning threshold value and duration that will open an incident, such as `5 units for at least 5 minutes`.
@@ -45,7 +45,7 @@ To define the custom metric values for your condition:
 2. Click on the policy you'd like to create the classic alert condition, or create a new policy.
 3. Select <DNT>**New alert condition**</DNT>, then select <DNT>**Build a classic alert**</DNT>.
 4. From the <DNT>**Categorize**</DNT> section, select the [product and type of condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions) for the custom metric.
-5. From the <DNT>**Select entities**</DNT> section, add one or more [targets (entities)](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition) that use your custom metric.
+5. From the <DNT>**Select entities**</DNT> section, add one or more [targets (entities)](/docs/new-relic-solutions/get-started/glossary/#alert-target) that use your custom metric.
 6. From the <DNT>**Set thresholds**</DNT> section, select one of the metrics from the <DNT>**Custom Metrics**</DNT> section in the Select drop down.
 7. Provide the [required threshold values](#custom-metrics-requirements) for your custom metric.
 

--- a/src/content/docs/alerts/get-notified/intro-notifications.mdx
+++ b/src/content/docs/alerts/get-notified/intro-notifications.mdx
@@ -9,6 +9,7 @@ metaDescription: "Notifications are how you integrate your New Relic data with t
 freshnessValidatedDate: never
 redirects:
   - /docs/alerts-applied-intelligence/notifications/intro-notifications
+  - /docs/alerts/new-relic-alerts-beta/managing-notification-channels/notification-channels-controlling-where-send-alerts
 ---
 
 DevOps teams have a lot to monitor as systems grow increasingly complex and it can be hard to keep track of what is going on, where. Notifications is a suite of tools that enable you to get the right information to the right people as soon as possible. Notifications send notification events to third-party services, such as Slack, Jira, ServiceNow, and email. You can also use webhooks to send your data to any compatible third-party service.

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -1117,7 +1117,7 @@ Whether you're considering New Relic or you're already using our capabilities, t
     id="alert-target"
     title="target"
   >
-    In the context of alerting, a <DNT>**target**</DNT> is a resource or component monitored by a New Relic monitoring tool that has been [identified in an alert condition](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/select-product-targets-alert-condition). When the data source for that target crosses the defined critical threshold, we open an incident. Depending on your policy's [incident preference](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents) setting, alerts may create an incident record and send notifications through the defined channels. See also [<DNT>**entity**</DNT>](#entity).
+    In the context of alerting, a <DNT>**target**</DNT> is a resource or component monitored by a New Relic monitoring tool that has been identified in an [alert condition](/docs/alerts/create-alert/create-alert-condition/alert-conditions/). When the data source for that target crosses the defined critical threshold, we open an incident. Depending on your policy's [incident preference](/docs/alerts/new-relic-alerts/configuring-alert-policies/specify-when-new-relic-creates-incidents) setting, alerts may create an incident record and send notifications through the defined channels. See also [<DNT>**entity**</DNT>](#entity).
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Per a request in the help-documentation channel (10/25/2024), fixed broken links on the [Alerting rules and limits](https://docs.newrelic.com/docs/alerts/admin/rules-limits-alerts/) doc.