### PR TITLE
.NET Agent: Add AWSSDK.DynamoDBv2 to the list of datastore clients instrumented

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -1533,7 +1533,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     </tr>
 
-                    <tr>
+                <tr>
                 <td>
                     Memcached
                 </td>
@@ -1550,6 +1550,26 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 2.0.0
                   * Latest verified compatible version: 3.2.3
+                </td>
+                </tr>
+
+                <tr>
+                <td>
+                    DynamoDB
+                </td>
+
+                <td className="fcenter">
+                    <Icon
+                    style={{color: '#328787'}}
+                    name="fe-check"
+                    />
+                </td>
+
+                <td>
+                  Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
+
+                  * Minimum supported version: 3.5.0
+                  * Latest verified compatible version: 4.0.0-preview.4
                 </td>
                 </tr>
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -1570,6 +1570,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.5.0
                   * Latest verified compatible version: 4.0.0-preview.4
+
+                  * Minimum agent version required: 10.33.0
                 </td>
                 </tr>
 


### PR DESCRIPTION
The .NET agent just released auto-instrumentation for `AWSSDK.DynamoDBv2` which is a database client in .NET.  This PR adds info to the compatibility and requirements document for this library.