### PR TITLE
Draft: Update Azure Functions docs based on testing

### DIFF
--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/compatibility-requirement-azure-monitoring.mdx
@@ -11,6 +11,14 @@ Before you [instrument Azure Functions](/docs/serverless-function-monitoring/azu
 
 * Azure Functions hosted on [consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan) or [dedicated plan](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan).
 
+<Callout variant="important">
+
+Note: [in-process](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library) functions hosted on Linux with a consumption plan are not supported.
+
+</Callout>
+
+* Your Azure function app must use version 4 of the [Azure Functions runtime](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions) or greater. Look for the following in your function app's .csproj file: `<AzureFunctionsVersion>v4</AzureFunctionsVersion>`.
+
 * You must have the [required permission to access kudu service](https://learn.microsoft.com/en-us/azure/app-service/resources-kudu#access-kudu-for-your-app). 
 
 * A New Relic account with either an [admin role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model/#roles) or an [Infrastructure manager role](/docs/accounts/original-accounts-billing/original-users-roles/users-roles-original-user-model#add-on).
@@ -44,7 +52,7 @@ Based on your hosting environment, the following Azure Function runtime stacks a
 <TabsPageItem id="2">
 
 * .NET stack: 
-  * .NET 4.8 (.NET agent version 10.37.0 and later)
+  * .NET 4.8 (.NET agent version 10.37.0 and later), Isolated model only
   * .NET 6 - 9, Isolated model
   * .NET 6 and 8, In-process model (.NET agent version 10.38.0 and later)
 

--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/install-serverless-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/install-serverless-azure-monitoring.mdx
@@ -155,15 +155,67 @@ Ensure that you add a comma at the end of the last existing line and update your
   
   ```json
   {
+    "name": "CORECLR_ENABLE_PROFILING",
+    "value": "1",
+    "slotSetting": false
+  },
+  {
+    "name": "CORECLR_NEW_RELIC_HOME",
+    "value": "C:\\home\\NewRelicAgent\\Core",
+    "slotSetting": false
+  },
+  {
+    "name": "CORECLR_PROFILER",
+    "value": "{36032161-FFC0-4B61-B559-F6C5D41BAE5A}",
+    "slotSetting": false
+  }, 
+  {
+    "name": "CORECLR_PROFILER_PATH_32",
+    "value": "C:\\home\\NewRelicAgent\\Core\\x86\\NewRelic.Profiler.dll",
+    "slotSetting": false
+  },
+  {
+    "name": "CORECLR_PROFILER_PATH_64",
+    "value": "C:\\home\\NewRelicAgent\\Core\\NewRelic.Profiler.dll",
+    "slotSetting": false
+  },
+  {
+    "name": "COR_ENABLE_PROFILING",
+    "value": "1",
+    "slotSetting": false
+  },
+  {
+    "name": "NEW_RELIC_HOME",
+    "value": "C:\\home\\NewRelicAgent\\Framework",
+    "slotSetting": false
+  },
+  {
+    "name": "COR_PROFILER",
+    "value": "{71DA0A04-7777-4EC6-9643-7D28B46A8A41}",
+    "slotSetting": false
+  }, 
+  {
+    "name": "COR_PROFILER_PATH_32",
+    "value": "C:\\home\\NewRelicAgent\\Framework\\x86\\NewRelic.Profiler.dll",
+    "slotSetting": false
+  },
+  {
+    "name": "COR_PROFILER_PATH_64",
+    "value": "C:\\home\\NewRelicAgent\\Framework\\NewRelic.Profiler.dll",
+    "slotSetting": false
+  },
+  {
+    "name": "NEW_RELIC_LOG_DIRECTORY",
+    "value": "C:\\home\\LogFiles\\NewRelic",
+    "slotSetting": false
+  },
+  {
     "name": "NEW_RELIC_LICENSE_KEY",
     "value": "<your newrelic license key here>",
     "slotSetting": false
   }
   ```
 
-  The Azure websites extension automatically configures all other required environment variables.
-
-  
   Optionally, you can specify the version of the .NET agent you want to install by adding the following environment variable:
 
   ```json

--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/install-serverless-azure-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/install-serverless-azure-monitoring.mdx
@@ -52,7 +52,7 @@ Depending on your deployment environment, select one of the following options to
             4. Select <DNT>**Search for an extension to install**</DNT> and enter `New Relic .NET Agent` in the <DNT>**Filter items**</DNT> box.
             5. Select the <DNT>**New Relic .NET Agent(vx.x.x) - New Relic**</DNT> extension and click <DNT>**Add**</DNT>.
             6. When installation is complete, the extension appears in the list of installed extensions. To verify correct installation, click the link under the <DNT>**Browse**</DNT> column to view the installation log.
-          The Azure Websites Extension configures all required environment variables except your license key (see the next step for details). The .NET agent is installed to `C:\home\NewRelicAgent` and log files are written to `C:\home\LogFiles\NewRelic`.
+           The .NET agent is installed to `C:\home\NewRelicAgent` and log files are written to `C:\home\LogFiles\NewRelic`.
       </Collapser>
       <Collapser id="nuget-package" title="Add the New Relic agent  NuGet package to your project">
         1. Add the latest version of the `NewRelic.Agent` NuGet package to your application project.


### PR DESCRIPTION
This PR updates our Azure Functions monitoring docs (compatibility/support and install instructions) based on testing I've recently done on various combinations of function model (isolated vs. in-process), host platform (Windows vs. Linux), hosting plan type (consumption or dedicated), function runtime (.NET Framework vs. .NET), and agent install method (Azure Site Extension vs. Agent NuGet package).

Summary of changes:
* Called out that we do not support the combination of Linux OS, Consumption plan and In-Process function model
* Called out that we only support functions using version 4 of the functions runtime
* Changed the environment variable instructions for the Windows + Azure Site Extension install method to explicitly set all of the profiling env vars, similar to the instructions for using the NuGet package install method, except that the paths to the files/folders point to where the site extension places the agent (`C:\home\NewRelicAgent`).  I removed the line "The Azure websites extension automatically configures all other required environment variables" because that turns out to be false in some cases (particularly consumption-type hosting plans).