### PR TITLE
feat: change Nav structure for release notes

### DIFF
--- a/src/content/docs/release-notes/index.mdx
+++ b/src/content/docs/release-notes/index.mdx
@@ -192,22 +192,10 @@ To take full advantage of New Relic's latest features, enhancements, and importa
   />
 
   <TechTile
-    name="Streaming Video & Ads for Browser"
+    name="Streaming Video & Ads"
     icon="logo-newrelic"
-    to="/docs/release-notes/streaming-browser-release-notes-"
-  />
-
-  <TechTile
-    name="Streaming Video & Ads for Mobile"
-    icon="logo-newrelic"
-    to="/docs/release-notes/streaming-mobile-release-notes"
+    to="/docs/release-notes/streaming-release-notes"
   />
   
-  <TechTile
-    name="Streaming Video & Ads for others"
-    icon="logo-newrelic"
-    to="/docs/release-notes/streaming-others-release-notes"
-  />
-
   
 </TechTileGrid>

--- a/src/content/docs/release-notes/streaming-release-notes/index.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/index.mdx
@@ -1,0 +1,3 @@
+---
+subject: Streaming Video & Ads 
+---

--- a/src/content/docs/release-notes/streaming-release-notes/streaming-browser-release-notes/index.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/streaming-browser-release-notes/index.mdx
@@ -1,3 +1,4 @@
 ---
-subject: Streaming Video & Ads for Browser
+subject: Streaming Video & Ads 
+category: Streaming Video & Ads for Browser
 ---

--- a/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/index.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/index.mdx
@@ -1,3 +1,4 @@
 ---
-subject: Streaming Video & Ads for Mobile
+subject: Streaming Video & Ads 
+category: Streaming Video & Ads for Mobile
 ---

--- a/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/streaming-android-agent-25-03-03.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/streaming-android-agent-25-03-03.mdx
@@ -1,9 +1,10 @@
 ---
-subject: Streaming Video & Ads for Mobile
+subject: Streaming Video & Ads
 title: Media agent for Android v3.0.0
 releaseDate: '2025-03-03'
 version: 3.0.0
 metaDescription: Release notes for Media agent for Android version 3.0.0
+category: Streaming Video & Ads for Mobile
 ---
 
 ## New features and enhancements

--- a/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/streaming-android-agent-25-03-05.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/streaming-android-agent-25-03-05.mdx
@@ -1,9 +1,10 @@
 ---
-subject: Streaming Video & Ads for Mobile
+subject: Streaming Video & Ads
 title: Media agent for Android v3.0.1
 releaseDate: '2025-03-05'
 version: 3.0.1
 metaDescription: Release notes for Media agent for Android version 3.0.1
+category: Streaming Video & Ads for Mobile
 ---
 
 ### Fix

--- a/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/streaming-ios-agent-25-03-03.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/streaming-mobile-release-notes/streaming-ios-agent-25-03-03.mdx
@@ -1,9 +1,10 @@
 ---
-subject: Streaming Video & Ads for Mobile
+subject: Streaming Video & Ads
 title: Media agent for iOS v3.0.0
 releaseDate: '2025-03-03'
 version: 3.0.0
 metaDescription: Release notes for Media agent for IOS version 3.0.0
+category: Streaming Video & Ads for Mobile
 ---
 
 ## New features and enhancements

--- a/src/content/docs/release-notes/streaming-release-notes/streaming-others-release-notes/index.mdx
+++ b/src/content/docs/release-notes/streaming-release-notes/streaming-others-release-notes/index.mdx
@@ -1,3 +1,4 @@
 ---
-subject: Streaming Video & Ads for others
+subject: Streaming Video & Ads 
+category: Streaming Video & Ads for others
 ---

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -10,19 +10,19 @@ import { TYPES } from '../utils/constants';
 import MDXContainer from '../components/MDXContainer';
 import { getTitle } from '../utils/releaseNotes';
 
