### PR TITLE
docs: Update broken xcframework-installation link in mobile-monitoring.yml

### DIFF
--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -62,7 +62,7 @@ pages:
                   - title: Swift package manager
                     path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/spm-installation
                   - title: XCFramework manual installation
-                    path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/manual-installation
+                    path: /docs/mobile-monitoring/new-relic-mobile-ios/installation/xcframework-installation
               - title: iOS compatibility and requirements
                 path: /docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements
               - title: iOS distributed tracing


### PR DESCRIPTION
The name of this file was changed right after it was first created, but the link has never updated to reflect that. This PR should fix that link. 

The target file is: src/content/docs/mobile-monitoring/new-relic-mobile-ios/installation/xcframework-installation.mdx
The commit where the filename was changed is: https://github.com/newrelic/docs-website/commit/4410df08b7bf51a6abf332fabeea1deb8931045a