### PR TITLE
feat(diagcli): Diagnostics CLI Release 3.4.0

### DIFF
--- a/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/pass-command-line-options-nrdiag.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/pass-command-line-options-nrdiag.mdx
@@ -149,12 +149,28 @@ To use the following command line options with the Diagnostics CLI:
       </td>
 
       <td>
-        Specify a namespace to use when executing the kubectl command
+        Specify the namespace from where to scrape the New Relic resources. If you are using Agent-control, you can also set the '-ac-agents-namespace' flag to specify the namespace where Agent-control Agents are running.
 
         Example syntax:
 
         ```
-        -k8s-namespace ./path/to/file
+        -k8s-namespace newrelic
+        ```
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `-ac-agents-namespace STRING`
+      </td>
+
+      <td>
+        Specify the namespace from where to scrape the Agent-control running agents.
+
+        Example syntax:
+
+        ```
+        -ac-agents-namespace newrelic
         ```
       </td>
     </tr>

--- a/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/diagnostics-cli-340.mdx
+++ b/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/diagnostics-cli-340.mdx
@@ -1,0 +1,18 @@
+---
+subject: Diagnostics CLI (nrdiag)
+releaseDate: '2025-07-10'
+version: 3.4.0
+downloadLink: 'https://download.newrelic.com/nrdiag/nrdiag_3.4.0.zip'
+---
+
+## Task Updates
+
+* A new command line option `-ac-agents-namespace` was added for specifying a namespace for Agent Control agents ([#243](https://github.com/newrelic/newrelic-diagnostics-cli/pull/243)). The following tasks have been updated to use the new namespace:
+  * K8s/Resources/Config
+  * K8s/Resources/Daemonset
+  * K8s/Resources/Deploy
+  * K8s/Resources/Pods
+
+## Fixes
+
+* GLIBC related errors such as `/lib64/libc.so.6: version 'GLIBC_2.34' not found` have been resolved ([#244](https://github.com/newrelic/newrelic-diagnostics-cli/pull/244)).


### PR DESCRIPTION
This adds the release notes for the Diagnostics CLI version 3.4.0 and adds the new command line option to the command line documenation.