### PR TITLE
docs(dotnet): Add documentation for the `<cloud>` configuration element.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3702,7 +3702,7 @@ This can also be configured via environment variable:
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
 ```
 
-### Cloud configuration [#cloud]
+### Cloud provider metadata [#cloud]
 
 The `cloud` element is a child of the `configuration` element. Use `cloud` to configure cloud provider metadata for your application.
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3733,8 +3733,6 @@ The `cloud` element supports the following sub-elements:
   </Collapser>
 </CollapserGroup>
 
-
-
 ### AI monitoring [#ai_monitoring]
 
 By default, AI monitoring is disabled. To enable AI monitoring, set the `enabled` attribute to `true` in the `aiMonitoring` element. The `aiMonitoring` element is a child of the `configuration` element.

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -274,6 +274,7 @@ NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=true
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
 NEW_RELIC_AI_MONITORING_ENABLED=true
 NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=true
+NEW_RELIC_CLOUD_AWS_ACCOUNT_ID=123456789012
 ```
 
 <CollapserGroup>
@@ -2030,6 +2031,7 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Capture HTTP Request Headers](#capture_http_request_headers)
 * [Application logging](#application_logging)
 * [Code level metrics](#code_level_metrics)
+* [Cloud provider metadata](#cloud)
 * [AI monitoring](#ai_monitoring)
 
 ### App pools [#include_exclude_apps]
@@ -3699,6 +3701,39 @@ This can also be configured via environment variable:
 ```ini
 NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
 ```
+
+### Cloud configuration [#cloud]
+
+The `cloud` element is a child of the `configuration` element. Use `cloud` to configure cloud provider metadata for your application.
+
+The `cloud` element supports the following sub-elements:
+
+<CollapserGroup>
+  <Collapser
+    id="cloud-aws"
+    title="aws"
+  >
+    Use this sub-element to configure AWS account ID for your application. 
+    
+    <Callout variant="important">
+      Note that this configuration is not normally required, as the agent will automatically detect the AWS account ID at runtime. If automatic detetction is not working, the agent will fall back to the value configured here.
+    </Callout>
+
+    ```xml
+    <cloud>
+      <aws accountId="123456789012" />
+    </cloud>
+    ```
+
+    This can also be configured via environment variable:
+
+    ```ini
+    NEW_RELIC_CLOUD_AWS_ACCOUNT_ID=123456789012
+    ```
+  </Collapser>
+</CollapserGroup>
+
+
 
 ### AI monitoring [#ai_monitoring]
 


### PR DESCRIPTION
Updates the .NET agent configuration documentation to include the `<cloud>` element.