### PR TITLE
chore: Add more details to the .NET agent's NoticeError page.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -1597,7 +1597,7 @@ The following list contains the different calls you can make with the API, inclu
 
     The agent adds the attributes only to the traced error; it does not send them to New Relic. For more information, see [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AddCustomAttribute).
 
-    When passing an exception to `NoticeError()`, we first determine the inner most Exception using Microsoft's `Exception.GetBaseException()` API.  This is the root cause of the error and what is displayed in APM.  We report the entire stack trace from the top-level Exception since that provides context and execution details.  This gives the most specific error information (from the base exception) while maintaining the full context of how the error propagated through the application.
+    When passing an exception to `NoticeError()`, determine the innermost exception using Microsoft's `Exception.GetBaseException()` API. This innermost exception represents the root cause of the error and is what is displayed in APM. The entire stack trace from the top-level exception is reported, as it provides relevant context and execution details. This approach offers the most specific error information from the base exception while preserving the complete context of how the error propagated through the application.
 
     Errors reported with this API are still sent to New Relic when they are reported within a transaction that results in an HTTP status code, such as a `404`, that is configured to be ignored by agent configuration. For more information, see our documentation about [managing errors in APM](/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected).
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -1597,6 +1597,8 @@ The following list contains the different calls you can make with the API, inclu
 
     The agent adds the attributes only to the traced error; it does not send them to New Relic. For more information, see [`AddCustomAttribute()`](/docs/apm/agents/net-agent/net-agent-api/net-agent-api/#AddCustomAttribute).
 
+    When passing an exception to `NoticeError()`, we first determine the inner most Exception using Microsoft's `Exception.GetBaseException()` API.  This is the root cause of the error and what is displayed in APM.  We report the entire stack trace from the top-level Exception since that provides context and execution details.  This gives the most specific error information (from the base exception) while maintaining the full context of how the error propagated through the application.
+
     Errors reported with this API are still sent to New Relic when they are reported within a transaction that results in an HTTP status code, such as a `404`, that is configured to be ignored by agent configuration. For more information, see our documentation about [managing errors in APM](/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected).
 
     Review the sections below to see examples of how to use this call.


### PR DESCRIPTION
## Give us some context

The .NET agent's NoticeError API page doesn't explain how we determine the exception details we report up.  This expands on that to reduce customer confusion.

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.