### PR TITLE
fix: JavaScriptError

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ionic-capacitor/get-started/introduction-new-relic-ionic-capacitor.mdx
@@ -333,7 +333,7 @@ The following customizations are available for the Capacitor agent.
     You can also find these errors by running this query:
 
     ```sql
-    SELECT * FROM `MobileHandledException` SINCE 24 hours ago
+    SELECT * FROM MobileHandledException SINCE 24 hours ago
     ```
   </Collapser>
 
@@ -350,7 +350,7 @@ The following customizations are available for the Capacitor agent.
     3. Run this query:
 
        ```sql
-       SELECT * FROM `JS Errors`
+       SELECT * FROM JavaScriptError
        ```
     4. Click <DNT>**Add to dashboard**</DNT>.
        <img title="Query builder" alt="This is an image of a sample query in the Query builder." src="/images/mobile_screenshot-full_query-example.webp"/>


### PR DESCRIPTION
```sql
SELECT * FROM `JS Errors`
```
Is not a valid query, events can't have white space in them. The image in the doc shows the correct query

<img width="1107" alt="image" src="https://github.com/user-attachments/assets/81f0b35b-081d-4e0e-b00c-8e835cfb25ea" />