### PR TITLE
chore: removed a line item from 12.23.0 of Node.js agent as it is not intended for public use

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-12-23-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/nodejs-release-notes/node-agent-12-23-0.mdx
@@ -5,14 +5,13 @@ version: 12.23.0
 downloadLink: 'https://www.npmjs.com/package/newrelic'
 security: []
 bugs: []
-features: ["Added ability to report only on entry and exit spans","Added Node.js 24 support"]
+features: ["Added Node.js 24 support"]
 ---
 
 ## Notes
 
 #### Features
 
-* Added ability to report only on entry and exit spans ([#3184](https://github.com/newrelic/node-newrelic/pull/3184)) ([1f909d3](https://github.com/newrelic/node-newrelic/commit/1f909d389f790733c8787a9db8b0ee71c26bb5ed))
 * Added Node.js 24 support ([#3080](https://github.com/newrelic/node-newrelic/pull/3080)) ([a538c2a](https://github.com/newrelic/node-newrelic/commit/a538c2a5e23b96be40fa3c014e60b912f695423e))
 
 #### Documentation


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

We mistakenly included a line item for a feature that is not intended for publich use.  It's shipped dark and is being used as an experiment by 1 customer.  To avoid confusion, we are removing it from the release notes.
