### PR TITLE
chore(PHP Agent): Adds Amazon DynamoDB to supported databases

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -586,7 +586,7 @@ The following databases and libraries are supported:
   <tbody>
     <tr>
       <td>
-        Firebird (PDO Driver only)
+        Amazon DynamoDB
       </td>
 
       <td>
@@ -596,7 +596,7 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        [Guzzle](/docs/agents/php-agent/frameworks-libraries/guzzle)
+        Firebird (PDO Driver only)
       </td>
 
       <td>
@@ -606,7 +606,7 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        Informix
+        [Guzzle](/docs/agents/php-agent/frameworks-libraries/guzzle)
       </td>
 
       <td>
@@ -616,7 +616,7 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        Memcached
+        Informix
       </td>
 
       <td>
@@ -626,7 +626,7 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        MongoDB
+        Memcached
       </td>
 
       <td>
@@ -636,7 +636,7 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        Microsoft SQL Server (PDO Driver only)
+        MongoDB
       </td>
 
       <td>
@@ -646,7 +646,7 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        MySQL
+        Microsoft SQL Server (PDO Driver only)
       </td>
 
       <td>
@@ -656,20 +656,27 @@ The following databases and libraries are supported:
 
     <tr>
       <td>
-        ODBC (PDO Driver only)
+        MySQL
       </td>
 
       <td>
         SQS (aws-sdk-php 3 library only)
       </td>
     </tr>
-        <tr>
+    <tr>
       <td>
-        Oracle
+        ODBC (PDO Driver only)
       </td>
 
       <td>
         Sybase (PDO Driver only)
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Oracle
+      </td>
+      <td>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
The PHP Agent 11.8.0.22 release added support for Amazon DynamoDB.  This PR updates the compatibility page for the PHP agent to reflect that.