### PR TITLE
remove terenary operator for agent ID and application ID

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -432,19 +432,13 @@ module.exports = {
           ],
         },
         newrelic: {
-          config: {
+          config: process.env.ENVIRONMENT === 'production' && {
             instrumentationType: 'proAndSPA',
             accountId: '10956800',
             trustKey: '1',
-            agentID:
-              process.env.ENVIRONMENT === 'production'
-                ? '35094662'
-                : '35094418',
+            agentID: '35094662',
             licenseKey: 'NRJS-649173eb1a7b28cd6ab',
-            applicationID:
-              process.env.ENVIRONMENT === 'production'
-                ? '35094662'
-                : '35094418',
+            applicationID: '35094662',
             beacon: 'staging-bam-cell.nr-data.net',
             errorBeacon: 'staging-bam-cell.nr-data.net',
             settings: {


### PR DESCRIPTION
Objective : 

- our docs website is instrumented with new relic browser agent 
- we are using a terenary operator for agent ID and application ID process.env.ENVIRONMENT === 'production' ? '35094662' : '35094418'
- because of this in lower environments such as staging or development , docs website is constantly pinging the new relic browser agent 
- there are multiple reasons for not letting new relic browser agent instrument with docs website ,on top that recently error tracking team flagged the browser agent in lower environments as high risk entity 
