### PR TITLE
Updated network dependencies table

### DIFF
--- a/src/install/npm/network-flow/linux-eu.mdx
+++ b/src/install/npm/network-flow/linux-eu.mdx
@@ -127,7 +127,7 @@ headingText: Network flow security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/network-flow/linux-us.mdx
+++ b/src/install/npm/network-flow/linux-us.mdx
@@ -127,7 +127,7 @@ headingText: Network flow security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/snmp/linux-eu.mdx
+++ b/src/install/npm/snmp/linux-eu.mdx
@@ -177,7 +177,7 @@ headingText: SNMP security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/snmp/linux-us.mdx
+++ b/src/install/npm/snmp/linux-us.mdx
@@ -177,7 +177,7 @@ headingText: SNMP security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/snmp/linux-usfedramp.mdx
+++ b/src/install/npm/snmp/linux-usfedramp.mdx
@@ -177,7 +177,7 @@ headingText: SNMP security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/syslog/linux-eu.mdx
+++ b/src/install/npm/syslog/linux-eu.mdx
@@ -123,7 +123,7 @@ headingText: Network syslog security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/syslog/linux-us-fedramp.mdx
+++ b/src/install/npm/syslog/linux-us-fedramp.mdx
@@ -123,7 +123,7 @@ headingText: Network syslog security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>

--- a/src/install/npm/syslog/linux-us.mdx
+++ b/src/install/npm/syslog/linux-us.mdx
@@ -123,7 +123,7 @@ headingText: Network syslog security prerequisites
       </td>
 
       <td>
-        `d28dx6y1hfq314.cloudfront.net` - CDN used behind the scenes by packagecloud.io
+        `d3fo0g5hm7lbuv.cloudfront.net` - CDN used behind the scenes by packagecloud.io
       </td>
 
       <td>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Network requirements table has an old CDN endpoint listed for AWS CloudFront:

Old domain: 
```
aschneider@~/Desktop: dig  @1.1.1.1 d28dx6y1hfq314.cloudfront.net

; <<>> DiG 9.10.6 <<>> @1.1.1.1 d28dx6y1hfq314.cloudfront.net
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57109
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;d28dx6y1hfq314.cloudfront.net.	IN	A

;; AUTHORITY SECTION:
cloudfront.net.		60	IN	SOA	ns-418.awsdns-52.com. hostmaster.cloudfront.net. 1377556270 16384 2048 1048576 60

;; Query time: 65 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Tue Feb 18 10:13:24 PST 2025
;; MSG SIZE  rcvd: 125
```

New domain:
```
aschneider@~/Desktop: dig  @1.1.1.1 d3fo0g5hm7lbuv.cloudfront.net

; <<>> DiG 9.10.6 <<>> @1.1.1.1 d3fo0g5hm7lbuv.cloudfront.net
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 31613
;; flags: qr rd ra; QUERY: 1, ANSWER: 4, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;d3fo0g5hm7lbuv.cloudfront.net.	IN	A

;; ANSWER SECTION:
d3fo0g5hm7lbuv.cloudfront.net. 60 IN	A	18.161.3.220
d3fo0g5hm7lbuv.cloudfront.net. 60 IN	A	18.161.3.45
d3fo0g5hm7lbuv.cloudfront.net. 60 IN	A	18.161.3.48
d3fo0g5hm7lbuv.cloudfront.net. 60 IN	A	18.161.3.114

;; Query time: 91 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Tue Feb 18 10:13:26 PST 2025
;; MSG SIZE  rcvd: 122
```