### PR TITLE
feat[Alert notification workflow][DO NOT MERGE]: Added new email validation steps and limits on adding email ID to destinations

### DIFF
--- a/src/content/docs/alerts/admin/rules-limits-alerts.mdx
+++ b/src/content/docs/alerts/admin/rules-limits-alerts.mdx
@@ -359,6 +359,37 @@ This page describes limits and rules pertaining to New Relic <InlinePopover type
       </td>
     </tr>
 
+    <tr>
+      <td>
+
+      </td>
+      <td>
+        Email addresses per destination
+      </td>
+      <td>
+        1 email address
+      </td>
+      <td>
+        * Free accounts: 5 email addresses per destination
+        * Paid accounts: 150 email addresses per destination
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+
+      </td>
+      <td>
+        Email addresses per organization per 24 hours
+      </td>
+      <td>
+        N/A
+      </td>
+      <td>
+        1000 unique email addresses (applies to all users)
+      </td>
+    </tr>
+
   </tbody>
 </table>
 

--- a/src/content/docs/alerts/get-notified/notification-integrations.mdx
+++ b/src/content/docs/alerts/get-notified/notification-integrations.mdx
@@ -16,6 +16,7 @@ Alerts notification integrations allow you to connect specific services and plat
 Read more about each of our specific notification integrations.
 
 <CollapserGroup>
+
   <Collapser
     className="freq-link"
     id="jira"
@@ -186,7 +187,7 @@ Read more about each of our specific notification integrations.
   >
     The email destination is created automatically when you choose <DNT>**Email**</DNT> as the notification channel for a [workflow](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/), so you don't need to configure that from the <DNT>**Destinations**</DNT> menu. Each email destination is unique to the workflow associated with it, and this means that it may appear as a duplicate in the destinations feed.
 
-    To send an email notification:
+    To configure workflow for alerts in email notification:
 
     1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts**</DNT>.
 
@@ -205,11 +206,11 @@ Read more about each of our specific notification integrations.
 
     5. Filter the data you need. You can choose between <DNT>**Basic**</DNT> and <DNT>**Advanced**</DNT> options to add the issues you want to send.
 
-    6. Click <DNT>**Additional settings**</DNT> to enrich your data. Enable <DNT>**Enrich your data**</DNT> to build a NRQL query.
+    6. To enrich your data or configure notification settings for muted issues, click <DNT>**Additional settings**</DNT>.
+        - To enrich data, enable <DNT>**Enrich your data**</DNT>, build NRQL query, then save and exit.
+        - To configure notification settings for muted issues, choose one of the available option as per your requirement.
 
-    7. Click <DNT>**Save and exit**</DNT>.
-
-    8. Select <DNT>**Email**</DNT> as notification method.
+    7. Select <DNT>**Email**</DNT> as notification method.
 
        <img
          width="60%;"
@@ -218,13 +219,19 @@ Read more about each of our specific notification integrations.
          src="/images/accounts_screenshot-crop_email-settings.webp"
        />
 
-    9. Add the emails you want to send notifications to. You can add one or more recipients.
+    9. Add recipients: 
+    Type the recipient name or email address. Destinations having the email address will appear in the feed - choose one. If you want to create a new destination:
+        1. From the feed one or click <DNT>**Create new destination**</DNT>.
+        2. To create a new destination, on the <DNT>**Add a destination**</DNT> page, add recipients by searching their email ID or username, enter a unique name for the destination, and save.
+            * If an email address is already associated with an existing destination, you'll be prompted to merge them. Select <DNT>**Merge**</DNT> to combine destinations.
+           * If you have added a new email address, the recipient will receive a verification email. The recipient must complete the verification process to start receiving notifications.
 
