### PR TITLE
fix: JSON response returns success to be true for VM data integration

### DIFF
--- a/src/install/vm/deployment/new.mdx
+++ b/src/install/vm/deployment/new.mdx
@@ -81,7 +81,7 @@ curl --location --request POST 'https://security-ingest-processor.service.newrel
 When you POST to the `v1/security/import/dependabot` endpoint, the HTTP response will include a request UUID. For example:
 
 ```json
-{"success":false,"errorMessage":null,"uuid":"4740e3c8-dbc4-46e6-a4b2-a7fb6f918d20"}
+{"success":true,"errorMessage":null,"uuid":"4740e3c8-dbc4-46e6-a4b2-a7fb6f918d20"}
 ```
 
 The request GUID is included in all `Log` data written to NRDB from the import job. These events are written in real time as the import job runs. To view the status and output of an import as it runs, use this NRQL query (replacing `YOUR_UUID` with the UUID returned from your HTTP POST):

--- a/src/install/vm/deployment/previous.mdx
+++ b/src/install/vm/deployment/previous.mdx
@@ -1,6 +1,6 @@
 ---
 componentType: default
-headingText: Upload previously detected  vulnerabilities through Dependabot Bulk Import 
+headingText: Upload previously detected  vulnerabilities through Dependabot Bulk Import
 ---
 
 Import previously detected issues so that New Relic has a complete view of the vulnerabilities detected by Dependabot by performing a bulk import.
@@ -64,7 +64,7 @@ curl --location --request POST 'https://security-ingest-processor.service.newrel
 When you POST to the `v1/security/import/dependabot` endpoint, the HTTP response will include a request UUID. For example:
 
 ```json
-{"success":false,"errorMessage":null,"uuid":"4740e3c8-dbc4-46e6-a4b2-a7fb6f918d20"}
+{"success":true,"errorMessage":null,"uuid":"4740e3c8-dbc4-46e6-a4b2-a7fb6f918d20"}
 ```
 
 The request GUID is included in all `Log` data written to NRDB from the import job. These events are written in real time as the import job runs. To view the status and output of an import as it runs, use this NRQL query (replacing `YOUR_UUID` with the UUID returned from your HTTP POST):


### PR DESCRIPTION
This PR is related to [NR-321768](https://new-relic.atlassian.net/browse/NR-321768)

One of the customers raised that the success value in JSON response is returned as false even after a successful import.
So, the changes have been made accordingly to return success value as true when the import is successful.