### PR TITLE
docs: typo in funnels doc

### DIFF
--- a/src/content/docs/nrql/using-nrql/funnels-evaluate-data-series-related-events.mdx
+++ b/src/content/docs/nrql/using-nrql/funnels-evaluate-data-series-related-events.mdx
@@ -39,7 +39,7 @@ FROM DATA_TYPE
 Funnel queries require the [`funnel` function](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-components-functions#func-funnel), an [attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute) to funnel, and at least two steps:
 
 1. Begin with the anchor step, which always represents 100% of the results.
-2. Continue with an additional step or steps that describe the number of users who have also completed additional actions, typically than the 100% from the anchor step. However, it could be 100% if every user who completes action (A) also completes the additional actions you're querying.
+2. Continue with an additional step or steps that describe the number of users who have also completed additional actions, typically less than the 100% from the anchor step. However, it could be 100% if every user who completes action (A) also completes the additional actions you're querying.
 
 ## Funnel query technical details
 


### PR DESCRIPTION
Happened to notice what I assume is a typo in the docs for funnel.
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.