### PR TITLE
chore:Update .NET agent MongoDB support to include 3.X.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -492,6 +492,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   Latest verified compatible version: 3.3.0
 
+                  Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
+
                   Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
                   * IMongoCollection.CountDocuments[Async]
                   * IMongoCollection.EstimatedDocumentCount[Async]
@@ -1499,6 +1501,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       Minimum supported version: 2.3.0
 
                       Latest verified compatible version: 3.3.0
+
+                      Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
                       Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
                       * `IMongoCollection.CountDocuments[Async]`

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -490,7 +490,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                   Minimum supported version: 2.3.0
 
-                  Latest verified compatible version: 2.29.0
+                  Latest verified compatible version: 3.3.0
 
                   Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
                   * IMongoCollection.CountDocuments[Async]
@@ -1498,7 +1498,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     <td>
                       Minimum supported version: 2.3.0
 
-                      Latest verified compatible version: 2.29.0
+                      Latest verified compatible version: 3.3.0
 
                       Beginning in agent version 10.12.0, the following methods added in or after driver version 2.7 are instrumented:
                       * `IMongoCollection.CountDocuments[Async]`


### PR DESCRIPTION
## Give us some context

Updates the .NET Agent compatibility page to expand MongoDB support to version 3.X

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.