### PR TITLE
Add Password Protection feature for Public Dashboards

### DIFF
--- a/src/content/whats-new/2025/07/whats-new-07-30-public-dash-pass-protection.md
+++ b/src/content/whats-new/2025/07/whats-new-07-30-public-dash-pass-protection.md
@@ -8,7 +8,7 @@ getStartedLink: 'https://docs.newrelic.com/docs/query-your-data/explore-query-da
 
 Secure your sensitive operational data with New Relic's new Password Protection feature for Public Dashboards! This exciting new capability allows you to add a password to your shared dashboards, ensuring only authorized individuals can access them. With auto-generated, complex passwords, session-based access, and API control, you can confidently share insights externally or with specific internal teams without compromising security. Plus, keep an eye out for upcoming enhancements like custom password options and more granular usage tracking!
 
-### Key features
+## Key features [#key-features]
 
 -   Password generation: Passwords are auto-generated and highly complex.
 -   Password storage: New Relic DOES NOT store the plain-text password. It's only displayed once upon creation or reset. Users must copy and securely store the password themselves.
@@ -17,7 +17,8 @@ Secure your sensitive operational data with New Relic's new Password Protection 
 -   API control: Full control over enabling, disabling, and resetting passwords is available via NerdGraph API.
 -   UI control: Users can enable/disable password protection and initiate a password reset.
 
-**Learn more:**
+### Learn more [#learn-more]
+
 -   [Password Protection for Public Dashboards](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#create-dashboard-url)
 -   [Password Protection via API](https://docs.newrelic.com/docs/apis/nerdgraph/examples/manage-live-dashboard-urls-via-api/#enable-password-dashboard-url-nerdgraph)
 -   [Password protection management & best practices](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally/#password-management)


### PR DESCRIPTION
This new feature enhances the security of publicly shared dashboards by allowing users to set passwords, ensuring only authorized access. It includes features like auto-generated passwords, session-based access, and API control.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? Adds a missing (and important) feature release to our what's new 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.