### PR TITLE
docs: Add description for NEW_RELIC_CLOUD_AWS_ACCOUNT_ID

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -439,6 +439,14 @@ You can find more environment variables in our [.NET configuration documentation
                 </ul>
             </td>
         </tr>
+        <tr>
+            <td>`NEW_RELIC_CLOUD_AWS_ACCOUNT_ID`</td>
+            <td></td>
+            <td></td>
+            <td>
+               Specify the AWS ACCOUNT ID for target datasource to get proper relation ship entity created with database and lambda function.
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -444,7 +444,7 @@ You can find more environment variables in our [.NET configuration documentation
             <td></td>
             <td></td>
             <td>
-               Specify the AWS ACCOUNT ID for target datasource to get proper relation ship entity created with database and lambda function.
+               Provide the AWS Account ID where your monitored resources (e.g., databases, Lambda functions) are located. This allows New Relic to correctly map and display                       relationships between these monitored entities.
             </td>
         </tr>
     </tbody>

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -444,7 +444,7 @@ You can find more environment variables in our [.NET configuration documentation
             <td></td>
             <td></td>
             <td>
-               Provide the AWS Account ID where your monitored resources (e.g., databases, Lambda functions) are located. This allows New Relic to correctly map and display                       relationships between these monitored entities.
+               Provide the AWS Account ID where your monitored resources (e.g., databases, Lambda functions) are located. This allows New Relic to correctly map and display  relationships between these monitored entities.
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
**Description:**

#### What does this PR do?

This PR introduces documentation for the `NEW_RELIC_CLOUD_AWS_ACCOUNT_ID` environment variable, which was previously undocumented.

#### Why is this change needed?

The purpose of the `NEW_RELIC_CLOUD_AWS_ACCOUNT_ID` variable was unclear without documentation. Adding this description helps users understand that this variable is essential for New Relic to correctly map entity relationships between monitored AWS resources (like databases and Lambda functions). This will improve the configuration experience and prevent setup errors.

#### Added Documentation

The following description has been added:

```html
<td>
  Provide the AWS Account ID where your monitored resources (e.g., databases, Lambda functions) are located. This allows New Relic to correctly map and display relationships between these monitored entities.
</td>
```