### PR TITLE
Markdown syntax highlighting tweaks for Ruby

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ignoring-specific-transactions.mdx
@@ -101,7 +101,7 @@ Note that regexes do not include any type of anchoring by default. The /secret/ 
 
 If necessary you may also provide a list of regexes in a comma-separated string, allowing you to set ignore regexes with an environment variable:
 
-```ini
+```sh
 NEW_RELIC_RULES_IGNORE_URL_REGEXES="secret,^/admin"
 ```
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation.mdx
@@ -197,7 +197,7 @@ Use fully qualified class names (using the `::` delimiter) that include any modu
 
 Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
 
-```
+```rb
 module MyCompany
   class Image
     def render_png
@@ -215,7 +215,7 @@ end
 
 Given that source code, the `newrelic.yml` config file might request instrumentation for both of these methods like so:
 
-```
+```yml
 automatic_custom_instrumentation_method_list:
   - MyCompany::Image#render_png
   - MyCompany::User.notify
@@ -223,13 +223,13 @@ automatic_custom_instrumentation_method_list:
 
 That configuration example uses YAML array syntax to specify both methods. Alternatively, you can use a comma-delimited string:
 
-```
+```yml
 automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
 ```
 
 Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, use this comma-delimited string format:
 
-```
+```sh
 export NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png, MyCompany::User.notify'
 ```
 

--- a/src/content/docs/apm/agents/ruby-agent/attributes/enable-disable-attributes-ruby.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/attributes/enable-disable-attributes-ruby.mdx
@@ -896,7 +896,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.enabled: false
         attributes.include: foo, bar
         transaction_tracer.attributes.enabled: true
@@ -919,7 +919,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     transaction_tracer.attributes.enabled: false
         attributes.include: one, two
         transaction_tracer.attributes.include: three, four
@@ -944,7 +944,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.enabled: true
         attributes.exclude: baz
     ```
@@ -966,7 +966,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.enabled: true
         attributes.include: foo, bar
         attributes.exclude: nerd, bar
@@ -989,7 +989,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.enabled: true
         attributes.exclude: username, UsErNaMe
     ```
@@ -1011,7 +1011,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.enabled: true
         attributes.include: custom*
         attributes.exclude: request.parameters.*
@@ -1034,7 +1034,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.enabled: true
         attributes.include: request.parameters.foo
         attributes.exclude: request.parameters.*
@@ -1057,7 +1057,7 @@ New Relic follows these rules when determining which attributes to include or ex
 
     Example configuration:
 
-    ```
+    ```yml
     attributes.include: foo
         transaction_events.attributes.exclude: foo
     ```
@@ -1086,7 +1086,7 @@ New Relic recommends having these URIs reported, as they can contain useful debu
 
 For example, adding the following key to your configuration file will stop the agent from reporting any of the URI-related properties:
 
-```
+```yml
 attributes.exclude: uri
 ```
 

--- a/src/content/docs/apm/agents/ruby-agent/attributes/ruby-attribute-examples.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/attributes/ruby-attribute-examples.mdx
@@ -21,7 +21,7 @@ Capturing request parameters is not enabled by default. The following configurat
   **Configuration:**
 </DNT>
 
-```
+```yml
 attributes.include: request.parameters.*
 ```
 
@@ -35,7 +35,7 @@ There may be situations where you would like to omit sensitive information from 
 
 <DNT>**Configuration**</DNT>:
 
-```
+```yml
 attributes.include: request.parameters.*
 attributes.exclude: [request.parameters.password, request.parameters.credit_card_no]
 ```
@@ -46,7 +46,7 @@ To capture only specific request parameters, you can simply pass a list to `attr
 
 <DNT>**Configuration**</DNT>:
 
-```
+```yml
 attributes.include: [request.parameters.user_id, request.parameters.shard_id]
 ```
 
@@ -54,7 +54,7 @@ attributes.include: [request.parameters.user_id, request.parameters.shard_id]
 
 By default Resque job arguments are not captured. To enable this functionality use the configuration below.
 
-```
+```yml
 attributes.include: job.resque.args.*
 ```
 
@@ -68,7 +68,7 @@ Arguments to Resque jobs are positional and the keys generated reflect this. For
 
 By default Sidekiq job arguments are not captured. To enable this functionality use the configuration below.
 
-```
+```yml
 attributes.include: job.sidekiq.args.*
 ```
 
@@ -86,7 +86,7 @@ In this example, attributes are disabled, so the include and exclude lists will 
   **Configuration:**
 </DNT>
 
-```
+```yml
 attributes.enabled: false
 attributes.include: request.parameters.*
 ```
