### PR TITLE
Update support-arm-graviton-x86-64.mdx

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/configuration/support-arm-graviton-x86-64.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/configuration/support-arm-graviton-x86-64.mdx
@@ -164,7 +164,7 @@ The following New Relic agents support AWS Graviton processors using ARM64, as w
       </td>
 
       <td>
-        Yes
+        Linux only
       </td>
 
       <td>
@@ -182,7 +182,7 @@ The following New Relic agents support AWS Graviton processors using ARM64, as w
       </td>
 
       <td>
-        Yes
+        Linux only
       </td>
 
       <td>


### PR DESCRIPTION
very important clarification, because some Windows IoT versions are also available as arm64, but neither the infra agent nor the OHI's are compiling to arm or arm64 binaries.
