### PR TITLE
chore(browser): Update browser agent harvest docs

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/additional-information.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/additional-information.mdx
@@ -40,7 +40,7 @@ Session replay minimizes impact on your applications performance with:
   * GZIP compression
   * Duplication reduction
   * Strategic payload harvesting: A large (compressed) payload is sent only when the full DOM is captured, which typically occurs when the replay feature is first imported. Subsequently, only small payloads related to the user's actions are sent. The browser agent will harvest data based on the first occurrence of the following conditions:
-    * The payload reaches more than 64 KB compressed.
-    * 60 seconds elapses.
+    * The payload reaches more than 16 kB compressed.
+    * 30 seconds elapses.
     * The visibility of the page changes (example, tab change, focus, navigation).
     * The session ends.

--- a/src/content/docs/browser/new-relic-browser/lab/debug-slowness.mdx
+++ b/src/content/docs/browser/new-relic-browser/lab/debug-slowness.mdx
@@ -82,7 +82,7 @@ Uh oh! You customers don't look happy. It's time to use New Relic browser monito
       src="/images/browser-lab-screenshot-backend.webp"
     />
 
-    The graph indicates that the back end took maximum 140 mili seconds to process the request in worst case. Does this mean your front end is causing delay?
+    The graph indicates that the back end took maximum 140 milliseconds to process the request in worst case. Does this mean your front end is causing delay?
 
     Click on <DNT>**Front end (Window load + AJAX) (50%)**</DNT>.
 

--- a/src/content/docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/page-load-timing-resources/instrumentation-browser-monitoring.mdx
@@ -165,42 +165,13 @@ For both https <DNT>**and**</DNT> http webpages, we transmit data via https. Thi
 
     <tr>
       <td>
-        Send page view timing data (`PageViewTiming`)
+        All other browser event data
       </td>
 
       <td>
