### PR TITLE
feat(ac): adding release notes for components

### DIFF
--- a/scripts/releaseNotes.mjs
+++ b/scripts/releaseNotes.mjs
@@ -65,6 +65,8 @@ const INCLUDE_AGENTS = new Set([
   'java',
   'kubernetes',
   'pipeline_control_gateway', 
+  'agent_control_deployment_chart', 
+  'agent_control_continuous_delivery_chart', 
   'node',
   'nodejs',
   'php',

--- a/src/content/docs/release-notes/agent-control-continuous-delivery-chart-release-notes/agent-control-continuous-delivery-chart-05-09-25.mdx
+++ b/src/content/docs/release-notes/agent-control-continuous-delivery-chart-release-notes/agent-control-continuous-delivery-chart-05-09-25.mdx
@@ -1,0 +1,10 @@
+---
+subject: Agent Control Continuous Delivery Chart
+releaseDate: '2025-09-05'
+version: 0.0.2
+metaDescription: Release notes for Agent Control Continuous Delivery Chart 0.0.2
+---
+
+### Agent Control Continuous Delivery Chart Release Notes - 0.0.2
+
+ - Support for remote upgrade of Agent Control Continuous Delivery component

--- a/src/content/docs/release-notes/agent-control-continuous-delivery-chart-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-control-continuous-delivery-chart-release-notes/index.mdx
@@ -1,0 +1,3 @@
+---
+subject: Agent Control Continuous Delivery Chart
+---

--- a/src/content/docs/release-notes/agent-control-deployment-chart-release-notes/agent-control-deployment-chart-05-09-25.mdx
+++ b/src/content/docs/release-notes/agent-control-deployment-chart-release-notes/agent-control-deployment-chart-05-09-25.mdx
@@ -1,0 +1,10 @@
+---
+subject: Agent Control Deployment Chart
+releaseDate: '2025-09-05'
+version: 0.0.74
+metaDescription: Release notes for Agent Control Deployment Chart 0.0.74
+---
+
+### Agent Control Deployment Chart Release Notes - 0.0.74
+
+ - Support for remote upgrade of Agent Control Deployment component

--- a/src/content/docs/release-notes/agent-control-deployment-chart-release-notes/index.mdx
+++ b/src/content/docs/release-notes/agent-control-deployment-chart-release-notes/index.mdx
@@ -1,0 +1,3 @@
+---
+subject: Agent Control Deployment Chart
+---

--- a/src/utils/getAgentName.js
+++ b/src/utils/getAgentName.js
@@ -18,6 +18,8 @@ const AGENTS = {
   'job-manager-release-notes': 'job manager',
   'kubernetes-integration-release-notes': 'kubernetes',
   'pipeline-control-gateway-release-notes': 'pipeline_control_gateway',
+  'agent-control-deployment-chart-release-notes': 'agent_control_deployment_chart',
+  'agent-control-continuous-delivery-chart-release-notes': 'agent_control_continuous_delivery_chart',
   'prometheus-agent-release-notes': 'prometheus',
   'logs-release-notes': 'logs',
   'fluentbit-release-notes': 'fluentbit',


### PR DESCRIPTION
## Give us some context

We are adding logs for two componenents of the agent control.
 - I added "chart" suffix since the versions refers to the chart, since in the future we might have also onHost support we need to differentiate it
 - I had to add "deployment" and "continuous delivery" since that is the actual name of the two components. 

"continuous delivery" could be called "cd" instead, I am opened to suggestions
