### PR TITLE
chore: restores the markdown based compatiblity with the begin/end markers

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -259,6 +259,7 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
   </Collapser>
 </CollapserGroup>
 
+{/* begin: compat-table */}
 ## Instrumented modules
 
 After installation, the agent automatically instruments with our catalog of
@@ -270,306 +271,57 @@ frameworks or libraries, you'll need to instrument the agent yourself using the
 **Note**: The latest supported version may not reflect the most recent supported
 version.
 
-<table>
-    <thead>
-        <tr>
-            <th>Package name</th>
-            <th>Minimum supported version</th>
-            <th>Latest supported version</th>
-            <th>Introduced in*</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>`@apollo/gateway`</td>
-            <td>2.3.0</td>
-            <td>2.8.4</td>
-            <td>`@newrelic/apollo-server-plugin@1.0.0`</td>
-        </tr>
-        <tr>
-            <td>`@apollo/server`</td>
-            <td>4.0.0</td>
-            <td>4.11.0</td>
-            <td>`@newrelic/apollo-server-plugin@2.1.0`</td>
-        </tr>
-        <tr>
-            <td>`@aws-sdk/client-bedrock-runtime`</td>
-            <td>3.474.0</td>
-            <td>3.629.0</td>
-            <td>11.13.0</td>
-        </tr>
-        <tr>
-            <td>`@aws-sdk/client-dynamodb`</td>
-            <td>3.0.0</td>
-            <td>3.629.0</td>
-            <td>8.7.1</td>
-        </tr>
-        <tr>
-            <td>`@aws-sdk/client-sns`</td>
-            <td>3.0.0</td>
-            <td>3.624.0</td>
-            <td>8.7.1</td>
-        </tr>
-        <tr>
-            <td>`@aws-sdk/client-sqs`</td>
-            <td>3.0.0</td>
-            <td>3.624.0</td>
-            <td>8.7.1</td>
-        </tr>
-        <tr>
-            <td>`@aws-sdk/lib-dynamodb`</td>
-            <td>3.377.0</td>
-            <td>3.624.0</td>
-            <td>8.7.1</td>
-        </tr>
-        <tr>
-            <td>`@aws-sdk/smithy-client`</td>
-            <td>3.47.0</td>
-            <td>3.374.0</td>
-            <td>8.7.1</td>
-        </tr>
-        <tr>
-            <td>`@elastic/elasticsearch`</td>
-            <td>7.16.0</td>
-            <td>8.15.0</td>
-            <td>11.9.0</td>
-        </tr>
-        <tr>
-            <td>`@grpc/grpc-js`</td>
-            <td>1.4.0</td>
-            <td>1.11.1</td>
-            <td>8.17.0</td>
-        </tr>
-        <tr>
-            <td>`@hapi/hapi`</td>
-            <td>20.1.2</td>
-            <td>21.3.10</td>
-            <td>9.0.0</td>
-        </tr>
-        <tr>
-            <td>`@koa/router`</td>
-            <td>11.0.2</td>
-            <td>12.0.1</td>
-            <td>3.2.0</td>
-        </tr>
-        <tr>
-            <td>`@langchain/core`</td>
-            <td>0.1.17</td>
-            <td>0.2.23</td>
-            <td>11.13.0</td>
-        </tr>
-        <tr>
-            <td>`@nestjs/cli`</td>
-            <td>9.0.0</td>
-            <td>10.4.4</td>
-            <td>10.1.0</td>
-        </tr>
-        <tr>
-            <td>`@prisma/client`</td>
-            <td>5.0.0</td>
-            <td>5.18.0</td>
-            <td>11.0.0</td>
-        </tr>
-        <tr>
-            <td>`@smithy/smithy-client`</td>
-            <td>2.0.0</td>
-            <td>3.1.12</td>
-            <td>11.0.0</td>
-        </tr>
-        <tr>
-            <td>`amqplib`</td>
-            <td>0.5.0</td>
-            <td>0.10.4</td>
-            <td>2.0.0</td>
-        </tr>
-        <tr>
-            <td>`apollo-server`</td>
-            <td>3.0.0</td>
-            <td>3.13.0</td>
-            <td>`@newrelic/apollo-server-plugin@1.0.0`</td>
-        </tr>
-        <tr>
-            <td>`apollo-server-express`</td>
-            <td>3.0.0</td>
-            <td>3.13.0</td>
-            <td>`@newrelic/apollo-server-plugin@1.0.0`</td>
-        </tr>
-        <tr>
-            <td>`aws-sdk`</td>
-            <td>2.2.48</td>
-            <td>2.1673.0</td>
-            <td>6.2.0</td>
-        </tr>
-        <tr>
-            <td>`bluebird`</td>
-            <td>2.0.0</td>
-            <td>3.7.2</td>
-            <td>1.27.0</td>
-        </tr>
-        <tr>
-            <td>`bunyan`</td>
-            <td>1.8.12</td>
-            <td>1.8.15</td>
-            <td>9.3.0</td>
-        </tr>
-        <tr>
-            <td>`cassandra-driver`</td>
-            <td>3.4.0</td>
-            <td>4.7.2</td>
-            <td>1.7.1</td>
-        </tr>
-        <tr>
-            <td>`connect`</td>
-            <td>3.0.0</td>
-            <td>3.7.0</td>
-            <td>2.6.0</td>
-        </tr>
-        <tr>
-            <td>`express`</td>
-            <td>4.6.0</td>
-            <td>4.19.2</td>
-            <td>2.6.0</td>
-        </tr>
-        <tr>
-            <td>`fastify`</td>
-            <td>2.0.0</td>
-            <td>4.28.1</td>
-            <td>8.5.0</td>
-        </tr>
-        <tr>
-            <td>`generic-pool`</td>
-            <td>3.0.0</td>
-            <td>3.9.0</td>
-            <td>0.9.0</td>
-        </tr>
-        <tr>
-            <td>`ioredis`</td>
-            <td>4.0.0</td>
-            <td>5.4.1</td>
-            <td>1.26.2</td>
-        </tr>
-        <tr>
-            <td>`kafkajs`</td>
-            <td>2.0.0</td>
-            <td>2.2.4</td>
-            <td>11.19.0</td>
-        </tr>
-        <tr>
-            <td>`koa`</td>
-            <td>2.0.0</td>
-            <td>2.15.3</td>
-            <td>3.2.0</td>
-        </tr>
-        <tr>
-            <td>`koa-route`</td>
-            <td>3.0.0</td>
-            <td>4.0.1</td>
-            <td>3.2.0</td>
-        </tr>
-        <tr>
-            <td>`koa-router`</td>
-            <td>11.0.2</td>
-            <td>12.0.1</td>
-            <td>3.2.0</td>
-        </tr>
-        <tr>
-            <td>`memcached`</td>
-            <td>2.2.0</td>
-            <td>2.2.2</td>
-            <td>1.26.2</td>
-        </tr>
-        <tr>
-            <td>`mongodb`</td>
-            <td>4.1.4</td>
-            <td>6.8.0</td>
-            <td>1.32.0</td>
-        </tr>
-        <tr>
-            <td>`mysql`</td>
-            <td>2.2.0</td>
-            <td>2.18.1</td>
-            <td>1.32.0</td>
-        </tr>
-        <tr>
-            <td>`mysql2`</td>
-            <td>2.0.0</td>
-            <td>3.11.0</td>
-            <td>1.32.0</td>
-        </tr>
-        <tr>
-            <td>`next`</td>
-            <td>13.4.19</td>
-            <td>14.2.5</td>
-            <td>12.0.0</td>
-        </tr>
-        <tr>
-            <td>`openai`</td>
-            <td>4.0.0</td>
-            <td>4.55.4</td>
-            <td>11.13.0</td>
-        </tr>
-        <tr>
-            <td>`pg`</td>
-            <td>8.2.0</td>
-            <td>8.12.0</td>
-            <td>9.0.0</td>
-        </tr>
-        <tr>
-            <td>`pg-native`</td>
-            <td>2.0.0</td>
-            <td>3.1.0</td>
-            <td>9.0.0</td>
-        </tr>
-        <tr>
-            <td>`pino`</td>
-            <td>7.0.0</td>
-            <td>9.3.2</td>
-            <td>8.11.0</td>
-        </tr>
-        <tr>
-            <td>`q`</td>
-            <td>1.3.0</td>
-            <td>1.5.1</td>
-            <td>1.26.2</td>
-        </tr>
-        <tr>
-            <td>`redis`</td>
-            <td>3.1.0</td>
-            <td>4.7.0</td>
-            <td>1.31.0</td>
-        </tr>
-        <tr>
-            <td>`restify`</td>
-            <td>11.0.0</td>
-            <td>11.1.0</td>
-            <td>2.6.0</td>
-        </tr>
-        <tr>
-            <td>`superagent`</td>
-            <td>3.0.0</td>
-            <td>10.0.0</td>
-            <td>4.9.0</td>
-        </tr>
-        <tr>
-            <td>`undici`</td>
-            <td>5.0.0</td>
-            <td>6.19.7</td>
-            <td>11.1.0</td>
-        </tr>
-        <tr>
-            <td>`when`</td>
-            <td>3.7.0</td>
-            <td>3.7.8</td>
-            <td>1.26.2</td>
-        </tr>
-        <tr>
-            <td>`winston`</td>
-            <td>3.0.0</td>
-            <td>3.14.1</td>
-            <td>8.11.0</td>
-        </tr>
-    </tbody>
-</table>
+| Package name | Minimum supported version | Latest supported version | Introduced in* |
+| --- | --- | --- | --- |
+| `@apollo/gateway` | 2.3.0 | 2.9.3 | `@newrelic/apollo-server-plugin@1.0.0` |
+| `@apollo/server` | 4.0.0 | 4.11.3 | `@newrelic/apollo-server-plugin@2.1.0` |
+| `@aws-sdk/client-bedrock-runtime` | 3.474.0 | 3.723.0 | 11.13.0 |
+| `@aws-sdk/client-dynamodb` | 3.0.0 | 3.724.0 | 8.7.1 |
+| `@aws-sdk/client-sns` | 3.0.0 | 3.723.0 | 8.7.1 |
+| `@aws-sdk/client-sqs` | 3.0.0 | 3.723.0 | 8.7.1 |
+| `@aws-sdk/lib-dynamodb` | 3.377.0 | 3.724.0 | 8.7.1 |
+| `@aws-sdk/smithy-client` | 3.47.0 | 3.374.0 | 8.7.1 |
+| `@elastic/elasticsearch` | 7.16.0 | 8.17.0 | 11.9.0 |
+| `@grpc/grpc-js` | 1.4.0 | 1.12.5 | 8.17.0 |
+| `@hapi/hapi` | 20.1.2 | 21.3.12 | 9.0.0 |
+| `@koa/router` | 11.0.2 | 13.1.0 | 3.2.0 |
+| `@langchain/core` | 0.1.17 | 0.3.27 | 11.13.0 |
+| `@nestjs/cli` | 9.0.0 | 10.4.9 | 10.1.0 |
+| `@opensearch-project/opensearch` | 2.1.0 | 3.0.0 | 12.10.0 |
+| `@prisma/client` | 5.0.0 | 6.2.1 | 11.0.0 |
+| `@smithy/smithy-client` | 2.0.0 | 4.1.0 | 11.0.0 |
+| `amqplib` | 0.5.0 | 0.10.5 | 2.0.0 |
+| `apollo-server` | 3.0.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
+| `apollo-server-express` | 3.0.0 | 3.13.0 | `@newrelic/apollo-server-plugin@1.0.0` |
+| `aws-sdk` | 2.2.48 | 2.1692.0 | 6.2.0 |
+| `bluebird` | 2.0.0 | 3.7.2 | 1.27.0 |
+| `bunyan` | 1.8.12 | 1.8.15 | 9.3.0 |
+| `cassandra-driver` | 3.4.0 | 4.7.2 | 1.7.1 |
+| `connect` | 3.0.0 | 3.7.0 | 2.6.0 |
+| `express` | 4.6.0 | 4.21.2 | 2.6.0 |
+| `fastify` | 2.0.0 | 5.2.1 | 8.5.0 |
+| `generic-pool` | 3.0.0 | 3.9.0 | 0.9.0 |
+| `ioredis` | 4.0.0 | 5.4.2 | 1.26.2 |
+| `kafkajs` | 2.0.0 | 2.2.4 | 11.19.0 |
+| `koa` | 2.0.0 | 2.15.3 | 3.2.0 |
+| `koa-route` | 3.0.0 | 4.0.1 | 3.2.0 |
+| `koa-router` | 11.0.2 | 13.0.1 | 3.2.0 |
+| `memcached` | 2.2.0 | 2.2.2 | 1.26.2 |
+| `mongodb` | 4.1.4 | 6.12.0 | 1.32.0 |
+| `mysql` | 2.2.0 | 2.18.1 | 1.32.0 |
+| `mysql2` | 2.0.0 | 3.12.0 | 1.32.0 |
+| `next` | 13.4.19 | 15.1.4 | 12.0.0 |
+| `openai` | 4.0.0 | 4.77.4 | 11.13.0 |
+| `pg` | 8.2.0 | 8.13.1 | 9.0.0 |
+| `pg-native` | 3.0.0 | 3.2.0 | 9.0.0 |
+| `pino` | 7.0.0 | 9.6.0 | 8.11.0 |
+| `q` | 1.3.0 | 1.5.1 | 1.26.2 |
+| `redis` | 3.1.0 | 4.7.0 | 1.31.0 |
+| `restify` | 11.0.0 | 11.1.0 | 2.6.0 |
+| `superagent` | 3.0.0 | 10.1.1 | 4.9.0 |
+| `undici` | 5.0.0 | 7.2.1 | 11.1.0 |
+| `when` | 3.7.0 | 3.7.8 | 1.26.2 |
+| `winston` | 3.0.0 | 3.17.0 | 8.11.0 |
 
 *When package is not specified, support is within the `newrelic` package.
 
