### PR TITLE
docs: Refine language in Oracle integration requirements

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -26,11 +26,15 @@ Our integration is compatible with Oracle Database from versions 11.2 to 23.
 
 Before installing the integration, make sure that you meet the following requirements:
 
-* A Linux distribution that is [supported by the New Relic infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure) . Note that RHEL, CentOS, and OEL versions prior to 7 are not supported.
-* The [New Relic infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) must be installed. [Install the infrastructure agent].
-* The [Oracle Instant Client](http://www.Oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html) must be installed on the same host where the infrastructure agent is running.
-* The `ORACLE_HOME` environment variable must be configured correctly for the root user, pointing to the appropriate [Oracle database directory](https://docs.oracle.com/database/121/ADMQS/GUID-EC18C4A6-3BA5-4C14-9D76-B0DD62FEFFF2.htm#ADMQS12369) .
-* An Oracle database user with [both <DNT>**CONNECT**</DNT> and <DNT>**SELECT**</DNT> privileges](#users-privileges) on the required global views.
+* A Linux distribution that is [supported by the New Relic infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure).
+    
+    <Callout variant="important">
+        RHEL, CentOS, and OEL versions prior to 7 are not supported.
+    </Callout>
+* [Install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) if it isn't already installed on your host.
+* Install the [Oracle Instant Client](http://www.Oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html) on the same host where the infrastructure agent is running.
+* Configure the `ORACLE_HOME` environment variable for the root user to refer to the correct [Oracle database directory](https://docs.oracle.com/database/121/ADMQS/GUID-EC18C4A6-3BA5-4C14-9D76-B0DD62FEFFF2.htm#ADMQS12369).
+* An Oracle database user with [both <DNT>**CONNECT**</DNT> and <DNT>**SELECT**</DNT> privileges](#enable-instance) on the required global views.
 * The Oracle database listener `listener.ora` must be configured to accept remote connections. By default, Oracle Database only listens for connections on localhost.
 
 <Callout variant="important">

--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/oracle-database-monitoring-integration.mdx
@@ -26,12 +26,12 @@ Our integration is compatible with Oracle Database from versions 11.2 to 23.
 
 Before installing the integration, make sure that you meet the following requirements:
 
-* Linux distro [compatible with infrastructure](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure), except for RHEL/CentOS/OEL versions lower than 7.
-* [Install the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic).
-* [Oracle Instant Client](http://www.Oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html) on the agent box.
-* Oracle database with `ORACLE_HOME` [configured to the correct directory](https://docs.oracle.com/database/121/ADMQS/GUID-EC18C4A6-3BA5-4C14-9D76-B0DD62FEFFF2.htm#ADMQS12369) for the root user.
-* Oracle database user with [both <DNT>**CONNECT**</DNT> and <DNT>**SELECT**</DNT> privileges](#users-privileges) on the required global views.
-* Oracle database with a `listener.ora` file configured to monitor from a remote connection. By default, Oracle Database only listens to localhost.
+* A Linux distribution that is [supported by the New Relic infrastructure agent](/docs/infrastructure/new-relic-infrastructure/getting-started/compatibility-requirements-new-relic-infrastructure) . Note that RHEL, CentOS, and OEL versions prior to 7 are not supported.
+* The [New Relic infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent-new-relic) must be installed. [Install the infrastructure agent].
+* The [Oracle Instant Client](http://www.Oracle.com/technetwork/database/database-technologies/instant-client/downloads/index.html) must be installed on the same host where the infrastructure agent is running.
+* The `ORACLE_HOME` environment variable must be configured correctly for the root user, pointing to the appropriate [Oracle database directory](https://docs.oracle.com/database/121/ADMQS/GUID-EC18C4A6-3BA5-4C14-9D76-B0DD62FEFFF2.htm#ADMQS12369) .
+* An Oracle database user with [both <DNT>**CONNECT**</DNT> and <DNT>**SELECT**</DNT> privileges](#users-privileges) on the required global views.
+* The Oracle database listener `listener.ora` must be configured to accept remote connections. By default, Oracle Database only listens for connections on localhost.
 
 <Callout variant="important">
   ARM64 architecture is not supported.


### PR DESCRIPTION
This commit revises the compatibility and requirements documentation for the Oracle integration to improve clarity and professionalism.

The primary changes include:
- Replaced technical slang like "agent box" with the more precise phrase "the same host where the infrastructure agent is running."
- Changed "distro" to the more formal "distribution."
- Clarified ambiguous phrases such as "compatible with infrastructure" and "configured to monitor from a remote connection" to be more explicit and universally understandable.

These changes do not alter the technical meaning of the requirements but ensure the documentation is clearer for a broader audience.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.