### PR TITLE
docs(azure-functions): Update supported runtimes for Azure Functions.

### DIFF
--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
@@ -52,7 +52,7 @@ Based on your hosting environment, the following Azure Function runtime stacks a
 
 <TabsPageItem id="2">
 
-* .NET: version 6 - 9, Isolated model only
+* .NET: version 6 - 9
 
 </TabsPageItem>
 

--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
@@ -31,7 +31,7 @@ End-to-end distributed tracing is supported only for HTTP requests. Additionally
 
 ## Supported runtimes
 
-Based on your hosting environment, the following runtimes are supported.
+Based on your hosting environment, the following Azure Function runtime stacks are supported.
 
 <Tabs>
   <TabsBar>
@@ -45,20 +45,20 @@ Based on your hosting environment, the following runtimes are supported.
   
 
 <TabsPageItem id="1">
-* .NET: `dotnet6.0`, `dotnet8.0`
+* .NET: version 6 - 9, Isolated model only
 
 </TabsPageItem>
 
 
 <TabsPageItem id="2">
 
-* .NET: `dotnet6.0`, `dotnet8.0` 
+* .NET: version 6 - 9, Isolated model only
 
 </TabsPageItem>
 
 <TabsPageItem id="3">
 
-* .NET: `dotnet6.0`, `dotnet8.0`
+* .NET: version 6 - 9, Isolated model only
 </TabsPageItem>
 
 </TabsPages>


### PR DESCRIPTION
Clarifies the runtime stacks that are currently supported for Azure Functions.