### PR TITLE
fix: translation of Fluent Bit package name to Spanish

### DIFF
--- a/src/i18n/content/es/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/openshift/fluent-bit.mdx
+++ b/src/i18n/content/es/docs/kubernetes-pixie/kubernetes-integration/troubleshooting/openshift/fluent-bit.mdx
@@ -17,7 +17,7 @@ Estás recibiendo errores como `cannot increase buffer: current=32000 requested=
 
 ## Solución
 
-Agregue el atributo `k8sBufferSize` para aumentar el tamaño del búfer del bit fluido.
+Agregue el atributo `k8sBufferSize` para aumentar el tamaño del búfer de Fluent Bit.
 
 ```yaml
 newrelic-logging:

--- a/src/i18n/content/es/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/i18n/content/es/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -38,8 +38,8 @@ La forma de reenviar su log depende de cómo instaló el agente de infraestructu
 ## Requisito del sistema [#system]
 
 * Agente de infraestructura versión 1.11.4 o superior
-* [Poco fluido](https://fluentbit.io/). El agente de infraestructura ya instala la última versión. Para actualizarlo o degradarlo a una versión específica, consulte los procedimientos [de instalación de Fluent Bit](#install-fb-version) .
-* Biblioteca OpenSSL 1.1.0 o mas alto
+* [Fluent Bit](https://fluentbit.io/). El agente de infraestructura ya instala la última versión. Para actualizarlo o degradarlo a una versión específica, consulte los procedimientos [de instalación de Fluent Bit](#install-fb-version) .
+* Biblioteca OpenSSL 1.1.0 o más alto
 * Se agregó soporte integrado para la arquitectura ARM64 en sistemas Linux (por ejemplo, la arquitectura AWS Graviton) en el agente de infraestructura [1.20.6](https://github.com/newrelic/infrastructure-agent/releases/tag/1.20.6).
 * Amazon Linux 2 y 2023
 * CentOS versión 8 y 9 Stream (Rocky Linux y AlmaLinux también son compatibles)
@@ -746,7 +746,7 @@ Nuestro proceso de instalación personalizado de Linux para monitoreo de infraes
    * `/var/db/newrelic-infra/newrelic-integrations/logging`
    * `/etc/newrelic-infra/logging.d`
 
-2. Descargue e instale [el paquete de bits fluidos (RPM)](https://github.com/newrelic/fluent-bit-package/releases) de New Relic ejecutando un comando similar a:
+2. Descargue e instale [el paquete de Fluent Bit (RPM)](https://github.com/newrelic/fluent-bit-package/releases) de New Relic ejecutando un comando similar a:
 
    ```shell
    yum localinstall fluent-bit-<some-version>.rpm

--- a/src/i18n/content/es/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1640.mdx
+++ b/src/i18n/content/es/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1640.mdx
@@ -20,7 +20,7 @@ Se lanzó una nueva versión del agente. Siga los procedimientos estándar para 
 
 * Corrección: Se solucionó el escape del carácter hash en el análisis de configuración YAML de nri-flex [#2028](https://github.com/newrelic/infrastructure-agent/pull/2028)
 * Corrección: Se eliminó la barra diagonal final en el prefijo obligatorio cuando la ruta está vacía [#2037](https://github.com/newrelic/infrastructure-agent/pull/2037)
-* Se actualizó la versión de bits fluidos a 3.2.10 [#2045](https://github.com/newrelic/infrastructure-agent/pull/2045)
+* Se actualizó la versión de Fluent Bit a 3.2.10 [#2045](https://github.com/newrelic/infrastructure-agent/pull/2045)
 * Chore(deps): Se actualizó la dependencia newrelic/nri-docker a v2.5.0 [#2027](https://github.com/newrelic/infrastructure-agent/pull/2027)
 * Chore(deps): Se actualizó la dependencia newrelic/nri-prometheus a la versión 2.25.0 [#2016](https://github.com/newrelic/infrastructure-agent/pull/2016)
 * Versiones de dependencia aumentadas [n.° 2046](https://github.com/newrelic/infrastructure-agent/pull/2046)


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

I noticed the [Fluent Bit](https://fluentbit.io/) product name was translated literally in the Spanish documentation, leading to nonsensical text (including things like "a little fluent" or "the fluent bits"). This fixes these occurrences.