### PR TITLE
docs: add default information for Network Sample default filtered devices

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-data/default-infra-data.mdx
+++ b/src/content/docs/infrastructure/infrastructure-data/default-infra-data.mdx
@@ -143,6 +143,31 @@ Select an event name in the following table to see its attributes.
 
       <td>
         `NetworkSample` captures the descriptive and state information for each network device associated with a server. It includes the device's interface and address information, as well as current usage data. We take a snapshot of this data every 10 seconds for each attached network interface and package it into a `NetworkSample` event, which is then sent to New Relic. This data appears on the [<DNT>**Network**</DNT> UI page](/docs/infrastructure/infrastructure-ui-pages/infra-hosts-ui-page#network).
+
+        <Callout variant="important">
+          Not all the network devices will be included by default, the filters in the following table will not generate `NetworkSample` for the matching interfaces unless the [network-inferface-filters](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#network-interface-filters) config attribute is modified.
+        </Callout>
+
+        <CollapserGroup>
+          <Collapser
+            id="filters-linux"
+            title="Linux"
+          >
+            Default network interface filters for Linux:
+
+            * Network interfaces that start with `dummy`, `lo`, `vmnet`, `sit`, `tun`, `tap`, or `veth`
+            * Network interfaces that contain `tun` or `tap`
+          </Collapser>
+
+          <Collapser
+            id="filters-windows"
+            title="Windows"
+          >
+            Default network interface filters for Windows:
+
+            * Network interfaces that start with `Loop`, `isatap`, or `Local`
+          </Collapser>
+        </CollapserGroup>
       </td>
     </tr>
 


### PR DESCRIPTION
This PR adds add the default information for Network Sample default filtered devices.