### PR TITLE
fix(accounts): Migrate archived pricing to public site

### DIFF
--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -10,6 +10,11 @@ const METADATA = [
   },
 ];
 
+// List of urls we don't want to have indexed by Swifttype or search engines
+const DO_NOT_INDEX = [
+  'docs/licenses/license-information/usage-plans/archived-add-on',
+];
+
 const surveyRecaptcha = (
   <script
     key="google-recaptcha"
@@ -29,8 +34,15 @@ const isAgileHandbookPage = (url) => {
 
 const isMdxTestPage = (url) => url.includes('docs/mdx-test-page');
 
-const isExcludedFromSwiftype = (url) =>
-  isStyleGuidePage(url) || isAgileHandbookPage(url) || isMdxTestPage(url);
+const doNotIndex = (url, arr) => {
+  return arr.some((item) => url.includes(item));
+};
+
+const isExcludedFromIndexing = (url) =>
+  isStyleGuidePage(url) ||
+  isAgileHandbookPage(url) ||
+  isMdxTestPage(url) ||
+  doNotIndex(url, DO_NOT_INDEX);
 
 const DocsSiteSeo = ({
   location,
@@ -77,8 +89,8 @@ const DocsSiteSeo = ({
       />
     )}
 
-    {isExcludedFromSwiftype(location.pathname) && (
-      <meta name="st:robots" content="noindex, nofollow" />
+    {isExcludedFromIndexing(location.pathname) && (
+      <meta name="robots" content="noindex, nofollow" />
     )}
 
     {(description || title) && (

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing.mdx
@@ -14,7 +14,7 @@ In addition to the primary billing factors of GB Ingested and billable users, yo
 * **Advanced Compute (formerly Add-on Compute)**: This add-on applies to usage-based billing for actions you run related to Codestream, Live Archives, and other features as made available. You are measured and billed based on your usage of [Advanced CCUs](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions/#compute-capacity-unit).
 
   <Callout variant="tip"> 
-    Your use of CodeStream under Advanced Compute will incur CCU charges, regardless of user type. This means that even free Basic users can now access CodeStream at a very low monthly cost of just the Advanced CCUs.
+    Your use of CodeStream under Advanced Compute will incur CCU charges, regardless of user type. This means that free Basic users can access Advanced Compute features and incur charges for Advanced CCUs.
 </Callout>
 * **EU Data Center for Original Data or Data Plus**: This add-on applies to your data option (original Data or Data Plus) when you select the European Union as your data region, as available.
 * **Extended Retention for Original Data or Data Plus**: This add-on applies if you exceed the default length of time your data is retained. This applies to all your data—not just logs—and is a good option if you need to make a lot of small queries or make queries on large volumes of data.

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing.mdx
@@ -14,7 +14,7 @@ In addition to the primary billing factors of GB Ingested and billable users, yo
 * **Advanced Compute (formerly Add-on Compute)**: This add-on applies to usage-based billing for actions you run related to Codestream, Live Archives, and other features as made available. You are measured and billed based on your usage of [Advanced CCUs](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions/#compute-capacity-unit).
 
   <Callout variant="tip"> 
-    Your use of CodeStream under Advanced Compute will incur CCU charges, regardless of user type. This means that free Basic users can access Advanced Compute features and incur charges for Advanced CCUs.
+    Your use of CodeStream under Advanced Compute will incur CCU charges, regardless of user type. This means that free basic users can access Advanced Compute features and incur charges for Advanced CCUs.
 </Callout>
 * **EU Data Center for Original Data or Data Plus**: This add-on applies to your data option (original Data or Data Plus) when you select the European Union as your data region, as available.
 * **Extended Retention for Original Data or Data Plus**: This add-on applies if you exceed the default length of time your data is retained. This applies to all your data—not just logs—and is a good option if you need to make a lot of small queries or make queries on large volumes of data.

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
@@ -145,7 +145,7 @@ Here's another example of an order item:
 New Relic - Pro Full Platform Users (PAYG)
 ```
 
-The `PAYG` at the end means your organization is on our pay-as-you-go [buying program](#usage-plans).
+"PAYG" at the end means your organization is on our pay-as-you-go [buying program](#usage-plans).
 
 For more details about order terms, see our [license docs](/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions).
 

--- a/src/content/docs/licenses/license-information/usage-plans/archived-add-on.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/archived-add-on.mdx
@@ -1,0 +1,309 @@
+---
+title: "Compute Add On (archived)"
+metaDescription: "This document contains details about the original Compute Add On"
+freshnessValidatedDate: 2024-11-06
+---
+
+(Not generally available after 2024-10-22)
+
+If your account has the original Compute Add On provisioned, you can use this page to refer to the details referenced in your order. This page contains the following:
+
+* A copy of the Compute Add-On description
+* A copy of the Compute Add On promotional tiered pricing
+
+
+## Add-on billing (optional) [#add-on-billing]
+
+In addition to the primary billing factors of ingest and billable users, you can also use optional billable add-ons to enhance your experience with New Relic:
+
+* Compute Add On: This add-on applies to usage-based billing for actions you run related to live archives and other add-ons as made available. It measures your usage based on [Compute Capacity Units (CCUs)](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions#compute-capacity-unit).
+
+
+## List Price for Compute Add On [#list-prices]
+
+<table>
+    <thead>
+    <tr>
+        <th>
+        Tiers
+        </th>
+
+        <th>
+        CCU Range
+        </th>
+
+        <th>
+        List Price per CCU per month<sup>1</sup>
+        </th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <tr>
+        <td>
+        1
+        </td>
+
+        <td>
+        0 - 100
+        </td>
+
+        <td>
+        ~~$3.8100~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        2
+        </td>
+
+        <td>
+        101 - 250
+        </td>
+
+        <td>
+        ~~$3.3020~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        3
+        </td>
+
+        <td>
+        251 - 500
+        </td>
+
+        <td>
+        ~~$2.8575~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        4
+        </td>
+
+        <td>
+        501 - 1,000
+        </td>
+
+        <td>
+        ~~$2.4638~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        5
+        </td>
+
+        <td>
+        1,001 - 2,500
+        </td>
+
+        <td>
+        ~~$2.1209~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        6
+        </td>
+
+        <td>
+        2,501 - 5,000
+        </td>
+
+        <td>
+        ~~$1.8161~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        7
+        </td>
+
+        <td>
+        5,001 - 10,000
+        </td>
+
+        <td>
+        ~~$1.5494~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        8
+        </td>
+
+        <td>
+        10,001 - 25,000
+        </td>
+
+        <td>
+        ~~$1.3208~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        9
+        </td>
+
+        <td>
+        25,001 - 50,000
+        </td>
+
+        <td>
+        ~~$1.1049~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        10
+        </td>
+
+        <td>
+        50,001 - 100,000
+        </td>
+
+        <td>
+        ~~$0.9017~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        11
+        </td>
+
+        <td>
+        100,001 - 250,000
+        </td>
+
+        <td>
+        ~~$0.7140~~ $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        12
+        </td>
+
+        <td>
+        250,001 - 500,000
+        </td>
+
+        <td>
+        $0.5503
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        13
+        </td>
+
+        <td>
+        500,001 - 1,000,000
+        </td>
+
+        <td>
+        $0.4229
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        14
+        </td>
+
+        <td>
+        1,000,001 - 5,000,000
+        </td>
+
+        <td>
+        $0.2959
+        </td>
+    </tr>
+
+    <tr>
+        <td>
+        15
+        </td>
+
+        <td>
+        5,000,001+
+        </td>
+
+        <td>
+        $0.1905
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+
+Notes:
+
+
+<sup>1</sup>  For eligible customers with full platform users, you are subject to limited-time promotional pricing for the first twelve tiers: $0.5503 per 1 CCU per month.
+
+If you are using the Enterprise edition, the EU data region, or other options available for CCU, the applicable List Price is calculated by multiplying the value in above table's List Price column by these factors:
+
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Option
+          </th>
+
+          <th>
+            Multiply list prices by
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Pro (EU)
+          </td>
+
+          <td>
+            1.1500
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Enterprise
+          </td>
+
+          <td>
+            1.3300
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Enterprise (EU)
+          </td>
+
+          <td>
+            1.5295
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    On a monthly basis, CCU usage will be charged for each CCU within each tier beginning at the initial tier at its corresponding price. Only those units exceeding the preceding tier(s) are entitled to the reduced List Price in the subsequent tier(s). Calculated charges are based on factors that have four decimal places. Amounts invoiced are rounded up to the nearest cent where applicable.
+  

--- a/src/content/docs/licenses/license-information/usage-plans/archived-add-on.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/archived-add-on.mdx
@@ -8,7 +8,7 @@ freshnessValidatedDate: 2024-11-06
 
 If your account has the original Compute Add On provisioned, you can use this page to refer to the details referenced in your order. This page contains the following:
 
-* A copy of the Compute Add-On description
+* A copy of the Compute Add On description
 * A copy of the Compute Add On promotional tiered pricing
 
 

--- a/src/content/docs/licenses/license-information/usage-plans/archived-add-on.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/archived-add-on.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Compute Add On (archived)"
-metaDescription: "This document contains details about the original Compute Add On"
+metaDescription: "This document contains details about the original New Relic Compute Add On"
 freshnessValidatedDate: 2024-11-06
 ---
 

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
@@ -63,7 +63,7 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
 
 **PAYG conversion table**
 
-The PAYG at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
+"PAYG" at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
 
 <table>
   <thead>

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
@@ -59,7 +59,7 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
   >
     * The Commitment Fee will be invoiced as per the 'Billing Terms' described in your Order. On a monthly cadence during the Commitment Term and through the end of the month in which the Commitment Fee is consumed in full, Per Unit usage of the Products will be multiplied by the corresponding rates and summed ("Monthly Product Usage").
 
-    * Starting on the first day immediately following the earlier of either (a) full depletion of the Commitment Fee, or (b) end of the Rollover Period, your Buying Program will convert from the Savings Plan to New Relic Pay As You Go ("PAYG") and your Products will convert as described in the PAYG Conversion Table below. Notwithstanding the foregoing, if the Commitment Fee or Rollover Balance expires upon the Renewal Date, then as of the Renewal Date your Monthly Product Usage will be billable under the PAYG Buying Program or in accordance with an immediately succeeding Order starting on the Renewal Date. Fees related to usage on PAYG will be paid monthly in arrears and calculated by multiplying the Per Unit usage of the Products by the PAYG List Price. PAYG conversions shall be at the higher of PAYG List Price or current rates/price defined in your Order based on Products provisioned pursuant to your Order. Products and pricing not defined in the Order are defined in the Usage Plan. 
+    * Starting on the first day immediately following the earlier of either (a) full depletion of the Commitment Fee, or (b) end of the Rollover Period, your Buying Program will convert from the Savings Plan to New Relic Pay As You Go ("PAYG") and your Products will convert as described in the PAYG Conversion Table below. Notwithstanding the foregoing, if the Commitment Fee or Rollover Balance expires upon the Renewal Date, then as of the Renewal Date your Monthly Product Usage will be billable under the PAYG Buying Program or in accordance with an immediately succeeding Order starting on the Renewal Date. Fees related to usage on PAYG will be paid monthly in arrears and calculated by multiplying the Per Unit usage of the Products by the List Price. PAYG conversions shall be at the higher of List Price or current rates/price defined in your Order based on Products provisioned pursuant to your Order. Products and pricing not defined in the Order are defined in the Usage Plan. 
 
 
       **PAYG conversion table**
@@ -130,6 +130,33 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
         </tbody>
       </table>
 
+    * The PAYG at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
+        <table>
+          <thead>
+            <tr>
+              <th>Savings Plan (From)</th>
+              <th>PAYG (To)</th>
+            </tr>
+          </thread>
+          <tbody>
+            <tr>
+              <td>                 
+                New Relic Savings Plan - Pro Full Platform Users
+              </td>
+              <td>
+                New Relic - Pro Full Platform Users (PAYG)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                New Relic Savings Plan - Data
+              </td>
+              <td>
+                New Relic - Data (PAYG)
+              </td>
+            </tr>
+          </tbody>
+        </table>    
     * Monthly Product Usage will be deducted from the Commitment Fee amounts that are paid in advance. If Monthly Product Usage exceeds any remaining unconsumed amounts, Customer will be invoiced for the difference on a monthly basis.
 
     * If Customer's Buying Program is converted from Savings Plan to New Relic Pay As You Go as described in the Order, then Customer may request termination of its PAYG Buying Program at any time with written notice to New Relic at [billing@newrelic.com](mailto:billing@newrelic.com) with fees being payable up until the effective date of such termination.
@@ -434,6 +461,10 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
     <sup>5</sup> Rounded up to nearest cent where applicable.
 
     <sup>6</sup> If your account is in the EU data region, multiply the List Price by 1.15.
+
+
+The Compute Add On Product is no longer generally available. If your current Order includes the Compute Add On Product, the terms described in [Compute Add On (archived)](/docs/licenses/license-information/usage-plans/archived-add-on) apply until the end of the applicable Commitment Term unless you amend your Order earlier.
+ 
   
   </Collapser>
 

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
@@ -137,7 +137,7 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
               <th>Savings Plan (From)</th>
               <th>PAYG (To)</th>
             </tr>
-          </thread>
+          </thead>
           <tbody>
             <tr>
               <td>                 

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
@@ -59,104 +59,39 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
   >
     * The Commitment Fee will be invoiced as per the 'Billing Terms' described in your Order. On a monthly cadence during the Commitment Term and through the end of the month in which the Commitment Fee is consumed in full, Per Unit usage of the Products will be multiplied by the corresponding rates and summed ("Monthly Product Usage").
 
-    * Starting on the first day immediately following the earlier of either (a) full depletion of the Commitment Fee, or (b) end of the Rollover Period, your Buying Program will convert from the Savings Plan to New Relic Pay As You Go ("PAYG") and your Products will convert as described in the PAYG Conversion Table below. Notwithstanding the foregoing, if the Commitment Fee or Rollover Balance expires upon the Renewal Date, then as of the Renewal Date your Monthly Product Usage will be billable under the PAYG Buying Program or in accordance with an immediately succeeding Order starting on the Renewal Date. Fees related to usage on PAYG will be paid monthly in arrears and calculated by multiplying the Per Unit usage of the Products by the List Price. PAYG conversions shall be at the higher of List Price or current rates/price defined in your Order based on Products provisioned pursuant to your Order. Products and pricing not defined in the Order are defined in the Usage Plan. 
+    * Starting on the first day immediately following the earlier of either (a) full depletion of the Commitment Fee, or (b) end of the Rollover Period, your Buying Program will convert from the Savings Plan to New Relic Pay As You Go ("PAYG") and your Products will convert as described in the PAYG Conversion Table below. Notwithstanding the foregoing, if the Commitment Fee or Rollover Balance expires upon the Renewal Date, then as of the Renewal Date your Monthly Product Usage will be billable under the PAYG Buying Program or in accordance with an immediately succeeding Order starting on the Renewal Date. Fees related to usage on PAYG will be paid monthly in arrears and calculated by multiplying the Per Unit usage of the Products by the List Price. PAYG conversions shall be at the higher of List Price or current rates/price defined in your Order based on Products provisioned pursuant to your Order. Products and pricing not defined in the Order are defined in the Usage Plan.
 
+    **PAYG conversion table**
 
-      **PAYG conversion table**
+    The PAYG at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
 
-      <table>
-        <thead>
-          <tr>
-            <th>
-              Savings Plan (From)
-            </th>
-
-            <th>
-              PAYG (To)
-            </th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <tr>
-            <td>
-              New Relic Savings Plan - Pro Full Platform Users
-            </td>
-
-            <td>
-              New Relic - Pro Full Platform Users (PAYG)
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              New Relic Savings Plan - Enterprise Full Platform Users
-            </td>
-
-            <td>
-              New Relic - Enterprise Full Platform Users (PAYG)
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              New Relic Savings Plan - Core Users
-            </td>
-
-            <td>
-              New Relic - Core Users (PAYG)
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              New Relic Savings Plan - Data
-            </td>
-
-            <td>
-              New Relic - Data (PAYG)
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              New Relic Savings Plan - Data Plus
-            </td>
-
-            <td>
-              New Relic - Data Plus (PAYG)
-            </td>
-          </tr>
-        </tbody>
-      </table>
-
-    * The PAYG at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
-        <table>
-          <thead>
-            <tr>
-              <th>Savings Plan (From)</th>
-              <th>PAYG (To)</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>                 
-                New Relic Savings Plan - Pro Full Platform Users
-              </td>
-              <td>
-                New Relic - Pro Full Platform Users (PAYG)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                New Relic Savings Plan - Data
-              </td>
-              <td>
-                New Relic - Data (PAYG)
-              </td>
-            </tr>
-          </tbody>
-        </table>    
+    <table>
+      <thead>
+        <tr>
+          <th>Savings Plan (From)</th>
+          <th>PAYG (To)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>                 
+            New Relic Savings Plan - Pro Full Platform Users
+          </td>
+          <td>
+            New Relic - Pro Full Platform Users (PAYG)
+          </td>
+        </tr>
+        <tr>
+          <td>
+            New Relic Savings Plan - Data
+          </td>
+          <td>
+            New Relic - Data (PAYG)
+          </td>
+        </tr>
+      </tbody>
+    </table>  
+          
     * Monthly Product Usage will be deducted from the Commitment Fee amounts that are paid in advance. If Monthly Product Usage exceeds any remaining unconsumed amounts, Customer will be invoiced for the difference on a monthly basis.
 
     * If Customer's Buying Program is converted from Savings Plan to New Relic Pay As You Go as described in the Order, then Customer may request termination of its PAYG Buying Program at any time with written notice to New Relic at [billing@newrelic.com](mailto:billing@newrelic.com) with fees being payable up until the effective date of such termination.

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
@@ -61,36 +61,36 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
 
     * Starting on the first day immediately following the earlier of either (a) full depletion of the Commitment Fee, or (b) end of the Rollover Period, your Buying Program will convert from the Savings Plan to New Relic Pay As You Go ("PAYG") and your Products will convert as described in the PAYG Conversion Table below. Notwithstanding the foregoing, if the Commitment Fee or Rollover Balance expires upon the Renewal Date, then as of the Renewal Date your Monthly Product Usage will be billable under the PAYG Buying Program or in accordance with an immediately succeeding Order starting on the Renewal Date. Fees related to usage on PAYG will be paid monthly in arrears and calculated by multiplying the Per Unit usage of the Products by the List Price. PAYG conversions shall be at the higher of List Price or current rates/price defined in your Order based on Products provisioned pursuant to your Order. Products and pricing not defined in the Order are defined in the Usage Plan.
 
-    **PAYG conversion table**
+**PAYG conversion table**
 
-    The PAYG at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
+The PAYG at the end of a Product name means your organization is on our PAYG Buying Program. Here are a couple of examples of how a Product name will indicate it has converted from Savings Plan to PAYG pursuant to your Order or the Usage Plan:
 
-    <table>
-      <thead>
-        <tr>
-          <th>Savings Plan (From)</th>
-          <th>PAYG (To)</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>                 
-            New Relic Savings Plan - Pro Full Platform Users
-          </td>
-          <td>
-            New Relic - Pro Full Platform Users (PAYG)
-          </td>
-        </tr>
-        <tr>
-          <td>
-            New Relic Savings Plan - Data
-          </td>
-          <td>
-            New Relic - Data (PAYG)
-          </td>
-        </tr>
-      </tbody>
-    </table>  
+<table>
+  <thead>
+    <tr>
+      <th>Savings Plan (From)</th>
+      <th>PAYG (To)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>                 
+        New Relic Savings Plan - Pro Full Platform Users
+      </td>
+      <td>
+        New Relic - Pro Full Platform Users (PAYG)
+      </td>
+    </tr>
+    <tr>
+      <td>
+        New Relic Savings Plan - Data
+      </td>
+      <td>
+        New Relic - Data (PAYG)
+      </td>
+    </tr>
+  </tbody>
+</table>  
           
     * Monthly Product Usage will be deducted from the Commitment Fee amounts that are paid in advance. If Monthly Product Usage exceeds any remaining unconsumed amounts, Customer will be invoiced for the difference on a monthly basis.
 


### PR DESCRIPTION
This PR is to insert archived pricing and product descriptions for the old Add On compute option.