### PR TITLE
Add steps to see relationship between otel service and AWS MQ broker

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -128,6 +128,26 @@ Relationships between a service and host entity require that the service
 includes the `host.id` resource attribute and that it matches the `host.id` of
 the host it is running on.
 
+### Service to AWS resources 
+
+#### Service to AWS MQ Broker 
+
+MQ Broker entity in New Relic corresponds to ActiveMQ broker engine in AWS Amazon MQ.
+
+Relationships between a service and MQ Broker entity requires the following:
+
+Service should generate the following span attributes:
+
+* `span.kind`: `producer` or `consumer` depending on whether the service produces or consumes messages from the message queue.
+* `messaging.system`: `activemq`
+* `server.address`: AWS connection endpoint of the Active MQ of the format `<broker id>.mq.<AWS region>.amazonaws.com`
+
+The MQ Broker entity to which the service is connecting should have the following tags:
+
+* `aws.mq.endpoint` : AWS connection endpoint of the memcached cluster matching with the span attribute `server.address` of the service.
+
+If the above condition is met, the service map shows the service producing or consuming messages from an instrumented MQ Broker. If the condition is not met, the service map shows the service calling an uninstrumented external service.
+
 ## Adding custom tags to an entity [#tags]
 
 You can use tags to organize and filter your entities in the UI.

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -134,9 +134,9 @@ the host it is running on.
 
 MQ Broker entity in New Relic corresponds to ActiveMQ broker engine in AWS Amazon MQ.
 
-Relationships between a service and MQ Broker entity requires the following:
+Relationships between a [service](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources/#services) and MQ Broker entity requires the following:
 
-Service should generate the following span attributes:
+The service should generate spans with the following attributes:
 
 * `span.kind`: `producer` or `consumer` depending on whether the service produces or consumes messages from the message queue.
 * `messaging.system`: `activemq`


### PR DESCRIPTION


## Give us some context

* What problems does this PR solve?
Added steps and requirements to see relationship between Otel Service and AWS MQ Broker entity in the Service Map
* If your issue relates to an existing GitHub issue, please link to it.
* 
<img width="1585" alt="image (1)" src="https://github.com/user-attachments/assets/e27cfb09-4036-4ab1-9ec9-4b145ba2a2d6" />
