### PR TITLE
Update nrql-syntax-clauses-functions.mdx

### DIFF
--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -3974,7 +3974,7 @@ NRQL does not support "coercion." This means that a float stored as a string is 
 
 You can convert a string with a numeric value or a boolean with a string value to their numeric and boolean equivalents, or convert a non-string value to a string value, with these functions:
 
-* Use the `numeric()` function to convert a number with a string format to a numeric value. The function can be built into a query that uses math functions on query results or NRQL aggregator functions, such as `average()`. Please note that if the NRQL value is in the [gauge format](/docs/data-apis/understand-data/metric-data/metric-data-type/), then `numeric()` cannot work on it. Instead, you must use the compatible query functions `latest(), min(), max(), sum(), count() or average()`.  
+* Use the `numeric()` function to convert a number with a string format to a numeric value. The function can be built into a query that uses math functions on query results or NRQL aggregator functions, such as `average()`. Please note that if the NRQL value is in the [gauge format](/docs/data-apis/understand-data/metric-data/metric-data-type/), then `numeric()` won't work on it. Instead, you must use the compatible query functions `latest()`, `min()`, `max()`, `sum()`, `count()` or `average()`.  
 * Use the `boolean()` function to convert a string value of `"true"` or `"false"` to the corresponding boolean value.
 * Use the `string()` function to convert a numeric, boolean, tuple, or array value to a string value.  See [`string()`](#func-string) above for more information.
 

--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -3974,7 +3974,13 @@ NRQL does not support "coercion." This means that a float stored as a string is 
 
 You can convert a string with a numeric value or a boolean with a string value to their numeric and boolean equivalents, or convert a non-string value to a string value, with these functions:
 
-* Use the `numeric()` function to convert a number with a string format to a numeric value. The function can be built into a query that uses math functions on query results or NRQL aggregator functions, such as `average()`. Please note that if the NRQL value is in the [gauge format](/docs/data-apis/understand-data/metric-data/metric-data-type/), then `numeric()` won't work on it. Instead, you must use the compatible query functions `latest()`, `min()`, `max()`, `sum()`, `count()` or `average()`.  
+* Use the `numeric()` function to convert a number with a string format to a numeric value. The function can be built into a query that uses math functions on query results or NRQL aggregator functions, such as `average()`. Please note that if the NRQL value is in the [gauge format](/docs/data-apis/understand-data/metric-data/metric-data-type/), then `numeric()` won't work on it. Instead, you must use one of these compatible query functions: 
+* `latest()`
+* `min()`
+* `max()`
+* `sum()`
+* `count()`
+* `average()`
 * Use the `boolean()` function to convert a string value of `"true"` or `"false"` to the corresponding boolean value.
 * Use the `string()` function to convert a numeric, boolean, tuple, or array value to a string value.  See [`string()`](#func-string) above for more information.
 

--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -3974,7 +3974,7 @@ NRQL does not support "coercion." This means that a float stored as a string is 
 
 You can convert a string with a numeric value or a boolean with a string value to their numeric and boolean equivalents, or convert a non-string value to a string value, with these functions:
 
-* Use the `numeric()` function to convert a number with a string format to a numeric value. The function can be built into a query that uses math functions on query results or NRQL aggregator functions, such as `average()`.
+* Use the `numeric()` function to convert a number with a string format to a numeric value. The function can be built into a query that uses math functions on query results or NRQL aggregator functions, such as `average()`. Please note that if the NRQL value is in the [gauge format](/docs/data-apis/understand-data/metric-data/metric-data-type/), then `numeric()` cannot work on it. Instead, you must use the compatible query functions `latest(), min(), max(), sum(), count() or average()`.  
 * Use the `boolean()` function to convert a string value of `"true"` or `"false"` to the corresponding boolean value.
 * Use the `string()` function to convert a numeric, boolean, tuple, or array value to a string value.  See [`string()`](#func-string) above for more information.
 


### PR DESCRIPTION
* fix: explain compatibility limitation of the NRQL numeric() function

Background
We (Infra Data Pipeline + Dirac) have discovered that some customers used numeric() on NRQL fields, where the query would break with the gauge format. After reaching out to some account teams in Sales, they asked us to explain this incompatibility in the docs.


