### PR TITLE
Remove sles 15.2 version support from infra docs as FB does not support it. 

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -123,7 +123,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Versions 12.5, 15.2, 15.3, 15.4, 15.5
+        Versions 12.5, 15.3, 15.4, 15.5
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
* After the recent fluent bit version upgrade to 3.1.9 , sles 15.2 support is removed , updating the [infra-docs ](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent/#os)
