### PR TITLE
chore: Update ruby-agent-requirements-supported-frameworks.mdx

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -211,7 +211,7 @@ Web servers supported by the Ruby agent include:
 
 ## Web frameworks [#web_frameworks]
 
-The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below.
+The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below. Please note that Grape, Padrino, and Sinatra aren't supported for Ruby 3.0+.
 
 <table>
   <thead>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -211,7 +211,7 @@ Web servers supported by the Ruby agent include:
 
 ## Web frameworks [#web_frameworks]
 
-The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below. Please note that Grape, Padrino, and Sinatra aren't supported for Ruby 3.0+.
+The Ruby agent doesn't support experimental versions. Web frameworks supported by the Ruby agent are listed below.
 
 <table>
   <thead>
@@ -300,6 +300,8 @@ The Ruby agent doesn't support experimental versions. Web frameworks supported b
         * 6.0.x
         * 6.1.x
         * 7.0.x
+        * 7.1.x
+        * 8.0.x
       </td>
 
       <td>
@@ -381,6 +383,8 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
         * 6.0.x
         * 6.1.x
         * 7.0.x
+        * 7.1.x
+        * 8.0.x
       </td>
 
       <td>
@@ -413,6 +417,19 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
       <td>
         * 7.x
         * 8.x
+      </td>
+
+      <td/>
+    </tr>
+
+    <tr>
+      <td>
+        OpenSearch
+      </td>
+
+      <td>
+        * 2.x
+        * 3.x
       </td>
 
       <td/>

--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -301,6 +301,7 @@ The Ruby agent doesn't support experimental versions. Web frameworks supported b
         * 6.1.x
         * 7.0.x
         * 7.1.x
+        * 7.2.x
         * 8.0.x
       </td>
 
@@ -384,6 +385,7 @@ The Ruby agent doesn't support experimental versions. Databases supported by the
         * 6.1.x
         * 7.0.x
         * 7.1.x
+        * 7.2.x
         * 8.0.x
       </td>
 


### PR DESCRIPTION
This document is out of date. This PR provides the following updates:
* adds support for Rails / Active Record 7.1, 7.2 and 8.0
* adds OpenSearch reference