### PR TITLE
fix(distributed tracing): Add link to setup

### DIFF
--- a/src/content/docs/distributed-tracing/concepts/introduction-distributed-tracing.mdx
+++ b/src/content/docs/distributed-tracing/concepts/introduction-distributed-tracing.mdx
@@ -41,10 +41,11 @@ Distributed tracing collects data as requests travel from one service to another
   Here is an example of a web transaction where agents measure the time spent in each service. Agents then send that timing information to New Relic as spans, and the spans are combined into one distributed trace.
 </figcaption>
 
-## Want to learn more before getting started? [#learn-more]
+## Get started[#learn-more]
 
 See these distributed tracing topics:
 
+* [Distributed tracing setup options](/docs/distributed-tracing/concepts/quick-start)
 * [How does distributed tracing work, and what types of distributed tracing are available?](/docs/distributed-tracing/concepts/how-new-relic-distributed-tracing-works/)
 * [How can I troubleshoot requests using the distributed tracing UI?](/docs/distributed-tracing/ui-data/understand-use-distributed-tracing-ui/)
 * [How should I plan my rollout of distributed tracing?](/docs/distributed-tracing/concepts/distributed-tracing-planning-guide/)


### PR DESCRIPTION
Somehow we lost a link to the distributed tracing setup page in the introduction. This adds a link back to that page.