### PR TITLE
Update postgresql-integration.mdx to reflect Postgres 17 support

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -743,7 +743,7 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
       <tbody>
         <tr>
-          <td colSpan="2">
+          <td>
             `bgwriter.checkpointsScheduledPerSecond`<br/>
             <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.checkpointsScheduledPerSecond`</span>
           </td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -726,7 +726,7 @@ The PostgreSQL integration collects the following metrics. Some metric names are
   >
 
   <Callout variant="tip">
-    Starting with PostgreSQL v17, some metrics have been renamed to better reflect their source tables. Updated names are shown indented below their previous versions.
+    With PostgreSQL v17, we renamed some metrics to better reflect their source tables. You can see the updated names indented below their earlier versions.
   </Callout>
     <table>
       <thead>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -32,7 +32,7 @@ To install the PostgreSQL monitoring integration, you must run through the follo
 
 ### PostgreSQL versions [#postgresql-versions]
 
-Our integration is compatible with PostgreSQL until version 17.
+Our integration is compatible with PostgreSQL 17 and lower.
 
 ### Supported managed services [#supported-ms]
 
@@ -724,6 +724,10 @@ The PostgreSQL integration collects the following metrics. Some metric names are
     id="instanceSample"
     title="PostgresqlInstanceSample metrics"
   >
+
+  <Callout variant="tip">
+    Starting with PostgreSQL v17, some metrics have been renamed to better reflect their source tables. Updated names are shown indented below their previous versions.
+  </Callout>
     <table>
       <thead>
         <tr>
@@ -738,13 +742,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
       </thead>
 
       <tbody>
-         <tr>
-          <td colSpan="2">
-            Note: Starting with PostgreSQL v17, some metrics have been renamed to better reflect their source tables. Updated names are shown indented below their previous versions.
-          </td>
-        </tr>
         <tr>
-          <td>
+          <td colSpan="2">
             `bgwriter.checkpointsScheduledPerSecond`<br/>
             <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.checkpointsScheduledPerSecond`</span>
           </td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -32,7 +32,7 @@ To install the PostgreSQL monitoring integration, you must run through the follo
 
 ### PostgreSQL versions [#postgresql-versions]
 
-Our integration is compatible with PostgreSQL until version 16.
+Our integration is compatible with PostgreSQL until version 17.
 
 ### Supported managed services [#supported-ms]
 
@@ -738,9 +738,15 @@ The PostgreSQL integration collects the following metrics. Some metric names are
       </thead>
 
       <tbody>
+         <tr>
+          <td colSpan="2">
+            Note: Starting with PostgreSQL v17, some metrics have been renamed to better reflect their source tables. Updated names are shown indented below their previous versions.
+          </td>
+        </tr>
         <tr>
           <td>
-            `bgwriter.checkpointsScheduledPerSecond`
+            `bgwriter.checkpointsScheduledPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.checkpointsScheduledPerSecond`</span>
           </td>
 
           <td>
@@ -750,7 +756,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
-            `bgwriter.checkpointsRequestedPerSecond`
+            `bgwriter.checkpointsRequestedPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.checkpointsRequestedPerSecond`</span>
           </td>
 
           <td>
@@ -760,7 +767,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
-            `bgwriter.buffersWrittenForCheckpointsPerSecond`
+            `bgwriter.buffersWrittenForCheckpointsPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.buffersWrittenForCheckpointsPerSecond`</span>
           </td>
 
           <td>
@@ -790,7 +798,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
-            `bgwriter.buffersWrittenByBackendPerSecond`
+            `bgwriter.buffersWrittenByBackendPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `io.buffersWrittenByBackendPerSecond`</span>
           </td>
 
           <td>
@@ -810,7 +819,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
-            `bgwriter.backendFsyncCallsPerSecond`
+            `bgwriter.backendFsyncCallsPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `io.backendFsyncCallsPerSecond`</span>
           </td>
 
           <td>
@@ -820,7 +830,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
-            `bgwriter.checkpointWriteTimeInMillisecondsPerSecond`
+            `bgwriter.checkpointWriteTimeInMillisecondsPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.checkpointWriteTimeInMillisecondsPerSecond`</span>
           </td>
 
           <td>
@@ -830,7 +841,8 @@ The PostgreSQL integration collects the following metrics. Some metric names are
 
         <tr>
           <td>
-            `bgwriter.checkpointSyncTimeInMillisecondsPerSecond`
+            `bgwriter.checkpointSyncTimeInMillisecondsPerSecond`<br/>
+            <span style={{ paddingLeft: "1em" }}>↳ `checkpointer.checkpointSyncTimeInMillisecondsPerSecond`</span>
           </td>
 
           <td>

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/postgresql/postgresql-integration.mdx
@@ -32,7 +32,7 @@ To install the PostgreSQL monitoring integration, you must run through the follo
 
 ### PostgreSQL versions [#postgresql-versions]
 
-Our integration is compatible with PostgreSQL 17 and lower.
+Our integration is compatible with PostgreSQL v17 and lower.
 
 ### Supported managed services [#supported-ms]
 


### PR DESCRIPTION

## Give us some context

* nri-postgresql on host integration now supports Postgres v17.
* Source table for PostgresInstanceMetrics changed which required changed to the collapsible section's table.
* https://github.com/newrelic/nri-postgresql/commit/70acad3f0cc7422d3731f685a755fc075387e333