### PR TITLE
chore: Update record-deployments-ruby-agent.mdx

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
@@ -48,15 +48,16 @@ You can use several optional values with `newrelic`. The `description` is short 
 ```bash
 deployments [OPTIONS] [description]
 OPTIONS:
-   -a, --appname=name           Set the application name.
-   -i, --appid=ID               Set the application ID
-                                If not provided, will connect to the New Relic collector to get it
-                                Default is app_name setting in newrelic.yml
-   -e, --environment=name       Override the (RAILS|RUBY)_ENV setting
-   -u, --user=USER              Specify the user deploying.
-   -r, --revision=REV           Specify the revision being deployed
-   -c, --changes                Read in a change log from the standard input
-   -h                           Print this help
+    -a, --appname=NAME                       Set the application name.
+                                             Default is app_name setting in newrelic.yml. Available only when using API v1.
+    -i, --appid=ID                           Set the application ID
+                                             If not provided, will connect to the New Relic collector to get it
+    -e, --environment=name                   Override the (RAILS|RUBY|RACK)_ENV setting
+    -u, --user=USER                          Specify the user deploying, for information only
+    -r, --revision=REV                       Specify the revision being deployed. Required when using New Relic REST API v2
+    -l, --license-key=KEY                    Specify the license key of the account for the app being deployed
+    -c, --changes                            Read in a change log from the standard input
+    -h                                       Show this help
 ```
 
 When using the `-c` option, you can pipe the change log into the script. If not piping when using the `-c` option, select `control-D` to signify the end of file (EOF).


### PR DESCRIPTION
Update help options output to include information about required keys for v1 and v2 API options
