### PR TITLE
chore: updated the eol date for synthetic IP ranges

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -123,7 +123,7 @@ It is recommended that you add the entire global ranges provided by New Relic to
   </tbody>
 </table>
 
-After **May 21, 2025**, the IP range list in JSON will be updated to remove the older IP ranges that are being deprecated. It is important to update your allow list by removing the older ones after this date.
+After **May 28, 2025**, the IP range list in JSON will be updated to remove the older IP ranges that are being deprecated. It is important to update your allow list by removing the older ones after this date.
 
 **Old IP Range:**
 

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -28,9 +28,9 @@ We will be migrating the IP address range for the New Relic service used by Synt
 
   * `64.251.192.0/20`
 
-* After **May 21, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
+* After **May 28, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 
-**Old IP ranges to remove:** Please refer to the table below for a complete list of current IP ranges **that need to be removed after May 21, 2025**.
+**Old IP ranges to remove:** Please refer to the table below for a complete list of current IP ranges **that need to be removed after May 28, 2025**.
 
 <table>
   <thead>


### PR DESCRIPTION
This PR updates the end-of-life date for the New Relic service IP ranges used by Synthetics monitors.