### PR TITLE
fix: Update what-entity-new-relic.mdx with the new exceptions in handling externals and uninstrumented guids

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -972,6 +972,13 @@ These are the relationships between entities that we create automatically:
   </Collapser>
 </CollapserGroup>
 
+
+### Handling Legacy Externals and Uninstrumented Entities Exceptions in Entity Relationships
+
+* If a service is invoked only intermittently, with intervals exceeding 10 minutes between calls, then the DFM, external services user interface, and possibly the trace details, will display a legacy external entity for that call. This may result in the duplication of an already instrumented service. This is the current behavior for all external calls.
+
+* If a service is accessed through multiple hostnames but tracing is not enabled for each instance, all maps will depict both an instrumented and an uninstrumented service for the corresponding child application. The solution to this issue is to ensure that tracing is activated for all such occurrences.
+
 ### Create custom entity relationships [#create-custom-relationship]
 
 When relationships are not automatically detected, you can manually create them using our [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/#manual-relationships), or you can do it in the New Relic UI with the <DNT>**Add/edit related entities**</DNT> link in <DNT>**Related entities**</DNT>. Currently, you can only manually create calls/called-by relationships between service entities.

--- a/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic.mdx
@@ -975,9 +975,9 @@ These are the relationships between entities that we create automatically:
 
 ### Handling Legacy Externals and Uninstrumented Entities Exceptions in Entity Relationships
 
-* If a service is invoked only intermittently, with intervals exceeding 10 minutes between calls, then the DFM, external services user interface, and possibly the trace details, will display a legacy external entity for that call. This may result in the duplication of an already instrumented service. This is the current behavior for all external calls.
+* If a service is invoked intermittently, with intervals exceeding 10 minutes between calls, the DFM, external services user interface, and trace details may display it as a legacy external entity. This could lead to duplication of an already instrumented service. This is the current behavior for all external calls.
 
-* If a service is accessed through multiple hostnames but tracing is not enabled for each instance, all maps will depict both an instrumented and an uninstrumented service for the corresponding child application. The solution to this issue is to ensure that tracing is activated for all such occurrences.
+* If a service is accessed through multiple hostnames but tracing is not enabled for each instance, all maps will depict both an instrumented and an uninstrumented service for the corresponding child application. To resolve this, ensure that tracing is activated for all instances.
 
 ### Create custom entity relationships [#create-custom-relationship]
 


### PR DESCRIPTION
Added exceptional cases where we might see both legacy externals and uninstrumented guids

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->


## Uninstrumented guids in entity relationships

* Added the exception cases where we might see both legacy external and uninstrumented for the same externals in the entity relationships for the services.

* This occurs when the entity relationships resolves external services with uninstrumented guids is deployed to prod.

* The feature is on hold, will update this doc with more details if required after the release
