### PR TITLE
NR-367015: Complex data types in body and attributes of OTLP Log Records

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs.mdx
@@ -191,7 +191,10 @@ See [OTLP attribute types](/docs/opentelemetry/best-practices/opentelemetry-otlp
 
 **[2]** If `LogRecord.time_unix_nanos` is not present, `timestamp` is set to the time New Relic received the data.
 
-**[3]** [Log parsing](/docs/logs/ui-data/parsing/) is applied to the `LogRecord.body` to attempt to extract attributes from plain log text. For example, if a JSON structured log format is used, the key / values become attributes on the resulting log. This is particularly useful when collecting logs from files or `stdout`. In this case, it's common to have no resource attributes associated with the log record (required for [APM service correlation](#service-correlation)) and no value for `LogRecord.trace_id` / `LogRecord.span_id` (required for [trace correlation](#trace-correlation)). Correlation will function as intended if the required fields can be successfully parsed.
+**[3]** [Log parsing](/docs/logs/ui-data/parsing/) is applied to the `LogRecord.body` to attempt to extract attributes from:
+- Plain log text: The string value will be set as the `message` attribute.
+- Stringified JSON: If a log is formatted as JSON but sent as a plain text string, the key-value pairs will become attributes of the resulting log. For more details, refer to the [JSON parsing](/docs/logs/log-api/introduction-log-api/#message-attribute-parsin) documentation. This is particularly useful when collecting logs from files or `stdout`. In this case, it's common to have no resource attributes associated with the log record (required for [APM service correlation](#service-correlation)) and no value for `LogRecord.trace_id` / `LogRecord.span_id` (required for [trace correlation](#trace-correlation)). [Logs in context](/docs/logs/logs-context/get-started-logs-context/) will function as intended if the required fields can be successfully parsed.
+- Map structure: If the data is formatted as a map according to the [OTLP spec](https://opentelemetry.io/docs/specs/otel/logs/data-model/#type-mapstring-any), it will be parsed and flattened into attributes, similar to JSON parsing. For more details, refer to the [JSON parsing](/docs/logs/log-api/introduction-log-api/#message-attribute-parsin) documentation.
 
 ## Correlation with OpenTelemetry APM service [#service-correlation]
 

--- a/src/content/docs/release-notes/logs-release-notes/logs-25-02-17.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-25-02-17.mdx
@@ -1,0 +1,17 @@
+---
+subject: Logs
+releaseDate: '2025-02-17'
+version: '250217'
+---
+
+### OpenTelemetry: Support for complex data structures
+
+New Relic now supports complex data structures in OTLP Logs. Checkout the details in the [OTEL best practices docs](/docs/opentelemetry/best-practices/opentelemetry-best-practices-logs).
+
+### Added
+
+* **Support complex data structures in OTLP Logs**: Your `LogRecord#body` and `LogRecord#attrbitues` can hold non-primitive values, such as arrays and [maps](https://opentelemetry.io/docs/specs/otel/logs/data-model/#type-mapstring-any).
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
We recently added support for complex data types (mainly KeyValueLists) in both OTLP LogRecord#attributes and LogRecord#body.

We think this doc update is required to let customers now about this extended support.