### PR TITLE
chore(k8s): add PHP to k8s agent operator support

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator.mdx
@@ -17,7 +17,7 @@ freshnessValidatedDate: 2024-06-28
 
 The Kubernetes APM auto-attach, formerly known as the Kubernetes agent operator, streamlines full-stack observability for Kubernetes environments by automating APM instrumentation alongside Kubernetes agent deployment. By enabling <InlinePopover type="APM"/> auto instrumentation, developers no longer need to manually manage [APM agents](/docs/apm/new-relic-apm/getting-started/introduction-apm/). The Kubernetes APM auto-attach will automatically install, upgrade and remove APM agents.
 
-It currently [supports](#k8s-supported-versions) Java, .NET, Node.js, Python, and Ruby with additional languages (PHP and Go) on the way.
+It currently [supports](#k8s-supported-versions) Java, .NET, Node.js, Python, Ruby, and PHP with Go on the way.
 
 ## How it works [#how-it-works]
 
@@ -94,7 +94,7 @@ Here's what the instrumentation CR lets you map out:
    * Name of the instrumentation CR
    * Where it will apply the instrumentation CR (thanks to `podLabelSelector` and `namespaceLabelSelector`)
    * APM agent (one per CR)
-   * APM agent version 
+   * APM agent version
    * APM config parameters (env vars)
    * License key (optional)
 
@@ -147,7 +147,7 @@ Both selectors support `matchLabel` and `matchExpressions`.
   >
 
   `matchExpressions` is a more expressive label selector in Kubernetes and supports set-based matching unlike the `matchLabels`, which you can only use for exact matching. You can use it with or without the `matchLabels` selector.
-  
+
   ```yaml
     ...
     selector:
@@ -158,9 +158,9 @@ Both selectors support `matchLabel` and `matchExpressions`.
         - {key: environment, operator: NotIn, values: [dev]}
     ...
   ```
-  
+
   You can add more expressions to the selector. As in the example, each expression must contain a key, an operator, and possibly (depending on the operator) a list of values. There are four valid operators:
-  
+
   * `In`: Label's value must match one of the specified values.
   * `NotIn`: Label's value must not match any of the specified values.
   * `Exists`: Pod must include a label with the specified key (the value isn't important). When using this operator, you shouldn't specify the values field.
@@ -186,7 +186,7 @@ You've got to specify the APM agent and its version within the instrumentation C
             </th>
             <th>
                 Available versions
-            </th>            
+            </th>
         </tr>
     </thead>
     <tbody>
@@ -199,7 +199,7 @@ You've got to specify the APM agent and its version within the instrumentation C
             </td>
             <td>
               [.NET](https://hub.docker.com/repository/docker/newrelic/newrelic-dotnet-init/general)
-            </td>            
+            </td>
         </tr>
         <tr>
             <td>
@@ -210,7 +210,7 @@ You've got to specify the APM agent and its version within the instrumentation C
             </td>
             <td>
               [Java](https://hub.docker.com/repository/docker/newrelic/newrelic-java-init/general)
-            </td>            
+            </td>
         </tr>
         <tr>
             <td>
@@ -221,7 +221,7 @@ You've got to specify the APM agent and its version within the instrumentation C
             </td>
             <td>
               [Node](https://hub.docker.com/repository/docker/newrelic/newrelic-node-init/general)
-            </td>            
+            </td>
         </tr>
         <tr>
             <td>
@@ -232,7 +232,7 @@ You've got to specify the APM agent and its version within the instrumentation C
             </td>
             <td>
               [Python](https://hub.docker.com/repository/docker/newrelic/newrelic-python-init/general)
-            </td>            
+            </td>
         </tr>
         <tr>
             <td>
@@ -243,7 +243,18 @@ You've got to specify the APM agent and its version within the instrumentation C
             </td>
             <td>
               [Ruby](https://hub.docker.com/repository/docker/newrelic/newrelic-ruby-init/general)
-            </td>            
+            </td>
+        </tr>
+        <tr>
+            <td>
+              php
+            </td>
+            <td>
+              `newrelic-php-init:latest`
+            </td>
+            <td>
+              [PHP](https://hub.docker.com/repository/docker/newrelic/newrelic-php-init/general)
+            </td>
         </tr>
     </tbody>
 </table>
@@ -281,6 +292,7 @@ In the above example, we show you how you can configure the agent settings globa
   * [Python](/docs/apm/agents/python-agent/configuration/python-agent-configuration/)
   * [.NET](/docs/apm/agents/net-agent/configuration/net-agent-configuration/)
   * [Ruby](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/)
+  * [PHP](/docs/apm/agents/php-agent/configuration/php-agent-configuration/)
 
 
 <Callout variant="important">
@@ -376,7 +388,7 @@ metadata:
   namespace: newrelic
 spec:
   agent:
-    language: java
+    language: ruby
     image: newrelic/newrelic-ruby-init:latest
   namespaceLabelSelector:
     matchExpressions:
@@ -489,8 +501,8 @@ Run this command to see the available charts:
     id="custom-apm"
     title="Can I use custom instrumentation with the Kubernetes APM auto-attach?"
   >
-    Yes, custom instrumentation will work the same as without APM auto-attach. The main difference is that the agent is now injected by APM auto-attach instead of installed in the container with the rest of the application dependencies. 
-    
+    Yes, custom instrumentation will work the same as without APM auto-attach. The main difference is that the agent is now injected by APM auto-attach instead of installed in the container with the rest of the application dependencies.
+
     You can still import and call the agent API to add custom instrumentation into your application. You can also utilize a configuration file or environment variables to add custom instrumentation if the particular agent you're using supports it. Note that agents have order of precendence between configuration via environment variables and configuration via configuration files, so you will need to make sure your environment variable configuration via the operator is not clashing with your configuration via configuration file. See each agents custom instrumentation docs for details:
 
     * [Java](/docs/apm/agents/java-agent/custom-instrumentation/java-custom-instrumentation/)
@@ -566,7 +578,7 @@ It's advised to uninstall any versions preceding 0.14 and proceed with the insta
 
 ## Support [#support]
 
-The Kubernetes APM auto-attach currently supports the latest version of these  APM agents: Java, .NET, Node.js, Python, and Ruby.
+The Kubernetes APM auto-attach currently supports the latest version of these  APM agents: Java, .NET, Node.js, Python, Ruby and PHP.
 
 Once is on general availability, the latest 3 versions of each of the APM agents will be supported.
 

--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator.mdx
@@ -17,7 +17,7 @@ freshnessValidatedDate: 2024-06-28
 
 The Kubernetes APM auto-attach, formerly known as the Kubernetes agent operator, streamlines full-stack observability for Kubernetes environments by automating APM instrumentation alongside Kubernetes agent deployment. By enabling <InlinePopover type="APM"/> auto instrumentation, developers no longer need to manually manage [APM agents](/docs/apm/new-relic-apm/getting-started/introduction-apm/). The Kubernetes APM auto-attach will automatically install, upgrade and remove APM agents.
 
-It currently [supports](#k8s-supported-versions) Java, .NET, Node.js, Python, Ruby, and PHP with Go on the way.
+It currently [supports](#k8s-supported-versions) Java, .NET, Node.js, Python, Ruby, and PHP.
 
 ## How it works [#how-it-works]
 
@@ -510,6 +510,8 @@ Run this command to see the available charts:
     * [Python](/docs/apm/agents/python-agent/custom-instrumentation/python-custom-instrumentation/)
     * [.NET](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation/)
     * [Ruby](/docs/apm/agents/ruby-agent/api-guides/ruby-custom-instrumentation/)
+    * [PHP](/docs/apm/agents/php-agent/features/php-custom-instrumentation/)
+
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Adds PHP to the list of supported languages for the K8s Agent Operator.
* Corrects a reference to java in a ruby-specific example.
* Formatting fixes.