### PR TITLE
[NR-353267] Fix Action name and indentation

### DIFF
--- a/src/content/docs/logs/ui-data/parsing.mdx
+++ b/src/content/docs/logs/ui-data/parsing.mdx
@@ -544,7 +544,7 @@ Note that variable names must be explicitly set and be lowercase like `%{URI:uri
   >
     The New Relic logs pipeline parses your log messages by default, but sometimes you have log messages that are formatted as key-value pairs. In this situation, you may want to be able to parse them and then be able to filter using the key-value attributes.
 
-    If that is the case, you can use the `key value pairs` [grok type](#grok-syntax), which will parse the key-value pairs captured by the grok pattern. This format relies on 3 main parts: the grok syntax, the prefix you would like to assign to the parsed key-value attributes, and the `key value pairs` [grok type](#grok-syntax). Using the `key value pairs` [grok type](#grok-syntax), you can extract and parse key-value pairs from logs that are not properly formatted; for example, if your logs are prefixed with a date/time string:
+    If that is the case, you can use the `keyvalue` [grok type](#grok-syntax), which will parse the key-value pairs captured by the grok pattern. This format relies on 3 main parts: the grok syntax, the prefix you would like to assign to the parsed key-value attributes, and the `keyvalue` [grok type](#grok-syntax). Using the `keyvalue` [grok type](#grok-syntax), you can extract and parse key-value pairs from logs that are not properly formatted; for example, if your logs are prefixed with a date/time string:
 
     ```json
       2015-05-13T23:39:43.945958Z key1=value1,key2=value2,key3=value3
@@ -623,9 +623,9 @@ Note that variable names must be explicitly set and be lowercase like `%{URI:uri
      You can customize the parsing behavior with the following options to suit your log formats:
 
     * **delimiter**
-     * **Description:** String separating each key-value pair.
-     * **Default Value:** `,` (comma)
-     * **Override:** Set the field `delimiter` to change this behavior.
+      * **Description:** String separating each key-value pair.
+      * **Default Value:** `,` (comma)
+      * **Override:** Set the field `delimiter` to change this behavior.
 
     * **keyValueSeparator**
       * **Description:** String used to assign values to keys.


### PR DESCRIPTION
This PR fixes the grok action name along with the indentation which was incorrect for one of the config parameter.
