### PR TITLE
Document new Kafka DT features in the Java agent

### DIFF
--- a/src/content/docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
+++ b/src/content/docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues.mdx
@@ -205,12 +205,26 @@ To collect distributed traces from Kafka:
       distributed_tracing:
         enabled: true
       ```
-    * Enable the Kafka-specific distributed tracing features by adding the following to your config file:
+    * Enable general Kafka-specific distributed tracing features by adding the following to your config file:
 
       ```yml
       class_transformer:
         com.newrelic.instrumentation.kafka-clients-spans-0.11.0.0:
           enabled: true
+      ```
+    * Enable spring-kafka instrumentation. (Warning: This may cause a spike in ingest and memory usage so it is disabled):
+      ```yml
+      class_transformer:
+        com.newrelic.instrumentation.spring-kafka-2.2.0:
+          enabled: true
+      ```
+    * Enable distributed tracing for batch calls for Kafka. (Batch call distributed traces are disabled by default as transactions can only accept 1 parent trace from a message):
+      ```yml
+      kafka:
+        spans:
+          distributed_trace: 
+            consume_many:
+              enabled: true
       ```
   </Collapser>
 
@@ -239,7 +253,9 @@ To collect distributed traces from Kafka:
     id="instrument-kafka-consumer"
     title="3. Instrument the Kafka consumer"
   >
-    To instrument your Kafka consumer, you'll need to start a transaction when the message is being processed. The agent stores the distributed tracing payload header under the `newrelic` key or under the W3C's `traceparent` and `tracestate` keys. Retrieve the header, then call the New Relic transaction API to accept the payload.
+  
+    ### Scenario 1: Using manual instrumentation with Kafka Client
+    To instrument your Kafka consumer via manual insteumantation, you'll need to start a transaction when the message is being processed. The agent stores the distributed tracing payload header under the `newrelic` key or under the W3C's `traceparent` and `tracestate` keys. Retrieve the header, then call the New Relic transaction API to accept the payload.
 
     For example:
 
@@ -270,6 +286,37 @@ To collect distributed traces from Kafka:
 
       // Accept distributed tracing headers to link this request to the originating request
       NewRelic.getAgent().getTransaction().acceptDistributedTraceHeaders(TransportType.Kafka, dtHeaders);
+    }
+    ```
+    ### Scenario 2: Using auto instrumentation for kafka clients
+    This will only apply for agents 8.21 and up. You can leverage auto instrumentation too to read distributed tracing for kafka consumers. 
+    This is accomplished by starting a transaction and calling the `poll(...)` method of a consumer when the transaction is happening.
+
+    This is disabled by dafault because consumer polling by default accepts multiple messages and transactions can only have one parent trace so only 1 message will be read.
+
+    To enable automatically accepting distributed traces for Kafka consumer polls, you need to enable distributed tracing for batch calls as showin in step 1.
+    
+    Example of instrumenting kafka consumer polls:
+
+    ```java
+      @Trace(dispatcher = true)
+      private void consumeMessage(KafkaConsumer<String, String> consumer) {
+          final ConsumerRecords<String, String> records = consumer.poll(1000);
+          // Process your records ....
+      }
+    ```
+
+    ### Scenario 3: Using Spring Kafka
+    If you are using Spring Kafka, you can enable auto instrumentation when for methods instrumented with `@KafkaListener`.
+    This creates transactions and auto-acceots distributed traces for consumers.
+    Due to Kafka being a high throughput platform, it is disabled to prevent too much ingest and memory ovehead. 
+    You can enable spring-kafka instrunenation with the config shown in step 1.
+
+    Example:
+    ```java
+    @KafkaListener(id = "foo", topics = "myTopic", clientIdPrefix = "myClientId")
+    public void listen(String data) {
+        ...
     }
     ```
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8210.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8210.mdx
@@ -21,7 +21,6 @@ security: [“Upgrades the com.newrelic.agent.java:infinite-tracing-protobuf for
 
 - Enhances visibility into Reactor `Mono.flatMap` calls [2308](https://github.com/newrelic/newrelic-java-agent/pull/2308)
 - Adds new instrumentation for Spring-Kafka and distributed tracing when using the core Kafka client library [2312](https://github.com/newrelic/newrelic-java-agent/pull/2312)
-- Adds a new Kafka instrumentation module named `kafka-clients-spans-consumer-0.11.0.0` that accepts distributed trace headers for consumers [2283](https://github.com/newrelic/newrelic-java-agent/pull/2283)
 - Adds `KafkaConsumerConfig` event support for Kafka 3.7+ [2358](https://github.com/newrelic/newrelic-java-agent/pull/2358)
 
 ## Fixes


### PR DESCRIPTION
Updates Kafka instrumentation docs for the Java Agent. This adds instructions for customers using spring-kafka and for auto instrumenting kafka clients for consumer distributed tracing.