### PR TITLE
docs(npm): Add UTC timezone requirement for ktranslate

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/network-flow-monitoring.mdx
@@ -15,6 +15,12 @@ You can use our guided install process to install the network flow monitoring ag
 
 Before you can start, you'll need to [sign up for a New Relic account](https://newrelic.com/signup). If you choose to install the agent manually, you also need:
 
+<Callout variant="important">
+#### Timezone requirement
+
+The server running `ktranslate` **must** be set to the **UTC** timezone. If a different timezone is configured, it can cause timestamp inconsistencies and prevent data from appearing correctly in New Relic.
+</Callout>
+
 * A New Relic [account ID](/docs/accounts/accounts-billing/account-setup/account-id).
 * A New Relic <InlinePopover type="licenseKey"/>.
 


### PR DESCRIPTION
The ktranslate agent requires the host operating system's timezone to be set to UTC to ensure accurate timestamping of flow data. If the timezone is set to a local value (e.g., JST, PST), it can lead to data ingestion issues or incorrect data visualization in the New Relic UI.

This commit adds an important callout to the "Prerequisites" section of the network flow monitoring documentation. This ensures users are aware of this critical requirement before they begin the installation process, helping to prevent common setup errors and subsequent troubleshooting.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.