### PR TITLE
feat: [Do not merge]Add fine-grained access control documentation for secrets management

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-secret-management-service.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-api-secret-management-service.mdx
@@ -840,6 +840,14 @@ Use the `{customerAdministration {secret}}` query to retrieve secrets along with
         </tr>
         <tr>
             <td>
+            `isSharable`
+            </td>
+            <td>
+            Indicates whether the secret is a [sharable secret](#sharable-secrets) with fine-grained access control. If `true`, the secret uses fine-grained permissions and is private to the creator by default. If `false`, it's a standard secret accessible to all users with permissions in the account or organization.
+            </td>
+        </tr>
+        <tr>
+            <td>
             `key`
             </td>
             <td>
@@ -901,6 +909,7 @@ Use the `{customerAdministration {secret}}` query to retrieve secrets along with
     "customerAdministration": {
       "secret": {
         "description": "ZXY",
+        "isSharable": false,
         "key": "Test2",
         "namespace": null,
         "retrievedValue": {
@@ -2083,6 +2092,7 @@ The list includes all secrets in the scope, including sharable secrets you may n
             The details of the listed secrets, including:
             * `description`: The description of the secret, if available.
             * `isDeleted`: Indicates whether the secret is in a soft-delete state or not.
+            * `isSharable`: Indicates whether the secret is a [sharable secret](#sharable-secrets) with fine-grained access control.
             * `key`: The key of the secret.
             * `latestVersion`: The latest version number of the secret.
             * `metadata`: Metadata associated with the secret, if any.
@@ -2121,6 +2131,7 @@ The list includes all secrets in the scope, including sharable secrets you may n
           {
             "description": "ZXY",
             "isDeleted": false,
+            "isSharable": false,
             "key": "test2",
             "latestVersion": 1,
             "metadata": {
@@ -2133,6 +2144,7 @@ The list includes all secrets in the scope, including sharable secrets you may n
           {
             "description": "XYZ",
             "isDeleted": false,
+            "isSharable": false,
             "key": "test2",
             "latestVersion": 0,
             "metadata": {
@@ -2145,6 +2157,7 @@ The list includes all secrets in the scope, including sharable secrets you may n
           {
             "description": "CBA",
             "isDeleted": false,
+            "isSharable": false,
             "key": "test1",
             "latestVersion": 1,
             "metadata": {


### PR DESCRIPTION
This update adds comprehensive documentation for the Fine-Grained Access (FGA) feature for the Secrets Management Service, including:

- New "Sharable secrets with fine-grained access" section explaining privacy by default, automatic ownership, and granular access control
- "Create a sharable secret" collapser with secretsManagementCreateSharableSecret mutation examples
- "Grant access to a sharable secret" collapser with authorizationManagementGrantAccess mutation examples
- Guidance for choosing between standard and sharable secrets
- Related topics section with DocTiles linking to relevant documentation
- Improved integration between access control and FGA concepts

Technical improvements:
- Clarified terminology for standard vs sharable secrets
- Added callout for secret type selection guidance
- Enhanced collapser descriptions for better user understanding
