### PR TITLE
chore: update gatsby-theme-newrelic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.10.5",
+    "@newrelic/gatsby-theme-newrelic": "9.10.6",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3616,10 +3616,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.10.5":
-  version "9.10.5"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.10.5.tgz#ef82ba58fde45e778bdc84488ff161f6c5fd1a36"
-  integrity sha512-95GD/fWH/i6hYjY89+n9LTtPIE+Cf505tWtCbIjKRZ82szsDtr+nghDbh6anc1M3iK89VYHF6FY15LkuDvGB7g==
+"@newrelic/gatsby-theme-newrelic@9.10.6":
+  version "9.10.6"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.10.6.tgz#7e64720873db48050891697644d332965924e279"
+  integrity sha512-amRd4W+P8vdhsyXAIfP80xFiway7i2wHGfBP8/LoyKZWsFiKbhiKvbuOGyjtOwn4aB51svj6DQwUQuH5NEbFOQ==
   dependencies:
     "@segment/analytics-next" "1.63.0"
     "@wry/equality" "^0.4.0"


### PR DESCRIPTION
updating gatsby theme version.
Contains the update to redirect to local sites when clicked on new relic banner