### PR TITLE
docs(logging): Add limitations of Log API to syslog page

### DIFF
--- a/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -20,6 +20,10 @@ To forward logs to New Relic using a syslog client, you need:
 * A valid New Relic <InlinePopover type="licenseKey"/> for the account you want to send logs to
 * Some minor changes to the syslog client's configuration, as explained in this document
 
+## Limitations
+
+Log lines exceeding 1MB in compressed size will be dropped, and other limitations from the [Log API](/docs/logs/log-api/introduction-log-api/#limits) may also apply. Please ensure your log lines are within this size limit to avoid data loss.
+
 ## Configure rsyslog versions 8 and higher (Amazon Linux, Redhat, Centos) [#rsyslog]
 
 <Callout variant="important">
@@ -190,6 +194,7 @@ If you're using rsyslog version 7 or below, the configuration files need to be a
    ```bash
    sudo yum install rsyslog-gnutls ca-certificates
    ```
+
 2. Optional: Configure `rsyslog` to tail log files and forward their contents to New Relic. Add the following to the `/etc/rsyslog.conf` file in order to enable its text file input module:
 
    ```properties
@@ -198,6 +203,7 @@ If you're using rsyslog version 7 or below, the configuration files need to be a
    $PrivDropToGroup adm
    $WorkDirectory /var/spool/rsyslog
    ```
+
 3. In the `/etc/rsyslog.d/` directory, create a text file named `newrelic.conf`.
 4. Check whether the `$IncludeConfig` options under `/etc/rsyslog.conf` already have a matching wildcard that will include the newly created `newrelic.conf` file under the `/etc/rsyslog.d` directory. Otherwise you'll need to explicitly include `/etc/rsyslog.d/newrelic.conf` in `/etc/rsyslog.conf` using `$IncludeConfig /etc/rsyslog.d/newrelic.conf`.
 5. Add the following to `newrelic.conf`. Replace the highlighted values. For `YOUR_LICENSE_KEY`, use your New Relic <InlinePopover type="licenseKey"/>:
@@ -230,11 +236,13 @@ If you're using rsyslog version 7 or below, the configuration files need to be a
 
    *.* @@newrelic.syslog.nr-data.net:6514;NRLogFormat
    ```
+
 6. Restart the `rsyslog` service by running:
 
    ```bash
    sudo systemctl restart rsyslog
    ```
+
 7. [Check your New Relic account](/docs/logs/ui-data/use-logs-ui) for logs.
 
 ## Configure syslog-ng [#syslog-ng]
@@ -246,6 +254,7 @@ To forward logs to New Relic with `syslog-ng`:
    ```bash
    sudo yum install ca-certificates
    ```
+
 2. Open the `syslog-ng` configuration file (`/etc/syslog-ng/syslog-ng.conf`) in a text editor.
 3. Define the sources to be monitored by adding:
 
@@ -254,6 +263,7 @@ To forward logs to New Relic with `syslog-ng`:
            internal();
    };
    ```
+
 4. Optional: Configure `syslog-ng` to tail files by adding the following to the `Sources` configuration block:
 
    ```properties
@@ -261,6 +271,7 @@ To forward logs to New Relic with `syslog-ng`:
            file("PATH_TO_FILE");
    };
    ```
+
 5. Define the New Relic `syslog` format. For `YOUR_LICENSE_KEY`, use your New Relic <InlinePopover type="licenseKey"/>.
 
    ```properties
@@ -268,6 +279,7 @@ To forward logs to New Relic with `syslog-ng`:
            template_escape(no);
    };
    ```
+
 6. Add the New Relic Syslog endpoint:
 
    ```properties
@@ -279,6 +291,7 @@ To forward logs to New Relic with `syslog-ng`:
          );
    };
    ```
+
 7. Add the following output to the log path configuration block:
 
    ```properties
@@ -288,11 +301,13 @@ To forward logs to New Relic with `syslog-ng`:
           destination(d_newrelic);
    };
    ```
+
 8. Restart `syslog-ng` by running:
 
    ```bash
    sudo service syslog-ng restart
    ```
+
 9. [Check your New Relic account](/docs/logs/ui-data/use-logs-ui) for logs.
 
 <Callout variant="tip">

--- a/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
+++ b/src/content/docs/logs/log-api/use-tcp-endpoint-forward-logs-new-relic.mdx
@@ -22,7 +22,7 @@ To forward logs to New Relic using a syslog client, you need:
 
 ## Limitations
 
-Log lines exceeding 1MB in compressed size will be dropped, and other limitations from the [Log API](/docs/logs/log-api/introduction-log-api/#limits) may also apply. Please ensure your log lines are within this size limit to avoid data loss.
+Log lines that exceed 1 MB in compressed size will be dropped. Other limitations from the [Log API](/docs/logs/log-api/introduction-log-api/#limits) may also apply. To prevent data loss, ensure your log lines are within this size limit.
 
 ## Configure rsyslog versions 8 and higher (Amazon Linux, Redhat, Centos) [#rsyslog]
 


### PR DESCRIPTION
This is to inform users that Log API limits would also apply for TPC syslog endpoints as it's the main entry point for logs.