### PR TITLE
chore: Announce support for .NET 9 in .NET Agent compatibility document

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -53,7 +53,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             The .NET agent is compatible with .NET Core version 3.1, and .NET 5.0, 6.0, 7.0, 8.0, and 9.0.
 
             <Callout variant="important">
-            The agent is only fully supported when instrumenting applications that target [.NET runtimes currently supported by Microsoft](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). The agent is likely to work with the unsupported runtimes listed below, but we do not test new versions of the agent with unsupported runtimes.
+            The agent is only fully supported when instrumenting applications that target [.NET runtimes currently supported by Microsoft](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). The agent is likely to work with the EOL'ed runtimes listed below, but we do not test new versions of the agent with EOL'ed runtimes.
             </Callout>
 
             <table style={{ width: "500px" }}>
@@ -72,7 +72,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             <tbody>
                 <tr>
                 <td>
-                    .NET Core 3.1
+                    .NET Core 3.1 (EOL)
                 </td>
 
                 <td>
@@ -82,7 +82,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 <tr>
                 <td>
-                    .NET 5.0
+                    .NET 5.0 (EOL)
                 </td>
                 <td>
                     8.35.0 and higher
@@ -91,7 +91,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 <tr>
                 <td>
-                    .NET 6.0
+                    .NET 6.0 (EOL)
                 </td>
                 <td>
                     9.2.0 and higher
@@ -100,7 +100,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 <tr>
                 <td>
-                    .NET 7.0
+                    .NET 7.0 (EOL)
                 </td>
                 <td>
                     10.0.0 and higher
@@ -306,7 +306,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
         >
             The .NET agent is compatible with applications targeting .NET Core 3.1, and .NET 5.0, 6.0, 7.0, 8.0, and 9.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core.
 
-            Supported:
+            Compatible:
 
             ```xml
             <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -50,7 +50,11 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             title=".NET Core version"
         >
 
-            The .NET agent supports .NET Core version 3.1, and .NET 5.0, 6.0, and 8.0.
+            The .NET agent is compatible with .NET Core version 3.1, and .NET 5.0, 6.0, 7.0, 8.0, and 9.0.
+
+            <Callout variant="important">
+            The agent is only fully supported when instrumenting applications that target [.NET runtimes currently supported by Microsoft](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core). The agent is likely to work with the unsupported runtimes listed below, but we do not test new versions of the agent with unsupported runtimes.
+            </Callout>
 
             <table style={{ width: "500px" }}>
             <thead>
@@ -106,6 +110,14 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <tr>
                 <td>
                     .NET 8.0
+                </td>
+                <td>
+                    10.0.0 and higher
+                </td>
+                </tr>
+                <tr>
+                <td>
+                    .NET 9.0
                 </td>
                 <td>
                     10.0.0 and higher
@@ -292,7 +304,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             id="target-framework-core"
             title="Target framework version"
         >
-            The .NET agent only supports applications targeting .NET Core 3.1, and .NET 5.0, 6.0, and 8.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core.
+            The .NET agent is compatible with applications targeting .NET Core 3.1, and .NET 5.0, 6.0, 7.0, 8.0, and 9.0. You can find the target framework in your `.csproj` file. Agent compatibility varies across different versions of .NET Core.
 
             Supported:
 
@@ -316,15 +328,13 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             <TargetFramework>net8.0</TargetFramework>
             ```
 
+            ```xml
+            <TargetFramework>net9.0</TargetFramework>
+            ```
+
             <Callout variant="important">
             On Linux ARM64 platforms, the .NET agent <DNT>**only**</DNT> supports target frameworks of `net5.0` or higher.
             </Callout>
-
-            Unsupported:
-
-            ```xml
-            <TargetFramework>net452</TargetFramework>
-            ```
 
             If you want to monitor an ASP.NET Core application targeting .NET Framework, ensure that you have enabled the .NET Framework support after installing the .NET agent.
         </Collapser>
@@ -343,7 +353,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
         >
             The .NET agent automatically instruments these application frameworks:
 
-            * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, 7.0, and 8.0 (includes Web API)
+            * ASP.NET Core MVC 2.0, 2.1, 2.2, 3.0, 3.1, 5.0, 6.0, 7.0, 8.0, and 9.0 (includes Web API)
             * ASP.NET Core Razor Pages 6.0, 7.0, and 8.0 (starting with .NET agent version 10.19.0)
         </Collapser>
 


### PR DESCRIPTION
.NET 9 just went GA: https://devblogs.microsoft.com/dotnet/announcing-dotnet-9/

This PR:

* Adds .NET 9 to the list of runtimes the .NET agent is compatible with
* Adds ASP.NET Core 9 to the list of web frameworks the .NET agent instruments
* Attempts to clarify our support stance on out-of-support versions of .NET.  The .NET agent actively refuses to profile any .NET application targeting a .NET Core runtime older than .NET Core 3.1.  For .NET Core 3.1 and newer, the agent will likely work.  However, Microsoft no longer supports .NET versions older than .NET 8.  We can only support (as in, provide tech support and bug fixes for) the agent instrumenting older versions so far; if the issue looks like a runtime problem we won't work on it.
* Removed a stray item about an unsupported .NET Framework version from the .NET Core versions support section.