### PR TITLE
chore: Updated the date for old ip ranges in synthetic monitoring doc and eol

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -123,7 +123,7 @@ It is recommended that you add the entire global ranges provided by New Relic to
   </tbody>
 </table>
 
-After **May 28, 2025**, the IP range list in JSON will be updated to remove the older IP ranges that are being deprecated. It is important to update your allow list by removing the older ones after this date.
+It is recommended not to remove the old IP ranges until notified.
 
 **Old IP Range:**
 

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -30,7 +30,7 @@ We will be migrating the IP address range for the New Relic service used by Synt
 
 * After **May 28, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 
-**Old IP ranges to remove:** Please refer to the table below for a complete list of current IP ranges **that need to be removed after May 28, 2025**.
+**Old IP ranges to remove:** The following table list the old IP ranges however, it is recommended not to remove the old IP ranges until notified.
 
 <table>
   <thead>


### PR DESCRIPTION
This PR answers the PM's call to remove the dates for old IP ranges as discussed in [this slack message](https://newrelic.slack.com/archives/D08AP3BMEF7/p1748941937021429).