### PR TITLE
docs(logs): Add new syslog mechanism to send the license key

### DIFF
--- a/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -301,7 +301,7 @@ To forward logs to New Relic with `syslog-ng`:
 
 ## Forwarders that doesn't allow to modify the syslog format
 
-Some forwarders or CDNs do not allow modification of the syslog format but do permit altering the message itself by appending or prepending data.
+Some forwarders, CDNs, or platforms (like AirWatch) do not allow modification of the syslog format but do permit altering the message itself by appending or prepending data.
 
 In such cases, you can use an alternative mechanism to pass the license key used to forward your logs. Simply append, prepend, or include `nrLicenseKey=<YOUR_LICENSE_KEY>` within the message. This method ensures that your logs are authenticated and forwarded to New Relic without needing to modify the syslog format.
 

--- a/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -156,7 +156,7 @@ To configure `rsyslog` versions 8 and above for Amazon Linux, Redhat, and Centos
           ## Ubuntu:
           ##/etc/ssl/certs/ca-certificates.crt
           ##Other systems:
-          ##Specify the full path to the system's generic CA certificate.          
+          ##Specify the full path to the system's generic CA certificate.
    )
 
    action(type="omfwd"
@@ -216,13 +216,13 @@ If you're using rsyslog version 7 or below, the configuration files need to be a
 
    ## Configure TLS and log forwarding
    ##Specify the full path to the system's CA certificate:
-   $DefaultNetstreamDriverCAFile <path to certificate> 
+   $DefaultNetstreamDriverCAFile <path to certificate>
    ## RHEL/CentOS/Amazon Linux:
    ##/etc/pki/tls/certs/ca-bundle.crt
    ## Ubuntu:
    ##/etc/ssl/certs/ca-certificates.crt
    ##Other systems:
-   ##Specify the full path to the system's generic CA certificate.  
+   ##Specify the full path to the system's generic CA certificate.
    $ActionSendStreamDriver gtls
    $ActionSendStreamDriverMode 1
    $ActionSendStreamDriverAuthMode x509/name
@@ -297,4 +297,24 @@ To forward logs to New Relic with `syslog-ng`:
 
 <Callout variant="tip">
   If you're running syslog-ng from a Docker container and experience issues, check [balait/syslog image documentation](https://hub.docker.com/r/balabit/syslog-ng/).
+</Callout>
+
+## Forwarders that doesn't allow to modify the syslog format
+
+Some forwarders or CDNs do not allow modification of the syslog format but do permit altering the message itself by appending or prepending data.
+
+In such cases, you can use an alternative mechanism to pass the license key used to forward your logs. Simply append, prepend, or include `nrLicenseKey=<YOUR_LICENSE_KEY>` within the message. This method ensures that your logs are authenticated and forwarded to New Relic without needing to modify the syslog format.
+
+For example, if your forwarder allows you to prepend data to the log message, you can configure it to add `nrLicenseKey=<YOUR_LICENSE_KEY>` at the beginning of each log message. Similarly, if appending data is allowed, you can add the license key at the end of each log message.
+
+This approach is particularly useful for CDNs, hardware devices, or managed services where modifying the syslog format is not possible. By including the license key within the message, you ensure that your logs are properly authenticated and received by New Relic.
+
+If you encounter any issues or need further assistance, refer to the documentation provided by your forwarder or CDN for specific instructions on how to append or prepend data to log messages.
+
+<Callout variant="important">
+  Remember to replace `<YOUR_LICENSE_KEY>` with your actual New Relic license key.
+</Callout>
+
+<Callout variant="caution">
+  If both methods are used (modifying the syslog format and including `nrLicenseKey=<YOUR_LICENSE_KEY>` in the message), the license key included in the message will take precedence.
 </Callout>


### PR DESCRIPTION
## Give us some context

Syslog TCP endpoint will include a new mechanism to allow customers to forward logs from platforms that doesn't allow to edit the syslog format, like AirWatch.

In this case the licenseKey will be parsed from message itself if prefixed with nrLicenseKey=

This PR document this new mechanism and how to use it.