### PR TITLE
Update monitor-scheduled-jobs.mdx

### DIFF
--- a/src/content/docs/alerts/create-alert/examples/monitor-scheduled-jobs.mdx
+++ b/src/content/docs/alerts/create-alert/examples/monitor-scheduled-jobs.mdx
@@ -19,16 +19,13 @@ This technique only works for regularly scheduled jobs that occur more frequentl
 
 In order to get the most out of this procedure, you'll need to know how to [create a condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions).
 
-This only works for <DNT>**Static**</DNT> or <DNT>**Anomaly**</DNT> [threshold types](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-nrql-alert-conditions#threshold-types)..
-
 ## How it works
 
-Typically, conditions use critical thresholds to trigger incidents. However, you can also trigger incidents with a loss of signal. To monitor a scheduled job and be notified if it doesn't happen, set your condition's threshold high or low enough so that it won't trigger an incident. That way, only a loss of signal will trigger an incident.
+Typically, conditions use critical thresholds to trigger incidents. However, you can also trigger incidents with a loss of signal. To monitor a scheduled job and be notified if it doesn't happen, set your signal loss timer to match the job schedule.
 
 ## Monitor a scheduled job
 
 1. [Create a condition](/docs/alerts-applied-intelligence/new-relic-alerts/alert-conditions/create-alert-conditions) related to the job you want to monitor.
-2. In <DNT>**Set your condition thresholds**</DNT>, set the <DNT>**Critical**</DNT> threshold above or below where it would ever trigger.
-3. Click <DNT>**+ Add lost signal threshold**</DNT>, then set the signal expiration duration time longer than your monitored job's scheduled cycle.
-4. Check <DNT>**Add lost signal threshold**</DNT>.
-5. Make sure you name your condition before you save it.
+2. Click <DNT>**+ Add lost signal threshold**</DNT>, then set the signal expiration duration time longer than your monitored job's scheduled cycle.
+3. Check <DNT>**Add lost signal threshold**</DNT>.
+4. Make sure you name your condition before you save it.


### PR DESCRIPTION
The regular static/anomaly threshold is not necessary for a Signal Loss alert. Also, there is no need to mention static/anomaly alerting methods, as there are no others, and they're not relevant in this case

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.