### PR TITLE
fix: Documention for otel to aws relationships

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -142,3 +142,73 @@ or with one of the methods below.
 Adding resource attributes prefixed with `tags` will result in a tag on your
 entity in New Relic. For example, adding the attribute `tags.mytag=myvalue`
 will result in the entity tag `mytag=myvalue`.
+
+
+#### AWS Lambda Alias
+
+The Amazon CloudWatch Metric Streams integration for
+[AWS Lambda Alias](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-lambda-monitoring-integration/)
+generates AWS Lambda Alias entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.Arn`
+
+If your services use OpenTelemetry instrumentation for Lambda with Aliases, it must emit
+the following attributes for a relationship to be generated:
+
+* `rpc.service`: This attribute must have the value `Lambda`.
+* `cloud.resource_id`: This attribute must match the corresponding aws.Arn tag of the
+  AWS Lambda Alias entity.
+
+
+#### AWS Kinesis Stream
+
+The Amazon CloudWatch Metric Streams integration for
+[AWS Kinesis](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-analytics-monitoring-integration/)
+generates AWS Kinesis Stream entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.Arn`
+
+If your services use OpenTelemetry instrumentation for Kinesis, it must emit
+the following attributes for a relationship to be generated:
+
+* `rpc.service`: This attribute must have the value `kinesis`.
+* `cloud.resource_id`: This attribute must match the corresponding aws.Arn tag of the
+  AWS Kinesis Stream entity.
+
+
+#### AWS Kinesis Delivery Stream
+
+The Amazon CloudWatch Metric Streams integration for
+[AWS Kinesis Delivery Stream](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-kinesis-data-firehose-monitoring-integration/)
+generates AWS Kinesis Delivery Stream entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.Arn` or `aws.arn`
+
+If your services use OpenTelemetry instrumentation for Kinesis Firehose, it must emit
+the following attributes for a relationship to be generated:
+
+* `instrumentation.provider`: This attribute must have the value `opentelemetry`.
+* `rpc.service`: This attribute must have the value `Firehose`.
+* `cloud.resource_id`: This attribute must match the corresponding aws.Arn or aws.arn tag of the
+  AWS Kinesis Delivery Stream entity.
+
+
+#### AWS Redshift Cluster
+
+The Amazon CloudWatch Metric Streams integration for
+[AWS Redshift](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-redshift-integration/)
+generates AWS Redshift Cluster entities in New Relic. These entities will have the
+following entity tags:
+
+* `aws.redshift.serverAddress`
+
+If your services use OpenTelemetry instrumentation for Redshift, it must emit
+the following attributes for a relationship to be generated:
+
+* `instrumentation.provider`: This attribute must have the value `opentelemetry`.
+* `rpc.service`: This attribute must have the value `Redshift`.
+* `server.address`: This attribute must match the corresponding aws.redshift.serverAddress tag of the
+  AWS Redshift Cluster entity.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

Adds a new section that models how we want to document relationships between our Amazon CloudWatch Metric Streams integration and OpenTelemetry services.

Objective
This PR updates documentation for Otel to AWS relationships,

- Lambda function alias
- Kinesis Stream
- Kinesis Delivery Stream
- Redshift cluster


## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.