### PR TITLE
Update java sqs doc with config warning

### DIFF
--- a/src/content/docs/apm/agents/java-agent/instrumentation/instrument-aws-sqs-message-queues.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/instrument-aws-sqs-message-queues.mdx
@@ -14,6 +14,21 @@ The Java Agent supports instrumentation for AWS SQS message queues. While our SQ
 
 To see all supported SQS libraries, refer to [Java compatibility and requirements page](/docs/agents/java-agent/getting-started/compatibility-requirements-java-agent). 
 
+<Callout variant="important">
+  Users of Java Agent 8.18.0 need to manually enable SQS instrumentation. You can enable this instrumentation in your `newrelic.yml` file:
+
+```yml
+class_transformer:
+  aws-java-sdk-sqs:
+    enabled: true
+```
+
+Alternatively, you can set the system property `-Dnewrelic.config.class_transformer.aws-java-sdk-sqs.enabled=true` or the environment variable `NEW_RELIC_CLASS_TRANSFORMER_AWS_JAVA_SDK_SQS_ENABLED=true`. 
+
+The instrumentation is enabled by default for other versions of the Java Agent. 
+
+</Callout>
+
 ## View SQS Distributed Tracing
 
 The AWS SQS SDK instrumentation automatically includes distributed trace headers as message attributes for SQS messages. This functionality is available starting from version 2.1.0. However, for message receiver operations, there isn't a built-in method to process these headers. We suggest that you implement custom instrumentation to read the distributed trace headers.


### PR DESCRIPTION
Update our SQS instrumentation page with a notice about required configuration for version 8.18.0 of the Java Agent. 