### PR TITLE
feat: Add Cancel Query Nerdgraph Block

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
@@ -71,7 +71,7 @@ Some important details about this query:
 
 ## Cancel an async query [#example-cancel-query]
 
-You can cancel an asynchronous query by using the `cancelAsyncQuery` mutation. This mutation takes the `queryId` of the
+You can cancel an asynchronous query by using the `cancelQuery` mutation. This mutation takes the `queryId` of the
 query you want to cancel. It will either return an `ACCEPTED` status, or `REJECTED` status with a reason for rejection.
 
 ```graphql

--- a/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
@@ -68,3 +68,17 @@ Some important details about this query:
 * The `account` argument must match the `account` argument from the original query.
 * This query will return results if asynchronous execution has completed; otherwise it will return `queryProgress` data.
 * The query can be repeated verbatim until results or an error are returned.
+
+## Cancel an async query [#example-cancel-query]
+
+You can cancel an asynchronous query by using the `cancelAsyncQuery` mutation. This mutation takes the `queryId` of the query you want to cancel.
+
+```graphql
+mutation {
+  cancelAsyncQuery(queryId: "YOUR_QUERY_ID") {
+    queryToken
+    accepted
+    rejectionCause
+  }
+}
+```

--- a/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
@@ -71,14 +71,15 @@ Some important details about this query:
 
 ## Cancel an async query [#example-cancel-query]
 
-You can cancel an asynchronous query by using the `cancelAsyncQuery` mutation. This mutation takes the `queryId` of the query you want to cancel.
+You can cancel an asynchronous query by using the `cancelAsyncQuery` mutation. This mutation takes the `queryId` of the
+query you want to cancel. It will either return an `ACCEPTED` status, or `REJECTED` status with a reason for rejection.
 
 ```graphql
 mutation {
-  cancelAsyncQuery(queryId: "YOUR_QUERY_ID") {
-    queryToken
-    accepted
-    rejectionCause
+  cancelQuery(queryId: "YOUR_QUERY_ID") {
+    queryId
+    requestStatus
+    rejectionReason
   }
 }
 ```

--- a/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/async-queries-nrql-tutorial.mdx
@@ -71,12 +71,12 @@ Some important details about this query:
 
 ## Cancel an async query [#example-cancel-query]
 
-You can cancel an asynchronous query by using the `cancelQuery` mutation. This mutation takes the `queryId` of the
+You can cancel an asynchronous query by using the `nrqlCancelQuery` mutation. This mutation takes the `queryId` of the
 query you want to cancel. It will either return an `ACCEPTED` status, or `REJECTED` status with a reason for rejection.
 
 ```graphql
 mutation {
-  cancelQuery(queryId: "YOUR_QUERY_ID") {
+  nrqlCancelQuery(queryId: "YOUR_QUERY_ID") {
     queryId
     requestStatus
     rejectionReason


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

As the Dirac CAT team aims to add cancel async query to Nerdgraph, we are looking to add a block to explain to customers how to do so. We are adding onto the existing Nerdgraph async query document to keep everything cohesive and in one doc.