### PR TITLE
feat: add section to experimental features doc about opting in for NPM and for APM

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
@@ -9,9 +9,8 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
-  This is an experimental browser feature and is subject to change. Use this feature with caution. It's available only with the browser agent installed via copy/paste or NPM.
+  This is an experimental browser feature and is subject to change. Use this feature with caution. Experimental features are available only for opt-in manually with copy and paste or NPM implementations of the agent. To gain access for APM-injected applications, reach out to your support representative. For more information on opting in, refer [experimental features](/docs/browser/new-relic-browser/configuration/experimental-features). 
 </Callout>
-
 
 [Marks](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) and [measures](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure) are standard methods to observe and report on the performance of your webpages. They're generic events native to the browser. You can use them to measure the duration of any task. The New Relic browser agent can automatically track marks and measures as store them as `BrowserPerformance` events.
 

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/page-resources.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/page-resources.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 [Resource Assets](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming) are reported natively by all major browser and allows you to observe and report on the performance of the assets your webpages import. New Relic Browser can automatically track these assets as `BrowserPerformance` events.
 
 <Callout variant="important">
-This feature is currently experimental and available only for opt-in on manual copy and paste, or NPM implementations of the agent. For more information on opting in, refer [experimental features](/docs/browser/new-relic-browser/configuration/experimental-features). Note that these features are subject to changes before GA.
+  This is an experimental browser feature and is subject to change. Use this feature with caution. Experimental features are available only for opt-in manually with copy and paste or NPM implementations of the agent. To gain access for APM-injected applications, reach out to your support representative. For more information on opting in, refer [experimental features](/docs/browser/new-relic-browser/configuration/experimental-features). 
 </Callout>
 
 Page resources detected by the browser agent will be queryable through the `BrowserPerformance` event type. You can use this data to create custom queries and dashboards in [New Relic One](/docs/new-relic-one/use-new-relic-one/get-started/introduction-new-relic-one).

--- a/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/experimental-features.mdx
@@ -4,7 +4,7 @@ metaDescription: "Opt-in to use experimental features in New Relic browser monit
 freshnessValidatedDate: never
 ---
 
-New Relic Browser features are exposed to customers in a controlled manner to ensure stability and reliability. However, some features are made available before they reach general availability. These are known as experimental features. To access them, you must opt in.
+New Relic Browser features are exposed to customers in a controlled manner to ensure stability and reliability. However, some features are made available before they reach general availability. These are known as experimental features. To gain access to features before they are generally available, you must opt in.
 
 ## Current experimental features
 
@@ -14,12 +14,14 @@ The following experimental features are available in New Relic Browser:
 
 
 <Callout variant="important">
-  Experimental features are available only for opt-in on manual copy and paste, or NPM implementations of the agent. These features are subject to change and should be used with caution.
+  Experimental features are available only for opt-in manually with copy and paste or NPM implementations of the agent. To gain access for APM-injected applications, reach out to your support representative. Experimental features are subject to change and should be used with caution.
 </Callout>
 
-## Opt in to use experimental features
+## Manually opting-in to use experimental features
 
-### Browser Performance - Marks, Measures & Resources
+### Copy/Paste Implementations
+
+#### Browser Performance - Marks, Measures & Resources
 1. Ensure you are using a version of the New Relic Browser agent compatible with the experimental feature, on a pro or pro+spa equivalent build.
 2. Find the New Relic browser agent code in your webpage HTML or JS application.
 3. In the `init` configuration object, add the `performance` feature configuration. Here's an example that enables both marks and measures detection:
@@ -36,3 +38,39 @@ The following experimental features are available in New Relic Browser:
   } }:
   ```
 4. Deploy your app.
+
+### NPM Implementations
+
+#### Browser Performance - Marks, Measures & Resources
+1. Ensure you are using a version of the New Relic Browser agent compatible with the experimental feature.
+2. Find the New Relic browser agent constructor in your application's implementation.
+3. In the `init` configuration object, add the `performance` feature configuration. Here's an example that enables both marks and measures detection:
+```js
+import { BrowserAgent } from '@newrelic/browser-agent/loaders/browser-agent'
+
+// Populate using values in copy-paste JavaScript snippet.
+const options = {
+  init: {
+    // ... other configurations
+    performance: {
+      capture_marks: true, // enable to capture browser performance marks (default false)
+      capture_measures: true // enable to capture browser performance measures (default false)
+      resources: {
+        enabled: true, // enable to capture browser peformance resource timings (default false)
+        asset_types: [], // Asset types to collect -- an empty array will collect all types (default []). See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/initiatorType for the list of types.
+        first_party_domains: [], // when included, will decorate any resource as a first party resource if matching (default [])
+        ignore_newrelic: true // ignore capturing internal agent scripts and harvest calls (default true)
+      }
+    }
+   },
+  info: { ... },
+  loader_config: { ... } 
+}
+
+// The agent loader code executes immediately on instantiation.
+new BrowserAgent(options)
+```
+See the [NPM package documentation](https://www.npmjs.com/package/@newrelic/browser-agent) for more information on how to configure the agent via NPM.
+
+## Opting-in for APM injected applications
+APM-served web applications can opt-in to experimental features by reaching out to your support representative, by filing a help ticket or by emailing `browser-agent@newrelic.com` with a subject line starting with `[Experimental Features]: `.


### PR DESCRIPTION
This PR extends from #19238 and #19499 to make a small adjustment to the sections describing how to opt in to using experimental features with the Browser Agent product.