### PR TITLE
NR-334798 Created docs that explain the new auto collected logs in the iOS agent (December 3rd)

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -35,7 +35,7 @@ In the New Relic platform, when the remote logging is turned on the iOS agent co
 The agent separates log messages using a `'\n\n'` delimiter. The timestamp reflects when the agent collected the log, not when the application wrote it. This might cause difference of milliseconds as the log message was buffered before being collected by the agent.
 
 <Callout variant="important">
-This feature interferes with Xcode's built-in console so you must ensure that it is not enabled while the debugger is attached.
+This feature interferes with Xcode's built-in console so it can not be enabled while the debugger is attached.
 </Callout>
 
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -30,7 +30,7 @@ In the New Relic platform, the remote log level controls the verbosity of logs s
 
 ## Automatic log collection
 
-In the New Relic platform, when the remote logging is turned on the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collection is set to `NRLogLevelInfo` but the feature is disabled by default. To enable it, use the `feature` flag.
+In the New Relic platform, when the remote logging is turned on the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collection is set to `NRLogLevelInfo` but the feature is disabled by default. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag.
 
 The agent separates log messages using a `'\n\n'` delimiter. The timestamp reflects when the agent collected the log, not when the application wrote it. This might cause difference of milliseconds as the log message was buffered before being collected by the agent.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -7,29 +7,35 @@ metaDescription: Suggestions for setting up the logging in your app with the New
 freshnessValidatedDate: never
 ---
 
-## Logging Guidelines
 
-### Overview
+To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Use the agent's logging APIs to send your mobile apps logs to New Relic. This ensures that your logs will be in one place for your analysis. For more information, refer our [mobile logging API](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
 
-To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Using the agent's logging APIs is the best way to send your mobile apps logs to New Relic. Your logs will be in one place where you can analyze them. For more information on our [mobile logging API](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
 
 ## Configuring log levels
 
+You can configure the iOS agent log levels for the agent and remote logging. 
+
 ### Agent Log Level
-The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to `NRLogLevelDebug`.
+
+The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This also include the New Relic agent logs. To view all New Relic agent logs set the log level to `NRLogLevelDebug`.
+
 
 ### Remote Log Level
-The remote log level is configured in New Relic One (NR1) and determines which log messages are sent from the device to New Relic. This setting allows you to control the verbosity of the transmitted logs, which are stored remotely. This helps manage data volume and keeps the focus on relevant information.
 
