### PR TITLE
fix: #tracer-enabled was reused

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3195,7 +3195,7 @@ The `distributedTracing` element supports the following attributes:
 
 <CollapserGroup>
   <Collapser
-    id="tracer-enabled"
+    id="dt-enabled"
     title="enabled"
   >
     <table>


### PR DESCRIPTION
the anchor `tracer-enabled` was reused for transaction traces and dt, so you can't link directly to the dt section

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.