### PR TITLE
chore(php): update supported alpine versions

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -175,7 +175,7 @@ Based on the information above the PHP agent, can be installed on operating syst
       </td>
 
       <td>
-        3.17, 3.18, 3.19, 3.20
+        3.17, 3.18, 3.19, 3.20, 3.21, 3.22
       </td>
 
       <td>


### PR DESCRIPTION
This PR adds `3.21` and `3.22` as supported alpine versions.