### PR TITLE
earliest wording

### DIFF
--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -1626,7 +1626,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
     It takes a single argument.
 
-    If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
+    If used in conjunction with a `FACET` it will return the earliest value for an attribute for each of the resulting facets.
 
     <CollapserGroup>
       <Collapser title="Get earliest country per user agent from PageView">


### PR DESCRIPTION
The `earliest()` function returns the earliest value for each facet, not the most recent.