### PR TITLE
Browser Session Replay - server side config clarification

### DIFF
--- a/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/configuration/setup-session-replay.mdx
+++ b/src/content/docs/browser/browser-monitoring/browser-pro-features/session-replay/configuration/setup-session-replay.mdx
@@ -7,7 +7,7 @@ freshnessValidatedDate: 2024-12-19
 To utilize session replay in New Relic, start by enabling this feature in your browser application settings. This step is essential for capturing user interactions on your web app, providing insights into user journeys, and troubleshooting issues effectively. Follow the steps below to enable session replay and ensure your browser agent is configured correctly.
 
   <Callout variant="important">
-    Certain settings, including enabling or disabling the session replay and adjusting the sample rates for overall sessions or for just those with errors, have been moved to server-side configuration. For example, after the snippet has been updated in your pages to include the session replay feature, there's no need to redeploy the script when changing the sample rates or disabling/re-enabling the feature. If the feature has not been included in the deployed script then the server-side configuration will not have any impact. This is applicable for browser agent version `1.259.0` or higher.
+    Certain settings, including enabling or disabling the session replay and adjusting the sample rates for overall sessions or for just those with errors, have been moved to server-side configuration. For example, after the snippet has been updated in your pages to include the session replay feature, there's no need to redeploy the script when changing the sample rates or when disabling or re-enabling the feature. If the feature has not been included in the deployed script then the server-side configuration will not have any impact. This is applicable for browser agent version `1.259.0` or higher.
   </Callout>
 
 ## Enable session replay [#enable-session-replay]


### PR DESCRIPTION
I have attempted to clarify in the callout that server-side configuration requires the deployed script to include the session replay feature, and that if it does not then the script does need to be updated and redeployed before server-side settings will take effect.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.