### PR TITLE
Update public docs to describe browser agent's harvest interval behavior

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/addpageaction.mdx
@@ -50,7 +50,7 @@ Reports a browser PageAction event along with a name and optional attributes.
 This API call sends a browser [`PageAction` event](/docs/insights/explore-data/custom-events/insert-browser-custom-events-attributes-insights-javascript-api) with your user-defined name and optional attributes to [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards), along with [several default attributes](/attribute-dictionary/?event=PageAction). This is useful to track any event that is not already tracked automatically by the browser agent, such as clicking a <DNT>**Subscribe**</DNT> button or accessing a tutorial.
 
 * `PageAction` events are sent every 30 seconds.
-* If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
+* If 1,000 events are observed or if the harvest payload size is greater than 16 KB, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
 
 <Callout variant="important">
   In earlier agent versions, events were dropped after 120 were observed. The event limit was increased from 120 to 1,000 in version [1.264.0](https://docs.newrelic.com/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.264.0/) and are no longer dropped.

--- a/src/content/docs/browser/new-relic-browser/browser-apis/recordCustomEvent.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/recordCustomEvent.mdx
@@ -50,7 +50,7 @@ Reports a custom browser event under a specified eventType with custom attribute
 This API call sends a custom browser event with your user-defined eventType and optional attributes to [dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-new-relic-one-dashboards), along with any custom attributes you may have set for your application. This is useful to track any event that is not already tracked automatically by the browser agent enhanced by rules and attribution you control.
 
 * `custom` events are sent every 30 seconds.
-* If 1,000 events are observed, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
+* If 1,000 events are observed or if the harvest payload size is greater than 16 KB, the agent will harvest the buffered events immediately, bypassing the harvest cycle interval.
 
 ## Parameters [#parameters]
 

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring.mdx
@@ -169,7 +169,7 @@ For both https <DNT>**and**</DNT> http webpages, we transmit data via https. Thi
       </td>
 
       <td>
-        Data is sent 10 seconds after the initial page load, and then every 30 seconds afterward.
+        Data is sent 10 seconds after the initial page load, and then every 30 seconds afterward. If the harvest payload size is greater than 16 KB, the data is sent early.
       </td>
     </tr>
 

--- a/src/content/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact.mdx
+++ b/src/content/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact.mdx
@@ -163,7 +163,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `PageViewTiming` events are harvested by all agents and includes timing data like core web vitals measurements. The first harvest happens 10 seconds after the `load` page lifecycle event. Additional harvests occur every 30 seconds as needed when there's data to send.  See the [PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of reported events.
+        `PageViewTiming` events are harvested by all agents and includes timing data like core web vitals measurements. The first harvest happens 10 seconds after the `load` page lifecycle event. Additional harvests occur every 30 seconds as needed when there's data to send or if the harvest payload size is greater than 16 KB. See the [PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of reported events.
       </td>
     </tr>
 
@@ -301,7 +301,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `PageAction` events are harvested after the `load` page lifecycle event, Subsequent harvests happen every 30 seconds.
+        `PageAction` events are harvested after the `load` page lifecycle event, Subsequent harvests happen every 30 seconds or if the harvest payload size is greater than 16 KB.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Adds a notice about the browser agent's harvest interval behavior. If the payload size is > 16KB or if it's been 30 seconds, we trigger a harvest for the data.

JIRA: https://new-relic.atlassian.net/browse/NR-419973