### PR TITLE
chore: Remove long task

### DIFF
--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details.mdx
@@ -158,20 +158,6 @@ The `BrowserInteraction` and `PageView` events end their reporting when they rec
 
     <tr>
       <td>
-        `longTask`
-      </td>
-
-      <td>
-        Long task reporting is available starting with [agent v1227](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1227). This event represents per entry observed by the experimental [PerformanceLongTaskTiming API](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming), which reports tasks that block the main UI thread for >50 ms.
-
-        NOTE: Though this event is available as an experimental feature, data for it is not automatically collected. It must be enabled in the browser agent's configuration using a flag on the `init` object, e.g. `init: { page_view_timing: { long_task: true } }`.
-
-        It's generally recommended to [break up and optimize](https://web.dev/optimize-long-tasks/) these tasks to prevent delays in processing user input or interactions. Long tasks may affect or closely relate to the `interactionToNextPaint` metric. Note that the API currently provides no in-depth context on the cause of these tasks and collates all long tasks within a browsing frame together, even if they consist of multiple different functions.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         `pageHide`
       </td>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

In this PR, we are removing `longTask` from the PageViewTiming's description page as the feature has been removed from the browser agent.

## Give us some context

**What problems does this PR solve?**
Long task was removed from the browser agent and documentation needs to be updated to reflect that, https://new-relic.atlassian.net/browse/NR-261376