### PR TITLE
feat(Release Notes): Add release notes for Go agent version 3.42.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-42-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-42-0.mdx
@@ -9,7 +9,7 @@ security: []
 ---
 
 <Callout variant="important">
-We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](https://docs.newrelic.com/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
 </Callout>
 
 
@@ -28,5 +28,5 @@ We recommend updating to the latest agent version as soon as it's available. If 
 
 ### Support statement
 We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
-See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.
 


### PR DESCRIPTION
Go Agent Release v3.42.0

## 3.42.0
### Added
  * Added `ConfigTransactionEventsMaxSamplesStored`and `ConfigErrorCollectorMaxSamplesStored` allowing full control of maximum samples stored for Transaction Events, Custom Insights Events, Error Events, and Log Events
  * Added support for the `MultiValueHeaders` property when extracting the headers from `events.APIGatewayProxyResponse` in nrlambda
      * Thank you to community member @rittneje for contributing to this solution

### Fixed
  * Removed unused variables and modernize by replacing interface{} with any in the `nrpxg5` integration
  * Fixed a bug where error events did not correctly mark expected errors
      * Thank you to community member @driimus for contributing to this solution
  * Bumped `nrwriter` integration to use v1.0.2
      * Thank you to community member @hiicharm for spotting this.

### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.