### PR TITLE
docs(dotnet): Update distributed trace sampler configuration

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3179,11 +3179,11 @@ The `datastoreTracer` element supports the following sub-elements:
 The `distributedTracing` element is a child of the `configuration` element.
 
 ```xml
-<distributedTracing enabled="false"
+<distributedTracing enabled="true"
    excludeNewrelicHeader="false"/>
 ```
 
-Distributed tracing lets you see the path that a request takes as it travels through a distributed system. It requires [.NET agent version 8.6.45.0 or higher](/docs/agents/net-agent/installation/update-net-agent) and is on by default in .NET agents 9.0.0.0 and higher.
+Distributed tracing lets you see the path that a request takes as it travels through a distributed system. It requires [.NET agent version 8.6.45.0 or higher](/docs/agents/net-agent/installation/update-net-agent) and is enabled by default in .NET agents 9.0.0.0 and higher.
 
 <Callout variant="important">
   Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) disables [cross application tracing](#cross_application_tracer), and has other effects on APM features. Before enabling, read the [planning guide](/docs/transition-guide-distributed-tracing).
@@ -3262,6 +3262,65 @@ The `distributedTracing` element supports the following attributes:
     If you do not want to utilize the `newrelic` header, setting this to `true` will result in the agent excluding the `newrelic` header and only using W3C Trace Context headers for distributed tracing.
   </Collapser>
 </CollapserGroup>
+
+#### Sampler Configuration
+
+The .NET agent currently supports 4 different sampling algorithms that can be configured for use in distributed tracing:
+
+* **Adaptive Sampler** - this is the original sampling algorithm used by the .NET agent and is enabled by default. Sampling decisions are made at random, with the goal of retaining a configured number of samples per sampling period.
+* **Trace Id Ratio Based Sampler** - this is an implementation of the Open Telemetry Trace Id Ratio Based Sampler which samples a configured percentage of traces based on the (randomly generated) Trace Id.
+* **Always On Sampler** - as the name implies, this sampler wil sample every trace. Note that enabling this sampler can have an impact on application performance and will result in increased data ingest cost. 
+* **Always Off Sampler** - The opposite of Always On; this sampler does not sample any traces. Useful in very specfic cases.
+
+The supported samplers can be configured at multiple levels:
+* **Root** - this is the sampler that is applied at the beginning of a trace. By default, the Adaptive Sampler is configured as the Root sampler.
+* **Remote Parent Sampled** - this is the sampler that is applied when the trace has a remote parent that has been sampled. It can be configured to use, for example, the Always On sampler to ensure that all traces in the current application are sampled. 
+* **Remote Parent Not Sampled** - this is the sampler that is applied when a trace has a remote parent that is not sampled.
+
+The sampler configuration element is a child of the `<distributedTracing>` element.
+
+```xml
+<distributedTracing ... >
+  <sampler>
+    <root>
+      ...
+    </root>
+    <remoteParentSampled>
+      ...
+    </remoteParentSampled>
+    <remoteParentNotSampled>
+      ...
+    </remoteParentNotSampled>
+  </sampler>
+</distributedTracing>
+```
+
+For each of the sampler levels, one of the following sampler configurations can be specified:
+```xml
+<adaptive />
+<traceIdRatio sampleRatio="0.12" />
+<alwaysOn />
+<alwaysOff />
+```
+
+The `<traceIdRatio>` element takes a `sampleRatio`, which is a value between 0.0 and 1.0 specifying the percentage of traces that should be sampled.
+
+By default, the Adaptive Sampler is used if there is no other configuration specified at a particular sampler level.
+
+The following environment variables can also be used to configure the distributed trace sampler, specifying one of the possible values for the sampler type:
+```
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT= default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED =  default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED = default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
+```
+If `traceIdRatioBased` is specified as the value of one these environment variables, a corresponding environment variable to specify the ratio is also required:
+```
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO=0.12
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO=0.12
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO=0.12
+```
+
+#### Span event reporting
 
 Distributed tracing reports span events. Span event reporting is enabled by default, but [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) must be enabled for spans to be reported. To disable span events, choose one of the following options:
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3265,7 +3265,7 @@ The `distributedTracing` element supports the following attributes:
 
 #### Sampler Configuration 
 
-<Callout variant="important>
+<Callout variant="important">
 Sampler configuration is available starting with .NET agent version 10.45.0
 </Callout>
 
@@ -3374,28 +3374,29 @@ The supported samplers can be configured at multiple levels:
 The `<sampler>` configuration element is a child of the `<distributedTracing>` element and is structured as follows:
 
 ```xml
-<distributedTracing ... >
-  <sampler>
-    <root>
-      ...
-    </root>
-    <remoteParentSampled>
-      ...
-    </remoteParentSampled>
-    <remoteParentNotSampled>
-      ...
-    </remoteParentNotSampled>
-  </sampler>
-</distributedTracing>
+  <distributedTracing ... >
+    <sampler>
+      <root>
+        ...
+      </root>
+      <remoteParentSampled>
+        ...
+      </remoteParentSampled>
+      <remoteParentNotSampled>
+        ...
+      </remoteParentNotSampled>
+    </sampler>
+  </distributedTracing>
 ```
 
 For each of the sampler levels, one of the following sampler configurations can be specified:
+
 ```xml
-<default /> # default is a synonym for <adaptive />
-<adaptive />
-<traceIdRatioBased ratio="0.12" />
-<alwaysOn />
-<alwaysOff />
+  <default /> # default is a synonym for <adaptive />
+  <adaptive />
+  <traceIdRatioBased ratio="0.12" />
+  <alwaysOn />
+  <alwaysOff />
 ```
 
 The `<traceIdRatioBased>` element has a required `ratio` attribute, which is a value between 0.0 and 1.0 specifying the percentage of traces that should be sampled.

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3263,7 +3263,11 @@ The `distributedTracing` element supports the following attributes:
   </Collapser>
 </CollapserGroup>
 
-#### Sampler Configuration
+#### Sampler Configuration 
+
+<Callout variant="important>
+Sampler configuration is available starting with .NET agent version 10.45.0
+</Callout>
 
 The .NET agent currently supports 4 different sampling algorithms that can be configured for use in distributed tracing:
 

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3271,17 +3271,107 @@ Sampler configuration is available starting with .NET agent version 10.45.0
 
 The .NET agent currently supports 4 different sampling algorithms that can be configured for use in distributed tracing:
 
-* **Adaptive Sampler** - this is the original sampling algorithm used by the .NET agent and is enabled by default. Sampling decisions are made at random, with the goal of retaining a configured number of samples per sampling period.
-* **Trace Id Ratio Based Sampler** - this is an implementation of the Open Telemetry Trace Id Ratio Based Sampler which samples a configured percentage of traces based on the (randomly generated) Trace Id.
-* **Always On Sampler** - as the name implies, this sampler wil sample every trace. Note that enabling this sampler can have an impact on application performance and will result in increased data ingest cost. 
-* **Always Off Sampler** - The opposite of Always On; this sampler does not sample any traces. Useful in very specfic cases.
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <DNT>
+              **Sampler Type**
+            </DNT>
+          </th>
+
+          <th>
+            <DNT>
+              **Description**
+            </DNT>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Adaptive Sampler
+          </td>
+          <td>
+            The original sampling algorithm used by the .NET agent and is enabled by default. Sampling decisions are made at random, with the goal of retaining a configured number of samples per sampling period.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Trace Id Ratio Based Sampler
+          </td>
+          <td>
+            An implementation of the Open Telemetry Trace Id Ratio Based Sampler which samples a configured percentage of traces based on the (randomly generated) Trace Id.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Always On Sampler
+          </td>
+          <td>
+            As the name implies, this sampler wil sample every trace. Note that enabling this sampler can have an impact on application performance and will result in increased data ingest. 
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Always Off Sampler
+          </td>
+          <td>
+            The opposite of Always On; this sampler does not sample any traces. Useful in very specfic cases.
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
 The supported samplers can be configured at multiple levels:
-* **Root** - this is the sampler that is applied at the beginning of a trace. By default, the Adaptive Sampler is configured as the Root sampler.
-* **Remote Parent Sampled** - this is the sampler that is applied when the trace has a remote parent that has been sampled. It can be configured to use, for example, the Always On sampler to ensure that all traces in the current application are sampled. 
-* **Remote Parent Not Sampled** - this is the sampler that is applied when a trace has a remote parent that is not sampled.
 
-The sampler configuration element is a child of the `<distributedTracing>` element.
+    <table>
+      <thead>
+        <tr>
+          <th>
+            <DNT>
+              **Sampler Level**
+            </DNT>
+          </th>
+
+          <th>
+            <DNT>
+              **Description**
+            </DNT>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Root
+          </td>
+          <td>
+            This is the sampler that is applied at the beginning of a trace. By default, the Adaptive Sampler is configured as the Root sampler.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Remote Parent Sampled
+          </td>
+          <td>
+            This is the sampler that is applied when the trace has a remote parent (i.e., the trace originated in an upstream service) that has been sampled. It can be configured to use, for example, the Always On sampler to ensure that all traces in the current application are sampled. 
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Remote Parent Not Sampled
+          </td>
+          <td>
+            This is the sampler that is applied when a trace has a remote parent (i.e., the trace originated in an upstream service) that was NOT sampled.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+The `<sampler>` configuration element is a child of the `<distributedTracing>` element and is structured as follows:
 
 ```xml
 <distributedTracing ... >
@@ -3311,10 +3401,10 @@ For each of the sampler levels, one of the following sampler configurations can 
 The `<traceIdRatioBased>` element has a required `ratio` attribute, which is a value between 0.0 and 1.0 specifying the percentage of traces that should be sampled.
 
 <Callout variant="important">
-By default, the **Adaptive Sampler** is used if there is no other configuration specified at a particular sampler level.
+The **Adaptive Sampler** will be used if there is no configuration specified at a particular sampler level or if the configuration element for that level is not specified at all.
 </Callout>
 
-The following environment variables can also be used to configure the distributed trace sampler at the various sampler levels, specifying one of the possible values for the sampler type:
+The following environment variables can be used to configure the distributed trace sampler at the various sampler levels, specifying one of the possible values for the sampler type:
 ```
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT= default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED =  default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3297,23 +3297,26 @@ The sampler configuration element is a child of the `<distributedTracing>` eleme
 
 For each of the sampler levels, one of the following sampler configurations can be specified:
 ```xml
+<default /> # default is a synonym for <adaptive />
 <adaptive />
-<traceIdRatio sampleRatio="0.12" />
+<traceIdRatioBased ratio="0.12" />
 <alwaysOn />
 <alwaysOff />
 ```
 
-The `<traceIdRatio>` element takes a `sampleRatio`, which is a value between 0.0 and 1.0 specifying the percentage of traces that should be sampled.
+The `<traceIdRatioBased>` element has a required `ratio` attribute, which is a value between 0.0 and 1.0 specifying the percentage of traces that should be sampled.
 
-By default, the Adaptive Sampler is used if there is no other configuration specified at a particular sampler level.
+<Callout variant="important">
+By default, the **Adaptive Sampler** is used if there is no other configuration specified at a particular sampler level.
+</Callout>
 
-The following environment variables can also be used to configure the distributed trace sampler, specifying one of the possible values for the sampler type:
+The following environment variables can also be used to configure the distributed trace sampler at the various sampler levels, specifying one of the possible values for the sampler type:
 ```
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT= default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED =  default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED = default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
 ```
-If `traceIdRatioBased` is specified as the value of one these environment variables, a corresponding environment variable to specify the ratio is also required:
+If `traceIdRatioBased` is specified as the value of one these environment variables, a corresponding environment variable to specify the ratio is also required for the same sampler level:
 ```
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO=0.12
 NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO=0.12


### PR DESCRIPTION
Updates the Distributed Tracing documentation for the .NET agent to add new configuration options that became available with .NET agent 10.45.0