### PR TITLE
feat: adding release notes for unified lambda request ID ingestion

### DIFF
--- a/src/content/docs/release-notes/logs-release-notes/logs-25-04-01.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-25-04-01.mdx
@@ -1,0 +1,17 @@
+---
+subject: Logs
+releaseDate: '2025-04-01'
+version: '250401'
+---
+
+### Enhanced AWS Lambda Log Processing with Request ID Injection
+
+New Relic enhances log processing for AWS Lambda functions by ensuring that request IDs are consistently added to logs lacking default runtime annotations. This improves traceability and observability across Lambda invocations.
+
+### Changed
+
+* **Consistent Request ID Annotation:** Logs from AWS Lambda functions now have request IDs added to every message using the UUID found in the first and last log entries. This ensures comprehensive traceability and completeness in log data, enabling more effective monitoring and debugging.
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

- This PR is to create release note for the introduction of request ID parameter for every log message of an AWS lambda event. In some scenarios, lambda's log messages for an event have request ID only for the first and the last message, while the messages in between have it missing. Recent changes (refer to the Jira ticket [here](https://new-relic.atlassian.net/browse/NR-333638)) have introduced populating request ID to all the log messages. 
- Confluence document for reference -> https://newrelic.atlassian.net/wiki/spaces/TDP/pages/3985965195/RequestId+for+CloudWatch+logs+generated+from+Lambda+function