### PR TITLE
add logging to feature list under browser agent start() API

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/start.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/start.mdx
@@ -45,6 +45,7 @@ See [Feature names](#feature-names) for a list of feature names which can be sta
 * session_replay
 * session_trace
 * spa
+* logging
 
   <Callout variant="important">
     The response body of the `page_view_event` harvest contains critical information for running the other features. Deferring the start of `page_view_event` will cause all other features to wait until `.start()` is called.
@@ -72,6 +73,7 @@ NREUM.init = {
   session_replay: {autoStart: false},
   session_trace: {autoStart: false},
   spa: {autoStart: false},
+  logging: {autoStart: false},
   // other configurations
   // ...
 }


### PR DESCRIPTION
* The start() API loads deferred features for the browser agent. The docs include a list of potential features to be deferred and how to configure this in the application
* Through testing I have discovered that if one of the features in not included, the browser agent will become active (in a lessened capacity)
* This PR adds the new feature, logging, which was introduced to the agent after the start() API was created.