### PR TITLE
Python Agent: Update supported Python versions and links

### DIFF
--- a/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/getting-started/compatibility-requirements-python-agent.mdx
@@ -51,7 +51,7 @@ If you don't have one already, [create a New Relic account](https://newrelic.com
       </td>
 
       <td>
-        Python (CPython/PyPy) versions supported: 3.7, 3.8, 3.9, 3.10, 3.11, and 3.12.
+        Python (CPython/PyPy) versions supported: 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, and 3.13.
 
         Recommendation: Use Python version 3.7 or higher with our agent.
 
@@ -178,15 +178,15 @@ The following are proposed time ranges. The actual release date may vary.
   <tbody>
     <tr>
       <td>
-        3.12
+        3.14
       </td>
 
       <td>
-        October 2023
+        October 2025
       </td>
 
       <td>
-        November 2023
+        November 2025
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -24,7 +24,7 @@ Used to instrument calls to datastores.
 
 ## Description
 
-`datastore_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `datastore_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `DatastoreTraceWrapper` that can be used as a decorator for a function to time calls to your datastore.
+`datastore_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `datastore_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` returns a [partial](https://docs.python.org/3.12/library/functools.html#functools.partial) of `DatastoreTraceWrapper` that can be used as a decorator for a function to time calls to your datastore.
 
 The `datastore_trace` decorator can be used on generators and coroutines with agent version 2.102.0.85 or higher. Timing of these objects begins when consumption starts, and ends when the object is exhausted or goes out of scope. This is a change from earlier versions where the metric represented the time taken to create the generator or coroutine object itself.
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -23,7 +23,7 @@ Report calls to external services as transaction trace segments.
 
 ## Description
 
-`external_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `external_trace` will appear on the externals tab in APM. `external_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `ExternalTraceWrapper` that can be used as a decorator for a function that calls an external service.
+`external_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `external_trace` will appear on the externals tab in APM. `external_trace` returns a [partial](https://docs.python.org/3.12/library/functools.html#functools.partial) of `ExternalTraceWrapper` that can be used as a decorator for a function that calls an external service.
 
 The `external_trace` decorator can be used on generators and coroutines with agent version 2.102.0.85 or higher. Timing of these objects begins when consumption starts, and ends when the object is exhausted or goes out of scope. This is a change from earlier versions where the metric represented the time taken to create the generator or coroutine object itself.
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
@@ -101,7 +101,7 @@ If you call `initialize` with no arguments, you must have already specified your
       </td>
 
       <td>
-        Optional. Sets the logging level. The agent uses [Python's logging module](https://docs.python.org/3.7/library/logging.html#logging-levels). Options are the same as for the [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) option in config file.
+        Optional. Sets the logging level. The agent uses [Python's logging module](https://docs.python.org/3.12/library/logging.html#logging-levels). Options are the same as for the [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) option in config file.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -31,7 +31,7 @@ Agent version 2.88.0.72 or higher.
 
 ## Description
 
-[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (and its associated calls) report message functions as [transactions](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. `message_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `MessageTraceWrapper` that can be used as a decorator for a message function.
+[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (and its associated calls) report message functions as [transactions](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. `message_trace` returns a [partial](https://docs.python.org/3.12/library/functools.html#functools.partial) of `MessageTraceWrapper` that can be used as a decorator for a message function.
 
 The `message_trace` decorator can be used on generators and coroutines with agent version 2.102.0.85 or higher. Timing of these objects begins when consumption starts, and ends when the object is exhausted or goes out of scope. This is a change from earlier versions where the metric represented the time taken to create the generator or coroutine object itself.
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -31,7 +31,7 @@ Agent version 2.88.0.72 or higher.
 
 ## Description
 
-This decorator returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `MessageTransactionWrapper` that can be used as a decorator for a messaging function. When used, the returned decorator records a message transaction and its message-related [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute).
+This decorator returns a [partial](https://docs.python.org/3.12/library/functools.html#functools.partial) of `MessageTransactionWrapper` that can be used as a decorator for a messaging function. When used, the returned decorator records a message transaction and its message-related [attributes](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute).
 
 If the decorator will not work in your application, you can use one of the following:
 

--- a/src/content/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/content/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -24,7 +24,7 @@ Adds additional attributes to function trace names.
 
 ## Description
 
-`profile_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `profile_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` returns a [partial](https://docs.python.org/3.7/library/functools.html#functools.partial) of `ProfileTraceWrapper` that can be used as a decorator for a function to time calls to your profiler.
+`profile_trace` is used to add more detail to your [transaction traces](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) in the form of additional segments. Any calls reported with `profile_trace` will appear on the [APM Databases page](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` returns a [partial](https://docs.python.org/3.12/library/functools.html#functools.partial) of `ProfileTraceWrapper` that can be used as a decorator for a function to time calls to your profiler.
 
 If you cannot use the decorator in your application, you can use the following call format: The wrapper form is `ProfileTraceWrapper`. It can be used to return a wrapped function without the use of a decorator.
 

--- a/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ Se utiliza para instrumentar llamadas a almacenes de datos.
 
 ## Descripción
 
-`datastore_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. Cualquier llamada reportada con `datastore_trace` aparecerá en la [página de base de datos de APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` devuelve una [parte](https://docs.python.org/3.7/library/functools.html#functools.partial) de `DatastoreTraceWrapper` que se puede usar como decorador para que una función programe llamadas a su almacenamiento de datos.
+`datastore_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. Cualquier llamada reportada con `datastore_trace` aparecerá en la [página de base de datos de APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` devuelve una [parte](https://docs.python.org/3.12/library/functools.html#functools.partial) de `DatastoreTraceWrapper` que se puede usar como decorador para que una función programe llamadas a su almacenamiento de datos.
 
 El decorador `datastore_trace` se puede utilizar en generadores y corrutinas con la versión del agente 2.102.0.85 o superior. El tiempo de estos objetos comienza cuando comienza el consumo y finaliza cuando el objeto se agota o sale del alcance. Este es un cambio con respecto a versiones anteriores donde la métrica representaba el tiempo necesario para crear el generador o el objeto de rutina.
 

--- a/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ Reportar llamadas a servicios externos como segmentos de traza de la transacció
 
 ## Descripción
 
-`external_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. Cualquier llamada reportada con `external_trace` aparecerá en la pestaña externos en APM. `external_trace` devuelve una [parte](https://docs.python.org/3.7/library/functools.html#functools.partial) de `ExternalTraceWrapper` que se puede usar como decorador para una función que llama a un servicio externo.
+`external_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. Cualquier llamada reportada con `external_trace` aparecerá en la pestaña externos en APM. `external_trace` devuelve una [parte](https://docs.python.org/3.12/library/functools.html#functools.partial) de `ExternalTraceWrapper` que se puede usar como decorador para una función que llama a un servicio externo.
 
 El decorador `external_trace` se puede utilizar en generadores y corrutinas con la versión del agente 2.102.0.85 o superior. El tiempo de estos objetos comienza cuando comienza el consumo y finaliza cuando el objeto se agota o sale del alcance. Este es un cambio con respecto a versiones anteriores donde la métrica representaba el tiempo necesario para crear el generador o el objeto de rutina.
 

--- a/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -25,7 +25,7 @@ Versión del agente 2.88.0.72 o superior.
 
 ## Descripción
 
-El mensaje de informe [`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (y sus llamadas asociadas) funciona como [transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. `message_trace` devuelve una [parte](https://docs.python.org/3.7/library/functools.html#functools.partial) de `MessageTraceWrapper` que puede usarse como decorador para una función de mensaje.
+El mensaje de informe [`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (y sus llamadas asociadas) funciona como [transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. `message_trace` devuelve una [parte](https://docs.python.org/3.12/library/functools.html#functools.partial) de `MessageTraceWrapper` que puede usarse como decorador para una función de mensaje.
 
 El decorador `message_trace` se puede utilizar en generadores y corrutinas con la versión del agente 2.102.0.85 o superior. El tiempo de estos objetos comienza cuando comienza el consumo y finaliza cuando el objeto se agota o sale del alcance. Este es un cambio con respecto a versiones anteriores donde la métrica representaba el tiempo necesario para crear el generador o el objeto de rutina.
 

--- a/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -25,7 +25,7 @@ Versión del agente 2.88.0.72 o superior.
 
 ## Descripción
 
-Este decorador devuelve una [parte](https://docs.python.org/3.7/library/functools.html#functools.partial) de `MessageTransactionWrapper` que puede usarse como decorador para una función de mensajería. Cuando se usa, el decorador devuelto registra una transacción de mensaje y su [atributo](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) relacionado con el mensaje.
+Este decorador devuelve una [parte](https://docs.python.org/3.12/library/functools.html#functools.partial) de `MessageTransactionWrapper` que puede usarse como decorador para una función de mensajería. Cuando se usa, el decorador devuelto registra una transacción de mensaje y su [atributo](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) relacionado con el mensaje.
 
 Si el decorador no funciona en su aplicación, puede utilizar uno de los siguientes:
 

--- a/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/i18n/content/es/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ Agrega un atributo adicional a la función de nombres de trazas.
 
 ## Descripción
 
-`profile_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. Cualquier llamada reportada con `profile_trace` aparecerá en la [página de base de datos de APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` devuelve una [parte](https://docs.python.org/3.7/library/functools.html#functools.partial) de `ProfileTraceWrapper` que se puede usar como decorador para que una función programe las llamadas a su generador de perfiles.
+`profile_trace` se utiliza para agregar más detalles a su [traza de la transacción](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) en forma de segmentos adicionales. Cualquier llamada reportada con `profile_trace` aparecerá en la [página de base de datos de APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` devuelve una [parte](https://docs.python.org/3.12/library/functools.html#functools.partial) de `ProfileTraceWrapper` que se puede usar como decorador para que una función programe las llamadas a su generador de perfiles.
 
 Si no puede utilizar el decorador en su aplicación, puede utilizar el siguiente formato de llamada: El formulario contenedor es `ProfileTraceWrapper`. Se puede utilizar para devolver una función envuelta sin el uso de un decorador.
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ newrelic.agent.datastore_trace(product, target, operation)
 
 ## 説明
 
-`datastore_trace` 追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`datastore_trace`で報告された呼び出しは、 [APM データベース ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page)に表示されます。`datastore_trace`は`DatastoreTraceWrapper`の[部分](https://docs.python.org/3.7/library/functools.html#functools.partial)を返します。これは、データストアへの呼び出しのタイミングをとる関数のデコレーターとして使用できます。
+`datastore_trace` 追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`datastore_trace`で報告された呼び出しは、 [APM データベース ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page)に表示されます。`datastore_trace`は`DatastoreTraceWrapper`の[部分](https://docs.python.org/3.12/library/functools.html#functools.partial)を返します。これは、データストアへの呼び出しのタイミングをとる関数のデコレーターとして使用できます。
 
 `datastore_trace`デコレーターは、エージェント バージョン 2.102.0.85 以降のジェネレーターとコルーチンで使用できます。これらのオブジェクトのタイミングは、消費が開始されたときに始まり、オブジェクトが使い果たされるか範囲外になると終了します。これは、メトリックがジェネレータまたはコルーチン オブジェクト自体の作成にかかった時間を表す以前のバージョンからの変更です。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ newrelic.agent.external_trace(library, url, method=None)
 
 ## 説明
 
-`external_trace` 追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`external_trace`で報告された呼び出しは、APM の外部タブに表示されます。`external_trace`は、外部サービスを呼び出す関数のデコレータとして使用できる`ExternalTraceWrapper`の[部分](https://docs.python.org/3.7/library/functools.html#functools.partial)を返します。
+`external_trace` 追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`external_trace`で報告された呼び出しは、APM の外部タブに表示されます。`external_trace`は、外部サービスを呼び出す関数のデコレータとして使用できる`ExternalTraceWrapper`の[部分](https://docs.python.org/3.12/library/functools.html#functools.partial)を返します。
 
 `external_trace`デコレーターは、エージェント バージョン 2.102.0.85 以降のジェネレーターとコルーチンで使用できます。これらのオブジェクトのタイミングは、消費が開始されたときに始まり、オブジェクトが使い果たされるか範囲外になると終了します。これは、メトリックがジェネレータまたはコルーチン オブジェクト自体の作成にかかった時間を表す以前のバージョンからの変更です。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
@@ -99,7 +99,7 @@ newrelic.agent.initialize(config_file=None, environment=None, ignore_errors=None
       </td>
 
       <td>
-        オプション。 ログレベルを設定します。 エージェントは[Python のログ モジュール](https://docs.python.org/3.7/library/logging.html#logging-levels)を使用します。 オプションは、構成ファイルの[`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level)オプションと同じです。
+        オプション。 ログレベルを設定します。 エージェントは[Python のログ モジュール](https://docs.python.org/3.12/library/logging.html#logging-levels)を使用します。 オプションは、構成ファイルの[`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level)オプションと同じです。
       </td>
     </tr>
   </tbody>

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -25,7 +25,7 @@ newrelic.agent.message_trace(library, operation, destination_type, destination_n
 
 ## 説明
 
-[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (およびそれに関連付けられた呼び出し) は、メッセージ関数を[トランザクション](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction)として報告します。`message_trace`は、追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`message_trace`は、メッセージ関数のデコレータとして使用できる`MessageTraceWrapper`の[部分](https://docs.python.org/3.7/library/functools.html#functools.partial)を返します。
+[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (およびそれに関連付けられた呼び出し) は、メッセージ関数を[トランザクション](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction)として報告します。`message_trace`は、追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`message_trace`は、メッセージ関数のデコレータとして使用できる`MessageTraceWrapper`の[部分](https://docs.python.org/3.12/library/functools.html#functools.partial)を返します。
 
 `message_trace`デコレーターは、エージェント バージョン 2.102.0.85 以降のジェネレーターとコルーチンで使用できます。これらのオブジェクトのタイミングは、消費が開始されたときに始まり、オブジェクトが使い果たされるか範囲外になると終了します。これは、メトリックがジェネレータまたはコルーチン オブジェクト自体の作成にかかった時間を表す以前のバージョンからの変更です。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -25,7 +25,7 @@ newrelic.agent.message_transaction(library, destination_type, destination_name, 
 
 ## 説明
 
-このデコレータは、メッセージング関数のデコレータとして使用できる`MessageTransactionWrapper`の[部分](https://docs.python.org/3.7/library/functools.html#functools.partial)を返します。使用すると、返されたデコレータはメッセージ トランザクションとそのメッセージ関連の[属性](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute)を記録します。
+このデコレータは、メッセージング関数のデコレータとして使用できる`MessageTransactionWrapper`の[部分](https://docs.python.org/3.12/library/functools.html#functools.partial)を返します。使用すると、返されたデコレータはメッセージ トランザクションとそのメッセージ関連の[属性](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute)を記録します。
 
 デコレーターがアプリケーションで動作しない場合は、以下のいずれかを使用することができます。
 

--- a/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/i18n/content/jp/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ newrelic.agent.profile_trace(name=None, group=None, label=None, params=None, dep
 
 ## 説明
 
-`profile_trace` 追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`profile_trace`で報告された呼び出しは、 [APM データベース ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page)に表示されます。`profile_trace`は`ProfileTraceWrapper`の[部分](https://docs.python.org/3.7/library/functools.html#functools.partial)を返します。これは、プロファイラーへの呼び出しのタイミングをとる関数のデコレータとして使用できます。
+`profile_trace` 追加セグメントの形式で[トランザクション追跡](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace)に詳細を追加するために使用されます。`profile_trace`で報告された呼び出しは、 [APM データベース ページ](/docs/apm/applications-menu/monitoring/databases-slow-queries-page)に表示されます。`profile_trace`は`ProfileTraceWrapper`の[部分](https://docs.python.org/3.12/library/functools.html#functools.partial)を返します。これは、プロファイラーへの呼び出しのタイミングをとる関数のデコレータとして使用できます。
 
 アプリケーションでデコレータを使用できない場合は、次の呼び出し形式を使用できます: ラッパー フォームは`ProfileTraceWrapper`です。デコレータを使用せずにラップされた関数を返すために使用できます。
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ newrelic.agent.datastore_trace(product, target, operation)
 
 ## 설명
 
-`datastore_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `datastore_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `datastore_trace` 은 데이터 저장소에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `DatastoreTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
+`datastore_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `datastore_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `datastore_trace` 은 데이터 저장소에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `DatastoreTraceWrapper` 의 [일부](https://docs.python.org/3.12/library/functools.html#functools.partial) 를 반환합니다.
 
 `datastore_trace` 데코레이터는 에이전트 버전이 2.102.0.85 이상인 생성기 및 코루틴에서 사용할 수 있습니다. 이러한 개체의 타이밍은 소비가 시작될 때 시작되고 개체가 소진되거나 범위를 벗어날 때 끝납니다. 이는 메트릭이 생성기 또는 코루틴 개체 자체를 생성하는 데 걸린 시간을 나타내는 이전 버전에서 변경된 사항입니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ newrelic.agent.external_trace(library, url, method=None)
 
 ## 설명
 
-`external_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `external_trace` 으로 보고된 모든 통화는 APM의 외부 탭에 표시됩니다. `external_trace` 은 외부 서비스를 호출하는 함수의 데코레이터로 사용할 수 있는 `ExternalTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
+`external_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `external_trace` 으로 보고된 모든 통화는 APM의 외부 탭에 표시됩니다. `external_trace` 은 외부 서비스를 호출하는 함수의 데코레이터로 사용할 수 있는 `ExternalTraceWrapper` 의 [일부](https://docs.python.org/3.12/library/functools.html#functools.partial) 를 반환합니다.
 
 `external_trace` 데코레이터는 에이전트 버전이 2.102.0.85 이상인 생성기 및 코루틴에서 사용할 수 있습니다. 이러한 개체의 타이밍은 소비가 시작될 때 시작되고 개체가 소진되거나 범위를 벗어날 때 끝납니다. 이는 메트릭이 생성기 또는 코루틴 개체 자체를 생성하는 데 걸린 시간을 나타내는 이전 버전에서 변경된 사항입니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
@@ -99,7 +99,7 @@ newrelic.agent.initialize(config_file=None, environment=None, ignore_errors=None
       </td>
 
       <td>
-        선택 과목. 로깅 수준을 설정합니다. 에이전트는 [Python의 로깅 모듈을](https://docs.python.org/3.7/library/logging.html#logging-levels) 사용합니다. 옵션은 구성 파일의 [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) 옵션과 동일합니다.
+        선택 과목. 로깅 수준을 설정합니다. 에이전트는 [Python의 로깅 모듈을](https://docs.python.org/3.12/library/logging.html#logging-levels) 사용합니다. 옵션은 구성 파일의 [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) 옵션과 동일합니다.
       </td>
     </tr>
   </tbody>

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -25,7 +25,7 @@ newrelic.agent.message_trace(library, operation, destination_type, destination_n
 
 ## 설명
 
-[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (및 관련 호출)은 메시지 기능을 [트랜잭션](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction) 으로 보고합니다. `message_trace` 은 추가 세그먼트 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부정보를 추가하는 데 사용됩니다. `message_trace` 는 메시지 함수의 데코레이터로 사용할 수 있는 `MessageTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
+[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (및 관련 호출)은 메시지 기능을 [트랜잭션](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction) 으로 보고합니다. `message_trace` 은 추가 세그먼트 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부정보를 추가하는 데 사용됩니다. `message_trace` 는 메시지 함수의 데코레이터로 사용할 수 있는 `MessageTraceWrapper` 의 [일부](https://docs.python.org/3.12/library/functools.html#functools.partial) 를 반환합니다.
 
 `message_trace` 데코레이터는 에이전트 버전이 2.102.0.85 이상인 생성기 및 코루틴에서 사용할 수 있습니다. 이러한 개체의 타이밍은 소비가 시작될 때 시작되고 개체가 소진되거나 범위를 벗어날 때 끝납니다. 이는 메트릭이 생성기 또는 코루틴 개체 자체를 생성하는 데 걸린 시간을 나타내는 이전 버전에서 변경된 사항입니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -25,7 +25,7 @@ newrelic.agent.message_transaction(library, destination_type, destination_name, 
 
 ## 설명
 
-이 데코레이터는 메시징 기능의 데코레이터로 사용할 수 있는 `MessageTransactionWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다. 사용되는 경우 반환된 데코레이터는 메시지 트랜잭션 및 해당 메시지 관련 [속성](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) 을 기록합니다.
+이 데코레이터는 메시징 기능의 데코레이터로 사용할 수 있는 `MessageTransactionWrapper` 의 [일부](https://docs.python.org/3.12/library/functools.html#functools.partial) 를 반환합니다. 사용되는 경우 반환된 데코레이터는 메시지 트랜잭션 및 해당 메시지 관련 [속성](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) 을 기록합니다.
 
 데코레이터가 애플리케이션에서 작동하지 않으면 다음 중 하나를 사용할 수 있습니다.
 

--- a/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/i18n/content/kr/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ newrelic.agent.profile_trace(name=None, group=None, label=None, params=None, dep
 
 ## 설명
 
-`profile_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `profile_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `profile_trace` 은 프로파일러에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `ProfileTraceWrapper` 의 [일부](https://docs.python.org/3.7/library/functools.html#functools.partial) 를 반환합니다.
+`profile_trace` 추가 세그먼트의 형태로 [트랜잭션 추적](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) 에 세부 정보를 추가하는 데 사용됩니다. `profile_trace` 으로 보고된 모든 호출은 [APM 데이터베이스 페이지](/docs/apm/applications-menu/monitoring/databases-slow-queries-page) 에 나타납니다. `profile_trace` 은 프로파일러에 대한 호출 시간을 지정하는 함수의 데코레이터로 사용할 수 있는 `ProfileTraceWrapper` 의 [일부](https://docs.python.org/3.12/library/functools.html#functools.partial) 를 반환합니다.
 
 애플리케이션에서 데코레이터를 사용할 수 없는 경우 다음 호출 형식을 사용할 수 있습니다. 래퍼 형식은 `ProfileTraceWrapper` 입니다. 데코레이터를 사용하지 않고 래핑된 함수를 반환하는 데 사용할 수 있습니다.
 

--- a/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
+++ b/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/datastoretrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ Usado para chamadas de instrumentos para armazenamentos de dados.
 
 ## Descrição
 
-`datastore_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. Todas as chamadas relatadas com `datastore_trace` aparecerão na [página do banco de dados do APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` retorna uma [parcial](https://docs.python.org/3.7/library/functools.html#functools.partial) de `DatastoreTraceWrapper` que pode ser usada como decorador de uma função para cronometrar chamadas para seu armazenamento de dados.
+`datastore_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. Todas as chamadas relatadas com `datastore_trace` aparecerão na [página do banco de dados do APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `datastore_trace` retorna uma [parcial](https://docs.python.org/3.12/library/functools.html#functools.partial) de `DatastoreTraceWrapper` que pode ser usada como decorador de uma função para cronometrar chamadas para seu armazenamento de dados.
 
 O decorador `datastore_trace` pode ser usado em geradores e corrotinas com agente versão 2.102.0.85 ou superior. O tempo desses objetos começa quando o consumo começa e termina quando o objeto se esgota ou sai do escopo. Esta é uma mudança em relação às versões anteriores, onde a métrica representava o tempo necessário para criar o gerador ou o próprio objeto de corrotina.
 

--- a/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
+++ b/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/externaltrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ Reportar chamadas para serviços externos como segmentos de rastreamento da tran
 
 ## Descrição
 
-`external_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. Todas as chamadas relatadas com `external_trace` aparecerão na guia externas do APM. `external_trace` retorna uma [parcial](https://docs.python.org/3.7/library/functools.html#functools.partial) de `ExternalTraceWrapper` que pode ser usada como decorador para uma função que chama um serviço externo.
+`external_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. Todas as chamadas relatadas com `external_trace` aparecerão na guia externas do APM. `external_trace` retorna uma [parcial](https://docs.python.org/3.12/library/functools.html#functools.partial) de `ExternalTraceWrapper` que pode ser usada como decorador para uma função que chama um serviço externo.
 
 O decorador `external_trace` pode ser usado em geradores e corrotinas com agente versão 2.102.0.85 ou superior. O tempo desses objetos começa quando o consumo começa e termina quando o objeto se esgota ou sai do escopo. Esta é uma mudança em relação às versões anteriores, onde a métrica representava o tempo necessário para criar o gerador ou o próprio objeto de corrotina.
 

--- a/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
+++ b/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/initialize-python-agent-api.mdx
@@ -99,7 +99,7 @@ Se você chamar `initialize` sem argumentos, você já deverá ter especificado 
       </td>
 
       <td>
-        Opcional. Define o nível de logging. O agente usa [o módulo de registro do Python](https://docs.python.org/3.7/library/logging.html#logging-levels). As opções são as mesmas da opção [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) no arquivo de configuração.
+        Opcional. Define o nível de logging. O agente usa [o módulo de registro do Python](https://docs.python.org/3.12/library/logging.html#logging-levels). As opções são as mesmas da opção [`log_level`](/docs/agents/python-agent/installation-configuration/python-agent-configuration#log_level) no arquivo de configuração.
       </td>
     </tr>
   </tbody>

--- a/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
+++ b/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/messagetrace-python-agent-api.mdx
@@ -25,7 +25,7 @@ Versão do agente 2.88.0.72 ou superior.
 
 ## Descrição
 
-[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (e suas chamadas associadas) reportam funções de mensagem como [transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. `message_trace` retorna uma [parcial](https://docs.python.org/3.7/library/functools.html#functools.partial) de `MessageTraceWrapper` que pode ser usada como decorador para uma função de mensagem.
+[`message_transaction`](/docs/agents/python-agent/python-agent-api/message_transaction) (e suas chamadas associadas) reportam funções de mensagem como [transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction). `message_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. `message_trace` retorna uma [parcial](https://docs.python.org/3.12/library/functools.html#functools.partial) de `MessageTraceWrapper` que pode ser usada como decorador para uma função de mensagem.
 
 O decorador `message_trace` pode ser usado em geradores e corrotinas com agente versão 2.102.0.85 ou superior. O tempo desses objetos começa quando o consumo começa e termina quando o objeto se esgota ou sai do escopo. Esta é uma mudança em relação às versões anteriores, onde a métrica representava o tempo necessário para criar o gerador ou o próprio objeto de corrotina.
 

--- a/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
+++ b/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/messagetransaction-python-agent-api.mdx
@@ -25,7 +25,7 @@ Versão do agente 2.88.0.72 ou superior.
 
 ## Descrição
 
-Este decorador retorna uma [parcial](https://docs.python.org/3.7/library/functools.html#functools.partial) de `MessageTransactionWrapper` que pode ser usada como decorador para uma função de mensagens. Quando usado, o decorador retornado registra uma transação de mensagem e seu [atributo](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) relacionado à mensagem.
+Este decorador retorna uma [parcial](https://docs.python.org/3.12/library/functools.html#functools.partial) de `MessageTransactionWrapper` que pode ser usada como decorador para uma função de mensagens. Quando usado, o decorador retornado registra uma transação de mensagem e seu [atributo](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#attribute) relacionado à mensagem.
 
 Se o decorador não funcionar em seu aplicativo, você poderá usar um dos seguintes:
 

--- a/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
+++ b/src/i18n/content/pt/docs/apm/agents/python-agent/python-agent-api/profiletrace-python-agent-api.mdx
@@ -21,7 +21,7 @@ Adiciona atributos adicionais aos nomes trace de função.
 
 ## Descrição
 
-`profile_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. Todas as chamadas relatadas com `profile_trace` aparecerão na [página do banco de dados do APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` retorna uma [parcial](https://docs.python.org/3.7/library/functools.html#functools.partial) de `ProfileTraceWrapper` que pode ser usada como decorador de uma função para cronometrar chamadas para seu profiler.
+`profile_trace` é usado para adicionar mais detalhes ao seu [rastreamento de transação](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction-trace) na forma de segmentos adicionais. Todas as chamadas relatadas com `profile_trace` aparecerão na [página do banco de dados do APM](/docs/apm/applications-menu/monitoring/databases-slow-queries-page). `profile_trace` retorna uma [parcial](https://docs.python.org/3.12/library/functools.html#functools.partial) de `ProfileTraceWrapper` que pode ser usada como decorador de uma função para cronometrar chamadas para seu profiler.
 
 Se você não puder usar o decorador em seu aplicativo, poderá usar o seguinte formato de chamada: O formulário wrapper é `ProfileTraceWrapper`. Pode ser usado para retornar uma função encapsulada sem o uso de um decorador.
 


### PR DESCRIPTION
This PR updates the following: 

- the list of supported Python versions for the Python Agent
- the Python version that will be supported in the future (3.14) and the estimated dates for support
- links to official Python documentation to a more-up-to-date version of Python