### PR TITLE
chore: add iframe section page for session replay

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/iframes.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/iframes.mdx
@@ -1,0 +1,18 @@
+---
+title: "Session replay and iframes"
+metaDescription: "Understand and troubleshoot common issues with session replay and iframes behavior"
+freshnessValidatedDate: 2025-02-19
+---
+
+The session replay feature, when enabled, might not allow you to view replay data for iframe content. This is due to the behavior of session replay in iframe scenarios, which depend on the origin of the iframe and the placement of the browser agent.
+
+Assuming a web page consists of a top-level window with a child iframe, these are the behaviors between session traces and iframes:   
+  * **Same-origin iframes**:
+    * If you place the browser agent in the top-level window, session replay captures both the window and the iframe.
+    * If you place the browser agent in the iframe, session replay only captures what's in the iframe.
+    * If you place the browser agent in both the top-level window and iframe, session replay captures what's happening independently in both the window and iframe, resulting in two separate sessions.
+  * **Cross-origin iframes**:
+    * If you place the browser agent in the top-level window, session replay only captures what's in the window. The iframe will appear blank in session replay.
+    * If you place the browser agent in the top-level iframe, session replay only captures what's in the iframe.
+
+Session replay is not compatible with `<frame>` elements.

--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/iframes.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/iframes.mdx
@@ -4,15 +4,19 @@ metaDescription: "Understand and troubleshoot common issues with session replay 
 freshnessValidatedDate: 2025-02-19
 ---
 
-The session replay feature, when enabled, might not allow you to view replay data for iframe content. This is due to the behavior of session replay in iframe scenarios, which depend on the origin of the iframe and the placement of the browser agent.
+When enabled, the session replay feature might not display replay data for iframe content. This limitation results from the session replay's behavior in iframe scenarios, which varies based on the iframe's origin and the browser agent's placement.
 
-Assuming a web page consists of a top-level window with a child iframe, these are the behaviors between session traces and iframes:   
+Assume a webpage contains a top-level window and a child `iframe`. The session replay behaviors, based on the placement of the browser agent, are as follows:   
+
   * **Same-origin iframes**:
-    * If you place the browser agent in the top-level window, session replay captures both the window and the iframe.
-    * If you place the browser agent in the iframe, session replay only captures what's in the iframe.
-    * If you place the browser agent in both the top-level window and iframe, session replay captures what's happening independently in both the window and iframe, resulting in two separate sessions.
+    * With the browser agent in the top-level window, session replay records both the window and the `iframe` content.
+    * With the browser agent solely in the `iframe`, session replay records only the content within the `iframe`.
+    * With the browser agent in both the top-level window and the `iframe`, session replay records each context independently, resulting in two distinct sessions.
   * **Cross-origin iframes**:
-    * If you place the browser agent in the top-level window, session replay only captures what's in the window. The iframe will appear blank in session replay.
-    * If you place the browser agent in the top-level iframe, session replay only captures what's in the iframe.
+    * With the browser agent in the top-level window, session replay captures only the window content; the `iframe` content will not be visible in the replay.
+    * With the browser agent in the iframe, session replay captures only the `iframe` content.
 
-Session replay is not compatible with `<frame>` elements.
+
+**Limitations:**
+
+* Session replay does not support `<frame>` elements.

--- a/src/nav/browser.yml
+++ b/src/nav/browser.yml
@@ -80,6 +80,8 @@ pages:
             path: /docs/browser/browser-monitoring/browser-pro-features/session-replay/nrai-summary
           - title: Troubleshooting session replay
             path: /docs/browser/browser-monitoring/browser-pro-features/session-replay/troubleshooting-session-replay
+          - title: Session replay and iframes
+            path: /docs/browser/browser-monitoring/browser-pro-features/session-replay/iframes
           - title: Advanced features
             path: /docs/browser/browser-monitoring/browser-pro-features/session-replay/advanced-features
           - title: Additional information


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Adds a new page in session replay called "Session replay and iframes". This makes it easier for users to find important information relating to how iframes behave with our session replay feature.

JIRA: https://new-relic.atlassian.net/browse/NR-312740

![Session_replay_and_iframes___New_Relic_Documentation](https://github.com/user-attachments/assets/4b65db63-48cc-4853-bbdc-763ed1a81002)
