### PR TITLE
Php/log label forwarding docs

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1779,7 +1779,7 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
       </tbody>
     </table>
 
-    Enables the sending of customs tags (labels) with agent-forwarded logs to New Relic.
+    Enables the sending of custom tags (labels) with agent-forwarded logs to New Relic.
 
     This feature was added in the 11.7.0 release of the PHP agent.
 

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1737,6 +1737,124 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
     newrelic.application_logging.forwarding.log_level = "INFO"
     ```
   </Collapser>
+
+
+  <Collapser
+    id="cfg-application_logging_forwarding_labels-enabled"
+    title="newrelic.application_logging.forwarding.labels.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            PERDIR
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables the sending of customs tags (labels) with agent-forwarded logs to New Relic.
+
+    This feature was added in the 11.7.0 release of the PHP agent.
+
+    Tags will appear as attributes on log events with the prefix `tags.` inserted at the front of the attribute name.
+
+      Example configuration file (`newrelic.ini`):
+
+      ```ini
+      newrelic.application_logging.forwarding.labels.enabled = true
+      ```
+  </Collapser>
+
+  <Collapser
+    id="cfg-application_logging_forwarding_labels-exclude"
+    title="newrelic.application_logging.forwarding.labels.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            PERDIR
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            List of strings (comma separated)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `""`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables the filtering of which custom tags (labels) are sent with agent-forwarded logs.
+
+    The value is a list of strings separated by commas.  Each string in the list will be matched in a case-insentive way
+    to the currently defined labels, and any exact matches will be removed from the labels which are forwarded.
+
+    For example, consider the following definition of labels:
+
+    ```ini
+    newrelic.labels = "Data Center, Business, Cost code"
+    ```
+
+    Now the following exclude rules:
+
+    ```ini
+    newrelic.application_logging.forwarding.labels.exclude = business, Cost Code
+    ```
+
+    will filter out the "Business" and "Cost code" labels because the comparision is done in a case-insensitive manner.
+
+    <Callout variant="tip">
+      The `newrelic.labels` INI value allows defining labels which contain the comma (",") character.  These labels cannot be 
+      filtered out using the `exxlude` INI value, as it relies on commas to separate the exclusion rules. It is recommended to 
+      not use the comma character in label values if excluding these labels from being added to log messages
+    </Callout>
+
+  </Collapser>
+
 </CollapserGroup>
 
 #### Log context data [#log-context-data]

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1851,7 +1851,7 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
 
     <Callout variant="tip">
       The `newrelic.labels` INI value allows defining labels which contain the comma (",") character.  These labels can't be 
-      filtered out using the `exxlude` INI value, as it relies on commas to separate the exclusion rules. It is recommended to 
+      filtered out using the `exlude` INI value, as it relies on commas to separate the exclusion rules. It is recommended to 
       not use the comma character in label values if excluding these labels from being added to log messages.
     </Callout>
 

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1556,6 +1556,8 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
 * `newrelic.application_logging.forwarding.enabled` enables or disables log forwarding
 * `newrelic.application_logging.forwarding.max_samples_stored` limits how many logs your app forwards to New Relic
 * `newrelic.application_logging.forwarding.log_level` lets you choose what kinds of logs your app forwards to New Relic
+* `newrelic.application_logging.forwarding.labels.enabled` enabled the sending of custom tags (labels) with agent-forwarded log messages
+* `newrelic.application_logging.forwarding.labels.exclude` lets you choose which labels are sent with agent-forwarded log messages
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1841,18 +1841,18 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
     newrelic.labels = "Data Center, Business, Cost code"
     ```
 
-    Now the following exclude rules:
+    The following exclude rules will filter out the `Business` and `Cost code` labels because the comparision is done in a case-insensitive manner.
 
     ```ini
     newrelic.application_logging.forwarding.labels.exclude = business, Cost Code
     ```
 
-    will filter out the "Business" and "Cost code" labels because the comparision is done in a case-insensitive manner.
+    
 
     <Callout variant="tip">
-      The `newrelic.labels` INI value allows defining labels which contain the comma (",") character.  These labels cannot be 
+      The `newrelic.labels` INI value allows defining labels which contain the comma (",") character.  These labels can't be 
       filtered out using the `exxlude` INI value, as it relies on commas to separate the exclusion rules. It is recommended to 
