### PR TITLE
Fix links in .NET agent manual distributed tracing doc

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
@@ -214,7 +214,7 @@ If your services communicate using an IPC mechanism that the agent doesn't autom
     To instrument the calling service:
 
     1. Make sure that the outbound message is sent within the context of a Transaction. [Custom instrumentation](docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
-    2. Invoke the agent API call for inserting tracing data into the message being sent (see the InsertDistributedTraceHeaders API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction)).
+    2. Invoke the agent API call for inserting tracing data into the message being sent (see the [InsertDistributedTraceHeaders API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction)).
   </Collapser>
 
   <Collapser

--- a/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent.mdx
@@ -213,8 +213,8 @@ If your services communicate using an IPC mechanism that the agent doesn't autom
   >
     To instrument the calling service:
 
-    1. Make sure that the outbound message is sent within the context of a Transaction. [Custom instrumentation](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
-    2. Invoke the agent API call for inserting tracing data into the message being sent (see the [.NET agent API](/docs/agents/net-agent/net-agent-api/itransaction#InsertDistributedTraceHeaders)).
+    1. Make sure that the outbound message is sent within the context of a Transaction. [Custom instrumentation](docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
+    2. Invoke the agent API call for inserting tracing data into the message being sent (see the InsertDistributedTraceHeaders API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction)).
   </Collapser>
 
   <Collapser
@@ -223,7 +223,7 @@ If your services communicate using an IPC mechanism that the agent doesn't autom
   >
     To instrument the called service:
 
-    1. Make sure that the incoming message is received within the context of a Transaction. [Custom instrumentation](https://docs.newrelic.com/docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
-    2. Invoke the agent API call for accepting tracing data from the incoming message (see the [.NET agent API](/docs/agents/net-agent/net-agent-api/itransaction#AcceptDistributedTraceHeaders)).
+    1. Make sure that the incoming message is received within the context of a Transaction. [Custom instrumentation](docs/apm/agents/net-agent/custom-instrumentation/custom-instrumentation-attributes-net/) may be necessary for this.
+    2. Invoke the agent API call for accepting tracing data from the incoming message (see the [AcceptDistributedTraceHeaders API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction)).
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This PR fixes some links in the .NET agent's distributed tracing doc, specifically to the API guide for the manual DT APIs.  We are unable to link directly to the APIs because they are in a "collapser-nested-inside-a-collapser", specifically the `ITransaction` collapser.  This PR changes the links to go to the `ITransaction` section, from which it should be easy enough to find the specific APIs.