### PR TITLE
Added release notes for aws log forwarders releases

### DIFF
--- a/src/content/docs/release-notes/aws-firehose-log-forwarder-release-notes/firehose-24-12-06.mdx
+++ b/src/content/docs/release-notes/aws-firehose-log-forwarder-release-notes/firehose-24-12-06.mdx
@@ -1,0 +1,9 @@
+---
+subject: AWS Firehose Log Forwarder 
+releaseDate: '2024-12-06'
+version: 1.0.0
+metaDescription: Release notes for AWS Firehose Log Forwarder version 1.0.0
+features: []
+bugs: []
+security: []
+---

--- a/src/content/docs/release-notes/aws-firehose-log-forwarder-release-notes/index.mdx
+++ b/src/content/docs/release-notes/aws-firehose-log-forwarder-release-notes/index.mdx
@@ -1,0 +1,3 @@
+---
+subject: AWS Firehose Log Forwarder
+---

--- a/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/index.mdx
+++ b/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/index.mdx
@@ -1,0 +1,3 @@
+---
+subject: AWS Lambda Log Forwarder
+---

--- a/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-24-12-06.mdx
+++ b/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-24-12-06.mdx
@@ -1,0 +1,9 @@
+---
+subject: AWS Lambda Log Forwarder 
+releaseDate: '2024-12-06'
+version: 1.0.0
+metaDescription: Release notes for AWS Lambda Log Forwarder version 1.0.0
+features: []
+bugs: []
+security: []
+---

--- a/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-25-01-21.mdx
+++ b/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-25-01-21.mdx
@@ -1,0 +1,21 @@
+---
+subject: AWS Lambda Log Forwarder 
+releaseDate: '2025-01-21'
+version: 1.1.0
+metaDescription: Release notes for AWS Lambda Log Forwarder version 1.1.0
+features: []
+bugs: []
+security: []
+---
+
+### Enhanced AWS Lambda Log Processing with Request ID Injection
+
+New Relic enhances log processing for AWS Lambda functions by ensuring that request IDs are consistently added to logs lacking default runtime annotations. This improves traceability and observability across Lambda invocations.
+
+### Changed
+
+* **Consistent Request ID Annotation:** Logs from AWS Lambda functions now have request IDs added to every message using the UUID found in the first and last log entries. This ensures comprehensive traceability and completeness in log data, enabling more effective monitoring and debugging.
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
Created release notes for AWS Log forwarder releases. These release notes are also used to power the version upgrade experience for the entities of type: `AWS Lambda Log Forwarder` and `AWS Firehose Log Forwarder` in the integrations and agents table under installed tab.