### PR TITLE
docs(dotnet): Fix incorrect configuration examples for AI Monitoring with the .NET agent.

### DIFF
--- a/src/install/ai-monitoring/agent-lang/dotnet-config.mdx
+++ b/src/install/ai-monitoring/agent-lang/dotnet-config.mdx
@@ -4,7 +4,7 @@ headingText: Configure the .NET agent
 freshnessValidatedDate: never
 ---
 
-To collect AI data, you need to set certain configurations to enable AI monitoring. We recommend applying these configurations in newrelic.ini, but if you have a more complex set up with multiple environments, you can configure with environment variables.
+To collect AI data, you need to set certain configurations to enable AI monitoring. We recommend applying these configurations in `newrelic.config`, but if you have a more complex set up with multiple environments, you can configure with environment variables.
 
 <CollapserGroup>
   <Collapser
@@ -14,11 +14,15 @@ To collect AI data, you need to set certain configurations to enable AI monitori
     Set these configurations to ingest AI monitoring data:
 
     ```xml
-    <customEvents enabled="true" maximumSamplesStored="100000"/>
+    <aiMonitoring enabled="true" />
     ```
 
     ```xml
-    <spanEvents enabled="true" maximumSamplesStored="10000"></spanEvents>
+    <customEvents enabled="true" maximumSamplesStored="100000" />
+    ```
+
+    ```xml
+    <spanEvents enabled="true" maximumSamplesStored="10000" />
     ```
 
     Here is an example configuration file:
@@ -31,9 +35,11 @@ To collect AI data, you need to set certain configurations to enable AI monitori
 
     ..........
 
-    <customEvents enabled="true" maximumSamplesStored="100000"/>
+      <aiMonitoring enabled="true" />
 
-    <spanEvents enabled="true" maximumSamplesStored="10000"></spanEvents>
+      <customEvents enabled="true" maximumSamplesStored="100000" />
+
+      <spanEvents enabled="true" maximumSamplesStored="10000" />
 
     </configuration>
     ```


### PR DESCRIPTION
Configuration examples for enabling AI Monitoring in the .NET agent were incorrect. This PR fixes that documentation.