### PR TITLE
chor: remove the new docs section as there no new docs

### DIFF
--- a/src/content/docs/release-notes/docs-release-notes/docs-9-25-2025.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-9-25-2025.mdx
@@ -4,10 +4,6 @@ releaseDate: '2025-09-25'
 version: 'Sep 20 - Sep 25, 2025'
 ---
 
-### New docs
-
-No new documentation was added this week.
-
 ### Major changes
 
 * Updated [New Relic pricing and billing](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing) with comprehensive table restructuring for improved clarity and organization.


### PR DESCRIPTION
We haven't added any new docs last week however RN contains an empty section for new docs. This PR removes that section.