### PR TITLE
feat: Update GCP permissions for 4 services

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -85,6 +85,20 @@ To customize your role you need to:
             * `bigquery.datasets.get`
             * `bigquery.tables.get`
             * `bigquery.tables.list`
+            * `bigquery.jobs.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Cloud Dataflow](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration)
+          </td>
+
+          <td>
+            * `dataflow.jobs.get`
+            * `dataflow.jobs.list`
+            * `dataflow.messages.list`
+            * `dataflow.metrics.get`
           </td>
         </tr>
 
@@ -123,11 +137,31 @@ To customize your role you need to:
 
         <tr>
           <td>
+            [Google Cloud Run](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration)
+          </td>
+
+          <td>
+            * `run.configurations.get`
+            * `run.configurations.list`
+            * `run.locations.list`
+            * `run.revisions.get`
+            * `run.revisions.list`
+            * `run.routes.get`
+            * `run.routes.list`
+            * `run.services.get`
+            * `run.services.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             [Google Cloud Spanner](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration)
           </td>
 
           <td>
+            * `spanner.instances.get`
             * `spanner.instances.list`
+            * `spanner.databases.get`
             * `spanner.databases.list`
             * `spanner.databases.getDdl`
           </td>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
 Update GCP custom roles permissions for Dataflow, Spanner, BigQuery, and Cloud Run
  - Add bigquery.jobs.list permission to BigQuery integration
  - Add Cloud Dataflow integration with required permissions (dataflow.jobs.get, dataflow.jobs.list, dataflow.messages.list, dataflow.metrics.get)
  - Add spanner.instances.get and spanner.databases.get permissions to Spanner integration
  - Add Cloud Run integration with required permissions (run.configurations.*, run.locations.list, run.revisions.*, run.routes.*, run.services.*)
 
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  **The feature already exists, just that we are enhancing the document for the customers.**

* If your issue relates to an existing GitHub issue, please link to it.
[https://new-relic.atlassian.net/browse/NR-484530]