### PR TITLE
docs: use 10e9, not 10e8, for GB Estimate calculation

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
@@ -65,7 +65,7 @@ The [usage UI](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new
     This query breaks down [Metric data](/docs/telemetry-data-platform/understand-data/new-relic-data-types/#dimensional-metrics) by the top ten metric names. You could also facet by `appName` or `host` to adjust the analysis.
 
     ```sql
-    FROM Metric SELECT bytecountestimate()/10e8 AS 'GB Estimate' 
+    FROM Metric SELECT bytecountestimate()/10e9 AS 'GB Estimate' 
     SINCE 24 hours ago
     FACET metricName LIMIT 10 TIMESERIES 1 hour
     ```


### PR DESCRIPTION
@annettejanewilson actually deserves the credit for spotting this 😄

Unless the definition of bytes or `GB` is unusual, dividing by `10e8` doesn't seem right!

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
    * The docs show an incorrect (and thus misleading) example query
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
    * Ought to be reasonably self-apparent
* If your issue relates to an existing GitHub issue, please link to it.
    * No it does not.