### PR TITLE
Ruby 10.x Migration Guide

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/migration-10x-guide.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/migration-10x-guide.mdx
@@ -58,7 +58,7 @@ Learn more about using [Distributed Tracing APIs](https://www.rubydoc.info/gems/
 
 The agent no longer supports the ability to send application deployment information using a Capistrano recipe or the `newrelic deployments` CLI command. To track changes and deployments in New Relic, please see our guide to [Change Tracking](/docs/change-tracking/change-tracking-introduction/) for a list of available options.
 
-## Removed NewRelic::Agent::SqlSampler#notice_sql and simplified `NewRelic::Agent::Datastores` APIs [#removed_and_simplified_apis]
+## Removed `NewRelic::Agent::SqlSampler#notice_sql` and simplified `NewRelic::Agent::Datastores` APIs [#removed_and_simplified_apis]
 
 ### Removed the NewRelic::Agent::SqlSampler#notice_sql method
 
@@ -88,13 +88,13 @@ The experimental feature, Configurable Security Policies (CSP), is no longer sup
 
 ActiveJob metrics and segments have been updated to include the job's class name for more specific reporting. Update all custom dashboards and NRQL alerts that query ActiveJob metrics and segments to reflect the new format.
  
-Old format
+Old format:
 ```ruby
 "Ruby/ActiveJob/#{QueueName}/#{Method}" # metrics
 "ActiveJob/#{Adapter}/Queue/#{Event}/Named/#{JobQueueName}" # segments
 ```
 
-New format
+New format:
 ```ruby
 "Ruby/ActiveJob/#{QueueName}/#{JobClassName}/#{Method}" # metrics
 "ActiveJob/#{Adapter}/Queue/#{Event}/Named/#{JobQueueName}/#{JobClassName}" # segments
@@ -104,12 +104,12 @@ New format
 
 The executable file for the agent's CLI has been renamed from `bin/newrelic` to `bin/newrelic_rpm`. This change resolves a name collision with the standalone New Relic CLI tool.
 
-Old command
+Old command:
 ```bash
 bin/newrelic install
 ```
 
-New command
+New command:
 ```bash
 bin/newrelic_rpm install
 ```


### PR DESCRIPTION
Migration Guide for Ruby agent v10 release. Ready to merge!