### PR TITLE
feat: Add tip regarding nondeterministic latest and earliest results

### DIFF
--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -1675,6 +1675,10 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
 
     If used in conjunction with a `FACET` it will return the earliest value for an attribute for each of the resulting facets.
 
+    <Callout variant="tip">
+      If multiple events or metrics have the same earliest timestamp, the one that is returned is random and may differ between multiple query runs. Faceting by an attribute that has different values for the events or metrics with the same timestamp can provide a more consistent result.
+    </Callout>
+
     <CollapserGroup>
       <Collapser title="Get earliest country per user agent from PageView">
         This query returns the earliest country code per each user agent from the `PageView` event.
@@ -1936,6 +1940,10 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     It takes a single argument.
 
     If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
+
+    <Callout variant="tip">
+      If multiple events or metrics have the same latest timestamp, the one that is returned is random and may differ between multiple query runs. Faceting by an attribute that has different values for the events or metrics with the same timestamp can provide a more consistent result.
+    </Callout>
 
     <CollapserGroup>
       <Collapser title="Get most recent country per user agent from PageView">

--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -1676,7 +1676,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     If used in conjunction with a `FACET` it will return the earliest value for an attribute for each of the resulting facets.
 
     <Callout variant="tip">
-      If multiple events or metrics have the same earliest timestamp, the one that is returned is random and may differ between multiple query runs. Faceting by an attribute that has different values for the events or metrics with the same timestamp can provide a more consistent result.
+    If multiple events or metrics share the same earliest timestamp, the returned result is random and may vary across different query runs. To achieve more consistent results, facet by an attribute with different values for these events or metrics.
     </Callout>
 
     <CollapserGroup>
@@ -1942,7 +1942,7 @@ SELECT histogram(duration, 10, 20) FROM PageView SINCE 1 week ago
     If used in conjunction with a `FACET` it will return the most recent value for an attribute for each of the resulting facets.
 
     <Callout variant="tip">
-      If multiple events or metrics have the same latest timestamp, the one that is returned is random and may differ between multiple query runs. Faceting by an attribute that has different values for the events or metrics with the same timestamp can provide a more consistent result.
+      If multiple events or metrics have the same latest timestamp, the returned result is random and may vary across query runs. To get more consistent results, facet by an attribute with different values for these events or metrics.
     </Callout>
 
     <CollapserGroup>


### PR DESCRIPTION
for rows with the same timestamp

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Customers are sometimes confused when they have multiple events or metrics with the same timestamp and get inconsistent results from the NRQL earliest() and latest() functions.  Add a tip explaining the issue and a potential remedy.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.