### PR TITLE
Update vmware-tanzu-nginx-buildpack-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/other-infrastructure-integrations/cloudfoundry-integrations/vmware-tanzu-nginx-buildpack-integration.mdx
+++ b/src/content/docs/infrastructure/other-infrastructure-integrations/cloudfoundry-integrations/vmware-tanzu-nginx-buildpack-integration.mdx
@@ -51,7 +51,7 @@ The following table provides version support information about the New Relic NGI
       </td>
 
       <td>
-        1.1.2
+        1.1.5
       </td>
     </tr>
 
@@ -61,7 +61,7 @@ The following table provides version support information about the New Relic NGI
       </td>
 
       <td>
-        January 06, 2025
+        August 11, 2025
       </td>
     </tr>
 
@@ -71,7 +71,7 @@ The following table provides version support information about the New Relic NGI
       </td>
 
       <td>
-        New Relic NGINX integration buildpack for VMware Tanzu 1.1.2
+        New Relic NGINX integration buildpack for VMware Tanzu 1.1.5
       </td>
     </tr>
 
@@ -138,7 +138,7 @@ You can install the buildpacks either as a tile in Ops Manager or individually u
     <TabsPageItem id="ops-manager-tile">
       <Steps>
         <Step>
-          Download the latest version of the tile (currently `newrelic-nginx-buildpack-1.1.2.pivotal`) from the [Broadcom download site](https://support.broadcom.com/group/ecx/productdownloads?subfamily=New%20Relic%20Nginx%20Integration%20Buildpack%20for%20VMware%20Tanzu), or from New Relic's [GitHub repo under releases](https://github.com/newrelic/newrelic-pcf-nginx-buildpack/releases).
+          Download the latest version of the tile (currently `newrelic-nginx-buildpack-1.1.5.pivotal`) from the [Broadcom download site](https://support.broadcom.com/group/ecx/productdownloads?subfamily=New%20Relic%20Nginx%20Integration%20Buildpack%20for%20VMware%20Tanzu), or from New Relic's [GitHub repo under releases](https://github.com/newrelic/newrelic-pcf-nginx-buildpack/releases).
         </Step>
 
         <Step>


### PR DESCRIPTION



* What problems does this PR solve?
The buildpack is mofiied for latest go build 1.23 and tested with latest OPS Manager 10.2.