### PR TITLE
docs(dotnet): Update log configuration documentations to reflect behavior in the latest agent version.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1056,7 +1056,7 @@ The `proxy` element supports the following attributes:
 
 ### Log element [#log]
 
-The `log` element is a child of the `configuration` element. The `log` element configures New Relic's logging . The agent generates its own log file to keep its logging information separate from your application's logs.
+The `log` element is a child of the `configuration` element. The `log` element configures New Relic's logging. The agent generates its own log file to keep its logging information separate from your application's logs.
 
 ```xml
 <log enabled="true"
@@ -1070,6 +1070,37 @@ The `log` element is a child of the `configuration` element. The `log` element c
 The `log` element supports the following attributes:
 
 <CollapserGroup>
+  <Collapser
+    id="log-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `false`, all logging is disabled. Alternatively, set the `NEW_RELIC_LOG_ENABLED` environment variable in the application's environment.
+  </Collapser>
+
   <Collapser
     id="log-level"
     title="level"
@@ -1143,7 +1174,7 @@ The `log` element supports the following attributes:
       </tbody>
     </table>
 
-    Records all data sent to and received from New Relic in both an auditlog log file and the standard log file.
+    Records all data sent to and received from New Relic in both an auditlog log file and the standard log file. Ignored if `enabled` is set to `false` or `console` is set to `true`.
   </Collapser>
 
   <Collapser
@@ -1174,38 +1205,9 @@ The `log` element supports the following attributes:
       </tbody>
     </table>
 
-    Send log messages to the console, in addition to the log file. Alternatively, set the `NEW_RELIC_LOG_CONSOLE` environment variable in the application's environment.
-  </Collapser>
+    Send log messages to the console instead of the log file (in agent versions prior to 10.35.0, logs are sent to both the console and the log file). Ignored if `enabled` is set to `false`. Alternatively, set the `NEW_RELIC_LOG_CONSOLE` environment variable in the application's environment.
 
-  <Collapser
-    id="log-enabled"
-    title="enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    If disabled, no logging is attempted. Intended for read-only file systems. Alternatively, set the `NEW_RELIC_LOG_ENABLED` environment variable in the application's environment.
+    Console logging in the profiler is limited to `info` level and higher due to performance considerations. 
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Updates documentation for the `<log>` configuration element to reflect .NET agent behavior as of version 10.35.0. 