### PR TITLE
chore: Updated language around using Node.js lambda layer with ESM

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/containerized-images.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/containerized-images.mdx
@@ -7,7 +7,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-If you're using a containerized image for a Lambda function and want to monitor your application, you'll need to add a pre-built [New Relic Lambda layer](https://gallery.ecr.aws/newrelic-lambda-layers-for-docker?page=1) to your Dockerfile that matches your function's runtime. 
+If you're using a containerized image for a Lambda function and want to monitor your application, you'll need to add a pre-built [New Relic Lambda layer](https://gallery.ecr.aws/newrelic-lambda-layers-for-docker?page=1) to your Dockerfile that matches your function's runtime.
 
 Here's a diagram showing the process of adding New Relic to the Dockerfile so you can monitor your function:
 
@@ -122,6 +122,8 @@ Here's a guide to adding our pre-built layer to your code.
 
           # CMD override to New Relic's handler wrapper
           CMD [ "newrelic-lambda-wrapper.handler" ]
+          # If your lambda function is ESM, use the New Relic's Node.js ESM handler wrapper
+          # CMD ["/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler"]
           ```
           Try out [working example](https://github.com/newrelic/newrelic-lambda-extension/tree/main/examples/sam/containerized-lambda/nodejs-sam-example) of a Node.js containerized Lambda function using SAM.
         </TabsPageItem>

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -73,7 +73,7 @@ Based on your runtime, you can set the following environment variables to furthe
             <td>`NEW_RELIC_USE_ESM`</td>
             <td>`false`</td>
             <td>`true`, `false`</td>
-            <td>**Required**: Enable ESM functions that use async/await and not callbacks by setting this to `true`</td>
+            <td>**DEPRECATED**: This will be removed from future versions of the Node.js lambda layer.  Instead set your handler to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`</td>
         </tr>
         <tr>
             <td>`NODE_OPTIONS`</td>
@@ -293,7 +293,7 @@ You can find more environment variables in our [Python configuration documentati
             <td>`/opt/lib/newrelic-dotnet-agent/libNewRelicProfiler.so`</td>
             <td>**Required**: Set this to `/opt/lib/newrelic-dotnet-agent/libNewRelicProfiler.so` to enable the .NET agent</td>
         </tr>
-        
+
         <tr>
             <td>`NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`</td>
             <td>`true`</td>
@@ -411,7 +411,7 @@ See more environment variables for the New Relic extension in our [documentation
     </TabsPageItem>
 
 
-    </TabsPages>    
+    </TabsPages>
 </Tabs>
 
 ## What's next

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/instrument-your-own.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/instrument-your-own.mdx
@@ -158,7 +158,7 @@ Depending on your needs, you can choose to either bypass the extension and only 
         // Add latest New Relic Lambda layer ARN from https://layers.newrelic-external.com
         const NewReliclayerArn = 'arn:aws:lambda:us-east-1:451483290750:layer:NewRelicNodeJS20X:39';
         const myFunction = new lambda.Function(this, "NewRelicExampleLambda", {
-          runtime: lambda.Runtime.NODEJS_20_X, 
+          runtime: lambda.Runtime.NODEJS_20_X,
           // Update functions handler to point to the New Relic Lambda wrapper
           handler: "newrelic-lambda-wrapper.handler",
           code: lambda.Code.fromAsset('lib/lambda-runtime-code'),
@@ -226,7 +226,9 @@ Depending on your needs, you can choose to either bypass the extension and only 
       * `RequestHandler` implementation: `com.newrelic.java.HandlerWrapper::handleRequest`.
       * `RequestStreamHandlerWrapper` implementation: `com.newrelic.java.HandlerWrapper::handleStreamsRequest`.
     * Python: `newrelic_lambda_wrapper.handler` (underscores).
-    * Node: `newrelic-lambda-wrapper.handler` (hyphens).
+    * Node:
+      * CommonJS: `newrelic-lambda-wrapper.handler` (hyphens).
+      * ESM: `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler` (hyphens).
     * For .Net you don't have to set the handler.
 
     Note that for Go, you must make source code changes to your Lambda function to instrument it. Configuration changes are not enough.

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -31,7 +31,7 @@ Besides these basic enablement problems, there are some additional problems that
 
   * If you're instrumenting with layers: make sure in your function configuration that the New Relic layer is merged before other layers (though if your function uses webpack, the New Relic layer should be merged after the webpack layer).
   * If you're instrumenting a Node.js function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports <DNT>**newrelic**</DNT> before it imports any dependencies you expect to monitor.
-  * If you're using ES Modules with a Node.js function, make sure change the handler function to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`. Additionally, set the environment variable of `NODE_PATH` to `--experimental-loader newrelic/esm-loader.mjs`.
+  * If you're using ES Modules with a Node.js function, make sure to change the handler function to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`. Additionally, set the environment variable of `NODE_PATH` to `--experimental-loader newrelic/esm-loader.mjs`.
 
 If none of these solutions help you, contact our [support team](https://support.newrelic.com/). The following information will help you when you talk to support technicians:
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/troubleshooting/troubleshoot-enabling-serverless-monitoring-aws-lambda.mdx
@@ -31,7 +31,7 @@ Besides these basic enablement problems, there are some additional problems that
 
   * If you're instrumenting with layers: make sure in your function configuration that the New Relic layer is merged before other layers (though if your function uses webpack, the New Relic layer should be merged after the webpack layer).
   * If you're instrumenting a Node.js function manually, make sure that [logging is enabled](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#logging_config), and that your function imports <DNT>**newrelic**</DNT> before it imports any dependencies you expect to monitor.
-  * If you're using ES Modules with a Node.js function, make sure that the environment variable `NEW_RELIC_USE_ESM` is set to `true`. Additionally, make sure you're using async/await or promises for handling asynchronous behavior in your function, as callback-based functions are not supported when using ES Modules.
+  * If you're using ES Modules with a Node.js function, make sure change the handler function to `/opt/nodejs/node_modules/newrelic-esm-lambda-wrapper/index.handler`. Additionally, set the environment variable of `NODE_PATH` to `--experimental-loader newrelic/esm-loader.mjs`.
 
 If none of these solutions help you, contact our [support team](https://support.newrelic.com/). The following information will help you when you talk to support technicians:
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

The Node.js lambda layer is changing behavior to support ESM.  We're deprecating the existing way. This PR updates the language to call out how to wrap lambdas using ESM. The functionality hasn't been released but will be released on March 17, 2025.


