### PR TITLE
fix: indenting bullet points to maintain numbered list

### DIFF
--- a/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
+++ b/src/content/docs/logs/logs-context/net-configure-logs-context-all.mdx
@@ -408,11 +408,9 @@ If you need to use the manual process to set up logs in context for .NET, follow
 2. [Install](/install/dotnet) or [update](/docs/agents/net-agent/installation/update-net-agent) to the latest .NET agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [.NET agent version 8.21 or higher](/docs/release-notes/agent-release-notes/net-release-notes/) and the [New Relic .NET agent API version 8.21 or higher](/docs/agents/net-agent/net-agent-api) for logs in context.
 3. Install or update to Microsoft [.NET Framework 4.5 or higher](https://dotnet.microsoft.com/download/dotnet-framework) or [.NET Core 2.0 or higher](https://dotnet.microsoft.com/download/dotnet-core).
 4. Install and configure any of the following logging extensions to enrich your log data, including:
-
-* [log4net](#log4net)
-* [NLog](#nlog)
-* [Serilog](#serilog)
-
+  * [log4net](#log4net)
+  * [NLog](#nlog)
+  * [Serilog](#serilog)
 5. Check your log data in the New Relic UI.
 
 ### Configure log4net extension [#log4net]


### PR DESCRIPTION
This numbered list restarts at `1` when it should be step `5` in our docs: 
<img width="1124" height="529" alt="image" src="https://github.com/user-attachments/assets/df2fd30d-9fb1-48ff-825c-2570a3aed823" />

I believe this is because we have un-indented bullet points in step 4, so I indented them and removed the white space to maintain the numbered list.