### PR TITLE
add: New Relic iOS agent 7.6.0 release notes

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-760.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-760.mdx
@@ -6,8 +6,9 @@ downloadLink: 'https://download.newrelic.com/ios_agent/NewRelic_XCFramework_Agen
 ---
 
 
-##Important
-- This release bumps the required iOS version of the New Relic iOS agent to iOS 16.
+## Important
+
+* This release bumps the required iOS version of the New Relic iOS agent to iOS 16.
 
 ## New in this release
 


### PR DESCRIPTION
Adds file `../release-notes/mobile-release-notes/ios-release-notes/ios-agent-760.mdx`
This change contains the New Relic iOS agent 7.6.0 release notes.