### PR TITLE
fix(nodejs): explain failure to open log behavior

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -912,13 +912,19 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    Complete path to the New Relic agent log, including the filename. Defaults to `filepath: require('path').join(process.cwd(), 'newrelic_agent.log')`. If the file cannot be created, then the agent will `console.error` an error saying “New Relic failed to open log file”, and then other log messages will be buffered in the Logger until there are 128MiB, and then further log messages will result in process.emitWarning of “[NRWARN001] NewRelicWarning: Dropping log message, buffer would overflow.” The agent creates a log file with the same permissions as the parent Node.js agent process.
+    Complete path to the New Relic agent log, including the filename. Defaults to `filepath: require('path').join(process.cwd(), 'newrelic_agent.log')`. If the agent can’t create the log file, then it:
+
+    * Logs `New Relic failed to open log file` using `console.error`
+    * Buffers subsequent log messages in memory
+    * When the memory buffer reaches its 128 MiB limit, the agent discards any new log messages and emits the following warning via `process.emitWarning`: `[NRWARN001] NewRelicWarning: Dropping log message, buffer would overflow.`
+    
+    When creating the log file, the agent sets the file permissions to 0o600 (readable/writable to the owner).
 
     * To write all logging to <DNT>**stdout**</DNT>, set this to `stdout`.
     * To write all logging to <DNT>**stderr**</DNT>, set this to `stderr`.
 
     <Callout variant="important">
-      This configuration had different behavior in agent versions lower than 7.0.0. For 6.x and under, the agent would shut down the process if it could not create this file.
+      For agent versions less than 7.0.0, the agent would shut down the process if it could not create this file.
     </Callout>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -914,8 +914,8 @@ This section defines the Node.js agent variables in the order they typically app
 
     Complete path to the New Relic agent log, including the filename. Defaults to `filepath: require('path').join(process.cwd(), 'newrelic_agent.log')`. If the agent can’t create the log file, then it:
 
-    * Logs `New Relic failed to open log file` using `console.error`
-    * Buffers subsequent log messages in memory
+    * Logs the `New Relic failed to open log file` error using `console.error`.
+    * Buffers all subsequent log messages in memory.
     * When the memory buffer reaches its 128 MiB limit, the agent discards any new log messages and emits the following warning via `process.emitWarning`: `[NRWARN001] NewRelicWarning: Dropping log message, buffer would overflow.`
     
     When creating the log file, the agent sets the file permissions to 0o600 (readable/writable to the owner).
@@ -924,7 +924,7 @@ This section defines the Node.js agent variables in the order they typically app
     * To write all logging to <DNT>**stderr**</DNT>, set this to `stderr`.
 
     <Callout variant="important">
-      For agent versions less than 7.0.0, the agent would shut down the process if it could not create this file.
+      In agent versions prior to 7.0.0, the agent would shut down the process if it was unable to create this file.
     </Callout>
   </Collapser>
 </CollapserGroup>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -912,10 +912,14 @@ This section defines the Node.js agent variables in the order they typically app
       </tbody>
     </table>
 
-    Complete path to the New Relic agent log, including the filename. Defaults to `filepath: require('path').join(process.cwd(), 'newrelic_agent.log')`. The agent will shut down the process if it cannot create this file. The agent creates a log file with the same permissions as the parent Node.js agent process.
+    Complete path to the New Relic agent log, including the filename. Defaults to `filepath: require('path').join(process.cwd(), 'newrelic_agent.log')`. If the file cannot be created, then the agent will `console.error` an error saying “New Relic failed to open log file”, and then other log messages will be buffered in the Logger until there are 128MiB, and then further log messages will result in process.emitWarning of “[NRWARN001] NewRelicWarning: Dropping log message, buffer would overflow.” The agent creates a log file with the same permissions as the parent Node.js agent process.
 
     * To write all logging to <DNT>**stdout**</DNT>, set this to `stdout`.
     * To write all logging to <DNT>**stderr**</DNT>, set this to `stderr`.
+
+    <Callout variant="important">
+      This configuration had different behavior in agent versions lower than 7.0.0. For 6.x and under, the agent would shut down the process if it could not create this file.
+    </Callout>
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
Fix obsolete documentation that claimed that nodejs exits after failing to open log file.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  Inaccurate statement in documentation
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  This PR is based on a conversation I had with [ChatGPT o3](https://chatgpt.com/share/68916102-b7cc-8003-b048-11b81f97949b). All hallucinations are my own.
* If your issue relates to an existing GitHub issue, please link to it.