### PR TITLE
fix(logs): (NR-371436) Clarify array support for logs

### DIFF
--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -461,7 +461,7 @@ Attributes may be of any of the following types:
       </td>
 
       <td>
-        Arrays will be _stringified_ and stored as strings. In the case of OpenTelemetry logs,
+        Arrays are converted to strings and then stored. OpenTelemetry logs support
         homogeneous arrays are supported. For more information see [arrays in OpenTelemetry](/docs/nrql/using-nrql/arrays-in-nrql/).
       </td>
     </tr>

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -462,7 +462,7 @@ Attributes may be of any of the following types:
 
       <td>
         Arrays are converted to strings and then stored. OpenTelemetry logs support
-        homogeneous arrays are supported. For more information see [arrays in OpenTelemetry](/docs/nrql/using-nrql/arrays-in-nrql/).
+        homogeneous arrays. For more information see [arrays in OpenTelemetry](/docs/nrql/using-nrql/arrays-in-nrql/).
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/logs/log-api/introduction-log-api.mdx
+++ b/src/content/docs/logs/log-api/introduction-log-api.mdx
@@ -461,7 +461,8 @@ Attributes may be of any of the following types:
       </td>
 
       <td>
-        (unsupported)
+        Arrays will be _stringified_ and stored as strings. In the case of OpenTelemetry logs,
+        homogeneous arrays are supported. For more information see [arrays in OpenTelemetry](/docs/nrql/using-nrql/arrays-in-nrql/).
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
We've never clarified the difference in array processing between opentelemetry and the rest of ingestion mechanisms.
This PR aims to fix that.

Bascially, we stringify all arrays except for Opentelemetry homogeneous (one type) arrays.

