### PR TITLE
chor: Add Prototype.js to browser compatibility exceptions

### DIFF
--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -205,6 +205,16 @@ The browser agent collects data on sites that use many popular frontend framewor
         The browser agent is not compatible with MooTools versions older than `1.6.0` or with any version that includes the mootools compatibility layer. If migrating from MooTools is not an option, we recommend using version `1.6.0-nocompat`.
       </td>
     </tr>
+
+    <tr>
+      <td>
+        Prototype.js
+      </td>
+
+      <td>
+        The browser agent is not compatible with Prototype.js due to the library's modification of native JavaScript objects and prototypes. This can cause conflicts with the agent's functionality and result in JavaScript errors such as `TypeError: this._each is not a function`.
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Added Prototype.js to the list of incompatible frameworks in browser monitoring documentation. The library modifies native JavaScript objects and prototypes, causing conflicts with the browser agent functionality and resulting in errors like 'TypeError: this._each is not a function'.

Based on GTSE NR-456846.