### PR TITLE
fix: poorly formatted code

### DIFF
--- a/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
+++ b/src/content/docs/apm/agents/java-agent/api-guides/guide-using-java-agent-api.mdx
@@ -22,7 +22,7 @@ freshnessValidatedDate: never
 The New Relic Java agent API lets you control, customize, and extend the functionality of the <InlinePopover type="apm"/> [Java agent](/docs/agents/java-agent/getting-started/new-relic-java). This API consists of:
 
 * Static methods on the `com.newrelic.api.agent.NewRelic` class
-* A [@Trace annotation](/docs/agents/java-agent/custom-instrumentation/java-instrumentation-annotation) for implementing custom instrumentation
+* A [`@Trace` annotation](/docs/agents/java-agent/custom-instrumentation/java-instrumentation-annotation) for implementing custom instrumentation
 * A hierarchy of API objects providing additional functionality
 
 Use this API to set up [custom instrumentation](/docs/agents/java-agent/custom-instrumentation/java-custom-instrumentation) of your Java app and collect more in-depth data. For detailed information about this API, see the complete [Javadoc on GitHub](http://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html).
@@ -49,7 +49,7 @@ You can call the API even without the agent running, but the methods will be a n
 
 ## Transactions
 
-To instrument [`Transactions`](/docs/apm/applications-menu/monitoring/transactions-page) in your application, use the following APIs.
+To instrument [transactions](/docs/apm/applications-menu/monitoring/transactions-page) in your application, use the following APIs.
 
 <table>
   <thead>
@@ -650,9 +650,11 @@ The following APIs provide additional functionality, such as setting app server 
       </td>
 
       <td>
-        [`public interface ErrorGroupCallback {
-                      String generateGroupingString(ErrorData errorData);
-                  }`](https://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html)
+        ```
+        <a href="https://newrelic.github.io/java-agent-api/javadoc/index.html?com/newrelic/api/agent/NewRelic.html">public interface ErrorGroupCallback {
+            String generateGroupingString(ErrorData errorData);
+        }()</a>
+        ```
       </td>
     </tr>
 


### PR DESCRIPTION
This code block was ugly and tough to read, so I put it in a codeblock

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/3b4a253d-9da7-430d-9c32-0f766c399c92" />