### PR TITLE
remove: important banner from New Relic iOS agent 7.5.9 rel notes

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-759.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-759.mdx
@@ -5,14 +5,6 @@ version: 7.5.9
 downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agent_7.5.9.zip'
 ---
 
-<Callout variant="important">
-Starting from iOS SDK version 7.5.4, a change has been implemented that causes previously suppressed Handled Exception events to be reported.
-
-Please update to New Relic iOS agent 7.5.9. We've identified a bug in iOS SDK version 7.5.8 that could cause incorrect data upload, and a fix is included in the New Relic iOS agent 7.5.9 release.
-
-Please update to New Relic iOS agent 7.5.9. We've identified a bug in iOS SDK version 7.5.7 that could cause a crash on agent launch, and a fix is included in the New Relic iOS agent 7.5.9 release.
-</Callout>
-
 ## Fixed in this release
 
 * Agent is built using Xcode 16.4.


### PR DESCRIPTION
remove: important banner from New Relic iOS agent 7.5.9 rel notes