### PR TITLE
.NET agent: clarify that SQL query parameter capture is available, but not enabled by default

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -1769,7 +1769,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 The .NET agent doesn't directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
 
-                Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
+                By default, the agent collects [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for all supported datastores. To request support for other datastores, contact support at [support.newrelic.com](https://support.newrelic.com).
 
                 If your datastore isn't listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
             </Collapser>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -666,7 +666,9 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             </tbody>
             </table>
 
-            The .NET agent doesn't directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
+            The .NET agent doesn't collect data about datastore server processes. It only collects data from datastore client library usage.  To directly monitor datastore server processes, use the New Relic infrastructure agent with [on-host integrations](/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/). 
+
+            By default, the .NET agent doesn't capture SQL parameters for stored procedures or parameterized queries in a query trace. To see these SQL parameters, you must enable the collection feature in the [agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#datastore-tracer-query-parameters).
 
             Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
 
@@ -1767,7 +1769,9 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </tbody>
                 </table>
 
-                The .NET agent doesn't directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
+                The .NET agent doesn't collect data about datastore server processes. It only collects data from datastore client library usage.  To directly monitor datastore server processes, use the New Relic infrastructure agent with [on-host integrations](/docs/infrastructure/host-integrations/get-started/introduction-host-integrations/).
+
+                By default, the .NET agent doesn't capture SQL parameters for stored procedures or parameterized queries in a query trace. To see these SQL parameters, you must enable the collection feature in the [agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#datastore-tracer-query-parameters).
 
                 By default, the agent collects [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for all supported datastores. To request support for other datastores, contact support at [support.newrelic.com](https://support.newrelic.com).
 

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -666,7 +666,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             </tbody>
             </table>
 
-            The .NET agent does not directly monitor datastore processes. Also, the .NET SQL parameter capture in a query trace does not list parameters for a parameterized query or a stored procedure.
+            The .NET agent doesn't directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
 
             Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
 
@@ -1265,8 +1265,6 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
             If your application is hosted in ASP.NET or another [fully supported framework](#app-frameworks-framework), the .NET agent will automatically instrument your application after install. If your app isn't automatically instrumented, or if you want to add instrumentation, use [custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation/).
 
-            The .NET agent doesn't directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
-
             <CollapserGroup>
             <Collapser
                 className="freq-link"
@@ -1768,6 +1766,10 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 </tbody>
                 </table>
+
+                The .NET agent doesn't directly monitor datastore processes. Also, by default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure. Collection of the SQL query parameters can be enabled in the agent [configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration/).
+
+                Collecting [instance details](/docs/apm/applications-menu/features/analyze-database-instance-level-performance-issues) for supported datastores is enabled by default. To request instance-level information from datastores not currently listed, get support at [support.newrelic.com](https://support.newrelic.com).
 
                 If your datastore isn't listed here, you can add custom instrumentation using the `RecordDatastoreSegment` method in the [.NET agent API](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#ITransaction).
             </Collapser>


### PR DESCRIPTION
This PR corrects some issues with the .NET agent's compatibility and support document regarding SQL query parameter capture.

Some form of the following statement appeared in three places in the documentation:

`By default the .NET SQL parameter capture in a query trace doesn't list parameters for a parameterized query or a stored procedure.`

1. In one case, the all-important "by default" was omitted.  This is fixed.
2. This statement appeared in one place in the document were it didn't make sense to.  This is deleted.
3. A statement about datastore instance detail collection was missing from one place, and it is added there.