### PR TITLE
Add direct install link to Pathpoint

### DIFF
--- a/src/content/docs/new-relic-solutions/business-observability/intro-pathpoint.mdx
+++ b/src/content/docs/new-relic-solutions/business-observability/intro-pathpoint.mdx
@@ -17,9 +17,7 @@ New Relic Pathpoint is a visualization application that offers a unique approach
 
 By monitoring and analyzing the health and performance of all phases of the journey, including relevant internal processes and external dependencies, Pathpoint allows organizations to easily identify and resolve issues that impact the journey, optimize internal processes, and improve the overall customer experience.
 
-Pathpoint is an open source catalog project developed by the New Relic labs team. See the [GitHub Pathpoint repository](https://github.com/newrelic/nr-labs-pathpoint).
-
-Want to understand Pathpoint benefits at a high level? See the [Pathpoint product page](https://newrelic.com/platform/pathpoint).
+Install the app directly from the [New Relic catalog](https://onenr.io/0bRm7rdJZQy).  You can also explore the [GitHub repository](https://github.com/newrelic/nr-labs-pathpoint).
 
 <img
   title="Business observability overview"


### PR DESCRIPTION
## Simplifies the installation instructions

- Add a direct link to the Pathpoint catalog page
- Remove a couple of unnecessary sentences