@@ -122,7 +122,7 @@ As a result, only `bar` is sent in traced errors and transaction events.
   **Configuration:**
 </DNT>
 
-```
+```yml
 attributes.enabled: true
 transaction_tracer.attributes.enabled: false
 attributes.exclude: foo
@@ -156,7 +156,7 @@ In this example, specific input keys are selected for certain output destination
   **Configuration:**
 </DNT>
 
-```
+```yml
 browser_monitoring.attributes.enabled: true
 attributes.exclude: food*
 attributes.include: food.fruit.*

--- a/src/content/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/distributed-tracing-ruby-agent.mdx
@@ -171,7 +171,7 @@ Before you start, first ensure you meet [the requirements](/docs/understand-depe
                   ```
                 * Environment variables:
 
-                  ```ini
+                  ```sh
                   NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
                   NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST="YOUR_TRACE_OBSERVER_HOST"
                   ```

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration.mdx
@@ -501,7 +501,7 @@ Use fully qualified class names (using the `::` delimiter) that include any modu
 
 Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
 
-```
+```rb
 module MyCompany
   class Image
     def render_png
@@ -519,7 +519,7 @@ end
 
 Given that source code, the `newrelic.yml` config file might request instrumentation for both of these methods like so:
 
-```
+```yaml
 automatic_custom_instrumentation_method_list:
   - MyCompany::Image#render_png
   - MyCompany::User.notify
@@ -527,13 +527,13 @@ automatic_custom_instrumentation_method_list:
 
 That configuration example uses YAML array syntax to specify both methods. Alternatively, you can use a comma-delimited string:
 
-```
+```yaml
 automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
 ```
 
 Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, use this comma-delimited string format:
 
-```
+```sh
 export NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png, MyCompany::User.notify'
 ```
 

--- a/src/content/docs/apm/agents/ruby-agent/features/developer-mode.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/developer-mode.mdx
@@ -116,7 +116,7 @@ Troubleshooting tips for Developer mode:
   >
     Developer mode reloads ActiveRecord method definitions for every reload and reports the time spent defining the methods (such as `define_attribute_method)`. This does not happen in production. To get real results to compare, add the following to the development environment:
 
-    ```ini
+    ```rb
     config.cache_classes = true
     ```
   </Collapser>

--- a/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
@@ -45,7 +45,7 @@ bundle exec newrelic deployment
 
 You can use several optional values with `newrelic`. The `description` is short text.
 
-```
+```bash
 deployments [OPTIONS] [description]
 OPTIONS:
    -a, --appname=name           Set the application name.

--- a/src/content/docs/apm/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin.mdx
@@ -24,7 +24,7 @@ These instructions are for installing the Ruby agent as a Rails plugin. For most
 
 To install the Rails plugin from Github, use the following commands for Rails versions 2 or higher:
 
-```
+```sh
 script/plugin install git://github.com/newrelic/newrelic-ruby-agent.git
 mv vendor/plugins/rpm vendor/plugins/newrelic-ruby-agent
 ```
@@ -51,7 +51,7 @@ Whenever you update the agent, confirm that your Ruby agent configuration file (
 <Callout variant="tip">
   You can reference secrets stored in [Rails credentials](https://edgeguides.rubyonrails.org/security.html#custom-credentials) in your `newrelic.yml` file using YAML interpolation:
 
-  ```
+  ```yml
     # When you have a key that exists in config/credentials.yml.enc like 'newrelic_license_key'...
     license_key: <%= Rails.application.credentials.newrelic_license_key %>
   ```
@@ -69,13 +69,13 @@ When using Subversion with the Rails plugin, be sure to remove the old agent plu
   Use the gem if possible.
 </Callout>
 
-```
+```sh
 svn rm vendor/plugins/newrelic-ruby-agent svn commit vendor/plugins -m "removing old version of newrelic"
 ```
 
 Then, to install the latest Ruby agent plugin:
 
-```
+```sh
 script/rails plugin install git://github.com/newrelic/newrelic-ruby-agent.git vendor/plugins/newrelic-ruby-agent
 mv vendor/plugins/rpm vendor/plugins/newrelic-ruby-agent
 svn add vendor/plugins/newrelic-ruby-agent
@@ -86,6 +86,6 @@ svn commit vendor/plugins -m "upgrading newrelic to version X.X.X"
 
 To uninstall the Rails plugin:
 
-```
+```sh
 svn rm vendor/plugins/newrelic-ruby-agent svn commit vendor/plugins
 ```


### PR DESCRIPTION
Add or correct the syntax highlighting language/format for some Ruby agent code blocks