### PR TITLE
Blog for AWS Cloudwatch Metric Stream Integration Cloudformation template update

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/updated-aws-cloudformation-templates.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/updated-aws-cloudformation-templates.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Update AWS CloudWatch Metric Streams integration using updated CloudFormation templates'
+title: 'CloudFormation update for AWS Metric Streams: Upgrade AWS Lambda runtime to Python 3.13'
 subject: Cloud integrations
 releaseDate: '2025-10-03'
 ---

--- a/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/updated-aws-cloudformation-templates.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/cloud-integration-release-notes/updated-aws-cloudformation-templates.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Update AWS CloudWatch Metric Streams integration using updated CloudFormation templates'
+subject: Cloud integrations
+releaseDate: '2025-10-03'
+---
+
+### Update
+
+  * We've released an update to the AWS CloudFormation template for our [Metric Streams integration](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-cwms/). This update resolves a critical issue that could prevent the stack from being updated and use modern AWS Lambda python runtimes.
+
+  * To apply the fix to your existing integration, please follow the steps below to update your CloudFormation stack:
+
+    1. **Navigate to CloudFormation**: Log in to your AWS Management Console and go to the **CloudFormation** service.
+
+    2.  **Select Your Stack**: Find and select your New Relic Metric Streams stack (it's often named `NewRelic-Metric-Streams-*`), then click **Update Stack** dropdown. From the options, select **Make a direct update**. For more information, see the [AWS documentation on directly updating stacks](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-direct.html).
+
+    3. **Replace Template**: On the update screen, you **must** select **Replace current template**.
+
+     **NOTE**: Do not use the "Use existing template" option, as it will not apply the necessary fixes.
+
+    4. **Provide the New Template URL**: Under the *Specify template* section, choose the **Amazon S3 URL** option and paste the following link:
+
+     ```https://nr-downloads-main.s3.amazonaws.com/cloud_integrations/aws/cloudformation/newrelic-cloudformation-mstreams.yml```
+
+    5. **Confirm and Update**: Click **Next** through the parameter and stack options pages. On the final review page, scroll to the bottom, check the box to **acknowledge that AWS CloudFormation might create IAM resources**, and click **Update stack**.
+
+    You can monitor the progress in the **Events** tab. The update is complete when the stack status changes to `UPDATE_COMPLETE`.


### PR DESCRIPTION
Blog about the Cloudformation template update for the AWS Cloudwatch Metric Stream Integration in the Cloud Integrations docs. This update brings new cloudformation template with the usage of latest AWS Lambda python Runtimes.