### PR TITLE
Use accountId function for querying limits

### DIFF
--- a/src/content/docs/data-apis/manage-data/query-limits.mdx
+++ b/src/content/docs/data-apis/manage-data/query-limits.mdx
@@ -134,7 +134,7 @@ From left to right, top to bottom:
        FROM Metric 
        SELECT rate(sum(newrelic.resourceConsumption.currentValue), 1 minute) / latest(newrelic.resourceConsumption.limitValue) * 100 
        WHERE limitTimeInterval = '1 minute' 
-       FACET limitName, consumingAccountId TIMESERIES LIMIT MAX
+       FACET limitName, accountId() TIMESERIES LIMIT MAX
        ```
 
     2. Click <DNT>**Add another query**</DNT>.
@@ -146,7 +146,7 @@ From left to right, top to bottom:
        FROM Metric 
        SELECT rate(sum(newrelic.resourceConsumption.currentValue), 1 minute) / latest(newrelic.resourceConsumption.limitValue) * 100 
        WHERE limitTimeInterval = '1 minute'
-       FACET limitName, consumingAccountId TIMESERIES LIMIT MAX
+       FACET limitName, accountId() TIMESERIES LIMIT MAX
        ```
 
     5. Finally, save it.
@@ -241,14 +241,14 @@ Attributes on `newrelic.resourceConsumption.limitValue` and `newrelic.resourceCo
 * `dataType`: What kind of data the metric is tracking, for example `Metric`, `Log`, or `APM`.
 * `Resource`: What resource is being consumed, for example `Requests` or `DPM`.
 * `limitTimeInterval`: What time window this resource is evaluated for limiting.
-* `consumingAccountId`:  The New Relic account where the resource is being consumed.
+* `accountId()`:  The New Relic account where the resource is being consumed.
 
 Attributes on `newrelic.resourceConsumption.impact`
 
 * `dataType`: The kind of data that is being impacted, for example `Metric`, `Log`, or `APM`.
 * `Resource`: What resource is being impacted, for example `Request Rate`.
 * `Impact`: A count of what is happening when resource has exceeded set limit, for example dropped requests.
-* `consumingAccountId`: The New Relic account where the resource is being consumed.
+* `accountId()`: The New Relic account where the resource is being consumed.
 
 ## Set alerts on resource metrics
 


### PR DESCRIPTION
`consumingAccountId` is no longer available, but the `accountId()` function can and should be used instead.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.