@@ -581,54 +333,14 @@ The Node.js agent supports the following AI platforms and integrations.
 
 Through the `@aws-sdk/client-bedrock-runtime` module, we support:
 
-<table>
-    <thead>
-        <tr>
-            <th>Model</th>
-            <th>Image</th>
-            <th>Text</th>
-            <th>Vision</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>AI21 Labs Jurassic-2</td>
-            <td>❌</td>
-            <td>✅</td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>Amazon Titan</td>
-            <td>❌</td>
-            <td>✅</td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>Anthropic Claude</td>
-            <td>❌</td>
-            <td>✅</td>
-            <td>❌</td>
-        </tr>
-        <tr>
-            <td>Cohere</td>
-            <td>❌</td>
-            <td>✅</td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>Meta Llama2</td>
-            <td>❌</td>
-            <td>✅</td>
-            <td>-</td>
-        </tr>
-        <tr>
-            <td>Meta Llama3</td>
-            <td>❌</td>
-            <td>✅</td>
-            <td>-</td>
-        </tr>
-    </tbody>
-</table>
+| Model | Image | Text | Vision |
+| --- | --- | --- | --- |
+| AI21 Labs Jurassic-2 | ❌ | ✅ | - |
+| Amazon Titan | ❌ | ✅ | - |
+| Anthropic Claude | ❌ | ✅ | ❌ |
+| Cohere | ❌ | ✅ | - |
+| Meta Llama2 | ❌ | ✅ | - |
+| Meta Llama3 | ❌ | ✅ | - |
 
 Note: if a model supports streaming, we also instrument the streaming variant.
 
