### PR TITLE
ebpf : add new env variable, update description for drop data env var

### DIFF
--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -177,7 +177,7 @@ The `newrelic-ebpf-agent.conf` file contains the following configuration paramet
         </tr>
         <tr>
             <td>`DROP_DATA_FOR_ENTITY`</td>
-            <td>Provides a comma-separated list of `NEW_RELIC_APP_NAME` values. The agent will drop data from processes matching these application names.</td>
+            <td>Regular expression pattern to match the specific name(s) of the entity set that you wish to exclude.</td>
             <td>`String`</td>
             <td>`""`</td>
         </tr>
@@ -222,6 +222,12 @@ The `newrelic-ebpf-agent.conf` file contains the following configuration paramet
             <td>Sets the maximum memory (in MiB) that the eBPF agent can use for its internal data table store. This is the primary way to control the agent's RAM usage.</td>
             <td>Integer</td>
             <td>`250`</td>
+        </tr>
+        <tr>
+            <td>`DOWNLOADED_PACKAGED_HEADERS_PATH`</td>
+            <td>Sets the path of the directory where the required linux headers are downloaded and placed for the eBPF agent to use. This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version.</td>
+            <td>`String (Path)`</td>
+            <td>`""`</td>
         </tr>
         <tr>
             <td>`PROTOCOLS_HTTP_ENABLED`</td>


### PR DESCRIPTION
In case where the linux headers cannot be downloaded, user can provide custom path where they can manually download the required linux headers through environment variable DOWNLOADED_PACKAGED_HEADERS_PATH. This is the path of the directory and not the headers itself. [PR](https://github.com/newrelic/newrelic-ebpf-agent/pull/574).

Description update for DROP_DATA_FOR_ENTITY

