### PR TITLE
Moved the tip in Agent Control setup instructions to be seen before i…

### DIFF
--- a/src/content/docs/new-relic-control/agent-control/setup.mdx
+++ b/src/content/docs/new-relic-control/agent-control/setup.mdx
@@ -22,7 +22,7 @@ For automating Agent Control setup across large-scale infrastructure, see [Set u
 1. Log in to New Relic.
 2. Ensure the correct account is selected.
 
-<Callout title="tip">
+<Callout title="important">
     To install Agent Control, it is mandatory to have a fleet. If you haven't yet created a fleet for this managed entity, you can create a fleet during the instalaltion in the Guided Install or complete the fleet creation process in **New Relic Control**, and then return to this guided installation step.
 </Callout>
 


### PR DESCRIPTION
…nstall

The tip was placed after showing users how to install. It should be called before users are shown how to install.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.