### PR TITLE
Update notification-integrations.mdx

### DIFF
--- a/src/content/docs/alerts/get-notified/notification-integrations.mdx
+++ b/src/content/docs/alerts/get-notified/notification-integrations.mdx
@@ -720,19 +720,9 @@ Read more about each of our specific notification integrations.
 
     ### Prerequisites [#slack-prereqs]
 
-    Your Slack workspace needs to have the [New Relic application](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info)(or the [EU App](https://slack.com/apps/AS5D75HQQ-new-relic-eu?tab=more_info) for `one.eu.newrelic` customers) installed. A workspace administrator must approve the application before you can individually install it. If you need assistance, follow these steps in the UI:
+    Your Slack workspace needs to have the [New Relic application](https://newrelic.slack.com/apps/AP92KQJS3-new-relic?tab=more_info)(or the [EU App](https://slack.com/apps/AS5D75HQQ-new-relic-eu?tab=more_info) for `one.eu.newrelic` customers) installed. A workspace administrator must approve the application before you can individually install it. 
 
-    1. Log in to New Relic.
-
-    2. Visit our [Help Center](https://one.newrelic.com/help-xp).
-
-    3. Click **Create a Support Case**.
-
-       ### Set up a Slack destination [#set-slack-destination]
-
-    4. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts**</DNT>, click <DNT>**Destinations**</DNT>, and then select <DNT>**Slack**</DNT>.
-
-    5. Click the <DNT>**Authenticate in one click**</DNT> button to go to the Slack landing page, and continue the OAuth2 authentication process. If you're not signed into the required workspace, you're redirected to Slack to sign in.
+    1. Click the <DNT>**Authenticate in one click**</DNT> button to go to the Slack landing page, and continue the OAuth2 authentication process. If you're not signed into the required workspace, you're redirected to Slack to sign in.
 
        <img
          width="60%;"
@@ -741,7 +731,7 @@ Read more about each of our specific notification integrations.
          src="/images/accounts_screenshot-crop_slack-destination-authentication.webp"
        />
 
-    6. Add your workspace name or select the relevant workspace, and click <DNT>**Continue**</DNT>.
+    2. Add your workspace name or select the relevant workspace, and click <DNT>**Continue**</DNT>.
 
        <img
          width="50%;"
@@ -750,7 +740,7 @@ Read more about each of our specific notification integrations.
          src="/images/accounts_screenshot-crop_slack-sign-in.webp"
        />
 
-    7. When signed in to the selected workspace, allow New Relic to perform the specified actions.
+    3. When signed in to the selected workspace, allow New Relic to perform the specified actions.
 
        <img
          width="40%;"
@@ -759,7 +749,7 @@ Read more about each of our specific notification integrations.
          src="/images/accounts_screenshot-crop_slack-destination-allow-access.webp"
        />
 
-    8. Click <DNT>**Allow**</DNT>, and return to the destination page.
+    4. Click <DNT>**Allow**</DNT>, and return to the destination page.
 
        <img
          width="80%;"


### PR DESCRIPTION
The Slack Integration install instructions lead the customer to believe they should contact NR support for assistance with approval of the application before they can individually install it. They should contact their internal Slack admin.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

The documentation leads the customer to believe they should contact NR support with their internal Slack permissions and provides instructions on how to create a case for this. This should be removed as support cannot help with this.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.