### PR TITLE
NR-368357: Add details about metric aggregate pruning rules in pipeline control cloud rules docs

### DIFF
--- a/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
@@ -442,7 +442,7 @@ You cannot drop the following events and attributes using cloud rules:
   </Collapser>
 </CollapserGroup>
 
-## Drop attributes on dimensional metric rollups
+## Drop attributes on dimensional metric rollups [#drop-attributes-on-dimensional-metric-rollups]
 
 [Dimensional metrics](/docs/data-apis/understand-data/new-relic-data-types/#metrics-conceptual) aggregate metrics into rollups for long term storage and as a way to optimize longer term queries. [Metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) are applied to this data.
 

--- a/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
@@ -49,7 +49,7 @@ Use cloud rules to target the following data types:
 
 * The limit on NRQL query length is **4096** characters. If it exceeds the length, the `INVALID_NRQL_TOO_LONG` error occurs. If you need to drop data based on a longer query that cannot be split, contact your [New Relic support](https://support.newrelic.com).
 * `JOIN` and [subqueries](/docs/query-your-data/nrql-new-relic-query-language/get-started/subqueries-in-nrql) are not supported.
-* You can provide a [`WHERE`](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions#sel-where) clause to select data with specific attributes. 
+* You can provide a [`WHERE`](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-clauses-functions#sel-where) clause to select data with specific attributes.
 * Features such as `LIMIT`, `TIMESERIES`, `COMPARE WITH`, `FACET`, and other clauses cannot be used.
 * `SINCE` and `UNTIL` are not supported. If you have time-specific rules (say, drop everything until a time in the future), use `WHERE timestamp < (epoch milliseconds in the future)`.
 * You can't use `SINCE` to drop historical data. Cloud rules only apply to data reported after the rule was created. If you need to delete data that has already been reported, refer to [Delete existing data](/docs/data-apis/manage-data/manage-data-retention/#deleting-data) or contact [New Relic support](https://support.newrelic.com).
@@ -66,7 +66,7 @@ Cloud rules apply to each data point independently. For example, let's look at t
     When creating rules, you are responsible for ensuring that the rules accurately identify and discard the data that meets the conditions that you have established. You are also responsible for monitoring the rule, as well as the data you disclose to New Relic.
 </Callout>
 
-```sql 
+```sql
 1. DELETE FROM MyEvent WHERE myAttr not in ('staging')
 2. DELETE FROM MyEvent WHERE myAttr not in ('production')
 3. DELETE FROM MyEvent WHERE myAttr in ('development')
@@ -106,11 +106,11 @@ To create and edit rules, you can either use the [Pipeline Control UI](/docs/tod
     mutation {
       entityManagementCreatePipelineCloudRule(
         pipelineCloudRuleEntity: {
-          description: "Event1 and Event2 are unimportant, see ticket DM-1234", 
+          description: "Event1 and Event2 are unimportant, see ticket DM-1234",
           name: "Drop all data for Event1 and Event2",
           nrql: "DELETE FROM Event1, Event2",
           scope: {
-            id: "your_nr_account_id", 
+            id: "your_nr_account_id",
             type: ACCOUNT
           }
         }
@@ -135,11 +135,11 @@ To create and edit rules, you can either use the [Pipeline Control UI](/docs/tod
     mutation {
       entityManagementCreatePipelineCloudRule(
         pipelineCloudRuleEntity: {
-          description: "Drops all data for MyCustomEvent that comes from the LoadGeneratingApp in the dev environment, because there is too much and we don’t look at it", 
+          description: "Drops all data for MyCustomEvent that comes from the LoadGeneratingApp in the dev environment, because there is too much and we don’t look at it",
           name: "Drop MyCustomEvent from LoadGeneratingApp in dev",
           nrql: "DELETE FROM MyCustomEvent WHERE appName='LoadGeneratingApp' AND environment='development'",
           scope: {
-            id: "your_nr_account_id", 
+            id: "your_nr_account_id",
             type: ACCOUNT
           }
         }
@@ -164,11 +164,11 @@ To create and edit rules, you can either use the [Pipeline Control UI](/docs/tod
     mutation {
       entityManagementCreatePipelineCloudRule(
         pipelineCloudRuleEntity: {
-          description: "Removes the user name and email fields from MyCustomEvent", 
+          description: "Removes the user name and email fields from MyCustomEvent",
           name: "Drop username and email from MyCustomEvent",
           nrql: "DELETE userName, userEmail FROM MyCustomEvent",
           scope: {
-            id: "your_nr_account_id", 
+            id: "your_nr_account_id",
             type: ACCOUNT
           }
         }
@@ -269,11 +269,11 @@ Drop data:
 mutation {
   entityManagementCreatePipelineCloudRule(
     pipelineCloudRuleEntity: {
-      description: "Since we only care about MyEvent in staging and production, let's drop all MyEvent data in the test environment", 
+      description: "Since we only care about MyEvent in staging and production, let's drop all MyEvent data in the test environment",
       name: "Drop MyEvent in test environment",
       nrql: "DELETE FROM MyEvent where environment = 'test'",
       scope: {
-        id: "your_nr_account_id", 
+        id: "your_nr_account_id",
         type: ACCOUNT
       }
     }
@@ -441,6 +441,61 @@ You cannot drop the following events and attributes using cloud rules:
     </table>
   </Collapser>
 </CollapserGroup>
+
+## Drop attributes on dimensional metric rollups
+
+[Dimensional metrics](/docs/data-apis/understand-data/new-relic-data-types/#metrics-conceptual) aggregate metrics into rollups for long term storage and as a way to optimize longer term queries. [Metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) are applied to this data.
+
+You can use this feature to decide which attributes you don't need for long term storage and query, but would like to maintain for real time queries.
+
+For example, adding `containerId` as an attribute can be useful for live troubleshooting or recent analysis, but may not be needed when querying over longer periods of time for larger trends. Due to how unique something like `containerId` can be, it can quickly drive you towards your [metric cardinality limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes) which when hit stops the synthesis of rollups for the remainder of that UTC day.
+
+This feature also allows you to keep the [high cardinality](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics/) attributes on the raw data and drop it from rollups which gives you more control over how quickly you approach your cardinaliity limits.
+
+### Usage
+
+<DNT>**Drop attributes from dimensional metrics rollups**</DNT> (with optional filter). This uses NRQL of the form:
+
+```sql
+DELETE dropAttr1, dropAttr2 FROM MetricAggregate (WHERE OPTIONAL_FILTER)
+```
+
+Here is an example NerdGraph request:
+
+```graphql
+mutation {
+  entityManagementCreatePipelineCloudRule(
+    pipelineCloudRuleEntity: {
+      description: "We don't care about targetAttr in the test environment in dimensional metric rolloups, let's drop those attributes",
+      name: "Drop targetAttr from Metric aggregate rollups in test environment",
+      nrql: "DELETE targetAttr FROM MetricAggregate where environment = 'test'",
+      scope: {
+        id: "your_nr_account_id",
+        type: ACCOUNT
+      }
+    }
+  ) {
+    entity {
+      id
+      name
+      nrql
+    }
+  }
+}
+```
+
+To verify it's working, wait 3 to 5 minutes for the rule to be picked up and for aggregate data to be generated. Then assuming the example NRQL above is your pipeline control cloud rule, run the following queries:
+
+```sql
+SELECT count(targetAttr) FROM Metric WHERE metricName = 'some.metric' TIMESERIES SINCE 2 hours ago
+SELECT count(targetAttr) FROM MetricRaw WHERE metricName = 'some.metric' TIMESERIES SINCE 2 hours ago
+```
+
+The first query retrieves metric rollups and should drop to 0 since `containerId` has been dropped per the new drop rule. The second query retrieves metric raws using the `MetricRaw` event type and should continue to hold steady since raw data is not impacted by the new drop rule. For more information on how to see the impact this will have on your cardinality, check out [Understand and query high cardinality metrics](/docs/data-apis/ingest-apis/metric-api/NRQL-high-cardinality-metrics).
+
+### Restrictions
+
+All restrictions that apply to drop attribute rules apply to drop attributes from dimensional metric rollup rules with the additional restriction that you can only target the `MetricAggregate` data type. They also do not work on `Metric` queries targeting data created by an [events to metrics](/docs/data-ingest-apis/get-data-new-relic/metric-api/events-metrics-service-create-metrics) rule or on `Metric` queries targeting [timeslice data](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql).
 
 ## Learn more
 


### PR DESCRIPTION


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * This PR adds details to our pipeline control docs about how to write rules which prune attributes from dimensional metric rollups. This is a new feature which was added to our recently released pipeline control cloud rules.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  * This feature ensures we have parity with the old NRQL drop rules which pipeline control cloud rules are a replacement for. The changes added in this document are very similar to the section we have in our docs for our legacy drop rules: https://docs.newrelic.com/docs/data-apis/manage-data/drop-data-using-nerdgraph/#drop-attributes-on-dimensional-metric-rollups
* If your issue relates to an existing GitHub issue, please link to it.