### PR TITLE
How to check the log for the Linux packaged version of KTranslate

### DIFF
--- a/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-health.mdx
+++ b/src/content/docs/network-performance-monitoring/advanced/ktranslate-container-health.mdx
@@ -16,6 +16,9 @@ The KTranslate container image has the `-tee_logs=true` and `-metrics=jchf` sett
 <Callout variant="tip">
   If you want to check the logs locally from the Docker host, run `docker logs $CONTAINER_NAME`. For example, `docker logs ktranslate-snmp`.
 </Callout>
+<Callout variant="tip">
+  If you want to check the log locally from the Linux package, run `journalctl -u ktranslate`.
+</Callout>
 
 The `-tee_logs=true` option sends logs to New Relic when polling devices. To see them, do the following:
 


### PR DESCRIPTION
Added a way to check the Linux package logs locally.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.