### PR TITLE
Update cloud-rules-api.mdx

### DIFF
--- a/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
@@ -314,6 +314,30 @@ mutation {
   }
 }
 ```
+
+## Update cloud rules [#update-rules]
+
+```graphql
+mutation UpdatePipelineCloudRule {
+    updatePipelineCloudRule(
+        id: "MTAyNTY1MHxOR0VQfFBJUEVMSU5FX0NMT1VEX1JVTEV8MDE5ODgwOTUtMmZjNC03MTQ3LTkxMjQtZDk3YjhiY2Y4NGNj", # Replace with your rule's actual entity ID
+        pipelineCloudRuleEntity: {
+            description: "Since we do not need dropAttr1 ingested we would drop this attribuute instead of dropAttr1 ",
+            name: "Update the name for Dropping dropAttr2 from MyEventToDrop",
+            nrql: "DELETE dropAttr2 FROM MyEventToDrop"
+        }
+    ) {
+        entity {
+            id
+            type
+            name
+            description
+            nrql
+        }
+    }
+}
+```
+
 ## Delete a cloud rule [#delete-rule]
 
 ```graphql


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

What problems does this PR solve?
This PR provides public documentation for updating existing Pipeline Cloud Rules via the NerdGraph API. Previously, there was no official guidance on how users could modify their existing cloud rules programmatically. This could resolve the gap for users who needed to adjust their data filtering rules over time (e.g., change the NRQL, description, or name) without having to delete and recreate them.

Add any context that will help us review your changes such as testing notes, links to related docs, screenshots, etc.
This new documentation enables users to manage their Pipeline Cloud Rules more flexibly. The update functionality was recently enhanced to ensure that all rule properties are correctly updated in the backend when the NRQL changes. This means users can now reliably modify their rules to adapt to evolving data ingestion needs. Below is the screenshot of the working endpoint that we tested out on internal-api for NerdGraph. For more ref: https://github.com/newrelic/docs-website/pull/21455