### PR TITLE
docs: Update download.newrelic.com networks

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -698,7 +698,11 @@ If your organization uses a firewall that restricts outbound traffic, follow the
 
 ## Agent downloads [#agent-download]
 
-[TLS](#tls) is required for all domains. Service for `download.newrelic.com` is provided through Fastly and is subject to change without warning. For the most current list of public IP addresses for New Relic agent downloads, see [api.fastly.com/public-ip-list](https://api.fastly.com/public-ip-list).
+[TLS](#tls) is required for all domains. Service for `download.newrelic.com` is provided through CDN and is subject to change without warning. 
+
+<Callout variant="important"> 
+New Relic is updating its IP configuration for agent downloads. Starting April 22, 2025, `download.newrelic.com` will use IP addresses from the block `162.247.240.0/22`. Please update your network settings to accommodate this change. 
+</Callout>
 
 ## Infrastructure details [#infrastructure]
 


### PR DESCRIPTION
We are updating the CDN that provides `download.newrelic.com`, therefore there is a need to update the docs with the new network block.