### PR TITLE
[chore]: Updating the Sourcemap API docs to revise limit 

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/upload-source-maps-un-minify-js-errors.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/upload-source-maps-un-minify-js-errors.mdx
@@ -152,6 +152,24 @@ If you have uploaded source maps to New Relic and still see minified stack trace
         If the `SourcesContent` component is not added, an error similar to `Whoops, that was the wrong file. Please try again.` will appear.
       </td>
     </tr>
+    <tr>
+      <td>
+        400 error: `Invalid source map`
+      </td>
+
+      <td>
+        This error occurs when one of the following happens:
+
+          * The source map isn't valid JSON.
+          * The source map doesn't follow the required schema.
+          * A directory was uploaded instead of a file.
+        
+        To fix this: 
+        
+          * Make sure the source map file contains valid JSON and follows the required schema.
+          * Upload a single source map file, not a directory.
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/upload-source-maps-api.mdx
@@ -59,7 +59,6 @@ In order to upload source maps to browser via the API, you'll need:
     There is no limit to the overall number of source maps you can upload. However, the API is rate-limited per account:
 
     * You can upload a maximum of 1000 source maps per minute.
-    * You can upload a maximum of 15,000 source maps per day.
     * Only one source map can be uploaded or published per API request.
 
       Source map files can be a maximum of 50Mb in size.
@@ -237,8 +236,11 @@ Below are some examples of using curl to publish, list, and delete source maps:
 
     ```bash
     curl -H "Api-Key: YOUR_NEW_RELIC_USER_API_KEY" \ 
-        https://sourcemaps.service.newrelic.com/v2/applications/YOUR_NEW_RELIC_APP_ID/sourcemaps
+        https://sourcemaps.service.newrelic.com/v2/applications/YOUR_NEW_RELIC_APP_ID/sourcemaps?limit=100
     ```
+    The default `limit` is set to `100`. You can specify a different limit by updating the `?limit={NEW-LIMIT}` to the end of the URL. You can fetch upto `500` source maps at a time.
+
+
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
This PR address the NR-417029 ticket updates in the Sourcemap and uUpload source maps to un-minify JS errors documentation.