### PR TITLE
Add unix timestamp requirement in addToTrace

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/addtotrace.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/addtotrace.mdx
@@ -82,6 +82,7 @@ Note that the number of events shared this way is limited by the Browser agent h
 
         * Required name/value pairs: `name`, `start`
         * Optional name/value pairs: `end`, `origin`
+        * `start` and `end` must be valid non-negative Unix timestamps and `end` cannot be before `start`
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Adds a note about argument requirements in addToTrace API method. `start` and `end` must be positive Unix stamps, and `end` cannot be before `start`.

## Give us some context

JIRA: https://new-relic.atlassian.net/browse/NR-366078

The argument requirements will be enforced for the addToTrace API method on next Browser agent release, which contain safeguards, but these requirements should be followed even without the safeguards in place.