### PR TITLE
Add metadata to AWS lambda log forwarder release notes

### DIFF
--- a/src/content/docs/release-notes/aws-firehose-log-forwarder-release-notes/firehose-24-12-06.mdx
+++ b/src/content/docs/release-notes/aws-firehose-log-forwarder-release-notes/firehose-24-12-06.mdx
@@ -3,14 +3,9 @@ subject: AWS Firehose Log Forwarder
 releaseDate: '2024-12-06'
 version: 1.0.0
 metaDescription: Release notes for AWS Firehose Log Forwarder version 1.0.0
-features:
-    - Accelerated AWS logs forwarding with New Relic's One-Step Observability
-    - Simplified logs onboarding with CloudFormation template for both logs and metrics
-    - Enhanced operational efficiency with a single onboarding workflow for AWS CloudWatch log forwarding via Amazon Data Firehose
-    - Organize your logs more effectively by adding attributes, making it easier to search, filter, analyze, and parse your data.
+features: ["Accelerated AWS logs forwarding with New Relic's One-Step Observability", "Simplified logs onboarding with CloudFormation template for both logs and metrics", "Enhanced operational efficiency with a single onboarding workflow for AWS CloudWatch log forwarding via Amazon Data Firehose", "Organize your logs more effectively by adding attributes, making it easier to search, filter, analyze, and parse your data."]
 bugs: []
-security:
-    - New Relic's API keys can be securely stored in AWS Secrets Management for enhanced security.
+security: ["New Relic's API keys can be securely stored in AWS Secrets Management for enhanced security."]
 ---
 
 ### Accelerated AWS logs forwarding with New Relic's One-Step Observability

--- a/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-24-12-06.mdx
+++ b/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-24-12-06.mdx
@@ -3,15 +3,9 @@ subject: AWS Lambda Log Forwarder
 releaseDate: '2024-12-06'
 version: 1.0.0
 metaDescription: Release notes for AWS Lambda Log Forwarder version 1.0.0
-features:
-    - Accelerated AWS services logs onboarding with one-step observability.
-    - Simplified logs and metrics onboarding using a CloudFormation template.
-    - Ability to set up log forwarding from multiple sinks (CloudWatch or S3) in a single workflow.
-    - Support for configuring triggers for up to 40 S3 buckets and log groups at once.
-    - Organize your logs more effectively by adding attributes, making it easier to search, filter, analyze, and parse your data.
+features: ["Accelerated AWS services logs onboarding with one-step observability.", "Simplified logs and metrics onboarding using a CloudFormation template.", "Ability to set up log forwarding from multiple sinks (CloudWatch or S3) in a single workflow.", "Support for configuring triggers for up to 40 S3 buckets and log groups at once.", "Organize your logs more effectively by adding attributes, making it easier to search, filter, analyze, and parse your data."]
 bugs: []
-security:
-    - New Relic's API keys can be securely stored in AWS Secrets Management for enhanced security.
+security: ["New Relic's API keys can be securely stored in AWS Secrets Management for enhanced security."]
 ---
 
 ### Accelerated AWS logs forwarding with New Relic's One-Step Observability

--- a/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-25-01-21.mdx
+++ b/src/content/docs/release-notes/aws-lambda-log-forwarder-release-notes/lambda-25-01-21.mdx
@@ -3,8 +3,7 @@ subject: AWS Lambda Log Forwarder
 releaseDate: '2025-01-21'
 version: 1.1.0
 metaDescription: Release notes for AWS Lambda Log Forwarder version 1.1.0
-features:
-    - Consistent Request ID annotation for all AWS Lambda log messages, improving traceability and observability.
+features: ["Consistent Request ID annotation for all AWS Lambda log messages, improving traceability and observability."]
 bugs: []
 security: []
 ---


### PR DESCRIPTION
This PR adds metadata (features, security) to release notes of AWS Lambda Log Forwarder. This metadata appears in the agent upgrade view in the installed tab. A similar experience for Fluent bit agent is shown in the screenshot below:


<img width="1912" alt="Screenshot 2025-06-24 at 3 13 02 PM" src="https://github.com/user-attachments/assets/a14f3b29-2662-4374-881e-00a4ebac8bde" />
