### PR TITLE
fix: Make it clear that we publicly just support `timestamp` as the log timestamp

### DIFF
--- a/src/content/docs/logs/ui-data/timestamp-support.mdx
+++ b/src/content/docs/logs/ui-data/timestamp-support.mdx
@@ -15,13 +15,13 @@ Timestamps have many formats without a single standard. They appear at the begin
 
 * If a log is sent with a `timestamp` attribute, or has a `timestamp` attribute parsed out of it, New Relic will use that timestamp for the log.
 * If a JSON log is sent with a `timestamp` field, New Relic will use that timestamp for the log when the JSON fields are extracted as attributes, and that timestamp will have precedence over any `timestamp` attribute.
-* If `timestamp` is not supplied, New Relic will use the log's ingest time as the timestamp.
+* If `timestamp` isn't supplied, New Relic will use the log's ingest time as the timestamp.
 
 Most log forwarders pass along timestamp information for you from the log source, so you may not need to
 specify the timestamp yourself.
 
 Note that there are "internal" timestamp fields that are used by some log forwarders, like `@timestamp`
-and `@realtime_timestamp`. New Relic will recognize these, but they should not be used by customers.
+and `@realtime_timestamp`. New Relic will recognize these, but they shouldn't be used by customers.
 To send the log timestamp, please use the `timestamp` attribute.
 
 ## Supported logs timestamp format [#format]

--- a/src/content/docs/logs/ui-data/timestamp-support.mdx
+++ b/src/content/docs/logs/ui-data/timestamp-support.mdx
@@ -13,10 +13,16 @@ A log event leaves behind a timestamp attribute, which tells you the exact momen
 
 Timestamps have many formats without a single standard. They appear at the beginning of the log event in most cases, but can sometimes appear much later in the log, or not at all.
 
-* By default, New Relic assigns the value of the log `timestamp` attribute (a reserved keyword) at the exact time the log is ingested. This is referred to as the ingest time.
-* When logs don't have a `timestamp` attribute, New Relic assigns a timestamp at time of ingest.
-* Logs in a JSON format contain some attribute that identifies the timestamp, like `timestamp`, `log_timestamp`, `time`, etc.
-* If we receive JSON logs with with a supported timestamp format, we override our ingest timestamp with the JSON attribute.
+* If a log is sent with a `timestamp` attribute, or has a `timestamp` attribute parsed out of it, New Relic will use that timestamp for the log.
+* If a JSON log is sent with a `timestamp` field, New Relic will use that timestamp for the log when the JSON fields are extracted as attributes, and that timestamp will have precedence over any `timestamp` attribute.
+* If `timestamp` is not supplied, New Relic will use the log's ingest time as the timestamp.
+
+Most log forwarders pass along timestamp information for you from the log source, so you may not need to
+specify the timestamp yourself.
+
+Note that there are "internal" timestamp fields that are used by some log forwarders, like `@timestamp`
+and `@realtime_timestamp`. New Relic will recognize these, but they should not be used by customers.
+To send the log timestamp, please use the `timestamp` attribute.
 
 ## Supported logs timestamp format [#format]
 

--- a/src/content/docs/logs/ui-data/timestamp-support.mdx
+++ b/src/content/docs/logs/ui-data/timestamp-support.mdx
@@ -13,16 +13,15 @@ A log event leaves behind a timestamp attribute, which tells you the exact momen
 
 Timestamps have many formats without a single standard. They appear at the beginning of the log event in most cases, but can sometimes appear much later in the log, or not at all.
 
-* If a log is sent with a `timestamp` attribute, or has a `timestamp` attribute parsed out of it, New Relic will use that timestamp for the log.
-* If a JSON log is sent with a `timestamp` field, New Relic will use that timestamp for the log when the JSON fields are extracted as attributes, and that timestamp will have precedence over any `timestamp` attribute.
-* If `timestamp` isn't supplied, New Relic will use the log's ingest time as the timestamp.
+* If a log is sent with a `timestamp` attribute, or if a `timestamp` attribute parsed from it, New Relic uses that timestamp for the log.
+* If a JSON log is sent with a `timestamp` field, New Relic uses that timestamp when extracting JSON fields as attributes, and it takes precedence over any existing `timestamp` attribute.
+* If `timestamp` isn't sent, New Relic uses the log's ingest time as the timestamp.
 
-Most log forwarders pass along timestamp information for you from the log source, so you may not need to
-specify the timestamp yourself.
+Most log forwarders pass along timestamp information from the log source, so you may not need to specify the timestamp yourself.
 
-Note that there are "internal" timestamp fields that are used by some log forwarders, like `@timestamp`
-and `@realtime_timestamp`. New Relic will recognize these, but they shouldn't be used by customers.
-To send the log timestamp, please use the `timestamp` attribute.
+<Callout variant="important">
+Some log forwarders use internal timestamp fields, such as`@timestamp` and `@realtime_timestamp`. New Relic recognizes these fields, but they shouldn't be used by customers. To send the log timestamp, please use the `timestamp` attribute.
+</Callout>
 
 ## Supported logs timestamp format [#format]
 


### PR DESCRIPTION
## Give us some context

When looking into a support ticket, I noticed that the Logs API docs were confusing about which fields we'd use as a timestamp. This PR attempts to clarify that.

Note that `log_timestamp` is only used in built-in parsing rules, and we intentionally don't use that attribute as the log time, maybe because originally we weren't confident that the parsing rules could parse timestamps correctly? 