-const sortByVersion = (
-  { frontmatter: { version: versionA } },
-  { frontmatter: { version: versionB } }
-) => {
-  if (!versionA || !versionB) {
-    return 0;
-  }
+// const sortByVersion = (
+//   { frontmatter: { version: versionA } },
+//   { frontmatter: { version: versionB } }
+// ) => {
+//   if (!versionA || !versionB) {
+//     return 0;
+//   }
 
-  return (
-    parseInt(versionB.replace(/\D/g, ''), 10) -
-    parseInt(versionA.replace(/\D/g, ''), 10)
-  );
-};
+//   return (
+//     parseInt(versionB.replace(/\D/g, ''), 10) -
+//     parseInt(versionA.replace(/\D/g, ''), 10)
+//   );
+// };
 
 const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   const { slug, disableSwiftype, currentPage } = pageContext;
@@ -47,8 +47,10 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   //     .entries()
   // );
   const sortedPosts = posts.slice().sort((a, b) => {
-  // Sort by releaseDate descending
-  return new Date(b.frontmatter.releaseDate) - new Date(a.frontmatter.releaseDate);
+    // Sort by releaseDate descending
+    return (
+      new Date(b.frontmatter.releaseDate) - new Date(a.frontmatter.releaseDate)
+    );
   });
 
   const title = `${subject} release notes`;
@@ -117,7 +119,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
         `}
       >
         <Timeline>
-          {sortedPosts.map((post, idx ) => {
+          {sortedPosts.map((post, idx) => {
             const isLast = idx === sortedPosts.length - 1;
             const { releaseDate } = post.frontmatter;
             const [monthOnly, year] = releaseDate.split(', ');
@@ -126,34 +128,34 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
 
             return (
               <Timeline.Item label={label} key={post.fields.slug}>
-                    <div
-                      key={post.version}
-                      css={css`
-                        margin-bottom: 2rem;
+                <div
+                  key={post.version}
+                  css={css`
+                    margin-bottom: 2rem;
 
-                        &:last-child {
-                          margin-bottom: ${isLast ? 0 : '4rem'};
-                        }
-                      `}
-                    >
-                      <Link
-                        to={post.fields.slug}
-                        css={css`
-                          display: inline-block;
-                          font-size: 1.25rem;
-                          margin-bottom: 0.5rem;
-                        `}
-                      >
-                        {getTitle(post.frontmatter)}
-                      </Link>
-                      <p
-                        css={css`
-                          margin-bottom: 0;
-                        `}
-                      >
-                        <MDXContainer body={post.body} />
-                      </p>
-                    </div>
+                    &:last-child {
+                      margin-bottom: ${isLast ? 0 : '4rem'};
+                    }
+                  `}
+                >
+                  <Link
+                    to={post.fields.slug}
+                    css={css`
+                      display: inline-block;
+                      font-size: 1.25rem;
+                      margin-bottom: 0.5rem;
+                    `}
+                  >
+                    {getTitle(post.frontmatter)}
+                  </Link>
+                  <p
+                    css={css`
+                      margin-bottom: 0;
+                    `}
+                  >
+                    <MDXContainer body={post.body} />
+                  </p>
+                </div>
               </Timeline.Item>
             );
           })}

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -34,18 +34,22 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   } = data;
 
   const now = useMemo(() => new Date(), []);
-  const postsByDate = Array.from(
-    posts
-      .reduce((map, post) => {
-        const { releaseDate } = post.frontmatter;
-        const [monthOnly, year] = releaseDate.split(', ');
-        const key =
-          year === now.getFullYear().toString() ? monthOnly : releaseDate;
+  // const postsByDate = Array.from(
+  //   posts
+  //     .reduce((map, post) => {
+  //       const { releaseDate } = post.frontmatter;
+  //       const [monthOnly, year] = releaseDate.split(', ');
+  //       const key =
+  //         year === now.getFullYear().toString() ? monthOnly : releaseDate;
 
-        return map.set(key, [...(map.get(key) || []), post]);
-      }, new Map())
-      .entries()
-  );
+  //       return map.set(key, [...(map.get(key) || []), post]);
+  //     }, new Map())
+  //     .entries()
+  // );
+  const sortedPosts = posts.slice().sort((a, b) => {
+  // Sort by releaseDate descending
+  return new Date(b.frontmatter.releaseDate) - new Date(a.frontmatter.releaseDate);
+  });
 
   const title = `${subject} release notes`;
 
@@ -113,13 +117,15 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
         `}
       >
         <Timeline>
