### PR TITLE
chore: Aded another comment explaining not to change the formatting nor contents of the markdown on the Node.js compatiblity page

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -259,7 +259,7 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
   </Collapser>
 </CollapserGroup>
 
-{/* The content between begin: compat-table and end: compat-table are automatically updated by the Node.js agent team bot. Do not change the contents nor the formatting of the data between the comments.*/}
+{/* The content between begin: compat-table and end: compat-table is automatically updated by the Node.js agent team bot. Don't change the contents and don't change the formatting of the data between the comments.*/}
 {/* begin: compat-table */}
 ## Instrumented modules
 

--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -259,6 +259,7 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
   </Collapser>
 </CollapserGroup>
 
+{/* The content between begin: compat-table and end: compat-table are automatically updated by the Node.js agent team bot. Do not change the contents nor the formatting of the data between the comments.*/}
 {/* begin: compat-table */}
 ## Instrumented modules
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

This is a followup to #19711 to add another comment explaining not to change the formatting nor contents of the data between the begin/end compat-table comments.

