### PR TITLE
chore: Add .NET 10 to the list of supported versions for the .NET agent

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -126,6 +126,14 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0 and higher
                 </td>
                 </tr>
+                <tr>
+                <td>
+                    .NET 10.0
+                </td>
+                <td>
+                    10.0.0 and higher
+                </td>
+                </tr>
             </tbody>
             </table>
 


### PR DESCRIPTION
Updates the .NET agent compatibility docs to include .NET 10 as a supported .NET version.