### PR TITLE
(fix) fix the collapser issue to resolve anchor tag error

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api.mdx
@@ -122,7 +122,7 @@ Use these API calls to record additional events:
  * [recordCustomEvent](https://newrelic.github.io/node-newrelic/API.html#recordCustomEvent)
  * [recordLogEvent](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent)
 
-## Transaction handle methods
+## Transaction handle methods [#transaction-handle]
 Use these API calls to [interact with the current transaction](https://newrelic.github.io/node-newrelic/TransactionHandle.html)
 
 ## Rules for naming and ignoring requests [#ignoring]
@@ -146,7 +146,7 @@ Here is the structure for rules in New Relic's Node.js agent.
     NEW_RELIC_NAMING_RULES='{"pattern":"^t","name":"u"},{"pattern":"^u","name":"t"}'
     ```
 
-    ## Optional rules attributes [#optional-rules-attribute]
+    ### Optional rules attributes
 
     Additional optional attributes are available:
 
@@ -213,7 +213,7 @@ Here is the structure for rules in New Relic's Node.js agent.
       </tbody>
     </table>
 
-    ## Testing your naming rules [#testing-naming-rules]
+    ### Testing your naming rules
 
     The Node.js agent comes with a command-line tool for testing naming rules. For more information, run the following command in terminal window in a directory where your app is installed:
 
@@ -221,7 +221,7 @@ Here is the structure for rules in New Relic's Node.js agent.
     node node_modules/.bin/newrelic-naming-rules
     ```
 
-    ## Naming rule examples [#examples-rules]
+    ### Naming rule examples
 
     Here are some examples of naming rules and the results.
 


### PR DESCRIPTION
I have created this PR in response to [this JIRA ticket](https://new-relic.atlassian.net/browse/NR-381873). This PR fixes the collapser issue in the Node API doc that was causing the anchor tag to display as plain text.