### PR TITLE
Update nrql-syntax-clauses-functions.mdx

### DIFF
--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -1497,7 +1497,6 @@ In this section we explain NRQL functions, both [aggregator functions](#aggregat
 
 You can use aggregator functions to filter and aggregate data. Some tips for using these:
 
-* Go to the full online course [Writing NRQL queries](https://learn.newrelic.com/writing-nrql-queries).
 * If you're using an aggregator function multiple times in the same query (for example, `SELECT median(one_metric), median(another_metric)`), it can cause problems in displaying results. To solve this, use the [`AS` function](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-as). For example:
   ```sql
   SELECT median(one_metric) AS 'med-a', median(another_metric) AS 'med-b'


### PR DESCRIPTION
As discussed with @zyria removing the link as the course is currently hidden on learn.newrelic.com but it is still able to be accessed with a link. We’d like the link removed so users won’t access the out of date course.