### PR TITLE
fix: client side rendering for redirection of old urls to new urls

### DIFF
--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@emotion/react';
 import { graphql } from 'gatsby';
@@ -49,6 +49,32 @@ const BasicDoc = ({ data, location, pageContext }) => {
   } = mdx;
   const { disableSwiftype } = pageContext;
 
+  useEffect(() => {
+  
+    if (typeof window !== 'undefined') {
+      
+      const { pathname, hash } = window.location;
+      // Redirect for #app-performance
+      if (
+        pathname === '/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/' &&
+        hash === '#app-performance'
+      ) {
+        window.location.replace(
+          '/docs/browser/browser-monitoring/browser-pro-features/session-replay/additional-information/#app-performance'
+        );
+      }
+      // Redirect for #manual-replays
+      if (
+        pathname === '/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/' &&
+        hash === '#manual-replays'
+      ) {
+        window.location.replace(
+          '/docs/browser/browser-monitoring/browser-pro-features/session-replay/advanced-features/#manual-replays'
+        );
+      }
+    }
+  }, []);
+  
   const headings = useMemo(() => {
     const slugs = new GithubSlugger();
     return (tableOfContents.items ?? []).map(({ title, url }) => {

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -50,13 +50,12 @@ const BasicDoc = ({ data, location, pageContext }) => {
   const { disableSwiftype } = pageContext;
 
   useEffect(() => {
-  
     if (typeof window !== 'undefined') {
-      
       const { pathname, hash } = window.location;
       // Redirect for #app-performance
       if (
-        pathname === '/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/' &&
+        pathname ===
+          '/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/' &&
         hash === '#app-performance'
       ) {
         window.location.replace(
@@ -65,7 +64,8 @@ const BasicDoc = ({ data, location, pageContext }) => {
       }
       // Redirect for #manual-replays
       if (
-        pathname === '/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/' &&
+        pathname ===
+          '/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/' &&
         hash === '#manual-replays'
       ) {
         window.location.replace(
@@ -74,7 +74,7 @@ const BasicDoc = ({ data, location, pageContext }) => {
       }
     }
   }, []);
-  
+
   const headings = useMemo(() => {
     const slugs = new GithubSlugger();
     return (tableOfContents.items ?? []).map(({ title, url }) => {


### PR DESCRIPTION
Implemented a mechanism to redirect all old/expired heading level urls to new urls with client side redirection 

Eg : Previous URL : [https://docs.newrelic.com/docs/browser/browser-monitoring/browser-pro-features/session-replay/#app-performance](https://docs.newrelic.com/docs/browser/browser-monitoring/browser-pro-features/session-replay/get-started/#app-performance) 
Present URL :   https://docs.newrelic.com/docs/browser/browser-monitoring/browser-pro-features/session-replay/additional-information/#app-performance