### PR TITLE
Fix Typo in the release notes. PLEASE REVIEW AND MERGE ASAP.

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8230.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8230.mdx
@@ -14,7 +14,6 @@ security: []
     variant="primary"
   >
     Download this agent version
-    Hi @hero, it seems the docs website has not been updated yet since yesterday. We have release notes we need updated into the site so we can announce the Java Agent agent release by the end of the week. When is the website is usually deployed and are there any issues with deploying it? I have noticed some errors when it was deploying too. I do not 
   </ButtonLink>
 </ButtonGroup>
 

--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8230.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8230.mdx
@@ -1,6 +1,6 @@
 ---
 subject:  Java agent
-releaseDate:  2025-08-13'
+releaseDate:  '2025-08-13'
 version:  8.23.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.23.0/'
 features: [“Support v24 of GraphQL”, “Add lettuce 6.5 instrumentation”, “Add lettuce dbName to datastore params where available”, “Add an environment variable to skip instrumenting certain applications”]
@@ -14,6 +14,7 @@ security: []
     variant="primary"
   >
     Download this agent version
+    Hi @hero, it seems the docs website has not been updated yet since yesterday. We have release notes we need updated into the site so we can announce the Java Agent agent release by the end of the week. When is the website is usually deployed and are there any issues with deploying it? I have noticed some errors when it was deploying too. I do not 
   </ButtonLink>
 </ButtonGroup>
 


### PR DESCRIPTION

I notices in the doc site deploys when merging into main the release notes has errored out due to a missing quote. I fixed it.

PLEASE MERGE ASAP. We need the Java Agent release notes up by the end of the day so we can announce our release.