### PR TITLE
Update java agent docs for 8.17.0 release

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-config-file-template.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-config-file-template.mdx
@@ -420,6 +420,18 @@ common: &default_settings
     # Default is false.
     audit_logging: false
 
+    # The time interval, in seconds, of how often JFR data is sent to New Relic.
+    # The default is 10 seconds.
+    harvest_interval: 10
+
+    # The size of the queue used to store JFR events. Increasing this can reduce gaps in JFR reported data
+    # but can also cause resource issues in the agent or cause data to be dropped if backend pipeline
+    # limits are exceeded.
+    # See: https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#limits
+    #      https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/
+    # Default is 250000
+    queue_size: 250000
+
   # User-configurable custom labels for this agent.  Labels are name-value pairs.
   # There is a maximum of 64 labels per agent.  Names and values are limited to 255 characters.
   # Names and values may not contain colons (:) or semicolons (;).

--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -162,6 +162,7 @@ The agent automatically instruments these frameworks and libraries:
     The agent automatically instruments the following frameworks. To install the Java agent on supported frameworks, see [Install the Java agent](/docs/agents/java-agent/installation/java-agent-manual-installation).
 
     * Akka 2.2.0-RC1 to latest
+    * Amazon Firehose SDK 2.1.0 to latest
     * Amazon Kinesis v1 and v2 SDKs
     * Amazon Lambda SDK 1.11.280 to latest
     * AmazonS3 client 1.2.13 to latest
@@ -197,6 +198,7 @@ The agent automatically instruments these frameworks and libraries:
     * Pekko 1.0.0 to latest
     * Pekko-Http 1.0.0 to latest
       * Scala 2.13
+      * Scala 3
     * Play Server 2.3.0 to latest {/* Play support will extend to latest once we support Pekko-Http */}
     * Quartz Job Scheduler 1.8.3 to 2.2.x
     * RESTEasy 2.2-RC-1 to latest
@@ -292,7 +294,7 @@ The agent automatically instruments these frameworks and libraries:
     * Oracle ojdbc5, ojdbc6, ojdbc7, ojdbc8, ojdbc10, ojdbc14
     * Postgres 8.0-312.jdbc3 to latest
     * R2DBC H2 0.8.x to 0.9.x
