### PR TITLE
fix: remove placeholder TODO link in cloud rules API documentation

### DIFF
--- a/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/cloud-rules-api.mdx
@@ -91,7 +91,7 @@ Creating rules about sensitive data can leak information about what kinds of dat
 Only new data will be dropped. Existing data [cannot be edited or deleted](/docs/telemetry-data-platform/ingest-manage-data/manage-data/manage-data-retention#data-deletion).
 
 # Managing cloud rules [#how-to]
-To create and edit rules, you can either use the [Pipeline Control UI](/docs/todo/replace/with/pipeline/control/ui/usage/doc) or the [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) API explorer _(**[one.newrelic.com](https://one.newrelic.com) > Apps > NerdGraph API explorer**)_.
+To create and edit rules, you can either use the Pipeline Control UI or the [NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) API explorer _(**[one.newrelic.com](https://one.newrelic.com) > Apps > NerdGraph API explorer**)_.
 
 <Callout variant="caution">
   Use caution when deciding to drop data. The data you drop can't be recovered. For more details on potential issues, see [Caution notes](#caution).


### PR DESCRIPTION
## Summary
- Remove broken TODO link placeholder in cloud-rules-api.mdx
- Simplify text to reference Pipeline Control UI directly instead of broken link

## Test plan
- [x] Verify the documentation renders correctly without the broken link
- [x] Confirm the text flows naturally after removing the TODO placeholder