### PR TITLE
Update run-integrations-manually.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/troubleshooting/run-integrations-manually.mdx
+++ b/src/content/docs/infrastructure/host-integrations/troubleshooting/run-integrations-manually.mdx
@@ -48,6 +48,19 @@ Example: Testing all files inside a folder:
 /usr/bin/newrelic-infra -dry_run -integration_config_path /any/absolute/path 
 ```
 
+Example: Dry run on Windows - Microsoft SQL Server (from an Administrator powershell)
+
+```
+cd "C:\Program Files\New Relic\newrelic-infra"; .\newrelic-infra.exe -dry_run -integration_config_path "C:\Program Files\New Relic\newrelic-infra\integrations.d\mssql-config.yml"
+```
+
+Example: Dry run on Windows wtih debug logs - Microsoft SQL Server (from an Administrator powershell)
+
+```
+cd "C:\Program Files\New Relic\newrelic-infra"; powershell -Command {  $env:NRIA_LOG_LEVEL="trace";  .\newrelic-infra.exe -dry_run -integration_config_path "C:\Program Files\New Relic\newrelic-infra\integrations.d\mssql-config.yml" }
+```
+
+
 For each integration execution, the command will print the name of the integration and its output.
 
 ```


### PR DESCRIPTION
adding 2 examples to dry-run an on-host integration for Windows

