### PR TITLE
bug: fix gateway minimum agent versions

### DIFF
--- a/src/content/docs/new-relic-control/pipeline-control/modify-agent-configuration.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/modify-agent-configuration.mdx
@@ -67,7 +67,7 @@ exports.config = {
 ```
 
 ## Supported data sources
-The following table lists the supported data sources for gateway. Note that support within gateway does not override [New Relic](https://docs.newrelic.com/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/) or [agent-specific](https://docs.newrelic.com/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/#eol-agents) end-of-life (EOL) policies.
+The following table lists the supported data sources for gateway. Note that support for the Gateway feature doesn't override the general [New Relic end-of-life (EOL) policies](/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/) or any applicable [agent-specific EOL policies.](/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/#eol-agents).
 
 <table>
     <tr>

--- a/src/content/docs/new-relic-control/pipeline-control/modify-agent-configuration.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/modify-agent-configuration.mdx
@@ -67,7 +67,7 @@ exports.config = {
 ```
 
 ## Supported data sources
-The following table lists the supported data sources for gateway:
+The following table lists the supported data sources for gateway. Note that support within gateway does not override [New Relic](https://docs.newrelic.com/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/) or [agent-specific](https://docs.newrelic.com/docs/licenses/end-of-life/notification-changes-new-relic-saas-features-distributed-software/#eol-agents) end-of-life (EOL) policies.
 
 <table>
     <tr>
@@ -76,31 +76,31 @@ The following table lists the supported data sources for gateway:
     </tr>
     <tr>
         <td>[.NET](/docs/apm/agents/net-agent/configuration/net-agent-configuration/)</td>
-        <td>8.0.0 - 10.38.0.0</td>
+        <td>8.17.438 and later</td>
     </tr>
     <tr>
         <td>[Go](/docs/apm/agents/go-agent/configuration/go-agent-configuration/)</td>
-        <td>2.2.0 - 3.37.0</td>
+        <td>2.2.0 and later</td>
     </tr>
     <tr>
         <td>[Java](/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file/)</td>
-        <td>4.9.0 - 8.19.0</td>
+        <td>4.9.0 and later</td>
     </tr>
     <tr>
         <td>[NodeJS](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/)</td>
-        <td>0.0.5 - 12.15.0</td>
+        <td>6.10.0 and later</td>
     </tr>
     <tr>
         <td>[PHP](/docs/apm/agents/php-agent/configuration/php-agent-configuration/)</td>
-        <td>6.4.0 - 11.7.0</td>
+        <td>10.0.0 and later</td>
     </tr>
     <tr>
         <td>[Python](/docs/apm/agents/python-agent/configuration/python-agent-configuration/)</td>
-        <td>0.0.0 - 10.7.0</td>
+        <td>4.10.0 and later</td>
     </tr>
     <tr>
         <td>[Ruby](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/)</td>
-        <td>6.1.0 - 9.17.0</td>
+        <td>6.1.0 and later</td>
     </tr>
 </table>
 


### PR DESCRIPTION
The Pipeline Control Gateway requires P17 from all APM Agents. This updates the table to list the minimum version to the earliest P17 version. It also specifically calls out that it does not override the existing EOL policies.