### PR TITLE
chore(metric API): timestamp value update

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -22,7 +22,7 @@ Use the [Metric API](/docs/introduction-new-relic-metric-api) to send custom met
 
 We report the metric types `count`, `gauge`, and `summary`. For more information on metrics see [our documentation](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type).
 
-Submit metric data to New Relic through an HTTP POST request. Each request is composed of one or more metric data points, which consist of a metric name, a timestamp, and a value.
+Submit metric data to New Relic through an HTTP POST request. Compose each request with one or more metric data points, that consist of a `name`, a `timestamp`, and a `value` for the metric.
 
 Follow this example to send your first metric data points to New Relic:
 

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -28,7 +28,7 @@ Follow this example to send your first metric data points to New Relic:
 
 1. Get the <InlinePopover type="licenseKey"/> for the account you want to report data to.
 2. Insert the license key into the following JSON, and then send the JSON to our [endpoint](#api-endpoint).
-3. Update the `timestamp` value from `CURRENT_TIMESTAMP` to a valid epoch timestamp.
+3. Update the `timestamp` value from `CURRENT_TIMESTAMP` to [a valid epoch timestamp](#json-payload-keys).
    This example creates a single metric data point for a metric named `memory.heap`, but you can create additional attributes or data points by specifying [metric types](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type) or adding [optional `common` blocks](#optional-map-attributes).
 
    ```bash

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -40,7 +40,7 @@ Follow this example to send your first metric data points to New Relic:
                "name":"memory.heap", 
                "type":"gauge", 
                "value":2.3, 
-               "timestamp":CURRENT_TIME, 
+               "timestamp":1704431659000, 
                "attributes":{"host.name":"dev.server.com"} 
            }] 
        }]'
@@ -194,7 +194,7 @@ The JSON payload uses this structure:
             "name": "service.errors.all",
             "type": "count",
             "value": 15,
-            "timestamp": CURRENT_TIME,
+            "timestamp": 1707110059000,
             "interval.ms": 10000,
             "attributes": {
               "service.response.statuscode": "400",
@@ -206,7 +206,7 @@ The JSON payload uses this structure:
             "name": "service.memory",
             "type": "gauge",
             "value": 2.7,
-            "timestamp": CURRENT_TIME,
+            "timestamp": 1707110059000,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"
@@ -324,7 +324,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "cache.misses",
             "type": "count",
             "value": 15,
-            "timestamp": CURRENT_TIME,
+            "timestamp": 1709615659000,
             "interval.ms": 10000,
             "attributes": {
               "cache.name": "myCache",
@@ -335,7 +335,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "temperature", 
             "type": "gauge", 
             "value": 15, 
-            "timestamp": CURRENT_TIME, 
+            "timestamp": 1709615659000, 
             "attributes": { 
               "city": "Portland", 
               "state": "Oregon" 
@@ -351,7 +351,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
               "max": 0.001708826
             },
             "interval.ms": 10000, 
-            "timestamp": CURRENT_TIME,
+            "timestamp": 1709615659000,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -22,7 +22,7 @@ Use the [Metric API](/docs/introduction-new-relic-metric-api) to send custom met
 
 We report the metric types `count`, `gauge`, and `summary`. For more information on metrics see [our documentation](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type).
 
-Metric data is submitted to New Relic through an HTTP POST request. Each request is composed of one or more metric data points, which consist of a metric name, a timestamp, and a value.
+Submit metric data to New Relic through an HTTP POST request. Each request is composed of one or more metric data points, which consist of a metric name, a timestamp, and a value.
 
 Follow this example to send your first metric data points to New Relic:
 

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -28,7 +28,7 @@ Follow this example to send your first metric data points to New Relic:
 
 1. Get the <InlinePopover type="licenseKey"/> for the account you want to report data to.
 2. Insert the license key into the following JSON, and then send the JSON to our [endpoint](#api-endpoint).
-3. Update the `timestamp` value from `CURRENT_TIMESTAMP` to [a valid epoch timestamp](#json-payload-keys).
+3. For `timestamp` replace `INSERT_CURRENT_TIMESTAMP` with a valid [epoch timestamp](#json-payload-keys).
    This example creates a single metric data point for a metric named `memory.heap`, but you can create additional attributes or data points by specifying [metric types](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type) or adding [optional `common` blocks](#optional-map-attributes).
 
    ```bash
@@ -40,7 +40,7 @@ Follow this example to send your first metric data points to New Relic:
                "name":"memory.heap", 
                "type":"gauge", 
                "value":2.3, 
-               "timestamp":CURRENT_TIMESTAMP, 
+               "timestamp":INSERT_CURRENT_TIMESTAMP, 
                "attributes":{"host.name":"dev.server.com"} 
            }] 
        }]'
@@ -194,7 +194,7 @@ The JSON payload uses this structure:
             "name": "service.errors.all",
             "type": "count",
             "value": 15,
