### PR TITLE
docs(dotnet): Update latest supported library versions for .NET agent

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -497,7 +497,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
         Use [Npgsql](https://www.nuget.org/packages/Npgsql/)
 
         * Minimum supported version: 4.0.0
-        * Latest verified compatible version: 4.0.13
+        * Latest verified compatible version: 7.0.7
 
         Prior versions of Npgsql may also be instrumented, but duplicate and/or missing metrics are possible.
                 </td>
@@ -572,7 +572,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.9.17
+            Latest verified compatible version: 2.9.25
                 </td>
                 </tr>
 
@@ -974,7 +974,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       
                   * Minimum supported version: 3.5.2
 
-                  * Latest verified compatible version: 6.6.0
+                  * Latest verified compatible version: 7.1.2
 
                 </td>
                 </tr>
@@ -1664,7 +1664,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             Use [Npgsql](https://www.nuget.org/packages/Npgsql/)
 
             * Minimum supported version: 4.0.0
-            * Latest verified compatible version: 4.0.5
+            * Latest verified compatible version: 7.0.7
 
             Prior versions of Npgsql may also be instrumented, but duplicate and/or missing metrics are possible.
                     </td>
@@ -2153,7 +2153,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                           
                       * Minimum supported version: 3.5.2
 
-                      * Latest verified compatible version: 6.6.0
+                      * Latest verified compatible version: 6.8.1
                     </td>
                     </tr>
 


### PR DESCRIPTION
Updates latest supported versions for libraries instrumented by the .NET agent. 

Also updates some references to .NET 10 that were missed in a previous PR.