### PR TITLE
chore(nodejs): Updated node migration guide with version 13 docs

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -24,6 +24,50 @@ Recommendation: Test your updated version before moving it into production. If y
 
 If you need to uninstall the agent and install a specific version of the agent, follow this uninstallation [guide](/docs/apm/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent/) and then reinstall a specific agent version with `npm install newrelic@LIST_VERSION_HERE` or update the version in your package.json and run `npm install`. 
 
+## Upgrade to Node.js agent version 13 [#node-agent-v13]
+
+Before upgrading to Node.js version 13, review this information for major changes.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "250px" }}>
+        <DNT>
+          **Major changes with Node.js agent v13**
+        </DNT>
+      </th>
+
+      <th>
+        <DNT>
+          **Comments**
+        </DNT>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Dropped Node.js 18 support.
+      </td>
+
+      <td>
+        * For further information see our [support policy](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Updated min supported version for `fastify` to 3.0.0, `pin`o` to 8.0.0, and `koa-route`r` to 12.0.0.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Updated AI Monitoring compatibility docs with new AWS Bedrock APIs
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Upgrade to Node.js agent version 12 [#node-agent-v12]
 
 Before upgrading to Node.js version 12, review this information for major changes.


### PR DESCRIPTION
Added node agent version 13 docs to the node migration/upgrade guide. 