### PR TITLE
chore(docs RN): Release note date correction

### DIFF
--- a/src/content/docs/release-notes/docs-release-notes/docs-5-16-2025.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-16-2025.mdx
@@ -1,7 +1,7 @@
 ---
 subject: "Docs"
 releaseDate: '2025-05-16'
-version: 'May 12-15, 2025'
+version: 'May 2-15, 2025'
 ---
 
 ### New docs


### PR DESCRIPTION
The RN was from 2 to 15 May, but named by mistake as 12 to15 may. Corrected it.
