### PR TITLE
Update java agent docs to accommodate use_controller_class_and_method_for_spring_transaction_naming config option

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -2678,7 +2678,7 @@ Set instrumentation related settings in the `class_transformer` section. You can
 
     Applies to Spring 4.3.x+ (spring-4.3.0 module) and Spring 6.x+ (spring-6.0.0 module).
 
-    This config exists in Java agent version 8.19.0+.
+    This config exists in Java agent version 8.25.0+.
   </Collapser>
 
 <Collapser


### PR DESCRIPTION
Adds documentation for the new Java agent 8.25.0+ configuration option `use_controller_class_and_method_for_spring_transaction_naming`.

  This option allows Spring Controller transactions to be named using the controller class name and method name (e.g., `/CustomerController/edit`) instead of using request mappings (e.g., `/api/v1/customer (POST)`).

  This helps prevent transaction name cardinality issues with complex URI patterns and takes precedence over the existing `enhanced_spring_transaction_naming` setting.