### PR TITLE
fix: move include/exclude examples to the global section

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -1423,7 +1423,14 @@ This section defines the variables for [Node.js agent attributes](/docs/agents/n
       </tbody>
     </table>
 
-    Prefix of attributes to exclude from all destinations. Allows `*` as wildcard at end.
+    Prefix of attributes to exclude from all destinations. Allows `*` as wildcard at end. For example, in the config file, this would include all parameters except `somethingSecret`:
+
+    ```js
+    attributes: { 
+      include: [ 'request.parameters.*' ],
+      exclude: [ 'request.parameters.somethingSecret' ]
+    }
+    ```
   </Collapser>
 
   <Collapser
@@ -1464,7 +1471,28 @@ This section defines the variables for [Node.js agent attributes](/docs/agents/n
       </tbody>
     </table>
 
-    Prefix of attributes to include from all destinations. Allows `*` as wildcard at end.
+    Prefix of attributes to include from all destinations. Allows `*` as wildcard at end. 
+
+    For example, in the `config` file, this would include all parameters:
+
+    ```js
+    attributes: { 
+      include: [ 'request.parameters.*' ]
+    }
+    ```
+
+    Using this example Express route definition and request URL:
+    
+    ```js
+    app.get('/api/users/:id', myMiddleware, myController)
+    ```
+      
+    ```sh
+    curl http://localhost:3000/api/users/abc123?id=true
+    ```
+    
+    The _route parameter_ is `id`, and has a value of `abc123`. This becomes the attribute `request.parameters.route.id: abc123` on the Transaction, root Segment, and Span. This example also has a _query parameter_ of `id`, which has a value of `true`. This would become the attribute `request.parameters.id: true` on the Transaction, root Segment, and Span.
+    
   </Collapser>
 
   <Collapser
@@ -2831,15 +2859,7 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    Prefix of attributes to exclude from transaction events. Allows `*` as wildcard at end. For example, in the config file, this would include all parameters except `somethingSecret`:
-
-    ```js
-    attributes: { 
-      include: [ 'request.parameters.*' ],
-      exclude: [ 'request.parameters.somethingSecret' ]
-    }
-    ```
-
+    Prefix of attributes to exclude from transaction events. Allows `*` as wildcard at end. 
   </Collapser>
 
   <Collapser
@@ -2881,27 +2901,6 @@ This section defines the Node.js agent variables in the order they typically app
     </table>
 
     Prefix of attributes to include in transaction events. Allows `*` as wildcard at end. 
-
-    For example, in the `config` file, this would include all parameters:
-
-    ```js
-    attributes: { 
-      include: [ 'request.parameters.*' ]
-    }
-    ```
-
-    Using this example Express route definition and request URL:
-    
-    ```js
-    app.get('/api/users/:id', myMiddleware, myController)
-    ```
-      
-    ```sh
-    curl http://localhost:3000/api/users/abc123?id=true
-    ```
-    
-    The _route parameter_ is `id`, and has a value of `abc123`. This becomes the attribute `request.parameters.route.id: abc123` on the Transaction, root Segment, and Span. This example also has a _query parameter_ of `id`, which has a value of `true`. This would become the attribute `request.parameters.id: true` on the Transaction, root Segment, and Span.
-    
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
I added these examples to the attributes include/exclude section recently, but I realized I added it only to the TransactionTrace include/exclude section when it should have been in the global section.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.