### PR TITLE
Fix convention for environment variables

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/opentelemetry/lambda-opentelemetry-dotnet.mdx
@@ -118,9 +118,9 @@ This guide assumes you have the following:
 
     exporters:
       otlp:
-        endpoint: ${NEW_RELIC_OPENTELEMETRY_ENDPOINT}
+        endpoint: ${env:NEW_RELIC_OPENTELEMETRY_ENDPOINT}
         headers:
-          api-key: ${NEW_RELIC_LICENSE_KEY}
+          api-key: ${env:NEW_RELIC_LICENSE_KEY}
 
     service:
       pipelines:


### PR DESCRIPTION
Currently used specification of environment variables to use in the yaml file is not correct. See https://opentelemetry.io/docs/collector/configuration/#environment-variables for details
