### PR TITLE
add Windows Server 2025 as supported OS for the infra agent

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -144,7 +144,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Windows Server 2016, 2019, and 2022, and their service packs.
+        Windows Server 2016, 2019, 2022 and 2025, and their service packs.
 
         Windows 10, Windows 11, and their service packs.
       </td>

--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -144,7 +144,7 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Windows Server 2016, 2019, 2022 and 2025, and their service packs.
+        Windows Server 2016, 2019, 2022, 2025, and their service packs.
 
         Windows 10, Windows 11, and their service packs.
       </td>


### PR DESCRIPTION
add Windows Server 2025 as supported OS for the NR Infrastructure Agent

The OHAI team has recently tested and certified Windows Server 2025 as supported, and this is just adding it into the list of supported OS for the Infrastructure Agent.