### PR TITLE
Added the version callout for Database performance monitoring

### DIFF
--- a/src/install/microsoft-sql/windows/query-level-monitoring-entra-id-service-principal.mdx
+++ b/src/install/microsoft-sql/windows/query-level-monitoring-entra-id-service-principal.mdx
@@ -5,6 +5,11 @@ componentType: default
 
 Database performance analysis allows you to monitor your SQL queries within your Microsoft SQL database, providing insights into execution times, resource consumption, and potential bottlenecks. This feature helps you optimize database operations. For more information, refer to [Database performance monitoring](/docs/infrastructure/infrastructure-data/query-level-monitoring).
 
+<Callout variant="important">
+    To use database performance monitoring, you need Microsoft SQL Server 2017 or later.
+
+</Callout>
+
 <CollapserGroup>
 
     <Collapser

--- a/src/install/microsoft-sql/windows/query.mdx
+++ b/src/install/microsoft-sql/windows/query.mdx
@@ -5,6 +5,11 @@ componentType: default
 
 Database performance analysis allows you to monitor your SQL queries within your Microsoft SQL database, providing insights into execution times, resource consumption, and potential bottlenecks. This feature helps you optimize database operations. For more information, refer to [Database performance monitoring](/docs/infrastructure/infrastructure-data/query-level-monitoring).
 
+<Callout variant="important">
+    To use database performance monitoring, you need Microsoft SQL Server 2017 or later.
+
+</Callout>
+
 <CollapserGroup>
 
     <Collapser


### PR DESCRIPTION
This PR is in response to the GitHub issue https://github.com/newrelic/docs-website/issues/21593 and [this request](https://newrelic.slack.com/archives/C0DSGL3FZ/p1756407192503689) on #help-documentation channel. It adds the supported Microsoft SQL Server version information for Database performance monitoring.