### PR TITLE
removed .net information from callout

### DIFF
--- a/src/content/docs/alerts/incident-management/response-intelligence-ai.mdx
+++ b/src/content/docs/alerts/incident-management/response-intelligence-ai.mdx
@@ -9,8 +9,6 @@ freshnessValidatedDate: never
 <Callout title="preview">
   We're still working on this feature, but we'd love for you to try it out!
 
-  If you have questions or feedback, or if you need help during the preview of the .NET agent's <DNT>**Instrumentation**</DNT> editor, send an email to [dotnet-li-editor-beta@newrelic.com](mailto:dotnet-li-editor-beta@newrelic.com).
-
   This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 


### PR DESCRIPTION
Removed the .NET information from the Preview callout as per the request received in this [thread](https://newrelic.slack.com/archives/C08G80APCK1/p1741348360749049)