### PR TITLE
docs: Remove secret limit note for service migration

### DIFF
--- a/src/content/docs/new-relic-solutions/build-nr-ui/nerdstoragevault.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/nerdstoragevault.mdx
@@ -111,9 +111,10 @@ query {
 
 ### Limits [#limits]
 
-* A maximum of 10 secrets can be stored per ACTOR.
 * A secret value is limited to 5000 characters.
 * A key value is limited to 64 characters.
+* A key value must only include alphanumeric, '_' or '-' characters
+	
 
 ### Permissions for working with `NerdStorageVault` [#permissions]
 


### PR DESCRIPTION
Description
Once we switch nerd-storage-vault to use Customer Secrets Service instead of Synthetics Locker, the secret limit per actor will no longer apply. This PR removes that note from the doc, and should be merged after the switch is made.

Related PR - https://github.com/newrelic/developer-website/pull/2282