### PR TITLE
Fix: Change from sessionStorage to localStorage

### DIFF
--- a/src/content/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking.mdx
+++ b/src/content/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking.mdx
@@ -13,7 +13,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-Browser monitoring's [page load timing](/docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process) feature can track sessions by using the sessionStorage API that can store a simple session identifier.
+Browser monitoring's [page load timing](/docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process) feature can track sessions by using the localStorage API that can store a simple session identifier.
 
 ## How it works [#process]
 
@@ -35,7 +35,7 @@ Session tracking will not work properly in these situations:
 
 * If users have DOM Storage disabled in their browser.
 * If the browser or page is configured to **not** allow loading and execution of third-party origin scripts through security policies or other means (which naturally means the agent as a whole will not function).
-* Browser storage APIs such as LocalStorage are cleared during an active session
+* Browser storage APIs such as localStorage are cleared during an active session
 
 ## Enable or disable tracking [#settings]
 

--- a/src/content/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking.mdx
+++ b/src/content/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking.mdx
@@ -30,12 +30,10 @@ Here is the basic process for session tracking:
   * Clicking
   * Scrolling
   * Typing
-
-Session tracking will not work properly in these situations:
-
-* If users have DOM Storage disabled in their browser.
-* If the browser or page is configured to **not** allow loading and execution of third-party origin scripts through security policies or other means (which naturally means the agent as a whole will not function).
-* Browser storage APIs such as localStorage are cleared during an active session
+* Session tracking will not work properly in these situations:
+  * If users have DOM Storage disabled in their browser.
+  * If the browser or page is configured to **not** allow loading and execution of third-party origin scripts through security policies or other means (which naturally means the agent as a whole will not function).
+  * Browser storage APIs such as localStorage are cleared during an active session.
 
 ## Enable or disable tracking [#settings]
 


### PR DESCRIPTION
The docs still stated sessionStorage as being used, but it has been localStorage that has been used for quite some time now. Also corrected the mention of localStorage to start with lower case letter.