### PR TITLE
chor: added new eol date for synthetic monitoring IPs

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -137,11 +137,6 @@ It is recommended to remove the following old IP ranges before 30th September 20
   </thead>
   <tbody>
     <tr>
-      <td>us-east-1</td>
-      <td>Washington, DC, USA</td>
-      <td>44.202.178.0/24, 44.202.180.0/23, 44.210.68.0/24, 44.210.110.0/25</td>
-    </tr>
-    <tr>
       <td>us-east-2</td>
       <td>Columbus, OH, USA</td>
       <td>3.145.224.0/24, 3.145.225.0/25, 3.145.234.0/24</td>

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -123,7 +123,7 @@ It is recommended that you add the entire global ranges provided by New Relic to
   </tbody>
 </table>
 
-It is recommended to remove the following old IP ranges before 30th September 2025.
+It is recommended to remove the following old IP ranges before September 30, 2025.
 
 **Old IP Range:**
 

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -45,9 +45,11 @@ IP addresses for released locations are subject to change. If a change is needed
   * 212.32.0.0/20 
   * 64.251.192.0/20
 
-  <DNT>**If no action is taken**</DNT>
-  
-  If you do not update your allowlists by **May 14, 2025**, your Synthetics checks may fail to connect to your applications, which may result in failed connections and trigger alerts.
+  The following IP ranges will remain in use for the `us-east-1` region:
+
+    * 44.202.178.0/24
+    * 44.202.180.0/23
+    * 44.210.68.0/24  
 </Callout>
 
 <table style={{ width: "300px" }}>
@@ -67,9 +69,9 @@ IP addresses for released locations are subject to change. If a change is needed
 </table>
 
 <Callout variant="important">
-It is recommended that you add the entire global ranges provided by New Relic to your allow list. The JSON file has now been updated to include a regional breakdown of the new IP ranges. Any region not mentioned in the new list will continue using old IPs.
+It is recommended that you add the entire global ranges provided by New Relic to your allowlist. The JSON file has now been updated to include a regional breakdown of the new IP ranges. Any region not mentioned in the new list will continue using old IPs.
 
-**New IP Range:**
+The following IP ranges are available for use:
 
 <table>
   <thead>
@@ -83,7 +85,7 @@ It is recommended that you add the entire global ranges provided by New Relic to
     <tr>
       <td>us-east-1</td>
       <td>Washington, DC, USA</td>
-      <td>152.38.128.64/26, 152.38.132.0/24, 64.251.196.0/24</td>
+      <td>152.38.128.64/26, 152.38.132.0/24, 64.251.196.0/24, 44.202.178.0/24, 44.202.180.0/23, 44.210.68.0/24</td>
     </tr>
     <tr>
       <td>us-east-2</td>
@@ -123,56 +125,6 @@ It is recommended that you add the entire global ranges provided by New Relic to
   </tbody>
 </table>
 
-It is recommended to remove the following old IP ranges before September 30, 2025.
-
-**Old IP Range:**
-
-<table>
-  <thead>
-    <tr>
-      <th>Region</th>
-      <th>Location</th>
-      <th>IP Range</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>us-east-2</td>
-      <td>Columbus, OH, USA</td>
-      <td>3.145.224.0/24, 3.145.225.0/25, 3.145.234.0/24</td>
-    </tr>
-    <tr>
-      <td>us-west-1</td>
-      <td>San Francisco, CA, USA</td>
-      <td>3.101.204.0/23, 3.101.212.0/24, 3.101.209.192/26</td>
-    </tr>
-    <tr>
-      <td>us-west-2</td>
-      <td>Portland, OR, USA</td>
-      <td>35.89.46.0/23, 35.92.27.0/24</td>
-    </tr>
-    <tr>
-      <td>eu-west-1</td>
-      <td>Dublin, IE</td>
-      <td>3.251.231.0/24, 3.251.230.64/26, 3.252.47.0/25</td>
-    </tr>
-    <tr>
-      <td>eu-west-2</td>
-      <td>London, England, UK</td>
-      <td>13.40.201.0/24, 13.40.208.0/25, 13.41.206.128/25, 13.41.206.64/26</td>
-    </tr>
-    <tr>
-      <td>eu-central-1</td>
-      <td>Frankfurt, DE</td>
-      <td>3.71.170.0/24, 3.71.103.96/27, 3.75.4.128/25</td>
-    </tr>
-    <tr>
-      <td>ap-southeast-2</td>
-      <td>Sydney, AU</td>
-      <td>3.26.252.0/24, 3.26.245.128/25, 3.27.51.0/25</td>
-    </tr>
-  </tbody>
-</table>
 
 </Callout>
 

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -123,7 +123,7 @@ It is recommended that you add the entire global ranges provided by New Relic to
   </tbody>
 </table>
 
