### PR TITLE
feat: Documentation for Otel to AWS relationships - Elasticache Redis cluster, SQS Queue, Lambda func, Elastic search cluster

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -161,3 +161,59 @@ the following attributes for a relationship to be generated:
   the ElastiCache entity.
 * `net.peer.port`: This attribute must match the corresponding port tag of the
   ElastiCache entity.
+
+
+#### SQS Queue
+
+The Amazon CloudWatch Metric Streams integration for
+[SQS](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/amazon-sqs-monitoring-integration/)
+generates SQS entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.region` or `aws.awsRegion`
+* `aws.accountId`
+* `displayName` or `aws.queueName` or `aws.sqs.QueueName`
+
+If your services use OpenTelemetry instrumentation for Redis it must emit
+the following attributes for a relationship to be generated:
+
+* `rpc.service`: This attribute must have the value `SQS`.
+* `aws.region`: This attribute must match the corresponding aws.region tag of
+  the SQS entity.
+* `aws.account.id`: This attribute must match the corresponding aws.account.id tag of the
+  SQS entity.
+* `messaging.destination`: This attribute must match the corresponding displayName or aws.queueName or aws.sqs.QueueName tag of the
+  SQS entity.
+
+#### AWS Lambda Function
+
+The Amazon CloudWatch Metric Streams integration for
+[AWS Lambda](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration/)
+generates AWS Lambda entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.functionArn`, `aws.lambda.functionArn`, or `aws.Arn`
+
+If your services use OpenTelemetry instrumentation for Lambda it must emit
+the following attributes for a relationship to be generated:
+
+* `rpc.service`: This attribute must have the value `Lambda`.
+* `cloud.resource_id`: This attribute must match the corresponding aws.functionArn, aws.lambda.functionArn, or aws.Arn tag of the
+  AWS Lambda entity.
+
+#### AWS Elasticsearch Cluster
+
+The Amazon CloudWatch Metric Streams integration for
+[AWS Elasticsearch](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticsearch-monitoring-integration/)
+generates AWS Elasticsearch entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.es.DomainEndpoint`
+
+If your services use OpenTelemetry instrumentation for Elasticsearch it must emit
+the following attributes for a relationship to be generated:
+
+* `db.system`: This attribute must have the value `elasticsearch`.
+* `server.address`: This attribute must match the corresponding aws.es.DomainEndpoint tag of the
+  AWS Elasticsearch entity.
+

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -162,7 +162,6 @@ the following attributes for a relationship to be generated:
 * `net.peer.port`: This attribute must match the corresponding port tag of the
   ElastiCache entity.
 
-
 #### SQS Queue
 
 The Amazon CloudWatch Metric Streams integration for

--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -142,3 +142,22 @@ or with one of the methods below.
 Adding resource attributes prefixed with `tags` will result in a tag on your
 entity in New Relic. For example, adding the attribute `tags.mytag=myvalue`
 will result in the entity tag `mytag=myvalue`.
+
+#### ElastiCache (Redis)
+
+The Amazon CloudWatch Metric Streams integration for
+[Elasticache](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-elasticache-monitoring-integration/)
+generates ElastiCache entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.elasticache.configurationEndpointAddress` or `aws.elasticache.endpointAddress` or `aws.elasticache.primaryEndpointAddress` or `aws.elasticache.readerEndpointAddress`
+* `aws.elasticache.configurationEndpointPort` or `aws.elasticache.endpointPort` or `aws.elasticache.primaryEndpointPort`, `aws.elasticache.readerEndpointPort`
+
+If your services use OpenTelemetry instrumentation for Redis it must emit
+the following attributes for a relationship to be generated:
+
+* `db.system`: This attribute must have the value `redis`.
+* `net.peer.name`: This attribute must match the corresponding endpoint tag of
+  the ElastiCache entity.
+* `net.peer.port`: This attribute must match the corresponding port tag of the
+  ElastiCache entity.


### PR DESCRIPTION
#### Objective

This PR updates documentation for Otel to AWS relationships,

1. **Elasticache Redis Cluster**
2. **SQS Queue**
3. **Lambda Function**
4. **Elasticsearch Cluster**