### PR TITLE
doc: fix invalid config reference for logging

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -214,7 +214,7 @@ To enable logs in context for <InlinePopover type="apm"/> apps monitored by Node
 
 3. Install [a supported framework](#automatic) to enrich your log data, or directly use [the agent's log forwarding API](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent).
 
-4. In your agent configuration, set `application_config.enabled` to `false`. (Otherwise, the agent will automatically instrument your logger and calling these enrichers yourself will do nothing.)
+4. In your agent configuration, set `application_logging.enabled` to `false`. (Otherwise, the agent will automatically instrument your logger and calling these enrichers yourself will do nothing.)
 
 5. Configure logs in context for Node.js using the appropriate log extension.
 


### PR DESCRIPTION
`application_config` is not a valid configuration option.  I believe it was meant to be `application_logging`.


Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.