### PR TITLE
Add release docs for Python Agent v10.13.0.

### DIFF
--- a/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
@@ -79,6 +79,8 @@ AI monitoring is compatible with these agent versions and AI libraries:
         * [Boto3 AWS SDK for Python](https://pypi.org/project/boto3/)  versions 1.28.57 and above.
         * [LangChain](https://pypi.org/project/langchain/) versions 0.1.0 and above.
         * [Google Gen AI SDK](https://pypi.org/project/google-genai/) versions 1.3.0 and above.
+        * [FastMCP](https://pypi.org/project/google-genai/) versions 2.3.3 and above.
+
       </td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-101300.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-101300.mdx
@@ -1,0 +1,36 @@
+---
+subject: 'Python agent'
+releaseDate: '2025-06-09'
+version: 10.13.0
+downloadLink: 'https://pypi.python.org/pypi/newrelic'
+features: ['Add support for Model Context Protocol (MCP)']
+bugs: ['Fix import logic for importlib.metadata and pkg_resources']
+---
+
+## Notes
+
+This release of the Python agent adds support for the Model Context Protocol (MCP) and fixes import logic for `importlib.metadata` and `pkg_resources`.
+
+Install the agent using `easy_install/pip/distribute` via the [Python Package Index](https://pypi.python.org/pypi/newrelic) or download it directly from the [New Relic download site](https://download.newrelic.com/python_agent/release).
+
+## New features
+
+* Add support for Model Context Protocol (MCP)
+
+  * Adds support for MCP calls in [mcp](https://pypi.org/project/mcp/) and [fastmcp](https://pypi.org/project/fastmcp/). The agent will now automatically instrument the following core MCP primitives:
+    * Tools (via `call_tool`)
+    * Resources (via `read_resource`)
+    * Prompts (via `get_prompt`)
+
+## Bug fixes
+
+* Fix import logic for `importlib.metadata` and `pkg_resources`
+
+  * Updates logic around import of `importlib.metadata` to also attempt to use the `importlib_metadata` backport before falling back to `pkg_resources.*`. This also removes use of `sys.version` conditionals and fixes issues where Python 3.9 could only use `pkg_resources` despite having `importlib.metadata` available.
+
+## Support statement
+
+We recommend updating to the latest agent version as soon as it's available. If you can't upgrade to the latest version, update your agents to a version no more than 90 days old. Read [more](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/) about keeping agents up to date.
+
+See the New Relic Python agent [EOL policy](/docs/apm/agents/python-agent/getting-started/python-agent-eol-policy/) for information about agent releases and support dates.
+


### PR DESCRIPTION
This PR adds release docs for Python Agent v10.13.0.