### PR TITLE
.NET agent: add troubleshooting doc for app hang on startup issue

### DIFF
--- a/src/content/docs/apm/agents/net-agent/troubleshooting/app-hangs-on-startup.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/app-hangs-on-startup.mdx
@@ -1,0 +1,31 @@
+---
+title: Application hangs on startup
+type: troubleshooting
+tags:
+  - Agents
+  - NET agent
+  - Troubleshooting
+metaDescription: How to prevent your .NET 8 application from hanging on startup 
+redirects:
+freshnessValidatedDate: never
+---
+
+## Problem
+
+Your .NET 8.x application hangs on startup when using the .NET agent.
+
+## Solution
+
+The root cause of this issue is a [bug](https://github.com/dotnet/runtime/issues/93175) in the .NET runtime.  This bug is fixed in .NET 9.  A fix was backported to .NET 8, but since the fix involves a breaking change, it is not enabled by default.
+
+To enable the fix, apply the following AppConfig to your application:
+
+```
+"configProperties": {
+ "System.Diagnostics.Tracing.CounterCallbackOnTimerThread": true
+} 
+```
+
+This setting can also be applied by changing your msbuild project file or using an environment variable.  See Microsoft's documentation of [.NET runtime configuration settings](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/).
+
+

--- a/src/content/docs/apm/agents/net-agent/troubleshooting/app-hangs-on-startup.mdx
+++ b/src/content/docs/apm/agents/net-agent/troubleshooting/app-hangs-on-startup.mdx
@@ -5,18 +5,18 @@ tags:
   - Agents
   - NET agent
   - Troubleshooting
-metaDescription: How to prevent your .NET 8 application from hanging on startup 
+metaDescription: Learn how to resolve startup hangs in .NET 8 applications caused by a known runtime issue. 
 redirects:
 freshnessValidatedDate: never
 ---
 
 ## Problem
 
-Your .NET 8.x application hangs on startup when using the .NET agent.
+When using the .NET agent, your .NET 8.x application may hang during startup due to a known runtime issue.
 
 ## Solution
 
-The root cause of this issue is a [bug](https://github.com/dotnet/runtime/issues/93175) in the .NET runtime.  This bug is fixed in .NET 9.  A fix was backported to .NET 8, but since the fix involves a breaking change, it is not enabled by default.
+This issue is caused by a [bug](https://github.com/dotnet/runtime/issues/93175) in the .NET runtime. While the bug is fixed in .NET 9, a backported fix is available for .NET 8. However, the fix introduces a breaking change and is not enabled by default.
 
 To enable the fix, apply the following AppConfig to your application:
 
@@ -26,6 +26,6 @@ To enable the fix, apply the following AppConfig to your application:
 } 
 ```
 
-This setting can also be applied by changing your msbuild project file or using an environment variable.  See Microsoft's documentation of [.NET runtime configuration settings](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/).
+You can also apply this setting by modifying your MSBuild project file or using an environment variable. For more details, refer to Microsoft's documentation on [.NET runtime configuration settings](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/).
 
 

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -388,6 +388,8 @@ pages:
           - title: Troubleshooting
             path: /docs/apm/agents/net-agent/troubleshooting
             pages:
+              - title: Application hangs on startup
+                path: /docs/apm/agents/net-agent/troubleshooting/app-hangs-on-startup
               - title: No data appears
                 path: /docs/apm/agents/net-agent/troubleshooting/no-data-appears-net
               - title: Generate logs for troubleshooting


### PR DESCRIPTION
This PR adds a short document to the troubleshooting section of the .NET agent docs.  The doc lets customers know about a workaround for a potential hang in their .NET 8 apps on startup.