### PR TITLE
chore(ruby-agent): Add a section for log frameworks

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks.mdx
@@ -827,6 +827,59 @@ New Relic is expanding its support for AI/ML libraries.
   </tbody>
 </table>
 
+## Logging libraries
+
+The agent can forward logs from the following libraries for [APM logs in context](/docs/logs/logs-context/get-started-logs-context/).
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+      **Library**
+      </th>
+      <th>
+      **Gem Name**
+      </th>
+      <th>
+      **Supported**
+      </th>
+      <th>
+      **Notes**
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+      **Logger**
+      </td>
+      <td>
+      `logger`
+      </td>
+      <td>
+      </td>
+      <td>
+      Support for APM log forwarding using Ruby's Logger library and any logging library that inherits from the Ruby
+      Logger, such as ActiveSupport::BroadcastLogger.
+      </td>
+    </tr>
+    <tr>
+      <td>
+      **Logstasher**
+      </td>
+      <td>
+      `logstasher`
+      </td>
+      <td>
+      1.x.x and above
+      </td>
+      <td>
+      Support for APM log forwarding.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Other libraries and technologies [#other_libraries]
 
 <table>
@@ -936,33 +989,6 @@ New Relic is expanding its support for AI/ML libraries.
       </td>
       <td>
       See [AWS Lambda Monitoring](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/introduction-lambda/) for more information.
-      </td>
-    </tr>
-    <tr>
-      <td>
-      **Logger**
-      </td>
-      <td>
-      `logger`
-      </td>
-      <td>
-      </td>
-      <td>
-      Support for APM log forwarding using Ruby's Logger library.
-      </td>
-    </tr>
-    <tr>
-      <td>
-      **Logstasher**
-      </td>
-      <td>
-      `logstasher`
-      </td>
-      <td>
-      1.x.x and above
-      </td>
-      <td>
-      Support for APM log forwarding.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Previously, it was difficult to tell what logging libraries had APM logs in context support. Now, it has its own table. We plan to add more logging libraries this quarter.