### PR TITLE
(chor): added the userActions events data for browser monitoing

### DIFF
--- a/src/content/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
+++ b/src/content/docs/data-apis/understand-data/event-data/events-reported-browser-monitoring.mdx
@@ -114,6 +114,15 @@ Select an event name in the following table to see its attributes.
         `Span` data is reported for [distributed tracing](/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing).
       </td>
     </tr>
+    <tr>
+      <td>
+        [`UserAction`](/attribute-dictionary/?event=UserAction)
+      </td>
+
+      <td>
+        `UserAction` event is captured as the result of a user interaction with the web application. This event includes action information and DOM target identifiers along with several default attributes, such as application and geographic data.
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/newrelic/docs-website/issues/19895) to add the `userAction` events data in the events reported by browser monitoring documentation. 
JIRA: [NR-497184](https://new-relic.atlassian.net/browse/NR-497184)

[NR-497184]: https://new-relic.atlassian.net/browse/NR-497184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