### PR TITLE
Update install-nodejs-agent.mdx to add a guide for module type

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -71,6 +71,37 @@ To install the Node.js agent:
    * Customize the `license_key` setting with <InlinePopover type="licenseKey"/>.
    * Customize the [`app_name`](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#app_name) setting with one or more [meaningful app names](/docs/apm/new-relic-apm/installation-and-configuration/naming-your-application).
 
+   <Callout variant="important">
+      When your package.json's type is module, rename your file to newrelic.cjs and the content should be as follows:
+
+      ```js
+      exports.config = {
+        app_name: [""],
+        license_key: "",
+        logging: {
+          level: "info",
+        },
+        allow_all_headers: true,
+        attributes: {
+          exclude: [
+            "request.headers.cookie",
+            "request.headers.authorization",
+            "request.headers.proxyAuthorization",
+            "request.headers.setCookie*",
+            "request.headers.x*",
+            "response.headers.cookie",
+            "response.headers.authorization",
+            "response.headers.proxyAuthorization",
+            "response.headers.setCookie*",
+            "response.headers.x*",
+          ],
+        },
+        experimental: { esModules: true }
+      };
+      ```
+   </Callout>
+
+
 6. Add `-r newrelic` to your app's startup script. For example, if your application's entry point is `./dist/server.js` then you would use the require flag like so:
 
    ```bash


### PR DESCRIPTION
I think that using the `module` type is more popular than `commonjs`, so I added a guide for it, and it worked for me.