### PR TITLE
Update opentelemetry-get-started-intro.mdx to remove duplicated word

### DIFF
--- a/src/content/docs/opentelemetry/get-started/opentelemetry-get-started-intro.mdx
+++ b/src/content/docs/opentelemetry/get-started/opentelemetry-get-started-intro.mdx
@@ -25,6 +25,6 @@ The pages below focus on common integration patterns, providing a foundation for
 
 <DocTiles>
   <DocTile title='APM monitoring' path="/docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-intro/">Monitor your applications and services by configuring the OpenTelemetry Protocol (OTLP) exporter to send data to New relic via the New Relic OTLP endpoint.</DocTile>
-  <DocTile title='Infrastructure monitoring' path="/docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro">Monitor your infrastructure hosts, containers, and more by configuring the the OpenTelemetry Collector to send data to New Relic.</DocTile>
+  <DocTile title='Infrastructure monitoring' path="/docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro">Monitor your infrastructure hosts, containers, and more by configuring the OpenTelemetry Collector to send data to New Relic.</DocTile>
   <DocTile title='General data processing' path="/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro">Monitor all other data by using the OpenTelemetry Collector to receive, process (enriching, transforming, sampling, filtering, etc), and export telemetry data to New Relic.</DocTile>
 </DocTiles>


### PR DESCRIPTION
Removed unnecessary duplicated word "the the"

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* A duplicated word has been entered
