### PR TITLE
feat: add release notes for logs handling of unpaired UTF surrogates

### DIFF
--- a/src/content/docs/release-notes/logs-release-notes/logs-25-04-02.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-25-04-02.mdx
@@ -1,0 +1,17 @@
+---
+subject: Logs
+releaseDate: '2025-04-02'
+version: '250402'
+---
+
+### Handling of Unpaired UTF Surrogates
+
+Previously, logs that contained surrogate characters, such as `\uD800`, were discarded and not ingested.
+
+### Changes
+
+With this improvement, these logs can now be successfully ingested.
+
+### Notes
+
+To stay up to date with the latest fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
* What problems does this PR solve?

This adds release notes of a logging ingestion change
