### PR TITLE
**DRAFT** docs(dotnet): Remove recently added environment variable configuration for in-process Azure functions.

### DIFF
--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/install-serverless-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/install-serverless-azure-monitoring.mdx
@@ -160,6 +160,9 @@ Ensure that you add a comma at the end of the last existing line and update your
     "slotSetting": false
   }
   ```
+
+  The Azure websites extension automatically configures all other required environment variables.
+
   
   Optionally, you can specify the version of the .NET agent you want to install by adding the following environment variable:
 
@@ -171,7 +174,7 @@ Ensure that you add a comma at the end of the last existing line and update your
   }
   ```
 
-  ### NewRelic.Agent Nuget package (Isolated mode functions):
+  ### NewRelic.Agent Nuget package:
 
   ```
   {
@@ -235,77 +238,6 @@ Ensure that you add a comma at the end of the last existing line and update your
     "slotSetting": false
   }
   ```
-
-  ### NewRelic.Agent Nuget package (In-process mode functions):
-
-  ```
-  {
-    "name": "CORECLR_ENABLE_PROFILING",
-    "value": "1",
-    "slotSetting": false
-  },
-  {
-    "name": "CORECLR_NEW_RELIC_HOME",
-    "value": "C:\\home\\site\\wwwroot\\newrelic",
-    "slotSetting": false
-  },
-  {
-    "name": "CORECLR_PROFILER",
-    "value": "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}",
-    "slotSetting": false
-  }, 
-  {
-    "name": "CORECLR_PROFILER_PATH_32",
-    "value": "C:\\home\\site\\wwwroot\\bin\\newrelic\\x86\\NewRelic.Profiler.dll",
-    "slotSetting": false
-  },
-  {
-    "name": "CORECLR_PROFILER_PATH_64",
-    "value": "C:\\home\\site\\wwwroot\bin\\newrelic\\NewRelic.Profiler.dll",
-    "slotSetting": false
-  },
-  {
-    "name": "COR_ENABLE_PROFILING",
-    "value": "1",
-    "slotSetting": false
-  },
-  {
-    "name": "NEW_RELIC_HOME",
-    "value": "C:\\home\\site\\wwwroot\\newrelic",
-    "slotSetting": false
-  },
-  {
-    "name": "NEW_RELIC_INSTALL_PATH",
-    "value": "c:\\home\\site\\wwwroot\\bin\\newrelic",
-    "slotSetting": false
-  },
-  {
-    "name": "COR_PROFILER",
-    "value": "{71DA0A04-7777-4EC6-9643-7D28B46A8A41}",
-    "slotSetting": false
-  }, 
-  {
-    "name": "COR_PROFILER_PATH_32",
-    "value": "C:\\home\\site\\wwwroot\\bin\\newrelic\\x86\\NewRelic.Profiler.dll",
-    "slotSetting": false
-  },
-  {
-    "name": "COR_PROFILER_PATH_64",
-    "value": "C:\\home\\site\\wwwroot\\bin\\newrelic\\NewRelic.Profiler.dll",
-    "slotSetting": false
-  },
-  {
-    "name": "NEW_RELIC_LOG_DIRECTORY",
-    "value": "C:\\home\\LogFiles\\NewRelic",
-    "slotSetting": false
-  },
-  {
-    "name": "NEW_RELIC_LICENSE_KEY",
-    "value": "<your newrelic license key here>",
-    "slotSetting": false
-  }
-  ```
-
   </TabsPageItem >
 
   <TabsPageItem id="containerized-configuration">


### PR DESCRIPTION
Removes in-process Azure function environment variable configuration that was recently added with #20304. 

A [fix](https://github.com/newrelic/newrelic-dotnet-agent/pull/3068) to the .NET agent was applied that makes the separate configuration for in-process Azure functions unnecessary. 

Hold for .NET agent 10.40.0 release. 