### PR TITLE
Add release notes for Python agent release v10.9.0.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100900.mdx
@@ -34,3 +34,4 @@ Install the agent using `easy_install/pip/distribute` via the [Python Package In
 We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
 
 See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.
+

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100900.mdx
@@ -3,21 +3,21 @@ subject: 'Python agent'
 releaseDate: '2025-04-11'
 version: 10.9.0
 downloadLink: 'https://pypi.python.org/pypi/newrelic'
-features: ['Add Opentelemetry compatible datastore span attributes']
+features: ['Add OpenTelemetry compatible datastore span attributes']
 bugs: ['Fix LangChain instrumentation for string response types', 'Disable Kombu instrumentation']
 ---
 
 ## Notes
 
-This release of the Python agent updates datastore span attribute names, fixes a bug in [LangChain](https://pypi.org/project/langchain/) instrumentation, and temporarily disables [Kombu](https://pypi.org/project/kombu/) instrumentation. 
+This release of the Python agent adds [OpenTelemetry](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md) compatible datastore span attribute names, fixes a bug in [LangChain](https://pypi.org/project/langchain/) instrumentation, and temporarily disables [Kombu](https://pypi.org/project/kombu/) instrumentation. 
 
 Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
 
 ## New features
 
-* Add Opentelemetry compatible datastore span attributes
+* Add OpenTelemetry compatible datastore span attributes
 
-  * The datastore span attributes are now more consistent with [Opentelemetry](https://opentelemetry.io/docs/languages/python/) naming conventions
+  * The datastore span attributes are now more consistent with [OpenTelemetry](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-spans.md) naming conventions
 
 ## Bug fixes
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100900.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-100900.mdx
@@ -1,0 +1,36 @@
+---
+subject: 'Python agent'
+releaseDate: '2025-04-11'
+version: 10.9.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add Opentelemetry compatible datastore span attributes']
+bugs: ['Fix LangChain instrumentation for string response types', 'Disable Kombu instrumentation']
+---
+
+## Notes
+
+This release of the Python agent updates datastore span attribute names, fixes a bug in [LangChain](https://pypi.org/project/langchain/) instrumentation, and temporarily disables [Kombu](https://pypi.org/project/kombu/) instrumentation. 
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## New features
+
+* Add Opentelemetry compatible datastore span attributes
+
+  * The datastore span attributes are now more consistent with [Opentelemetry](https://opentelemetry.io/docs/languages/python/) naming conventions
+
+## Bug fixes
+
+* Fix LangChain instrumentation for string response types
+
+  * Previously, when [LangChain](https://pypi.org/project/langchain/) returned string-type responses, the agent only captured the first character of the string. This has been corrected.
+
+* Disable Kombu instrumentation
+
+  * Existing [Kombu](https://pypi.org/project/kombu/) instrumentation in the agent is crashing with a `TypeError` being raised from the `inspect` module. This instrumentation has been temporarily disabled and will be re-enabled in a future release once the root cause of the crash is identified and patched.
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.


### PR DESCRIPTION
This PR adds release notes for Python Agent v10.9.0.