-      not use the comma character in label values if excluding these labels from being added to log messages
+      not use the comma character in label values if excluding these labels from being added to log messages.
     </Callout>
 
   </Collapser>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1556,7 +1556,7 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
 * `newrelic.application_logging.forwarding.enabled` enables or disables log forwarding
 * `newrelic.application_logging.forwarding.max_samples_stored` limits how many logs your app forwards to New Relic
 * `newrelic.application_logging.forwarding.log_level` lets you choose what kinds of logs your app forwards to New Relic
-* `newrelic.application_logging.forwarding.labels.enabled` enabled the sending of custom tags (labels) with agent-forwarded log messages
+* `newrelic.application_logging.forwarding.labels.enabled` enables or disables the sending of custom tags (labels) with agent-forwarded log messages
 * `newrelic.application_logging.forwarding.labels.exclude` lets you choose which labels are sent with agent-forwarded log messages
 
 <CollapserGroup>

--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -1553,11 +1553,11 @@ Keep in mind that changing your settings in your local agent configuration file 
 
 If you're using a [supported logging framework](/docs/logs/logs-context/configure-logs-context-php), you can direct the agent to forward your app logs to New Relic.
 
-* `newrelic.application_logging.forwarding.enabled` enables or disables log forwarding
-* `newrelic.application_logging.forwarding.max_samples_stored` limits how many logs your app forwards to New Relic
-* `newrelic.application_logging.forwarding.log_level` lets you choose what kinds of logs your app forwards to New Relic
-* `newrelic.application_logging.forwarding.labels.enabled` enables or disables the sending of custom tags (labels) with agent-forwarded log messages
-* `newrelic.application_logging.forwarding.labels.exclude` lets you choose which labels are sent with agent-forwarded log messages
+* `newrelic.application_logging.forwarding.enabled` enables or disables log forwarding.
+* `newrelic.application_logging.forwarding.max_samples_stored` limits how many logs your app forwards to New Relic.
+* `newrelic.application_logging.forwarding.log_level` lets you choose what kinds of logs your app forwards to New Relic.
+* `newrelic.application_logging.forwarding.labels.enabled` enables or disables the sending of custom tags (labels) with agent-forwarded log messages.
+* `newrelic.application_logging.forwarding.labels.exclude` lets you choose which labels are sent with agent-forwarded log messages.
 
 <CollapserGroup>
   <Collapser
@@ -1832,8 +1832,8 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
 
     Enables the filtering of which custom tags (labels) are sent with agent-forwarded logs.
 
-    The value is a list of strings separated by commas.  Each string in the list will be matched in a case-insentive way
-    to the currently defined labels, and any exact matches will be removed from the labels which are forwarded.
+    The value is a list of strings separated by commas.  Each string in the list will be matched in a case-insensitive way
+    to the currently defined labels, and any exact matches will be removed from the labels that are forwarded.
 
     For example, consider the following definition of labels:
 
@@ -1841,7 +1841,7 @@ If you're using a [supported logging framework](/docs/logs/logs-context/configur
     newrelic.labels = "Data Center, Business, Cost code"
     ```
 
-    The following exclude rules will filter out the `Business` and `Cost code` labels because the comparision is done in a case-insensitive manner.
+    The following exclude rules will filter out the `Business` and `Cost code` labels because the comparison is done in a case-insensitive manner.
 
     ```ini
     newrelic.application_logging.forwarding.labels.exclude = business, Cost Code

--- a/src/content/docs/logs/logs-context/custom-tags-agent-forwarder-logs.mdx
+++ b/src/content/docs/logs/logs-context/custom-tags-agent-forwarder-logs.mdx
@@ -25,3 +25,4 @@ Supported languages:
 * Java: coming soon
 * [Node.js](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration): agent version 12.8.0 or higher.
 * [Python](/docs/apm/agents/python-agent/configuration/python-agent-configuration) agent versions 10.3.0 or higher.
+* [PHP](/docs/apm/agents/php-agent/configuration/php-agent-configuration/) agent versions 11.7.0 or higher.


### PR DESCRIPTION
Adds documentation for log label forwarding for the PHP agent which is coming in an upcoming release.

Please do not merge when approved - I will let you know when the release is completed and merging can happen.

