### PR TITLE
Update setname.mdx

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/setname.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setname.mdx
@@ -1,7 +1,7 @@
 ---
 title: setName (SPA API)
 type: apiDoc
-shortDescription: Sets the name and trigger of a SPA&#039;s browser interaction that is not a route change or URL change.
+shortDescription: Sets the name and trigger of a SPA&#039;s browser interaction regardless of the type of interaction.
 tags:
   - Browser
   - Browser monitoring


### PR DESCRIPTION
setName() API call sets the name and trigger of a SPA's browser interaction regardless of the type of interaction. Currently, it says it only set the name for BrowserInteractions that are not a route change or URL change.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* This corrects the documentation to accurately describe the behavior of the Browser Agent's setName() SPA API call 