### PR TITLE
fix: fix typo in example query

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/page-resources.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/page-resources.mdx
@@ -23,7 +23,7 @@ Page resources detected by the browser agent will be queryable through the `Brow
 Example queries to view page resource timing data:
 
 ```nrql
-FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryName = 'resource'
+FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryType = 'resource'
 ```
 
 ```nrql


### PR DESCRIPTION
This PR fixes a typo that was found by a customer that is present in an example query in our public preview of page resources capture.