### PR TITLE
.NET agent: Update gpg key import commands; remove sudo from commands in Dockerfiles

### DIFF
--- a/src/install/dotnet/installation/azure-linux-container.mdx
+++ b/src/install/dotnet/installation/azure-linux-container.mdx
@@ -28,7 +28,7 @@ COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 && echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
@@ -61,7 +61,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 && echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent
 

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -27,7 +27,7 @@ COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 && echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
@@ -62,7 +62,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 # Install the agent
 RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
 && echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg \
+&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent
 

--- a/src/install/dotnet/installation/linuxInstall2.mdx
+++ b/src/install/dotnet/installation/linuxInstall2.mdx
@@ -40,7 +40,7 @@ To start installing the agent, choose your package manager:
       2. Enable New Relic's GPG key to allow apt to find New Relic packages. To avoid possible errors about public keys, run this command as root:
 
          ```bash
-         wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --dearmor -o /usr/share/keyrings/newrelic-apt.gpg
+         wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg
          ```
       3. Update the local package list:
 


### PR DESCRIPTION
This PR:

1. Updates the syntax for the `gpg` command that imports the public signing key for an APT repo to be more robust (it will handle being run multiple times)
2. Alters those commands for `Dockerfile` examples to no longer prefix the command with `sudo` as this is both unnecessary (Dockerfile commands run as root by default) and will cause the instructions to fail (sudo isn't installed or enabled by default in most Docker images)