### PR TITLE
fix: agent env injection in k8s-agent-operator.mdx

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/installation/k8s-agent-operator.mdx
@@ -407,12 +407,13 @@ The instrumentation CR provides the capability to inject environment variables i
 ```yaml
 ...
 spec:
-  env:
-    # Example overriding the appName configuration by using a label of the pod
-    - name: NEW_RELIC_APP_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['app.kubernetes.io/name']
+  agent:
+    env:
+      # Example overriding the appName configuration by using a label of the pod
+      - name: NEW_RELIC_APP_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.labels['app.kubernetes.io/name']
 ...
 ```
 


### PR DESCRIPTION
This fixes the schema for injecting environment variables in the agent runtime (spec.env -> spec.agent.env).
