### PR TITLE
NR-484509 background attribute doc points to data dictionary

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings.mdx
@@ -282,7 +282,7 @@ withApplicationVersion("MY APP VERSION")
         <tbody>
           <tr>
             <td>
-              Enable or disable background reporting when application goes to the background state.
+              Enable or disable background reporting when application goes to the background state. When enabled, the agent reports data captured while the app is in the background, and the [`background` attribute](/attribute-dictionary/?event=MobileSession&attribute=background) is added to session attributes.
             </td>
 
             <td>
@@ -1202,7 +1202,7 @@ NewRelic.enableFeatures(NRMAFeatureFlags.NRFeatureFlag_OfflineStorage)
         <tbody>
           <tr>
             <td>
-              Enable or disable background reporting when application goes to the background state.
+              Enable or disable background reporting when application goes to the background state. When enabled, the agent reports data captured while the app is in the background, and the [`background` attribute](/attribute-dictionary/?event=MobileSession&attribute=background) is added to session attributes.
             </td>
 
             <td>


### PR DESCRIPTION
Summary
This PR adds the background attribute definition to the mobile monitoring data dictionary and creates bidirectional links between the background reporting feature documentation and the data dictionary.
https://source.datanerd.us/docs-eng/attribute-dictionary/pull/153

Changes
Updated background reporting sections for Android and iOS to include links to the new background attribute in the data dictionary
Helps users understand what data is captured when they enable this feature

Issue: NR-484509