### PR TITLE
feat: Update Diagnostics CLI Documentation for kubernetes

### DIFF
--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/diagnostics-cli-nrdiag.mdx
@@ -39,6 +39,7 @@ The Diagnostics CLI is available for Linux, macOS, and Windows. It can detect co
 * <DNT>**Infrastructure monitoring**</DNT>: Linux and Windows agents
 * <DNT>**Mobile agents**</DNT>: iOS and Android
 * <DNT>**Synthetic monitoring**</DNT>: Containerized private minions (CPM)
+* <DNT>**Kubernetes**</DNT>: Kubernetes, Agent Control, Helm and Flux
 
 The Diagnostics CLI does not require `superuser` or `admin` permissions to run, although we recommend those permissions for some checks. It will return an error if it does not have permissions to read the files it scans.
 

--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/pass-command-line-options-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/pass-command-line-options-nrdiag.mdx
@@ -145,6 +145,22 @@ To use the following command line options with the Diagnostics CLI:
 
     <tr>
       <td>
+        `-k8s-namespace STRING`
+      </td>
+
+      <td>
+        Specify a namespace to use when executing the kubectl command
+
+        Example syntax:
+
+        ```
+        -k8s-namespace ./path/to/file
+        ```
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         `-output-path STRING`
       </td>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This updates the Diagnostics CLI Documenation to include kubernetes compatability and the new command line option `-k8s-namespace`. 