@@ -637,82 +349,26 @@ Note: if a model supports streaming, we also instrument the streaming variant.
 
 The following general features of Langchain are supported:
 
-<table>
-    <thead>
-        <tr>
-            <th>Agents</th>
-            <th>Chains</th>
-            <th>Tools</th>
-            <th>Vectorstores</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>✅</td>
-            <td>✅</td>
-            <td>✅</td>
-            <td>✅</td>
-        </tr>
-    </tbody>
-</table>
+| Agents | Chains | Tools | Vectorstores |
+| --- | --- | --- | --- |
+| ✅ | ✅ | ✅ | ✅ |
 
 Models/providers are generally supported transitively by our instrumentation of the provider's module.
 
-<table>
-    <thead>
-        <tr>
-            <th>Provider</th>
-            <th>Supported</th>
-            <th>Transitively</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Azure OpenAI</td>
-            <td>❌</td>
-            <td>❌</td>
-        </tr>
-        <tr>
-            <td>Amazon Bedrock</td>
-            <td>❌</td>
-            <td>❌</td>
-        </tr>
-        <tr>
-            <td>OpenAI</td>
-            <td>✅</td>
-            <td>✅</td>
-        </tr>
-    </tbody>
-</table>
+| Provider | Supported | Transitively |
+| --- | --- | --- |
+| Azure OpenAI | ❌ | ❌ |
+| Amazon Bedrock | ❌ | ❌ |
+| OpenAI | ✅ | ✅ |
 
 
 ### OpenAI
 
 Through the `openai` module, we support:
 
