### PR TITLE
Update Python agent configuration settings page

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration.mdx
@@ -3547,7 +3547,7 @@ Event harvest configuration settings include:
           </th>
 
           <td>
-            Config file
+            Config file, environment variable
           </td>
         </tr>
 
@@ -3598,7 +3598,7 @@ Event harvest configuration settings include:
           </th>
 
           <td>
-            Config file
+            Config file, environment variable
           </td>
         </tr>
 
@@ -3650,7 +3650,7 @@ Event harvest configuration settings include:
           </th>
 
           <td>
-            Config file
+            Config file, environment variable
           </td>
         </tr>
 
@@ -3702,7 +3702,7 @@ Event harvest configuration settings include:
           </th>
 
           <td>
-            Config file
+            Config file, environment variable
           </td>
         </tr>
 
@@ -4755,7 +4755,7 @@ These instrumentation package specific settings are available via the agent conf
           </th>
 
           <td>
-            Config file
+            Config file, environment variable
           </td>
         </tr>
 


### PR DESCRIPTION
This PR updates the configuration settings page for the Python agent to include "environment variable" in settings that are also enabled through environment variables.