### PR TITLE
go agent v3.40.1

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-40-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-40-1.mdx
@@ -1,0 +1,23 @@
+---
+subject: Go agent
+releaseDate: '2025-07-18'
+version: 3.40.1
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.40.1'
+features: []
+bugs: ["Reverted utilization.go back to v3.39.0","Removed awssupport_test.go tests that added direct dependencies to go module"]
+security: []
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+
+## 3.40.1
+### Fixed
+  * Reverted utilization.go back to v3.39.0 release due to deadlock bug
+  * Removed awssupport_test.go tests that added direct dependencies to go module
+
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.


### PR DESCRIPTION
## 3.40.1
### Fixed
  * Reverted utilization.go back to v3.39.0 release due to deadlock bug
  * Removed awssupport_test.go tests that added direct dependencies to go module