### PR TITLE
Update view-system-limits.mdx

### DIFF
--- a/src/content/docs/data-apis/manage-data/view-system-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/view-system-limits.mdx
@@ -41,7 +41,7 @@ What the color-coding in the incident table means:
 Some tips on using the limits UI:
 
 * To get more detail about a table entry, try clicking it. Some entries have more detail, including associated NRQL queries.
-* When you select a time range greater than six hours, the chart uses average values, which may smooth out spikes. This is the reason you may see the message "For the time window chosen, the 'Max limit usage' value represents the average of your usage limits." To see more accurate results, use a time range below six hours.
+* When you select a time range greater than six hours, the chart uses average values, which may smooth out spikes. This is the reason you may see the message "For the time window chosen, the 'Max limit usage' value represents the average of your usage limits." To see more accurate results, use a time range of 24 hours.
 * It's possible for the use of a resource to be over a limit while not generating an incident. For example, query limit events are generated for a one-minute level, but incidents are only generated for continually exceeding that limit at the 5-minute level.
 
 If you want more detail than the UI provides, see [Query your resource use](/docs/data-apis/manage-data/query-limits).


### PR DESCRIPTION
We have a ticket to change the behavior in the UI so that violations only query the last 24 hours, as we recently discovered violation queries are not accurate outside of this time range: https://new-relic.atlassian.net/browse/NR-358126

The number is not accurate for 1 hour or time less than 24 hours.