### PR TITLE
chore: Clarify requirements for Browser agent DT

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing.mdx
@@ -29,7 +29,7 @@ Make sure you have the necessary minimum versions for your <InlinePopover type="
   **Browser monitoring:**
 </DNT>
 
-* For distributed tracing: [Browser Pro+SPA agent](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types) with [distributed tracing enabled](#enable) and [Browser agent version 1153](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1153) or higher
+* For distributed tracing: [Browser Pro agent](/docs/browser/new-relic-browser/configuration/change-browser-agent-type#agent-types) with [distributed tracing enabled](#enable) and [Browser agent version 1211](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1211) or higher
 * For [cross-origin resource sharing](#cors): [Browser agent version 1158](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1158) or higher
 * For [W3C trace context](https://www.w3.org/TR/trace-context/) support: [Browser agent version 1173](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1173) or higher
 

--- a/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
+++ b/src/content/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring.mdx
@@ -192,7 +192,7 @@ The browser agent collects data on sites that use many popular frontend framewor
       </td>
 
       <td>
-        This library is not compatible with our [Pro+SPA agent](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types) due to the way this library wraps promises. If you're using this library, we recommend selecting the [Pro agent type](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types).
+        This library is not compatible with our [Pro+SPA agent](/docs/browser/new-relic-browser/configuration/change-browser-agent-type#agent-types) due to the way this library wraps promises. If you're using this library, we recommend selecting the [Pro agent type](/docs/browser/new-relic-browser/configuration/change-browser-agent-type#agent-types).
       </td>
     </tr>
 

--- a/src/content/docs/browser/new-relic-browser/installation/update-browser-agent.mdx
+++ b/src/content/docs/browser/new-relic-browser/installation/update-browser-agent.mdx
@@ -42,7 +42,7 @@ To verify your browser version number, try one of the following:
 
 ## Check your installation type
 
-There are different [agent types](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types). The Pro+SPA agent loader files use the format `js-agent.newrelic.com/nr-loader-<type>-<version>.min.js`.
+There are different [agent types](/docs/browser/new-relic-browser/configuration/change-browser-agent-type#agent-types). The Pro+SPA agent loader files use the format `js-agent.newrelic.com/nr-loader-<type>-<version>.min.js`.
 To verify the version of the browser script loader on your page, inspect the newrelic global object (v1224 or higher):
 
 1. Open the developer tools of your browser.

--- a/src/content/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring.mdx
+++ b/src/content/docs/browser/single-page-app-monitoring/get-started/install-single-page-app-monitoring.mdx
@@ -22,4 +22,4 @@ When you set up your first monitored app in a New Relic account, you must agree 
 
 ## Enable or disable SPA monitoring [#enable-spa]
 
-When you [enable browser monitoring](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#enable), SPA monitoring is included by default because it gives access to a range of our most recent features, including distributed tracing. Some older agent installations may need to be upgraded. Read more about [browser agent types](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#agent-types).
+When you [enable browser monitoring](/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent#enable), SPA monitoring is included by default because it gives access to a range of our most recent features, including distributed tracing. Some older agent installations may need to be upgraded. Read more about [browser agent types](/docs/browser/new-relic-browser/configuration/change-browser-agent-type#agent-types).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

## Give us some context

This PR clarifies Distributed Tracing requirements for Browser agent to reduce the amount of customer support questions. It requires the Pro agent (not the Pro+SPA agent) and version 1211 (not version 1153). It also fixes the link to our agent types to refer to a page that actually has the agent types listed.