### PR TITLE
feat(browser): Experimental features section

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-features.mdx
@@ -21,4 +21,4 @@ Check out our key <InlinePopover type="browser"/> features:
 * <DNT>[Browsers](/docs/browser/new-relic-browser/browser-pro-features/browsers-problem-patterns-type-or-platform/)</DNT>: View webpage data by browser type or platform
 * <DNT>[Distributed tracing](/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing/)</DNT>: Connect backend and frontend performance
 * <DNT>[Browser apps index](/docs/browser/new-relic-browser/getting-started/browser-apps-index/)</DNT>: View a list of all your browser apps
-* <DNT>[Marks and Measures](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures/)</DNT>: Automatically track native marks and measures
+* <DNT>[Marks and measures](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures/)</DNT>: Automatically track native marks and measures

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-features.mdx
@@ -21,3 +21,4 @@ Check out our key <InlinePopover type="browser"/> features:
 * <DNT>[Browsers](/docs/browser/new-relic-browser/browser-pro-features/browsers-problem-patterns-type-or-platform/)</DNT>: View webpage data by browser type or platform
 * <DNT>[Distributed tracing](/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing/)</DNT>: Connect backend and frontend performance
 * <DNT>[Browser apps index](/docs/browser/new-relic-browser/getting-started/browser-apps-index/)</DNT>: View a list of all your browser apps
+* <DNT>[Marks and Measures](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures/)</DNT>: Automatically track native marks and measures

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
@@ -33,13 +33,13 @@ To enable this feature:
 
 Once enabled, the agent stores marks and measures data under the `BrowserPerformance` event type in New Relic. To find this data, try the following queries and then create custom dashboards to track performance.
 
-Query 1: This NRQL query retrieves all `BrowserPerformance` events for the specified `appName` ("My Application") where the `entryName` is either `mark` or `measure`. 
+**Query 1**: This NRQL query retrieves all `BrowserPerformance` events for the specified `appName` ("My Application") where the `entryName` is either `mark` or `measure`. 
 
     ```nrql
     FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure'
     ```
 
