### PR TITLE
Update change-applied-intelligence-correlation-logic-decisions.mdx

### DIFF
--- a/src/content/docs/alerts/organize-alerts/change-applied-intelligence-correlation-logic-decisions.mdx
+++ b/src/content/docs/alerts/organize-alerts/change-applied-intelligence-correlation-logic-decisions.mdx
@@ -82,7 +82,7 @@ You can get data from any of the following sources:
     To get data from alerts:
 
     1. From <DNT>**[one.newrelic.com](https://one.newrelic.com/all-capabilities)**</DNT>, click <DNT>**Alerts**</DNT>.
-    2. On the left under <DNT>**incident intelligence**</DNT>, click <DNT>**Sources**</DNT>, and then click <DNT>**Alerts**</DNT>.
+    2. On the left under <DNT>**Alerts**</DNT>, click <DNT>**Sources**</DNT>, and then click <DNT>**Alerts**</DNT>.
     3. Select the policies you want to connect to alerts, and click <DNT>**Connect**</DNT>.
 
        You can add additional alerts policies or remove policies you've already connected in <DNT>**Sources > Alerts**</DNT>.


### PR DESCRIPTION
Incident Intelligence is no longer a menu option. It is simply called Alerts.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve? Incident Intelligence is now called Alerts in the menu.
<img width="1138" height="620" alt="Alerts___Sources___New_Relic" src="https://github.com/user-attachments/assets/4445b59f-39e9-4b1e-a4cf-a67a07684244" />
