### PR TITLE
fix(Catalogs): Update "Software Catalogs" => "Applications Catalog"

### DIFF
--- a/src/content/docs/service-architecture-intelligence/catalogs/catalogs.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/catalogs.mdx
@@ -3,7 +3,9 @@ title: "Catalogs"
 tag: 
     - "Service Architecture Intelligence"
     - "Catalogs"
-    - "Software Catalog"
+    - "Applications Catalog"
+    - "Repositories Catalog"
+    - "Infrastructure Catalog"
 metaDescription: "Catalogs offer a single pane view to enhance the observability and management of software systems in your organization. The unified view of system entities facilitates well-informed decision-making, streamlined operations, and improved collaboration across teams."
 freshnessValidatedDate: never
 ---
@@ -29,13 +31,13 @@ By consolidating data from multiple sources—including <DNT>[Teams](/docs/servi
 
 -  **Unified view**: Catalogs is integrated with various sources such as <DNT>[Teams](/docs/service-architecture-intelligence/teams/teams)</DNT>, <DNT>[Scorecards](/docs/service-architecture-intelligence/scorecards/getting-started)</DNT>, <DNT>[Maps](/docs/service-architecture-intelligence/maps/advanced-maps/)</DNT>, and <DNT>[repository](/docs/codestream/observability/repo-association/)</DNT> into a single cohesive interface. This displays high-value entity types with detailed metadata including golden metrics and insights to provide a deeper understanding of system status.
 
--  **Personalized experience**: <DNT>Software Catalogs</DNT> allows users to customize their view to focus on the most relevant content. This helps users to streamline workflows and enhance productivity.
+-  **Personalized experience**: <DNT>Applications Catalog</DNT> allows users to customize their view to focus on the most relevant content. This helps users to streamline workflows and enhance productivity.
 
--  **Seamless integration**: <DNT>Software Catalogs</DNT> connects users with other New Relic capabilities to allow them to explore data in depth and gain a thorough understanding of entities. 
+-  **Seamless integration**: <DNT>Applications Catalog</DNT> connects users with other New Relic capabilities to allow them to explore data in depth and gain a thorough understanding of entities. 
 
 - **Ownership**: <DNT>Catalogs</DNT> displays the entity ownership information in the <DNT>Teams</DNT> column. Hover over the <DNT>Teams</DNT> link for more information. Click the <DNT>Teams</DNT> link to visit the <DNT>Teams Hub</DNT> page. For more information, refer  <DNT>[Teams](/docs/service-architecture-intelligence/teams/teams)</DNT>.
 
-- **<DNT>Score</DNT>**: <DNT>Software Catalogs</DNT> is integrated with Scorecards to show how your entities are performing against company defined best practices. For more information, refer <DNT>[Scorecards.](/docs/service-architecture-intelligence/scorecards/getting-started)</DNT>
+- **<DNT>Score</DNT>**: <DNT>Applications Catalog</DNT> is integrated with Scorecards to show how your entities are performing against company defined best practices. For more information, refer <DNT>[Scorecards.](/docs/service-architecture-intelligence/scorecards/getting-started)</DNT>
 
 
 


### PR DESCRIPTION
## Description

Catalogs have undergone some naming changes. In particular, what we previously called "Sofware Catalogs" is now called "Applications Catalog".

This PR updates the documentation accordingly, so that our UI and docs are aligned.

<img width="681" alt="Screenshot 2025-05-26 at 11 42 58" src="https://github.com/user-attachments/assets/6fc44468-df9c-4630-978a-f1da8bae35a1" />
