### PR TITLE
The ServiceName of Azure has been modified.

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure.mdx
@@ -1,12 +1,12 @@
 ---
-title: Node.js agent on Microsoft Azure Web Apps
+title: Node.js agent on Microsoft Azure App Services
 tags:
   - Agents
   - Nodejs agent
   - Hosting services
   - Azure
   - Azure Site Extension
-metaDescription: How to install APM for Node.js on Microsoft Azure Web Apps.
+metaDescription: How to install APM for Node.js on Microsoft Azure App Services.
 redirects:
   - /docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure
   - /docs/agents/nodejs-agent/installation-configuration/install-nodejs-agent-azure-site-extension
@@ -26,13 +26,13 @@ You need to install the agent manually for Linux-hosted web apps, which we descr
 
 ## Manual Installation [#manual-installation]
 
-Learn about special considerations for using Microsoft Azure Web Apps as a hosting service with New Relic's Node.js agent.
+Learn about special considerations for using Microsoft Azure App Services as a hosting service with New Relic's Node.js agent.
 
 ## What you need [#compatibility]
 
-In addition to the [Compatibility and requirements for the Node.js agent](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent), this tutorial assumes you have a working installation of Node.js and the Windows Azure SDK for Node.js for your platform:
+In addition to the [Compatibility and requirements for the Node.js agent](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent), this tutorial assumes you have a working installation of Node.js and the Azure SDK for js for your platform:
 
-* Install the Azure SDK for Node.js.
+* Install the Azure SDK for js.
 * Ensure Git is installed.
 
 <Callout variant="important">
@@ -57,13 +57,13 @@ node -r newrelic server.js
 
 ## Adding app settings in Azure [#azure_settings]
 
-After installation, you must configure your app in Azure Web Apps:
+After installation, you must configure your app in Azure App Services:
 
 1. Sign in to <DNT>**[portal.azure.com](https://portal.azure.com)**</DNT>.
 2. Select <DNT>**App Services > (select a Node.js app) > Configure**</DNT>.
 3. Add the following to the <DNT>**app settings**</DNT>:
 
-   * `new_relic_app_name`: Your Windows Azure website name
+   * `new_relic_app_name`: Your Azure App Services name
    * `new_relic_license_key`: Your New Relic <InlinePopover type="licenseKey"/>
 4. Save your settings.
 5. Restart your Node.js app.
@@ -79,11 +79,11 @@ azure account download "YOUR_SUBSCRIPTION_NAME"
 azure account import "PATH_TO_PUBLISH_SETTINGS_FILE"
 azure site config add "new_relic_app_name=REPLACE_WITH_YOUR_APP_NAME"
 azure site config add "new_relic_license_key=REPLACE_WITH_YOUR_LICENSE_KEY"
-azure site restart AZURE_WEB_APP_NAME
+azure site restart AZURE_APP_SERVICES_NAME
 ```
 
 ## Using environment variables [#variables]
 
-If your agent runs in PaaS environments such as Heroku or Azure Web Apps, all of the configuration variables in `newrelic.js` have counterparts that can be set as environment variables. You can freely mix and match variables in the configuration file. Environment variables [override your configuration file settings](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#methods-and-precedence).
+If your agent runs in PaaS environments such as Heroku or Azure App Services, all of the configuration variables in `newrelic.js` have counterparts that can be set as environment variables. You can freely mix and match variables in the configuration file. Environment variables [override your configuration file settings](/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration#methods-and-precedence).
 
 For example, as a convenience to Azure users, the agent will use `APP_POOL_ID` as the application name ([`NEW_RELIC_APP_NAME`](/docs/nodejs/configuring-nodejs-with-environment-variables#app_name)) if it's set, so you can use the name you chose without setting it twice. For more information, see [Configuring Node.js with environment variables](/docs/nodejs/configuring-nodejs-with-environment-variables).


### PR DESCRIPTION
Windows Azure Web Sites has been rebranded by Microsoft as Azure App Services. It's neither Windows Azure Web Sites nor Azure Web App.

Additionally, the Azure SDK for Node.js has been deprecated and integrated into the new Azure SDK for JavaScript.

https://www.zdnet.com/article/microsoft-to-rebrand-windows-azure-as-microsoft-azure/ https://azure.microsoft.com/en-us/blog/announcing-azure-app-service/

https://github.com/azure/azure-sdk-for-js
https://github.com/Azure/azure-sdk-for-node?tab=readme-ov-file

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.