### PR TITLE
chore: Add configuration for adding labels to agent-forwarded logs.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3554,6 +3554,7 @@ There are three main sub-features:
 2. Log forwarding: When enabled, the agent will capture log data and send it to New Relic.
    * Context data (via [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
    * Log-level filtering:  When configured with one or more log levels in a comma-separated list, the agent will prevent messages at those levels from being captured and forwarded.
+   * Labels: When enabled, the agent will add custom labels to agent-forwarded logs. The `exclude` attribute is a case-insensitive comma-separated list of label names to exclude from being added.  The `exclude` attribute is empty by default, which results in all labels being added.
 3. Local log decoration: When enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 
 For more details, see [our docs on using .NET agent logs in context](/docs/logs/logs-context/net-configure-logs-context-all).
@@ -3563,6 +3564,7 @@ For more details, see [our docs on using .NET agent logs in context](/docs/logs/
   <metrics enabled="true" />
   <forwarding enabled="true" maxSamplesStored="10000" logLevelDenyList="">
     <contextData enabled="false" include="" exclude="" />
+    <labels enabled="false" exclude="" />
   </forwarding>
   <localDecorating enabled="false" />
 </applicationLogging>
@@ -3579,6 +3581,8 @@ NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE="myCustomAttribute
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE="myCustomAttribute2, myOtherCustomAttributeMoreSpecificName"
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
 NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST="debug, warn"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE="label1, label2"
 NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=true
 ```
 
@@ -3659,6 +3663,17 @@ The `applicationLogging` element supports the following attributes and sub-eleme
     The `exclude` attribute is a comma-separated list of names of attributes to exclude when context data capture is enabled, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE`. The default value is an empty string, which means "exclude nothing."
 
     The include and exclude lists follow the [same precedence rules as other agent attributes configuration](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls).
+  </Collapser>
+
+<Collapser
+    id="labels"
+    title="labels (tags)"
+  >
+    Use this sub-element, which is a child of the `forwarding` element, to configure adding your [labels](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#labels-tags) (tags) to agent-forwarded logs, in agent versions 10.34.0 and higher.
+
+    Set the `enabled` attribute to `true` to enable adding your labels to to agent-forwarded logs, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED`. The default value is `false`.
+
+    The `exclude` attribute is a case-insensitive comma-separated list of label names to exclude when labels is enabled, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE`. The default value is an empty string, which means "exclude nothing."  This attribute does not support wildcards or regex.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3554,7 +3554,7 @@ There are three main sub-features:
 2. Log forwarding: When enabled, the agent will capture log data and send it to New Relic.
    * Context data (via [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
    * Log-level filtering:  When configured with one or more log levels in a comma-separated list, the agent will prevent messages at those levels from being captured and forwarded.
-   * Labels: When enabled, the agent will add custom labels to agent-forwarded logs. The `exclude` attribute is a case-insensitive comma-separated list of label names to exclude from being added.  The `exclude` attribute is empty by default, which results in all labels being added.
+   * Labels: When enabled, the agent will add custom labels to agent-forwarded logs. You can use the `exclude` attribute, which is a case-insensitive, comma-separated list of label names. By default, the agent adds custom labels when the `exclude` attribute is empty.
 3. Local log decoration: When enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 
 For more details, see [our docs on using .NET agent logs in context](/docs/logs/logs-context/net-configure-logs-context-all).
@@ -3669,11 +3669,11 @@ The `applicationLogging` element supports the following attributes and sub-eleme
     id="labels"
     title="labels (tags)"
   >
-    Use this sub-element, which is a child of the `forwarding` element, to configure adding your [labels](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#labels-tags) (tags) to agent-forwarded logs, in agent versions 10.34.0 and higher.
+    Use this sub-element, which is a child of the `forwarding` element, to configure adding your [labels (tags)](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#labels-tags) to agent-forwarded logs, in agent versions 10.34.0 and higher.
 
-    Set the `enabled` attribute to `true` to enable adding your labels to to agent-forwarded logs, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED`. The default value is `false`.
+    Set the `enabled` attribute to `true` to enable adding your labels to agent-forwarded logs. You can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED`. The default value is `false`.
 
-    The `exclude` attribute is a case-insensitive comma-separated list of label names to exclude when labels is enabled, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE`. The default value is an empty string, which means "exclude nothing."  This attribute does not support wildcards or regex.
+    The `exclude` attribute is a case-insensitive, comma-separated list of label names to exclude when you enable labels. You can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE`. The default value is an empty string, which means "exclude nothing".  This attribute does not support wildcards or regex.
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3554,7 +3554,7 @@ There are three main sub-features:
 2. Log forwarding: When enabled, the agent will capture log data and send it to New Relic.
    * Context data (via [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes.  The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
    * Log-level filtering:  When configured with one or more log levels in a comma-separated list, the agent will prevent messages at those levels from being captured and forwarded.
-   * Labels: When enabled, the agent will add custom labels to agent-forwarded logs. You can use the `exclude` attribute, which is a case-insensitive, comma-separated list of label names. By default, the agent adds custom labels when the `exclude` attribute is empty.
+   * Labels: When enabled, the agent adds custom labels to agent-forwarded logs. You can use the `exclude` attribute, which is a case-insensitive, comma-separated list of label names. By default, the agent adds custom labels when the `exclude` attribute is empty.
 3. Local log decoration: When enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
 
 For more details, see [our docs on using .NET agent logs in context](/docs/logs/logs-context/net-configure-logs-context-all).


### PR DESCRIPTION
## Give us some context

Updates the .NET Agent config doc to include configuration for the new feature adding labels to agent-forwarded logs.
