### PR TITLE
Correct Blob API URL

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-rag.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-rag.mdx
@@ -189,7 +189,7 @@ Here's an example of how to upload a document using a `curl` `bash` command:
 
 ### Sample query
 ```shell
-curl -X POST https://blob-api.one-service.newrelic.com/v1/e/organizations/$ORGANIZATION_ID/RagDocuments \
+curl -X POST https://blob-api.service.newrelic.com/v1/e/organizations/$ORGANIZATION_ID/RagDocuments \
      -H 'Api-Key: NRAK-XXXXXXXXXX' \
      -H 'NewRelic-Entity: {"name": "Runbooks for API service" }' \
      -H 'Content-Type: application/json' \


### PR DESCRIPTION
Change https://blob-api.one-service.newrelic.com to https://blob-api.service.newrelic.com for accuracy

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Change https://blob-api.one-service.newrelic.com to https://blob-api.service.newrelic.com for accuracy
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.