### PR TITLE
Docs: Remove stale links from NR app dev guide

### DIFF
--- a/src/content/docs/new-relic-solutions/build-nr-ui/build-nr-app.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/build-nr-app.mdx
@@ -29,7 +29,7 @@ New Relic applications are React JavaScript applications that:
 * Feature visualizations that you've tailored specifically for your organization.
 * Display data from any source you want, whether from a New Relic-monitored entity or data from another service or API.
 
-Keep reading to learn more about what you can do with New Relic apps. Or, if you want to skip ahead and start building your own apps, first read the [requirements on our developer site](https://developer.newrelic.com/build-apps/permission-manage-apps).
+Keep reading to learn more about what you can do with New Relic apps. Or, if you want to skip ahead and start building your own apps, head over to the [development environment setup guide](/docs/new-relic-solutions/new-relic-one/build-nr-apps/set-up-dev-env/).
 
 ## New Relic: a programmable platform [#what-is-it]
 
@@ -37,7 +37,7 @@ We strive to have an automated user experience that provides optimal value for a
 
 Now, we give you control over the fundamental building blocks of our platform. Using the same tools our engineers use to build the New Relic platform, you can build custom applications that align with your unique organizational structure and business needs. If you know how to use React, GraphQL, and NRQL (our query language), building an application will take you only a few minutes.
 
-Check out the [guides on our developer site](https://developer.newrelic.com/build-apps) for help building custom applications. Or, for a quick overview of how to get started with building your own app, watch this short YouTube video (approx. 3:15 minutes).
+Check out the [developer guide](/docs/new-relic-solutions/tutorials/build-hello-world-app/) for help building custom applications. Or, for a quick overview of how to get started with building your own app, watch this short YouTube video (approx. 3:15 minutes).
 
 <Video
   id="QX7wMf6wTSU"
@@ -65,4 +65,4 @@ With New Relic, you can solve any data-driven challenge, no matter how complex. 
   If your visualization needs are relatively simple, consider using [custom charts](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder) and [custom dashboards](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards).
 </Callout>
 
-Now, visit our [developer site](http://developer.newrelic.com) and start building!
+Now, visit the [Hello World example](/docs/new-relic-solutions/tutorials/build-hello-world-app/) and start building!


### PR DESCRIPTION
The links in the app dev guide link to the developer site, which gives a 404.