### PR TITLE
docs(dotnet): Add OpenAI to supported LLM frameworks

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -732,7 +732,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     3.7.200.0
                 </td>
                 <td>
-                    10.23.0
+                    10.23.0 (`InvokeModelAsync`)
+                    10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
                     3.7.412.4
@@ -746,7 +747,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     2.0.0
                 </td>
                 <td>
-                    10.37.0
+                    10.37.0 (`CompleteChat`, `CompleteChatAsync`)
                 </td>
                 <td>
                     2.1.0
@@ -760,7 +761,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     2.0.0
                 </td>
                 <td>
-                    10.37.0
+                    10.37.0 (`CompleteChat`, `CompleteChatAsync`)
                 </td>
                 <td>
                     2.1.0
@@ -1832,7 +1833,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         3.7.200.0
                     </td>
                     <td>
-                        10.23.0
+                        10.23.0 (`InvokeModelAsync`)
+                        10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
                         3.7.412.4
@@ -1846,7 +1848,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         2.0.0
                     </td>
                     <td>
-                        10.37.0
+                        10.37.0 (`CompleteChat`, `CompleteChatAsync`)
                     </td>
                     <td>
                         2.1.0
@@ -1860,7 +1862,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         2.0.0
                     </td>
                     <td>
-                        10.37.0
+                        10.37.0 (`CompleteChat`, `CompleteChatAsync`)
                     </td>
                     <td>
                         2.1.0

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -737,7 +737,34 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                     3.7.412.4
                 </td>
-
+                </tr>
+                <tr>
+                <td>
+                    OpenAI
+                </td>
+                <td>
+                    2.0.0
+                </td>
+                <td>
+                    10.37.0
+                </td>
+                <td>
+                    2.1.0
+                </td>
+                </tr>
+                <tr>
+                <td>
+                    Azure.AI.OpenAI
+                </td>
+                <td>
+                    2.0.0
+                </td>
+                <td>
+                    10.37.0
+                </td>
+                <td>
+                    2.1.0
+                </td>
                 </tr>
             </tbody>
             </table>
@@ -1811,6 +1838,34 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         3.7.412.4
                     </td>
                     </tr>
+                    <tr>
+                    <td>
+                        OpenAI
+                    </td>
+                    <td>
+                        2.0.0
+                    </td>
+                    <td>
+                        10.37.0
+                    </td>
+                    <td>
+                        2.1.0
+                    </td>
+                    </tr>
+                    <tr>
+                    <td>
+                        Azure.AI.OpenAI
+                    </td>
+                    <td>
+                        2.0.0
+                    </td>
+                    <td>
+                        10.37.0
+                    </td>
+                    <td>
+                        2.1.0
+                    </td>
+                    </tr>                
                 </tbody>
                 </table>
             </Collapser>


### PR DESCRIPTION
* Adds OpenAI (and Azure.AI.OpenAI) to the list of supported LLM frameworks for the .NET agent.
* Updates AWS Bedrock, OpenAI and Azure.AI.OpenAI to clarify the methods that are instrumented.