### PR TITLE
feat(kubernetes): Update docs to support k8s v1.32 and add deprecation notice for v1.27

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements.mdx
@@ -71,7 +71,7 @@ Our integration is compatible and is continuously tested on the following Kubern
       </td>
 
       <td>
-        1.27 to 1.31
+        1.28 to 1.32
       </td>
     </tr>
   </tbody>

--- a/src/content/eol/2025/03/deprecation-notice-v1.27-and-lower.md
+++ b/src/content/eol/2025/03/deprecation-notice-v1.27-and-lower.md
@@ -1,7 +1,8 @@
 ---
 title: 'Deprecation notice: Kubernetes'
 subject: Kubernetes integration
-releaseDate: '2025-03-24'
+publishDate: '2025-03-24'
+eolEffectiveDate: '2025-03-24'
 ---
 
 Effective Monday, March 3, 2025, our Kubernetes integration drops support for Kubernetes v1.27 and lower. The Kubernetes integration v3.40.1 and higher will only be compatible with Kubernetes versions 1.28 and higher. For more information, read this note or contact your account team.

--- a/src/content/eol/2025/03/deprecation-notice-v1.27-and-lower.md
+++ b/src/content/eol/2025/03/deprecation-notice-v1.27-and-lower.md
@@ -5,15 +5,15 @@ publishDate: '2025-03-24'
 eolEffectiveDate: '2025-03-24'
 ---
 
-Effective Monday, March 3, 2025, our Kubernetes integration drops support for Kubernetes v1.27 and lower. The Kubernetes integration v3.40.1 and higher will only be compatible with Kubernetes versions 1.28 and higher. For more information, read this note or contact your account team.
+Effective Monday, March 3, 2025, our Kubernetes integration will not support Kubernetes v1.27 and earlier. The Kubernetes integration v3.40.1 and later will be compatible only with Kubernetes versions 1.28 and later. For more information, read this note or contact your account team.
 
 ## Background [#bg]
 
-Enabling compatibility with the latest Kubernetes versions and adding new features to our Kubernetes offering prevents us from offering first-class support to versions v1.27 and lower.
+Enabling compatibility with the latest Kubernetes versions and adding new features to our Kubernetes offering prevents us from offering first-class support to versions v1.27 and earlier.
 
 ## What's happening [#whats-happening]
 
-* Most major Kubernetes cloud providers have already deprecated v1.27 and lower.
+* Most major Kubernetes cloud providers have already deprecated v1.27 and earlier.
 
 ## What do you need to do [#what-to-do]
 

--- a/src/content/eol/2025/03/deprecation-notice-v1.27-and-lower.md
+++ b/src/content/eol/2025/03/deprecation-notice-v1.27-and-lower.md
@@ -1,0 +1,25 @@
+---
+title: 'Deprecation notice: Kubernetes'
+subject: Kubernetes integration
+releaseDate: '2025-03-24'
+---
+
+Effective Monday, March 3, 2025, our Kubernetes integration drops support for Kubernetes v1.27 and lower. The Kubernetes integration v3.40.1 and higher will only be compatible with Kubernetes versions 1.28 and higher. For more information, read this note or contact your account team.
+
+## Background [#bg]
+
+Enabling compatibility with the latest Kubernetes versions and adding new features to our Kubernetes offering prevents us from offering first-class support to versions v1.27 and lower.
+
+## What's happening [#whats-happening]
+
+* Most major Kubernetes cloud providers have already deprecated v1.27 and lower.
+
+## What do you need to do [#what-to-do]
+
+It's easy: [Upgrade your Kubernetes clusters](/docs/integrations/kubernetes-integration/installation/kubernetes-installation-configuration#update) to a supported version.
+
+## What happens if you don't make any changes to your account [#account]
+
+The Kubernetes integration may continue to work with unsupported versions. However, we can't guarantee the quality of the solution as new releases may cause some incompatibilities.
+
+Please note that we won't accept support requests for these versions that have reached the end of life stage.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
Bumps the supported k8s version to 1.32 and adds a deprecation notice for v1.27 and lower.

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.