### PR TITLE
chore [fix]: For customers on compute pricing plan, user type setup is not required

### DIFF
--- a/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/okta-scimsso-application-configuration.mdx
@@ -82,7 +82,12 @@ Next, you'll assign users. Assigning users is done using two different tabs in t
 
 When you've added one or more groups, you should be able to see the users you've added by going to the [<DNT>**User management**</DNT> UI page](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where).
 
-## Step 5. Set your users' user type [#user-type]
+<Callout variant="important">
+If your organization is on a **[Compute pricing plan](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/)**, you can skip **Step 5** entirely. On Compute plans, all users are automatically [Full Platform users](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/), so you don't need to manage their user type.
+
+</Callout>
+
+## Step 5. Set your users' user type (For User-based plans) [#user-type]
 
 When your users are provisioned in New Relic, you're able to see them in the [<DNT>**User management**</DNT> UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where).
 


### PR DESCRIPTION
…

Added a callout to highlight that if a customer is on compute pricing plan, user type setup is not required, as all the users are full platform users.

This changes is based on https://newrelic-neworg.lightning.force.com/lightning/r/Case/500Ph00000mwnEXIAY/view
