### PR TITLE
Restore Pricing section for public dashboards

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/share-charts-dashboards-externally.mdx
@@ -130,16 +130,6 @@ Share the live dashboard URL with external users to allow them to access the sha
 * **Session-based access**: After accessing the dashboard, the session remains active for 120 hours. If they try to access the dashboard after this period, or the browser session expires, they are prompted for the password. If there is a password reset, the session expires as soon as the widgets are refreshed. The external users need to enter the new password.
 
 * **reCAPTCHA verification**: If they have multiple failed attempts to access the dashboard, they need to complete a reCAPTCHA verification before entering the password again.
-
-### Pricing [#public-dashboard-pricing]
-
-When sharing live dashboard URLs, it's important to understand the associated costs and how to manage them effectively. <DNT>**Public Dashboards**</DNT> is an Advanced Compute Product feature offered as an [add-on](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing) or as a part of the Compute pricing model. Advanced [CCUs](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions/#compute-capacity-unit) are consumed when queries are run from the dashboard visualizations, which happens in the following cases:
-* On page load
-* On time picker changes
-* On refresh-rate triggers
-
-You can monitor your usage costs from **[New Relic Administration](https://one.newrelic.com/admin-portal) > Consumption Management > Advanced capabilities**. To optimize your costs, refer to the [pricing management best practices](#pricing-management) section.
-
 </Collapser>
 
 <Collapser id="revoke-dashboard-url" title="Revoke URLs">
@@ -273,7 +263,16 @@ You can monitor your usage costs from **[New Relic Administration](https://one.n
 </Collapser>
 
 </CollapserGroup>
-  
+
+### Pricing [#public-dashboard-pricing]
+
+When sharing live dashboard URLs, it's important to understand the associated costs and how to manage them effectively. <DNT>**Public Dashboards**</DNT> is an Advanced Compute Product feature offered as an [add-on](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing) or as a part of the Compute pricing model. Advanced [CCUs](/docs/licenses/license-information/product-definitions/new-relic-one-pricing-definitions/#compute-capacity-unit) are consumed when queries are run from the dashboard visualizations, which happens in the following cases:
+* On page load
+* On time picker changes
+* On refresh-rate triggers
+
+You can monitor your usage costs from **[New Relic Administration](https://one.newrelic.com/admin-portal) > Consumption Management > Advanced capabilities**. To optimize your costs, refer to the [pricing management best practices](#pricing-management) section.
+
   ### Best practices [#best-practices]
 
   To manage public dashboard related pricing and password security efficiently, follow these best practices:


### PR DESCRIPTION
Reintroduced the Pricing section with details on costs and management when sharing live dashboard URLs.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

We want to move the Pricing part from the Share dashboard externally collapsed area  (1st screenshot) to a separate section within the same page (2nd screenshot).

This will make the Pricing section more easy to find/understand for customers (thus, avoiding unnecessary questions like this one: https://newrelic.slack.com/archives/C062TE58B8C/p1764609796003089).
## before
<img width="998" height="713" alt="Screenshot 2025-12-01 at 14 54 41" src="https://github.com/user-attachments/assets/82d761c3-2bf5-465d-8597-22a0cafe4a89" />


## after
<img width="1090" height="659" alt="Screenshot 2025-12-01 at 14 54 49" src="https://github.com/user-attachments/assets/425f5509-1ec4-4937-936e-dbff4118e973" />
