### PR TITLE
fix: update go easy instrumentation docs to 0.5.0

### DIFF
--- a/src/content/docs/apm/agents/go-agent/installation/install-automation-new-relic-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/installation/install-automation-new-relic-go.mdx
@@ -52,13 +52,15 @@ The scope of what this tool can instrument in your application is limited to the
 * Capturing errors in any function wrapped or traced by a transaction
 * Tracing locally defined functions that are invoked in the application's `main()` method with a transaction
 * Tracing async functions and function literals with an async segment
-* Wrapping HTTP handlers
+* Adding middleware to supported libraries for tracing
 * Injecting distributed tracing into external traffic
 
 ### Supported Libraries [#supported-libraries]
 
 * standard library
 * net/http
+* gin
+* gRPC
 
 ## Installation [#go-easy-install]
 
@@ -74,7 +76,7 @@ go install github.com/newrelic/go-easy-instrumentation@latest
         id="setup-go-path"
         title="Setting up your GOPATH"
     >
-    The easiest way to use the installed `go-easy-instrumentation` binary is by adding your `GOPATH` bin to your `PATH`.
+    To install `go-easy-instrumentation` make sure `GOPATH` bin is in your `PATH`.
 
     <CollapserGroup>
       <Collapser
@@ -106,7 +108,7 @@ This tool works best with Git. We recommend you verify your application is on a 
 
 1. Run the following CLI command to create a file named `new-relic-instrumentation.diff` in your working directory:
     ```sh
-    go-easy-instrumentation -path ../my-application/
+    go-easy-instrumentation instrument ../my-application/
     ```
 2. Open the `.diff` file and verify or correct the contents.
 3. When you are satisfied with the instrumentation suggestions, save the file, and then apply the changes:


### PR DESCRIPTION
https://github.com/newrelic/go-easy-instrumentation/releases/tag/0.5.0

Brings the docs for go easy instrumentation up to date with the latest state of the project.