### PR TITLE
Update Python DT page

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/distributed-tracing-python-agent.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/distributed-tracing-python-agent.mdx
@@ -223,7 +223,7 @@ Recommendation: Before performing any custom instrumentation, read:
 * [How distributed tracing works](/docs/apm/distributed-tracing/getting-started/how-new-relic-distributed-tracing-works)
 * [Troubleshoot missing data](/docs/apm/distributed-tracing/troubleshooting/troubleshooting-missing-trace-data)
 
-If a service is not passing the trace header to other services, you can use the distributed tracing payload APIs to instrument the [calling service](#calling-service) and the [called service](#called-service). The calling service uses an API call to generate a payload, which is accepted by the called service.
+If a service is not passing the trace header to other services, you can use the distributed tracing header APIs to instrument the [calling service](#calling-service) and the [called service](#called-service). The calling service uses an API call to generate headers, which are accepted by the called service.
 
 <CollapserGroup>
   <Collapser
@@ -233,9 +233,9 @@ If a service is not passing the trace header to other services, you can use the 
     To instrument the calling service:
 
     1. Ensure the [version of the APM agent](#compatibility-requirements) that monitors the calling service supports distributed tracing.
-    2. Invoke the agent API call for generating a distributed trace payload (see the [Python agent API](/docs/agents/python-agent/python-agent-api/create_distributed_trace_payload)).
-       <Callout variant="important">To maintain proper ordering of spans in a trace, ensure you <DNT>**generate the payload in the context of the span that sends it**</DNT>.</Callout>
-    3. Add that payload to the call made to the destination service (for example, in a header).
+    2. Invoke the agent API call for inserting distributed trace headers (see the [Python agent API](/docs/agents/python-agent/python-agent-api/insertdistributedtraceheaders-python-agent-api)).
+       <Callout variant="important">To maintain proper ordering of spans in a trace, ensure you <DNT>**generate the headers in the context of the span that sends it**</DNT>.</Callout>
+    3. Add those headers to the call made to the destination service.
     4. (Optional) Identify the call as an external call (see the [Python agent API](/docs/agents/python-agent/python-agent-api/external-trace)).
   </Collapser>
 
@@ -247,12 +247,12 @@ If a service is not passing the trace header to other services, you can use the 
 
     1. Ensure the [version of the APM agent](#compatibility-requirements) that monitors the called service supports distributed tracing.
 
-    2. If the New Relic agent on the called service does not identify a New Relic transaction, use the agent API to declare a transaction. Here's one way to tell that a transaction is not in progress: when `transaction = current_transaction()` is run, `transaction` is `None`. Or, if `result = accept_distributed_trace_payload(payload)` is run, then the result is `False`.
+    2. If the New Relic agent on the called service does not identify a New Relic transaction, use the agent API to declare a transaction. Here's one way to tell that a transaction is not in progress: when `transaction = current_transaction()` is run, `transaction` is `None`..
 
        Use [`background_task`](/docs/agents/python-agent/python-agent-api/background_task) to report a [non-web transaction](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions#define). For more on Python instrumentation, see [Monitor transactions and segments](/docs/agents/python-agent/api-guides/guide-using-python-agent-api#transaction-segments).
 
-    3. Extract the payload from the call that you received (for example, in a header).
+    3. Extract the headers from the call that you received.
 
-    4. Invoke the call for accepting the payload (see the [Python agent API](/docs/agents/python-agent/python-agent-api/accept_distributed_trace_payload).
+    4. Invoke the call for accepting the headers (see the [Python agent API](/docs/agents/python-agent/python-agent-api/acceptdistributedtraceheaders-python-agent-api)).
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This PR updates the links and wording of the Python Agent's Distributed Tracing page.  The Python Agent has since deprecated the create/accept payload APIs and has moved towards insert/accept headers APIs.  The docs no longer link to nor reference the old APIs