### PR TITLE
docs: Update .NET agent install documentation for APT installs on Linux 

### DIFF
--- a/src/install/dotnet/installation/azure-linux-container.mdx
+++ b/src/install/dotnet/installation/azure-linux-container.mdx
@@ -27,9 +27,8 @@ COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget https://download.newrelic.com/548C16BF.gpg \
-&& apt-key add 548C16BF.gpg \
+&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
@@ -48,7 +47,7 @@ ENTRYPOINT ["dotnet", "./YOUR_APP_NAME.dll"]
 ### Example Linux multi-stage dockerfile
 
 ```dockerfile
-# This example uses .NET 6.0.  For other versions, see https://hub.docker.com/_/microsoft-dotnet-sdk/
+# This example uses .NET 8.0.  For other versions, see https://hub.docker.com/_/microsoft-dotnet-sdk/
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 
 # Build your application
@@ -61,9 +60,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget https://download.newrelic.com/548C16BF.gpg \
-&& apt-key add 548C16BF.gpg \
+&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent
 

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -19,16 +19,15 @@ Here are example Docker files for Linux. Additional examples for multiple Linux 
 
 ```dockerfile
 # Use the correct tagged version for your application's targeted runtime.  See https://hub.docker.com/_/microsoft-dotnet-aspnet/ 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
 
 # Publish your application.
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget https://download.newrelic.com/548C16BF.gpg \
-&& apt-key add 548C16BF.gpg \
+&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
@@ -49,8 +48,8 @@ ENTRYPOINT ["dotnet", "./YOUR_APP_NAME.dll"]
 ### Example Linux multi-stage dockerfile
 
 ```dockerfile
-# This example uses .NET 6.0.  For other versions, see https://hub.docker.com/_/microsoft-dotnet-sdk/
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS base
+# This example uses .NET 8.0.  For other versions, see https://hub.docker.com/_/microsoft/dotnet-sdk/
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 
 # Build your application
 WORKDIR /src
@@ -58,13 +57,12 @@ RUN dotnet new mvc -o YOUR_APP_NAME
 RUN dotnet publish -c Release -o /app ./YOUR_APP_NAME
 
 # The runtime tag version should match the SDK tag version
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget https://download.newrelic.com/548C16BF.gpg \
-&& apt-key add 548C16BF.gpg \
+&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent
 

--- a/src/install/dotnet/installation/linuxInstall2.mdx
+++ b/src/install/dotnet/installation/linuxInstall2.mdx
@@ -35,12 +35,12 @@ To start installing the agent, choose your package manager:
       1. Configure the New Relic APT repository by adding `deb https://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`:
 
          ```bash
-         echo 'deb https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
+         echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
          ```
       2. Enable New Relic's GPG key to allow apt to find New Relic packages. To avoid possible errors about public keys, run this command as root:
 
          ```bash
-         wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
+         wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg
          ```
       3. Update the local package list:
 


### PR DESCRIPTION
This PR updates the instructions for configuring New Relic's APT repository for .NET agent installs:

- Replace `apt-key add`, which is deprecated, with the current best practice of saving the public key to a particular file and then configuring the repo definition to be signed by that file.
- Replace the old public key with a newly-generated one that is more secure.
- Replace .NET 6 (which is EOL) with .NET 8 in example Dockerfiles.

Note: this is *not* a breaking change for customers who have already configured their system(s) with the old instructions.