### PR TITLE
Update azure-monitor.mdx

### DIFF
--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -292,5 +292,5 @@ On a typical deployment, migrating from Azure API polling to the Azure monitor i
 <Callout variant="important">
   If both integrations are enabled for the same resource type, you may see duplicate metrics. This can happen if you use a generic name field to filter your results that can be shared from the Azure monitor and the Azure Polling integrations. The results from multiple resources could be joined unintentionally.
 
-  Note that metrics can still be differentiated by faceting using the field `collector.name`. `collector.name` may not always be available on an API polling resource, and its absense is an indication of no Azure Monitor coverage. Also note that rate limits as enforced by Azure will be shared between any current polling integrations and the Azure monitor.
+  Note that metrics can still be differentiated by faceting using the field `collector.name`. `collector.name` may not always be available on an API polling resource, and its absence is an indication of no Azure monitor coverage. Also note that rate limits as enforced by Azure will be shared between any current polling integrations and the Azure monitor.
 </Callout>

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -292,5 +292,5 @@ On a typical deployment, migrating from Azure API polling to the Azure monitor i
 <Callout variant="important">
   If both integrations are enabled for the same resource type, you may see duplicate metrics. This can happen if you use a generic name field to filter your results that can be shared from the Azure monitor and the Azure Polling integrations. The results from multiple resources could be joined unintentionally.
 
-  Note that metrics can still be differentiated by faceting using the field `collector.name`. `collector.name` may not always be available on an API polling resource, its absense an indication of no Azure Monitor coverage. Also note that rate limits as enforced by Azure will be shared between any current polling integrations and the Azure monitor.
+  Note that metrics can still be differentiated by faceting using the field `collector.name`. `collector.name` may not always be available on an API polling resource, and its absense is an indication of no Azure Monitor coverage. Also note that rate limits as enforced by Azure will be shared between any current polling integrations and the Azure monitor.
 </Callout>

--- a/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
+++ b/src/content/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor.mdx
@@ -292,5 +292,5 @@ On a typical deployment, migrating from Azure API polling to the Azure monitor i
 <Callout variant="important">
   If both integrations are enabled for the same resource type, you may see duplicate metrics. This can happen if you use a generic name field to filter your results that can be shared from the Azure monitor and the Azure Polling integrations. The results from multiple resources could be joined unintentionally.
 
-  Note that metrics can still be differentiated by faceting using the field `collector.name`. Also note that rate limits as enforced by Azure will be shared between any current polling integrations and the Azure monitor.
+  Note that metrics can still be differentiated by faceting using the field `collector.name`. `collector.name` may not always be available on an API polling resource, its absense an indication of no Azure Monitor coverage. Also note that rate limits as enforced by Azure will be shared between any current polling integrations and the Azure monitor.
 </Callout>


### PR DESCRIPTION
Adjusting assumption that collector.name is always available, as confirmed in NR-316614.

## Give us some context

* What problems does this PR solve?

Current wording in callout box suggests collector.name is always available, can confuse customers when it's not there.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  
  This issue confirmed in NR-316614.