### PR TITLE
docs: corrected spelling

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100.mdx
@@ -171,7 +171,7 @@ The `waitForAndFindElement(locator, timeout)` and `waitForPendingRequests(timeou
 
     <tr id="headers-removeMultiple">
       <td>
-        `$headers.removeMmultiple(headers: {key:value...})`
+        `$headers.removeMultiple(headers: {key:value...})`
       </td>
 
       <td>


### PR DESCRIPTION
correct spelling of $headers.removeMultiple()

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

$headers.removeMmultiple() should be $headers.removeMultiple()