### PR TITLE
Update compatability requirement for Java lambda layers

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
@@ -65,6 +65,9 @@ Based on the type of instrumentation, the following runtimes are supported.
 
 </Tabs>
 
+## Supported Libraries
+* Java: New Relic Java's layered and SDK instrumentation are compatable with `com.amazonaws:aws-lambda-java-events` versions `3.0.0` till latest/
+
 ## What's next
 
 <DocTiles>


### PR DESCRIPTION
I added a section in the compatibility docs for Java Lambda SDK and Layers. This is to guide customers if they are using an older version of `com.amazonaws:aws-lambda-java-events` and to tell them to upgrade to a comparable version.