### PR TITLE
Update FB and logs release notes

### DIFF
--- a/src/content/docs/release-notes/fluentbit-release-notes/fluentbit-25-05-12.mdx
+++ b/src/content/docs/release-notes/fluentbit-release-notes/fluentbit-25-05-12.mdx
@@ -1,0 +1,27 @@
+---
+subject: Fluent Bit
+releaseDate: '2025-05-12'
+version: 3.2.10
+metaDescription: Release notes for Fluent bit version 3.2.10
+features: []
+bugs: [
+  "filter_modifier: fixed log event memory leak",
+  "core_processor: fixed log decoding errors from missing flags",
+  "core_record_accessor: fixed log access on record parsing failures",
+  "out_http: corrected status handling for compressed logs"
+]
+---
+
+### Support for Fluent Bit 3.2.10
+
+Users will now receive Fluent Bit version 3.2.10, which includes fixes for known vulnerabilities. For more details, refer https://fluentbit.io/announcements/.
+
+### Changed
+
+* Infrastructure agent recommends Fluent Bit 3.2.10 packages.
+* [Fluent Bit Output Plugin Docker image](https://hub.docker.com/r/newrelic/newrelic-fluentbit-output) uses Fluent Bit 3.2.10.
+* [New Relic Logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) installs the new plugin image (newrelic-logging chart version 1.27.0)
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).

--- a/src/content/docs/release-notes/logs-release-notes/logs-25-05-12.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-25-05-12.mdx
@@ -1,0 +1,19 @@
+---
+subject: Logs
+releaseDate: '2025-05-12'
+version: 250512
+---
+
+### Support for Fluent Bit 3.2.10
+
+Users will now receive Fluent Bit version 3.2.10, which includes fixes for known vulnerabilities. For more details, refer https://fluentbit.io/announcements/.
+
+### Changed
+
+* Infrastructure agent recommends Fluent Bit 3.2.10 packages.
+* [Fluent Bit Output Plugin Docker image](https://hub.docker.com/r/newrelic/newrelic-fluentbit-output) uses Fluent Bit 3.2.10.
+* [New Relic Logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) installs the new plugin image (newrelic-logging chart version 1.27.0)
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
We have updated Fluentbit version from 3.2.7 to 3.2.10 . Changing the docs here to reflect the same.