### PR TITLE
Remove Ruby version restriction

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -211,7 +211,7 @@ Web servers supported by the Ruby agent include:
 
 ## Web frameworks [#web_frameworks]
 
-The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below.
+The Ruby agent doesn't support experimental versions. The Ruby agents supports the following Web frameworks:
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -211,7 +211,7 @@ Web servers supported by the Ruby agent include:
 
 ## Web frameworks [#web_frameworks]
 
-The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below. Please note that Grape, Padrino, and Sinatra aren't supported for Ruby 3.0+.
+The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below.
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -216,7 +216,7 @@ The Ruby agent doesn't support experimental versions. The Ruby agents supports t
 <table>
   <thead>
     <tr>
-      <th style={{ width: "150px" }}>
+      <th style={{ width: "200px" }}>
         Web frameworks
       </th>
 


### PR DESCRIPTION
The Ruby < 3.0 restriction is no longer accurate.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.