### PR TITLE
Php agent release 11.10

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -4142,7 +4142,7 @@ This section lists the settings that affect the reporting of PHP packages.
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
         <tr>
@@ -4158,6 +4158,58 @@ This section lists the settings that affect the reporting of PHP packages.
     </table>
 
     When set to `true`, the agent will try using [Composer's runtime API](https://getcomposer.org/doc/07-runtime.md) for package detection.
+
+  </Collapser>
+  <Collapser
+    id="inivar-package-detection-use-composer-api-once-per-process"
+    title="newrelic.vulnerability_management.composer_api.per_process_detection"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Scope:
+          </th>
+
+          <td>
+            SYSTEM
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Type:
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default:
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+        <tr>
+          <th>
+            Notes:
+          </th>
+
+          <td>
+            Introduced in PHP agent version 11.10
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Controls the frequency at which Composer API samples the runtime environment for package data.
+    When set to `true`, sampling will only occur once per process. If false, Composer will sample
+    the environment every request, increasing the frequency which this package detection is performed.
 
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-10-0-24.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-10-0-24.mdx
@@ -1,0 +1,64 @@
+---
+subject: PHP agent
+releaseDate: '2025-06-25'
+version: 11.10.0.24
+downloadLink: 'https://download.newrelic.com/php_agent/archive/11.10.0.24'
+features: ['Security RX: Composer runtime API will be used by default to detect packages used by PHP applications']
+bugs: ['Fix undefined behavior when Composer runtime API is used']
+security: ['upgrade golang to 1.24.4', 'rotate New Relic's public key used to verify signature of APT repository']
+---
+
+## New Relic PHP agent v11.10.0.24
+
+### New features
+
+* [Security RX](https://docs.newrelic.com/docs/vulnerability-management/overview/): Composer runtime API will be used by default to detect packages used by PHP applications [#1055](https://github.com/newrelic/newrelic-php-agent/pull/1055)
+
+### Security updates
+* [#1089](https://github.com/newrelic/newrelic-php-agent/issues/1089) - security(daemon): upgrade golang to 1.24.4 [#1090](https://github.com/newrelic/newrelic-php-agent/pull/1090)
+* [#973](https://github.com/newrelic/newrelic-php-agent/issues/973) - security: rotate New Relic's public key used to verify signature of http://apt.newrelic.com/debian/ APT repository. See [here](https://docs.newrelic.com/docs/apm/agents/php-agent/installation/php-agent-installation-ubuntu-debian/#configure-repo) for details.
+
+### Bug fixes
+
+* fix(agent): Fix undefined behavior when Composer runtime API is used [#1086](https://github.com/newrelic/newrelic-php-agent/pull/1086)
+
+### Notice
+
+#### Default value for `newrelic.code_level_metrics.enabled` INI changes in next release
+
+The default Code Level Metrics configuration will change in an upcoming release from enabled to disabled.  If you do not use Code Level Metrics, you should see no impact and will not have to take any action.  If you do rely on Code Level Metrics, ensure that your newrelic.ini configuration file has the  `newrelic.code_level_metrics.enabled` INI setting uncommented and set to true.
+e.g:
+```
+newrelic.code_level_metrics.enabled = true
+```
+This change only impacts the default configuration value. Manually set configuration values will be honored, and core CLM behavior will remain unaffected.
+
+### Support statement
+
+* The following frameworks/libraries that the PHP Agent has previously EOL'd support for will be removed in the next release:
+
+  * Guzzle 3.x
+  * Kohana
+  * Silex
+  * Symfony 1.x-3.x
+  * Zend 1.x-2.x
+
+* PHP Agent support for the following library/framework versions will end September 30, 2025:
+
+  * WordPress 5.9
+  * Drupal 8.x
+  * Laravel 6.x, 8.x
+  * PHPUnit 8.x
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [New Relic PHP Agent EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+  **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
+  The PHP agent packages that are affected are:
+
+  * newrelic-php5
+  * newrelic-php5-common
+  * newrelic-daemon
+</Callout>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-10-0-24.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-10-0-24.mdx
@@ -5,7 +5,7 @@ version: 11.10.0.24
 downloadLink: 'https://download.newrelic.com/php_agent/archive/11.10.0.24'
 features: ['Security RX: Composer runtime API will be used by default to detect packages used by PHP applications']
 bugs: ['Fix undefined behavior when Composer runtime API is used']
-security: ['upgrade golang to 1.24.4', 'rotate New Relic\'s public key used to verify signature of APT repository']
+security: ["upgrade golang to 1.24.4", "rotate New Relic's public key used to verify signature of APT repository"]
 ---
 
 ## New Relic PHP agent v11.10.0.24

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-10-0-24.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-10-0-24.mdx
@@ -5,7 +5,7 @@ version: 11.10.0.24
 downloadLink: 'https://download.newrelic.com/php_agent/archive/11.10.0.24'
 features: ['Security RX: Composer runtime API will be used by default to detect packages used by PHP applications']
 bugs: ['Fix undefined behavior when Composer runtime API is used']
-security: ['upgrade golang to 1.24.4', 'rotate New Relic's public key used to verify signature of APT repository']
+security: ['upgrade golang to 1.24.4', 'rotate New Relic\'s public key used to verify signature of APT repository']
 ---
 
 ## New Relic PHP agent v11.10.0.24


### PR DESCRIPTION
Updates for the PHP agent v11.10.0:

Add 'PHP agent v11.10.0' release notes and supporting documentation that was updated to reflect functionality changes.