### PR TITLE
NR-K8s Otel Collector for GKE Autopilot config update.

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-otel.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-otel.mdx
@@ -98,13 +98,7 @@ To get OpenTelemetry up and running in your cluster, follow these steps:
 5. If you're using a GKE AutoPilot cluster, it's necessary to apply the following configuration in your `values.yaml` file to ensure compatibility and proper functionality of the OpenTelemetry Collectors.
 
    ```yaml
-   privileged: false
-   receivers:
-       filelog:
-           enabled: false
-   daemonset:
-       containerSecurityContext:
-           privileged: false
+   gkeAutopilot: true
    ```
 
 ## Uninstall your Kubernetes cluster with OpenTelemetry [#uninstall]


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
These settings are no longer required to run the otel collector on GKE Autopilot. 
Users just need to set the `gkeAutopilot` config in the values.yaml to true. 

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.