### PR TITLE
chore: updated description for ssm and sm with role overview

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -413,14 +413,32 @@ You can find more environment variables in our [.NET configuration documentation
             <td>`NEW_RELIC_LICENSE_KEY_SECRET`</td>
             <td></td>
             <td></td>
-            <td>Specify the name of the Secret key from AWS Secrets Manager that contains your license key. Note: This is only used if NEW_RELIC_LICENSE_KEY is not set.</td>
+            <td>
+                Specify the **name** or **ARN** of the secret from AWS Secrets Manager that contains your New Relic license key.
+                <br/><br/>
+                **Notes:**
+                <ul>
+                    <li>This is only used if `` `NEW_RELIC_LICENSE_KEY` `` is not set.</li>
+                    <li>The secret must be in the same AWS region as your Lambda function.</li>
+                    <li>Your Lambda function's execution role needs the `` `secretsmanager:GetSecretValue` `` permission for this secret.</li>
+                </ul>
+            </td>
         </tr>
         <tr>
             <td>`NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME`</td>
             <td></td>
             <td></td>
-            <td>Specify the SSM parameter name from the AWS Systems Manager Parameter Store that contains your license key. Note: This is only used if NEW_RIC_LICENSE_KEY is not set</td>
-        </tr>      
+            <td>
+                Specify the **name** or **ARN** of the parameter from the AWS Systems Manager Parameter Store that contains your New Relic license key.
+                <br/><br/>
+                **Notes:**
+                <ul>
+                    <li>This is only used if `` `NEW_RELIC_LICENSE_KEY` `` is not set.</li>
+                    <li>The SSM parameter must be in the same AWS region as your Lambda function.</li>
+                    <li>Your Lambda function's execution role needs the `` `ssm:GetParameter` `` permission for this parameter.</li>
+                </ul>
+            </td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
### **Description**

This PR updates the documentation for `NEW_RELIC_LICENSE_KEY_SECRET` and `NEW_RELIC_LICENSE_KEY_SSM_PARAMETER_NAME`.

The new descriptions clarify that users can provide either the **name or the ARN** of the secret/parameter. They also include important requirements:

* The AWS secret or parameter must be in the **same region** as the Lambda function.
* The function's execution role needs the appropriate **IAM permissions** (`secretsmanager:GetSecretValue` or `ssm:GetParameter`).