### PR TITLE
Add update Pipeline docs

### DIFF
--- a/.idea/thriftCompilerAssist.xml
+++ b/.idea/thriftCompilerAssist.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ThriftCompilerAssist">
+    <compilers />
+  </component>
+</project>

--- a/src/content/docs/new-relic-control/pipeline-control/update-pipeline-rules.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/update-pipeline-rules.mdx
@@ -1,0 +1,56 @@
+---
+title: Update pipeline rules
+metaDescription: 'Learn how to update pipeline rules to manage the flow of data from your monitored entities to New Relic.'
+freshnessValidatedDate: never
+---
+
+You can modify existing Pipeline rules to adjust their filtering criteria, data types, or deployment scope. This section focuses on updating pipeline cloud rules using the New Relic API (NerdGraph).
+
+<Callout variant="important">
+  - Pipeline Control rules only apply to data that arrives from the moment you create the rule, they don't delete data that's already been ingested.
+  - Gateway rules require deployment of the gateway.
+  - When updating a rule, the changes apply to data ingested from the moment the update is deployed. It does not affect data that's already been ingested. Always test and monitor your updated rules to ensure they're working as intended.
+</Callout>
+
+## Via NerdGraph [#via-nerdgraph]
+To update an existing Cloud rule, you'll use the updatePipelineCloudRule mutation in NerdGraph. This allows you to change the rule's name, description, and, crucially, its NRQL.
+
+1. Identify the rule:
+You'll need the unique entity ID of the Pipeline Cloud Rule you wish to update. You can find this ID by querying your rules using NerdGraph (e.g., actor { entitySearch(query: "type = 'PIPELINE_CLOUD_RULE'") { results { entities { id name } } } }).
+
+2. Construct your mutation:
+Use the updatePipelineCloudRule mutation, providing the rule's id and a pipelineCloudRuleEntity object containing the fields you want to change.
+  - id: The entity ID of the Pipeline Cloud Rule you identified in step 1.
+  - pipelineCloudRuleEntity: An object containing the updated details. You can provide any or all of the below fields:
+- nrql: The updated NRQL query that defines what data or attributes to drop. This should be a DELETE NRQL query (e.g., DELETE FROM MyEvent or DELETE attribute FROM MyEvent).
+- name: The new name for your rule (optional).
+- description: The new description for your rule (optional).
+
+3. NerdGraph Example to Update a rule:
+Suppose you have an existing rule that drops dropAttr1 from MyEventToDrop eventType, and you need to change it to drop dropAttr2 instead.
+Call the Update Mutation:
+```graphql
+mutation UpdatePipelineCloudRule {
+    updatePipelineCloudRule(
+        id: "MTAyNTY1MHxOR0VQfFBJUEVMSU5FX0NMT1VEX1JVTEV8MDE5ODgwOTUtMmZjNC03MTQ3LTkxMjQtZDk3YjhiY2Y4NGNj", # Replace with your rule's actual entity ID
+        pipelineCloudRuleEntity: {
+            description: "Since we do not need dropAttr1 ingested we would drop this attribuute instead of dropAttr1 ",
+            name: "Update the name for Dropping dropAttr2 from MyEventToDrop",
+            nrql: "DELETE dropAttr2 FROM MyEventToDrop"
+        }
+    ) {
+        entity {
+            id
+            type
+            name
+            description
+            nrql
+        }
+    }
+}
+```
+
+4. Verify the update:
+- Check the API response: The entity object in the response will reflect the updated name, description, and nrql.
+- Monitor your data: Send new data that would be affected by the rule and confirm that the dropping behavior has changed as expected. For example, if you changed from dropping attr1 to attr2, ensure attr1 is now ingested and attr2 is no longer appearing.
+- Check the database (for internal verification): Confirm that the action field and both nrql and pipeline_cloud_rule_nrql columns in the drop_rules table are updated correctly.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? 
   This PR provides public documentation for updating existing Pipeline Cloud Rules via the NerdGraph API. Previously, there was no official guidance on how users could modify their existing cloud rules programmatically. This could resolve the gap for users who needed to adjust their data filtering rules over time (e.g., change the NRQL, description, or name) without having to delete and recreate them.
   
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  This new documentation enables users to manage their Pipeline Cloud Rules more flexibly. The update functionality was recently enhanced to ensure that all rule properties are correctly updated in the backend when the NRQL changes. This means users can now reliably modify their rules to adapt to evolving data ingestion needs. Below is the screenshot of the working endpoint that we tested out on internal-api for NerdGraph:
  
<img width="1917" height="912" alt="Screenshot 2025-08-08 at 5 02 19 PM" src="https://github.com/user-attachments/assets/536a10d9-0e6f-4fb7-9d14-aa1b6caddaef" />
