### PR TITLE
docs: agent control split namespaces

### DIFF
--- a/src/content/docs/new-relic-control/agent-control/setup.mdx
+++ b/src/content/docs/new-relic-control/agent-control/setup.mdx
@@ -39,11 +39,15 @@ To install Agent Control on one of your Kubernetes clusters, log in to New Relic
 
 ### Verify installation [#verify-install]
 
-1. Run the following command to check the status of your pods:
+1. Run the following commands to check the status of your pods:
 
-```shell
-kubectl get pods -n newrelic
-```
+  Agent Control will install sub-agents on a different namespace for security reasons.
+  To verify that everything is working correctly, you will have to check that the Agent Control pods are running in one namespace and the sub-agents pods are running in a different one.
+
+  ```shell
+  kubectl get pods -n newrelic-agent-control    # Check Agent Control pods
+  kubectl get pods -n newrelic                  # Check sub-agents pods
+  ```
 
 2. Log in to New Relic, and go to **Fleet Control**.
 3. Go to the Fleets page and select the fleet you chose during installation.

--- a/src/content/docs/new-relic-control/agent-control/troubleshooting.mdx
+++ b/src/content/docs/new-relic-control/agent-control/troubleshooting.mdx
@@ -139,10 +139,14 @@ Follow these steps to gather all the data:
     ./nrdiag -suites K8s-agent-control
     ```
 
-    - Specify a different namespace using the `--k8s-namespace` flag:
-:
+    - Specify a different namespace for Agent Control using the `--k8s-namespace` flag:
     ```bash
     ./nrdiag -suites K8s-agent-control --k8s-namespace=newrelic
+    ```
+
+    - Specify a different namespace for sub-agents using the `ac-agents-namespace` flag:
+    ```bash
+    ./nrdiag -suites K8s-agent-control --k8s-namespace=newrelic-agent-control --ac-agents-namespace=newrelic
     ```
 
 3. The expected output should look like the report below:

--- a/src/content/docs/new-relic-control/agent-control/troubleshooting.mdx
+++ b/src/content/docs/new-relic-control/agent-control/troubleshooting.mdx
@@ -149,7 +149,7 @@ Follow these steps to gather all the data:
     ./nrdiag -suites K8s-agent-control --k8s-namespace=newrelic-agent-control --ac-agents-namespace=newrelic
     ```
 
-3. The expected output should look like the report below:
+3. The expected output should look like the following report:
 
     ```bash
     [output] Check Results


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?

Updated the agent control docs regarding a new feature we introduced: "Split namespaces".
Now we install k8s agents in one namespace, and flux and Agent Control in a different namespace.