### PR TITLE
fix(What's new): Correct the image paths

### DIFF
--- a/src/content/whats-new/2024/11/whats-new-11-11-data-explorer.md
+++ b/src/content/whats-new/2024/11/whats-new-11-11-data-explorer.md
@@ -13,18 +13,18 @@ The data explorer acts as a metric catalog where you can easily view your metric
 
 Plus, if you're working with OpenTelemetry, the data explorer will show descriptions to help you better understand your OTel metrics.
 
-![An animated gif showing the data explorer in New Relic.](./images/data-explorer-metrics.gif "An animated gif showing the data explorer in New Relic.")
+![An animated gif showing the data explorer in New Relic.](/images/data-explorer-metrics.gif "An animated gif showing the data explorer in New Relic.")
 <figcaption> Explore your metrics and automatically generate a query with the data explorer.</figcaption>
 
 ### Explore events
 Browse all the NR events including your custom events. Know what every event and attribute is thanks to the integrated data dictionary.
 
-![Screenshot showing the data explorer with events in New Relic.](./images/data-explorer-events.webp "Screenshot showing the data explorer with events in New Relic.")
+![Screenshot showing the data explorer with events in New Relic.](/images/data-explorer-events.webp "Screenshot showing the data explorer with events in New Relic.")
 
 ### See all logs
 Explore all log partitions with an easy point and click interface that helps you create queries  and explore all your attributes and values. You can even dive deeper into individual logs for additional details, without leaving your query.
 
-![Screenshot showing the data explorer with logs in New Relic.](./images/data-explorer-logs.webp "Screenshot showing the data explorer with logs in New Relic.")
+![Screenshot showing the data explorer with logs in New Relic.](/images/data-explorer-logs.webp "Screenshot showing the data explorer with logs in New Relic.")
 
 ## Integrated with the new querying UI
 Because it's built into the [new query your data](https://docs.newrelic.com/whats-new/2024/02/whats-new-02-21-new-query-experience/) capability, you can access the data explorer from anywhere in the platform, without losing the context of what you are already working on. Plus, you can use up to [100 separate tabs](https://docs.newrelic.com/whats-new/2024/05/whats-new-05-16-query-tabs/) to streamline your data exploration with multiple queries.


### PR DESCRIPTION
We had a "What's new" post that was pointing to the old local `image` directory. This should correct that.