### PR TITLE
chore[Logs]: Removed the restriction about HIPAA accounts using log patterns

### DIFF
--- a/src/content/docs/logs/ui-data/find-unusual-logs-log-patterns.mdx
+++ b/src/content/docs/logs/ui-data/find-unusual-logs-log-patterns.mdx
@@ -70,16 +70,6 @@ If you see <DNT>**Patterns are turned off**</DNT> in your logs UI, click <DNT>**
 
     <tr>
       <td>
-        HIPAA accounts
-      </td>
-
-      <td>
-        The log patterns feature is not FedRAMP compliant. FedRAMP or other HIPAA accounts are not eligible to use patterns.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         Log pattern matching limits
       </td>
 


### PR DESCRIPTION
No HIPAA accounts are eligible for using log patterns. So, removing that restriction from the Availability(https://docs.newrelic.com/docs/logs/ui-data/find-unusual-logs-log-patterns/#availability) table.

Source: https://newrelic.slack.com/archives/D094GDL7Q2C/p1765303099805389
