### PR TITLE
Document relationships between AWS integrations and OTel services

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -128,6 +128,62 @@ Relationships between a service and host entity require that the service
 includes the `host.id` resource attribute and that it matches the `host.id` of
 the host it is running on.
 
+### Amazon CloudWatch Metric Streams
+
+Your infrastructure hosted in AWS can be monitored with New Relic's integration
+with [Amazon CloudWatch Metric Streams](/install/aws-cloudwatch/). This is not
+an OpenTelemetry solution for monitoring your infrastructure. However, New
+Relic supports a number of relationships between OpenTelemetry instrumented
+services and infrastructure monitored using Amazon CloudWatch Metric Streams.
+
+<Callout variant="important">
+  The relationships described below leverage OpenTelemetry semantic conventions.
+  Many of these conventions are not yet stable and are still evolving.
+  Instrumentation that produces telemetry for the frameworks below vary in
+  their level of maturity and conformance to the semantic conventions. As
+  such, the instrumentation you use may not emit the attributes required for
+  these relationships to work. Please reach out to the maintainers of the
+  instrumentation you're using with any questions about the instrumentation's
+  maturity with respect to OpenTelemetry's semantic conventions.
+</Callout>
+
+#### ElastiCache (Memcached)
+
+The Amazon CloudWatch Metric Streams integration for
+[Elasticache](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration/)
+generates ElastiCache entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.elasticache.configurationEndpointAddress` or `aws.elasticache.endpointAddress`
+* `aws.elasticache.configurationEndpointPort` or `aws.elasticache.endpointPort`
+
+If your services use OpenTelemetry instrumentation for Memcached it must emit
+the following attributes for a relationship to be generated:
+
+* `db.system`: This attribute must have the value `memcached`.
+* `net.peer.name`: This attribute must match the corresponding endpoint tag of
+  the ElastiCache entity.
+* `net.peer.port`: This attribute must match the corresponding port tag of the
+  ElastiCache entity.
+
+#### Amazon MQ (ActiveMQ)
+
+The Amazon CloudWatch Metric Streams integration for
+[Amazon MQ](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-mq-integration)
+generates Amazon MQ entities in New Relic. These entities will have the
+following entity tag:
+
+* `aws.mq.endpoint`
+
+If your services use OpenTelemetry instrumentation for ActiveMQ it must
+the following attributes for a relationship to be generated:
+
+* `messaging.system`: This attribute must have the value `activemq`.
+* `server.address`: This attribute must match the corresponding endpoint tag
+  of the Amazon MQ entity.
+* `span.kind`: This relationship is generated from span data where `span.kind`
+  is `producer` or `consumer`.
+
 ## Adding custom tags to an entity [#tags]
 
 You can use tags to organize and filter your entities in the UI.


### PR DESCRIPTION
Supersedes #19847 and #19846.

Adds a new section that models how we want to document relationships between our Amazon CloudWatch Metric Streams integration and OpenTelemetry services.

@Sanjalee-NewRelic please review this PR. I have not personally vetted the details because I have never used our Amazon CloudWatch Metric Streams integration. I'm relying on you to ensure the information is accurate. Let's settle on the format of this PR and get it merged before you open up more PRs.