### PR TITLE
docs(dotnet): Update distributed trace sampler configuration

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3266,7 +3266,7 @@ The `distributedTracing` element supports the following attributes:
 #### Sampler Configuration 
 
 <Callout variant="important">
-Sampler configuration is available starting with .NET agent version 10.45.0
+Sampler configuration is available starting with .NET agent version 10.45.0.
 </Callout>
 
 The .NET agent currently supports 4 different sampling algorithms that can be configured for use in distributed tracing:


### PR DESCRIPTION
Updates the Distributed Tracing documentation for the .NET agent to add new configuration options that became available with .NET agent 10.45.0