-It is recommended not to remove the old IP ranges until notified.
+It is recommended to remove the following old IP ranges before 30th September 2025.
 
 **Old IP Range:**
 

--- a/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/administration/synthetic-public-minion-ips.mdx
@@ -49,7 +49,8 @@ IP addresses for released locations are subject to change. If a change is needed
 
     * 44.202.178.0/24
     * 44.202.180.0/23
-    * 44.210.68.0/24  
+    * 44.210.68.0/24
+    * 44.210.110.0/25
 </Callout>
 
 <table style={{ width: "300px" }}>
@@ -85,7 +86,7 @@ The following IP ranges are available for use:
     <tr>
       <td>us-east-1</td>
       <td>Washington, DC, USA</td>
-      <td>152.38.128.64/26, 152.38.132.0/24, 64.251.196.0/24, 44.202.178.0/24, 44.202.180.0/23, 44.210.68.0/24</td>
+      <td>152.38.128.64/26, 152.38.132.0/24, 64.251.196.0/24, 44.202.178.0/24, 44.202.180.0/23, 44.210.68.0/24, 44.210.110.0/25</td>
     </tr>
     <tr>
       <td>us-east-2</td>

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -30,7 +30,7 @@ We will be migrating the IP address range for the New Relic service used by Synt
 
 * After **May 28, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 
-**Old IP ranges to remove:** The following table list the old IP ranges however, it is recommended not to remove the old IP ranges until notified.
+**Old IP ranges to remove:** The following table list the old IP ranges that you must remove before 30th September 2025.
 
 <table>
   <thead>

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -31,7 +31,8 @@ We will be migrating the IP address range for the New Relic service used by Synt
 * The following IP ranges will remain in use for the `us-east-1` region:
   * 44.202.178.0/24
   * 44.202.180.0/23
-  * 44.210.68.0/24  
+  * 44.210.68.0/24
+  * 44.210.110.0/25
 
 * After **September 30, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -33,9 +33,9 @@ We will be migrating the IP address range for the New Relic service used by Synt
   * 44.202.180.0/23
   * 44.210.68.0/24  
 
-* After **May 28, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
+* After **September 30, 20255**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 
-**Old IP ranges to remove:** The following table list the old IP ranges that you must remove before 30th September 2025.
+**Old IP ranges to remove:** The following table list the old IP ranges that you must remove before September 30, 2025.
 
 <table>
   <thead>

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -28,6 +28,11 @@ We will be migrating the IP address range for the New Relic service used by Synt
 
   * `64.251.192.0/20`
 
+* The following IP ranges will remain in use for the `us-east-1` region:
+  * 44.202.178.0/24
+  * 44.202.180.0/23
+  * 44.210.68.0/24  
+
 * After **May 28, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 
 **Old IP ranges to remove:** The following table list the old IP ranges that you must remove before 30th September 2025.

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -42,11 +42,6 @@ We will be migrating the IP address range for the New Relic service used by Synt
   </thead>
   <tbody>
     <tr>
-      <td>us-east-1</td>
-      <td>Washington, DC, USA</td>
-      <td>44.202.178.0/24 <br>44.202.180.0/23 <br> 44.210.68.0/24 <br> 44.210.110.0/25</td>
-    </tr>
-    <tr>
       <td>us-east-2</td>
       <td>Columbus, OH, USA</td>
       <td>3.145.224.0/24 <br> 3.145.225.0/25 <br> 3.145.234.0/24</td>

--- a/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
+++ b/src/content/eol/2025/02/eol-01-31-25-synthetics-ip.md
@@ -33,7 +33,7 @@ We will be migrating the IP address range for the New Relic service used by Synt
   * 44.202.180.0/23
   * 44.210.68.0/24  
 
-* After **September 30, 20255**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
+* After **September 30, 2025**, remove the old IP ranges from the allowlist. Failure to do so may result in failed connections and trigger alerts.
 
 **Old IP ranges to remove:** The following table list the old IP ranges that you must remove before September 30, 2025.
 


### PR DESCRIPTION
This PRs adds a new date to remove old IPs from the synthetic monitors 