### PR TITLE
fix examples

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/newrelic-metrics-adapter.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/newrelic-metrics-adapter.mdx
@@ -78,9 +78,9 @@ You can configure multiple metrics in the metrics adapter and change some parame
 The following example is a Helm values file that enable the metrics adapter on the `nri-bundle` chart installation, and configures the `nginx_average_requests` metric:
 
 ```yaml
-metrics-adapter:
-  enabled: true
+
 newrelic-k8s-metrics-adapter:
+  enabled: true
   personalAPIKey: <Personal API Key>
   config:
     accountID: <Account ID>
@@ -97,7 +97,7 @@ There is an HPA consuming the external metric as follows:
 
 ```yaml
 kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 metadata:
   name: nginx-scaler
 spec:


### PR DESCRIPTION
- See the [nri-bundle values.yaml](https://github.com/newrelic/helm-charts/blob/8a36c205015dffc346561650284e9ee6516f9d0c/charts/nri-bundle/values.yaml#L52) for the most up-to-date  options.
- The `autoscaling/v2beta2` api version was deprecated in Kubernetes v1.23. Use `kubectl api-versions | grep autoscaling` to check your cluster's version.