### PR TITLE
fix(K8s): Added the caution note about the summary page

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
@@ -34,7 +34,7 @@ To successfully complete the steps below, you should already be familiar with Op
 
 * Instrumented your applications with [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup/), and successfully sent data to New Relic via OpenTelemetry Protocol (OTLP).
 
-If you've general questions about using Collectors with New Relic, see our [Introduction to OpenTelemetry Collector with New Relic](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
+If you have general questions about using Collectors with New Relic, see our [Introduction to OpenTelemetry Collector with New Relic](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
 ## Configure your application to send telemetry data to the OpenTelemetry Collector [#instrument]
 
@@ -205,7 +205,7 @@ You can choose one of these options to monitor your cluster:
 You should be able to verify that your configurations are working once you have successfully linked your OpenTelemetry data with your Kubernetes data.
 
 <Callout variant="caution">
-  Note that the [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) has a limitation. You must monitor Kubernetes and APM with New Relic's proprietary agents or with OpenTelemetry. If you've a mix of different instrumentation providers (New Relic and OpenTelemetry), you won't see any data on this page.
+ The [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) only displays data from applications monitored by New Relic's agents or OpenTelemetry. If your environment uses a mix of different instrumentation providers, you may not see complete data on this page.
 </Callout>
 
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
@@ -205,7 +205,7 @@ You can choose one of these options to monitor your cluster:
 You should be able to verify that your configurations are working once you have successfully linked your OpenTelemetry data with your Kubernetes data.
 
 <Callout variant="caution">
-  Note that the [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) works when both Kubernetes and APM are monitored either exclusively by New Relic's proprietary agents or entirely by OpenTelemetry. If there is a mix of different instrumentation providers (New Relic and OpenTelemetry), you won't see any data on this page.
+  Note that the [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) has a limitation. You must monitor Kubernetes and APM with New Relic's proprietary agents or with OpenTelemetry. If you've a mix of different instrumentation providers (New Relic and OpenTelemetry), you won't see any data on this page.
 </Callout>
 
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
@@ -30,11 +30,11 @@ To successfully complete the steps below, you should already be familiar with Op
   * `OTEL_EXPORTER_OTLP_ENDPOINT`: See [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp/) for more info.
   * `NEW_RELIC_API_KEY`: See [New Relic API keys](/docs/apis/intro-apis/new-relic-api-keys/) for more info.
 
-* Installed the [New Relic Kubernetes integration](/install/kubernetes) in your cluster.
+* Installed your [Kubernetes cluster with OpenTelemetry](/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-otel/#install).
 
 * Instrumented your applications with [OpenTelemetry](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup/), and successfully sent data to New Relic via OpenTelemetry Protocol (OTLP).
 
-If you have general questions about using Collectors with New Relic, see our [Introduction to OpenTelemetry Collector with New Relic](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
+If you've general questions about using Collectors with New Relic, see our [Introduction to OpenTelemetry Collector with New Relic](/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-intro).
 
 ## Configure your application to send telemetry data to the OpenTelemetry Collector [#instrument]
 
@@ -204,6 +204,11 @@ You can choose one of these options to monitor your cluster:
 
 You should be able to verify that your configurations are working once you have successfully linked your OpenTelemetry data with your Kubernetes data.
 
+<Callout variant="caution">
+  Note that the [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) works when both Kubernetes and APM are monitored either exclusively by New Relic's proprietary agents or entirely by OpenTelemetry. If there is a mix of different instrumentation providers (New Relic and OpenTelemetry), you won't see any data on this page.
+</Callout>
+
+
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & Services**</DNT> and select your application inside <DNT>**Services - OpenTelemetry**</DNT>.
 
 2. Click <DNT>**Kubernetes**</DNT> on the left navigation pane.
@@ -216,7 +221,7 @@ You should be able to verify that your configurations are working once you have 
 />
 
 <figcaption>
-  Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & Services > (selected app) > Kubernetes**</DNT>
+  Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & Services > (selected app) > Kubernetes**</DNT> to see the Kubernetes summary page.
 </figcaption>
 
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes.mdx
@@ -205,7 +205,7 @@ You can choose one of these options to monitor your cluster:
 You should be able to verify that your configurations are working once you have successfully linked your OpenTelemetry data with your Kubernetes data.
 
 <Callout variant="caution">
- The [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) only displays data from applications monitored by New Relic's agents or OpenTelemetry. If your environment uses a mix of different instrumentation providers, you may not see complete data on this page.
+ The [Kubernetes summary page](/docs/apm/apm-ui-pages/monitoring/kubernetes-summary-page) only displays data from applications monitored by New Relic agents or OpenTelemetry. If your environment uses a mix of different instrumentation providers, you may not see complete data on this page.
 </Callout>
 
 


### PR DESCRIPTION
Added the caution note about the summary page on the [Link OpenTelemetry-instrumented applications to Kubernetes](https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-otel-applications-kubernetes/).

Request (10-31-2024) from the [help-k8s-experience](https://newrelic.slack.com/archives/C043X7A8JRF/p1723651316136359) Slack channel.