### PR TITLE
Remove reference to New Relic One

### DIFF
--- a/src/content/docs/apm/transactions/workload-performance-monitoring/introdution.mdx
+++ b/src/content/docs/apm/transactions/workload-performance-monitoring/introdution.mdx
@@ -30,7 +30,7 @@ You need to enable distributed tracing to use Transaction 360. Most of the exper
 
 ## Getting started
 
-To get started with Transaction 360, you need to enable distributed tracing in your New Relic account. Once enabled, you can access the Transaction 360 feature from the New Relic One homepage.
+To get started with Transaction 360, you need to enable distributed tracing in your New Relic account. Once enabled, you can access the Transaction 360 feature from the transactions area in New Relic.
 
 
 ## What's next


### PR DESCRIPTION
Hey docs folks -- this is a spot fix, but it needs to be made on the hundreds of spots in the docs that refer to the product as "New Relic One." That's not the name for the product that we use anymore (for at least a year). In addition, there's not a home page, so I removed the reference to home page. Getting to transaction 360 isn't straightforward and it's not part of "All Capabilities" if that's what this was referring to — you need to go to the transaction page for a service and open it from there. 

Here's the spot in the style guide that describes how to refer to New Relic: https://newrelic.atlassian.net/wiki/spaces/PD/pages/3804889254/Product+and+capabilities+capitalization+trademarks+and+usage

Note that there's also a guideline not to say "New Relic's" 

Thanks.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.