### PR TITLE
Update NR public IP space in networks.mdx

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -521,9 +521,11 @@ The ports used for `otlp.nr-data.net` and `otlp.eu01.nr-data.net` are:
 
 We use these blocks for data ingestion:
 
-* US data center endpoints: `162.247.240.0/22`,`152.38.128.0/19`
-* EU data center endpoints: `185.221.84.0/22`,`212.32.0.0/20`
-* Other data center endpoints: `64.251.192.0/20`
+* `162.247.240.0/22`
+* `152.38.128.0/19`
+* `185.221.84.0/22`
+* `212.32.0.0/20`
+* `64.251.192.0/20`
 
 ## User-facing domains [#user-facing-domains]
 
@@ -779,16 +781,10 @@ Synthetic private minions report to a specific endpoint based on region. To allo
       </td>
 
       <td>
-        US data center region:
-
         * `162.247.240.0/22`
         * `152.38.128.0/19`
-
-          EU data center region:
         * `185.221.84.0/22`
         * `212.32.0.0/20`
-
-          Other data center region:
         * `64.251.192.0/20`
       </td>
     </tr>
@@ -799,24 +795,18 @@ Synthetic private minions report to a specific endpoint based on region. To allo
 
 Endpoints that use `api.newrelic.com` (such as our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph)) and our New Relic-generated [webhooks for alert policies](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-controlling-where-send-alerts#webhook) use an IP address from designated network blocks for the US or [EU region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center). [TLS is required](#tls) for all addresses in these blocks.
 
-Network blocks for US data center region:
+Network blocks:
 
 * `162.247.240.0/22`
 * `18.246.82.0/25` (effective August 20, 2023)
 * `3.145.244.128/25` (effective August 20, 2023)
 * `20.51.136.0/25` (effective June 20, 2024)
 * `152.38.128.0/19` (effective June 20, 2024)
-
-Network blocks for EU data center region:
-
 * `158.177.65.64/29`
 * `159.122.103.184/29`
 * `161.156.125.32/28`
 * `3.77.79.0/25` (effective August 20, 2023)
 * `212.32.0.0/20` (effective June 20, 2024)
-
-Network blocks for other data center region:
-
 * `3.27.118.128/25` (effective June 20, 2024)
 * `4.197.217.128/25` (effective June 20, 2024)
 * `64.251.192.0/20` (effective June 20, 2024)


### PR DESCRIPTION
Removing regional data center references because we no longer have data centers and can use this IP space in any cloud globally.  We also have globally available services vis CDN that are affected by the legacy, regional data center references.  This request is coming from the New Relic Network Engineering team, who is responsible for our public IP space.  Please DM me if there are questions.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.