### PR TITLE
Update Java Supported Frameworks and Libraries

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -199,6 +199,7 @@ The agent automatically instruments these frameworks and libraries:
     * Jersey 1.0.1 to latest
     * JSF (Java Server Faces)
     * JUL (Java util logging) (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
+    * Kotlin Coroutines 1.4.0 to latest
     * Log4j1 1.2.17 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
     * Log4j2 2.6 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)
     * Logback 1.1 to latest (for our [logs in context](/docs/logs/logs-context/java-configure-logs-context-all/) feature)


### PR DESCRIPTION
Update the list of supported Frameworks and Libraries to include Kotlin Coroutines 1.4.0+