### PR TITLE
ktlo[PAYG price revise]: Update the per GB price

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing.mdx
@@ -91,11 +91,11 @@ Here's a table with comparisons of the two options. Prices and limits are monthl
       </td>
 
       <td>
-        $0.35/GB Ingested
+        $0.40/GB Ingested
       </td>
 
       <td>
-        $0.55/GB Ingested
+        $0.60/GB Ingested
       </td>
 
       <td/>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
@@ -334,11 +334,11 @@ Here are some query recommendations for helping you understand the estimated cos
     SELECT latest(GigabytesIngestedBillable) * YOUR_PER_GB_COST
     ```
 
-    Here's an example of this query using a [per-GB cost of $0.35](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-prices):
+    Here's an example of this query using a [per-GB cost of $0.40](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-prices):
 
     ```sql
     FROM NrMTDConsumption 
-    SELECT latest(GigabytesIngestedBillable) * .35
+    SELECT latest(GigabytesIngestedBillable) * .40
     ```
   </Collapser>
 

--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/additional-information.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/additional-information.mdx
@@ -14,7 +14,7 @@ The most accurate way to project your cost per replay is to enable the feature f
 
 Here's an example:
 
-1 million (sessions) x 5% (sampling_rate) x 0.0053 (gb_per_replay) x $0.35 (cost_per_gb) = $92.75 for 50,000 replays
+1 million (sessions) x 5% (sampling_rate) x 0.0053 (gb_per_replay) x $0.40 (cost_per_gb) = $106 for 50,000 replays
 
 To control your consumption, [adjust your sampling rates](/docs/browser/browser-monitoring/browser-pro-features/session-replay/configuration/setup-session-replay/#configure-sampling-rates).
 

--- a/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
+++ b/src/content/docs/licenses/license-information/usage-plans/new-relic-usage-plan.mdx
@@ -227,7 +227,7 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
           </td>
 
           <td>
-            $0.35
+            $0.40
           </td>
         </tr>
 
@@ -245,7 +245,7 @@ Undefined terms used in this Usage Plan or Order shall have the meaning set fort
           </td>
 
           <td>
-            $0.55
+            $0.60
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
Updating the PAYG per GB price:
- Data plan from $0.35 to $0.40
- Data plus plan from $0.55 to $0.60
