### PR TITLE
Update APM UI documentation for Go runtime metrics

### DIFF
--- a/src/content/docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui.mdx
+++ b/src/content/docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui.mdx
@@ -283,7 +283,17 @@ The Go runtime page shows golden signals alongside Go runtime metrics to
 correlate runtime issues with service usage.
 
 The queries assume data is produced by the [OpenTelemetry Go runtime instrumentation library](https://opentelemetry.io/docs/specs/semconv/runtime/go-metrics/).
-Note, there are currently no semantic conventions for Go runtime metrics.
+
+<Callout variant="important">
+The [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/runtime/go-metrics.md)
+for Go runtime metrics are still under development. The Go runtime page targets
+an older version of the conventions. You must enable the old conventions by
+enabling the `OTEL_GO_X_DEPRECATED_RUNTIME_METRICS` environment variable. For more
+information refer to the [documentation](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/9a6e0bf68e1da495be52faf152b5b4e6fb09d475/instrumentation/runtime/internal/x/README.md)
+for the instrumentation.
+
+New Relic will eventually support the new conventions once they become stable.
+</Callout>
 
 ### Logs [#logs-page]
 


### PR DESCRIPTION
Added information about the development status of semantic conventions for Go runtime metrics and instructions for enabling deprecated conventions.