### PR TITLE
Add compatibility/support statements for System.Data.ODBC

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -616,6 +616,32 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
                 </tr>
 
+                <tr>
+                <td>
+                    System.Data.ODBC
+                </td>
+
+                <td className="fcenter">
+                    <Icon
+                    style={{color: '#328787'}}
+                    name="fe-check"
+                    />
+                </td>
+
+                <td>
+                  Use [System.Data.Odbc](https://www.nuget.org/packages/System.Data.Odbc/).
+
+                  * Minimum supported version: 8.0.0
+                  * Latest verified compatible version: 9.0.1
+
+                  * Minimum agent version required: 10.35.0
+                  * Note: the following features that are supported for ODBC datastore calls in .NET Framework (using the built-in System.Data namespace) are not supported for .NET 8+:
+                    * Connection `Open/OpenAsync` calls
+                    * SqlDataReader `Read/NextResult` calls
+                    * Slow SQL traces
+                </td>
+                </tr>
+
             </tbody>
             </table>
 
@@ -1386,6 +1412,23 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       * Minimum supported version: .NET Framework 4.6.2
                       * Latest verified compatible version: 4.8
                     </td>
+                    </tr>
+
+                    <tr>
+                    <td>
+                        System.Data.ODBC
+                    </td>
+
+                    <td className="fcenter">
+                        <Icon
+                        style={{color: '#328787'}}
+                        name="fe-check"
+                        />
+                    </td>
+                        Use the built-in `System.Data.ODBC` namespace from .NET Framework.
+                        * Available in all currently supported .NET Framework agent version.
+                        * All versions of .NET Framework currently supported by Microsoft are verified compatible.
+                    <td/>
                     </tr>
 
                     <tr>


### PR DESCRIPTION
The .NET Agent recently (version 10.35.0) released new instrumentation for the `System.Data.ODBC` database client library in .NET 8+.  This PR adds a row to our compatibilty/support doc for this instrumentation.

I also noticed we didn't have any support statement for ODBC for .NET Framework, even though we've supported that for years now, so I added one.