-          {postsByDate.map(([date, posts], idx) => {
-            const isLast = idx === postsByDate.length - 1;
+          {sortedPosts.map((post, idx ) => {
+            const isLast = idx === sortedPosts.length - 1;
+            const { releaseDate } = post.frontmatter;
+            const [monthOnly, year] = releaseDate.split(', ');
+            const currentYear = now.getFullYear().toString();
+            const label = year === currentYear ? monthOnly : releaseDate;
 
             return (
-              <Timeline.Item label={date} key={date}>
-                {posts.sort(sortByVersion).map((post) => {
-                  return (
+              <Timeline.Item label={label} key={post.fields.slug}>
                     <div
                       key={post.version}
                       css={css`
@@ -148,8 +154,6 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
                         <MDXContainer body={post.body} />
                       </p>
                     </div>
-                  );
-                })}
               </Timeline.Item>
             );
           })}

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -10,7 +10,6 @@ import { TYPES } from '../utils/constants';
 import MDXContainer from '../components/MDXContainer';
 import { getTitle } from '../utils/releaseNotes';
 
-
 const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   const { slug, disableSwiftype, currentPage } = pageContext;
   const {
@@ -21,7 +20,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   } = data;
 
   const now = useMemo(() => new Date(), []);
-  
+
   const sortedPosts = posts.slice().sort((a, b) => {
     // Sort by releaseDate descending
     return (

--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -10,19 +10,6 @@ import { TYPES } from '../utils/constants';
 import MDXContainer from '../components/MDXContainer';
 import { getTitle } from '../utils/releaseNotes';
 
-// const sortByVersion = (
-//   { frontmatter: { version: versionA } },
-//   { frontmatter: { version: versionB } }
-// ) => {
-//   if (!versionA || !versionB) {
-//     return 0;
-//   }
-
-//   return (
-//     parseInt(versionB.replace(/\D/g, ''), 10) -
-//     parseInt(versionA.replace(/\D/g, ''), 10)
-//   );
-// };
 
 const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   const { slug, disableSwiftype, currentPage } = pageContext;
@@ -34,18 +21,7 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   } = data;
 
   const now = useMemo(() => new Date(), []);
-  // const postsByDate = Array.from(
-  //   posts
-  //     .reduce((map, post) => {
-  //       const { releaseDate } = post.frontmatter;
-  //       const [monthOnly, year] = releaseDate.split(', ');
-  //       const key =
-  //         year === now.getFullYear().toString() ? monthOnly : releaseDate;
-
-  //       return map.set(key, [...(map.get(key) || []), post]);
-  //     }, new Map())
-  //     .entries()
-  // );
+  
   const sortedPosts = posts.slice().sort((a, b) => {
     // Sort by releaseDate descending
     return (


### PR DESCRIPTION
**Currently in release notes navigation section we only have one level of nesting which hinders the categorisation in release notes**
**This PR is created to enhance the categorisation of release notes , Add an additional level under the primary subject grouping. This will allow for more granular categorisation of release notes by leveraging a secondary frontmatter field Category 
Release Notes -> [Primary Subject] -> [Secondary Category] -> [Individual Release Note]**

[Jira Ticket](https://new-relic.atlassian.net/browse/NR-412539)