### PR TITLE
Update attribute-dictionary.json to include the `trace.id` attribute in the `AjaxRequest` events

### DIFF
--- a/src/data/attribute-dictionary.json
+++ b/src/data/attribute-dictionary.json
@@ -494,6 +494,22 @@
         ],
         "name": "userAgentVersion",
         "units": null
+      },
+      {
+        "definition": "<p>The unique ID (a randomly generated string) used to identify a single request as it crosses inter- and intra- process boundaries. This ID allows the linking of spans in a distributed trace. Included when distributed tracing is enabled.</p>\n",
+        "events": [
+          "DistributedTraceSummary",
+          "MobileRequest",
+          "MobileRequestError",
+          "Span",
+          "Transaction",
+          "TransactionError",
+          "AjaxRequest"
+        ],
+        "name": "trace.id",
+        "units": {
+          "label": "ID"
+        }
       }
     ],
     "dataSources": [
@@ -3170,7 +3186,8 @@
           "MobileRequestError",
           "Span",
           "Transaction",
-          "TransactionError"
+          "TransactionError",
+          "AjaxRequest"
         ],
         "name": "trace.id",
         "units": {
@@ -9909,7 +9926,8 @@
           "MobileRequestError",
           "Span",
           "Transaction",
-          "TransactionError"
+          "TransactionError",
+          "AjaxRequest"
         ],
         "name": "trace.id",
         "units": {
@@ -10581,7 +10599,8 @@
           "MobileRequestError",
           "Span",
           "Transaction",
-          "TransactionError"
+          "TransactionError",
+          "AjaxRequest"
         ],
         "name": "trace.id",
         "units": {
@@ -16743,7 +16762,8 @@
           "MobileRequestError",
           "Span",
           "Transaction",
-          "TransactionError"
+          "TransactionError",
+          "AjaxRequest"
         ],
         "name": "trace.id",
         "units": {
@@ -19930,7 +19950,8 @@
           "MobileRequestError",
           "Span",
           "Transaction",
-          "TransactionError"
+          "TransactionError",
+          "AjaxRequest"
         ],
         "name": "trace.id",
         "units": {
@@ -20476,7 +20497,8 @@
           "MobileRequestError",
           "Span",
           "Transaction",
-          "TransactionError"
+          "TransactionError",
+          "AjaxRequest"
         ],
         "name": "trace.id",
         "units": {


### PR DESCRIPTION
The `trace.id` attribute has been added by the DEM Platform to `AjaxRequest` events, enhancing traceability and monitoring.

## Give us some context

* What problems does this PR solve?
A customer had a problem with this kind of events (`AjaxRequest`) and this new attribute will improve traceability.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
Internal PR: https://source.datanerd.us/browser/bam-consumer/pull/1960
Internal Jira ticket: [NR-360938](https://new-relic.atlassian.net/browse/NR-360938)

[NR-360938]: https://new-relic.atlassian.net/browse/NR-360938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