### PR TITLE
Update install-nodejs-agent.mdx to add guide for pm2 deployment

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -76,6 +76,11 @@ To install the Node.js agent:
    ```bash
    node -r newrelic ./dist/server.js
    ```
+   An example PM2 command:
+
+   ```sh
+   pm2 start --node-args="-r newrelic" index.js --name 'myapp'
+   ```
 
    An example Docker command:
 


### PR DESCRIPTION
I think there are many Node.js apps deployed using PM2, so I added a guide for it.
 I used this command, and it worked for me.