### PR TITLE
Update "Historical data for training" sections  within Predict docs

### DIFF
--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -849,7 +849,7 @@ Here're some examples:
 
       Prediction window: Predicts a range equal to 20% of the total time span specified in your query window.
 
-      Historical data for training: Uses historical data from the current query window and the two preceding ones to generate predictions.
+      Historical data for training: Uses historical data from the current query window and the two preceding ones to generate predictions. If a `seasonality` hyperparameter is provided and the seasonality is greater than the query window, we use historical data spanning three times the seasonality instead.
 
       Time interval: Aligns with the data point interval of the time series in the query window to ensure consistency in data projection.
       </Collapser>

--- a/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
+++ b/src/content/docs/nrql/nrql-syntax-clauses-functions.mdx
@@ -849,7 +849,7 @@ Here're some examples:
 
       Prediction window: Predicts a range equal to 20% of the total time span specified in your query window.
 
-      Historical data for training: Uses historical data from the current query window and the two preceding ones to generate predictions. If a `seasonality` hyperparameter is provided and the seasonality is greater than the query window, we use historical data spanning three times the seasonality instead.
+      Historical data for training: Uses historical data from the last three query windows (the current one and the two preceding it). However, if you provide a `seasonality` hyperparameter that is greater than the query window, the model instead uses historical data spanning a period equal to three times the seasonality.
 
       Time interval: Aligns with the data point interval of the time series in the query window to ensure consistency in data projection.
       </Collapser>

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/nrql-predictions.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/nrql-predictions.mdx
@@ -102,7 +102,7 @@ The `PREDICT` clause in a query comes with the following default behaviors:
 * **Seasonality**: Automatically detects whether seasonality is present in the historic data. If seasonality is detected, the identified season length is used in the Holt-Winters seasonal algorithm. If no seasonality is found, it constructs a non-seasonal model.
 * **Hyperparameters**: Sets the hyperparameters for the Holt-Winters algorithm based upon the seasonality and historical data.
 * **Prediction window**: Predicts a range equal to 20% of the total time span specified in your query window.
-* **Historical data for training**: Uses historical data from the current query window and the two preceding ones to generate predictions.
+* **Historical data for training**: Uses historical data from the current query window and the two preceding ones to generate predictions. If a `seasonality` hyperparameter is provided and the seasonality is greater than the query window, we use historical data spanning three times the seasonality instead.
 * **Time interval**: Aligns with the data point interval of the time series in the query window to ensure consistency in data projection.
 
 ## Customizing the predictive model [#customize-prediction-range]

--- a/src/content/docs/query-your-data/explore-query-data/use-charts/nrql-predictions.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/use-charts/nrql-predictions.mdx
@@ -102,7 +102,7 @@ The `PREDICT` clause in a query comes with the following default behaviors:
 * **Seasonality**: Automatically detects whether seasonality is present in the historic data. If seasonality is detected, the identified season length is used in the Holt-Winters seasonal algorithm. If no seasonality is found, it constructs a non-seasonal model.
 * **Hyperparameters**: Sets the hyperparameters for the Holt-Winters algorithm based upon the seasonality and historical data.
 * **Prediction window**: Predicts a range equal to 20% of the total time span specified in your query window.
-* **Historical data for training**: Uses historical data from the current query window and the two preceding ones to generate predictions. If a `seasonality` hyperparameter is provided and the seasonality is greater than the query window, we use historical data spanning three times the seasonality instead.
+* **Historical data for training**: Uses historical data from the last three query windows (the current one and the two preceding it). However, if you provide a `seasonality` hyperparameter that is greater than the query window, the model instead uses historical data spanning a period equal to three times the seasonality.
 * **Time interval**: Aligns with the data point interval of the time series in the query window to ensure consistency in data projection.
 
 ## Customizing the predictive model [#customize-prediction-range]


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
We've recently updated the default behavior in how we gather historical data for training and have updated our public facing documentation accordingly so customers are aware of the changes.

Overall, we use a historical data spanning `3 * seasonality` when we have a PREDICT query with the following: 

- No `USING` clause
- A `hyperparameter` with a `seasonality` which is not `NONE` or `AUTO`
- A `seasonality` that's greater than the query duration