### PR TITLE
Update opentelemetry-best-practices-resources.mdx

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-resources.mdx
@@ -184,6 +184,26 @@ the following attributes for a relationship to be generated:
 * `span.kind`: This relationship is generated from span data where `span.kind`
   is `producer` or `consumer`.
 
+#### Amazon Managed Kafka (MSK)
+
+The Amazon CloudWatch Metric Streams integration for
+[MSK](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-managed-kafka-msk-integration)
+generates MSK entities in New Relic. These entities will have the
+following entity tag:
+
+* `aws.clusterName` or `aws.kafka.ClusterName`
+* `aws.awsRegion` or `aws.region`
+* `aws.topic` or `aws.kafka.Topic`
+
+If your services use OpenTelemetry instrumentation for MSK it must have
+the following attributes for a relationship to be generated:
+
+* `messaging.destination.name`: The MSK topic to which the service is either producing messages or consuming messages.
+* `server.address`: This attribute must match the corresponding endpoint tag
+  of the MSK entity.
+* `span.kind`: This relationship is generated from span data where `span.kind`
+  is `producer` or `consumer`.
+
 ## Adding custom tags to an entity [#tags]
 
 You can use tags to organize and filter your entities in the UI.


### PR DESCRIPTION
Adds a new section that models how we want to document relationships between our Amazon CloudWatch Metric Streams integration for AWS MSK and OpenTelemetry services.
