### PR TITLE
docs: Document sortType and flag sortBy as deprecated for entities query components

### DIFF
--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitiesByDomainTypeQuery.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitiesByDomainTypeQuery.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'EntitiesByDomainTypeQuery'
 metaDescription: 'Learn how to work the EntitiesByDomainTypeQuery component'
-freshnessValidatedDate: 2024-06-03
+freshnessValidatedDate: 2024-12-05
 ---
 
 Query entities by entityDomain and entityType.
@@ -44,7 +44,7 @@ import { EntitiesByDomainTypeQuery } from 'nr1'
 <EntitiesByDomainTypeQuery
   entityDomain="INFRA"
   entityType="HOST"
-  sortBy={[EntitiesByDomainTypeQuery.SORT_TYPE.ALERT_SEVERITY]}
+  sortType={[EntitiesByDomainTypeQuery.SORT_TYPE.ALERT_SEVERITY]}
 >
   {({ data, error, fetchMore }) => {
     if (error) {
@@ -269,7 +269,17 @@ console.log('Second page data', secondPage.data);
 
     <tr>
       <td>
-        `sortBy` <h5>enum\[]</h5>
+        `sortBy` <h4>DEPRECATED</h4>
+      </td>
+
+      <td>
+        <Callout variant="caution" title="Due November 1st, 2023">The sortBy is deprecated, use sortType instead </Callout>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `sortType` <h5>enum\[]</h5>
       </td>
 
       <td>

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitiesByGuidsQuery.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitiesByGuidsQuery.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'EntitiesByGuidsQuery'
 metaDescription: 'Learn how to work the EntitiesByGuidsQuery component'
-freshnessValidatedDate: 2024-06-03
+freshnessValidatedDate: 2024-12-05
 ---
 
 Query a list of entities by their GUIDs.
@@ -24,6 +24,36 @@ import { EntitiesByGuidsQuery } from 'nr1'
     'MTIzNDU2fEZPT3xCQVJ8OTg3NjU0MzIx',
     'MTIzNDU2fEZPT3xCQVJ8OTg3NjU0MzUz',
   ]}
+>
+  {({ loading, error, data }) => {
+    if (loading) {
+      return <Spinner />;
+    }
+
+
+    if (error) {
+      return 'Error!';
+    }
+
+
+    return (
+      <List items={data.entities} rowHeight={20}>
+        {({ item }) => <ListItem key={item.guid}>{item.name}</ListItem>}
+      </List>
+    );
+  }}
+</EntitiesByGuidsQuery>
+```
+
+#### Fetch with sorting criteria
+
+```js
+<EntitiesByGuidsQuery
+  entityGuids={[
+    'MTIzNDU2fEZPT3xCQVJ8OTg3NjU0MzIx',
+    'MTIzNDU2fEZPT3xCQVJ8OTg3NjU0MzUz',
+  ]}
+  sortType={[EntitiesByGuidsQuery.SORT_TYPE.ALERT_SEVERITY]}
 >
   {({ loading, error, data }) => {
     if (loading) {
@@ -168,7 +198,17 @@ EntitiesByGuidsQuery.query({
 
     <tr>
       <td>
-        `sortBy` <h5>enum\[]</h5>
+        `sortBy` <h4>DEPRECATED</h4>
+      </td>
+
+      <td>
+        <Callout variant="caution" title="Due November 1st, 2023">The sortBy is deprecated, use sortType instead </Callout>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `sortType` <h5>enum\[]</h5>
       </td>
 
       <td>

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitiesByNameQuery.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitiesByNameQuery.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'EntitiesByNameQuery'
 metaDescription: 'Learn how to work the EntitiesByNameQuery component'
-freshnessValidatedDate: 2024-06-03
+freshnessValidatedDate: 2024-12-05
 ---
 
 Query entities by their name.
@@ -18,6 +18,33 @@ import { EntitiesByNameQuery } from 'nr1'
 
 ```js
 <EntitiesByNameQuery name="abc1-prod-metrics">
+  {({ loading, error, data, fetchMore }) => {
+    if (error) {
+      return 'Error!';
+    }
+
+
+    return (
+      <List
+        items={data.entities}
+        rowCount={data.count}
+        rowHeight={20}
+        onLoadMore={fetchMore}
+      >
+        {({ item }) => <ListItem key={item.guid}>{item.name}</ListItem>}
+      </List>
+    );
+  }}
+</EntitiesByNameQuery>
+```
+
+#### Fetch with sorting criteria
+
+```js
+<EntitiesByNameQuery 
+  name="abc1-prod-metrics"
+  sortType={[EntitiesByNameQuery.SORT_TYPE.ALERT_SEVERITY]}
+>
   {({ loading, error, data, fetchMore }) => {
     if (error) {
       return 'Error!';
@@ -207,7 +234,18 @@ console.log('Second page data', secondPage.data);
 
     <tr>
       <td>
-        `sortBy` <h5>enum\[]</h5>
+        `sortBy` <h4>DEPRECATED</h4>
+      </td>
+
+      <td>
+        <Callout variant="caution" title="Due November 1st, 2023">The sortBy is deprecated, use sortType instead </Callout>
+      </td>
+    </tr>
+
+
+    <tr>
+      <td>
+        `sortType` <h5>enum\[]</h5>
       </td>
 
       <td>

--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitySearchQuery.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/query-and-storage/EntitySearchQuery.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'EntitySearchQuery'
 metaDescription: 'Learn how to work the EntitySearchQuery component'
-freshnessValidatedDate: 2024-06-03
+freshnessValidatedDate: 2024-12-05
 ---
 
 Search for entities.
@@ -60,7 +60,7 @@ function render() {
 ```js
 <EntitySearchQuery
   entityDomain="APM"
-  sortBy={[EntitySearchQuery.SORT_TYPE.ALERT_SEVERITY]}
+  sortType={[EntitySearchQuery.SORT_TYPE.ALERT_SEVERITY]}
 >
   {({ data, error, fetchMore }) => {
     if (error) {
@@ -330,7 +330,17 @@ console.log('Second page data', secondPage.data);
 
     <tr>
       <td>
-        `sortBy` <h5>enum\[]</h5>
+        `sortBy` <h4>DEPRECATED</h4>
+      </td>
+
+      <td>
+        <Callout variant="caution" title="Due November 1st, 2023">The sortBy is deprecated, use sortType instead </Callout>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `sortType` <h5>enum\[]</h5>
       </td>
 
       <td>


### PR DESCRIPTION
The property `sortBy` was deprecated while ago in favor of `sortType`.

In the PR I also added some missing examples to show how `sortType` is used.

The deprecation is already over, the plan is to remove `sortBy` as soon as possible but first we have to verify that it is not used, so we are going to implement its use. In no case we are going to remove the property if it has use.