### PR TITLE
Update go-agent-logging.mdx

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-logging.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-logging.mdx
@@ -19,7 +19,7 @@ To use the Go agent methods for writing log and audit files, see [log.go on the 
 
 ## Logrus integration example [#logrus]
 
-New Relic offers an [integration for the Logrus logging system](https://github.com/newrelic/go-agent/blob/master/_integrations/nrlogrus/nrlogrus.go). Here is an example of using the New Relic Logrus integration in an application:
+New Relic offers an [integration for the Logrus logging system](https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrlogrus/nrlogrus.go). Here is an example of using the New Relic Logrus integration in an application:
 
 1. Import both `github.com/sirupsen/logrus` and `github.com/newrelic/go-agent/v3/integrations/nrlogrus`.
 2. Set the log level and assign the Logger output to Logrus. For example:


### PR DESCRIPTION
Update docs url

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
This is to resolve an issue spotted here:
https://github.com/newrelic/go-agent/issues/1031

Specifically, [this docs page](https://docs.newrelic.com/docs/apm/agents/go-agent/configuration/go-agent-logging/) points to [a dead link](https://github.com/newrelic/go-agent/blob/master/_integrations/nrlogrus/nrlogrus.go) within the Go Agent repo. This PR should update it to the [correct address](https://github.com/newrelic/go-agent/blob/master/v3/integrations/nrlogrus/nrlogrus.go). 
