### PR TITLE
(NR-320588) Adding some documentation for a new query limit

### DIFF
--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -109,7 +109,7 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
     <tr>
       <td>
-        Alerts query scan operations per minute, per account ([learn more](#query-scan-limit))
+        Alert query scan operations per minute, per account ([learn more](#query-scan-limit))
       </td>
 
       <td>
@@ -359,9 +359,9 @@ To request a limit increase, talk to your New Relic account representative.
 
 Note that using [sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) can significantly increase the number of data points. Consider using a longer duration of Sliding window aggregation to reduce the number of data points produced.
 
-## Alerts query scan operations per minute [#query-scan-limit]
+## Alert query scan operations per minute [#query-scan-limit]
 
-The alert condition `Alerts query scan operations per minute` limit applies to the total rate of query scan operations on ingested events.
+The alert condition `Alert query scan operations per minute` limit applies to the total rate of query scan operations on ingested events.
 A query scan operation is the work performed by the New Relic pipeline to match ingested events to alert queries registered in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
 
 If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.

--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -337,7 +337,7 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
 The alert condition `Matched data points per minute` limit applies to the total rate of matched [data points](/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/understand-technical-concepts/streaming-alerts-key-terms-concepts) for the alerting queries in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
 
-If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
+If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions **aren't** affected.
 
 You can see your matched data points and any limit incidents in the [limits UI](/docs/data-apis/manage-data/view-system-limits).
 
@@ -364,7 +364,7 @@ Note that using [sliding windows](/docs/query-your-data/nrql-new-relic-query-lan
 The alert condition `Alert query scan operations per minute` limit applies to the total rate of query scan operations on ingested events.
 A query scan operation is the work performed by the New Relic pipeline to match ingested events to alert queries registered in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
 
-If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
+If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions **aren't** affected.
 
 You can see your query scan operations and any limit incidents in the [limits UI](/docs/data-apis/manage-data/view-system-limits).
 

--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -12,30 +12,32 @@ redirects:
   - /docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-new-relic-alerts
   - /docs/alerts-applied-intelligence/new-relic-alerts/rules-limits-glossary/rules-limits-alerts/
   - /docs/alerts-applied-intelligence/new-relic-alerts/learn-alerts/rules-limits-alerts
-freshnessValidatedDate: never
+freshnessValidatedDate: 2024-10-30
 ---
 
-Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
+This page describes limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
 <table>
   <thead>
     <tr>
       <th width={275}>
-        <DNT>
+          **Category**
+
+      </th>
+      <th width={275}>
           **Limited condition**
-        </DNT>
+
       </th>
 
       <th>
-        <DNT>
+
           **Minimum value**
-        </DNT>
+
       </th>
 
       <th>
-        <DNT>
           **Maximum value**
-        </DNT>
+
       </th>
     </tr>
   </thead>
@@ -43,17 +45,9 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
   <tbody>
     <tr>
       <td id="policy">
-        <DNT>
-          **Alert policies:**
-        </DNT>
+    Alert policies
+
       </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
       <td>
         [Alert policy name](/docs/alerts/organize-alerts/create-edit-or-find-alert-policy/)
       </td>
@@ -68,32 +62,28 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
     </tr>
 
     <tr>
+    <td>
+
+    </td>
       <td>
         [Policies per account](/docs/alerts/new-relic-alerts-beta/getting-started/best-practices-alert-policies)
       </td>
 
       <td>
-        n/a
+        N/A
       </td>
 
       <td>
-        10000 policies
+        10K policies
       </td>
     </tr>
 
     <tr>
       <td id="condition">
         <DNT>
-          **Alert conditions:**
+          Alert conditions
         </DNT>
       </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
       <td>
         Matched data points per minute, per account ([learn more](#query-limit))
       </td>
@@ -108,6 +98,9 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         Alert query scan operations per minute, per account ([learn more](#query-scan-limit))
       </td>
@@ -117,11 +110,14 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        2,500,000,000
+        2.5B
       </td>
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         [Condition name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions)
       </td>
@@ -136,6 +132,9 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         [Conditions per policy](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions)
       </td>
@@ -150,8 +149,11 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
-        [Alert conditions per account](/docs/alerts/create-alert/create-alert-condition/alert-conditions)
+        [Alert conditions per account](/docs/alerts/create-alert/create-alert-conditioN/Alert-conditions)
       </td>
 
       <td>
@@ -159,11 +161,14 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        4000 conditions
+        4K conditions
       </td>
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         [Targets (product entities)](/docs/new-relic-solutions/get-started/glossary/#alert-target) per condition
       </td>
@@ -173,12 +178,15 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        5000 targets for NRQL conditions
-        1000 targets for non-NRQL conditions
+        5K targets for NRQL conditions
+        1K targets for non-NRQL conditions
       </td>
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         [Thresholds](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-thresholds-trigger-alert) per condition
       </td>
@@ -195,29 +203,25 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
     <tr>
       <td id="incidents">
         <DNT>
-          **Alert incidents:**
+          Alert incidents
         </DNT>
       </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
       <td>
         [Custom incident descriptions](/docs/alerts/create-alert/condition-details/alert-custom-incident-descriptions)
       </td>
 
-      n/a
+      N/A
       <td/>
 
       <td>
-        4000 characters
+        4K characters
       </td>
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         [Duration for condition incident](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-thresholds-trigger-alert)
       </td>
@@ -232,6 +236,9 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         Incidents per issue
       </td>
@@ -241,13 +248,16 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        10,000 incidents
+        10K incidents
 
         Incidents beyond this limit will not be persisted.
       </td>
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         Incident search API: page size
       </td>
@@ -257,7 +267,7 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        1000 pages (25K incidents)
+        1K pages (25K incidents)
 
         <Callout variant="tip">
           Only use the `only-open` parameter to retrieve all open incidents. If you have more than 25K open incidents and need to retrieve them via the REST API, contact support.
@@ -267,31 +277,25 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
     <tr>
       <td id="workflows">
-        <DNT>
-          **Workflows:**
-        </DNT>
+      Workflows
       </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
       <td>
         [Workflows per account](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows)
       </td>
 
       <td>
-        n/a
+        N/A
       </td>
 
       <td>
-        Initial limit 1000
+        Initial limit: 1K
       </td>
     </tr>
 
     <tr>
+        <td>
+    
+    </td>
       <td>
         Workflow filter size
       </td>
@@ -301,23 +305,14 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
       </td>
 
       <td>
-        4096 characters per workflow
+        4,096 characters per workflow
       </td>
     </tr>
 
     <tr>
       <td id="channel">
-        <DNT>
-          **Notification channels (Legacy):**
-        </DNT>
+          Notification channels (Legacy)
       </td>
-
-      <td/>
-
-      <td/>
-    </tr>
-
-    <tr>
       <td>
         Channel limitations
       </td>
@@ -369,11 +364,11 @@ If this limit is exceeded, you won't be able to create or update conditions for 
 You can see your query scan operations and any limit incidents in the [limits UI](/docs/data-apis/manage-data/view-system-limits).
 
 When matching events to alert queries, all events from the [data type](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/#what-you-can-query) that the query references must be examined. Here are a few common ways to have fewer events in a given data type (which will decrease the alert query scan operations):
-* When alerting on Logs data, use [log partitions](/docs/tutorial-manage-large-log-volume/organize-large-logs/) to limit which logs are being scanned for alert queries.
-* When alerting on Custom Events, break up larger custom event types
-* Use Custom Events instead of alerting on Transaction events
-* [Create metrics](/docs/data-apis/convert-to-metrics/analyze-monitor-data-trends-metrics/) to aggregate data
-* Use [metric timeslice queries](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/) when possible instead of alerting on Transaction events
+* When alerting on logs data, use [log partitions](/docs/tutorial-manage-large-log-volume/organize-large-logs/) to limit which logs are being scanned for alert queries.
+* When alerting on custom events, break up larger custom event types.
+* Use custom events instead of alerting on transaction events.
+* [Create metrics](/docs/data-apis/convert-to-metrics/analyze-monitor-data-trends-metrics/) to aggregate data.
+* Use [metric timeslice queries](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/) when possible instead of alerting on transaction events.
 
 In addition to the above tips, cleaning up any unused or unneeded alert queries (alert conditions) will decrease the number of query scan operations.
 

--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -109,6 +109,20 @@ Limits and rules pertaining to New Relic <InlinePopover type="alerts"/>:
 
     <tr>
       <td>
+        Alerts query scan operations per minute, per account ([learn more](#query-scan-limit))
+      </td>
+
+      <td>
+        N/A
+      </td>
+
+      <td>
+        2,500,000,000
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         [Condition name](/docs/alerts/new-relic-alerts-beta/configuring-alert-policies/define-alert-conditions)
       </td>
 
@@ -330,8 +344,8 @@ You can see your matched data points and any limit incidents in the [limits UI](
 To understand what conditions are leading to the most throughput, you can perform a query like:
 
 ```sql
-FROM NrAiSignal 
-SELECT sum(aggregatedDataPointsCount) AS 'alert matched data points' 
+FROM NrAiSignal
+SELECT sum(aggregatedDataPointsCount) AS 'alert matched data points'
 FACET conditionId
 ```
 
@@ -344,3 +358,23 @@ Some tips on optimizing your matched data points:
 To request a limit increase, talk to your New Relic account representative.
 
 Note that using [sliding windows](/docs/query-your-data/nrql-new-relic-query-language/nrql-query-tutorials/create-smoother-charts-sliding-windows) can significantly increase the number of data points. Consider using a longer duration of Sliding window aggregation to reduce the number of data points produced.
+
+## Alerts query scan operations per minute [#query-scan-limit]
+
+The alert condition `Alerts query scan operations per minute` limit applies to the total rate of query scan operations on ingested events.
+A query scan operation is the work performed by the New Relic pipeline to match ingested events to alert queries registered in a New Relic [account](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure).
+
+If this limit is exceeded, you won't be able to create or update conditions for the impacted account until the rate goes below the limit. Existing alert conditions are **not** affected.
+
+You can see your query scan operations and any limit incidents in the [limits UI](/docs/data-apis/manage-data/view-system-limits).
+
+When matching events to alert queries, all events from the [data type](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/#what-you-can-query) that the query references must be examined. Here are a few common ways to have fewer events in a given data type (which will decrease the alert query scan operations):
+* When alerting on Logs data, use [log partitions](/docs/tutorial-manage-large-log-volume/organize-large-logs/) to limit which logs are being scanned for alert queries.
+* When alerting on Custom Events, break up larger custom event types
+* Use Custom Events instead of alerting on Transaction events
+* [Create metrics](/docs/data-apis/convert-to-metrics/create-metrics-other-data-types/) when possible
+* Use [metric timeslice queries](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/) when possible instead of alerting on Transaction
+
+In addition to the above tips, cleaning up any unused or unneeded alert queries (alert conditions) will decrease the number of query scan operations.
+
+To request a limit increase, talk to your New Relic account representative.

--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -372,8 +372,8 @@ When matching events to alert queries, all events from the [data type](/docs/nrq
 * When alerting on Logs data, use [log partitions](/docs/tutorial-manage-large-log-volume/organize-large-logs/) to limit which logs are being scanned for alert queries.
 * When alerting on Custom Events, break up larger custom event types
 * Use Custom Events instead of alerting on Transaction events
-* [Create metrics](/docs/data-apis/convert-to-metrics/create-metrics-other-data-types/) when possible
-* Use [metric timeslice queries](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/) when possible instead of alerting on Transaction
+* [Create metrics](/docs/data-apis/convert-to-metrics/analyze-monitor-data-trends-metrics/) to aggregate data
+* Use [metric timeslice queries](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/) when possible instead of alerting on Transaction events
 
 In addition to the above tips, cleaning up any unused or unneeded alert queries (alert conditions) will decrease the number of query scan operations.
 


### PR DESCRIPTION
We are adding a new limit that will be enforced on alert query registration, so this commit adds some documentation around the default limit and adds some pointers on working with it.

## Give us some context

* This PR adds a blurb to documentation about a limit that will be added soon around alert queries (conditions).