### PR TITLE
fix: remove `<a>` tags from codeblocks

### DIFF
--- a/src/content/docs/alerts/scale-automate/rest-api/rest-api-calls-alerts.mdx
+++ b/src/content/docs/alerts/scale-automate/rest-api/rest-api-calls-alerts.mdx
@@ -365,29 +365,29 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#type">type</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>": [
+          "type": "string",
+          "name": "string",
+          "enabled": boolean,
+          "entities": [
             integer
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
+          "metric": "string",
           "gc_metric": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#condition-scope">condition_scope</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_close_timer">violation_close_timer</a>": integer,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+          "condition_scope": "string",
+          "violation_close_timer": integer,
+          "runbook_url": "string",
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+              "duration": "string",
+              "operator": "string",
+              "priority": "string",
+              "threshold": "string",
+              "time_function": "string"
             }
           ],
           "user_defined": {
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_metric">metric</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_value_function">value_function</a>": "string"
+            "metric": "string",
+            "value_function": "string"
           }
         }
       }'
@@ -417,30 +417,30 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#type">type</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>": [
+          "type": "string",
+          "name": "string",
+          "enabled": boolean,
+          "entities": [
             integer
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
+          "metric": "string",
+          "metric": "string",
           "gc_metric": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#condition-scope">condition_scope</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_close_timer">violation_close_timer</a>": integer,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+          "condition_scope": "string",
+          "violation_close_timer": integer,
+          "runbook_url": "string",
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+              "duration": "string",
+              "operator": "string",
+              "priority": "string",
+              "threshold": "string",
+              "time_function": "string"
             }
           ],
           "user_defined": {
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_metric">metric</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_value_function">value_function</a>": "string"
+            "metric": "string",
+            "value_function": "string"
           }
         }
       }'
@@ -514,35 +514,35 @@ These API functions include links to the API Explorer, where you can create, upd
     '{
       "nrql_condition": {
         "type": "string",
-        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
-        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
+        "name": "string",
+        "runbook_url": "string",
+        "enabled": boolean,
         "terms": [
           {
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+            "duration": "string",
+            "operator": "string",
+            "priority": "string",
+            "threshold": "string",
+            "time_function": "string"
           }
         ],
-        "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_value_function">value_function</a>": "string",
+        "value_function": "string",
         "nrql": {
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#nrql-query">query</a>": "string"
+          "query": "string"
         },
         "signal": {
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#signal_aggregation_window">aggregation_window</a>": "string",
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#signal_slide_by">slide_by</a>": "integer",
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#signal_aggregation_method">aggregation_method</a>": "string",
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#signal_aggregation_delay">aggregation_delay</a>": integer,
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#signal_aggregation_timer">aggregation_timer</a>": integer,
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#fill_option">fill_option</a>": "string",
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#fill_value">fill_value</a>": "string"
+          "aggregation_window": "string",
+          "slide_by": "integer",
+          "aggregation_method": "string",
+          "aggregation_delay": integer,
+          "aggregation_timer": integer,
+          "fill_option": "string",
+          "fill_value": "string"
         },
         "expiration": {
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#expiration_duration">expiration_duration</a>": "string",
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#expiration_duration">open_violation_on_expiration</a>": boolean,
-    	  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#expiration_duration">close_violations_on_expiration</a>": boolean
+          "expiration_duration": "string",
+          "open_violation_on_expiration": boolean,
+          "close_violations_on_expiration": boolean
         }
       }
     }'
@@ -572,21 +572,21 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "nrql_condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
+          "name": "string",
+          "runbook_url": "string",
+          "enabled": boolean,
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+              "duration": "string",
+              "operator": "string",
+              "priority": "string",
+              "threshold": "string",
+              "time_function": "string"
             }
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_value_function">value_function</a>": "string",
+          "value_function": "string",
           "nrql": {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#nrql-query">query</a>": "string"
+            "query": "string"
           }
         }
       }'
@@ -660,22 +660,22 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "external_service_condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#type">type</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>": [
+          "type": "string",
+          "name": "string",
+          "enabled": boolean,
+          "entities": [
             integer
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#external_service_url">external_service_url</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+          "external_service_url": "string",
+          "metric": "string",
+          "runbook_url": "string",
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+              "duration": "string",
+              "operator": "string",
+              "priority": "string",
+              "threshold": "string",
+              "time_function": "string"
             }
           ]
         }
@@ -706,22 +706,22 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "external_service_condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#type">type</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>": [
+          "type": "string",
+          "name": "string",
+          "enabled": boolean,
+          "entities": [
             integer
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#external_service_url">external_service_url</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+          "external_service_url": "string",
+          "metric": "string",
+          "runbook_url": "string",
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+              "duration": "string",
+              "operator": "string",
+              "priority": "string",
+              "threshold": "string",
+              "time_function": "string"
             }
           ]
         }
@@ -793,10 +793,10 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "synthetics_condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#monitor_id">monitor_id</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean
+          "name": "string",
+          "monitor_id": "string",
+          "runbook_url": "string",
+          "enabled": boolean
         }
       }'
       ```
@@ -821,36 +821,36 @@ These API functions include links to the API Explorer, where you can create, upd
 
       ```shell
       curl -X PUT 'https://api.newrelic.com/v2/alerts_conditions/$CONDITION_ID.json' \
