### PR TITLE
Add release notes/ docs for Python Agent v10.11.0.

### DIFF
--- a/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
@@ -78,6 +78,7 @@ AI monitoring is compatible with these agent versions and AI libraries:
         * [OpenAI](https://pypi.org/project/openai/) library versions 0.28.0 and above.
         * [Boto3 AWS SDK for Python](https://pypi.org/project/boto3/)  versions 1.28.57 and above.
         * [LangChain](https://pypi.org/project/langchain/) versions 0.1.0 and above.
+        * [Google Gen AI SDK](https://pypi.org/project/google-genai/) versions 1.3.0 and above.
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-101100.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-101100.mdx
@@ -1,0 +1,31 @@
+---
+subject: 'Python agent'
+releaseDate: '2025-05-01'
+version: 10.11.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for Google Gemini via Google Generative AI SDK', 'Instrument new Kinesis methods']
+---
+
+## Notes
+
+This release of the Python agent adds support for Google Gemini via the Google Generative AI SDK and instruments new Kinesis methods.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## New features
+
+* Add support for Google Gemini via Google Generative AI SDK
+
+  * Adds support for [google-genai](https://pypi.org/project/google-genai/). The agent will automatically instrument `embed_content` calls for synchronous and asynchronous [embeddings](https://ai.google.dev/gemini-api/docs/embeddings). The agent also now supports synchronous and asynchronous [text generations](https://ai.google.dev/gemini-api/docs/text-generation) for text inputs in non-streaming cases. This includes calls made to `generate_content` for single text-only inputs and calls to `send_message` for multi-turn conversations.
+
+* Instrument new AWS Kinesis methods
+
+  * Adds [botocore](https://pypi.org/project/botocore/) instrumentation to support new [AWS Kinesis](https://aws.amazon.com/kinesis/) methods including `tag_resource`, `untag_resource`, and `list_tags_for_resource`.
+
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.
+


### PR DESCRIPTION
This PR adds release notes for Python Agent v10.11.0. It also updates the AIM docs to list support for the Google Gen AI SDK.