-Query 2: This NRQL query calculates the average `entryDuration` for mark and measure events within the specified `appName`. The `FACET entryName` clause groups the results by the `entryName` field, providing separate average durations for mark and measure events. This can be useful for comparing the average performance of marks versus measures. 
+**Query 2**: This NRQL query calculates the average `entryDuration` for mark and measure events within the specified `appName`. The `FACET entryName` clause groups the results by the `entryName` field, providing separate average durations for mark and measure events. This can be useful for comparing the average performance of marks versus measures. 
 
     ```nrql
     FROM BrowserPerformance SELECT average(entryDuration) WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure' FACET entryName

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
@@ -9,15 +9,15 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
-  This is an experimental browser feature. These features are subject to change and should be used with caution. They are only available when using the browser agent installed via copy/paste or NPM.
+  This is an experimental browser feature and is subject to change. Use this feature with caution. It's available only with the browser agent installed via copy/paste or NPM.
 </Callout>
 
 
-[Marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [measures](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) are standard methods to observe and report on the performance of your webpages. They are generic events native to the browser and can be used to measure the duration of any task. The New Relic browser agent can automatically track marks and measures as store them as `BrowserPerformance` events.
+[Marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [measures](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) are standard methods to observe and report on the performance of your webpages. They're generic events native to the browser. You can use them to measure the duration of any task. The New Relic browser agent can automatically track marks and measures as store them as `BrowserPerformance` events.
 
 ## Enable marks and measures monitoring [#enable-feature]
 
-To enable this feature, you'll be making the following changes to your browser agent: 
+To enable this feature: 
 
 1. Make sure you're using browser agent 1.272.0 or later. 
 2. Locate the agent code in your webpage HTML or JS application.

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
@@ -1,0 +1,32 @@
+---
+title: 'Automatically track native marks and measures'
+tags:
+  - Browser
+  - Browser monitoring
+  - Experimental features
+metaDescription: "Observes and reports on the performance of your webpages by automatically tracking native marks and measures."
+redirects:
+  - /docs/new-relic-browser/browser-pro-features/browser-features
+freshnessValidatedDate: never
+---
+
+[Marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [measures](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) are standard methods to observe and report on the performance of your webpages. They are generic events native to the browser and can be used to measure the duration of any task. New Relic Browser can automatically track these marks and measures as `BrowserPerformance` events.
+
+<Callout variant="important">
+This feature is currently experimental and is only available for opt-in on copy/paste or NPM implementations of the agent. Please see [experimental features](/docs/browser/new-relic-browser/configuration/experimental-features) for more information on opting in to use experimental features. Please note that experimental features are subject to changes before general availability.
+</Callout>
+
+Marks and measures detected by the browser agent will be queryable through the `BrowserPerformance` event type. You can use this data to create custom queries and dashboards in [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one).
+
+## Examine performance details [#view_details]
+
+Example queries to view marks and measures data:
+
+```nrql
+FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure'
+```
+
+```nrql
+FROM BrowserPerformance SELECT average(entryDuration) WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure' FACET entryName
+```
+

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
@@ -5,28 +5,43 @@ tags:
   - Browser monitoring
   - Experimental features
 metaDescription: "Observes and reports on the performance of your webpages by automatically tracking native marks and measures."
-redirects:
-  - /docs/new-relic-browser/browser-pro-features/browser-features
 freshnessValidatedDate: never
 ---
 
-[Marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [measures](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) are standard methods to observe and report on the performance of your webpages. They are generic events native to the browser and can be used to measure the duration of any task. New Relic Browser can automatically track these marks and measures as `BrowserPerformance` events.
-
 <Callout variant="important">
-This feature is currently experimental and is only available for opt-in on copy/paste or NPM implementations of the agent. Please see [experimental features](/docs/browser/new-relic-browser/configuration/experimental-features) for more information on opting in to use experimental features. Please note that experimental features are subject to changes before general availability.
+  This is an experimental browser feature. These features are subject to change and should be used with caution. They are only available when using the browser agent installed via copy/paste or NPM.
 </Callout>
 
-Marks and measures detected by the browser agent will be queryable through the `BrowserPerformance` event type. You can use this data to create custom queries and dashboards in [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one).
 
-## Examine performance details [#view_details]
+[Marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [measures](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) are standard methods to observe and report on the performance of your webpages. They are generic events native to the browser and can be used to measure the duration of any task. The New Relic browser agent can automatically track marks and measures as store them as `BrowserPerformance` events.
 
-Example queries to view marks and measures data:
+## Enable marks and measures monitoring [#enable-feature]
 
-```nrql
-FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure'
-```
+To enable this feature, you'll be making the following changes to your browser agent: 
 
-```nrql
-FROM BrowserPerformance SELECT average(entryDuration) WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure' FACET entryName
-```
+1. Make sure you're using browser agent 1.272.0 or later. 
+2. Locate the agent code in your webpage HTML or JS application.
+3. In the `init` configuration object, and add the `performance` feature configuration. 
+
+    Here's an example to enable both marks and measures detection:
+    ```js
+    <script type="text/javascript"> ;window.NREUM||(NREUM={});init={ …, performance: {capture_marks: true, capture_measures: true} }:
+    ```
+4. Deploy your app.
+
+## Find your data in New Relic [#find-data]
+
+Once enabled, the agent stores marks and measures data under the `BrowserPerformance` event type in New Relic. To find this data, try the following queries and then create custom dashboards to track performance.
+
+Query 1: This NRQL query retrieves all `BrowserPerformance` events for the specified `appName` ("My Application") where the `entryName` is either `mark` or `measure`. 
+
+    ```nrql
+    FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure'
+    ```
+
+Query 2: This NRQL query calculates the average `entryDuration` for mark and measure events within the specified `appName`. The `FACET entryName` clause groups the results by the `entryName` field, providing separate average durations for mark and measure events. This can be useful for comparing the average performance of marks versus measures. 
+
+    ```nrql
+    FROM BrowserPerformance SELECT average(entryDuration) WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure' FACET entryName
+    ```
 

--- a/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
@@ -1,0 +1,29 @@
+---
+title: 'Experimental Features'
+metaDescription: "Opt-in to use experimental features in New Relic Browser before they are generally available."
+redirects:
+  - /docs/browser/new-relic-browser/configuration
+freshnessValidatedDate: never
+---
+
+New Relic Browser features are exposed to customers in a controlled manner to ensure they are stable and reliable. However, some features are exposed before they generally available. These features are called **experimental features**. To access these features, you must opt in to use them.
+
+## Current experimental features
+
+The following experimental features are available in New Relic Browser:
+* [Automatically track native marks and measures as `BrowserPerformance` events](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures).
+
+## Opt in to use experimental features
+
+### Marks and Measures
+<Callout variant="important">
+  Experimental features are only available for opt-in on copy/paste or NPM implementations of the agent. These features are subject to change and should be used with caution.
+</Callout>
+
+1. Ensure you are using the latest version of the New Relic Browser agent, on a pro or pro+spa equivalent build.
+2. Find the New Relic browser agent code in your webpage HTML or JS application.
+3. In the `init` configuration object and add the `performance` feature configuration. Here's an example that enables both marks and measures detection:
+  ```js
+  <script type="text/javascript"> ;window.NREUM||(NREUM={});init={ …, performance: {capture_marks: true, capture_measures: true} }:
+  ```
+4. Deploy your app.

--- a/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
@@ -11,7 +11,7 @@ New Relic Browser features are exposed to customers in a controlled manner to en
 ## Current experimental features
 
 The following experimental features are available in New Relic Browser:
-* [Automatically track native marks and measures as `BrowserPerformance` events](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures).
+* Browser Agent v1.272.0 - [Automatically track native marks and measures as `BrowserPerformance` events](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures).
 
 ## Opt in to use experimental features
 
@@ -20,7 +20,7 @@ The following experimental features are available in New Relic Browser:
   Experimental features are only available for opt-in on copy/paste or NPM implementations of the agent. These features are subject to change and should be used with caution.
 </Callout>
 
-1. Ensure you are using the latest version of the New Relic Browser agent, on a pro or pro+spa equivalent build.
+1. Ensure you are using a version of the New Relic Browser agent compatible with the experimental feature, on a pro or pro+spa equivalent build.
 2. Find the New Relic browser agent code in your webpage HTML or JS application.
 3. In the `init` configuration object and add the `performance` feature configuration. Here's an example that enables both marks and measures detection:
   ```js

