### PR TITLE
Fix formatting in AWS integration deletion instructions

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/set-up-aws-api-polling.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/set-up-aws-api-polling.mdx
@@ -110,7 +110,7 @@ By default, the Amazon EC2 <DNT>**AmazonEC2ReadOnlyAccess**</DNT> permission gra
 
 For API polling integrations, if you don't see any tags within a few minutes of set up, delete the integration and try the set-up procedures again.  
 
-You can delete the integration by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS > **Manage services**</DNT>. Remove individual integrations or the entire account linkage as needed.
+You can delete the integration by going to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS > Manage services**</DNT>. Remove individual integrations or the entire account linkage as needed.
 
 Note that not all integrations support tags collection. You can enable (or disable) tags collection in the integration settings. New Relic automatically imports custom tags you have added or edited for your AWS resources. Most metrics received via CloudWatch metric streams will have [custom tags as dimensions](/docs/integrations/amazon-integrations/aws-integrations-list/aws-metric-stream/#tags-collection).
 


### PR DESCRIPTION
Fix the formatting issue in this document.