### PR TITLE
Troubleshooting for k8s apm auto-attach & non-rails

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/troubleshooting/no-data-kubernetes-auto-attach.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/troubleshooting/no-data-kubernetes-auto-attach.mdx
@@ -1,0 +1,41 @@
+---
+title: No data with Kubernetes APM auto-attach
+type: troubleshooting
+tags:
+  - Agents
+  - Ruby agent
+  - Kubernetes
+  - Troubleshooting
+metaDescription: 'If you are not seeing New Relic data for a non-Rails Ruby application using the Kubernetes APM auto-attach, you may need to explicitly call `Bundler.require`.'
+freshnessValidatedDate: never
+---
+
+## Problem
+
+You are using the New Relic Ruby agent with the Kubernetes APM auto-attach for a non-Rails framework (like Sinatra), but no APM data is appearing in your New Relic account.
+
+## Solution
+
+Explicitly call `Bundler.require` early in your application's startup process.
+
+For many frameworks, this can be done by adding it to your main application file or a `config.ru` file before your application classes are defined.
+
+Example (`config.ru` or `app.rb`):
+
+```ruby
+# config.ru
+
+require 'bundler'
+Bundler.require
+
+# ... rest of your application's startup code
+require_relative './my_sinatra_app'
+run MySinatraApp
+```
+After adding this code, redeploy your application. Data should begin appearing in New Relic within a few minutes.
+
+## Cause
+
+The Kubernetes APM auto-attach works by patching the `Bundler::Runtime#require` method to inject the `newrelic_rpm` gem into your application.
+
+While Rails applications automatically call `Bundler.require` during their boot process, many other frameworks do not. If `Bundler.require` is never called, the New Relic agent is never loaded into your application's environment. Adding this line ensures the agent is loaded as expected.


### PR DESCRIPTION
Add a troubleshooting guide for Kubernetes APM auto-attach and non-rails frameworks.