-Configuration: The remote log level can be set in the Application tab of the New Relic One dashboard. For more information on setting the remote log level, refer [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+In the New Relic platform, the remote log level controls the verbosity of logs sent from a device to New Relic. This helps to manage the data volume and keeps the focus on relevant information.
+
+**Configuration**: On the New Relic dashboard, you can set up the remote log level in **Application** tab. For more information on setting the remote log level, refer [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+
+
 
 ## Automatic log collection
 
-If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is disabled by default. To enable it, use the `` feature flag.
-The agent uses a `'\n\n'` delimiter to separate log messages. The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
+In the New Relic platform, when the remote logging is turned on the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collection is set to `NRLogLevelInfo` but the feature is disabled by default. To enable it, use the `feature` flag.
 
-<Callout variant="warning">
-This feature interferes with Xcode's built-in console so it can not be enabled while the debugger is attached.
+The agent separates log messages using a `'\n\n'` delimiter. The timestamp reflects when the agent collected the log, not when the application wrote it. This might cause difference of milliseconds as the log message was buffered before being collected by the agent.
+
+<Callout variant="important">
+This feature interferes with Xcode's built-in console so you must ensure that it is not enabled while the debugger is attached.
 </Callout>
 
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -8,7 +8,7 @@ freshnessValidatedDate: never
 ---
 
 
-To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Use the agent's logging APIs to send your mobile apps logs to New Relic. This ensures that your logs will be in one place for your analysis. For more information, refer our [mobile logging API](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
+To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Use the agent's logging APIs to send your mobile apps logs to New Relic. This ensures that your logs are at one place for your analysis. For more information, refer our [mobile logging API](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
 
 
 ## Configuring log levels
@@ -17,26 +17,24 @@ You can configure the iOS agent log levels for the agent and remote logging.
 
 ### Agent Log Level
 
-The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This also include the New Relic agent logs. To view all New Relic agent logs set the log level to `NRLogLevelDebug`.
+The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This also includes the New Relic agent logs. To view all New Relic agent logs, set the log level to `NRLogLevelDebug`.
 
 
 ### Remote Log Level
 
 In the New Relic platform, the remote log level controls the verbosity of logs sent from a device to New Relic. This helps to manage the data volume and keeps the focus on relevant information.
 
-**Configuration**: On the New Relic dashboard, you can set up the remote log level in **Application** tab. For more information on setting the remote log level, refer [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+**Configuration**: On the New Relic dashboard, you can set up the remote log level in <DNT>**Application**</DNT> tab. For more information on setting the remote log level, refer [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
 
 
 
 ## Automatic log collection
 
-In the New Relic platform, when the remote logging is turned on the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The logs collected this way are set to `NRLogLevelInfo`. This feature is disabled by default. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag.
+In the New Relic platform, when the remote logging is enabled, the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The logs collected this way are set to `NRLogLevelInfo`. This feature is disabled by default. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag.
 
 The agent separates log messages using a `'\n\n'` delimiter. The timestamp reflects when the agent collected the log, not when the application wrote it. This might cause difference of milliseconds as the log message was buffered before being collected by the agent.
 
 <Callout variant="important">
-This feature interferes with Xcode's built-in console so it can not be enabled while the debugger is attached.
+This feature interferes with Xcode's built-in console, so it can not be enabled while the debugger is attached.
 </Callout>
 
-
-<InstallFeedback />

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -30,7 +30,7 @@ In the New Relic platform, the remote log level controls the verbosity of logs s
 
 ## Automatic log collection
 
-In the New Relic platform, when the remote logging is turned on the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collection is set to `NRLogLevelInfo` but the feature is disabled by default. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag.
+In the New Relic platform, when the remote logging is turned on the iOS agent collects all logs written on `stdout` and `stderr` from the app.  It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The logs collected this way are set to `NRLogLevelInfo`. This feature is disabled by default. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag.
 
 The agent separates log messages using a `'\n\n'` delimiter. The timestamp reflects when the agent collected the log, not when the application wrote it. This might cause difference of milliseconds as the log message was buffered before being collected by the agent.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -25,7 +25,7 @@ Configuration: The remote log level can be set in the Application tab of the New
 
 ## Automatic log collection
 
-If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is enabled by default and can be disabled using the `NRFeatureFlag_AutoCollectLogs` feature flag.
+If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is disabled by default and can be enabled using the `` feature flag.
 The agent uses a `'\n\n'` delimiter to separate log messages. The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
 
 <Callout variant="warning">

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -11,7 +11,7 @@ freshnessValidatedDate: never
 
 ### Overview
 
-To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Using the agent's logging APIs is the best way to send your mobile apps logs to New Relic. Your logs will be in one place where you can analyze them. For more information on our [mobile logging api](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
+To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Using the agent's logging APIs is the best way to send your mobile apps logs to New Relic. Your logs will be in one place where you can analyze them. For more information on our [mobile logging API](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
 
 ## Configuring log levels
 
@@ -19,17 +19,17 @@ To ensure consistent and comprehensive logging throughout the project, the iOS a
 The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to `NRLogLevelDebug`.
 
 ### Remote Log Level
-The remote log level is configured in New Relic One (NR1) and determines which log messages are sent from the device to New Relic. This setting allows you to control the verbosity of logs that are transmitted and stored remotely, helping to manage data volume and focus on relevant information.
+The remote log level is configured in New Relic One (NR1) and determines which log messages are sent from the device to New Relic. This setting allows you to control the verbosity of the transmitted logs, which are stored remotely. This helps manage data volume and keeps the focus on relevant information.
 
-Configuration: The remote log level can be set in the Application tab of the New Relic One dashboard. For more information on setting the remote log level, see [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+Configuration: The remote log level can be set in the Application tab of the New Relic One dashboard. For more information on setting the remote log level, refer [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
 
 ## Automatic log collection
 
-If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is disabled by default and can be enabled using the `` feature flag.
+If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is disabled by default. To enable it, use the `` feature flag.
 The agent uses a `'\n\n'` delimiter to separate log messages. The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
 
 <Callout variant="warning">
-This feature interferes with Xcode's built in console so it can not be enabled while the debugger is attached.
+This feature interferes with Xcode's built-in console so it can not be enabled while the debugger is attached.
 </Callout>
 
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -7,30 +7,29 @@ metaDescription: Suggestions for setting up the logging in your app with the New
 freshnessValidatedDate: never
 ---
 
-# Logging with the New Relic iOS agent
 ## Logging Guidelines
 
 ### Overview
 
-To ensure consistent and comprehensive logging throughout the project, it is recommended to use the provided agent logging APIs. Our logging APIs offer various logging levels to capture different types of messages. For more information on our [mobile logging api](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/newrelic-logger).
+To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Using the agent's logging APIs is the best way to send your mobile apps logs to New Relic. Your logs will be in one place where you can analyze them. For more information on our [mobile logging api](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
 
 ## Configuring log levels
 
 ### Agent Log Level
-The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to NRLogLevelDebug. For more information on setting the agent log level, see [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to NRLogLevelDebug.
 
 ### Remote Log Level
 The remote log level is configured in New Relic One (NR1) and determines which log messages are sent from the device to New Relic. This setting allows you to control the verbosity of logs that are transmitted and stored remotely, helping to manage data volume and focus on relevant information.
 
 Configuration: The remote log level can be set in the Application tab of the New Relic One dashboard. For more information on setting the remote log level, see [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
 
-## Auto Collect logs
+## Automatic log collection
 
-The auto log functionality of the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default log level of logs collected in this way is NRLogLevelInfo.
-The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
+If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is enabled by default and can be disabled using the `NRFeatureFlag_AutoCollectLogs` feature flag.
+The agent uses a '\n\n' delimiter to separate log messages. The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
 
 <Callout variant="warning">
-This feature interferes with Xcode's built in console so it is disabled while the debugger is attached.
+This feature interferes with Xcode's built in console so it can not be enabled while the debugger is attached.
 </Callout>
 
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -11,12 +11,12 @@ freshnessValidatedDate: never
 
 ### Overview
 
-To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Using the agent's logging APIs is the best way to send your mobile apps logs to New Relic. Your logs will be in one place where you can analyze them. For more information on our [mobile logging api](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+To ensure consistent and comprehensive logging throughout the project, the iOS agent provides logging APIs. Using the agent's logging APIs is the best way to send your mobile apps logs to New Relic. Your logs will be in one place where you can analyze them. For more information on our [mobile logging api](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs/#ios).
 
 ## Configuring log levels
 
 ### Agent Log Level
-The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to NRLogLevelDebug.
+The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to `NRLogLevelDebug`.
 
 ### Remote Log Level
 The remote log level is configured in New Relic One (NR1) and determines which log messages are sent from the device to New Relic. This setting allows you to control the verbosity of logs that are transmitted and stored remotely, helping to manage data volume and focus on relevant information.
@@ -26,7 +26,7 @@ Configuration: The remote log level can be set in the Application tab of the New
 ## Automatic log collection
 
 If remote logging is turned on in New Relic One the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default level of logs collected in this way is `NRLogLevelInfo`. This feature is enabled by default and can be disabled using the `NRFeatureFlag_AutoCollectLogs` feature flag.
-The agent uses a '\n\n' delimiter to separate log messages. The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
+The agent uses a `'\n\n'` delimiter to separate log messages. The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
 
 <Callout variant="warning">
 This feature interferes with Xcode's built in console so it can not be enabled while the debugger is attached.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging.mdx
@@ -1,0 +1,37 @@
+---
+title: Logging with the iOS agent
+tags:
+  - Mobile logging
+  - New Relic Mobile iOS
+metaDescription: Suggestions for setting up the logging in your app with the New Relic agent
+freshnessValidatedDate: never
+---
+
+# Logging with the New Relic iOS agent
+## Logging Guidelines
+
+### Overview
+
+To ensure consistent and comprehensive logging throughout the project, it is recommended to use the provided agent logging APIs. Our logging APIs offer various logging levels to capture different types of messages. For more information on our [mobile logging api](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/newrelic-logger).
+
+## Configuring log levels
+
+### Agent Log Level
+The agent log level is configured in the New Relic agent and determines which log messages are written to the device's console. This will include the logs our agent uses, to see all logs the agent uses set the log level to NRLogLevelDebug. For more information on setting the agent log level, see [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+
+### Remote Log Level
+The remote log level is configured in New Relic One (NR1) and determines which log messages are sent from the device to New Relic. This setting allows you to control the verbosity of logs that are transmitted and stored remotely, helping to manage data volume and focus on relevant information.
+
+Configuration: The remote log level can be set in the Application tab of the New Relic One dashboard. For more information on setting the remote log level, see [mobile logs](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs).
+
+## Auto Collect logs
+
+The auto log functionality of the iOS agent collects all logs written by the app to stdout and stderr. It captures all calls to `NSLog()`,  Swift `print()`, and other print-family functions. The default log level of logs collected in this way is NRLogLevelInfo.
+The timestamp of the log message is the time the log was collected by the agent, not the time the log was written by the app. This might cause several milliseconds of difference because the log message was buffered before being collected by the agent.
+
+<Callout variant="warning">
+This feature interferes with Xcode's built in console so it is disabled while the debugger is attached.
+</Callout>
+
+
+<InstallFeedback />

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -1174,10 +1174,10 @@ NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting])
             </td>
 
             <td>
-              Log collection is enabled by default. To disable it, add the following feature flag:
+              Log collection is disabled by default. To enable it, add the following feature flag:
 
 ```swift
-NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_AutoCollectLogs])
+NewRelic.disableFeatures([NRMAFeatureFlags.NRFeatureFlag_AutoCollectLogs])
 ```
 For more information, see [iOS agent logging](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging).
             </td>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -1170,7 +1170,7 @@ NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting])
         <tbody>
           <tr>
             <td>
-              Enable or disable the collection of stdout & stderr for remote logging.
+              Enable or disable the collection of `stdout` & `stderr` for remote logging.
             </td>
 
             <td>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -1151,6 +1151,39 @@ NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_BackgroundReporting])
           </tr>
         </tbody>
       </table>
+
+      ## Automatic log collection [#ios-log-collection]
+
+      <table>
+        <thead>
+          <tr>
+            <th style={{ width: "800px" }}>
+              Description
+            </th>
+
+            <th>
+              Example
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+              Enable or disable the collection of stdout & stderr for remote logging.
+            </td>
+
+            <td>
+              Log collection is enabled by default. To disable it, add the following feature flag:
+
+```swift
+NewRelic.enableFeatures([NRMAFeatureFlags.NRFeatureFlag_AutoCollectLogs])
+```
+For more information, see [iOS agent logging](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging).
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </TabsPageItem>
 
     <TabsPageItem id="capacitor">

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-753.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-753.mdx
@@ -8,7 +8,7 @@ downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agen
 ## Fixed in this release
 * The tracked headers set in [addHTTPHeaderTrackingFor](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/add-tracked-headers) are now correctly added to network request events manually captured using [noticeNetworkRequestForURL](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-success).
 * Fixed a bug in the new event system that prevented adding an attribute with a key that contain a reserved key string as a prefix.
-* Made changes to address the NRMA__deallocInteractionHistoryList crash that some users reported in the field.
+* Made changes to address the `NRMA__deallocInteractionHistoryList` crash reported by users.
 
 ## Other notes
 * The iOS agent now supports automatic log collection for remote logging. This feature is limited to `NSLog()`,  Swift `print()`, and other print-family functions. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag. For more information on how to enable and configure remote logging, visit our [documentation](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging).

--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-753.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-753.mdx
@@ -1,0 +1,20 @@
+---
+subject: iOS agent
+releaseDate: '2024-12-04'
+version: 7.5.3
+downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.5.3.zip'
+---
+
+## Fixed in this release
+* The tracked headers set in [addHTTPHeaderTrackingFor](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/add-tracked-headers) are now correctly added to network request events manually captured using [noticeNetworkRequestForURL](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-success).
+* Fixed a bug in the new event system that prevented adding an attribute with a key that contain a reserved key string as a prefix.
+* Made changes to address the NRMA__deallocInteractionHistoryList crash that some users reported in the field.
+
+## Other notes
+* The iOS agent now supports automatic log collection for remote logging. This feature is limited to `NSLog()`,  Swift `print()`, and other print-family functions. To enable it, use the `NRFeatureFlag_AutoCollectLogs` feature flag. For more information on how to enable and configure remote logging, visit our [documentation](/docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging).
+* Changed the agent to agent to consistently send the sampled flag as '01' (true) in the W3C Traceparent header to maintain trace continuity with OpenTelemetry agents, which expect '00' (false) for dropped spans and '01' (true) for sampled spans.
+
+## Support statement
+
+* As of iOS agent version 7.4.1, the iOS agent will consolidate previously separate XCFramework and tvOS agents into a singular iOS agent.
+* As of this release, the oldest supported version of the [XCFramework](/docs/release-notes/mobile-release-notes/ios-release-notes/xcframework-agent-736) is 7.3.6.

--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -74,7 +74,7 @@ pages:
               - title: iOS config and feature flags
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags
               - title: iOS Logging
-                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-remote-logging
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-remote-logging
               - title: iOS/tvOS crash reporting
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-tvos-crash-reporting
               - title: Enable Swift interaction traces

--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -73,6 +73,8 @@ pages:
             pages:
               - title: iOS config and feature flags
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-agent-configuration-feature-flags
+              - title: iOS Logging
+                path: /docs/mobile-monitoring/new-relic-mobile-ios/api-guides/ios-remote-logging
               - title: iOS/tvOS crash reporting
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/configuration/ios-tvos-crash-reporting
               - title: Enable Swift interaction traces
@@ -240,6 +242,8 @@ pages:
         path: /docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-failures
       - title: Track HTTP requests headers
         path: /docs/mobile-monitoring/new-relic-mobile/mobile-sdk/add-tracked-headers
+      - title: Logs page
+        path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs
   - title: Best practices
     path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/mobile-monitoring-best-practices-guide
   - title: Overview of app launch times


### PR DESCRIPTION
https://new-relic.atlassian.net/browse/NR-334798

These docs changes are to add information on the newly created feature of the iOS agent to collect the stdout and stderr output of the apps it instruments. 

Do not merge this before December 3rd
