### PR TITLE
Amend iOS agent 7.5.4: Add note about multiple handled exception fix

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-754.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-754.mdx
@@ -10,6 +10,7 @@ downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agen
 * Fixed crash that could occur when recording handled exceptions.
 * Fixed various crashes that could occur when using the New Relic iOS agent.
 * The New Relic iOS agent now includes Session Attributes in Mobile Logs.
+* Fixed an issue that could occur when sending multiple handled exceptions to New Relic. The New Relic iOS agent will now will prevent data loss when sending multiple handled exceptions.
 
 ## Support statement
 


### PR DESCRIPTION
Amend iOS agent 7.5.4: Add note about multiple handled exception fix