### PR TITLE
[feat]: Added New Relic AI integration with ServiceNow Now Assist support docs

### DIFF
--- a/src/content/docs/agentic-ai/agentic-integration/servicenow-integration.mdx
+++ b/src/content/docs/agentic-ai/agentic-integration/servicenow-integration.mdx
@@ -1,0 +1,66 @@
+---
+title: New Relic AI for ServiceNow Now Assist
+metaDescription: "New Relic AI integration with ServiceNow's Now Assist will assist ServiceNow users—such as operators, first responders, and support agents - in gauging the severity of an incident by understanding its impact on other services and users, identifying probable root cause theories for an incident, and facilitating escalation to collaborators to mitigate the issue."
+tags:
+  - ServiceNow Now Assist integration 
+  - New Relic AI
+  - Agentic AI
+freshnessValidatedDate: never
+---
+
+<Callout title="preview">
+    We're still working on this feature, but we'd love for you to try it out!
+
+    This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
+
+
+  This feature uses New Relic Generative AI, subject to [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy) and [service specific terms](https://newrelic.com/termsandconditions/service-specific).
+</Callout>
+
+
+New Relic AI integration with ServiceNow's Now Assist will assist ServiceNow users—such as operators, first responders, and support agents - in:
+
+* Gauging the severity of an incident by understanding its impact on other services and users
+* Identifying probable root cause theories for an incident
+* Facilitating escalation to collaborators to mitigate the issue
+
+This guide will walk you through the process of installing and using the New Relic AI within ServiceNow's Now Assist.
+
+
+## Setup [#setup]
+
+
+In order to use the New Relic AI extension with ServiceNow, you will need:
+
+* A New Relic [user API key](/docs/apis/intro-apis/new-relic-api-keys/#overview-keys). If a New Relic user is deleted in New Relic, their user keys are also deactivated and will no longer work. To ensure a secure and uninterrupted integration, please take note of the following recommendations:
+
+  * Use a `service user` account to avoid disruption when a personal or individual account is terminated.
+  * Although `user keys` provide access to multiple accounts, they are linked to a single specific account: the account they were created from. If an account is deleted, any user keys associated with that account will become invalid. Therefore, ensure that the account you create the key for is long-lived.
+  * Verify that the user for whom the user key is used possesses the Read only permission.
+  
+  <Callout variant="tip" title="Note">
+    Please be aware that the User Key provided will enable every user within your ServiceNow account to access this integration.
+  </Callout>
+
+  * To configure New Relic AI within Now Assist, follow the steps outlined [here.](https://www.servicenow.com/docs/csh?topicname=now-assist-itom-use-aia.html&version=latest)
+
+
+## Interact with the New Relic AI through Now Assist [#new-relic-tool]
+
+In ServiceNow:
+
+1. Navigate to <DNT>**All > Event Management > Express List**</DNT>.
+2. Select an alert, making sure that the source is New Relic.
+3. Click the <DNT>Now Assist</DNT> icon to open the panel.
+4. Ask Now Assist a question about the alert.
+5. Type in any of the supported prompts, you can mix and match as well:
+      * What is the severity of this alert?
+      * What entities are impacted?
+      * What are probable cause theories?
+      * Who should I pull in for the investigation?
+      * Are there recent deployments?
+      * What is the alert impact, probable cause theories, and who to pull in for the investigation?
+
+    <Callout variant="tip" title="tip">
+      Your conversation in the Now Assist panel is specific to the alert that you selected in Step 2. To ask about a different alert, open that alert, and select the Now Assist icon to start a new conversation.
+    </Callout>

--- a/src/nav/agentic-ai.yml
+++ b/src/nav/agentic-ai.yml
@@ -25,3 +25,5 @@ pages:
       #   path: /docs/agentic-ai/agentic-integration/amazonq-integration
       - title: Gemini Code Assist integration
         path: /docs/agentic-ai/agentic-integration/gemini-integration
+      - title: ServiceNow integration
+        path: /docs/agentic-ai/agentic-integration/servicenow-integration


### PR DESCRIPTION
This PR adds the documentation support for the New Relic AI integration with ServiceNow Now Assist. It addresses WR [NR-410008](https://new-relic.atlassian.net/browse/NR-410008) by providing a comprehensive guide to setup and use New Relic AI in Now Assist.

[NR-410008]: https://new-relic.atlassian.net/browse/NR-410008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