### PR TITLE
add a troubleshooting page to reset the infra agent inventory and metadata cache

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/infra-agent-inventory-reset.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/infra-agent-inventory-reset.mdx
@@ -1,0 +1,48 @@
+---
+title: Force an inventory reset from the Infrastructure Agent
+type: troubleshooting
+tags:
+  - Infrastructure
+  - Infrastructure monitoring troubleshooting
+  - Troubleshoot infrastructure
+freshnessValidatedDate: 2025-05-21
+---
+
+## Problem [#problem]
+
+The agent is working but some of the metadata or inventory data appears incorrect, and the local caching is preventing correct data to be sent from the infrastructure agent.
+
+## Solution [#solution]
+
+Linux
+Stop the Infrastructure Agent
+```
+systemctl stop newrelic-infra
+```
+Delete temporary files
+```
+rm -rf /var/db/newrelic-infra/data
+```
+Start the Infrastructure Agent
+```
+systemctl start newrelic-infra
+```
+
+Windows
+In an Administrator PowerShell prompt, stop the Infrastructure Agent
+```
+net stop newrelic-infra
+```
+Delete temporary files
+```
+Remove-Item -Path “C:\ProgramData\New Relic\newrelic-infra\data” -Recurse -Force
+```
+Start the Infrastructure Agent
+```
+net start newrelic-infra
+```
+
+## Cause [#cause]
+
+The agent caches metadata & inventory data locally, to determine what delta to send.
+In some situations, it might be desired to reset this local cache / state, so that all data is sent accross. 

--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/infra-agent-inventory-reset.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/infra-agent-inventory-reset.mdx
@@ -1,5 +1,5 @@
 ---
-title: Force an inventory reset from the Infrastructure Agent
+title: Force an inventory reset from the infrastructure agent
 type: troubleshooting
 tags:
   - Infrastructure

--- a/src/nav/infrastructure.yml
+++ b/src/nav/infrastructure.yml
@@ -1029,6 +1029,8 @@ pages:
             path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/host-name-changes
           - title: Network connectivity issues
             path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/network-connection-issues
+          - title: Force an inventory reset from the infrastructure agent
+            path: /docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/infra-agent-inventory-reset
       - title: Troubleshoot logs
         pages:
           - title: Infrastructure logging behavior


### PR DESCRIPTION
add a troubleshooting page to reset the infra agent inventory and metadata cache