### PR TITLE
feat:[Do not merge]: New map experience doc update for GA

### DIFF
--- a/src/content/docs/new-relic-solutions/new-relic-one/ui-data/service-maps/service-maps.mdx
+++ b/src/content/docs/new-relic-solutions/new-relic-one/ui-data/service-maps/service-maps.mdx
@@ -140,12 +140,6 @@ In the New Relic UI, your out-of-process services are referred to as [web extern
 
 ## New Maps experience [#about-advanced-maps]
 
-<Callout title="preview">
-  We're still working on this feature, but we'd love for you to try it out!
-
-  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
-</Callout>
-
 While the existing service map offers valuable insights, it has certain limitations:
 * **Fragmented experience**: Navigation across different views can lead to fragmented insights.
 * **Incomplete map**: Limited ability to explore the entire cloud estate.

--- a/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
+++ b/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
@@ -10,12 +10,6 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-<Callout title="preview">
-  We're still working on this feature, but we'd love for you to try it out!
-
-  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy). The public preview includes access to <DNT>**[Auto-Discovery](/docs/infrastructure/amazon-integrations/connect/set-up-auto-discovery-of-aws-entities)**</DNT> and <DNT>**[Transaction 360](/docs/apm/transactions/workload-performance-monitoring/transaction-workloads)**</DNT>, bundled together. Having opted into the preview, you gain access to all three capabilities at no cost; opting out of the preview applies to all three as well. 
-</Callout>
-
 <DNT>**Maps**</DNT> provides a unified and integrated view of your cloud estate, allowing seamless navigation and exploration of services and infrastructure. It integrates tracing, infrastructure, and performance data into a cohesive experience, addressing limitations of other map experiences.
 
 ## Service map vs. Maps [#differences]
