### PR TITLE
fix: Incorrect Link to Before You Begin Section

### DIFF
--- a/src/content/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
+++ b/src/content/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
@@ -45,7 +45,7 @@ To install the Collector, follow the [OpenTelemetry documentation](https://opent
 Run the Collector with the configuration below, making sure you replace the following:
 
 * Replace `<INSERT_NEW_RELIC_OTLP_ENDPOINT>` with the appropriate [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol).
-* Replace `<INSERT_NEW_RELIC_LICENSE_KEY>` with your [license key](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol/#prereqs).
+* Replace `<INSERT_NEW_RELIC_LICENSE_KEY>` with your [license key](/docs/opentelemetry/best-practices/opentelemetry-otlp/#before-you-begin).
 
 ```yaml
 receivers:

--- a/src/i18n/content/es/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
+++ b/src/i18n/content/es/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
@@ -36,7 +36,7 @@ Para instalar el recolector, siga la [documentaciónOpenTelemetry ](https://open
 Ejecute el recolector con la siguiente configuración, cerciorar de reemplazar lo siguiente:
 
 * Reemplace `<INSERT_NEW_RELIC_OTLP_ENDPOINT>` con el [extremo OTLP New Relic ](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol)apropiado.
-* Reemplace `<INSERT_NEW_RELIC_LICENSE_KEY>` con su [clave de licencia](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol/#prereqs).
+* Reemplace `<INSERT_NEW_RELIC_LICENSE_KEY>` con su [clave de licencia](/docs/opentelemetry/best-practices/opentelemetry-otlp/#before-you-begin).
 
 ```yaml
 receivers:

--- a/src/i18n/content/fr/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
+++ b/src/i18n/content/fr/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
@@ -36,7 +36,7 @@ Pour installer le Collector, suivez la [documentation OpenTelemetry](https://ope
 Exécutez le Collector avec la configuration ci-dessous, en vous assurant de remplacer les éléments suivants :
 
 * Remplacez `<INSERT_NEW_RELIC_OTLP_ENDPOINT>` par le [point de terminaison OTLP New Relic](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol) approprié.
-* Remplacez `<INSERT_NEW_RELIC_LICENSE_KEY>` par votre [clé de licence](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol/#prereqs).
+* Remplacez `<INSERT_NEW_RELIC_LICENSE_KEY>` par votre [clé de licence](/docs/opentelemetry/best-practices/opentelemetry-otlp/#before-you-begin).
 
 ```yaml
 receivers:

--- a/src/i18n/content/jp/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
+++ b/src/i18n/content/jp/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
@@ -36,7 +36,7 @@ OpenTelemetryコレクターは、 [OTLP/HTTPエクスポーター](https://gith
 以下の設定でコレクターを実行し、次の内容を必ず置き換えてください。
 
 * `<INSERT_NEW_RELIC_OTLP_ENDPOINT>`適切な[New Relic OTLP エンドポイント](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol)に置き換えます。
-* `<INSERT_NEW_RELIC_LICENSE_KEY>`[ライセンスキー](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol/#prereqs)に置き換えます。
+* `<INSERT_NEW_RELIC_LICENSE_KEY>`[ライセンスキー](/docs/opentelemetry/best-practices/opentelemetry-otlp/#before-you-begin)に置き換えます。
 
 ```yaml
 receivers:

--- a/src/i18n/content/kr/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
+++ b/src/i18n/content/kr/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
@@ -36,7 +36,7 @@ OpenTelemetry 수집기는 [OTLP/HTTP 내보내기 도구를](https://github.com
 아래 설정으로 수집기를 실행하고, 다음 내용을 바꾸세요.
 
 * `<INSERT_NEW_RELIC_OTLP_ENDPOINT>` 적절한 [뉴렐릭 OTLP 엔드포인트](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol) 로 바꿉니다.
-* `<INSERT_NEW_RELIC_LICENSE_KEY>` (를) [인스턴스 키로](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol/#prereqs) 바꿉니다.
+* `<INSERT_NEW_RELIC_LICENSE_KEY>` (를) [인스턴스 키로](/docs/opentelemetry/best-practices/opentelemetry-otlp/#before-you-begin) 바꿉니다.
 
 ```yaml
 receivers:

--- a/src/i18n/content/pt/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
+++ b/src/i18n/content/pt/docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro.mdx
@@ -36,7 +36,7 @@ Para instalar o coletor, siga a [documentaçãoOpenTelemetry ](https://opentelem
 Execute o coletor com a configuração abaixo, certificando-se de substituir o seguinte:
 
 * Substitua `<INSERT_NEW_RELIC_OTLP_ENDPOINT>` pelo [ponto de extremidade OTLP do New Relic](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol) apropriado.
-* Substitua `<INSERT_NEW_RELIC_LICENSE_KEY>` pela sua [chave de licença](/docs/opentelemetry/best-practices/opentelemetry-otlp/#endpoint-port-protocol/#prereqs).
+* Substitua `<INSERT_NEW_RELIC_LICENSE_KEY>` pela sua [chave de licença](/docs/opentelemetry/best-practices/opentelemetry-otlp/#before-you-begin).
 
 ```yaml
 receivers:


### PR DESCRIPTION
Fixes links to an anchor that was changed from `#prereq` to `#before-you-begin` in d451c5c27fbc2885e31ddcce0e75999ffe8e356b.