### PR TITLE
Chore: [Do not merge]: Added NerdGraph and NRQL query references in REST API v2 examples

### DIFF
--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/application-error-rate-example-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/application-error-rate-example-v2.mdx
@@ -14,6 +14,10 @@ freshnessValidatedDate: never
 
 This is an example of how to use the New Relic Data API (v2) to get your application's average error rate over a specific time period. This value appears as a percentage above the [Error rate chart](#avg-error-image) on your [APM <DNT>**Summary**</DNT> page](/docs/apm/applications-menu/monitoring/apm-overview-page).
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 To use the API, you need:
 
 * An [API key](/docs/apis/rest-api-v2/getting-started/introduction-new-relic-rest-api-v2#api_key).

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/average-response-time-examples-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/average-response-time-examples-v2.mdx
@@ -16,6 +16,10 @@ freshnessValidatedDate: never
 
 Here is an example of how to use the New Relic API Explorer (v2) to get your application's average response time over a specified time period.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## Average response time [#average_response]
 
 The average response time (milliseconds) is the value that appears on the main chart for your app on the [APM <DNT>**Summary**</DNT> page](/docs/applications-menu/applications-overview). New Relic uses this formula to calculate response time:

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2.mdx
@@ -20,6 +20,10 @@ By default, the alias is the same as the name used in the agent configuration fi
 
 ## Set application alias and modify Apdex thresholds [#set_app_alias]
 
+<Callout variant="important">
+While the example utilizes New Relic's REST API v2, we recommend using [NerdGraph](/docs/apis/nerdgraph/examples/mobile-monitoring-config-nerdgraph) for mobile application monitoring. To explore its capabilities, check [the NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).
+</Callout>
+
 To change the alias for the app name from the New Relic REST API (v2), use this command. You can also change the app alias from New Relic's [API Explorer](/docs/apis/rest-api-v2/api-explorer-v2/getting-started-new-relics-api-explorer) by selecting [<DNT>**Applications > Update**</DNT>](https://rpm.newrelic.com/api/explore/applications/update).
 
 * You will need to supply the `${APP_ID}`, `${API_KEY}`, and the alias `name` you want the application to be displayed as in the New Relic UI.

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/get-average-cpu-usage-host-app.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/get-average-cpu-usage-host-app.mdx
@@ -12,6 +12,10 @@ freshnessValidatedDate: never
 
 You can use the New Relic REST API (v2) to get the average CPU usage for your application on a single host. This value appears on the [APM <DNT>**Summary**</DNT> page](/docs/apm/applications-menu/monitoring/apm-overview-page) in the <DNT>**Hosts**</DNT> table, in the column labeled <DNT>**CPU usage**</DNT>.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## Get CPU usage for a host
 
 To get the average CPU usage for one of your app's hosts, use a single command to obtain the metric `names[]=CPU/User+Time` with `values[]=percent`. This example shows the time range for the [default time period](/docs/apis/rest-api-v2/requirements/specifying-time-range-v2) (last 30 minutes):

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/get-average-throughput-app-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/get-average-throughput-app-v2.mdx
@@ -16,7 +16,11 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-You can use the New Relic REST API (v2) to obtain the average throughput for your app, including [web application](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#transaction) and [non-web application](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#non-web-transaction) throughput. These values appear in the [Throughput chart](/docs/apm/applications-menu/monitoring/apm-overview-page-view-transaction-apdex-usage-data#overview_charts) on your app's <DNT>**APM Summary**</DNT> page:
+You can use the New Relic REST API (v2) to obtain the average throughput for your app, including [web application](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#transaction) and [non-web application](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#non-web-transaction) throughput. These values appear in the [Throughput chart](/docs/apm/applications-menu/monitoring/apm-overview-page-view-transaction-apdex-usage-data#overview_charts) on your app's <DNT>**APM Summary**</DNT> page.
+
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
 
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > APM & services > (select an app)**</DNT>.
 2. Click the app's <DNT>**Transaction time chart**</DNT> title, then select your choice.

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/get-host-memory-used-application.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/get-host-memory-used-application.mdx
@@ -12,6 +12,11 @@ freshnessValidatedDate: never
 
 You can use the New Relic REST API (v2) to obtain the average memory usage for your application on a single host. This value appears on the [APM <DNT>**Summary**</DNT> page](/docs/apm/applications-menu/monitoring/apm-overview-page) in the <DNT>**Hosts**</DNT> table, in the column labeled <DNT>**Memory**</DNT>, or in the corresponding chart.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
+
 ## Get memory usage for a host
 
 To obtain the average Memory usage for one of your app's hosts, use the following command to obtain the metric `names[]=Memory/Physical` with `values[]=percent`.

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/get-web-transaction-time-data-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/get-web-transaction-time-data-v2.mdx
@@ -26,6 +26,10 @@ The [metric timeslice data](/docs/data-analysis/metrics/analyze-your-metrics/dat
 
 This describes how to use the REST API (v2) to obtain the data shown on the <DNT>**Web transaction time**</DNT> chart.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## General API values [#general]
 
 When making your own calculations, be aware of the following:

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/getting-apdex-data-apps-or-browsers-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/getting-apdex-data-apps-or-browsers-v2.mdx
@@ -16,6 +16,10 @@ freshnessValidatedDate: never
 
 Here are some examples of how to use the New Relic REST API (v2) to get [Apdex](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction) data for your application and browser, for a specific [application ID](/docs/apm/apis/requirements/identification-code) and [API key](/docs/apis/rest-api-v2/requirements/rest-api-key#viewing). By default, this will provide a list of values every minute for the [last 30 minutes](/docs/apm/apis/api-v2-examples/specifying-time-range-v2) in JSON format.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 When acquiring data, the values returned may be affected by the time period you specify and the way the data is stored. For more information, see [Extracting metric data](/docs/apis/extracting-metric-data).
 
 ## Metric names and values for Apdex [#apdex-names]

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/list-apps-host-ids-instance-ids.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/list-apps-host-ids-instance-ids.mdx
@@ -14,6 +14,10 @@ freshnessValidatedDate: never
 
 Here are examples of how to use the New Relic REST API (v2) to get the list of [instance IDs](/docs/apis/rest-api-v2/requirements/listing-host-instance-application-server-ids#locating_instance_id) and [host IDs](/docs/apis/rest-api-v2/requirements/listing-host-instance-application-server-ids#locating_host_id) for an application. The list shows any that have reported for approximately the last hour.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## List current IDs by application name [#list_current_ids]
 
 You can also use the [REST API Explorer's <DNT>**Applications > List**</DNT>](/docs/apis/using-the-api-explorer) to list the ID details. Enter the correct application name.

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/list-your-app-id-metric-timeslice-data-v2.mdx
@@ -19,6 +19,10 @@ Here are examples of how to use the New Relic REST API (v2) to get metric names 
 
 When acquiring data, the values returned may be affected by the time period you specify and the way the data is stored. For more information, see [Extracting metric timeslice data](/docs/apis/extracting-metric-data).
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## List all application IDs [#view_all_app_id]
 
 You can also use New Relic's REST [API Explorer](/docs/apm/apis/api-explorer-v2/parts-api-explorer) to get the same [metric timeslice data for your app](/docs/apm/apis/api-v2-examples/metric-data-examples-api-v2) information as this example.

--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/summary-data-examples-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/summary-data-examples-v2.mdx
@@ -23,6 +23,10 @@ Summary data is not the same as using `summarize` to get an [average of metric v
 
 Also, the data presented may correspond to specific metric timeslice data values that can be acquired by other means. However, the summary data will not match those values due to the difference in the time base and the nature of the rolling average.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## Application summary examples [#app]
 
 New Relic provides summary information for applications as a rolling <DNT>**three- to four-minute average**</DNT>.

--- a/src/content/docs/apis/rest-api-v2/basic-functions/calculate-average-metric-values-summarize.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/calculate-average-metric-values-summarize.mdx
@@ -13,6 +13,10 @@ redirects:
 freshnessValidatedDate: never
 ---
 
+<Callout variant="important">
+While the example utilizes New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 By default, New Relic REST API calls return a series of metric data values based on [time range restrictions](/docs/apm/apis/requirements/extracting-metric-data#time). To obtain the average of these values, include `&summarize=true` in your API call. For example:
 
 ```sh

--- a/src/content/docs/apis/rest-api-v2/basic-functions/extract-metric-timeslice-data.mdx
+++ b/src/content/docs/apis/rest-api-v2/basic-functions/extract-metric-timeslice-data.mdx
@@ -22,6 +22,10 @@ One type of New Relic data is [metric timeslice data](/docs/data-analysis/metric
 
 This doc explains how to do this with the REST API. Note that the API is not intended for bulk data extraction of minute-by-minute data points.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## Time based data [#time-based]
 
 All time values returned by the REST API and the API Explorer are UTC (Universal Time Coordinated). Be sure to [adjust the time values](/docs/apm/apis/api-v2-examples/specifying-time-range-api-v2) for data collection as necessary.

--- a/src/content/docs/apis/rest-api-v2/browser-examples-v2/add-or-list-browser-apps-api-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/browser-examples-v2/add-or-list-browser-apps-api-v2.mdx
@@ -12,6 +12,9 @@ redirects:
   - /docs/apis/rest-api-v2/browser-examples-v2/adding-or-listing-browser-apps-api-v2
 freshnessValidatedDate: never
 ---
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NerdGraph](/docs/apis/nerdgraph/examples/browser-monitoring-config-nerdgraph) for browser configurations. To explore its capabilities, check the [NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).
+</Callout>
 
 Here are examples of how to use the New Relic REST API (v2) to add apps to [<InlinePopover type="browser"/>](/docs/browser/new-relic-browser/welcome-new-relic-browser/new-relic-browser) or to get a list of your browser apps for a specific [API key](/docs/apis/rest-api-v2/requirements/api-keys). This helps you manage deployment outside of New Relic. These API calls are useful, for example, with larger organizations deploying multiple apps, or for integration partners who facilitate New Relic account creation and browser monitoring deployments.
 

--- a/src/content/docs/apis/rest-api-v2/browser-examples-v2/average-browser-end-user-page-throughput-example-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/browser-examples-v2/average-browser-end-user-page-throughput-example-v2.mdx
@@ -16,6 +16,10 @@ The average browser throughput appears at the top right of the <DNT>**Throughput
 
 ## Average page throughput [#h2-average]
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 To obtain the [average](/docs/apm/apis/requirements/calculating-average-metric-values-summarize) for the [time range](/docs/apm/apis/requirements/specifying-time-range-api-v2) (default is last 30 minutes), use the following command. Be sure to replace the `$APP_ID` and `$API_KEY` variables in this example with your specific [application ID](/docs/apm/apis/requirements/identification-code) and [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key#viewing).
 
 ```sh

--- a/src/content/docs/apis/rest-api-v2/browser-examples-v2/average-browser-page-load-time-example-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/browser-examples-v2/average-browser-page-load-time-example-v2.mdx
@@ -16,6 +16,10 @@ The average browser [page load time](/docs/browser/new-relic-browser/page-load-t
 
 ## Average page load time [#h2-average]
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 To obtain the [average](/docs/apm/apis/requirements/calculating-average-metric-values-summarize) for the [time range](/docs/apm/apis/requirements/specifying-time-range-api-v2) (default is last 30 minutes), use the following command. Be sure to replace the `$APP_ID` and `$API_KEY` variables in this example with your specific [application ID](/docs/apm/apis/requirements/identification-code) and [REST API key](/docs/apis/rest-api-v2/requirements/rest-api-key#viewing).
 
 ```sh

--- a/src/content/docs/apis/rest-api-v2/browser-examples-v2/obtaining-browser-end-user-page-load-time-data-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/browser-examples-v2/obtaining-browser-end-user-page-load-time-data-v2.mdx
@@ -23,6 +23,10 @@ The [metric timeslice data](/docs/data-analysis/metrics/analyze-your-metrics/dat
 
 This describes how to use the New Relic REST API (v2) to obtain the data shown on the <DNT>**Browser page load time**</DNT> chart.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 ## General API values [#general]
 
 When making your own calculations, be aware of the following:

--- a/src/content/docs/apis/rest-api-v2/mobile-examples-v2/mobile-crash-count-crash-rate-example-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/mobile-examples-v2/mobile-crash-count-crash-rate-example-v2.mdx
@@ -12,6 +12,10 @@ freshnessValidatedDate: never
 
 This describes how to use the New Relic REST API (v2) to get your mobile application's overall and version-specific <DNT>**crash count**</DNT> and <DNT>**crash rate**</DNT>, which appear on the [<DNT>**Summary**</DNT> page](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/mobile-apps-overview-page) in the upper right corner.
 
+<Callout variant="important">
+While the examples utilize New Relic's REST API v2, we recommend using [NRQL functions](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/) for executing metric timeslice queries. Each API value can be mapped to an equivalent NRQL function. To learn how to create NRQL queries based on these API examples, refer to our [documentation](/docs/apis/rest-api-v2/migrate-to-nrql/).
+</Callout>
+
 These examples use the default time period of the last 30 minutes. To obtain crash data for a different [time range](/docs/apis/rest-api-v2/requirements/specifying-time-range-v2), add the time period to the commands.
 
 <Callout variant="tip">

--- a/src/content/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls.mdx
+++ b/src/content/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls.mdx
@@ -15,21 +15,21 @@ freshnessValidatedDate: never
 Your REST API call returns a `301` error message that may include some or all of this information:
 
 ```sh
-curl -X GET 'http://rpm.newrelic.com/v2/applications/1234567890.json' \
+curl -X GET 'http://api.newrelic.com/v2/applications/1234567890.json' \
      -H 'X-Api-Key:YOUR_API_KEY' -i
 [output] HTTP/1.1 301 Moved Permanently
 [output] Status: 301 Moved Permanently
-[output] Location: http://rpm.newrelic.com/v2/applications/1234567890.json
+[output] Location: http://api.newrelic.com/v2/applications/1234567890.json
 [output] ...
-[output] You are being redirected https://rpm.newrelic.com/v2/applications/1234567890.json
+[output] You are being redirected https://api.newrelic.com/v2/applications/1234567890.json
 ```
 
 OR
 
 ```sh
-curl -X GET 'http://rpm.newrelic.com/v2/applications/1234567890.json' \
+curl -X GET 'http://api.newrelic.com/v2/applications/1234567890.json' \
      -H 'X-Api-Key:YOUR_API_KEY'
-[output] You are being redirected https://rpm.newrelic.com/v2/applications/1234567890.json
+[output] You are being redirected https://api.newrelic.com/v2/applications/1234567890.json
 ```
 
 ## Solution

--- a/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
+++ b/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
@@ -31,7 +31,8 @@ See how deployment markers work in this short video (4:30 minutes):
 
 ## Options for tracking deployments [#options]
 
-You can use the New Relic [REST API v2](/docs/apis/rest-api-v2/requirements/new-relic-rest-api-v2-getting-started) to record new deployments and retrieve a list of past deployments. In addition, some APM agents have agent-specific methods to record deployments automatically.
+While you can use either the New Relic [REST API v2](/docs/apis/rest-api-v2/requirements/new-relic-rest-api-v2-getting-started) or [NerdGraph](/docs/change-tracking/change-tracking-graphql) to record new deployments and retrieve a list of past deployments, we recommend using NerdGraph.
+You can use the New Relic  to record new deployments and retrieve a list of past deployments. Additionally, some APM agents offer agent-specific methods to automatically record deployments.
 
 You can use your [Slack](https://slack.com/) integration with New Relic, or a simple webhook, to notify your team in real time of deployments for applications monitored by APM. Slack provides a webhook URL that allows you to post generic JSON that will appear formatted in a chosen Slack channel.
 
@@ -50,6 +51,10 @@ There are a few places where you can view deployments in the New Relic UI after 
 </Callout>
 
 ## Record deployments with the REST API [#api-instructions]
+
+<Callout variant="important">
+[NerdGraph](/docs/change-tracking/change-tracking-graphql) is the recommended API for querying New Relic data, retrieving account information, and configuring features. To explore its capabilities, check [the NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).
+</Callout>
 
 You can use the New Relic REST API v2 to record deployments and get a list of past deployments.
 

--- a/src/content/docs/apm/reports/api-examples-sla-reports.mdx
+++ b/src/content/docs/apm/reports/api-examples-sla-reports.mdx
@@ -285,7 +285,10 @@ Here are some tips for planning which metrics to collect.
 
 The following sections contain code examples to acquire the data for values described above for the Daily (24hr) SLA statistics in the default GMT/UTC time zone. Adjust the `from=` and `to=` for your [time range](/docs/apm/apis/requirements/specifying-time-range-api-v2) as desired.
 
-There are syntactical differences between New Relic's REST API v2 and v1. The examples show how to use each.
+<Callout variant="important">
+Although the examples include both New Relic's REST API v2 and NerdGraph, we recommend using [NerdGraph](/docs/apis/nerdgraph/examples/nerdgraph-slm) for querying New Relic data, retrieving account information, and configuring features. To explore its capabilities, check [the NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).
+</Callout>
+
 
 ## REST API v2 commands [#examples_v2]
 
@@ -365,6 +368,60 @@ There are syntactical differences between New Relic's REST API v2 and v1. The ex
       curl.header_in_body=true
     end
     puts response.body_str
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## NerdGraph API commands [#nerdgraph-commands]
+
+<CollapserGroup>
+
+  <Collapser
+    id="app-nerdgraph-response-time"
+    title="App average response time (NerdGraph)"
+  >
+    To obtain the Application average response time, execute the following query in the [NerdGraph API Explorer](/docs/apis/nerdgraph/get-started/nerdgraph-explorer/):
+
+    ```graphql
+    SELECT average(apm.service.transaction.duration) as duration 
+    FROM WHERE (entity.guid = 'Nzc5ODIwfEFQTXxBUFBMSUNBVElPTnwzMjMzNDE2') 
+    FACET weekOf(timestamp) 
+    LIMIT MAX 
+    SINCE '2025-02-03' 
+    TIMESERIES 
+    ```
+  </Collapser>
+
+  <Collapser
+    id="app-nerdgraph-request-count"
+    title="App request count (NerdGraph)"
+  >
+    To obtain the Application request count, execute the following query in the [NerdGraph API Explorer](/docs/apis/nerdgraph/get-started/nerdgraph-explorer/):
+
+    ```graphql
+    SELECT ((count(apm.service.transaction.duration))/1000) 
+    FROM WHERE (entity.guid = 'Nzc5ODIwfEFQTXxBUFBMSUNBVElPTnwzMjMzNDE2') 
+    FACET weekOf(timestamp) 
+    LIMIT MAX 
+    SINCE '2025-02-03' 
+    TIMESERIES 
+    ```
+  </Collapser>  
+
+  <Collapser
+    id="apdex-nerdgraph"
+    title="Apdex SLA data (NerdGraph)"
+  >
+    To obtain the Apdex related data, execute the following query in the [NerdGraph API Explorer](/docs/apis/nerdgraph/get-started/nerdgraph-explorer/):
+
+    ```graphql
+    SELECT apdex(apm.service.apdex) 
+    FROM Metric 
+    WHERE (entity.guid = 'Nzc5ODIwfEFQTXxBUFBMSUNBVElPTnwzMjMzNDE2') 
+    FACET weekOf(timestamp) 
+    LIMIT MAX 
+    SINCE '2025-02-03' 
+    TIMESERIES
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
The REST API v2 are going to be EOLed and we are encouraging users to use NerdGraph and NRQL functions. So, added links callouts with references in the REST API v2 example pages, so that user can switch and use  NerdGraph and NRQL functions.