### PR TITLE
fix: html syntax highlighting

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/troubleshooting-session-replay.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/troubleshooting-session-replay.mdx
@@ -51,9 +51,9 @@ If you don't find your problem listed here, you can always reach out to [New Rel
 
   Here's an example of adding the `crossorigin="anonymous"` attribute:
 
-```HTML
+  ```html
   <link rel="stylesheet" href="assets.yoursite.com/styles.css" crossorigin="anonymous">
-```
+  ```
 
 ## Replays not visible in your iframes [#no-replays-in-iframes]
 


### PR DESCRIPTION
language identifiers are case sensitive `html` works, `HTML` doesn't

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.