### PR TITLE
chore: Add step to update Jenkins entity.name WHERE statements

### DIFF
--- a/src/content/docs/infrastructure/other-infrastructure-integrations/monitoring-jenkins-ot.mdx
+++ b/src/content/docs/infrastructure/other-infrastructure-integrations/monitoring-jenkins-ot.mdx
@@ -97,6 +97,7 @@ After you've sent your Jenkins pipeline data to New Relic, you can also easily m
 2. Select an account and click <DNT>**Begin installation**</DNT>.
 3. If you've already completed the [validation](#validation), select <DNT>**done**</DNT> to move onto the next step.
 4. The quickstart deploys the resources to your account. Click <DNT>**see your data**</DNT> to get to the dashboard.
+5. If your service name (`OTEL_SERVICE_NAME`) is configured as something other than `jenkins`, edit the `entity.name` WHERE conditions on the prebuilt dashboard to use the configured service name.
 
 <img
   title="Jenkins quickstart dashboard in New Relic"

--- a/src/content/docs/infrastructure/other-infrastructure-integrations/monitoring-jenkins-ot.mdx
+++ b/src/content/docs/infrastructure/other-infrastructure-integrations/monitoring-jenkins-ot.mdx
@@ -97,7 +97,9 @@ After you've sent your Jenkins pipeline data to New Relic, you can also easily m
 2. Select an account and click <DNT>**Begin installation**</DNT>.
 3. If you've already completed the [validation](#validation), select <DNT>**done**</DNT> to move onto the next step.
 4. The quickstart deploys the resources to your account. Click <DNT>**see your data**</DNT> to get to the dashboard.
-5. If your service name (`OTEL_SERVICE_NAME`) is configured as something other than `jenkins`, edit the `entity.name` WHERE conditions on the prebuilt dashboard to use the configured service name.
+<Callout variant="important">
+  If your service name (`OTEL_SERVICE_NAME`) is configured as something other than `jenkins`, update the `WHERE` conditions of `entity.name` on the prebuilt dashboard to use the configured service name.
+</Callout>
 
 <img
   title="Jenkins quickstart dashboard in New Relic"


### PR DESCRIPTION
The quickstart dashboard needs updated if a customer uses anything other than jenkins for the service name. This isn't obvious in the current form of the doc, so I added an additional step.