### PR TITLE
fix: broken link to NRU course

### DIFF
--- a/src/content/docs/tutorial-create-alerts/manage-alert-quality.mdx
+++ b/src/content/docs/tutorial-create-alerts/manage-alert-quality.mdx
@@ -21,7 +21,7 @@ You're a good candidate for AQM if:
 * Your customers discover your issues before your monitoring tools do.
 
 <Callout variant="tip">
-  Want to try a hands on learning approach before you start implementing this in your account? Check out the [alert quality management lab](https://learn.newrelic.com/hands-on-lab-alert-quality-management).
+  Want to try a hands on learning approach before you start implementing this in your account? Check out the [alert quality management course](https://learn.newrelic.com/elevate-your-alerts-alert-quality-management).
 </Callout>
 
 ## Why use alert quality management? [#why-aqm]


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
There was an outdated link to an NRU course that was giving a 404 error - this replaces that link with the correct one. 

* Add any context that will help us review your changes such as testing notes,
old link: https://learn.newrelic.com/hands-on-lab-alert-quality-management
new link: https://learn.newrelic.com/elevate-your-alerts-alert-quality-management