### PR TITLE
fix: Fix the broken link issue for AWS metric stream

### DIFF
--- a/src/install/config/aws-cloudwatch.yaml
+++ b/src/install/config/aws-cloudwatch.yaml
@@ -8,6 +8,8 @@ redirects:
     - /docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup
     - /docs/infrastructure/amazon-integrations/connect/cloudwatch-metric-streams/aws-metric-stream
     - /docs/infrastructure/amazon-integrations/connect/cloudwatch-metric-streams/aws-metric-stream-setup
+    - /docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream
+    - /docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream
     - /docs/infrastructure/amazon-integrations/connect/aws-metric-stream
 
 #----------------------------------------------------------------


### PR DESCRIPTION
Added a redirect to the AWS metric stream documentation to fix a broken link issue.