### PR TITLE
Remove `gcp_cloud_run.use_instance_as_host` in Node.js agent

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -5187,51 +5187,6 @@ For a configuration example, see our documentation for the [node agent url obfus
   </Collapser>
 </CollapserGroup>
 
-## GCP Cloud Run [#gcp_cloud_run]
-
-<CollapserGroup>
-  <Collapser
-    id="gcp_cloud_run"
-    title="gcp_cloud_run.use_instance_as_host"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_GCP_CLOUD_RUN_USE_INSTANCE_AS_HOST`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    If true, the agent will use the Cloud Run ID from the GCP metadata to set the hostname of the running application.
-  </Collapser>
-</CollapserGroup>
-
 ## Worker Threads [#worker-threads]
 
 In agent versions prior to 11.0.0, the agent ran in both main and worker threads.  In version 11.0.0 the agent stopped running in worker threads due to its incompatibility with our async context propagation. The ability to run in worker threads was restored in version 11.3.0 but you must set `worker_threads.enabled` to `true`.  The behavior of running in the worker threads varies and we do not officially support it. Some things like metrics generation, and self contained transaction traces may work but this is a use at your own risk capability.


### PR DESCRIPTION
This config flag has been removed in the Node.js agent en lieu of a new config flag under utilization: `utilization.gcp_use_instance_as_host`, which will be added to the docs in a later PR.