### PR TITLE
chore: fix the broken link for inline popups

### DIFF
--- a/src/data/popovers_en.json
+++ b/src/data/popovers_en.json
@@ -115,7 +115,7 @@
       "header": "User key",
       "text": "Your user key allows you to make queries using Nerdgraph or our REST API for any accounts you have access to.",
       "learnMore": "Learn more",
-      "learnMoreUrl": "https://docs.newrelic.com/docs/apis/intro-apis/new-relic-keys/#user-key",
+      "learnMoreUrl": "https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#user-key",
       "primaryButton": "Open in New Relic",
       "primaryButtonUrl": "https://one.newrelic.com/api-keys"
     }


### PR DESCRIPTION
Fixing the broken link issue in the inline pop-up at https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/ for userKeys. We received this request in [this slack thread](https://newrelic.slack.com/archives/C0DSGL3FZ/p1738076995900659) on #help-documentation channel.