### PR TITLE
Adding advanced functions to NRQL Reference page in public docs

### DIFF
--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -2214,7 +2214,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
 ### Non-aggregator functions [#non-aggregator-functions]
 
-Use non-aggregator functions for non-numerical data in NRQL queries.
+Use non-aggregator functions to return values for each data point within NRQL queries.
 
 <CollapserGroup>
   <Collapser
@@ -2914,6 +2914,13 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
 
         ```sql
         SELECT sum(mySummary) FROM Metric where getField(mySummary, count) > 10
+        ```
+
+        You can use square brackets `[ ]` as a shorthand for `getField()`:
+
+        
+        ```sql
+        SELECT max(mySummary[count]) FROM Metric
         ```
       </Collapser>
     </CollapserGroup>
@@ -3670,6 +3677,158 @@ Use non-aggregator functions for non-numerical data in NRQL queries.
     title={<InlineCode>stddev(attribute)</InlineCode>}
   >
     Use the `stddev()` function to return one [standard deviation](https://en.wikipedia.org/wiki/Standard_deviation) for a numeric attribute over the time range specified. It takes a single argument. If the attribute is not numeric, it will return a value of zero.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="abs"
+    title={<InlineCode>abs(attribute)</InlineCode>}
+  >
+    Use the `abs()` function to return the [absolute value](https://en.wikipedia.org/wiki/Absolute_value) of `attribute`.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="floor"
+    title={<InlineCode>floor(attribute)</InlineCode>}
+  >
+    Use the `floor()` function to return the integer closest to `attribute` by rounding down.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="ceil"
+    title={<InlineCode>ceil(attribute)</InlineCode>}
+  >
+    Use the `ceil()` function to return the integer closest to `attribute` by rounding up.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="clamp_max"
+    title={<InlineCode>clamp_max(attribute, limit)</InlineCode>}
+  >
+    Use the `clamp_max()` function to impose an upper limit on the value of `attribute`.
+
+    `clamp_max()` takes the following arguments:
+
+    * `attribute` - A numeric attribute.
+    * `limit` - The upper limit for the `attribute` value.  
+
+
+    **Example**    
+    You can use `clamp_max()` to ensure outliers don't skew the scale of a timeseries graph:
+
+    ```sql
+      SELECT clamp_max(average(duration), 10) FROM Transaction TIMESERIES
+    ```
+    
+    The above query returns the `duration` unless it exceeds 10, in which case it will return 10.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="clamp_min"
+    title={<InlineCode>clamp_min(attribute, limit)</InlineCode>}
+  >
+    Use the `clamp_min()` function to impose an lower limit on the value of `attribute`.
+
+    `clamp_min()` takes the following arguments:
+
+    * `attribute` - A numeric attribute.
+    * `limit` - The lower limit for the `attribute` value.  
+
+
+    **Example**    
+    You can use `clamp_min()` to ensure outliers don't skew the scale of a timeseries graph:
+
+    ```sql
+      SELECT clamp_min(average(duration), 1) FROM Transaction TIMESERIES
+    ```
+    
+    The above query returns the `duration` unless it's below 1, in which case it will return 1.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="pow"
+    title={<InlineCode>pow(attribute, exponent)</InlineCode>}
+  >
+    Use the `pow()` function to raise `attribute` to the power of `exponent`.
+
+    `pow()` takes the following arguments:
+
+    * `attribute` - A numeric attribute.
+    * `exponent` - A numeric attribute to raise `attribute` to the power of.  
+
+
+    **Example**    
+    The below query will return `duration` raised to the power of 4:
+
+    ```sql
+      SELECT pow(duration, 4) FROM Transaction
+    ```
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="sqrt"
+    title={<InlineCode>sqrt(attribute)</InlineCode>}
+  >
+    Use the `sqrt()` function to return the [square root](https://en.wikipedia.org/wiki/Square_root) of `attribute`.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="exp"
+    title={<InlineCode>exp(attribute)</InlineCode>}
+  >
+    Use the `exp()` function to return the [natural exponential function](https://en.wikipedia.org/wiki/Exponential_function) of `attribute`.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="ln"
+    title={<InlineCode>ln(attribute)</InlineCode>}
+  >
+    Use the `ln()` function to return the [natural logarithm](https://en.wikipedia.org/wiki/Natural_logarithm) of `attribute`.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="log2"
+    title={<InlineCode>log2(attribute)</InlineCode>}
+  >
+    Use the `log2()` function to return the [logarithm base 2](https://en.wikipedia.org/wiki/Binary_logarithm) of `attribute`.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="log10"
+    title={<InlineCode>log10(attribute)</InlineCode>}
+  >
+    Use the `log10()` function to return the [logarithm base 10](https://en.wikipedia.org/wiki/Common_logarithm) of `attribute`.
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="log"
+    title={<InlineCode>log(attribute, base)</InlineCode>}
+  >
+    Use the `log()` function to compute the logarithm of `attribute` with a base of `base`.
+
+    `log()` takes the following arguments:
+
+    * `attribute` - A numeric attribute.
+    * `base` - A numeric attribute to use as the base when computing the logarithm of `attribute`.  
+
+
+    **Example**    
+    The below query will compute the logarithm of `duration` with a base of 4:
+
+    ```sql
+      SELECT log(duration, 4) FROM Transaction
+    ```
   </Collapser>
 
   <Collapser

--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -2805,6 +2805,9 @@ Use non-aggregator functions to return values for each data point within NRQL qu
     * `field` - The index of the array element or the compound data type's field name.  
 
 
+    You can also use square brackets `[ ]` as a shorthand for `getField()`.  
+
+
     <CollapserGroup>
       <Collapser title="Extracting an element from an array">
 
@@ -2820,7 +2823,7 @@ Use non-aggregator functions to return values for each data point within NRQL qu
         SELECT getField(durations, 2) FROM Foo
         ```
 
-        You can use square brackets `[ ]` as a shorthand for `getField()`. The following query will also return `90`:
+        The following query using the `getField()` shorthand notation will also return `90`:
 
         ```sql
         SELECT durations[2] FROM Foo
@@ -2916,7 +2919,7 @@ Use non-aggregator functions to return values for each data point within NRQL qu
         SELECT sum(mySummary) FROM Metric where getField(mySummary, count) > 10
         ```
 
-        You can use square brackets `[ ]` as a shorthand for `getField()`:
+        Query using the shorthand notation for `getField()`:
 
         
         ```sql


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Jira Issue: NR-417400

The [NRQL reference](https://docs.newrelic.com/docs/nrql/nrql-syntax-clauses-functions/) page should contain an exhaustive list of all of our NRQL functions. Currently this page is missing the [NRQL advanced functions](https://docs.newrelic.com/docs/nrql/nrql-tutorials/nrql-tutorial-advanced-functions/) which this PR introduces.