### PR TITLE
fix: fix field names in examples

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/marks-and-measures.mdx
@@ -32,15 +32,15 @@ To enable this feature:
 
 Once enabled, the agent stores marks and measures data under the `BrowserPerformance` event type in New Relic. To find this data, try the following queries and then create custom dashboards to track performance.
 
-**Query 1**: This NRQL query retrieves all `BrowserPerformance` events for the specified `appName` ("My Application") where the `entryName` is either `mark` or `measure`. 
+**Query 1**: This NRQL query retrieves all `BrowserPerformance` events for the specified `appName` ("My Application") where the `entryType` is either `mark` or `measure`. 
 
     ```nrql
-    FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure'
+    FROM BrowserPerformance SELECT * WHERE appName = 'My Application' AND entryType = 'mark' OR entryType = 'measure'
     ```
 
-**Query 2**: This NRQL query calculates the average `entryDuration` for mark and measure events within the specified `appName`. The `FACET entryName` clause groups the results by the `entryName` field, providing separate average durations for mark and measure events. This can be useful for comparing the average performance of marks versus measures. 
+**Query 2**: This NRQL query calculates the average `entryDuration` for measure events within the specified `appName`. The `FACET entryName` clause groups the results by the `entryName` field, providing separate average durations for unique measure events. This can be useful for comparing the average performance of individual measures. 
 
     ```nrql
-    FROM BrowserPerformance SELECT average(entryDuration) WHERE appName = 'My Application' AND entryName = 'mark' OR entryName = 'measure' FACET entryName
+    FROM BrowserPerformance SELECT average(entryDuration) WHERE appName = 'My Application' AND entryType = 'measure' FACET entryName
     ```
 


### PR DESCRIPTION
This PR fixes `entryName` field mistakes in the examples page for Marks and Measures.  in various places, `entryName` should have been `entryType`.  As well, the bottom example was updated to be more useful.