### PR TITLE
Chore: remove region restriction notes on alerts product

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/choose-your-data-center.mdx
@@ -44,8 +44,6 @@ New Relic offers almost all the same active products, features, support offering
 * APM's [weekly performance reports](/docs/apm/reports/other-performance-analysis/weekly-performance-report) are not available.
 * Deprecated products and features are not available.
 
-[New Relic's incident intelligence](/docs/new-relic-one/use-new-relic-one/new-relic-ai/get-started-incident-intelligence) service operates solely in the US whether you store your data in New Relic's US region data center or New Relic's EU region data center, by using New Relic incident intelligence, you consent that New Relic may move and store your data in the US region.
-
 ## Data costs [#data-costs]
 
 Costs for data ingest are dependent on your data center region. For details, see [the list price table](/docs/licenses/license-information/usage-plans/new-relic-one-usage-plan-descriptions/#list-price).

--- a/src/content/docs/alerts/overview.mdx
+++ b/src/content/docs/alerts/overview.mdx
@@ -223,10 +223,6 @@ This diagram shows how alerts work: you create an alert policy that includes an 
 </table>
 
 
-## Note about EU/US data centers [#eu-datacenter]
-
-New Relic's alerts service is performed in the United States. By using New Relic alerts, you agree that New Relic may move your data to, and process your data in, the US region. This applies whether you store your data in New Relic's US region data center or in our [EU region data center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/). 
-
 Ready to try New Relic for yourself? [Sign up for your free New Relic account](https://newrelic.com/signup) and follow our [quick launch guide](/docs/new-relic-solutions/get-started/intro-new-relic/#get-started) so you can start maximizing your data today! If you need any help, check out our [tutorial series](/docs/tutorial-create-alerts/create-new-relic-alerts/) on creating alerts to get started.
 
 <Callout variant="tip">


### PR DESCRIPTION
* What problems does this PR solve? Since correlation services move to AWS from GCP. The Alerts (including Incident Intelligence product is not subject to region restrictions anymore. Thus removing those notes presence.

* Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.

This has been approved by SLCreview. See relevant ticket. 
