### PR TITLE
(chore): remove the redundancy from the toc

### DIFF
--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -210,12 +210,10 @@ pages:
             path: /docs/apis/nerdgraph/examples/nerdgraph-metric-normalization-rule
           - title: Scorecards tutorial
             path: /docs/apis/nerdgraph/examples/nerdgraph-scorecards-tutorial
-          - title: Teams tutorial
-            path: /docs/apis/nerdgraph/examples/nerdgraph-teams-tutorial
-          - title: Metric normalization rules tutorial
-            path: /docs/apis/nerdgraph/examples/nerdgraph-metric-normalization-rule
           - title: Secrets management service
             path: /docs/apis/nerdgraph/examples/nerdgraph-api-secret-management-service
+          - title: Teams tutorial
+            path: /docs/apis/nerdgraph/examples/nerdgraph-teams-tutorial
       - title: REST APIs
         pages:
           - title: REST API v2


### PR DESCRIPTION
This PR removes the redundancy from the table of contents in the `telemetry-data-platform.yml` file.