### PR TITLE
Update Metric API max attributes per metric limit

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -96,7 +96,7 @@ The following default limits apply for all Metric data:
       </td>
 
       <td>
-        100
+        150
       </td>
     </tr>
 


### PR DESCRIPTION
Reflects an increase in the Metric API's max attributes per metric limit from 100 -> 150 as of today (Monday Oct 13)