### PR TITLE
docs: updated mysql whatsNext.mdx to reflect Mysql 8.0 and above support

### DIFF
--- a/src/install/mysql/whatsNext.mdx
+++ b/src/install/mysql/whatsNext.mdx
@@ -238,7 +238,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Amount of free memory in bytes for the query cache.
+            Amount of free memory in bytes for the query cache. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -252,7 +252,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Percentage of queries that are retrieved from the cache.
+            Percentage of queries that are retrieved from the cache. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -266,7 +266,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Number of noncached queries (not cacheable, or not cached due to the `query_cache_type setting`) per second.
+            Number of noncached queries (not cacheable, or not cached due to the `query_cache_type setting`) per second. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -280,7 +280,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Percentage of query cache memory that is being used.
+            Percentage of query cache memory that is being used. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -811,7 +811,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Number of free memory blocks in the query cache.
+            Number of free memory blocks in the query cache. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -825,7 +825,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Number of query cache hits per second.
+            Number of query cache hits per second. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -839,7 +839,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Number of queries added to the query cache.
+            Number of queries added to the query cache. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -853,7 +853,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Number of queries per second that were deleted from the query cache because of low memory.
+            Number of queries per second that were deleted from the query cache because of low memory. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -867,7 +867,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Number of queries per second registered in the query cache.
+            Number of queries per second registered in the query cache. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 
@@ -881,7 +881,7 @@ The MySQL integration collects the following metrics:
           </td>
 
           <td>
-            Total number of blocks in the query cache.
+            Total number of blocks in the query cache. Not supported from [MySQL 8.0](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html)
           </td>
         </tr>
 


### PR DESCRIPTION
- nri-mysql on host integration now also supports Mysql 8.0 and above.
- The query cache variables are removed from MySQL 8.0 [refer](https://dev.mysql.com/doc/refman/5.7/en/query-cache-status-and-maintenance.html) which need to be reflected in the docs after the feature gets released.
- https://github.com/newrelic/nri-mysql/commit/8a56a6331727a35a4e8e2d3931665e686dfedd9c