### PR TITLE
feat: document record custom event api for upcoming Browser Agent release

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/recordCustomEvent.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/recordCustomEvent.mdx
@@ -1,0 +1,127 @@
+---
+title: recordCustomEvent
+type: apiDoc
+shortDescription: Reports a custom browser event under a specified eventType with custom attributes.
+tags:
+  - Browser
+  - Browser monitoring
+  - Browser agent and SPA API
+metaDescription: Browser API call to report a custom browser event under a specified eventType with custom attributes.
+redirects:
+  - /docs/browser/new-relic-browser/browser-agent-apis/browser-api-newrelicaddpageaction
+  - /docs/browser/new-relic-browser/browser-agent-api/browser-api-newrelicaddpageaction
+  - /docs/browser/new-relic-browser/browser-agent-spa-api/newrelicaddpageaction-browser-agent-api
+  - /docs/browser/browser-monitoring/browser-agent-and-spa-api
+  - /docs/browser/new-relic-browser/browser-agent-spa-api/view-all-methods
+  - /docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action
+freshnessValidatedDate: never
+---
+
+## Syntax [#syntax]
+
+```js
+newrelic.recordCustomEvent(string $eventType[, JSON object $attributes])
+```
+
+Reports a custom browser event under a specified eventType with custom attributes.
+
+## Requirements
+
+* Browser Pro or Pro+SPA agent (v1.277.0 or higher)
+* If you're using npm to install the browser agent, you must enable the `generic_events` feature when instantiating the `BrowserAgent` class. In the `features` array, add the following:
+
+  ```js
+  import { GenericEvents } from '@newrelic/browser-agent/features/generic_events';
+
+  const options = {
+    info: { ... },
+    loader_config: { ... },
+    init: { ... },
+    features: [
+      GenericEvents
+    ]
+  }
+  ```
+
+  For more information, see the [npm browser installation documentation](https://www.npmjs.com/package/@newrelic/browser-agent#new-relic-browser-agent).
+
+## Description [#description]
+
+This API call sends a custom browser event with your user-defined eventType and optional attributes to [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards), along with any custom attributes you may have set for your application. This is useful to track any event that is not already tracked automatically by the browser agent enhanced by rules and attribution you control.
+
+* `custom` events are sent every 30 seconds.
+* If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
+
+## Parameters [#parameters]
+
+<table>
+  <thead>
+    <tr>
+      <th width="25%">
+        Parameter
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `$eventType`
+
+        _string_
+      </td>
+
+      <td>
+        Required. The eventType to store the event data under
+
+        Avoid using [reserved NRQL words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) or pre-existing eventTypes when you name the attribute or value.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `$attributes`
+
+        _JSON object_
+      </td>
+
+      <td>
+        Optional. JSON object with one or more key/value pairs. For example: `{key:"value"}`. The key is reported as its own `PageAction` attribute with the specified values.
+
+        Avoid using [reserved NRQL words](/docs/insights/event-data-sources/custom-events/data-requirements-limits-custom-event-data/#reserved-words) when you name the attribute/value.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Important considerations and best practices include:
+
+You should aim to limit the total number of event types to approximately five. Custom eventTypes are meant to be used to encapsulate high-level categories. For example, you might create an event type Gestures.
+
+Do not use eventType to name custom events. Create eventTypes to house a category of data and attributes within that category to name an event or use the optional name parameter. While you can create numerous custom events, it's important to keep your data manageable by limiting the number of eventTypes reported.
+
+## Examples [#examples]
+
+### Record link clicks (JavaScript) [#example-link-click-js]
+
+This example records a custom event whenever a user clicks the <DNT>**Submit**</DNT> button in a form. The event is recorded with an `eventType` of `FormAction`, which was used to contain many events related to actions taken on a form:
+
+```html
+<a href="/demo" id="try-me">Try Me!</a>
+<script>
+    document.getElementById('submit').addEventListener('click', function(e) {
+        newrelic.recordCustomEvent('FormAction', { element: 'submit', action: 'click' });
+    })
+</script>
+```
+
+You can then query the number of times the <DNT>**Submit**</DNT> button was clicked with the following NRQL query:
+
+```sql
+SELECT count(*) FROM FormAction WHERE element = 'submit' AND action = 'click' SINCE 1 hour ago
+```
+

--- a/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/collect-custom-attributes.mdx
@@ -266,7 +266,7 @@ To enable and use custom attributes for APM, follow the procedure for your <Inli
 
 ## Browser monitoring: Record custom attributes [#collecting_browser]
 
-The browser agent provides an API to specify extra details associated with a page view or browser interaction, either by [forwarding attributes from APM to browser monitoring](/docs/insights/insights-data-sources/custom-data/insert-data-via-new-relic-browser#custom-attribute-forward-apm) or by [specifying custom attributes through JavaScript](/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute). Values forwarded from the APM agent are encoded and injected into browser attributes by our browser agent.
+The browser agent provides an API to specify extra details associated with browser events across a page load, either by [forwarding attributes from APM to browser monitoring](/docs/insights/insights-data-sources/custom-data/insert-data-via-new-relic-browser#custom-attribute-forward-apm) or by [specifying custom attributes through JavaScript](/docs/browser/new-relic-browser/browser-agent-spa-api/set-custom-attribute). Values forwarded from the APM agent are encoded and injected into browser attributes by our browser agent.
 
 ## Infrastructure monitoring: Record custom attributes [#collecting_browser]
 

--- a/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes.mdx
@@ -26,13 +26,81 @@ freshnessValidatedDate: never
 
 You can use browser monitoring in New Relic to add [custom events and attributes](/docs/insights/insights-data-sources/custom-data/report-custom-event-data).
 
-## Page actions and views [#overview]
+## Custom attributes [#attributes]
 
-Use the browser API's [`addPageAction`](/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action) call to capture events, actions, route changes, or any end-user interactions with your application. The `addPageAction` call adds an event named `PageAction` that contains the action name and any custom attribute names and values you capture along with it. The `PageAction` event also contains any custom attributes you added to the `PageView` event.
+Add custom attributes to all browser events so you can query or filter your data to answer more questions about your application.
 
-Add custom attributes to the `PageView` event so you can query or filter your data to answer more questions about your application.
+## Custom events [#events]
+
+Use the browser API's [`recordCustomEvent`](/docs/browser/new-relic-browser/browser-agent-spa-api/record-custom-event) method to capture any event with custom attribution.
+
+## Page actions [#overview]
+
+Use the browser API's [`addPageAction`](/docs/browser/new-relic-browser/browser-agent-spa-api/add-page-action) call to capture events, actions, route changes, or any end-user interactions with your application. The `addPageAction` call adds an event named `PageAction` that contains the action name, metadata relating to your page and any custom attribute names and values you capture along with it.
 
 ## Prerequisites [#requirements]
+
+In order to report `Custom` events, verify these prerequisites:
+
+<table>
+  <thead>
+    <tr>
+      <th width={200}>
+        <DNT>
+          **Requirement**
+        </DNT>
+      </th>
+
+      <th>
+        <DNT>
+          **Comments**
+        </DNT>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Agent version
+      </td>
+
+      <td>
+        Your browser monitoring agent version must be [1.277.0 or higher](/docs/browser/new-relic-browser/installation-configuration/upgrading-browser-agent#checking).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Client browser version
+      </td>
+
+      <td>
+        To record `Custom` events, the browser must [support cross-domain XHRs](/docs/browser/new-relic-browser/getting-started/compatibility-requirements#browser-types).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Events per cycle
+      </td>
+
+      <td>
+        `Custom` events are buffered with other Browser events and are sent every 30 seconds. If 1,000 total events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Event/attribute naming, data type, size
+      </td>
+
+      <td>
+        Ensure you follow [general requirements](/docs/insights/insights-data-sources/custom-data/data-requirements#general) around event/attribute naming syntax, data types, and size.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 In order to report `PageAction` events, verify these prerequisites:
 
@@ -80,7 +148,7 @@ In order to report `PageAction` events, verify these prerequisites:
       </td>
 
       <td>
-        `PageAction` events are sent every 30 seconds. If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
+        `PageAction` events are buffered with other Browser events and are sent every 30 seconds. If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
       </td>
     </tr>
 
@@ -96,6 +164,19 @@ In order to report `PageAction` events, verify these prerequisites:
   </tbody>
 </table>
 
+## Create custom events [#creating-custom-events]
+
+To create a `custom` event:
+
+1. Ensure the [browser agent is installed](/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent) for your app.
+2. Call the [`newrelic.recordCustomEvent`](/docs/browser/new-relic-browser/browser-apis/record-custom-event) function in the relevant part of your application's JavaScript.
+3. Wait a couple minutes for the application to run and report relevant `custom` events under the eventType you specified.
+4. Run a NRQL query of the event that includes the `eventType` attribute you used to capture the event (and any associated attributes you sent along with the event).
+  - For example, if you sent a `custom` event with an `eventType` of `Foo` and an attribute of `bar: 123`, you could run a query like this:
+    ```sql
+    SELECT * FROM Foo WHERE bar = 123
+    ```
+
 ## Create PageAction events [#creating-pageactions]
 
 To create a `PageAction` event:
@@ -104,19 +185,23 @@ To create a `PageAction` event:
 2. Call the [`newrelic.addPageAction`](/docs/browser/new-relic-browser/browser-agent-spa-api/newrelicaddpageaction-browser-agent-api) function in the relevant part of your application's JavaScript.
 3. Wait a couple minutes for the application to run and report relevant `PageAction` events.
 4. Run a [NRQL query](/docs/query-data/nrql-new-relic-query-language/nrql-query-examples/insights-query-examples-new-relic-browser-spa) of the `PageAction` event that includes the `actionName` attribute you used to capture the event (and any associated attributes you sent along with the action).
+  - For example, if you sent a `PageAction` event with an `actionName` of `Foo` and an attribute of `bar: 123`, you could run a query like this:
+    ```sql
+    SELECT * FROM PageAction WHERE actionName = 'Foo' AND bar = 123
+    ```
 
-## Add custom attributes to PageView event [#custom-attributes]
+## Add custom attributes to Browser events [#custom-attributes]
 
-The `PageView` event is a default browser-reported event. You can add custom attributes to the `PageView` event. Any custom attributes you add to the `PageView` event are also automatically added to the `PageAction` event.
+You can add custom attributes to all Browser events. Any custom attributes you add using the `setCustomAttribute` API will be added to all events captured.
 
-There are two ways to add custom attributes to the `PageView` event:
+There are two ways to add custom attributes:
 
 <CollapserGroup>
   <Collapser
     id="custom-attribute-via-browser-api"
     title={<>Use <Link to="/docs/browser/new-relic-browser/browser-agent-spa-api/newrelicsetcustomattribute-browser-agent-api"><InlineCode>setCustomAttribute</InlineCode></Link> browser API call</>}
   >
-    To add a custom attribute to the `PageView` event via the browser agent, use the [`setCustomAttribute`](/docs/browser/new-relic-browser/browser-agent-spa-api/newrelicsetcustomattribute-browser-agent-api) browser API call. This allows you to capture an attribute to be annotated on any `PageAction` event.
+    To add a custom attribute to Browser events via the browser agent, use the [`setCustomAttribute`](/docs/browser/new-relic-browser/browser-agent-spa-api/newrelicsetcustomattribute-browser-agent-api) browser API call.
   </Collapser>
 
   <Collapser
@@ -241,9 +326,219 @@ There are two ways to add custom attributes to the `PageView` event:
   </Collapser>
 </CollapserGroup>
 
-## PageAction and PageView attributes [#default-attributes]
+## Important considerations and best practices include:
 
-To see the default attributes of `PageAction` and `PageView`, see [Browser events](/docs/insights/insights-data-sources/default-events-attributes/browser-default-events-attributes-insights).
+You should aim to limit the total number of custom event types to approximately five. Custom event types are meant to be used to encapsulate high-level categories. For example, you might create an event type called Gestures that contains many events with various purposes.
+
+Avoid using event type to name custom events. Create event types to house a category of data and use attributes within that category to differentiate events. While you can create numerous custom events, it's important to keep your data manageable by limiting the number of event types reported.
+
+## Included Attribution
+
+Custom browser events are decorated with the following attributes intended to help you understand the context of the browser environment when the event occurred:
+
+<CollapserGroup>
+  <Collapser
+    id="custom-event-attributes"
+    title="Custom event attributes"
+  >
+       <table>
+         <thead>
+           <tr>
+             <th style={{ width: "100px" }}>
+               Attribute
+             </th>
+
+             <th>
+               Description
+             </th>
+           </tr>
+         </thead>
+
+         <tbody>
+           <tr>
+             <td>
+               appId
+             </td>
+
+             <td>
+                The New Relic entity's application ID.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               appName
+             </td>
+
+             <td>
+                The New Relic entity's application name.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               asn
+             </td>
+
+             <td>
+                Autonomous System Number.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               asnLatitude
+             </td>
+
+             <td>
+                The latitude associated with the ASN
+             </td>
+           </tr>
+           <tr>
+             <td>
+               asnLongitude
+             </td>
+
+             <td>
+                The longitude associated with the ASN
+             </td>
+           </tr>
+           <tr>
+             <td>
+               asnOrganization
+             </td>
+
+             <td>
+                The organization associated with the ASN
+             </td>
+           </tr>
+           <tr>
+             <td>
+               city
+             </td>
+
+             <td>
+                The city where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               countryCode
+             </td>
+
+             <td>
+                The country code where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               currentUrl
+             </td>
+
+             <td>
+                The URL where the event occurred, which includes soft navigations
+             </td>
+           </tr>
+           <tr>
+             <td>
+               deviceType
+             </td>
+
+             <td>
+                The type of device on which the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               entityGuid
+             </td>
+
+             <td>
+                The New Relic entity's GUID.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               name
+             </td>
+
+             <td>
+                The transaction name if supplied by APM
+             </td>
+           </tr>
+           <tr>
+             <td>
+               pageUrl
+             </td>
+
+             <td>
+                The URL where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               regionCode
+             </td>
+
+             <td>
+                The region code where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               session
+             </td>
+
+             <td>
+                The session identifier tied to the user session where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               sessionTraceId
+             </td>
+
+             <td>
+                The session trace ID tied to the page load where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               timestamp
+             </td>
+
+             <td>
+                The unix timestamp of the event.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               userAgentName
+             </td>
+
+             <td>
+                The name of the user agent where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               userAgentOS
+             </td>
+
+             <td>
+                The operating system of the user agent where the event occurred.
+             </td>
+           </tr>
+           <tr>
+             <td>
+               userAgentVersion
+             </td>
+
+             <td>
+                The version of the user agent where the event occurred.
+             </td>
+           </tr>
+         </tbody>
+       </table>
+  </Collapser>
+</CollapserGroup>
 
 ## Troubleshooting
 
@@ -284,6 +579,18 @@ Here are some troubleshooting tips:
 
       <td>
         If your `PageAction` events do not appear when you query, review the [requirements](#requirements).
+
+        If the requirements are met, check that you're not using [reserved attribute names or invalid values](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api#limits).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `Custom` events
+      </td>
+
+      <td>
+        If your `custom` events do not appear when you query, review the [requirements](#requirements).
 
         If the requirements are met, check that you're not using [reserved attribute names or invalid values](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api#limits).
       </td>

--- a/src/content/docs/data-apis/custom-data/custom-events/report-custom-event-data.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-custom-event-data.mdx
@@ -89,8 +89,8 @@ Methods for sending custom events and attributes include:
         [Browser monitoring agent](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring)
       </td>
 
-      <td>
-        Add custom attributes to the `PageView` event via the browser API call [`setCustomAttribute`](/docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api). Send [`PageAction` event and attributes](/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes) via the browser API.
+      <td>        
+        Use the browser agent APIs to [send custom events](/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes) and [set custom attributes](/docs/browser/new-relic-browser/browser-agent-spa-api/setcustomattribute-browser-agent-api).
 
         Forward [APM agent custom attributes](/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes/) to the `PageView` event.
       </td>


### PR DESCRIPTION
This PR adds documentation around a new API being released by the browser agent in v1.277.0.  It also updates some old docs that were out of date in some regards.