### PR TITLE
create a new prometheus agent directory

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/prometheus-agent-release-notes/index.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/prometheus-agent-release-notes/index.mdx
@@ -1,0 +1,3 @@
+---
+subject: Prometheus agent
+---

--- a/src/content/docs/release-notes/infrastructure-release-notes/prometheus-agent-release-notes/prometheus-agent-100.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/prometheus-agent-release-notes/prometheus-agent-100.mdx
@@ -1,0 +1,15 @@
+---
+subject: Prometheus agent
+releaseDate: '2024-01-06'
+version: 1.0.0
+---
+
+## Notes
+
+
+
+## Changelog
+
+
+### Major changes
+

--- a/src/utils/getAgentName.js
+++ b/src/utils/getAgentName.js
@@ -17,6 +17,7 @@ const AGENTS = {
   'java-release-notes': 'java',
   'job-manager-release-notes': 'job manager',
   'kubernetes-integration-release-notes': 'kubernetes',
+  'prometheus-agent-release-notes': 'prometheus',
   'logs-release-notes': 'logs',
   'fluentbit-release-notes': 'fluentbit',
   'net-maui-release-notes': '.net maui',


### PR DESCRIPTION
As per the request received in [this thread](https://newrelic.slack.com/archives/C086WV76C9Z/p1735641690446999), created a new release notes category for Prometheus agent release notes.