### PR TITLE
feat: Add Node v24 to the list of supported Node runtimes

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -81,6 +81,19 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
       <tbody>
         <tr>
           <td>
+            24
+          </td>
+
+          <td>
+            October 2025
+          </td>
+
+          <td>
+            June 30, 2025 with Node.js agent v12.23.0
+          </td>
+        </tr>
+        <tr>
+          <td>
             22
           </td>
 


### PR DESCRIPTION
The Node.js agent released support for the latest Node runtime, 24, in version 12.23.0 of the agent. We should reflect this change in the Node agent system requirements list.