### PR TITLE
docs: Clean up the manual distributed tracing section of the .NET agent's main distributed tracing doc

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
@@ -198,13 +198,13 @@ Recommendation: Before performing any custom instrumentation, read:
 * [How distributed tracing works](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works)
 * [Troubleshoot missing data](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data)
 
-The .NET agent automatically handles the propagation of tracing data across external communication channels (e.g. HTTP requests, message queues) when it automatically instruments a client library for that channel (e.g. [HTTPClient](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-8.0) or [RabbitMQ.Client](https://www.nuget.org/packages/rabbitmq.client)).
-If your services communicate using an IPC mechanism that the agent does not automatically instrument, you will need to use the .NET agent's distributed tracing APIs to propagate the tracing data between services.
+The .NET agent automatically sends tracing data across IPC channels (message queues, for example) when it auto-instruments a client for that channel ([RabbitMQ.Client](https://www.nuget.org/packages/rabbitmq.client), for example).
+If your services communicate using an IPC mechanism that the agent doesn't automatically instrument, you need to use the agent's distributed tracing APIs to propagate the tracing data between services.
 <Callout variant="important">
-  In order for the manual tracing APIs to work, the communications channel you are using must support some kind of key-value pair storage (a "carrier") that is associated with the message object being sent and recieved. This is sometimes called "headers" or a "property bag", but it will depend on whatever messaging library you are working with.
+  In order for the manual tracing APIs to work, the communications channel you are using must support some kind of key-value pair storage (a "carrier") associated with the transmitted messages. This is sometimes called "headers" or a "property bag", but it will depend on whatever messaging library you are working with.
 </Callout>
 
-[Here is an example](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/custom-distributed-tracing) that you can build and run to demonstrate how this works for Azure Service Bus (which we do not automatically instrument at present).
+[Here is an example](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/custom-distributed-tracing) that you can build and run to show how this works.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
@@ -195,10 +195,16 @@ Before you start, first ensure you meet [the requirements](/docs/understand-depe
 
 Recommendation: Before performing any custom instrumentation, read:
 
-* [How distributed tracing works](/docs/apm/distributed-tracing/getting-started/how-new-relic-distributed-tracing-works)
+* [How distributed tracing works](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works)
 * [Troubleshoot missing data](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data)
 
-If a service is not passing the trace header to other services, you can use the distributed tracing payload APIs to instrument the [calling service](#calling-service) and the [called service](#called-service). The calling service uses an API call to generate a payload, which is accepted by the called service.
+The .NET agent automatically handles the propagation of tracing data across external communication channels (e.g. HTTP requests, message queues) when it automatically instruments a client library for that channel (e.g. [HTTPClient](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-8.0) or [RabbitMQ.Client](https://www.nuget.org/packages/rabbitmq.client)).
+If your services communicate using an IPC mechanism that the agent does not automatically instrument, you will need to use the .NET agent's distributed tracing APIs to propagate the tracing data between services.
+<Callout variant="important">
+  In order for the manual tracing APIs to work, the communications channel you are using must support some kind of key-value pair storage (a "carrier") that is associated with the message object being sent and recieved. This is sometimes called "headers" or a "property bag", but it will depend on whatever messaging library you are working with.
+</Callout>
+
+[Here is an example](https://github.com/newrelic/newrelic-dotnet-examples/tree/main/custom-distributed-tracing) that you can build and run to demonstrate how this works for Azure Service Bus (which we do not automatically instrument at present).
 
 <CollapserGroup>
   <Collapser
@@ -207,13 +213,8 @@ If a service is not passing the trace header to other services, you can use the 
   >
     To instrument the calling service:
 
-    1. Ensure the [version of the APM agent](#compatibility-requirements) that monitors the calling service supports distributed tracing.
-    2. Invoke the agent API call for generating a distributed trace payload (see the [.NET agent API](/docs/agents/net-agent/net-agent-api/itransaction#CreateDistributedTracePayload)).
-
-       <Callout variant="important">
-         To maintain proper ordering of spans in a trace, ensure you <DNT>**generate the payload in the context of the span that sends it**</DNT>.
-       </Callout>
-    3. Add that payload to the call made to the destination service (for example, in a header).
+    1. Make sure that the outbound message is sent within the context of a Transaction. [Custom instrumentation](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
+    2. Invoke the agent API call for inserting tracing data into the message being sent (see the [.NET agent API](/docs/agents/net-agent/net-agent-api/itransaction#InsertDistributedTraceHeaders)).
   </Collapser>
 
   <Collapser
@@ -222,9 +223,7 @@ If a service is not passing the trace header to other services, you can use the 
   >
     To instrument the called service:
 
-    1. Ensure the [version of the APM agent](#compatibility-requirements) that monitors the called service supports distributed tracing.
-    2. If the New Relic agent on the called service does not identify a New Relic transaction, use the agent API to declare a transaction. Here's one way to tell that a transaction is not in progress: `CreateDistributedTracePayload()` returns an [empty payload](/docs/agents/net-agent/net-agent-api/idistributedtracepayload). To create a transaction, see [Introduction to .NET custom instrumentation](/docs/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation).
-    3. Extract the payload from the call that you received (for example, in a header).
-    4. Invoke the call for accepting the payload (see the [.NET agent API](/docs/agents/net-agent/net-agent-api/itransaction#AcceptDistributedTracePayload)).
+    1. Make sure that the incoming message is received within the context of a Transaction. [Custom instrumentation](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
+    2. Invoke the agent API call for accepting tracing data from the incoming message (see the [.NET agent API](/docs/agents/net-agent/net-agent-api/itransaction#AcceptDistributedTraceHeaders)).
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
1. Link to the correct APIs in the API guide doc
2. Add link to buildable/runnable example in our agent's examples repo
3. Add callout regarding the need to find a "carrier" for key-value pairs in whatever message object the customer is working with