-<table>
-    <thead>
-        <tr>
-            <th>Audio</th>
-            <th>Chat</th>
-            <th>Completions</th>
-            <th>Embeddings</th>
-            <th>Files</th>
-            <th>Images</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>❌</td>
-            <td>✅</td>
-            <td>✅</td>
-            <td>✅</td>
-            <td>❌</td>
-            <td>❌</td>
-        </tr>
-    </tbody>
-</table>
-
+| Audio | Chat | Completions | Embeddings | Files | Images |
+| --- | --- | --- | --- | --- | --- |
+| ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
 
 {/* end: compat-table */}
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

This restores the markdown based tables in compatibility report.  Our agent automates updating this as our deps that we certify change.  This has been around for almost a year and cannot be changed, [PR that introduced this](https://github.com/newrelic/docs-website/pull/17321/files).  It looks like this [commit](https://github.com/newrelic/docs-website/commit/f8c8f6f3ea3d6df89422ae28400aa8fca2aeeb1a) broke it. Back in august we had to fix this [here](https://github.com/newrelic/docs-website/pull/18401). Please put into your process docs that this cannot be changed.

This PR restores the begin/end markers and seeds it with our latest information. Here's an example [PR](https://github.com/newrelic/docs-website/pull/19624) that you will see in the future as we updated this from our releases