### PR TITLE
chore[live URLs]: live URLs can only be managed by NerdGraph API. Updated Doc

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally.mdx
@@ -323,7 +323,7 @@ To share a chart with external users, you must complete all the setups outlined 
 
 <Callout variant="caution">Anyone with the live chart URLs can view all the information from the chart. Share information carefully and in accordance with your company's internal policies and procedures.</Callout>
 
-<Callout variant="tip">You can create and manage live chart URLs through both the UI and the [NerdGraph API](/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api). </Callout>
+<Callout variant="tip">You can create live chart URLs through both the UI and the [NerdGraph API](/docs/apis/nerdgraph/examples/manage-live-chart-urls-via-api). However, you can only manage (view, update or delete) live chart URLs through the NerdGraph API.</Callout>
 
 
 To generate a shareable link for your chart:


### PR DESCRIPTION

live URLs can only be managed by NerdGraph API. Updated the callout to reflect it correctly
