### PR TITLE
Update with correct link

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
-  Enable the [AWS CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
+  Enable the [AWS CloudWatch Metric Streams integration](/docs.newrelic.com/install/aws-cloudwatch/) to monitor all CloudWatch metrics from your AWS services, including custom namespaces. Individual integrations are no longer our recommended option.
 </Callout>
 
 New Relic offers an integration for collecting your [Amazon Web Services Managed Streaming for Apache Kafka](https://aws.amazon.com/msk/) data. This document explains how to activate this integration and describes the data that can be reported.


### PR DESCRIPTION
Currently, the link to the AWS CloudWatch Metric Streams integration in the `Important` callout box results in a 404. This PR updates the link to redirect to the appropriate page. 