### PR TITLE
Update Ruby Agent EOL policy to call out SemVer usage

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -4,7 +4,7 @@ metaDescription: Policies, start and end dates for support of New Relic Ruby age
 freshnessValidatedDate: never
 ---
 
-The following are the specific policies and dates for support of our Ruby agent. See our documentation about [general EOL policies](/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/) for information about New Relic's overall end-of-life policy.
+The following are the specific policies and dates for support of our Ruby agent. New Relic Agents follow [Semantic Versioning](https://semver.org/) to indicate **MAJOR** versions may include breaking changes. **MAJOR** versions may drop support for language runtimes that have reached End-of-Life according to the maintainer. Additionally, **MAJOR** versions may drop support for and remove certain instrumentation. See our documentation about [general EOL policies](/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/) for information about New Relic's overall end-of-life policy.
 
 ## New Relic Ruby agent releases and support dates [#ruby-eol]
 


### PR DESCRIPTION
Adding some clarification to our Ruby Agent EOL policy regarding breaking changes.