### PR TITLE
Update to New Relic's network document

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -17,7 +17,7 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important">
-  New Relic has discontinued the use of the following IP ranges: 3.145.244.128/25, 3.77.79.0/25, 20.51.136.0/25, 4.197.217.128/25, 18.246.82.0/25, 158.177.65.64/29, 159.122.103.184/29, 161.156.125.32/28. As of May 1, 2025 these ranges may be reallocated by the cloud provider to other customers for purposes out of our control. Please update your network configurations accordingly.
+  New Relic has discontinued the use of the following IP ranges: 3.145.244.128/25, 3.77.79.0/25, 3.27.118.128/25, 20.51.136.0/25, 4.197.217.128/25, 18.246.82.0/25, 158.177.65.64/29, 159.122.103.184/29, 161.156.125.32/28. As of May 1, 2025 these ranges may be reallocated by the cloud provider to other customers for purposes out of our control. Please update your network configurations accordingly.
 </Callout>
 
 
@@ -801,7 +801,7 @@ Synthetic private minions report to a specific endpoint based on region. To allo
 Endpoints that use `api.newrelic.com` (such as our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph)) and our New Relic-generated [webhooks for alert policies](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-controlling-where-send-alerts#webhook) use an IP address from designated network blocks for the US or [EU region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center). [TLS is required](#tls) for all addresses in these blocks.
 
 <Callout variant="important">
-  New Relic has discontinued the use of the following IP ranges: 3.145.244.128/25, 3.77.79.0/25, 20.51.136.0/25, 4.197.217.128/25, 18.246.82.0/25, 158.177.65.64/29, 159.122.103.184/29, 161.156.125.32/28. As of May 1, 2025 these ranges may be reallocated by the cloud provider to other customers for purposes out of our control. Please update your network configurations accordingly.
+  New Relic has discontinued the use of the following IP ranges: 3.145.244.128/25, 3.77.79.0/25, 3.27.118.128/25, 20.51.136.0/25, 4.197.217.128/25, 18.246.82.0/25, 158.177.65.64/29, 159.122.103.184/29, 161.156.125.32/28. As of May 1, 2025 these ranges may be reallocated by the cloud provider to other customers for purposes out of our control. Please update your network configurations accordingly.
 </Callout>
 
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -22,7 +22,7 @@ freshnessValidatedDate: never
 
 
 <DNT>
-  **This list is current. Networks, IPs, domains, ports, and endpoints last updated March 4, 2024.**
+  **This list is current. Networks, IPs, domains, ports, and endpoints last updated March 4, 2025.**
 </DNT>
 
 This is a list of the networks, IP addresses, domains, ports, and endpoints used by API clients or agents to communicate with New Relic. [TLS is required for all domains](#tls).

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -808,7 +808,7 @@ Endpoints that use `api.newrelic.com` (such as our [NerdGraph API](/docs/apis/ne
 Network blocks:
 * `162.247.240.0/22`
 * `152.38.128.0/19` (effective June 20, 2024)
-* `185.221.84.0/22` (effective March 4, 2025)
+* `185.221.84.0/22`
 * `212.32.0.0/20` (effective June 20, 2024)
 * `64.251.192.0/20` (effective June 20, 2024)
 

--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -16,8 +16,13 @@ redirects:
 freshnessValidatedDate: never
 ---
 
+<Callout variant="important">
+  New Relic has discontinued the use of the following IP ranges: 3.145.244.128/25, 3.77.79.0/25, 20.51.136.0/25, 4.197.217.128/25, 18.246.82.0/25, 158.177.65.64/29, 159.122.103.184/29, 161.156.125.32/28. As of May 1, 2025 these ranges may be reallocated by the cloud provider to other customers for purposes out of our control. Please update your network configurations accordingly.
+</Callout>
+
+
 <DNT>
-  **This list is current. Networks, IPs, domains, ports, and endpoints last updated April 23, 2024.**
+  **This list is current. Networks, IPs, domains, ports, and endpoints last updated March 4, 2024.**
 </DNT>
 
 This is a list of the networks, IP addresses, domains, ports, and endpoints used by API clients or agents to communicate with New Relic. [TLS is required for all domains](#tls).
@@ -795,21 +800,21 @@ Synthetic private minions report to a specific endpoint based on region. To allo
 
 Endpoints that use `api.newrelic.com` (such as our [NerdGraph API](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph)) and our New Relic-generated [webhooks for alert policies](/docs/alerts/new-relic-alerts/managing-notification-channels/notification-channels-controlling-where-send-alerts#webhook) use an IP address from designated network blocks for the US or [EU region](/docs/using-new-relic/welcome-new-relic/get-started/introduction-eu-region-data-center). [TLS is required](#tls) for all addresses in these blocks.
 
-Network blocks:
+<Callout variant="important">
+  New Relic has discontinued the use of the following IP ranges: 3.145.244.128/25, 3.77.79.0/25, 20.51.136.0/25, 4.197.217.128/25, 18.246.82.0/25, 158.177.65.64/29, 159.122.103.184/29, 161.156.125.32/28. As of May 1, 2025 these ranges may be reallocated by the cloud provider to other customers for purposes out of our control. Please update your network configurations accordingly.
+</Callout>
 
+
+Network blocks:
 * `162.247.240.0/22`
-* `18.246.82.0/25` (effective August 20, 2023)
-* `3.145.244.128/25` (effective August 20, 2023)
-* `20.51.136.0/25` (effective June 20, 2024)
 * `152.38.128.0/19` (effective June 20, 2024)
-* `158.177.65.64/29`
-* `159.122.103.184/29`
-* `161.156.125.32/28`
-* `3.77.79.0/25` (effective August 20, 2023)
+* `185.221.84.0/22` (effective March 4, 2025)
 * `212.32.0.0/20` (effective June 20, 2024)
-* `3.27.118.128/25` (effective June 20, 2024)
-* `4.197.217.128/25` (effective June 20, 2024)
 * `64.251.192.0/20` (effective June 20, 2024)
+
+JSON file of New Relic public IP addresses
+* You can automate your allow lists based on this file: [IP range list](https://nr-downloads-main.s3.us-east-1.amazonaws.com/networking/newrelic-ip-ranges.json)
+
 
 These network blocks also apply to third-party ticketing integrations and [New Relic cloud integrations](/docs/integrations/infrastructure-integrations/get-started/introduction-infrastructure-integrations/#cloud-integrations). However, they don't apply to the [Azure Monitor integration](/docs/infrastructure/microsoft-azure-integrations/azure-integrations-list/azure-monitor/).
 


### PR DESCRIPTION
Updates to NR networks.  Removed CSP provided blocks no longer used and added a json file of NR space so it can be consumed programmatically.  I am on the New Relic Network team.  We are doing some house cleaning with our documentation.