### PR TITLE
Revise OS versions for SNMP monitoring setup

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/snmp-performance-monitoring.mdx
@@ -59,14 +59,13 @@ It's recommended to deploy the SNMP monitoring agent as a container for either D
     * One of these supported operating systems:
     * x84_64/amd64-based CPUs:
 
-      * CentOS 8
       * Debian 12 (Bookworm)
       * Debian 11 (Bullseye)
       * Debian 10 (Buster)
-      * RedHat Enterprise Linux 9 up to 9.5
+      * RedHat Enterprise Linux 9 up to 9.7
       * Ubuntu 20.04 (Focal LTS)
       * Ubuntu 22.04 (Jammy LTS)
-      * Ubuntu 23.04 (Lunar)
+      * Ubuntu 24.04 (Noble LTS)
 
       <Callout variant="important">
         To receive SNMP Traps, the agent must bind to UDP 162. In a host-based install, the following command will be included during the install process. When executed, KTranslate will be run with elevated privileges.


### PR DESCRIPTION
Updated supported operating systems for SNMP performance monitoring.

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
    * Some unsupported OSes remained
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
    * Ubuntu: https://ubuntu.com/about/release-cycle
    * RHEL: https://access.redhat.com/support/policy/updates/errata
    * Debian: https://wiki.debian.org/DebianReleases
    * CentOS: https://www.centos.org/centos-linux-eol/
* If your issue relates to an existing GitHub issue, please link to it.
    * https://github.com/newrelic/docs-website/pull/22375