### PR TITLE
feat(agent-control): AC does not support multiple installation in the same cluster

### DIFF
--- a/src/content/docs/new-relic-control/agent-control/overview.mdx
+++ b/src/content/docs/new-relic-control/agent-control/overview.mdx
@@ -17,7 +17,7 @@ Before you begin deploying Agent Control to your Kubernetes clusters, ensure tha
 - **New Relic license key:** You'll need a license key to report telemetry to your New Relic account.
 - **Kubernetes cluster name:** Have the name of your Kubernetes cluster ready. You'll reference it during the installation process.
 - **Auth Domain Manager:** To set up Agent Control and connect it to Fleet Control, you must have the Authentication Domain Manager role. For more info, refer to [User Management Concepts](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#admin-settings).
-- **Existing instrumentation:** If your Kubernetes cluster is already instrumented with New Relic, you must uninstall the existing instrumentation before installing Agent Control. After installing Agent Control, you can use Fleet Control to install and manage infrastructure agents and instrumentation on the cluster. For guidance, refer to [Manage existing instrumentation with Agent Control](/docs/new-relic-control/agent-control/reinstrumentation).
+- **Existing instrumentation:** If your Kubernetes cluster is already instrumented with New Relic, you must uninstall the existing instrumentation before installing Agent Control. After installing Agent Control, you can use Fleet Control to install and manage infrastructure agents and instrumentation on the cluster. For guidance, refer to [Manage existing instrumentation with Agent Control](/docs/new-relic-control/agent-control/reinstrumentation). Please note, installing multiple instances of Agent Control in the same cluster is not supported.
 
 ## Compatibility
 

--- a/src/content/docs/new-relic-control/agent-control/overview.mdx
+++ b/src/content/docs/new-relic-control/agent-control/overview.mdx
@@ -17,7 +17,11 @@ Before you begin deploying Agent Control to your Kubernetes clusters, ensure tha
 - **New Relic license key:** You'll need a license key to report telemetry to your New Relic account.
 - **Kubernetes cluster name:** Have the name of your Kubernetes cluster ready. You'll reference it during the installation process.
 - **Auth Domain Manager:** To set up Agent Control and connect it to Fleet Control, you must have the Authentication Domain Manager role. For more info, refer to [User Management Concepts](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#admin-settings).
-- **Existing instrumentation:** If your Kubernetes cluster is already instrumented with New Relic, you must uninstall the existing instrumentation before installing Agent Control. After installing Agent Control, you can use Fleet Control to install and manage infrastructure agents and instrumentation on the cluster. For guidance, refer to [Manage existing instrumentation with Agent Control](/docs/new-relic-control/agent-control/reinstrumentation). Please note, installing multiple instances of Agent Control in the same cluster is not supported.
+- **Existing instrumentation:** If your Kubernetes cluster is already instrumented with New Relic, you must uninstall the existing instrumentation before installing Agent Control. After installing Agent Control, you can use Fleet Control to install and manage infrastructure agents and instrumentation on the cluster. For guidance, refer to [Manage existing instrumentation with Agent Control](/docs/new-relic-control/agent-control/reinstrumentation).
+
+<Callout title="warning">
+  Multiple installations of Agent Control on the same cluster are not supported.
+</Callout>
 
 ## Compatibility
 

--- a/src/content/docs/new-relic-control/agent-control/overview.mdx
+++ b/src/content/docs/new-relic-control/agent-control/overview.mdx
@@ -19,7 +19,7 @@ Before you begin deploying Agent Control to your Kubernetes clusters, ensure tha
 - **Auth Domain Manager:** To set up Agent Control and connect it to Fleet Control, you must have the Authentication Domain Manager role. For more info, refer to [User Management Concepts](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#admin-settings).
 - **Existing instrumentation:** If your Kubernetes cluster is already instrumented with New Relic, you must uninstall the existing instrumentation before installing Agent Control. After installing Agent Control, you can use Fleet Control to install and manage infrastructure agents and instrumentation on the cluster. For guidance, refer to [Manage existing instrumentation with Agent Control](/docs/new-relic-control/agent-control/reinstrumentation).
 
-<Callout title="warning">
+<Callout variant="caution" title="warning">
   Multiple installations of Agent Control on the same cluster are not supported.
 </Callout>
 


### PR DESCRIPTION


Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.

This PR tries to clarify that installing multiple instance of Agent Control in the same k8s cluster is not supported.