-    * R2DBC MariaDB 1.0.2 to 1.1.1
+    * R2DBC MariaDB 1.0.2 to latest
     * R2DBC MySQL 0.8.x to latest
     * R2DBC MSSQL 0.8.0 to latest
     * R2DBC Oracle 0.x to latest

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8170.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8170.mdx
@@ -1,0 +1,108 @@
+---
+subject:  Java agent
+releaseDate:  2025-12-19'
+version:  8.17.0
+downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.17.0/'
+features: [“Add support for jdbc-mariadb 3.0.0 till latest and r2dbc-mariadb 1.1.2 till latest ”, “Auto discover AWS account ID in the DynamoDB and Lambda SDKs”, “Support pekko-http on scala 3 for versions 1.0.0 till latest”, “Allow JFR queue size and harvest interval to be configured via agent config”, “Add AWS Firehose SDK Instrumentation”, “”, “Implement a new instrumentation module for r2dbc-mysql 1.1.3+”, “Memory usage reduced for the r2dbc-mssql and m2dbc-mysql modules”]
+bugs: [“Resolved a potential token timeout issue with the reactor-3.3.0 module”]
+security: []
+---
+<ButtonGroup>
+  <ButtonLink
+    role="button"
+    to="https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.17.0/"
+    variant="primary"
+  >
+    Download this agent version
+  </ButtonLink>
+</ButtonGroup>
+
+## New features and improvements
+
+- Add support for jdbc-mariadb 3.0.0 till latest and r2dbc-mariadb 1.1.2 till latest - credit to @dhilpipre - clone of 2142 by @jtduffy in [2146](https://github.com/newrelic/newrelic-java-agent/pull/2146)
+- Auto discover AWS account ID in the DynamoDB instrumentation by @meiao in [2148](https://github.com/newrelic/newrelic-java-agent/pull/2148)
+- Auto discover AWS account ID in the Lambda sdk instrumentation by @meiao in [2167](https://github.com/newrelic/newrelic-java-agent/pull/2167)
+- Support pekko-http on scala 3 for versions 1.0.0 till latest by @kanderson250 in [2163](https://github.com/newrelic/newrelic-java-agent/pull/2163)
+- Allow JFR queue size and harvest interval to be configured via agent config by @jtduffy in [2168](https://github.com/newrelic/newrelic-java-agent/pull/2168)
+  New configs are:
+```
+  jfr:
+    # The time interval, in seconds, of how often JFR data is sent to New Relic.
+    # The default is 10 seconds.
+    harvest_interval: 10
+
+    # The size of the queue used to store JFR events. Increasing this can reduce gaps in JFR reported data
+    # but can also cause resource issues in the agent or cause data to be dropped if backend pipeline
+    # limits are exceeded.
+    # See: https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/#limits
+    #      https://docs.newrelic.com/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/
+    # Default is 250000
+    queue_size: 250000
+```
+- Add AWS Firehose SDK Instrumentation for versions 2.1.0 till latest by @obenkenobi in [2149](https://github.com/newrelic/newrelic-java-agent/pull/2149)
+- Implement a new instrumentation module for r2dbc-mysql 1.1.3+ by @jbedell-newrelic in [2169](https://github.com/newrelic/newrelic-java-agent/pull/2169)
+- Memory usage reduced for the r2dbc-mssql and m2dbc-mysql modules by @jbedell-newrelic in [2169](https://github.com/newrelic/newrelic-java-agent/pull/2169)
+- Log when multiple, different, traceparent headers found on inbound request and only report `invalid parent header count` supportability metric when that scenario occurs by @jtduffy in [2154](https://github.com/newrelic/newrelic-java-agent/pull/2154)
+- Expected NPE in noticeTracer no longer logs full stack trace by @jasonjkeller in [2143](https://github.com/newrelic/newrelic-java-agent/pull/2143)
+
+## Fixes
+
+- Resolved a potential token timeout issue with the reactor-3.3.0 module by @jbedell-newrelic in [2169](https://github.com/newrelic/newrelic-java-agent/pull/2169)
+
+## IAST
+
+- CSEC version bump to 1.6.0 [2173](https://github.com/newrelic/newrelic-java-agent/pull/2173)
+- Changelog: https://github.com/newrelic/csec-java-agent/releases/tag/1.6.0
+
+
+
+## Update to latest version [#procedures]
+
+To identify which version of the Java agent you're currently using, run `java -jar newrelic.jar -v`. Your Java agent version will be printed to your console.
+
+Then, to update to the latest Java agent version:
+
+1. Back up the **entire** [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent) to another location. Rename that directory to `NewRelic_Agent#.#.#`, where `#.#.#` is the agent version number.
+2. [Download the agent.](/docs/release-notes/agent-release-notes/java-release-notes).
+3. Unzip the new agent download file, then copy `newrelic-api.jar` and `newrelic.jar` into the original [Java agent root directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#java-agent).
+4. Compare your old `newrelic.yml` with the newly downloaded `newrelic.yml` from the zip, and [update the file if needed](#diff).
+5. Restart your Java dispatcher.
+
+If you experience issues after the Java agent update, restore from the backed-up New Relic agent directory.
+
+## Update agent config differences [#diff]
+
+We add new settings to `newrelic.yml` as we release new versions of the agent. You can use `diff` or another diffing utility to see what's changed, and add the new config settings to your old file. Make sure not to overwrite any customizations you've made to the file, such as your license key, app name, or changes to default settings.
+
+For example, if you `diff` the default `newrelic.yml` files for Java agent versions 7.10.0 and 7.11.0, the results printed to the console will be like:
+
+```yaml
+➜ diff newrelic_7.10.0.yml newrelic_7.11.0.yml
+...
+107a108,119
+>       # Whether the log events should include context from loggers with support for that.
+>       include_context_data:
+>
+>         # When true, application logs will contain context data.
+>         enabled: false
+>
+>         # A comma separated list of attribute keys whose values should be sent to New Relic.
+>         #include:
+>
+>         # A comma separated list of attribute keys whose values should not be sent to New Relic.
+>         #exclude:
+>
+125a138
+>
+128c141
+<     enabled: false
+---
+>     enabled: true
+...
+```
+
+In this example, these lines were added to the default `newrelic.yml` in Java agent version 7.11.0. If you're moving to 7.11.0 or higher, you should add these new lines to your original `newrelic.yml`.
+
+## Support statement:
+
+* New Relic recommends that you upgrade the agent regularly to ensure that you're getting the latest features and performance benefits. Additionally, older releases will no longer be supported when they reach [end-of-life](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/notification-changes-new-relic-saas-features-distributed-software/).

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8170.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8170.mdx
@@ -1,6 +1,6 @@
 ---
 subject:  Java agent
-releaseDate:  2025-12-19'
+releaseDate:  '2025-12-19'
 version:  8.17.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.17.0/'
 features: [“Add support for jdbc-mariadb 3.0.0 till latest and r2dbc-mariadb 1.1.2 till latest ”, “Auto discover AWS account ID in the DynamoDB and Lambda SDKs”, “Support pekko-http on scala 3 for versions 1.0.0 till latest”, “Allow JFR queue size and harvest interval to be configured via agent config”, “Add AWS Firehose SDK Instrumentation”, “”, “Implement a new instrumentation module for r2dbc-mysql 1.1.3+”, “Memory usage reduced for the r2dbc-mssql and m2dbc-mysql modules”]


### PR DESCRIPTION
New Java Agent docs for the 8.17.0 release. Please merge as soon as possible.