### PR TITLE
Chore(Vulnerability-integration): Omit minor version of PHP APM agent in description

### DIFF
--- a/src/content/docs/vulnerability-management/integrations/intro.mdx
+++ b/src/content/docs/vulnerability-management/integrations/intro.mdx
@@ -180,9 +180,9 @@ CVE detection coverage differs between agents:
     id="php-packages"
     title="PHP package support"
   >
-    As of release [v10.17.0.7](/docs/release-notes/agent-release-notes/php-release-notes/2/#new-relic-php-agent-v101707), New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) supports detecting CVEs in the core packages of these [frameworks](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/#frameworks).
+    As of release [v10.17](/docs/release-notes/agent-release-notes/php-release-notes/2/#new-relic-php-agent-v101707), New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) supports detecting CVEs in the core packages of these [frameworks](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/#frameworks).
 
-    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, till [v11.2.0.15](/docs/release-notes/agent-release-notes/php-release-notes/#new-relic-php-agent-v112015) you can configure the New Relic [PHP APM agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) to detect vulnerabilities in all your packages.
+    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, as of release [v11.2](/docs/release-notes/agent-release-notes/php-release-notes/#new-relic-php-agent-v112015) you can configure the New Relic [PHP APM agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) to detect vulnerabilities in all your packages.
     
     
     <Callout variant="tip">

--- a/src/content/docs/vulnerability-management/integrations/intro.mdx
+++ b/src/content/docs/vulnerability-management/integrations/intro.mdx
@@ -182,7 +182,7 @@ CVE detection coverage differs between agents:
   >
     As of release [v10.17](/docs/release-notes/agent-release-notes/php-release-notes/2/#new-relic-php-agent-v101707), New Relic [PHP APM Agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) supports detecting CVEs in the core packages of these [frameworks](/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/#frameworks).
 
-    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, as of release [v11.2](/docs/release-notes/agent-release-notes/php-release-notes/#new-relic-php-agent-v112015) you can configure the New Relic [PHP APM agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) to detect vulnerabilities in all your packages.
+    If your project uses [Composer](https://getcomposer.org/) to manage dependencies, as of release [v11.2](/docs/release-notes/agent-release-notes/php-release-notes/#new-relic-php-agent-v112015), you can configure the New Relic [PHP APM agent](/docs/apm/agents/php-agent/getting-started/introduction-new-relic-php) to detect vulnerabilities in all your packages.
     
     
     <Callout variant="tip">


### PR DESCRIPTION

Omitted minor version of PHP APM agent in the description, as suggested by PM. Linked to [NR-351079](https://new-relic.atlassian.net/browse/NR-351079)


[NR-351079]: https://new-relic.atlassian.net/browse/NR-351079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