### PR TITLE
Fix the broken link issue

### DIFF
--- a/src/install/config/aws-cloudwatch.yaml
+++ b/src/install/config/aws-cloudwatch.yaml
@@ -5,6 +5,7 @@ metaDescription: 'Install the Amazon CloudWatch Metric Streams integration'
 introFilePath: 'src/install/aws-cloudwatch/intro.mdx'
 redirects:
     - /docs/infrastructure/amazon-integrations/get-started/aws-metric-stream-setup
+    - /docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup
     - /docs/infrastructure/amazon-integrations/connect/cloudwatch-metric-streams/aws-metric-stream
     - /docs/infrastructure/amazon-integrations/connect/cloudwatch-metric-streams/aws-metric-stream-setup
     - /docs/infrastructure/amazon-integrations/connect/aws-metric-stream


### PR DESCRIPTION
We have received this issue to fix the broken link for AWS Metric Steam Setup.