-           -H "X-Api-Key:<a href='/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key'>$API_KEY</a>" -i \
+           -H "X-Api-Key:$API_KEY" -i \
            -H "$API_KEY" -i \
            -H 'Content-Type: application/json' \
            -d \
       '{
         "condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#type">type</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>": [
+          "type": "string",
+          "name": "string",
+          "enabled": boolean,
+          "entities": [
             integer
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#metric">metric</a>": "string",
+          "metric": "string",
+          "metric": "string",
           "gc_metric": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#condition-scope">condition_scope</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_close_timer">violation_close_timer</a>": integer,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
+          "condition_scope": "string",
+          "violation_close_timer": integer,
+          "runbook_url": "string",
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_duration">duration</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_operator">operator</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_threshold">threshold</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#terms_time_function">time_function</a>": "string"
+              "duration": "string",
+              "operator": "string",
+              "priority": "string",
+              "threshold": "string",
+              "time_function": "string"
             }
           ],
           "user_defined": {
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_metric">metric</a>": "string",
-            "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#user_defined_value_function">value_function</a>": "string"
+            "metric": "string",
+            "value_function": "string"
           }
         }
       }'
@@ -920,20 +920,20 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "location_failure_condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>":
+          "name": "string",
+          "runbook_url": "string",
+          "enabled": boolean,
+          "entities":
           [
-              "string"
+            "string"
           ],
           "terms": [
-              {
-                  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#priority">priority</a>": "string",
-                  "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#threshold">threshold</a>": integer,
-              }
+            {
+              "priority": "string",
+              "threshold": integer,
+            }
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_time_limit_seconds">violation_time_limit_seconds</a>": integer
+          "violation_time_limit_seconds": integer
         }
       }'
       ```
@@ -962,20 +962,20 @@ These API functions include links to the API Explorer, where you can create, upd
            -d \
       '{
         "location_failure_condition": {
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#name">name</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#runbook_url">runbook_url</a>": "string",
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#enabled">enabled</a>": boolean,
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#entities">entities</a>":
+          "name": "string",
+          "runbook_url": "string",
+          "enabled": boolean,
+          "entities":
           [
             "string"
           ],
           "terms": [
             {
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#priority">priority</a>": "string",
-              "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#threshold">threshold</a>": integer,
+              "priority": "string",
+              "threshold": integer,
             }
           ],
-          "<a href="/docs/alerts-applied-intelligence/new-relic-alerts/advanced-alerts/rest-api-alerts/alerts-conditions-api-field-names#violation_time_limit_seconds">violation_time_limit_seconds</a>": integer
+          "violation_time_limit_seconds": integer
         }
       }'
       ```
@@ -1036,10 +1036,10 @@ These API functions include links to the API Explorer, where you can list, add a
     * The `entity_id` This is the specific [entity (alert target)](/docs/alerts/new-relic-alerts-beta/getting-started/alerts-glossary#alert-entity) to be monitored.
     * The `entity_type`, which must be one of the following:
 
-      * Application
-      * BrowserApplication
-      * MobileApplication
-      * KeyTransaction
+      * `Application`
+      * `BrowserApplication`
+      * `MobileApplication`
+      * `KeyTransaction`
 
       <DNT>
         **[API Explorer](https://api.newrelic.com/docs/#/Alerts%20Entity%20Conditions/get_alerts_entity_conditions__entity_id__json) > Alerts Entity Conditions > GET > list**
@@ -1063,10 +1063,10 @@ These API functions include links to the API Explorer, where you can list, add a
     * The `condition_id` (available from <DNT>**[API Explorer](https://api.newrelic.com/docs/#/Alerts%20Conditions/get_alerts_conditions_json) > Alerts Conditions > GET > List**</DNT>)
     * The `entity_type`, which must be one of the following:
 
-      * Application
-      * BrowserApplication
-      * MobileApplication
-      * KeyTransaction
+      * `Application`
+      * `BrowserApplication`
+      * `MobileApplication`
+      * `KeyTransaction`
 
       <DNT>
         **[API Explorer](https://api.newrelic.com/docs/#/Alerts%20Conditions/get_alerts_conditions_json) > Alerts Entity Conditions > PUT > Add**
@@ -1091,10 +1091,10 @@ These API functions include links to the API Explorer, where you can list, add a
     * The `condition_id` (available from <DNT>**[API Explorer](https://api.newrelic.com/docs/#/Alerts%20Conditions/get_alerts_conditions_json) > Alerts Conditions > GET > List**</DNT>)
     * The `entity_type`, which must be one of the following:
 
-      * Application
-      * BrowserApplication
-      * MobileApplication
-      * KeyTransaction
+      * `Application`
+      * `BrowserApplication`
+      * `MobileApplication`
+      * `KeyTransaction`
 
       <DNT>
         **[API Explorer](https://api.newrelic.com/docs/#/Alerts%20Entity%20Conditions/delete_alerts_entity_conditions__entity_id__json) > Alerts Entity Conditions > DELETE > Remove**


### PR DESCRIPTION
you can't have hyperlinks in formatted codeblocks, it renders as plain text:

<img width="771" alt="image" src="https://github.com/user-attachments/assets/1731565f-9d90-4ad4-bd57-cc12c3f20705">


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.