### PR TITLE
8.21.0 MemoryLeak changes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8210.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8210.mdx
@@ -8,7 +8,7 @@ bugs: [“Fixes the distributed_tracing.sampler config”, “Fixes an Illegal A
 security: [“Upgrades the com.newrelic.agent.java:infinite-tracing-protobuf for better security with infinite tracing”, “Replaces snakeyaml with com.konloch:safeyaml to address a security vulnerability”]
 ---
 <Callout variant="caution">
-**Known issues**: this release has a known issue with certain uses of Netty Reactor that can cause memory leaks.
+**Known issues**: This release has a known issue with certain uses of Netty Reactor that can cause memory leaks.
 Please consider using another version.
 </Callout>
 


### PR DESCRIPTION
It was discovered that v8.21.0 could produce a memory leak in certain situations with Netty Reactor due to the changes included here.

