### PR TITLE
Create troubleshooting doc frequent-fluent-bit-restart-events.mdx

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/frequent-fluent-bit-restart-events.mdx
+++ b/src/content/docs/infrastructure/infrastructure-troubleshooting/troubleshoot-infrastructure/frequent-fluent-bit-restart-events.mdx
@@ -1,0 +1,79 @@
+---
+title: Frequent Fluent Bit Restart Events
+type: troubleshooting
+tags:
+  - Infrastructure
+  - Infrastructure monitoring troubleshooting
+  - Troubleshoot infrastructure
+  - Fluent Bit
+metaDescription: Troubleshooting steps to resolve the infrastructure agent bug causing endless Fluent Bit restart events due to hostname resolution issues.
+redirects:
+  - /docs/infrastructure/new-relic-infrastructure/troubleshooting/fluent-bit-restart-loop
+  - /docs/infrastructure/new-relic-infrastructure/troubleshooting/fix-fluent-bit-endless-restart
+  - /docs/infrastructure/new-relic-infrastructure/troubleshooting/fluent-bit-hostname-resolution
+  - /docs/infrastructure/new-relic-infrastructure/troubleshooting/fluent-bit-start-stop
+freshnessValidatedDate: never
+---
+
+## Problem
+
+The New Relic infrastructure agent is sending endless `Fluent Bit Started` and `Fluent Bit Stopped` events, but Fluent Bit is not actually restarting. This creates noise in logs, may impact monitoring accuracy, and can cause significant spikes in data ingestion that may result in unexpected billing charges.
+
+## Cause
+
+This is caused by a bug in the infrastructure agent's hostname resolution component. The agent incorrectly detects constant hostname changes, triggering the LogForwarderSupervisor to send false restart events for Fluent Bit. You may see thousands of debug messages like:
+
+```
+time="2024-04-20T02:46:47Z" level=debug msg="Notifying observers." change=2 component=HostnameResolver
+time="2024-04-20T02:46:47Z" level=debug msg="Observer notified." component=HostnameResolver name=LogForwarderSupervisor
+```
+
+## Solution
+
+You can resolve this issue by modifying the hostname resolution behavior in your infrastructure agent configuration. This fix works for both Windows and Linux systems.
+
+Add the following configuration to your infrastructure agent configuration file:
+
+**Linux**: `/etc/newrelic-infra.yml`
+**Windows**: `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`
+
+```yml
+dns_hostname_resolution: false
+override_hostname: "your-server-hostname"
+```
+
+Replace `"your-server-hostname"` with your actual server hostname.
+
+This configuration:
+- Disables reverse DNS lookups that may be causing unstable hostname detection
+- Forces the agent to use a specific hostname, preventing any hostname change detection
+
+### Apply the configuration
+
+After adding the configuration:
+
+1. Save the configuration file
+2. Restart the New Relic infrastructure agent:
+
+   **Linux**:
+   ```bash
+   sudo systemctl restart newrelic-infra
+   ```
+
+   **Windows**:
+   ```powershell
+   Restart-Service newrelic-infra
+   ```
+
+## Verification
+
+To confirm the issue is resolved:
+
+1. Monitor your infrastructure agent logs for the absence of repeated `HostnameResolver` messages
+2. Check that `Fluent Bit Started` and `Fluent Bit Stopped` events are no longer appearing continuously in the NR dashboard
+3. Verify that log forwarding continues to function normally and you are able to see the logs as per your logging configuration
+
+## Additional resources
+
+* [Infrastructure agent hostname resolution documentation](https://github.com/newrelic/infrastructure-agent/blob/master/docs/hostname_resolution.md)
+* [Infrastructure agent configuration settings](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/)


### PR DESCRIPTION
This PR adds a troubleshooting page to the docs to address frequent Fluent Bit restarting events.
It outlines the cause related to hostname resolution issues and provides steps to resolve this by updating configuration settings.
