### PR TITLE
Update get-started-logs-context.mdx

### DIFF
--- a/src/content/docs/logs/logs-context/get-started-logs-context.mdx
+++ b/src/content/docs/logs/logs-context/get-started-logs-context.mdx
@@ -157,7 +157,7 @@ When you set up an <InlinePopover type="apm"/> agent, you automatically get a ch
   src="/images/logs_screenshot-crop_logging-metrics.webp"
 />
 
-This chart shows a count of logs. If you haven't disabled the log forwarding, you can click on the chart links that will take you to the logs themselves. Even if you turn off the log forwarding, this chart still shows the potential logs you could inspect if you had APM log forwarding enabled.
+This chart shows a count of logs. If you haven't disabled log forwarding, you can click on the chart links that will take you to the logs themselves. Even if you disable log forwarding, this chart still shows the potential logs you could inspect if you had log forwarding enabled.
 
 Logging metrics are reported via the `apm.service.logging.lines` attribute, as shown in the following query:
 

--- a/src/content/docs/logs/logs-context/get-started-logs-context.mdx
+++ b/src/content/docs/logs/logs-context/get-started-logs-context.mdx
@@ -157,7 +157,7 @@ When you set up an <InlinePopover type="apm"/> agent, you automatically get a ch
   src="/images/logs_screenshot-crop_logging-metrics.webp"
 />
 
-This chart shows a count of logs. If you haven't disabled APM log forwarding, you can click on the chart links that will take you to the logs themselves. Even if you turn off APM log forwarding, this chart still shows the potential logs you could inspect if you had APM log forwarding enabled.
+This chart shows a count of logs. If you haven't disabled the log forwarding, you can click on the chart links that will take you to the logs themselves. Even if you turn off the log forwarding, this chart still shows the potential logs you could inspect if you had APM log forwarding enabled.
 
 Logging metrics are reported via the `apm.service.logging.lines` attribute, as shown in the following query:
 


### PR DESCRIPTION
The scenario where the chart would still show metrics of logs not sent to New Relic also applies to other log forwarding methods, not only the APM log forwarding.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.