### PR TITLE
docs: Update GRANT SELECT permissions for nri-oracledb

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -116,6 +116,7 @@ In the Oracle database, execute the following statements to create a new user an
    * `cdb_data_files`
    * `cdb_pdbs`
    * `cdb_users`
+   * `dba_users`
    * `gv_$sysmetric`
    * `gv_$pgastat`
    * `gv_$instance`
@@ -143,6 +144,7 @@ In the Oracle database, execute the following statements to create a new user an
      GRANT SELECT ON cdb_data_files TO USERNAME;
      GRANT SELECT ON cdb_pdbs TO USERNAME;
      GRANT SELECT ON cdb_users TO USERNAME;
+     GRANT SELECT ON dba_users TO USERNAME;
      GRANT SELECT ON gv_$sysmetric TO USERNAME;
      GRANT SELECT ON gv_$pgastat TO USERNAME;
      GRANT SELECT ON gv_$instance TO USERNAME;


### PR DESCRIPTION
- Add GRANT SELECT permissions to handle non-cdb oracle database to fetch locked accounts from standard database