### PR TITLE
docs(infra_integration_interval): Add infra agent integrations max interval note section

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format.mdx
+++ b/src/content/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format.mdx
@@ -607,6 +607,10 @@ The properties of this section modify the way the infrastructure agent executes 
 
     The default is `30s`, and the minimum accepted value is `15s`. Any value lower than `15s` is automatically set to `15s`.
 
+    <Callout variant="important">
+      Please note that for accurate reporting of metrics (especially rate metrics), the interval must be set to 5m (5 minutes) or less. Longer intervals can lead to inaccurate or missing data for these specific metrics.
+    </Callout>
+
     Example:
 
     ```


### PR DESCRIPTION
Added infra agent integrations max interval note section

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

Give us some context
What problems does this PR solve?
Infra agent integration have a interval field which can have time interval in min,sec,hr, But for rate metrics we have a TTL of 5 min for comparision with the previous value, So added a Note section in the doc explaining we can have a greater time interval bt that will lead to an inaccurate metrics calculation. So 5 min is the max interval time that is suggested from NR

Add any context that will help us review your changes such as testing notes,
links to related docs, screenshots, etc.
https://docs.newrelic.com/docs/infrastructure/host-integrations/infrastructure-integrations-sdk/specifications/host-integrations-standard-configuration-format/#interval

If your issue relates to an existing GitHub issue, please link to it.