### PR TITLE
fix(Advance-config): Fixed the link directing to the entity definitions repo

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/advanced-config.mdx
@@ -390,7 +390,7 @@ global:
           </td>
 
           <td>
-            Value used during entity synthesis for New Relic. This is automatically created based on the matched `mib_profile` and must match one of the rules in the [entity-definitions](https://github.com/newrelic/entity-definitions/search?q=%22attribute%3A+provider%22+filename%3Adefinition.yml) repository in order for an entity to be created. If you are manually adding devices, you will need to take caution to make sure this value is valid.
+            Value used during entity synthesis for New Relic. This is automatically created based on the matched `mib_profile` and must match one of the rules in the [entity-definitions](https://github.com/search?q=repo%3Anewrelic/entity-definitions%20path%3Adefinition.yml&type=code) repository in order for an entity to be created. If you are manually adding devices, you will need to take caution to make sure this value is valid.
           </td>
         </tr>
 


### PR DESCRIPTION
Fixed the link that is directing to the entity definitions repo looking for all 'definition.yml' files inside the 'entity-types' repo.

Change in the page: /docs/network-performance-monitoring/advanced/advanced-config/#devices