### PR TITLE
.NET Agent: Update all APT repo install instructions

### DIFF
--- a/src/install/dotnet/installation/azure-linux-container.mdx
+++ b/src/install/dotnet/installation/azure-linux-container.mdx
@@ -26,9 +26,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
 # Install the agent
-RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
+RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
+&& echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /etc/apt/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
@@ -59,9 +59,9 @@ RUN dotnet publish -c Release -o /app ./YOUR_APP_NAME
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
 # Install the agent
-RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
+RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
+&& echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /etc/apt/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent
 

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -25,9 +25,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
 # Install the agent
-RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
+RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
+&& echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /etc/apt/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent \
 && rm -rf /var/lib/apt/lists/*
@@ -60,9 +60,9 @@ RUN dotnet publish -c Release -o /app ./YOUR_APP_NAME
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
 # Install the agent
-RUN apt-get update && apt-get install -y wget ca-certificates gnupg \
-&& echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
-&& wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg \
+RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
+&& echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
+&& curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /etc/apt/keyrings/newrelic-apt.gpg \
 && apt-get update \
 && apt-get install -y newrelic-dotnet-agent
 

--- a/src/install/dotnet/installation/linuxInstall2.mdx
+++ b/src/install/dotnet/installation/linuxInstall2.mdx
@@ -32,15 +32,19 @@ To start installing the agent, choose your package manager:
 
   <TabsPages>
     <TabsPageItem id="apt">
+      <Callout variant="important">
+        The following commands assume that you have `sudo` installed and are able to use it, as well as having `curl` and `gpg` installed.
+      </Callout>
+
       1. Configure the New Relic APT repository by adding `deb https://apt.newrelic.com/debian/ newrelic non-free` to `/etc/apt/sources.list.d/newrelic.list`:
 
          ```bash
-         echo 'deb [signed-by=/usr/share/keyrings/newrelic-apt.gpg] https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
+         echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] https://apt.newrelic.com/debian/ newrelic non-free' | sudo tee /etc/apt/sources.list.d/newrelic.list
          ```
-      2. Enable New Relic's GPG key to allow apt to find New Relic packages. To avoid possible errors about public keys, run this command as root:
+      2. Enable New Relic's GPG key to allow apt to find New Relic packages.
 
          ```bash
-         wget -O- https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/newrelic-apt.gpg
+         curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor | sudo tee /etc/apt/keyrings/newrelic-apt.gpg >/dev/null
          ```
       3. Update the local package list:
 


### PR DESCRIPTION
This PR makes the following changes to all APT-based install instructions for the .NET agent:

1. Switch from `wget` to `curl`, as curl is more likely to be installed by default on most Linux distros.
2. Signing key location moved from `/usr/share/keyrings` to `/etc/apt/keyrings` based on new information about where these keyfiles should go by convention (keys managed "manually" by users go in /etc/apt/keyrings; /usr/share/keyrings is for keys managed by packages)
3. Using `gpg --dearmor` instead of what was there before allows these instructions to work on newer distros like Debian 13 where the APT command has been upgraded to >=v3 and it uses Sequoia instead of GNUPG for its OpenPGP key verification needs.