### PR TITLE
fix: update with latest changes to actions and APIs

### DIFF
--- a/src/content/docs/workflow-automation/create-a-workflow-automation/start-schedule.mdx
+++ b/src/content/docs/workflow-automation/create-a-workflow-automation/start-schedule.mdx
@@ -38,16 +38,16 @@ The start operations can be triggered through the [StartWorkflowRun](/docs/workf
       defaultValue: "User"
     key:
       type: String
-      defaultValue: "${{ :secrets:11933347:USERNAME_AWS_ACCESS_KEY_ID }}"
+      defaultValue: "${{ :secrets:12345678:USERNAME_AWS_ACCESS_KEY_ID }}"
     access:
       type: String
-      defaultValue: "${{ :secrets:11933347:USERNAME_AWS_SECRET_ACCESS_KEY }}"
+      defaultValue: "${{ :secrets:12345678:USERNAME_AWS_SECRET_ACCESS_KEY }}"
     token:
       type: String
-      defaultValue: "${{ :secrets:11933347:USERNAME_AWS_SESSION_TOKEN }}"
+      defaultValue: "${{ :secrets:12345678:USERNAME_AWS_SESSION_TOKEN }}"
     region:
       type: String
-      defaultValue: us-east-2
+      defaultValue: us-east-1
 
   steps:
     - name: invoke1
@@ -65,29 +65,30 @@ The start operations can be triggered through the [StartWorkflowRun](/docs/workf
 
     - name: logOutput
       type: action
-      action: newrelic.instrumentation.log
+      action: newrelic.ingest.sendLogs
       version: 1
       inputs:
-        message: 'The lambda function message output is:${{ .steps.invoke1.outputs.payload.body }}'
-        licenseKey: '${{ :secrets:STAGING_NEW_RELIC_LICENSE_KEY }}'
+        logs:
+          - message: 'The lambda function message output is:${{ .steps.invoke1.outputs.payload.body }}'
 ```
 
 This workflow can be started with the following NerdGraph mutation, assuming the AWS temporary secrets have been previously stored with the secretsManagementCreateSecretNerdGraph mutations.
 
 ```graphql
-    mutation { 
-        autoflowsStartWorkflowRun(accountId: 11933347,
-        definition: {
-            name: "lambda1",
-        }, workflowInputs: [
+    mutation {
+        workflowAutomationStartWorkflowRun(
+          scope: { type: ACCOUNT id: "12345678" }
+          definition: { name: "lambda1" }
+          workflowInputs: [
             {key: "key" value: "${{ :secrets:testUser123_AWS_ACCESS_KEY_ID }}"}
             {key: "access" value: "${{ :secrets:testUser123_AWS_SECRET_ACCESS_KEY }}"}
             {key: "token" value: "${{ :secrets:testUser123_AWS_SESSION_TOKEN }}"}
             {key: "region" value:"us-east-2"}
             {key: "username" value: "Julien"}
-        ]) 
+          ]
+        )
         { runId }
-    } 
+    }
 ```
 Executing the mutation returns a `runId`, such as `7bd25287-2af8-42e1-b783-80f4e760a40b`. This `runId` can be used to query the logs and view the following output:
 
@@ -99,4 +100,4 @@ Executing the mutation returns a `runId`, such as `7bd25287-2af8-42e1-b783-80f4e
 
 ## Schedule a workflow automation
 
-A workflow can be scheduled to run at a specific frequency using the [CreateSchedule](/docs/workflow-automation/autoflow-api-documentation) API.
+A workflow can be scheduled to run at a specific frequency using the [CreateSchedule](/docs/workflow-automation/workflow-automation-apis) API.

--- a/src/content/docs/workflow-automation/create-a-workflow-automation/use-a-template.mdx
+++ b/src/content/docs/workflow-automation/create-a-workflow-automation/use-a-template.mdx
@@ -26,20 +26,6 @@ The Workflow Automation templates provide a quick way to create workflows that a
 ## Workflow Automation templates
 
 <CollapserGroup>
-  <Collapser
-    id="starter-template"
-    title="Starter template"
-  >
-    **Purpose:** 
-    
-    Create a workflow automation using the starter template to fetch the current time from a public API and log it in your New Relic account.
-
-    **Prerequisites:**
-
-    - Access to [worldtimeapi.org](https://worldtimeapi.org/) to fetch the current time.
-    - New Relic ingest credentials for logging data.
-
-  </Collapser>
 
   <Collapser
     id="send-report-to-slack"
@@ -69,7 +55,7 @@ The Workflow Automation templates provide a quick way to create workflows that a
 
     - AWS credentials with permissions for API Gateway and Systems Manager.
     - A configured Slack app for receiving notifications and approvals.
-  
+
   </Collapser>
 
   <Collapser

--- a/src/content/docs/workflow-automation/setup-and-configuration/actions-catalog.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configuration/actions-catalog.mdx
@@ -196,14 +196,14 @@ Begin by setting up AWS credentials, which includes creating IAM users and roles
             awsSessionToken: ${{ :secrets:awsSessionToken }}
             payload: ${{ .workflowInputs.payload }}
             selectors: ${{ .workflowInputs.selectors }}
-        
+
         - name: logOutput
           type: action
-          action: newrelic.instrumentation.log
+          action: newrelic.ingest.sendLogs
           version: 1
           inputs:
-            message: 'The lambda function message output is:${{ .steps.awsLambda.outputs.payload.body }}'
-            licenseKey: '${{ :secrets:STAGING_NEW_RELIC_LICENSE_KEY }}'
+            logs:
+              - message: 'The lambda function message output is:${{ .steps.awsLambda.outputs.payload.body }}'
   ```
           </td>
           <td>
@@ -233,10 +233,10 @@ Begin by setting up AWS credentials, which includes creating IAM users and roles
           <td>
   ```yaml
   {
-    executedVersion=$LATEST, 
-    statusCode=200, 
+    executedVersion=$LATEST,
+    statusCode=200,
     payload={
-      statusCode=200.0, 
+      statusCode=200.0,
       body=\"Hello R2-D2\"
     }
   }
@@ -245,7 +245,7 @@ Begin by setting up AWS credentials, which includes creating IAM users and roles
   ```yaml
     {
     payload={
-      statusCode=200.0, 
+      statusCode=200.0,
       body=\"Hello R2-D2\"
     }
   }
@@ -947,7 +947,7 @@ Begin by setting up AWS credentials, which includes creating IAM users and roles
         id="aws.execute.api"
         title="Execute an AWS API"
     >
-    
+
 This action allows you to execute any AWS API operation for a specified service. It supports providing AWS credentials, region, service name, API name, and optional parameters. The action can return outputs such as success status, response data, and error messages, making it versatile for interacting with AWS services programmatically.
 
 <Tabs>
@@ -1157,28 +1157,28 @@ This action allows you to execute any AWS API operation for a specified service.
     - name: wait
           type: wait
           seconds: 2
-          
+
         - name: logOutput
           type: action
-          action: newrelic.instrumentation.log
+          action: newrelic.ingest.sendLogs
           version: 1
           inputs:
-            message: 'The execute API message output is:${{ .steps.executeApi.outputs.response.Item }}'
-            licenseKey: '${{ :secrets:STAGING_NEW_RELIC_LICENSE_KEY }}'
+            logs:
+              - message: 'The execute API message output is:${{ .steps.executeApi.outputs.response.Item }}'
         - name: logOutput1
           type: action
-          action: newrelic.instrumentation.log
+          action: newrelic.ingest.sendLogs
           version: 1
           inputs:
-            message: 'does execute API have any error :${{ .steps.executeApi.outputs.errorMessage }}'
-            licenseKey: '${{ :secrets:STAGING_NEW_RELIC_LICENSE_KEY }}'
+            logs:
+              - message: 'does execute API have any error :${{ .steps.executeApi.outputs.errorMessage }}'
         - name: logOutput2
           type: action
-          action: newrelic.instrumentation.log
+          action: newrelic.ingest.sendLogs
           version: 1
           inputs:
-            message: 'is execute successful :${{ .steps.executeApi.outputs.success }}'
-            licenseKey: '${{ :secrets:STAGING_NEW_RELIC_LICENSE_KEY }}'
+            logs:
+              - message: 'is execute successful :${{ .steps.executeApi.outputs.success }}'
   ```
             </td>
         </tr>
@@ -1197,7 +1197,7 @@ This action allows you to execute any AWS API operation for a specified service.
         id="http.get"
         title="Executes a HTTP GET request"
     >
-    
+
 Perform an HTTP GET call.
 
 <Callout variant="tip">
@@ -2315,10 +2315,11 @@ Executes a Graphql command against newrelic NerdGraph API. The command can eithe
               steps:
                 - name: logStep
                   type: action
-                  action: newrelic.instrumentation.log
+                  action: newrelic.ingest.sendLogs
                   version: 1
                   inputs:
-                    message: 'Hello World'
+                    logs:
+                      - message: 'Hello World'
             ```
           </td>
           <td>
@@ -2431,7 +2432,7 @@ Executes a cross-accounts NRQL query through the NerdGraph API.
   ```yaml
     {
       results=[
-        { message=[INFO] - Workflow: test has ended, messageId=39af98 }, 
+        { message=[INFO] - Workflow: test has ended, messageId=39af98 },
         { message=[INFO] - Workflow: test - Step query has started, messageId=649c612 },
         ...
       ]
@@ -2577,7 +2578,7 @@ Sends a message to a slack channel, with an optional file attachment.
             <td>Required</td>
             <td>secret</td>
             <td>The slack bot token to use. This should be passed as a secret syntax. Refer to [Add Slack configuration](/docs/autoflow/overview#add-the-slack-integration)for instructions on setting up a token.</td>
-            <td>`${{ :secrets:stagingSlackToken }}`</td>
+            <td>`${{ :secrets:slackToken }}`</td>
         </tr>
         <tr>
             <td>**channel**</td>
@@ -2673,10 +2674,10 @@ Sends a message to a slack channel, with an optional file attachment.
       steps:
         - name: send_slack_message
           type: action
-          action: slack.chat.postMessage 
+          action: slack.chat.postMessage
           version: 1
           inputs:
-            token: ${{ :secrets:dn_staging_slack_token }}
+            token: ${{ :secrets:slackToken }}
             channel: ${{ .workflowInputs.channel }}
             text: ${{ .workflowInputs.text }}
   ```
@@ -2687,7 +2688,7 @@ Sends a message to a slack channel, with an optional file attachment.
             "inputs": [
               {
                 "key" : "channel",
-                "value" : "test-channel-workflow"
+                "value" : "my-channel"
               },
               {
                 "key" : "text",
@@ -2733,8 +2734,8 @@ Example 2: Attach a file
           action: slack.chat.postMessage
           version: 1
           inputs:
-            token: ${{ :secrets:dn_staging_slack_token }}
-            channel: test-channel-workflow
+            token: ${{ :secrets:slackToken }}
+            channel: my-channel
             text: "Please find the attached file:"
             attachment:
               filename: 'file.txt'
@@ -2801,7 +2802,7 @@ Get a reaction of a message from Slack channel.
             <td>Required</td>
             <td>secret</td>
             <td>The slack bot token to use. This should be passed as a secret syntax. Refer to [Add Slack configuration](/docs/autoflow/overview#add-the-slack-integration)for instructions on setting up a token.</td>
-            <td>`${{ :secrets:stagingSlackToken }}`</td>
+            <td>`${{ :secrets:slackToken }}`</td>
         </tr>
         <tr>
             <td>**channelID**</td>
@@ -2859,7 +2860,7 @@ Get a reaction of a message from Slack channel.
   <TabsPageItem id="chatgetreactionsexample">
 
     Example 1: slack get reactions
-    
+
 <table>
   <thead>
       <tr>
@@ -2880,7 +2881,7 @@ Get a reaction of a message from Slack channel.
           action: slack.chat.getReactions
           version: 1
           inputs:
-            token: ${{ :secrets:dn_staging_slack_token }}
+            token: ${{ :secrets:slackToken }}
             channelID: ${{ .steps.promptUser.outputs.channelID }}
             threadTs: ${{ .steps.promptUser.outputs.threadTs }}
             timeout: ${{ .workflowInputs.timeout }}
@@ -2949,7 +2950,7 @@ Get a reaction of a message from Slack channel.
 
 This action is used to transform from epoch timestamp to date/time. Possible references:
 
-* https://en.wikipedia.org/wiki/List_of_tz_database_time_zones 
+* https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 * https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
 
 Refer [fromEpoch](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) for more information.
@@ -3088,8 +3089,8 @@ Refer [fromEpoch](https://docs.oracle.com/javase/8/docs/api/java/time/format/Dat
           <td>
           ```json
                   mutation {
-                    autoflowsStartWorkflowRun(
-                      accountId: 12345678
+                    workflowAutomationStartWorkflowRun(
+                      scope: { type: ACCOUNT id: "12345678" }
                       definition: { name: "from_epoch" }
                       workflowInputs: [
                         {key: "timestamp", value: "1738236424003"}
@@ -3108,9 +3109,9 @@ Refer [fromEpoch](https://docs.oracle.com/javase/8/docs/api/java/time/format/Dat
     {
       "date": "2025-01-30",
       "time": "16:57:04.003"
-      "datetime": "2025-57-30 16:00", 
+      "datetime": "2025-57-30 16:00",
       "timezone": {
-        "abbreviation": "IST", 
+        "abbreviation": "IST",
         "id": "Asia/Kolkata"
         }
     }
@@ -3225,9 +3226,9 @@ This action is used to transform various type of input (JSON, map) to a CSV form
             </td>
             <td>
             ```json
-              mutation { 
+              mutation {
                 startWorkflowRun(
-                  accountId: 12345678
+                  scope: { type: ACCOUNT id: "12345678" }
                   definition: {
                       name: "nrqltocsv",
                   }
@@ -3235,9 +3236,9 @@ This action is used to transform various type of input (JSON, map) to a CSV form
                     {key: "accountId" value: "12345678"}
                     {key: "nrql" value: "FROM TransactionError SELECT error.message, error.class, transactionName, request.uri, query WHERE appName like 'my-app-1%' AND error.expected IS FALSE SINCE 1 hour ago LIMIT 50"}
                   ]
-                ) 
+                )
                 { runId }
-              } 
+              }
             ```
             </td>
             <td></td>

--- a/src/content/docs/workflow-automation/workflow-automation-apis/create-schedule.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/create-schedule.mdx
@@ -53,9 +53,9 @@ If the action is successful, the service sends back the following data:
 ```graphql
     mutation {
       workflowAutomationCreateSchedule(
-        accountId: 11933347
-        definition: {name: "healthyHeartbeat", version: 1}
-        cronExpression: "*/1 * * * *"
+        scope: { type: ACCOUNT id: "12345678" }
+        definition: {name: "my-daily-workflow", version: 1}
+        cronExpression: "0 0 * * *"
       ) {
         scheduleId
       }

--- a/src/content/docs/workflow-automation/workflow-automation-apis/definition-schema.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/definition-schema.mdx
@@ -34,7 +34,7 @@ Workflow definitions are written in YAML. Keys use a `camelCase` naming conventi
   - **Type**: Map of maps
   - **Max. size**: 100
   - **Description**: A map of workflow inputs that the workflow accepts.
-  - **Example**: 
+  - **Example**:
 
   ```java
     workflowInputs:
@@ -88,8 +88,8 @@ Workflow definitions are written in YAML. Keys use a `camelCase` naming conventi
 
 ## Step Types
 
-### **action** 
-    
+### **action**
+
     A step that runs a specific action. Refer to [Action Catalog](/docs/workflow-automation/actions-catalog) for the available options.
 
     - **`steps[*].action`** (Required)
@@ -97,54 +97,58 @@ Workflow definitions are written in YAML. Keys use a `camelCase` naming conventi
       - **Description**: The fully qualified name of the action function to run. It should follow the following convention:
 
         `<company domain>.<category of work>.<action name in camelCase>`
-      - **Example**: 
+      - **Example**:
         - Action using New Relic services (e.g. through NerdGraph): `newrelic.dashboards.getDashboard`
         - Action using Slack: `slack.chat.postMessage`
-  
+
     - **`steps[*].version`** (Required)
       - **Type**: String
       - **Description**: The version of the action function to run.
 
     - **`steps[*].inputs`** (Optional)
       - **Type**: Map of values (includes [expressions]())
-      - **Description**: 
+      - **Description**:
         - The inputs to pass to the action function. The specific inputs accepted are defined by each action.
         - Inputs can use expressions. See the [Expressions Strings]() section for details.
-  
+
       <Callout variant="important">
         No sensitive data (no API keys or secrets, no PII, PHI or any personally identifiable data) should be passed-in as arguments.
       </Callout>
 
     - **`steps[*].inputs.selectors`** (Optional)
       - **Type**: list of map in the form of `name` with `expression`.
-      - **Description**: 
+      - **Description**:
         - The `selectors` input allows to redefine the output to only return the specified elements.
         - Expression can be used. See the [Expressions Strings]() section for details.
       - **Example**
-        - In the given example we are getting the `timezone` and `datetime` as response of http.get action.
-        
-        ```yaml
-            name: calendar_demo
+        - In the given example we are getting the `pageUrl` and `statusDescription` as response of http.get action.
 
-            workflowInputs:
-              timezone:
-                type: String
-                defaultValue: 'America/Los_Angeles'
-              accountId:
-                type: Int
+        ```yaml
+            name: status
+            description: A workflow for checking the status of New Relic components
 
             steps:
-              - name: getCurrentTime
+              - name: query1
                 type: action
                 action: http.get
                 version: 1
                 inputs:
-                  url: 'https://worldtimeapi.org/api/timezone/${{ .workflowInputs.timezone }}'
+                  url: "https://status.newrelic.com/api/v2/status.json"
                   selectors:
-                    - name: timezone
-                      expression: '.responseBody | fromjson.abbreviation'
-                    - name: datetime
-                      expression: '.responseBody | fromjson.datetime'
+                    - name: statusCode
+                      expression: '.statusCode'
+                    - name: pageUrl
+                      expression: '.responseBody | fromjson | .page.url'
+                    - name: statusDescription
+                      expression: '.responseBody | fromjson | .status.description'
+
+              - name: logOutput1
+                type: action
+                action: newrelic.ingest.sendLogs
+                version: 1
+                inputs:
+                  logs:
+                    - message: "status is '${{ .steps.query1.outputs.statusDescription }}' details at ${{ .steps.query1.outputs.pageUrl }}"
           ```
 
 ### **loop**
@@ -273,7 +277,7 @@ For more details see below:
 
       **Use break/continue in a loop**
 
-      To change the flow of a for loop, you can use `next: break` or `next: continue`. Note that `break` and `continue` are reserved jump targets defined implicitly within a loop. Using use `next: break` or `next: continue` outside of a loop will jump to the end of the workflow steps. 
+      To change the flow of a for loop, you can use `next: break` or `next: continue`. Note that `break` and `continue` are reserved jump targets defined implicitly within a loop. Using use `next: break` or `next: continue` outside of a loop will jump to the end of the workflow steps.
 
       - The `end` serves as the same as `break` if it's used inside a loop
       - Next can be used in both switch steps or any type of step.
@@ -322,7 +326,7 @@ For more details see below:
     - **`steps[*].for`** (Required)
       - **Type**: constant
       - **Description**: Signal starting of a loop
-    
+
     - **`steps[*].in`** (Required)
         - **Type**: string (expression)
         - **Description**: An expression that need to evaluate to a collection of elements.
@@ -341,17 +345,18 @@ For more details see below:
                   steps:
                     - name: step1
                       type: action
-                      action: newrelic.instrumentation.log
+                      action: newrelic.ingest.sendLogs
                       version: 1
                       inputs:
-                        message: "Loop: ${{ .steps.loopStep.loop.element }}"
+                        logs:
+                          - message: "Loop: ${{ .steps.loopStep.loop.element }}"
           ```
 
 ### **switch**
-  
+
     - A step that checks various conditionals and takes the first branch that evaluates to true.
     - A switch can contain any number of condition elements in a list. It will check the conditions in order and process the first one that evaluates to true. If none evaluate to true, it will run its next step as defined in steps[*].next
-  
+
   - **`steps[*].switch`** (Required)
     - **Type**: array
     - **Description**: An array of switch cases, specifying the ordered list of conditions to evaluate.
@@ -374,13 +379,13 @@ For more details see below:
           next: displaySuccess
       next: displayUnexpected
     ```
-  
+
 ### wait
 
   A step that causes the workflow run to wait a certain number of seconds before continuing. It can also listen for one or more signals. If no signal is received during the wait, it will proceed as normal. The signals are defined in a list. Each signal must have a corresponding next step defined. The first signal to be received is the one that will be processed. The value received for the signal will be stored in the step output for the wait step and can be used for logic our processing in later steps.
 
-  - Example: 
-  
+  - Example:
+
     ```yaml
       name: waitSignalExample
       workflowInputs:
@@ -391,17 +396,19 @@ For more details see below:
           signals: [{name: 'mySignalName', next: 'firstStep'}]
         - name: endStep
           type: action
-          action: newrelic.instrumentation.log
+          action: newrelic.ingest.sendLogs
           version: 1
           inputs:
-            message: "didn't get signal"
+            logs:
+              - message: "didn't get signal"
           next: end
         - name: firstStep
           type: action
-          action: newrelic.instrumentation.log
+          action: newrelic.ingest.sendLogs
           version: 1
           inputs:
-            message: ${{ .steps.waitStep.outputs.signalInputs.myString }}
+            logs:
+              - message: ${{ .steps.waitStep.outputs.signalInputs.myString }}
     ```
 
   - **`steps[*].seconds`** (Required)
@@ -510,19 +517,9 @@ Examples:
 
 ```yaml
   steps:
-  - name: mySecretStep
-    type: action
-    action: newrelic.instrumentation.log
-    inputs:
-      message: My message
-      licenseKey: ${{ :secrets:<SECRET_NAME> }}
-```
-
-```yaml
-  steps:
   - name: bearer_auth
     type: action
-    action: utils.http.post
+    action: http.post
     inputs:
       headers:
         Authorization: Bearer ${{ :secrets:<SECRET_NAME> }}
@@ -530,73 +527,82 @@ Examples:
 
 ## Examples
 
-- Calendar Demo
+- Hello World
 
 ```yaml
-  name: calendar_demo
+name: helloWorld
+description: 'A hello world workflow'
 
-  workflowInputs:
-    timezone:
-      type: String
-      defaultValue: 'America/Los_Angeles'
-    accountId:
-      type: Int
+workflowInputs:
+  name:
+    type: String
+    defaultValue: World
+    required: false
+    validations:
+      - type: maxLength
+        errorMessage: "name must be at most 100 characters"
+        length: 100
+  slackTokenSecret:
+    type: String
+    defaultValue: "${{ :secrets:SLACK_TOKEN }}"
+  slackChannel:
+    type: String
+    defaultValue: my-channel
+    validations:
+      - type: regex
+        errorMessage: "A slack channel name must be lowercase and can only contain letters, numbers, and hyphens"
+        pattern: "^[a-z0-9\\-]+$"
+    required: true
 
-  steps:
-    - name: getCurrentTime
-      type: action
-      action: http.get
-      version: 1
-      inputs:
-        url: 'https://worldtimeapi.org/api/timezone/${{ .workflowInputs.timezone }}'
-        selectors:
-          - name: timezone
-            expression: '.responseBody | fromjson.abbreviation'
-          - name: datetime
-            expression: '.responseBody | fromjson.datetime'
+steps:
+  - name: init1
+    type: assign
+    inputs:
+      greeting: Hello ${{ .workflowInputs.name }}
 
-    - name: logTime
-      type: action
-      action: newrelic.instrumentation.log
-      version: 1
-      inputs:
-        message: 'DEMO: In the ${{ .steps.getCurrentTime.outputs.timezone }} timezone, the current time is ${{ .steps.getCurrentTime.outputs.datetime }}'
-        licenseKey: ${{ :secrets:STAGING_NEW_RELIC_LICENSE_KEY }}
+  - name: logName
+    type: action
+    action: newrelic.ingest.sendLogs
+    version: 1
+    inputs:
+      logs:
+        - message: ${{ .steps.init1.outputs.greeting }}
 
-    - name: wait
-      type: wait
-      seconds: 1
+  - name: waiting1
+    type: wait
+    seconds: 1
 
-    - name: queryForLog
-      type: action
-      action: newrelic.nrql.query
-      version: 1
-      inputs:
-        accountIds: ['${{ .workflowInputs.accountId }}']
-        query: FROM Log SELECT * WHERE message LIKE 'DEMO:%${{ .steps.getCurrentTime.outputs.datetime }}'
+  - name: queryForLog
+    type: action
+    action: newrelic.nrdb.query
+    version: 1
+    inputs:
+      query: >-
+        FROM Log SELECT * WHERE message LIKE '${{ .steps.init1.outputs.greeting
+        }}'
 
-    - name: checkQuery
-      type: switch
-      switch:
-        - condition: ${{ .steps.queryForLog.outputs.results | length > 0 }}
-          next: postResultsMessage
+  - name: checkResult
+    type: switch
+    switch:
+      - condition: ${{ .steps.queryForLog.outputs.results | length > 0 }}
+        next: FoundMessage
 
-    - name: postWaitingMessage
-      type: action
-      action: slack.chat.postMessage
-      version: 1
-      inputs:
-        channel: test-channel-workflow
-        text: Waiting for log message...
-        token: ${{ :secrets:dn_staging_slack_token }}
-      next: wait
+  - name: waitingMessage
+    type: action
+    action: slack.chat.postMessage
+    version: 1
+    inputs:
+      channel: ${{ .workflowInputs.slackChannel }}
+      text: Waiting for log message...
+      token: ${{ .workflowInputs.slackTokenSecret }}
+    next: waiting1
 
-    - name: postResultsMessage
-      type: action
-      action: slack.chat.postMessage
-      version: 1
-      inputs:
-        channel: test-channel-workflow
-        text: 'Found log message! ${{ .steps.queryForLog.outputs.results[0].message }}'
-        token: ${{ :secrets:dn_staging_slack_token }}
+  - name: FoundMessage
+    type: action
+    action: slack.chat.postMessage
+    version: 1
+    inputs:
+      channel: ${{ .workflowInputs.slackChannel }}
+      text: Found message! ${{ .steps.queryForLog.outputs.results[0].message }}
+      token: ${{ .workflowInputs.slackTokenSecret }}
 ```

--- a/src/content/docs/workflow-automation/workflow-automation-apis/get-action-definitions.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/get-action-definitions.mdx
@@ -5,7 +5,7 @@ tags:
   - workflow
   - Get Schedules
   - workflow automation API
-metaDescription: "Returns all action definitions stored in the Workflow Service. This operation is behind NerdGraph, under account stitch point."
+metaDescription: "Returns all action definitions stored. This operation is behind NerdGraph, under account stitch point."
 freshnessValidatedDate: never
 ---
 
@@ -22,430 +22,113 @@ freshnessValidatedDate: never
 ## Example [#example]
 
 ```graphql
-    {
-      actor {
-        account(id: 12345678) {
-          workflowAutomation {
-            actionDefinitions {
-              results {
-                description
-                inputs {
-                  name
-                  required
-                  secretAllowed
-                }
-                name
-                outputs {
-                  name
-                }
-                timeout {
-                  action
-                }
-                version
+{
+  "data": {
+    "actor": {
+      "account": {
+        "workflowAutomation": {
+          "actionDefinitions": {
+            "results": [
+              {
+                "description": "Reboot one or more EC2 instances in an AWS account.",
+                "inputs": [
+                  {
+                    "name": "awsRoleArn",
+                    "required": false,
+                    "secretAllowed": false
+                  },
+                  {
+                    "name": "awsAccessKeyId",
+                    "required": false,
+                    "secretAllowed": true
+                  },
+                  {
+                    "name": "awsSecretAccessKey",
+                    "required": false,
+                    "secretAllowed": true
+                  },
+                  {
+                    "name": "awsSessionToken",
+                    "required": false,
+                    "secretAllowed": true
+                  },
+                  {
+                    "name": "region",
+                    "required": true,
+                    "secretAllowed": false
+                  },
+                  {
+                    "name": "instanceIds",
+                    "required": true,
+                    "secretAllowed": false
+                  },
+                  {
+                    "name": "selectors",
+                    "required": false,
+                    "secretAllowed": false
+                  }
+                ],
+                "name": "aws.ec2.rebootInstances",
+                "outputs": [
+                  {
+                    "name": "success"
+                  },
+                  {
+                    "name": "response"
+                  },
+                  {
+                    "name": "errorMessage"
+                  }
+                ],
+                "timeout": {
+                  "action": 25
+                },
+                "version": 1
+              },
+              {
+                "description": "Send logs to New Relic.",
+                "inputs": [
+                  {
+                    "name": "attributes",
+                    "required": false,
+                    "secretAllowed": false
+                  },
+                  {
+                    "name": "logs",
+                    "required": true,
+                    "secretAllowed": false
+                  },
+                  {
+                    "name": "licenseKey",
+                    "required": false,
+                    "secretAllowed": true
+                  },
+                  {
+                    "name": "selectors",
+                    "required": false,
+                    "secretAllowed": false
+                  }
+                ],
+                "name": "newrelic.ingest.sendLogs",
+                "outputs": [
+                  {
+                    "name": "success"
+                  },
+                  {
+                    "name": "errorMessage"
+                  }
+                ],
+                "timeout": {
+                  "action": 20
+                },
+                "version": 1
               }
-            }
+              # more ...
+            ]
           }
         }
       }
     }
-```
-returns the following
-
-```graphql
-    {
-      "data": {
-        "actor": {
-          "account": {
-            "workflowAutomation": {
-              "actionDefinitions": {
-                "results": [
-                  {
-                    "description": null,
-                    "inputs": [
-                      {
-                        "name": "token",
-                        "required": true,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "channel",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "text",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "threadTs",
-                        "required": false,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "attachment",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "slack.chat.postMessage",
-                    "outputs": [
-                      {
-                        "name": "threadTs"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "Execute a GraphQL query or mutation against New Relic NerdGraph API.",
-                    "inputs": [
-                      {
-                        "name": "graphql",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "variables",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "newrelic.nerdgraph.execute",
-                    "outputs": [
-                      {
-                        "name": "actor"
-                      },
-                      {
-                        "name": "data"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "Reports a custom event to New Relic.",
-                    "inputs": [
-                      {
-                        "name": "accountId",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "eventDataJson",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "licenseKey",
-                        "required": true,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "region",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "newrelic.instrumentation.createEvent",
-                    "outputs": [],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": null,
-                    "inputs": [
-                      {
-                        "name": "url",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "urlParams",
-                        "required": false,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "headers",
-                        "required": false,
-                        "secretAllowed": true
-                      }
-                    ],
-                    "name": "internal.http.get",
-                    "outputs": [
-                      {
-                        "name": "statusCode"
-                      },
-                      {
-                        "name": "responseBody"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "Deletes an object from an S3 bucket.",
-                    "inputs": [
-                      {
-                        "name": "awsSecretAccessKey",
-                        "required": true,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "awsAccessKeyId",
-                        "required": true,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "region",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "bucket",
-                        "required": true,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "key",
-                        "required": true,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "aws.s3.deleteObject",
-                    "outputs": [],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "Runs a NRQL query.",
-                    "inputs": [
-                      {
-                        "name": "accountIds",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "query",
-                        "required": true,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "newrelic.nrql.query",
-                    "outputs": [
-                      {
-                        "name": "results"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "Log reports a log to New Relic.",
-                    "inputs": [
-                      {
-                        "name": "message",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "licenseKey",
-                        "required": true,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "region",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "newrelic.instrumentation.log",
-                    "outputs": [],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "Returns a greeting message that says hello as follows:\n\nIf name is provided, Hello, {name}!\n\nIf name is not provided, Hello! What's your name?\n",
-                    "inputs": [
-                      {
-                        "name": "name",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "example.messaging.sayHello",
-                    "outputs": [
-                      {
-                        "name": "greeting"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": null,
-                    "inputs": [
-                      {
-                        "name": "url",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "urlParams",
-                        "required": false,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "headers",
-                        "required": false,
-                        "secretAllowed": true
-                      }
-                    ],
-                    "name": "utils.http.get",
-                    "outputs": [
-                      {
-                        "name": "statusCode"
-                      },
-                      {
-                        "name": "responseBody"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": null,
-                    "inputs": [],
-                    "name": "utils.uuid.generate",
-                    "outputs": [
-                      {
-                        "name": "uuid"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": null,
-                    "inputs": [
-                      {
-                        "name": "url",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "urlParams",
-                        "required": false,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "headers",
-                        "required": false,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "body",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "internal.http.post",
-                    "outputs": [
-                      {
-                        "name": "statusCode"
-                      },
-                      {
-                        "name": "responseBody"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": null,
-                    "inputs": [
-                      {
-                        "name": "url",
-                        "required": true,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "urlParams",
-                        "required": false,
-                        "secretAllowed": false
-                      },
-                      {
-                        "name": "headers",
-                        "required": false,
-                        "secretAllowed": true
-                      },
-                      {
-                        "name": "body",
-                        "required": false,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "utils.http.post",
-                    "outputs": [
-                      {
-                        "name": "statusCode"
-                      },
-                      {
-                        "name": "responseBody"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  },
-                  {
-                    "description": "transform an input data value to a csv format",
-                    "inputs": [
-                      {
-                        "name": "data",
-                        "required": true,
-                        "secretAllowed": false
-                      }
-                    ],
-                    "name": "utils.transform.toCSV",
-                    "outputs": [
-                      {
-                        "name": "csv"
-                      }
-                    ],
-                    "timeout": {
-                      "action": 15
-                    },
-                    "version": "1.0.0"
-                  }
-                ]
-              }
-            }
-          }
-        }
-      },
-    }
+  }
+}
 ```

--- a/src/content/docs/workflow-automation/workflow-automation-apis/get-workflow-definition.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/get-workflow-definition.mdx
@@ -38,7 +38,7 @@ freshnessValidatedDate: never
 ```graphql
   {
     actor {
-      account(id: 11933347) {
+      account(id: 12345678) {
         workflowAutomation {
           workflow(name: "find_entity", version: 1) {
             definition {

--- a/src/content/docs/workflow-automation/workflow-automation-apis/start-workflow-run.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/start-workflow-run.mdx
@@ -28,11 +28,11 @@ freshnessValidatedDate: never
     - Version
       - Integer
       - Optional, otherwise uses latest version.
-    
+
   - IdempotencyKey
     - UUID format [`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`]
     - Optional
-  
+
   - Input
     - List of objects with the format:
       - key: string
@@ -51,10 +51,10 @@ freshnessValidatedDate: never
 ```graphql
     mutation {
       workflowAutomationStartWorkflowRun(
-        accountId: 11933347
+        scope: { type: ACCOUNT id: "12345678" }
         definition: {name: "entity_tag"}
         workflowInputs: [
-          {key: "entityGuid", value: "MTE5MzMzNDd8VklafERBU0hCT0FSRHxkYToxMDQ4NzI"}, 
+          {key: "entityGuid", value: "MTE5MzMzNDd8VklafERBU0hCT0FSRHxkYToxMDQ4NzI"},
           {key: "tagKey", value: "demo1"}, {key: "tagValue", value: "abc"}
           ]
       ) {

--- a/src/content/docs/workflow-automation/workflow-automation-apis/using-workflow-automation-api.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/using-workflow-automation-api.mdx
@@ -74,7 +74,7 @@ This document describes some of the available Workflow Automation API calls. For
         </tr>
         <tr>
             <td>
-            Schedule of a workflow definition. 
+            Schedule of a workflow definition.
             <p>
             <Callout variant="important">
               This doesn’t stop already running workflow instance.
@@ -119,7 +119,7 @@ This document describes some of the available Workflow Automation API calls. For
         </tr>
         <tr>
             <td>
-            Return all action definitions stored in the Workflow Service.
+            Return all action definitions stored.
             </td>
             <td>
             [`GetActionDefinitions`](/docs/workflow-automation/workflow-automation-apis/get-action-definitions)

--- a/src/content/docs/workflow-automation/workflow-automation-apis/validate-workflow-definition.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/validate-workflow-definition.mdx
@@ -35,7 +35,7 @@ freshnessValidatedDate: never
 ```graphql
       query workflowDefinitionValidation {
         actor {
-          account(id: 11933347) {
+          account(id: 12345678) {
             workflowAutomation {
               workflowDefinitionValidation(
                 definition: {yaml: "ICAgICAgICAgICAgICAgIG5hbWU6IG15V29ya2Zsb3cKCiAgICAgICAgICAgICAgICBzdGVwczoKICAgICAgICAgICAgICAgICAgLSBuYW1lOiBvbmx5U3RlcAogICAgICAgICAgICAgICAgICAgIHR5cGU6IHdhaXQKICAgICAgICAgICAgICAgICAgICBzZWNvbmRzOiAtNDIKCiAgICAgICAgICAgICAgICAgIC0gbmFtZTogJycKICAgICAgICAgICAgICAgICAgICB0eXBlOiB3YWl0CiAgICAgICAgICAgICAgICAgICAgc2Vjb25kczogLTQyCgogICAgICAgICAgICAgICAgICAtIG5hbWU6IG9ubHlTdGVwCiAgICAgICAgICAgICAgICAgICAgdHlwZTogYWN0aW9uCiAgICAgICAgICAgICAgICAgICAgYWN0aW9uOiBDb25zb2xlTG9nCiAgICAgICAgICAgICAgICAgICAgdmVyc2lvbjogIiIKICAgICAgICAgICAgICAgICAgICBpbnB1dHM6CiAgICAgICAgICAgICAgICAgICAgICAgZm9vOiAiIg=="}


### PR DESCRIPTION
Change list:

- Updated action names with current naming, for example `utils.http.post` is now `http.post`
- Also updated newrelic.ingest.sendLogs with new input format
- Replace old naming of `autoflows` with `workflowAutomation`
- Remove references to timezone api, and replace with simpler example using NewRelic status API and `Hello World` workflow
- Update APIs with latest schema (dropping reference to accountId in some APIs)

