### PR TITLE
Announce `newrelic deployments` deprecation

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/features/record-deployments-ruby-agent.mdx
@@ -14,6 +14,12 @@ redirects:
 freshnessValidatedDate: never
 ---
 
+<Callout variant="caution">
+  Support for recording deployments using the `newrelic deployments` command is deprecated and will be removed in agent version 10.0.0. Users should migrate to recording deployments directly via New Relic's APIs. 
+  
+  For more information, please see [Change Tracking documentation](/docs/change-tracking/change-tracking-introduction/).
+</Callout>
+
 The [New Relic Ruby agent](/docs/agents/ruby-agent/getting-started/new-relic-ruby) allows you to send information about application deployments by using the [REST API](/docs/apm/new-relic-apm/maintenance/recording-deployments) or a Capistrano recipe (versions 2.x and 3.x) distributed with the Ruby agent. You can then [view deployments in the New Relic UI](/docs/apm/applications-menu/events/deployments-page). By default, all deployment information is recorded in your production environment. You can also customize the `rails_env` variable for other environments, such as staging.
 
 ## Assign an application name [#Installation]


### PR DESCRIPTION
The `newrelic deployments` command is being [deprecated](https://github.com/newrelic/newrelic-ruby-agent/pull/3262/files) in the agent. We should add a warning to our docsite.