### PR TITLE
docs(dotnet): Add .NET Framework to supported Azure Function stacks

### DIFF
--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
@@ -45,20 +45,20 @@ Based on your hosting environment, the following Azure Function runtime stacks a
   
 
 <TabsPageItem id="1">
-* .NET stack: .NET 6 - 9, Isolated model only; 
+* .NET stack: .NET 6 - 9, Isolated model only
 
 </TabsPageItem>
 
 
 <TabsPageItem id="2">
 
-* .NET stack: .NET 4.8 (.NET agent version 10.37.0 and later) and .NET 6 - 9, Isolated model only; 
+* .NET stack: .NET 4.8 (.NET agent version 10.37.0 and later) and .NET 6 - 9, Isolated model only
 
 </TabsPageItem>
 
 <TabsPageItem id="3">
 
-* .NET stack: .NET 6 - 9, Isolated model only; 
+* .NET stack: .NET 6 - 9, Isolated model only
 </TabsPageItem>
 
 </TabsPages>

--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
@@ -45,20 +45,20 @@ Based on your hosting environment, the following Azure Function runtime stacks a
   
 
 <TabsPageItem id="1">
-* .NET: version 6 - 9, Isolated model only
+* .NET stack: .NET 6 - 9, Isolated model only; 
 
 </TabsPageItem>
 
 
 <TabsPageItem id="2">
 
-* .NET: version 6 - 9
+* .NET stack: .NET 4.8 (.NET agent version 10.37.0 and later) and .NET 6 - 9, Isolated model only; 
 
 </TabsPageItem>
 
 <TabsPageItem id="3">
 
-* .NET: version 6 - 9, Isolated model only
+* .NET stack: .NET 6 - 9, Isolated model only; 
 </TabsPageItem>
 
 </TabsPages>


### PR DESCRIPTION
Update Azure Function documentation to list .NET Framework 4.8 as a support Azure Function runtime stack, as of .NET agent v10.37.0.