### PR TITLE
chore: adding custom secret key manager

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -409,6 +409,18 @@ You can find more environment variables in our [.NET configuration documentation
             <td></td>
             <td>Bypass checks by supplying them as comma-separated values within a string. Use `handler`, `agent`, `sanity`, `vendor`, or `all` string values</td>
         </tr>
+        <tr>
+            <td>`NEW_RELIC_LICENSE_KEY_SECRET`</td>
+            <td></td>
+            <td></td>
+            <td>Specify the name of the Secret key from AWS Secrets Manager that contains your license key. Note: This is only used if NEW_RELIC_LICENSE_KEY is not set.</td>
+        </tr>
+        <tr>
+            <td>`NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME`</td>
+            <td></td>
+            <td></td>
+            <td>Specify the SSM parameter name from the AWS Systems Manager Parameter Store that contains your license key. Note: This is only used if NEW_RIC_LICENSE_KEY is not set</td>
+        </tr>      
     </tbody>
 </table>
 


### PR DESCRIPTION
## Description
This PR updates the configuration documentation to include new, more secure methods for providing the New Relic license key. It introduces two new environment variables that allow users to fetch the key from AWS Secrets Manager or AWS Systems Manager (SSM) Parameter Store instead of setting it directly as a plaintext variable

## Changes
Adds documentation for the `NEW_RELIC_LICENSE_KEY_SECRET` environment variable to fetch the license key from AWS Secrets Manager.

Adds documentation for the `NEW_RELIC_LICENSE_KEY_SSM_PARAMETER` environment variable to fetch the license key from AWS SSM Parameter Store.

Clarifies the order of precedence for how the license key is loaded.

## Configuration Logic
The documentation now explains that the application uses the following order of precedence to find the license key:

`NEW_RELIC_LICENSE_KEY`: If this variable is set, its value is used directly.

`NEW_RELIC_LICENSE_KEY_SECRET` or `NEW_RELIC_LICENSE_KEY_SSM_PARAMETER`: If `NEW_RELIC_LICENSE_KEY` is not set, the extension will attempt to use one of these variables to fetch the key from the respective AWS service.