### PR TITLE
Remove erroneous second decimal in query-time-range.mdx

### DIFF
--- a/src/content/docs/nrql/using-nrql/query-time-range.mdx
+++ b/src/content/docs/nrql/using-nrql/query-time-range.mdx
@@ -108,7 +108,7 @@ The time is relative to the time you run the query. For example, assume that you
       </td>
 
       <td style="font-family:monospace">
-        2023-12-18T12:34:54.<DNT>**.787**</DNT>Z
+        2023-12-18T12:34:54<DNT>**.787**</DNT>Z
       </td>
     </tr>
 


### PR DESCRIPTION
I noticed one of the examples has an extra decimal before the milliseconds of a timestamp.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.