### PR TITLE
Update requirements-infrastructure-agent.mdx

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -25,7 +25,7 @@ Before [installing our infrastructure agent](/docs/infrastructure/install-infras
 The infrastructure agent supports these processor architectures:
 
 * <DNT>**Linux**</DNT>: 64-bit for x86 processor architectures (also requires 64-bit package manager and dependencies)
-* <DNT>**Windows**</DNT>: both 32 and 64-bit for x86 processor architectures
+* <DNT>**Windows**</DNT>: 64-bit for x86 processor architectures
 * <DNT>**ARM**</DNT>: arm64 architecture including [AWS Graviton 2 processor](https://aws.amazon.com/ec2/graviton/) is supported on compatible Linux operating sytems. On-host integrations are also supported (with the exception of the Oracle integration).
 * <DNT>**macOS**</DNT>: both 64-bit x86 and Apple silicon.
 
@@ -143,9 +143,9 @@ The infrastructure agent supports these operating systems up to their manufactur
       </td>
 
       <td>
-        Windows Server 2016, 2019, 2022, 2025, and their service packs.
+        Windows Server 2016, 2019, 2022 and 2025.
 
-        Windows 10, Windows 11, and their service packs.
+        Windows 10 (Microsoft EOL date October 14th 2025), Windows 11.
       </td>
     </tr>
 


### PR DESCRIPTION
Small clarification of supported Windows OS.
Windows 10 has a Microsoft EOL date, which will also the date we will stop supporting it.
Windows Server did not have any "Service Packs" anymore since Windows 2008 (long out of support already).