### PR TITLE
Java Agent v8.25.0 Release Notes [MERGE ON 11/12/2025]

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8250.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-8250.mdx
@@ -1,7 +1,7 @@
 ---
-subject:  Java agent
-releaseDate:  '2025-11-12'
-version:  8.25.0
+subject: Java agent
+releaseDate: '2025-11-12'
+version: 8.25.0
 downloadLink: 'https://download.newrelic.com/newrelic/java-agent/newrelic-agent/8.25.0/'
 features: [“Adds Java 25 Support”, “Adds Logback-1.5.20 Support”, “Introduces a config option to update Spring Controller transaction naming”]
 bugs: [“Error Class Naming: fixed parsing logic”, “Error Logging: fixed potential memory issue”]
@@ -27,16 +27,14 @@ security: []
 - Introduces a preference config for multiple hosts during datastore detection by @jbedell-newrelic in [2508](https://github.com/newrelic/newrelic-java-agent/pull/2508)
 - Adds a system property to configure the artifact skip function by @jtduffy in [2509](https://github.com/newrelic/newrelic-java-agent/pull/2509)
 - Adds a configuration option allowing Spring Controller transactions to be named using the controller class name and method name by @sharvath-newrelic in [2532](https://github.com/newrelic/newrelic-java-agent/pull/2532)
-- Implement SamplerConfig, centralizing all `distributed_tracing.sampler` configs into the `SamplerConfig` by @jasonjkeller in [2529](https://github.com/newrelic/newrelic-java-agent/pull/2529)
-- Updated `kafka-clients-spans-0.11.0.0` producer instrumentation to use modern distributed tracing API’s with W3C Trace Context support by @sharvath-newrelic in [2516](https://github.com/newrelic/newrelic-java-agent/pull/2516)
+- Implements SamplerConfig, centralizing all `distributed_tracing.sampler` configs into the `SamplerConfig` by @jasonjkeller in [2529](https://github.com/newrelic/newrelic-java-agent/pull/2529)
+- Updates `kafka-clients-spans-0.11.0.0` producer instrumentation to use modern distributed tracing API’s with W3C Trace Context support by @sharvath-newrelic in [2516](https://github.com/newrelic/newrelic-java-agent/pull/2516)
 
 ## Fixes
 
 - Fixes parsing of error class names by @sharvath-newrelic in [2497](https://github.com/newrelic/newrelic-java-agent/pull/2497)
-- Fixed a potential memory issue caused by excessively large stack traces in error logging by @jtduffy in [2498](https://github.com/newrelic/newrelic-java-agent/pull/2498)
+- Fixes a potential memory issue caused by excessively large stack traces in error logging by @jtduffy in [2498](https://github.com/newrelic/newrelic-java-agent/pull/2498)
 - Clarify logging messages for invalid attributes on custom events and logging events by @sharvath-newrelic in [2501](https://github.com/newrelic/newrelic-java-agent/pull/2501)
-
-
 
 ## Deprecations
 


### PR DESCRIPTION
Adds release notes for java agent v8.25.0
Tentative release date is 11/12/2025. Hold merge until the agent is released.
[Issue #2564](https://github.com/newrelic/newrelic-java-agent/issues/2564)