### PR TITLE
Fixed incorrect syntax in NerdGraph examples on nerdgraph-api-notifications-destinations.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-notifications-destinations.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-notifications-destinations.mdx
@@ -224,8 +224,8 @@ In order to create a destination, different inputs must be supplied for each des
         auth: {
           type: BASIC,
           basic: {
-            "user": YOUR_EMAIL,
-            "password": YOUR_PASSWORD
+            user: YOUR_EMAIL,
+            password: YOUR_PASSWORD
           }
         },
         properties: [
@@ -261,8 +261,8 @@ In order to create a destination, different inputs must be supplied for each des
         auth: {
           type: BASIC,
           basic: {
-            "user": YOUR_EMAIL,
-            "password": YOUR_PASSWORD
+            user: YOUR_EMAIL,
+            password: YOUR_PASSWORD
           }
         },
         properties: [
@@ -308,8 +308,8 @@ In order to create a destination, different inputs must be supplied for each des
         auth: {
           type: BASIC,
           basic: {
-            "user": YOUR_EMAIL,
-            "password": YOUR_PASSWORD
+            user: YOUR_EMAIL,
+            password: YOUR_PASSWORD
           }
         },
         properties: [
@@ -371,8 +371,8 @@ In order to create a destination, different inputs must be supplied for each des
         auth: {
           type: BASIC,
           basic: {
-            "user": YOUR_IAM_USER,
-            "password": YOUR_PASSWORD
+            user: YOUR_IAM_USER,
+            password: YOUR_PASSWORD
           }
         },
         properties: [


### PR DESCRIPTION
In the BASIC auth examples, both the user and password field names were wrapped in double quotes. Theses are field names, not values.

When the example is pasted as into the NerdGraph API Explorer, the following error is displayed:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/24969de1-ce60-4dc0-883d-88c2a808ae1f" />

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.