### PR TITLE
chore: .NET agent, forgot to add DynamoDB to the other section

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -584,6 +584,28 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
                 </tr>
 
+                <tr>
+                <td>
+                    DynamoDB
+                </td>
+
+                <td className="fcenter">
+                    <Icon
+                    style={{color: '#328787'}}
+                    name="fe-check"
+                    />
+                </td>
+
+                <td>
+                  Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
+
+                  * Minimum supported version: 3.5.0
+                  * Latest verified compatible version: 4.0.0-preview.4
+
+                  * Minimum agent version required: 10.33.0
+                </td>
+                </tr>
+
             </tbody>
             </table>
 


### PR DESCRIPTION
I forgot to add this info to both section (Framework and Core) for the .NET agent yesterday.  This PR corrects the oversight.