### PR TITLE
chore: Clarify pause and start functionality

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/pauseReplay.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/pauseReplay.mdx
@@ -46,6 +46,6 @@ newrelic.pauseReplay()
 ### Resuming a paused replay
 
 ```js
-newrelic.pauseReplay()
-newrelic.recordReplay()
+  newrelic.pauseReplay()
+  newrelic.recordReplay()
 ```

--- a/src/content/docs/browser/new-relic-browser/browser-apis/recordReplay.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/recordReplay.mdx
@@ -46,5 +46,5 @@ For information about pausing and resuming a replay, refer to [`newrelic.pauseRe
 ### Forcing a replay to start recording
 
 ```js
-newrelic.recordReplay()
+  newrelic.recordReplay()
 ```


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

## Give us some context

Adds instructions to Browser session replay on how to resume a replay that was paused. We get support questions over this so we want to clarify this behavior in the docs.