### PR TITLE
fix(Node.js): Fixed docs about node agent support tagging

### DIFF
--- a/src/content/docs/logs/logs-context/custom-tags-agent-forwarder-logs.mdx
+++ b/src/content/docs/logs/logs-context/custom-tags-agent-forwarder-logs.mdx
@@ -23,5 +23,5 @@ Supported languages:
 * [Ruby](/docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/) agent versions 9.16.0 or higher.
 * Go: coming soon
 * Java: coming soon
-* Node.js: coming soon
+* [Node.js](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration): agent version 12.8.0 or higher.
 * [Python](/docs/apm/agents/python-agent/configuration/python-agent-configuration) agent versions 10.3.0 or higher.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
The Node.js agent added support for tagging in agent version 12.8.0. 