### PR TITLE
chore: Add browser agent features table

### DIFF
--- a/src/content/docs/browser/new-relic-browser/configuration/change-browser-agent-type.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/change-browser-agent-type.mdx
@@ -64,3 +64,198 @@ We have three types of browser agents: Lite, Pro, and Pro+SPA.
     </tr>
   </tbody>
 </table>
+
+## Browser agent features [#agent-features]
+
+Our features included with the browser agent depend on the browser agent type.
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Feature
+      </th>
+
+      <th>
+        Lite
+      </th>
+
+      <th>
+        Pro
+      </th>
+
+      <th>
+        Pro+SPA
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Page View
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Page View Timing (inc. CWV)
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Ajax Requests
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        JavaScript Errors
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Logs
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Metrics (Errors and Ajax Requests)
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Generic Events
+        <ul>
+          <li>Page Actions</li>
+          <li>User Actions</li>
+          <li>Browser Performance</li>
+        </ul>
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Session Trace
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        SPA
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        FALSE
+      </td>
+
+      <td>
+        TRUE
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Adds a new table in "Change browser agent type" page to show differences in included agent features based on browser agent type. This is to avoid confusion from customers on what features are supported by which agent type.

JIRA: https://new-relic.atlassian.net/browse/NR-121970

<img width="1703" alt="Change_browser_agent_type___New_Relic_Documentation" src="https://github.com/user-attachments/assets/df3dbddc-fcec-458f-b20d-2606b1fc2c5d" />