### PR TITLE
Deprecate alert notification channels

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-alert-notification-channels.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-alert-notification-channels.mdx
@@ -1,5 +1,5 @@
 ---
-title: "NerdGraph tutorial: Alert notification channels"
+title: "NerdGraph tutorial: Alert notification channels (deprecated)"
 tags:
   - Alerts
   - Alerts and NerdGraph


### PR DESCRIPTION
Deprecate alert notification channels

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* Add deprecate notice to alert notification channels page here 
* Link to altered page: https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-api-alert-notification-channels/