@@ -148,6 +142,10 @@ Get familiar with the components of <DNT>**Maps**</DNT>, which visualize the rel
       <td><strong>Health status summary</strong></td>
       <td>The Health status summary provides a quick overview of node statuses, using color-coded indicators and counts to help you identify areas requiring attention. You can [instrument uninstrumented nodes](#node-instrumentation) directly from the status summary.</td>
     </tr>
+      <tr>
+      <td><strong>Service level availability (SLA) indication</strong></td>
+      <td>The SLA indication appears if the availability percentage of the node drops below the SLA threshold. To learn more about the SLA, refer to [Service level availability commitment](/docs/licenses/license-information/referenced-policies/service-level-availability-commitment/).</td>
+    </tr>
     <tr>
       <td><strong>Clusters</strong></td>
       <td>
@@ -157,10 +155,9 @@ Get familiar with the components of <DNT>**Maps**</DNT>, which visualize the rel
         * Belong to the same entity domain and type.
         * Exhibit the same dependencies (inbound or outbound).
 
-        A cluster displays the number of nodes it contains, and the color of the cluster depends on the health status of the nodes within.
+      A cluster displays the number of nodes it contains, and the color of the cluster depends on the health status of the nodes within.
         * **Red**: At least one critical node
         * **Yellow**: At least one degraded node but no critical nodes
-        * **Green**: All nodes are operational
 
         Select a cluster to view the nodes in the right panel of the map. Reveal nodes from the panel to display them individually on the map outside the cluster.
       </td>
@@ -170,7 +167,7 @@ Get familiar with the components of <DNT>**Maps**</DNT>, which visualize the rel
 
 ## Map entry points [#entry-points]
 
-<DNT>**Maps**</DNT> provides a consistent mapping experience accessible through various entry points. Depending on the type of entity you select to explore, separate views are available to show services, teams, infrastructure resources, or dynamic data flows. This unified approach offers clear insights into service interactions, infrastructure dependencies, team operations, and data flows.
+<DNT>**Maps**</DNT> provides a consistent mapping experience accessible through various entry points. Depending on the type of entity you select to explore, separate views are available to show services, teams, infrastructure resources, entity relationships in a workload, or dynamic data flows. This unified approach offers clear insights into service interactions, infrastructure dependencies, team operations, and data flows.
 
 <CollapserGroup>
     <Collapser
@@ -205,8 +202,8 @@ To access the map for a service from an alert:
       3. To open the map, on the host page, click <DNT>**Infrastructure**</DNT>.
 
 To access the infrastructure associated with a service on the map:
-  1. From <DNT>**[one.newrelic.com](https://one.newrelic.com)**</DNT>, open map for any service in <DNT>**APM & services**</DNT>, <DNT>**Mobile**</DNT>, or <DNT>**Browser**</DNT>.
-  2. To open the <DNT>**Dynamic Flow Map**</DNT>, point to a node and click <DNT>**Inspect infrastructure**</DNT>.
+  1. From <DNT>**[one.newrelic.com](https://one.newrelic.com)**</DNT>, open map for any service in <DNT>**APM & services**</DNT>, <DNT>**Mobile**</DNT>, <DNT>**Browser**</DNT>, or <DNT>**Workloads**</DNT>.
+  2. To open the <DNT>**Infrastructure Map**</DNT>, point to a node and click <DNT>**Inspect infrastructure**</DNT>.
 
     </Collapser>   
     <Collapser
@@ -228,7 +225,22 @@ To access the infrastructure associated with a service on the map:
       >
       The [<DNT>**Dynamic Flow Map**</DNT>](/docs/service-architecture-intelligence/maps/dynamic-flow-map) offers a detailed view of data flow through your services, including interactions with databases and other backend components. It provides insights into performance and potential bottlenecks, allowing for effective troubleshooting.
 
-    </Collapser>       
+    </Collapser>   
+    <Collapser
+      id="dynamic-workload-map"
+      title="Visualize the entity relationships in a workload"
+      >
+      <DNT>**Maps**</DNT> allow you to visualize relationships and dependencies among the entities in a workload. They provide a comprehensive view of relationships, health status, SLA, and data flow of the entities in a workload, allowing you to explore and manage dependencies effectively.
+
+      To access the workload map:
+
+      1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Workloads**</DNT>.
+      2. From the <DNT>**Workloads**</DNT> page, select the workload you want to view.
+      3. To open the map, from the second-left nav, click <DNT>**Maps**</DNT>.
+
+    To learn more about workloads, refer to [The workloads UI](/docs/new-relic-solutions/new-relic-one/workloads/use-workloads/) page.
+
+    </Collapser>        
   </CollapserGroup>
 
 <Callout variant="important">
@@ -288,7 +300,6 @@ With the features and components of <DNT>**Maps**</DNT>, you can explore and man
       Groups are named based on the selected attribute. For example, if you are grouping the nodes by the `Account` attribute, the group name appears as `Account: <account name>`. Groups are color-coded according to the health status of the nodes within them, as follows:
       * **Red**: At least one critical node
       * **Yellow**: At least one degraded node but no critical nodes
-      * **Green**: All nodes are operational
 
       You can expand groups to view the nodes and nested sub-groups within them. As per your requirement you can reorder group levels by shuffling attributes in the <DNT>**Group by**</DNT> drop-down.
 

--- a/src/content/docs/service-architecture-intelligence/maps/dynamic-flow-map.mdx
+++ b/src/content/docs/service-architecture-intelligence/maps/dynamic-flow-map.mdx
@@ -10,11 +10,6 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-<Callout title="preview">
-  We're still working on this feature, but we'd love for you to try it out!
-
-  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy). 
-</Callout>
 
 <DNT>**Dynamic Flow Map**</DNT> is a visualization tool that provides a map view of aggregated trace data. It highlights performance signals related to a specific service, called focal node. The map uses tracing data to display relationships between services participating in traces with the focal node, correlating performance changes across upstream and downstream entities. This helps identify performance bottlenecks in applications and services, aiding in pinpointing the root cause.
 


### PR DESCRIPTION
For the GA release updating the following in Maps doc:
- Adding the workload map
- Adding SLA indicator details
- Adding new screenshots with new isometric node icons
- Explaining new icons
- Removing the operational health indicator icon
- Removing the PP callout
- Adding the new way of map onboarding
