### PR TITLE
Update nerdgraph-streaming-export.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
@@ -106,7 +106,8 @@ Alternatively, you can follow the Azure guide [here](https://learn.microsoft.com
 1. In the left column, click <DNT>**Event Hubs**</DNT>.
 2. Then click <DNT>**+Event Hub**</DNT> to create an Event Hub.
 3. Enter the desired Event Hub Name. Save this, as you'll need it later to create the streaming export rule.
-4. Once the Event Hub is created, click on the Event Hub.
+4. For <DNT>**Retention**</DNT>, select the <DNT>**Delete**</DNT> `Cleanup policy` and desired `Retention time (hrs)`. Please note that streaming export is currently not supported for Event Hubs with <DNT>**Compact**</DNT> retention policy.
+5. Once the Event Hub is created, click on the Event Hub.
   </Step>
   <Step>
 ### Create and attach a shared access policy [#event-hub-policy]

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
@@ -103,11 +103,16 @@ Alternatively, you can follow the Azure guide [here](https://learn.microsoft.com
   <Step>
 ### Create an Event Hub[#create-event-hub]
 
-1. In the left column, click <DNT>**Event Hubs**</DNT>.
-2. Then click <DNT>**+Event Hub**</DNT> to create an Event Hub.
-3. Enter the desired Event Hub Name. Save this, as you'll need it later to create the streaming export rule.
-4. For <DNT>**Retention**</DNT>, select the <DNT>**Delete**</DNT> `Cleanup policy` and desired `Retention time (hrs)`. Please note that streaming export is currently not supported for Event Hubs with <DNT>**Compact**</DNT> retention policy.
-5. Once the Event Hub is created, click on the Event Hub.
+    1. In the left column, click <DNT>**Event Hubs**</DNT>.
+    2. Then click <DNT>**+Event Hub**</DNT> to create an Event Hub.
+    3. Enter the desired Event Hub Name. Save this, as you'll need it later to create the streaming export rule.
+    4. For <DNT>**Retention**</DNT>, select the <DNT>**Delete**</DNT> `Cleanup policy` and desired `Retention time (hrs)`.
+
+    <Callout variant="important">
+      Streaming export is currently not supported for Event Hubs with <DNT>**Compact**</DNT> retention policy.
+    </Callout>
+
+    5. Once the Event Hub is created, click on the Event Hub.
   </Step>
   <Step>
 ### Create and attach a shared access policy [#event-hub-policy]


### PR DESCRIPTION
Update the steps of configuring Azure Event Hubs to communicate what retention policy is supported by Streaming Export.

## Give us some context

* What problems does this PR solve?
   * Informs users how to configure their Event Hub to ensure a working streaming export Azure rule 
   * Clarifies what retention policy is not currently supported in streaming export
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
   * Screenshots of the UI described it the edited section.
       * Supported configuration:
<img width="756" alt="image" src="https://github.com/user-attachments/assets/619089db-1237-43e9-aee1-f5305d7b98f9">
       * Invalid configuration: 
<img width="754" alt="image" src="https://github.com/user-attachments/assets/5c443e61-ddc5-4346-89d5-f013f434a439">
