### PR TITLE
chore: Update record-deployments.mdx

### DIFF
--- a/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
+++ b/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
@@ -319,7 +319,7 @@ Some agents have additional methods to record deployments:
 * <DNT>**Node.js**</DNT>: No agent-specific methods. Use the [REST API](#api).
 * <DNT>**PHP**</DNT>: Use a [PHP script](/docs/agents/php-agent/features/recording-deployments-using-php-script).
 * <DNT>**Python**</DNT>: Use the [`record-deploy`](/docs/agents/python-agent/installation-configuration/python-agent-admin-script#record-deploy) subcommand of the `newrelic-admin` script.
-* <DNT>**Ruby**</DNT>: Use a [Capistrano recipe](/docs/agents/ruby-agent/features/recording-deployments-ruby-agent#capistrano3).
+* <DNT>**Ruby**</DNT>: Use a Capistrano recipe or the `newrelic deployments` command. More details [here](/docs/agents/ruby-agent/features/recording-deployments-ruby-agent).
 
 ## View deployment details [#dep_procedures]
 


### PR DESCRIPTION
This document doesn't reference the full scope of options to record deployments with the Ruby agent. 

Updating the bullet point to include our other options.