### PR TITLE
docs: .NET Agent, add Kinesis and Firehose instrumentation support statements

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -975,6 +975,34 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
                 </tr>
 
+                <tr>
+                <td>
+                  AWSSDK.Kinesis (Amazon Kinesis Data Streams) (agent versions 10.40.0 and newer)
+                </td>
+
+                <td>
+                  * The operations `PutRecord(s)Async` and `GetRecordsAsync` are instrumented as message broker operations.  Other Kinesis operations are instrumented as basic method calls.
+                    
+                  * Minimum supported version: 3.7.0
+                    
+                  * Latest verified compatible version: 3.7.402.101
+                </td>
+                </tr>
+
+                <tr>                
+                <td>
+                  AWSSDK.KinesisFirehose (Amazon Kinesis Firehose) (agent versions 10.40.0 and newer)
+                </td>
+
+                <td>
+                  * All Kinesis Firehose operations are instrumented as basic method calls.
+                    
+                  * Minimum supported version: 3.7.0
+                    
+                  * Latest verified compatible version: 3.7.402.39
+                </td>
+                </tr>
+
             </tbody>
             </table>
 
@@ -2084,6 +2112,34 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         * Minimum supported version: 3.7.0
                     
                         * Latest verified compatible version: 3.7.400.104
+                    </td>
+                    </tr>
+
+                    <tr>
+                    <td>
+                    AWSSDK.Kinesis (Amazon Kinesis Data Streams) (agent versions 10.40.0 and newer)
+                    </td>
+
+                    <td>
+                    * The operations `PutRecord(s)Async` and `GetRecordsAsync` are instrumented as message broker operations.  Other Kinesis operations are instrumented as basic method calls.
+                        
+                    * Minimum supported version: 3.7.0
+                        
+                    * Latest verified compatible version: 3.7.402.101
+                    </td>
+                    </tr>
+
+                    <tr>                   
+                    <td>
+                    AWSSDK.KinesisFirehose (Amazon Kinesis Firehose) (agent versions 10.40.0 and newer)
+                    </td>
+
+                    <td>
+                    * All Kinesis Firehose operations are instrumented as basic method calls.
+                        
+                    * Minimum supported version: 3.7.0
+                        
+                    * Latest verified compatible version: 3.7.402.39
                     </td>
                     </tr>
 


### PR DESCRIPTION
.NET agent release 10.40.0 contains new instrumentation for AWSSDK.Kinesis and AWSSDK.KinesisFirehose.  This PR updates our support documentation to include it.