### PR TITLE
PHP Agent Release 11.6.0.19 (Feb 18 2025)

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -630,7 +630,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        RabbitMQ (php-amqplib library only)
+        RabbitMQ (php-amqplib 3.7 library only)
       </td>
     </tr>
 
@@ -660,7 +660,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        SQS (aws-sdk-php library only)
+        SQS (aws-sdk-php 3 library only)
       </td>
     </tr>
         <tr>

--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -562,7 +562,7 @@ The following frameworks are supported:
       <td>
         Yii
       </td>
-      <td>2.0</td>
+      <td>1.1, 2.0</td>
       <td></td>
     </tr>
 
@@ -590,7 +590,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        Oracle
+        [PHPUnit](/docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-insights)
       </td>
     </tr>
 
@@ -600,7 +600,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        [PHPUnit](/docs/agents/php-agent/frameworks-libraries/analyze-phpunit-test-data-insights)
+        PDO Drivers
       </td>
     </tr>
 
@@ -610,7 +610,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        PDO Drivers
+        Postgres
       </td>
     </tr>
 
@@ -620,7 +620,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        Postgres
+        [Predis](/docs/agents/php-agent/frameworks-libraries/predis)
       </td>
     </tr>
 
@@ -630,7 +630,7 @@ The following databases and libraries are supported:
       </td>
 
       <td>
-        [Predis](/docs/agents/php-agent/frameworks-libraries/predis)
+        RabbitMQ (php-amqplib library only)
       </td>
     </tr>
 
@@ -657,6 +657,15 @@ The following databases and libraries are supported:
     <tr>
       <td>
         ODBC (PDO Driver only)
+      </td>
+
+      <td>
+        SQS (aws-sdk-php library only)
+      </td>
+    </tr>
+        <tr>
+      <td>
+        Oracle
       </td>
 
       <td>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-6-0-19.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-6-0-19.mdx
@@ -1,0 +1,43 @@
+---
+subject: PHP agent
+releaseDate: '2025-02-18'
+version: 11.6.0.19
+downloadLink: 'https://download.newrelic.com/php_agent/archive/11.6.0.19'
+features: ['Add aws-sdk-php 3 SQS support', 'Add php-amqplib 3.7 RabbitMQ support', 'Add Yii 1.1 RabbitMQ support', 'Add message segment MessageBroker functionality']
+bugs: ['Fixes memory leak in Laravel Queue Instrumentation', 'Fixes nr_header_create_distributed_trace_map memory leak', 'Fixes daemon to enable go_vet check']
+security: ['Upgrade Golang version to 1.23.6']
+---
+
+## New Relic PHP agent v11.6.0.19
+
+### New features
+
+* Added support for aws-sdk-php SQS version 3 instrumentation
+* Added support for php-amqplib version 3.7 RabbitMQ instrumentation
+* Added support for Yii version 1.1 instrumentation
+* The agent will now generate MessageBroker metrics and attributes
+
+### Security
+
+* Daemon Golang version upgraded to 1.23.6
+
+### Bug fixes
+
+* Fixed daemon to enable `go vet` check on pull requests
+* Fixed memory leak in Laravel Queue Instrumentation
+* Fixed nr_header_create_distributed_trace_map memory leak
+
+### Support statement
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [New Relic PHP Agent EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+  **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
+  The PHP agent packages that are affected are:
+
+  * newrelic-php5
+  * newrelic-php5-common
+  * newrelic-daemon
+</Callout>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

This PR updates the documentation to reflect the new release and features of the PHP Agent 11.6.0.19 with expected release date of noon PST on Feb 18 2025.