### PR TITLE
fix: doc writer note removed from plain text

### DIFF
--- a/src/content/docs/alerts/your-first-nrql-condition.mdx
+++ b/src/content/docs/alerts/your-first-nrql-condition.mdx
@@ -111,7 +111,7 @@ Here, we'll walk you through the five steps of creating your first alert so you 
 
         Setting your lost signal threshold requires knowledge of your system and what you're looking to understand. In the case of web transaction time, let's say New Relic collects a signal every minute. A lost signal could indicate a much larger latency issue. So, we recommend setting the time to your comfort level and then checking the box to <DNT>**open a new lost signal incident**</DNT>.
 
-        <!--  TODO need new screenshot  -->
+        <CONTRIBUTOR_NOTE> TODO need new screenshot </CONTRIBUTOR_NOTE>
         <img title="" alt="" src="/images/alerts_screenshot-crop_lost-signal-threshold.webp"/>
       </Collapser>
     </CollapserGroup>

--- a/src/content/docs/alerts/your-first-nrql-condition.mdx
+++ b/src/content/docs/alerts/your-first-nrql-condition.mdx
@@ -111,7 +111,7 @@ Here, we'll walk you through the five steps of creating your first alert so you 
 
         Setting your lost signal threshold requires knowledge of your system and what you're looking to understand. In the case of web transaction time, let's say New Relic collects a signal every minute. A lost signal could indicate a much larger latency issue. So, we recommend setting the time to your comfort level and then checking the box to <DNT>**open a new lost signal incident**</DNT>.
 
-        // TODO need new screenshot
+        <!--  TODO need new screenshot  -->
         <img title="" alt="" src="/images/alerts_screenshot-crop_lost-signal-threshold.webp"/>
       </Collapser>
     </CollapserGroup>


### PR DESCRIPTION
This editors note is in plain text.

<img width="754" height="725" alt="image" src="https://github.com/user-attachments/assets/e7447ae6-75b7-41f5-985c-e121e0d6fd64" />

 `//` is not a comment in markdown, `<!-- this is a comment -->` 