--- a/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
@@ -1,29 +1,12 @@
 ---
-title: 'Experimental Features'
-metaDescription: "Opt-in to use experimental features in New Relic Browser before they are generally available."
-redirects:
-  - /docs/browser/new-relic-browser/configuration
+title: 'Experimental features in browser monitoring'
+metaDescription: "Opt-in to use experimental features in New Relic browser monitoring before they're generally available."
 freshnessValidatedDate: never
 ---
 
-New Relic Browser features are exposed to customers in a controlled manner to ensure they are stable and reliable. However, some features are exposed before they generally available. These features are called **experimental features**. To access these features, you must opt in to use them.
+New Relic Browser offers a range of features to enhance your application monitoring capabilities. To ensure stability and reliability, some features are released in an experimental state. These features are subject to change, may not be fully supported, and should be used with caution.
 
 ## Current experimental features
 
-The following experimental features are available in New Relic Browser:
-* Browser Agent v1.272.0 - [Automatically track native marks and measures as `BrowserPerformance` events](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures).
-
-## Opt in to use experimental features
-
-### Marks and Measures
-<Callout variant="important">
-  Experimental features are only available for opt-in on copy/paste or NPM implementations of the agent. These features are subject to change and should be used with caution.
-</Callout>
-
-1. Ensure you are using a version of the New Relic Browser agent compatible with the experimental feature, on a pro or pro+spa equivalent build.
-2. Find the New Relic browser agent code in your webpage HTML or JS application.
-3. In the `init` configuration object and add the `performance` feature configuration. Here's an example that enables both marks and measures detection:
-  ```js
-  <script type="text/javascript"> ;window.NREUM||(NREUM={});init={ …, performance: {capture_marks: true, capture_measures: true} }:
-  ```
-4. Deploy your app.
+The following experimental features are available:
+* Browser agent v1.272.0: [Automatically track native marks and measures as `BrowserPerformance` events](/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures)

--- a/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
@@ -4,7 +4,8 @@ metaDescription: "Opt-in to use experimental features in New Relic browser monit
 freshnessValidatedDate: never
 ---
 
-New Relic Browser offers a range of features to enhance your application monitoring capabilities. To ensure stability and reliability, some features are released in an experimental state. These features are subject to change, may not be fully supported, and should be used with caution.
+New Relic browser agent offers a range of features to enhance your application monitoring capabilities. Some features are released in experimental state to ensure stability and reliability. These features may change or may lack support. You must use them with caution.
+
 
 ## Current experimental features
 

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -81,7 +81,7 @@ pages:
       - title: User actions
         path: /docs/browser/browser-monitoring/browser-pro-features/user-actions
       - title: Marks and measures
-      path: /docs/browser/new-relic-browser/browser-pro-features/marks-and-measures
+        path: /docs/browser/new-relic-browser/browser-pro-features/marks-and-measures
   - title: Monitor single page applications (SPA)
     pages:
       - title: Introduction to SPA monitoring

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -54,6 +54,8 @@ pages:
     pages:
       - title: Browser monitoring features
         path: /docs/browser/new-relic-browser/browser-pro-features/browser-features
+      - title: Experimental features
+        path: /docs/browser/new-relic-browser/configuration/experimental-features
       - title: Summary page
         path: /docs/browser/browser-monitoring/getting-started/browser-summary-page
       - title: Session replay
@@ -78,6 +80,8 @@ pages:
         path: /docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing
       - title: User actions
         path: /docs/browser/browser-monitoring/browser-pro-features/user-actions
+      - title: Marks and measures
+      path: /docs/browser/new-relic-browser/browser-pro-features/marks-and-measures
   - title: Monitor single page applications (SPA)
     pages:
       - title: Introduction to SPA monitoring


### PR DESCRIPTION
Add an experimental section for a new feature the browser agent is adding.  Added a feature description that interlinks with the experiments feature.  Follow up when the feature is GA'd will be to remove the feature from the section. More features in the browser agent roadmap will be added to the experiment section over time.