### PR TITLE
Chore[S3-integration]: add information about metrics delays

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-s3-monitoring-integration.mdx
@@ -19,7 +19,7 @@ freshnessValidatedDate: never
 
 [New Relic infrastructure integrations](/docs/infrastructure/integrations-getting-started/getting-started/introduction-infrastructure-integrations) include an integration for reporting your Amazon S3 data to New Relic. This document explains how to activate the integration and describes the data reported.
 
-AWS specifies that [S3 CloudWatch metrics are best-effort](https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-dimensions.html) and are not always current. If CloudwWtch metrics are delayed by more than 48 hours at the time of collection, [New Relic won't be able to ingest them](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/). 
+AWS states that [S3 CloudWatch metrics are provided on a best-effort](https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-dimensions.html) basis and may not always be current. If the CloudWatch metrics are delayed over 48 hours at collection, [New Relic cannot ingest them](https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/).
 
 ## Features [#features]
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
S3 metrics (bucket) are notorious for being extremely late. Sometimes these metrics are over 48h late, which makes NR unable to ingest them, since they exceed the max age of NR's Metrics API. Customers often request support to understand why their metrics are missing. They should raise their concerns with AWS so they emit these metrics more timely. 
  
* Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.
The changes are documented in the documentation through links. 