### PR TITLE
docs(dotnet): Update Couchbase compatibility requirements

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -408,6 +408,22 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 <tr>
                 <td>
+                    Couchbase
+                </td>
+
+                <td/>
+
+                <td>
+                    Use [CouchbaseNetClient](https://www.nuget.org/packages/CouchbaseNetClient/).
+
+                    * Minimum supported version: 3.2.0
+                    * Latest verified compatible version: 3.6.6
+                    * Minimum agent version required: 10.40.0
+                </td>
+                </tr>
+
+                <tr>
+                <td>
                     Microsoft SQL Server
                 </td>
 
@@ -1388,10 +1404,11 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       Use [CouchbaseNetClient](https://www.nuget.org/packages/CouchbaseNetClient/).
 
                       * Minimum supported version: 2.0.0
-                      * Latest verified compatible version: 2.3.8
-                      * Known incompatible versions: 2.4.0+
+                      * Latest verified compatible version: 3.6.6
+                      * Version 3.2.0 and later are supported beginning with .NET agent v10.40.0
+                      * Known incompatible versions: 3.0.x, 3.1.x
 
-                      With Couchbase, the following are not instrumented by default in favor of their multi-document counterparts:
+                      With CouchbaseNetClient 2.x, the following are not instrumented by default in favor of their multi-document counterparts:
 
                       * `Get(string key)`
                       * `GetDocument(string key)`


### PR DESCRIPTION
Updates .NET agent compatibility docs to add CouchbaseNetClient v3.x instrumentation support.