### PR TITLE
Update update-serverless-monitoring-aws-lambda.mdx

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/update-serverless-monitoring-aws-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/update-serverless-monitoring-aws-lambda.mdx
@@ -80,7 +80,7 @@ If you [manually installed the ingest function from the AWS Serverless Applicati
 
    This command outputs several fields, one of which is the `ChangeSetId`: an ARN for the change set that you just created. Copy that ARN.
 
-   If you have created the existing CloudFormation stack with the stack parameter FunctionRole, specify the function role name with --parameter-overrides as below.
+   If you have created the existing CloudFormation stack with the stack parameter FunctionRole, specify the function role name with `--parameter-overrides` as below.
 
    ```bash
    aws serverlessrepo create-cloud-formation-change-set \


### PR DESCRIPTION
fix: fix the update-sar section to prevent errors.

* Added CAPABILITY_IAM to the capabilities options of the command. You will receive errors like below on "aws serverlessrepo create-cloud-formation-change-set" when you don't  provide the capability.

```
An error occurred (BadRequestException) when calling the CreateCloudFormationChangeSet operation: Required capabilities [CAPABILITY_IAM] were not provided.
```

* Added the command for the situation where users specified the FunctionRole stack parameter when they create the existing CFn stacks.
  * The existing command described on the doc only assumes situations where users don't provide the stack parameter FunctionRole.
  * If users don't provide the stack parameter while they specify it on the stack creation, CloudFormation will delete the lambda function resource NewRelicLogIngestionFunctionNoCap and create NewRelicLogIngestionFunction instead. As both of the Lambda resources have the same resource names (FunctionName), you will receive errors like below which indicate lambda function name conflicts on the new lambda creations. The change-set executions will be failed.

```
newrelic-log-ingestion-<PART_OF_STACK_IDS> already exists in stack <STACK_ARN>
```

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  * To solve CFn change set execution errors on stack updates in the situation where users created the existing stacks with the stack parameter FunctionRole.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.
  * N/A