### PR TITLE
fix: rss redirection in email

### DIFF
--- a/plugins/gatsby-plugin-release-note-rss/gatsby-node.js
+++ b/plugins/gatsby-plugin-release-note-rss/gatsby-node.js
@@ -12,6 +12,7 @@ const parseISO = preferDefault(require('date-fns/parseISO'));
 const jsxImagesToChildren = require('../utils/jsxImagesToChildren');
 const handlers = require('../utils/handlers');
 const { getTitle } = require('../../src/utils/releaseNotes');
+const visit  = require('unist-util-visit');
 
 // NOTE: remove-imports and remove-exports are now depreciated
 const htmlGenerator = unified()
@@ -88,6 +89,15 @@ const releaseNotesQuery = async (graphql) => {
 const getFeedItem = (node, siteMetadata, imageHashMap) => {
   const { frontmatter, slug, mdxAST } = node;
   const { releaseDate, subject, version } = frontmatter;
+
+  const baseUrl = 'https://docs.newrelic.com';
+
+  // Traverse and update the MDX AST to prepend base URL to relative links
+  visit(mdxAST, 'link', (node) => {
+    if (node.url.startsWith('/docs/')) {
+      node.url = `${baseUrl}${node.url}`;
+    }
+  });
 
   const transformedAST = htmlGenerator.runSync(mdxAST);
   const html = htmlGenerator.stringify(


### PR DESCRIPTION
We are exposing RSS xml endpoints for Release Notes to customers  
Some Costumers might use RSS Readers like https://feeder.co/reader
and Some Customers prefer to receive Emails if any new release notes are published
For these second set of Customers The redirect links are not working properly in mail
This PR Addresses in fixing this redirection issue

[Issue](https://github.com/newrelic/docs-website/issues/18734)
[Ticket](https://new-relic.atlassian.net/browse/NR-378976)
