### PR TITLE
Added the Microsoft Team Webhook-based connector EOL information

### DIFF
--- a/src/content/docs/alerts/get-notified/destinations.mdx
+++ b/src/content/docs/alerts/get-notified/destinations.mdx
@@ -20,6 +20,12 @@ The supported destination platforms include:
 * ServiceNow: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/).
 * Slack: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/), [errors inbox](/docs/errors-inbox/), and [Discussions](/docs/new-relic-solutions/new-relic-one/ui-data/collaborate/collaboration-slack-integration/).
 * Webhook: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/).
+
+
+  <Callout variant="important">
+    If you are using Microsoft Office 365 webhook-based connectors in Teams for New Relic alerts, you should update their webhook URLs to the new format by January 31, 2025. For more information on updating the webhook URL, refer [Microsoft's End-of-Life (EOL) for Office 365 connectors in Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/).
+  </Callout>
+
 * Email: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) and [Discussions](/docs/new-relic-solutions/new-relic-one/ui-data/collaborate/collaborate-with-teammates/).
 * AWS EventBridge: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/).
 * PagerDuty: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/).

--- a/src/content/docs/alerts/get-notified/destinations.mdx
+++ b/src/content/docs/alerts/get-notified/destinations.mdx
@@ -23,7 +23,7 @@ The supported destination platforms include:
 
 
   <Callout variant="important">
-    If you are using Microsoft Office 365 webhook-based connectors in Teams for New Relic alerts, you should update their webhook URLs to the new format by January 31, 2025. For more information on updating the webhook URL, refer [Microsoft's End-of-Life (EOL) for Office 365 connectors in Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/).
+    If you are using Microsoft Office 365 webhook-based connectors in Teams for New Relic alerts, you should update the webhook URLs to the new format by January 31, 2025. For more information on updating the webhook URL, refer [Microsoft's End-of-Life (EOL) for Office 365 connectors in Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/).
   </Callout>
 
 * Email: Available in [workflows](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/) and [Discussions](/docs/new-relic-solutions/new-relic-one/ui-data/collaborate/collaborate-with-teammates/).


### PR DESCRIPTION
As per [this slack request](https://newrelic.slack.com/archives/C084BRFD831/p1734014599821469), I have add the EOL note for Microsoft Office 365 webhook-based connectors in Teams. We will remove this note once [this ticket](https://new-relic.atlassian.net/browse/NR-353569) gets closed.