### PR TITLE
changed 10e9 to 10e8

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/usage-queries-alerts.mdx
@@ -65,7 +65,7 @@ The [usage UI](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new
     This query breaks down [Metric data](/docs/telemetry-data-platform/understand-data/new-relic-data-types/#dimensional-metrics) by the top ten metric names. You could also facet by `appName` or `host` to adjust the analysis.
 
     ```sql
-    FROM Metric SELECT bytecountestimate()/10e9 AS 'GB Estimate' 
+    FROM Metric SELECT bytecountestimate()/10e8 AS 'GB Estimate' 
     SINCE 24 hours ago
     FACET metricName LIMIT 10 TIMESERIES 1 hour
     ```


### PR DESCRIPTION
Fixed typo in usage query for GB conversion issue: Customer reported that the NRQL query for converting bytes to GB was using 10e9 (which equals 10 GB) instead of 1e9 or 10e8 (which both equal 1 GB). This caused the query to return the number of 10 GB units rather than GB. 

**Resolution**: Updated the divisor from 10e9 to 10e8 in the bytecountestimate queries to correctly convert bytes to gigabytes. 

Source: Customer feedback via @XiXiaPdx, who explained the math:
1e9 = 1,000,000,000 = 1 GB ✓
10e8 = 10 × 100,000,000 = 1,000,000,000 = 1 GB ✓
10e9 = 10,000,000,000 = 10 GB ✗