### PR TITLE
Add callout for OS which does not support logforwarding

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -163,7 +163,7 @@ The infrastructure agent supports these operating systems up to their manufactur
 </table>
 
 <Callout variant="important">
-  Currently, log forwarding is not supported on Ubuntu 16.04, Ubuntu 21.04, and Windows Server 2016.
+  Currently, log forwarding isn't supported on Ubuntu 16.04, Ubuntu 21.04, and Windows Server 2016.
 </Callout>
 
 You can also monitor Amazon BottleRocket workloads:

--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -162,6 +162,10 @@ The infrastructure agent supports these operating systems up to their manufactur
   </tbody>
 </table>
 
+<Callout variant="important">
+  Currently, log forwarding is not supported on Ubuntu 16.04, Ubuntu 21.04, and Windows Server 2016.
+</Callout>
+
 You can also monitor Amazon BottleRocket workloads:
 
 * When running EC2 instances, use the [containerized agent](/docs/infrastructure/install-infrastructure-agent/linux-installation/docker-container-infrastructure-monitoring).


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
* Added callout for OS which does not support logforwarding in [infra-agent docs](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent/#os)
