### PR TITLE
Revise job manager configuration equations and terms 

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration.mdx
@@ -1890,7 +1890,7 @@ $$C_{req} = N_{mon} \times D_{avg,m} \times \frac{1}P_{avg,m}$$
 
 When using these formulas, remember to account for these factors:
 
-  * **Job duration ($D_j$):** Your average should include jobs that **time out** (often \~3 minutes), as these hold a core for their entire duration.
+  * **Job duration ($D_{avg,m}$):** Your average should include jobs that **time out** (often \~3 minutes), as these hold a core for their entire duration.
   * **Job failures and retries:** When a monitor fails, it's automatically retried. These retries are additional jobs that add to the total load. A monitor that consistently fails and retries **effectively multiplies its period**, significantly impacting throughput.
   * **Scaling out:** In addition to adding more cores to a host (scaling up), you can deploy additional synthetics job managers with the same private location key to load balance jobs across multiple environments (scaling out).
 
@@ -1981,7 +1981,7 @@ Where $D_{avg,s}$ is the **average job duration** in **seconds**.
 
 $$Parallelism = \frac{N_m}{Completions}$$
 
-Where $N_m$ is the **number** of synthetics jobs you need to run every **5 minute**.
+Where $N_m$ is the **number** of synthetic jobs you need to run every **5 minutes.**
 
 The following queries can be used to obtain average duration and rate for a private location.
 


### PR DESCRIPTION
Updated equations and variables for calculating required CPU cores and job metrics in synthetic monitoring documentation.

- unify duration variables and specify units as m or s for minutes or seconds
- clarify rates versus counts with R_ or N_
- standardizing LaTeX using `$\mathrm{...}$` (roman font) for multi-letter variable names like "Parallelism" to distinguish them from single-letter variables.
- use `period` instead of `frequency`
- add to description for ping runtime scaling