### PR TITLE
chore: Updated nav link to Azure Site Extension instructions for Node

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -476,7 +476,7 @@ pages:
               - title: Install Node.js agent for Docker
                 path: /docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-docker
               - title: Install Node.js agent on Azure with our Site Extension
-                path: /docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-azure-site-extension
+                path: /docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-azure-site-extension
               - title: Node.js agent configuration
                 path: /docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration
               - title: Distributed tracing
@@ -954,7 +954,7 @@ pages:
             pages:
               - title: Azure Container Apps and Service Apps
                 path: /docs/apm/agents/python-agent/hosting-services/python-azure-containerapps-appservice
-              - title: Touchless integration for Azure Container Apps and Service Apps 
+              - title: Touchless integration for Azure Container Apps and Service Apps
                 path: /docs/apm/agents/python-agent/hosting-services/python-azure-touchless-integration
               - title: GAE flex
                 path: /docs/apm/agents/python-agent/hosting-services/install-python-agent-gae-flexible-environment


### PR DESCRIPTION
## Give us some context

The navigation link to [this page](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent-azure-site-extension/) is incorrect. Following it leads users to our 404 page. This corrects the link.