-       * You can find users with New Relic accounts by searching for their email address.
-       * To add a user without a New Relic account or email distribution list, enter their full email address.
-       * Each list of email addresses added to the email settings will create its own unique destination, which will appear in the destination feed.
-       * When you create a destination with an email address already associated with an existing destination, a prompt will appear offering the option to merge the two. Selecting <DNT>**Merge**</DNT> will combine the destinations, ensuring notifications are efficiently routed to the intended recipient.
-       * You can follow the email notifications per destination in the [notifications log](/docs/alerts-applied-intelligence/notifications/destinations/#notifications-log).
+      <Callout variant="tip">
+ Email destination limits:
+                  * **Free accounts**: Each destination can have a maximum of 5 email addresses.
+                  * **Paid accounts**: Each destination can have a maximum of 150 email addresses.
+                  * **Organization limit**: 1000 unique email addresses can be added per customer organization per 24 hours (applies to all users).
+</Callout>
 
     10. Customize the email message.
 
@@ -237,6 +244,10 @@ Read more about each of our specific notification integrations.
     12. Click <DNT>**Save**</DNT>.
 
     13. Click <DNT>**Activate workflow**</DNT>.
+
+    <Callout variant="tip">
+         You can keep track of all notifications generated for the email per destination in the [notifications log](/docs/alerts-applied-intelligence/notifications/destinations/#notifications-log).
+    </Callout>
 
     From the Workflow main page, you can enable, edit, delete, or copy workflow id to clipboard the created workflow.
   </Collapser>
@@ -971,6 +982,7 @@ Read more about each of our specific notification integrations.
     }
     ```
   </Collapser>
+
 </CollapserGroup>
 
 ## Migrate your legacy Slack destinations to the new Slack destination [#migrate-slack]

--- a/src/content/docs/alerts/get-notified/notification-integrations.mdx
+++ b/src/content/docs/alerts/get-notified/notification-integrations.mdx
@@ -226,7 +226,7 @@ Read more about each of our specific notification integrations.
             * If an email address is already associated with an existing destination, you'll be prompted to merge them. Select <DNT>**Merge**</DNT> to combine destinations.
            * If you have added a new email address, the recipient will receive a verification email. The recipient must complete the verification process to start receiving notifications.
 
-      <Callout variant="tip">
+      <Callout variant="important">
  Email destination limits:
                   * **Free accounts**: Each destination can have a maximum of 5 email addresses.
                   * **Paid accounts**: Each destination can have a maximum of 150 email addresses.

--- a/src/content/docs/alerts/get-notified/notification-integrations.mdx
+++ b/src/content/docs/alerts/get-notified/notification-integrations.mdx
@@ -220,9 +220,9 @@ Read more about each of our specific notification integrations.
        />
 
     9. Add recipients: 
-    Type the recipient name or email address. Destinations having the email address will appear in the feed - choose one. If you want to create a new destination:
-        1. From the feed one or click <DNT>**Create new destination**</DNT>.
-        2. To create a new destination, on the <DNT>**Add a destination**</DNT> page, add recipients by searching their email ID or username, enter a unique name for the destination, and save.
+    Type the recipient name or email address. Destinations having that user will appear in the feed - choose one. If you want to create a new destination for the user:
+        1. From the feed click <DNT>**Create new destination**</DNT>.
+        2. On the <DNT>**Add a destination**</DNT> page, add recipients by searching their email ID or username, enter a unique name for the destination, and save.
             * If an email address is already associated with an existing destination, you'll be prompted to merge them. Select <DNT>**Merge**</DNT> to combine destinations.
            * If you have added a new email address, the recipient will receive a verification email. The recipient must complete the verification process to start receiving notifications.
 


### PR DESCRIPTION

- Introduced validation of new email IDs added in destination for configuring email alert forkflow.
- Added the limit details on how many email IDs can be added in one destination depending on the account type
- Add the org level limit of max 1000 mail IDs cam be added in 24 hours.

https://docs.google.com/document/d/1vfk7NyhM8hBK1GbG-OPWnZEgBG_ZCIzgt7abPriVtIQ/edit?tab=t.b2ud6pp0bbq3