-            "timestamp":CURRENT_TIMESTAMP,
+            "timestamp":INSERT_CURRENT_TIMESTAMP,
             "interval.ms": 10000,
             "attributes": {
               "service.response.statuscode": "400",
@@ -206,7 +206,7 @@ The JSON payload uses this structure:
             "name": "service.memory",
             "type": "gauge",
             "value": 2.7,
-            "timestamp":CURRENT_TIMESTAMP,
+            "timestamp":INSERT_CURRENT_TIMESTAMP,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"
@@ -269,7 +269,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
       </td>
 
       <td>
-        <DNT>**Required**</DNT>. The metric's start time in [Unix time](https://currentmillis.com/). The default uses UTC time zone. This field also support seconds, microseconds, and nanoseconds. However, the data will be converted to milliseconds for storage and query. Metrics reported with a timestamp older than 48 hours in the past or more than 24 hours in the future from the time they are reported are dropped.
+        <DNT>**Required**</DNT>. The metric's start time in [Unix time](https://currentmillis.com/). The default uses UTC time zone. This field also support seconds, microseconds, and nanoseconds. However, the data will be converted to milliseconds for storage and query. Metrics are dropped if they have a timestamp more than 48 hours in the past or more than 24 hours in the future from the time they are reported.
       </td>
     </tr>
 
@@ -324,7 +324,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "cache.misses",
             "type": "count",
             "value": 15,
-            "timestamp":CURRENT_TIMESTAMP,
+            "timestamp":INSERT_CURRENT_TIMESTAMP,
             "interval.ms": 10000,
             "attributes": {
               "cache.name": "myCache",
@@ -335,7 +335,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "temperature", 
             "type": "gauge", 
             "value": 15, 
-            "timestamp":CURRENT_TIMESTAMP, 
+            "timestamp":INSERT_CURRENT_TIMESTAMP, 
             "attributes": { 
               "city": "Portland", 
               "state": "Oregon" 
@@ -351,7 +351,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
               "max": 0.001708826
             },
             "interval.ms": 10000, 
-            "timestamp":CURRENT_TIMESTAMP,
+            "timestamp":INSERT_CURRENT_TIMESTAMP,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"

--- a/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/report-metrics-metric-api.mdx
@@ -28,7 +28,7 @@ Follow this example to send your first metric data points to New Relic:
 
 1. Get the <InlinePopover type="licenseKey"/> for the account you want to report data to.
 2. Insert the license key into the following JSON, and then send the JSON to our [endpoint](#api-endpoint).
-3. Update the `timestamp` with a valid epoch timestamp.
+3. Update the `timestamp` value from `CURRENT_TIMESTAMP` to a valid epoch timestamp.
    This example creates a single metric data point for a metric named `memory.heap`, but you can create additional attributes or data points by specifying [metric types](/docs/telemetry-data-platform/ingest-manage-data/understand-data/metric-data-type) or adding [optional `common` blocks](#optional-map-attributes).
 
    ```bash
@@ -40,7 +40,7 @@ Follow this example to send your first metric data points to New Relic:
                "name":"memory.heap", 
                "type":"gauge", 
                "value":2.3, 
-               "timestamp":1704431659000, 
+               "timestamp":CURRENT_TIMESTAMP, 
                "attributes":{"host.name":"dev.server.com"} 
            }] 
        }]'
@@ -194,7 +194,7 @@ The JSON payload uses this structure:
             "name": "service.errors.all",
             "type": "count",
             "value": 15,
-            "timestamp": 1707110059000,
+            "timestamp":CURRENT_TIMESTAMP,
             "interval.ms": 10000,
             "attributes": {
               "service.response.statuscode": "400",
@@ -206,7 +206,7 @@ The JSON payload uses this structure:
             "name": "service.memory",
             "type": "gauge",
             "value": 2.7,
-            "timestamp": 1707110059000,
+            "timestamp":CURRENT_TIMESTAMP,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"
@@ -269,7 +269,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
       </td>
 
       <td>
-        <DNT>**Required**</DNT>. The metric's start time in [Unix time](https://currentmillis.com/). The default uses UTC time zone. This field also support seconds, microseconds, and nanoseconds. However, the data will be converted to milliseconds for storage and query. Metrics reported with a timestamp older than 48 hours ago or newer than 24 hours from the time they are reported are dropped.
+        <DNT>**Required**</DNT>. The metric's start time in [Unix time](https://currentmillis.com/). The default uses UTC time zone. This field also support seconds, microseconds, and nanoseconds. However, the data will be converted to milliseconds for storage and query. Metrics reported with a timestamp older than 48 hours in the past or more than 24 hours in the future from the time they are reported are dropped.
       </td>
     </tr>
 
@@ -324,7 +324,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "cache.misses",
             "type": "count",
             "value": 15,
-            "timestamp": 1709615659000,
+            "timestamp":CURRENT_TIMESTAMP,
             "interval.ms": 10000,
             "attributes": {
               "cache.name": "myCache",
@@ -335,7 +335,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
             "name": "temperature", 
             "type": "gauge", 
             "value": 15, 
-            "timestamp": 1709615659000, 
+            "timestamp":CURRENT_TIMESTAMP, 
             "attributes": { 
               "city": "Portland", 
               "state": "Oregon" 
@@ -351,7 +351,7 @@ Each metric data point map in the `metrics` array uses the following key-value s
               "max": 0.001708826
             },
             "interval.ms": 10000, 
-            "timestamp": 1709615659000,
+            "timestamp":CURRENT_TIMESTAMP,
             "attributes": {
               "host.name": "dev.server.com",
               "app.name": "foo"


### PR DESCRIPTION
- The values for "timestamp" key in the example payloads were "CURRENT_TIME," which were invalid as per the "Required key-value pairs" table. Updated the values with some epoch time samples.
- Refactored a sentence from passive voice to active voice.