### PR TITLE
feat: added cloud variables configuration section

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -919,6 +919,53 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 </CollapserGroup>
 
+# Cloud variables [#cloud_config]
+
+This section defines the Node.js agent variables to create a relationship between cloud providers and APM applications.
+
+<CollapserGroup>
+  <Collapser
+    id="log-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_CLOUD_AWS_ACCOUNT_ID`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The AWS account ID for the AWS account associated with this app.
+  </Collapser>
+</CollapserGroup>
+
 ## Audit logging [#audit_log]
 
 This section defines the Node.js agent variables in the order they typically appear in the `audit_log: {` section of your app's `newrelic.js` configuration file.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -919,7 +919,7 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 </CollapserGroup>
 
-# Cloud variables [#cloud_config]
+## Cloud variables [#cloud_config]
 
 This section defines the Node.js agent variables to create a relationship between cloud providers and APM applications.
 
@@ -936,7 +936,7 @@ This section defines the Node.js agent variables to create a relationship betwee
           </th>
 
           <td>
-            String
+            Integer
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -925,8 +925,8 @@ This section defines the Node.js agent variables to create a relationship betwee
 
 <CollapserGroup>
   <Collapser
-    id="log-enabled"
-    title="enabled"
+    id="cloud-variables"
+    title="cloud.aws.account_id"
   >
     <table>
       <tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

The PR adds a cloud configuration section to the node.js agent configuration page. Right now, the only item in the cloud config is for `cloud.aws.account_id`.

Relates to https://github.com/newrelic/node-newrelic/pull/2691 and https://github.com/newrelic/node-newrelic/pull/2701