-        Data is sent 10 seconds after the initial page load, and then every 30 seconds afterward. If the harvest payload size is greater than 16 KB, the data is sent early.
+        See [Browser agent harvests](/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact#agent-harvests)
       </td>
     </tr>
 
-    <tr>
-      <td>
-        Send AJAX and JavaScript error data
-      </td>
-
-      <td>
-        Once every 10 seconds when there is activity via https
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Send session trace data
-      </td>
-
-      <td>
-        Every ten seconds when there is activity and a session trace is occurring via https
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Send SPA data
-      </td>
-
-      <td>
-        At the end of an interaction via https
-      </td>
-    </tr>
   </tbody>
 </table>

--- a/src/content/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact.mdx
+++ b/src/content/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact.mdx
@@ -97,6 +97,8 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
 
 ### Browser agent harvests [#agent-harvests]
 
+Browser events are first harvested after the PageView event is successfully collected, and then every 30 seconds thereafter. If any event type exceeds 16 kB of data before the next scheduled harvest, an early harvest is triggered for that event.  Additionally, a final harvest occurs whenever the document transitions to `hidden` via a `visibilitychange` event (e.g. when a user navigates away, switches tabs, closes the tab, minimizes or closes the browser, or, on mobile, switches from the browser to another app).
+
 <table>
   <thead>
     <tr>
@@ -163,7 +165,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `PageViewTiming` events are harvested by all agents and includes timing data like core web vitals measurements. The first harvest happens 10 seconds after the `load` page lifecycle event. Additional harvests occur every 30 seconds as needed when there's data to send or if the harvest payload size is greater than 16 KB. See the [PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of reported events.
+        `PageViewTiming` events are harvested by all agents and includes timing data like core web vitals measurements. See the [PageViewTiming docs](/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details/#interactivity-metrics) for a list of reported events.
       </td>
     </tr>
 
@@ -185,7 +187,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `JavaScriptError` metrics are harvested every 10 seconds after the `load` page lifecycle event. This harvest is sent as metric timeslice data and also includes the Ajax metrics.
+        `JavaScriptError` metrics are sent together with Ajax metrics as timeslice data.
       </td>
     </tr>
 
@@ -229,7 +231,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `AjaxRequest` events are harvested every 10 seconds after the `load` page lifecycle event unless the `SPA` agent is in use. If using the `SPA` agent, the first harvest will happen after the `load` page lifecycle event. Subsequent harvests will either happen every 10 seconds or when the `SPA` agent notices a route change.
+        `AjaxRequest` events follows the 30 seconds harvest cycle unless the `SPA` agent is in use. If using the `SPA` agent, the first harvest will happen after the `load` page lifecycle event and additional harvests will either happen every 30 seconds or when the `SPA` agent notices a route change.
       </td>
     </tr>
 
@@ -251,7 +253,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        Session trace data is harvested after the `load` page lifecycle event. Subsequent harvest happen every 10 seconds if enough data has been collected. Session traces send the most data, but they are heavily sampled. Only about 75 page views per hour get enabled to send session trace data.
+        Session traces can generate a large amount of data, but that can be controlled by sampling. By default, only about 90 page views per hour will be sampled to send session trace data.  There is also an option to set a custom sampling rate.
       </td>
     </tr>
 
@@ -273,11 +275,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        Session replay events are harvested when one of the following occurs:
-
-        * When the compressed data collected for the session reaches a maximum size of 64 KB.
-        * If the user remains on the same page for more than 60 seconds.
-        * When visibility of the page changes (tab change, focus, navigation, etc)
+        In addition to the the general harvest cycles, session replay harvests that include snapshots and metadata payloads will be harvested immediately.
 
         The endpoint can differ depending on the locale, but an example for US would be `https://bam.nr-data.net/browser/blobs`.
       </td>
@@ -301,7 +299,6 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `PageAction` events are harvested after the `load` page lifecycle event, Subsequent harvests happen every 30 seconds or if the harvest payload size is greater than 16 KB.
       </td>
     </tr>
 
@@ -323,7 +320,70 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
       </td>
 
       <td>
-        `BrowserInteraction` events are harvested immediately after the interaction finishes. The first harvest happens after the `load` page lifecycle event. There will always be at least one interaction that represents the initial page load. Additional interactions are collected only if the URL changes (representing route change). `AjaxRequest` events are also harvested at the same time if they occur during an interaction.
+        `BrowserInteraction` events are harvested immediately after the interaction finishes. There will always be at least one interaction that represents the initial page load. Additional interactions are collected only if the URL changes (representing route change). `AjaxRequest` events are also harvested at the same time if they occur during an interaction.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Browser logs
+      </td>
+
+      <td>
+        no
+      </td>
+
+      <td>
+        yes
+      </td>
+
+      <td>
+        yes
+      </td>
+
+      <td>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [UserAction](/attribute-dictionary/?event=UserAction) events
+      </td>
+
+      <td>
+        no
+      </td>
+
+      <td>
+        yes
+      </td>
+
+      <td>
+        yes
+      </td>
+
+      <td>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [BrowserPerformance](/attribute-dictionary/?event=BrowserPerformance) events
+      </td>
+
+      <td>
+        no
+      </td>
+
+      <td>
+        yes
+      </td>
+
+      <td>
+        yes
+      </td>
+
+      <td>
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact.mdx
+++ b/src/content/docs/browser/new-relic-browser/performance-quality/browser-monitoring-performance-impact.mdx
@@ -97,7 +97,7 @@ The agent consists of multiple scripts to reduce the initial size of the "loader
 
 ### Browser agent harvests [#agent-harvests]
 
-Browser events are first harvested after the PageView event is successfully collected, and then every 30 seconds thereafter. If any event type exceeds 16 kB of data before the next scheduled harvest, an early harvest is triggered for that event.  Additionally, a final harvest occurs whenever the document transitions to `hidden` via a `visibilitychange` event (e.g. when a user navigates away, switches tabs, closes the tab, minimizes or closes the browser, or, on mobile, switches from the browser to another app).
+Browser events are first harvested after the PageView event is successfully collected, and then every 30 seconds thereafter. If any event type exceeds 16 kB of data before the next scheduled harvest, an early harvest is triggered for that event.  Additionally, a final harvest occurs whenever the document transitions to `hidden` via a `visibilitychange` event (e.g. when a user navigates away, switches tabs, closes the tab, minimizes or closes the browser, or switches from the browser to another app if they're on a mobile device).
 
 <table>
   <thead>


### PR DESCRIPTION
- Add new summary as source-of-truth for harvest cycle timing + final harvest
- Add new rows for Browser logs, UserAction, and BrowserPerformance events

## Give us some context

Per this [ticket](https://new-relic.atlassian.net/browse/NR-399281), we are updating the browser agent harvest docs.
