### PR TITLE
Update synthetics nerdgraph examples to indicate optional fields more clearly

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-synthetics-tutorial.mdx
@@ -97,28 +97,28 @@ Configure simple browser, scripted browser, and step monitors to use one or more
 
   <Collapser
     id="optional-fields"
-    title="Define optional fields"
+    title="Define fields for specific monitor types"
   >
-    Some fields are for more advanced configurations. These are optional.
+    Some fields detail additional configurations for specific monitor types. Use the fields related to the type of monitor you are creating or updating. These fields are required unless indicated otherwise.
 
     For [ping monitors](#create-ping), these include:
 
-      * `HEADER_NAME`: Your custom header names that appear on the request.
+      * `HEADER_NAME`: Your custom header names that appear on the request. (optional)
 
-      * `HEADER_VALUE`: The custom header value on the request.
+      * `HEADER_VALUE`: The custom header value on the request. (optional)
 
-      * `REDIRECT_IS_FAILURE`: Your monitor reports a failure if it's redirected.
+      * `REDIRECT_IS_FAILURE`: Your monitor reports a failure if it's redirected. Defaults to false. (optional)
 
-      * `VALIDATION_TEXT`: If this text is not included in your monitor's response, it returns a failure.
+      * `VALIDATION_TEXT`: If this text is not included in your monitor's response, it returns a failure. (optional)
 
-      * `TLS_VALIDATION`: Verifies the [validity](/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors/#simple) of the SSL certificate chain.
+      * `TLS_VALIDATION`: Verifies the [validity](/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors/#simple) of the SSL certificate chain. Defaults to false. (optional)
 
-      * `BYPASS_HEAD_REQUEST`: Bypasses the initial HEAD request and instead makes a GET request.
+      * `BYPASS_HEAD_REQUEST`: Bypasses the initial HEAD request and instead makes a GET request. Defaults to false. (optional)
 
 
     For [simple browser monitors](#create-simple-browser):
 
-      * `RUNTIME_TYPE`: The runtime type used by your monitor. "CHROME_BROWSER" is the only accepted value.
+      * `RUNTIME_TYPE`: The runtime type used by your monitor. "CHROME_BROWSER" is the only accepted value. 
 
       * `RUNTIME_TYPE_VERSION`: The runtime type version used by your monitor. "100" is the only accepted value.
 
@@ -178,7 +178,7 @@ Configure simple browser, scripted browser, and step monitors to use one or more
 
     For all monitors:
 
-      * `APDEX_TARGET`: The monitor's Apdex target used to populate SLA reports. Defaults to 7 seconds (7000ms).
+      * `APDEX_TARGET`: The monitor's Apdex target used to populate SLA reports. Defaults to 7 seconds (7000ms). (optional)
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
## Update Nerdgraph API examples to correctly indicate which fields are optional for monitors

* The existing docs place several mandatory fields for monitor runtimes in the 'optional' section. Many of these are not optional, even though they have only one accepted value. 
* Specifically, the RUNTIME_* options are not optional; even though they have only one acceptable value, if they are not specified the defaults used by the backend are invalid (the legacy runtime options).
* The issue above is exacerbated by the Nerdgraph Explorer - the runtime values _are_ considered optional in the backend, so the explorer doesn't enforce them. However the request will fail without them due to invalid defaults being used. Users will refer to the docs for an explanation.
* To address this, this PR changes the section title and marks the fields which are actually optional.

A more ideal version of this would be to change the API to use more correct defaults, but this should help in the meantime.
