### PR TITLE
What-new for apm-serverless convergence

### DIFF
--- a/src/content/whats-new/2025/12/whats-new-12-09-apm-serverless-convergence-ga.md
+++ b/src/content/whats-new/2025/12/whats-new-12-09-apm-serverless-convergence-ga.md
@@ -1,0 +1,44 @@
+---
+title: 'APM+Serverless convergence with Rust-based extension now available'
+summary: 'New Relic Serverless monitoring is now integrated into APM with enhanced tracing, AI-driven insights, and a new Rust-based extension for improved performance.'
+releaseDate: '2025-12-09'
+getStartedLink: 'https://newrelic.com/signup'
+learnMoreLink: 'https://docs.newrelic.com/docs/serverless-function-monitoring/overview/'
+---
+
+Serverless architectures have transformed how we build applications, but observing them has remained fragmented. Teams often struggle to trace requests that span traditional services and serverless functions, leading to blind spots and slower troubleshooting.
+
+New Relic's **APM+Serverless Convergence** solves this by bringing serverless monitoring directly into APM, providing unified observability across your entire application stack—from containers and APIs to Lambda functions—all in one seamless view.
+
+## A single view for AWS Lambda and traditional applications
+
+**True APM-grade observability for serverless:** Take advantage of transaction tracing, dependency mapping, and performance insights for your Lambda functions and serverless architecture.
+
+**Seamless stitching across your entire application journey:** Watch requests flow from your traditional services through your serverless functions with complete visibility and context.
+
+**Platform-wide intelligence that drives real efficiency:** Correlate serverless performance with your broader application ecosystem and uncover optimization opportunities.
+
+By reducing context switching and providing AI-driven cost optimization, you'll detect and resolve issues faster—while lowering unnecessary cloud spend.
+
+## What makes New Relic's APM+Serverless convergence stand out
+
+* **Unified view across your stack** – Correlate Lambda invocation data, API calls, and database queries in one trace
+* **Integration with all APM benefits** – Serverless monitoring now provides easy access to all APM capabilities (TXN360, Error Inbox, NR AI, etc.) for Lambda functions
+* **Faster root cause analysis** – Trace errors, latency, and cold starts to pinpoint bottlenecks
+* **Cold start and latency tracking** – Detect high-latency invocations and failure patterns automatically
+* **New Rust-based extension** – Enhanced efficiency and reliability with our optimized Rust-based Lambda extension
+
+## Enhanced performance with rust
+
+Our new Rust-based extension delivers improved performance and reliability for Lambda function monitoring. This optimization reduces overhead while providing more accurate telemetry data, ensuring your serverless functions run efficiently without compromising observability.
+
+## Get started
+
+Ready to unlock full-stack visibility in your serverless applications? [Learn more about APM+Serverless Convergence](https://docs.newrelic.com/docs/serverless-function-monitoring/overview/) to start monitoring your complete application journey—without the guesswork.
+
+
+**Additional resources:**
+
+* [Serverless monitoring platform](https://newrelic.com/platform/serverless-monitoring)
+* [APM+Serverless convergence blog](https://newrelic.com/blog/how-to-relic/enable-debugging-and-innovation-with-serverless-monitoring)
+* [Rust extension blog](https://newrelic.com/blog/how-to-relic/a-new-era-for-new-relics-lambda-extension-from-go-to-rust)


### PR DESCRIPTION
This PR adds the Whats-new for APM-Serverless Convergence.
Merge on: 09-Dec-2025