### PR TITLE
fix: redirect-fix

### DIFF
--- a/src/content/docs/browser/new-relic-browser/configuration/public-preview-features.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/public-preview-features.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'Browser monitoring features in public preview'
 metaDescription: "Opt-in to use public preview features in New Relic browser monitoring before they're generally available."
+redirects:
+  - /docs/browser/new-relic-browser/configuration/experimental-features
 freshnessValidatedDate: never
 ---
 


### PR DESCRIPTION
This PR fixes the broken link issue by added a redirect. We received [this request](https://newrelic.slack.com/archives/C0DSGL3FZ/p1754193931448199) in our help-documentaion slack channel.