### PR TITLE
feat[public dashboard]: Migrating all public sharing chart related NerdGraph queries to one page

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
@@ -1,61 +1,107 @@
 ---
-title: "NerdGraph tutorial: List and revoke public sharing chart URLs"
+title: "NerdGraph tutorial: Create, update, and revoke public sharing chart URLs"
 tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic NerdGraph to list and revoke live chart URLs
+metaDescription: Use New Relic NerdGraph to create, update, and revoke live chart URLs
 freshnessValidatedDate: never
 ---
 
-You can list and revoke publicly accessible live chart URLs using queries and mutations in [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph).
+After configuring the required [security and access settings](/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts/), you can create, manage, and revoke publicly accessible live chart URLs using queries and mutations in [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/). To perform these actions, navigate to the [GraphQL Explorer](https://one.newrelic.com/nerdgraph-graphiql?state=2f361eaf-e5b7-41a4-5eec-e6910bbc7c47) and follow the provided instructions. Additionally, this can be done through the [New Relic UI](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
 
-To do this:
-
-1. Go to [GraphiQL Explorer](https://api.newrelic.com/graphiql).
-2. [List all live chart URLs](#list) created within your New Relic account.
-3. [Revoke any live chart URL you want to](#revoke).
-
-<Callout variant="tip">
-  To create publicly accessible live chart URLs, refer our [docs](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
+<Callout variant="caution">
+  Anyone with access to the live dashboard or chart URLs can view all the information from the dashboard. Ensure that information is shared cautiously and in compliance with your company's internal policies and procedures.
 </Callout>
 
-## List all live chart URLs [#list]
+<CollapserGroup>
 
-Use the following query to retrieve a list of existing live chart URLs:
+  <Collapser 
+    id="create-livechart-url" 
+    title="Create a live chart URL"
+  >
+
+ You can fetch embeddable chart links for the data to use in an application. 
+ For example, instead of a single count of [transaction](/docs/data-apis/understand-data/event-data/events-reported-apm/#transaction-event), you can create a [chart](/docs/query-your-data/explore-query-data/use-charts/chart-types/#widget-types) that illustrates a time series of bucketed counts over time. Add `TIMESERIES` to your query with `embeddedChartUrl`:
+
+ ```graphql
+  {
+    actor {
+    account(id: YOUR_ACCOUNT_ID) {
+      nrql(query: "SELECT count(*) from Transaction TIMESERIES") {
+        embeddedChartUrl
+      }
+    }
+    }
+  }
+```
+
+This NerdGraph query example returns the URL for the chart in the following response:
 
 ```graphql
-{
-  actor {
-    dashboard {
-      liveUrls {
-        liveUrls {
-          title
-          url
-          createdAt
-          type
+  {
+    "data": {
+      "actor": {
+        "account": {
+          "nrql": {
+            "embeddedChartUrl": "https://chart-embed.service.newrelic.com/charts/EMBEDDABLE-CHART-ID"
         }
+       }
+     }
+    }
+  }
+```
+</Collapser>
+
+<Collapser 
+    id="revoke-livechart-url" 
+    title="Revoke a live chart URL"
+  >
+
+ Use the following query to revoke the live chart URL you specify:
+
+ ```graphql
+    mutation {
+      dashboardWidgetRevokeLiveUrl(uuid: "YOUR_LIVE_CHART_UUID") {
+        uuid
         errors {
           description
+          type
         }
       }
     }
-  }
+```
+
+</Collapser>
+
+<Collapser 
+    id="list-livechart-urls" 
+    title="List all live chart URLs"
+  >
+
+ Use the following query to retrieve a list of existing live chart URLs:
+
+ ```graphql
+    {
+      actor {
+        dashboard {
+          liveUrls {
+            liveUrls {
+              title
+              url
+              createdAt
+              type
+       }
+       errors {
+        description
+       }
+     }
+   }
+ }
 }
 ```
 
-## Revoke any live chart URL [#revoke]
+</Collapser>
 
-Use the following query to revoke the live chart URL you specify:
 
-```graphql
-mutation {
-  dashboardWidgetRevokeLiveUrl(uuid: "YOUR_LIVE_CHART_UUID") {
-    uuid
-    errors {
-      description
-      type
-    }
-  }
-}
-```
+</CollapserGroup>

--- a/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
@@ -13,7 +13,7 @@ Charts are visual representations of data helping you understand and analyze inf
 With the appropriate [security and access settings](/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts/), you can create, manage, and revoke publicly accessible live chart URLs using queries and mutations in [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/). Alternatively, you can perform these actions via the [New Relic UI](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
 
 <Callout variant="caution">
-  Anyone with access to the live dashboard or chart URLs can view all the information from the dashboard. Ensure that information is shared cautiously and in compliance with your company's internal policies and procedures.
+  Anyone with access to the live chart URLs can view all the information from the dashboard. Ensure that information is shared cautiously and in compliance with your company's internal policies and procedures.
 </Callout>
 
 For creating, revoking, or listing a publicly accessible live chart URL from NerdGraph: go to [GraphQL Explorer](https://one.newrelic.com/nerdgraph-graphiql?state=2f361eaf-e5b7-41a4-5eec-e6910bbc7c47) and then follow these instructions.
@@ -106,11 +106,11 @@ For creating, revoking, or listing a publicly accessible live chart URL from Ner
         }
       }
 
-        //Parameters:
-        {
-          id: xxxxxxxx
-          query: SELECT count(*) from Transaction TIMESERIES
-        }
+        # Parameters:
+        #  {
+        #   id: xxxxxxxx
+        #   query: SELECT count(*) from Transaction TIMESERIES
+        #  }
      ```
  
      #### Sample response
@@ -170,10 +170,10 @@ For creating, revoking, or listing a publicly accessible live chart URL from Ner
         }
       }
 
-    //Parameters:
-    {
-      uuid: xxx1afc8-6d1f-xxxx-9a33-373f64212xxx
-    }
+    # Parameters:
+    #  {
+    #    uuid: xxx1afc8-6d1f-xxxx-9a33-373f64212xxx
+    #  }
 
     ```
  

--- a/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
@@ -1,50 +1,127 @@
 ---
-title: "NerdGraph tutorial: Create, update, and revoke public sharing chart URLs"
+title: "NerdGraph tutorial: Create, revoke, and list public sharing chart URLs"
 tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic NerdGraph to create, update, and revoke live chart URLs
+metaDescription: How to use New Relic NerdGraph APIs to create, list, and revoke live chart URLs
 freshnessValidatedDate: never
 ---
 
-After configuring the required [security and access settings](/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts/), you can create, manage, and revoke publicly accessible live chart URLs using queries and mutations in [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/). To perform these actions, navigate to the [GraphQL Explorer](https://one.newrelic.com/nerdgraph-graphiql?state=2f361eaf-e5b7-41a4-5eec-e6910bbc7c47) and follow the provided instructions. Additionally, this can be done through the [New Relic UI](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
+Charts are visual representations of data helping you understand and analyze information from your apps, infrastructure, or services. You can convert these charts into URLs and share them publicly. Public chart links allow you to easily share graphs and data with others, even if they don't have a New Relic account.
+
+With the appropriate [security and access settings](/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts/), you can create, manage, and revoke publicly accessible live chart URLs using queries and mutations in [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/). Alternatively, you can perform these actions via the [New Relic UI](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
 
 <Callout variant="caution">
   Anyone with access to the live dashboard or chart URLs can view all the information from the dashboard. Ensure that information is shared cautiously and in compliance with your company's internal policies and procedures.
 </Callout>
 
+For creating, revoking, or listing a publicly accessible live chart URL from NerdGraph: go to [GraphQL Explorer](https://one.newrelic.com/nerdgraph-graphiql?state=2f361eaf-e5b7-41a4-5eec-e6910bbc7c47) and then follow these instructions.
+
 <CollapserGroup>
 
   <Collapser 
-    id="create-livechart-url" 
+    id="fetch-account-id" 
+    title="Fetch your account id"
+  >
+  
+  For creating public sharing chart URLs, you need an account ID. This API allows you to retrieve your account ID using the actor query.
+
+  #### Sample request
+
+  ```graphql
+   {
+    actor {
+      accounts {
+        id
+       }
+     }
+   }
+  ```
+
+  #### Sample response
+
+  ```graphql
+   {
+      "data": {
+        "actor": {
+          "accounts": [
+            {
+              "id": xxxxxxxx
+            },
+            {
+              "id": xxxxxxxx
+            }
+          ]
+        }
+      }
+    }
+  ```
+  </Collapser>
+  
+  <Collapser 
+    id="create-livechart-url"
     title="Create a live chart URL"
   >
 
- You can fetch embeddable chart links for the data to use in an application. 
- For example, instead of a single count of [transaction](/docs/data-apis/understand-data/event-data/events-reported-apm/#transaction-event), you can create a [chart](/docs/query-your-data/explore-query-data/use-charts/chart-types/#widget-types) that illustrates a time series of bucketed counts over time. Add `TIMESERIES` to your query with `embeddedChartUrl`:
+ This API allows you to execute NRQL queries on a specified account and retrieve an embedded chart URL based on the query results.
 
- ```graphql
-  {
-    actor {
-    account(id: YOUR_ACCOUNT_ID) {
-      nrql(query: "SELECT count(*) from Transaction TIMESERIES") {
-        embeddedChartUrl
+ #### Input parameters
+ 
+     <table>
+       <thead>
+         <tr>
+           <th>Parameter</th>
+           <th>Data Type</th>
+           <th>Is it Required?</th>
+           <th>Description</th>
+         </tr>
+       </thead>
+       <tbody>
+         <tr>
+           <td>id</td>
+           <td>Integer</td>
+           <td>Yes</td>
+           <td>Your account ID refers to the unique identifier associated with the account you wish to query.</td>
+         </tr>
+         <tr>
+           <td>query</td>
+           <td>String</td>
+           <td>Yes</td>
+           <td>The NRQL query to execute.</td>
+         </tr>
+       </tbody>
+     </table>
+ 
+     #### Sample request
+ 
+     ```graphql
+      {
+        actor {
+          account(id: YOUR_ACCOUNT_ID) {
+            nrql(query: "$query") {
+              embeddedChartUrl
+            }
+          }
+        }
       }
-    }
-    }
-  }
-```
 
-This NerdGraph query example returns the URL for the chart in the following response:
-
+        //Parameters:
+        {
+          id: xxxxxxxx
+          query: SELECT count(*) from Transaction TIMESERIES
+        }
+     ```
+ 
+     #### Sample response
+      
 ```graphql
   {
     "data": {
       "actor": {
         "account": {
           "nrql": {
-            "embeddedChartUrl": "https://chart-embed.service.newrelic.com/charts/EMBEDDABLE-CHART-ID"
+            "embeddedChartUrl": "https://chart-embed.xxx-xxx.newrelic.com/charts/e187axxx-xxxx-449e-xxxx-4fb7a520xxxx"
         }
        }
      }
@@ -58,20 +135,61 @@ This NerdGraph query example returns the URL for the chart in the following resp
     title="Revoke a live chart URL"
   >
 
- Use the following query to revoke the live chart URL you specify:
-
- ```graphql
-    mutation {
-      dashboardWidgetRevokeLiveUrl(uuid: "YOUR_LIVE_CHART_UUID") {
-        uuid
-        errors {
-          description
-          type
+ This API mutation allows you to revoke the live URL associated with a specific dashboard widget.
+#### Input parameters
+ 
+     <table>
+       <thead>
+         <tr>
+           <th>Parameter</th>
+           <th>Data Type</th>
+           <th>Is it Required?</th>
+           <th>Description</th>
+         </tr>
+       </thead>
+       <tbody>
+         <tr>
+           <td>uuid</td>
+           <td>String</td>
+           <td>Yes</td>
+           <td>The unique identifier of the public live URL.</td>
+         </tr>
+       </tbody>
+     </table>
+ 
+     #### Sample request
+ 
+     ```graphql
+      mutation {
+        dashboardWidgetRevokeLiveUrl(uuid: "YOUR_LIVE_CHART_UUID") {
+          uuid
+          errors {
+            description
+            type
+          }
         }
       }
-    }
-```
 
+    //Parameters:
+    {
+      uuid: xxx1afc8-6d1f-xxxx-9a33-373f64212xxx
+    }
+
+    ```
+ 
+     #### Sample response
+      
+```graphql
+   {
+    "data": {
+      "dashboardWidgetRevokeLiveUrl": {
+        "errors": null,
+        "uuid": "xxx1afc8-6d1f-xxxx-9a33-373f64212xxx"
+      }
+    }
+   }
+
+```
 </Collapser>
 
 <Collapser 
@@ -79,29 +197,64 @@ This NerdGraph query example returns the URL for the chart in the following resp
     title="List all live chart URLs"
   >
 
- Use the following query to retrieve a list of existing live chart URLs:
+ This API allows you to retrieve live URLs associated with dashboard widgets.
+
+ #### Sample request
 
  ```graphql
     {
       actor {
         dashboard {
           liveUrls {
-            liveUrls {
-              title
-              url
-              createdAt
-              type
-       }
-       errors {
-        description
-       }
-     }
-   }
+              liveUrls {
+                title
+                url
+                createdAt
+                type
+              }
+            errors {
+            description
+          }
+        }
+      }
+    }
  }
-}
 ```
 
+#### Sample response
+```graphql
+    {
+      "data": {
+        "actor": {
+          "dashboard": {
+            "liveUrls": {
+              "errors": null,
+              "liveUrls": [
+                {
+                  "createdAt": 1753xxxx346xx,
+                  "title": "",
+                  "type": "WIDGET",
+                  "url":   "ttps://chart-embed.xxx-xxx.newrelic.com/herald/9ac583f4-b43e-4750-841b-9f1aa39cde00"
+                },
+                {
+                  "createdAt": 1753xxxx572xx,
+                  "title": "",
+                  "type": "WIDGET",
+                  "url": "https://chart-embed.xxx-xxx.newrelic.com/herald/5d81451a-4dfb-42de-9682-dae4d7fb7962"
+                },
+                {
+                  "createdAt": 17289xxxx694xx,
+                  "title": "",
+                  "type": "WIDGET",
+                  "url": "ttps://chart-embed.xxx-xxx.newrelic.com/herald/c1eac5ac-4a93-42d4-8b25-36078ecc8d79"
+                }
+              ]
+            }
+          }
+        }
+      }
+   }
+
+```
 </Collapser>
-
-
 </CollapserGroup>

--- a/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api.mdx
@@ -13,7 +13,7 @@ Charts are visual representations of data helping you understand and analyze inf
 With the appropriate [security and access settings](/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts/), you can create, manage, and revoke publicly accessible live chart URLs using queries and mutations in [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/). Alternatively, you can perform these actions via the [New Relic UI](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
 
 <Callout variant="caution">
-  Anyone with access to the live chart URLs can view all the information from the dashboard. Ensure that information is shared cautiously and in compliance with your company's internal policies and procedures.
+  Anyone with access to the live chart URLs can view all the information from the underlying chart query. Ensure that information is shared cautiously and in compliance with your company's internal policies and procedures.
 </Callout>
 
 For creating, revoking, or listing a publicly accessible live chart URL from NerdGraph: go to [GraphQL Explorer](https://one.newrelic.com/nerdgraph-graphiql?state=2f361eaf-e5b7-41a4-5eec-e6910bbc7c47) and then follow these instructions.

--- a/src/content/docs/apis/nerdgraph/examples/manage-live-dashboard-urls-via-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/manage-live-dashboard-urls-via-api.mdx
@@ -13,7 +13,7 @@ With the necessary [security and access set up](/docs/query-your-data/explore-qu
 You can also do it from the [New Relic UI](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#dashboard).
 
 <Callout variant="caution">
-  Anyone with the live dashboard or chart URLs can view all the information from the dashboard. Share information carefully and in accordance with your company's internal policies and procedures.
+  Anyone with the live dashboard URLs can view all the information from the dashboard. Share information carefully and in accordance with your company's internal policies and procedures.
 </Callout>
 
 For creating, updating, or revoking a publicly accessible live dashboard URL from NerdGraph, you need the GUID of the dashboard you want to share.

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-nrql-tutorial.mdx
@@ -93,37 +93,7 @@ For how to create a dashboard with data from multiple accounts, see [the NerdGra
 
 ## Create embeddable charts [#embeddable-charts]
 
-In addition to returning raw data, you can fetch embeddable chart links for the data to use in an application. For example, instead of a single count of [transaction](/docs/insights/insights-data-sources/default-data/apm-default-event-attributes-insights#transaction-event), you can create a [chart](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-types) that illustrates a time series of bucketed counts over time. Add `TIMESERIES` to your query with `embeddedChartUrl`:
-
-```graphql
-{
-  actor {
-    account(id: YOUR_ACCOUNT_ID) {
-      nrql(query: "SELECT count(*) from Transaction TIMESERIES") {
-        embeddedChartUrl
-      }
-    }
-  }
-}
-```
-
-This NerdGraph query example returns the URL for the chart in the following response:
-
-```json
-{
-  "data": {
-    "actor": {
-      "account": {
-        "nrql": {
-          "embeddedChartUrl": "https://chart-embed.service.newrelic.com/charts/EMBEDDABLE-CHART-ID"
-        }
-      }
-    }
-  }
-}
-```
-
-If you view the embedded chart URL using any standard HTTP client, it returns an image showing a visualization of the response to the query you submitted. These charts follow the same [embedded chart rules](/docs/using-new-relic/user-interface-functions/share-your-data/embed-charts-external-webpages#rules) as embedded charts that are created elsewhere. To change the style of the data visualization, pass a `chartType` argument to `embeddedChartUrl`.
+In addition to returning raw data, you can fetch embeddable chart links for the data to use in an application. Please refer to our [public chart docs](/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#chart).
 
 ## Suggested facets [#suggest-facets]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally.mdx
@@ -241,7 +241,13 @@ To keep your pricing optimal, consider the following standard practices:
     <TabsPageItem id="chart">
     
     ## Share your chart [#share-chart-externally]
-To share a chart with external users, ensure you have completed all the setup steps outlined in the [Prerequisites](#prerequisites-public-dashboard). To generate a shareable link for your chart:
+To share a chart with external users, ensure you have completed all the setup steps outlined in the [Prerequisites](#prerequisites-public-dashboard).
+
+<Callout variant="tip">
+  You can create and manage live chart URLs through both the UI and the [NerdGraph API](/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api/).
+</Callout>
+
+To generate a shareable link for your chart:
 1. Go to <DNT>**[one.newrelic.com > Dashboards](https://one.newrelic.com/dashboards)**</DNT>.
 2. Open the dashboard in which the chart is available.
 3. In the top-right corner of the chart, click the <Icon name="fe-more-horizontal"/> icon.

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -170,7 +170,7 @@ pages:
                 path: /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api
               - title: Move dashboards to other accounts
                 path: /docs/apis/nerdgraph/examples/export-import-dashboards-using-api
-              - title: Manage public sharing chart URLs
+              - title: Create and manage public sharing chart URLs
                 path: /docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api
               - title: Manage public sharing dashboard URLs
                 path: /docs/apis/nerdgraph/examples/manage-live-dashboard-urls-via-api         

--- a/src/nav/telemetry-data-platform.yml
+++ b/src/nav/telemetry-data-platform.yml
@@ -170,7 +170,7 @@ pages:
                 path: /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api
               - title: Move dashboards to other accounts
                 path: /docs/apis/nerdgraph/examples/export-import-dashboards-using-api
-              - title: Create and manage public sharing chart URLs
+              - title: Manage public sharing chart URLs
                 path: /docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api
               - title: Manage public sharing dashboard URLs
                 path: /docs/apis/nerdgraph/examples/manage-live-dashboard-urls-via-api         


### PR DESCRIPTION
Reorganized Public Charts NerdGraph API documentation. 
Added collapsers for create, revoke, and list the live chart URLs.
Jira ticket: https://new-relic.atlassian.net/browse/NR-439954
