### PR TITLE
fix: multiline curl commands need `\` escapes

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-alerts/rest-api-calls-new-relic-infrastructure-alerts.mdx
+++ b/src/content/docs/infrastructure/infrastructure-alerts/rest-api-calls-new-relic-infrastructure-alerts.mdx
@@ -288,7 +288,8 @@ curl -v -X DELETE --header "Api-Key:$API_KEY" "https://infra-api.newrelic.com/v2
         For example:
 
         ```sh
-        curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d
+        curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' \
+             -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d \
         '{
            "data":{
               "type":"infra_process_running",
@@ -354,7 +355,8 @@ curl -v -X DELETE --header "Api-Key:$API_KEY" "https://infra-api.newrelic.com/v2
           For example:
 
           ```sh
-          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d
+          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' \
+               -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d \
           '{
              "data":{
                 "type":"infra_metric",
@@ -402,7 +404,8 @@ curl -v -X DELETE --header "Api-Key:$API_KEY" "https://infra-api.newrelic.com/v2
           For example:
 
           ```sh
-          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d
+          curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' \
+               -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d \
           '{
              "data":{
                 "type":"infra_host_not_reporting",


### PR DESCRIPTION
these commands give errors: 

```sh
 curl -X POST 'https://infra-api.newrelic.com/v2/alerts/conditions' -H "Api-Key:$API_KEY" -i -H 'Content-Type: application/json' -d
'{
   "data":{
      "type":"infra_process_running",
      "name":"Java is running",
      "enabled":true,
      "where_clause":"(hostname LIKE '\''%cassandra%'\'')",
      "policy_id":policy_id,
      "comparison":"equal",
      "critical_threshold":{
         "value":0,
         "duration_minutes":6
      },
      "process_where_clause":"(commandName = '\''java'\'')"
   }
}'

# response:
curl: option -d: requires parameter
```

you need `\` escape char before the line break or the command runs without the json on the next line

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.