### PR TITLE
Add Security Bulletin NR25-02 for Fluent Bit vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ src/images/infrastructure_screenshot_full_sonarqube-dashboard.webp
 
 # Local Netlify folder
 .netlify
+
+# Claude Code documentation (local only)
+.claude/

--- a/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr25-02.mdx
+++ b/src/content/docs/security/new-relic-security/security-bulletins/security-bulletin-nr25-02.mdx
@@ -1,0 +1,188 @@
+---
+title:  "NR25-02- Fluent Bit Plugins (CVE-2025-12969, CVE-2025-12970, CVE-2025-12972, CVE-2025-12977, CVE-2025-12978)"
+tags:
+  - Security
+  - Security bulletin
+  - Log forwarding
+  - Fluent Bit
+metaDescription: "Security bulletin for Windows and Linux infrastructure agent and Fluent Bit, the Kubernetes plugin, and the Fluent Bit output plugin." 
+releaseDate: '2025-12-11' 
+---
+
+<DNT>**Vulnerability Identifier:**</DNT> NR25-02
+
+<DNT>**Priority:**</DNT> High
+
+## Summary
+
+By default, New Relic does not include or enable the specific plugins that are affected by the security vulnerabilities identified in certain versions of Fluent Bit. The specific plugins and their associated vulnerabilities are:
+
+* Forward input plugin (in_forward) - Affected by [CVE-2025-12969](https://nvd.nist.gov/vuln/detail/CVE-2025-12969) 
+* Docker input plugin (in_docker) - Affected by [CVE-2025-12970](https://nvd.nist.gov/vuln/detail/CVE-2025-12970)
+* File output plugin (out_file) - Affected by [CVE-2025-12972](https://nvd.nist.gov/vuln/detail/CVE-2025-12972)  
+* HTTP, Splunk, and Elasticsearch input plugins (in_http, in_splunk, in_elasticsearch) - Affected by [CVE-2025-12978](https://nvd.nist.gov/vuln/detail/CVE-2025-12978) & [CVE-2025-12977](https://nvd.nist.gov/vuln/detail/CVE-2025-12977) 
+
+However, to support customers that have enabled these optional plugins, we recommend customers to upgrade to the latest available versions of these packages which bundle the patched version of Fluent Bit (v4.0.13, v4.1.1, v4.2.0 or higher): 
+
+* Infrastructure Agent - Windows
+* Infrastructure Agent - Linux
+* Kubernetes Plugin
+* New Relic Fluent Bit Output Plugin Docker Image
+
+## Action required
+
+New Relic strongly advises our customers who are using the aforementioned log forwarding instrumentation to take immediate action as follows. If you are unable to upgrade to the latest agent versions containing Fluent Bit v4.0.13, v4.1.1, or v4.2.0, we recommend disabling the affected plugins specified above to mitigate the risk.
+
+<table>
+  <thead>
+    <th>
+      <td>
+        Solution
+      </td>
+    </th>
+
+    <th>
+      <td>
+        Action Required
+      </td>
+    </th>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Infrastructure agent - Windows
+      </td>
+
+      <td>
+        Upgrade the Infrastructure agent to version v1.71.2 or later
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Infrastructure agent - Linux
+      </td>
+
+      <td>
+        Upgrade the Infrastructure agent to version v1.71.2 or later AND update Fluent Bit to version v4.2.0 or later
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Kubernetes plugin
+      </td>
+
+      <td>
+        Upgrade using either newrelic-logging-1.33.0 or nri-bundle-6.0.28
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        New Relic Fluent Bit Output Plugin Docker Image
+      </td>
+
+      <td>
+        Update to version 3.2.1
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+New Relic has provided the following resources to assist with these updates: 
+
+* [Update the Infrastructure Agent](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent/)
+* [Update Fluent Bit with the Linux Infrastructure Agent](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/#install-fb-version)
+* [Install the newest helm charts for the Kubernetes Plugin](https://github.com/newrelic/helm-charts/tree/master?tab=readme-ov-file#Installthecharts)
+* [Install the Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/installation/kubernetes-integration-install-configure/)
+* [Fluent Bit plugin for log forwarding](/docs/logs/forward-logs/fluent-bit-plugin-log-forwarding/)
+
+## Frequently Asked Questions
+
+1. **How can I find out if I'm using the vulnerable plugins?**
+
+   * Check your Fluent Bit configuration file(s) for use of the tag_key parameter in input plugins e.g. HTTP, Splunk, or Elasticsearch  which may leave your installation vulnerable to the attacks described in CVE-2025-12978 and CVE-2025-12977
+   * Check your Fluent Bit configuration file(s) for use of the File output plugin, especially where the File configuration parameter has not been set, which may leave your installation vulnerable to the attacks described in CVE-2025-12972
+   * Check your Fluent Bit configuration file(s) for use of the Docker metrics input plugin, which may leave your installation vulnerable to the attacks described in CVE-2025-12970
+   * Check your Fluent Bit configuration file(s) for use of the Forward input plugin, which may leave your installation vulnerable to the attacks described in CVE-2025-12969
+
+2. **I am using the Infrastructure Agent but have disabled log forwarding. Am I impacted?**
+
+   If you previously used New Relic log forwarding instrumentation (listed above), and used the affected plugins, you might still be impacted. New Relic recommends that you upgrade your agents, or at minimum disable the affected plugins. Additionally, New Relic recommends that all customers identify any other uses of Fluent Bit in their environments and update them to at least version v4.0.13, v4.1.1, or v4.2.0.
+
+3. **How can I find out which Fluent Bit version I'm using?**
+
+<table>
+  <thead>
+    <th>
+      <td>
+        Agent
+      </td>
+    </th>
+
+    <th>
+      <td>
+        Steps
+      </td>
+    </th>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Infrastructure agent and standalone Fluent Bit
+      </td>
+
+      <td>
+        * For your Infrastructure agents, navigate to the [Infrastructure Inventory](/docs/infrastructure/infrastructure-data/infrastructure-ui-pages/infra-inventory-ui-page/) UI and search for Fluent Bit. Then, check the Fluent Bit version installed on a given host
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Kubernetes
+      </td>
+
+      <td>
+        * For New Relic Logging Helm chart version 1.25.0 or higher, Navigate to the Installed tab and search for Fluent bit in the entities field
+
+        * Otherwise, run the following NRQL query: 
+          `FROM K8sContainerSample select latest(containerImage) Where podName like '%newrelic-logging%' FACET clusterName`
+
+          Then, check which Fluent Bit version was installed with the [output plugin](https://github.com/newrelic/helm-charts/releases/tag/nri-bundle-6.0.28).
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+4. **What should I do if there are no patched artifacts available for my OS?**
+
+   * There is no patched FluentBit upstream package available for Ubuntu 16, 18, and 20. If you are running on any of these distributions, we recommend you remove the affected input plugins to protect from vulnerabilities. 
+   * We are working to provide patched packages for SLES 12.5 and 15.4 as soon as possible. Until we roll out the updated packages for these distributions, we recommend removing the affected plugins to protect from vulnerabilities.
+   * We are working to provide a patched package for Debian 13 as soon as possible. Until we roll out a patched package for this distribution, we recommend removing the affected plugins to protect from vulnerabilities.
+
+## Supporting Release Notes
+
+[Fluent Bit release notes](/docs/release-notes/fluentbit-release-notes/)
+
+[Infrastructure Release Notes](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/)
+
+[Fluent Bit Output Plugin Release Notes](https://github.com/newrelic/newrelic-fluent-bit-output/releases)
+
+## Technical vulnerability information
+
+[CVE-2025-12969](https://nvd.nist.gov/vuln/detail/CVE-2025-12969)
+
+[CVE-2025-12970](https://nvd.nist.gov/vuln/detail/CVE-2025-12970)
+
+[CVE-2025-12972](https://nvd.nist.gov/vuln/detail/CVE-2025-12972)
+
+[CVE-2025-12977](https://nvd.nist.gov/vuln/detail/CVE-2025-12977)
+
+[CVE-2025-12978](https://nvd.nist.gov/vuln/detail/CVE-2025-12978)
+
+## Publication History
+
+December 11, 2025 - NR25-02 Published

--- a/src/nav/new-relic-security.yml
+++ b/src/nav/new-relic-security.yml
@@ -57,6 +57,8 @@ pages:
         path: /docs/security/security-privacy/information-security/security-bulletins
   - title: Security bulletins
     pages:
+      - title: 'NR25-02'
+        path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr25-02
       - title: 'NR25-01'
         path: /docs/security/new-relic-security/security-bulletins/security-bulletin-nr25-01
       - title: 'NR24-02'


### PR DESCRIPTION
- Add properly formatted security bulletin NR25-02.mdx
- Document CVE-2025-12969, CVE-2025-12970, CVE-2025-12972, CVE-2025-12977, CVE-2025-12978
- Include upgrade instructions for Infrastructure Agent, Kubernetes Plugin, and Fluent Bit Output Plugin
- Add comprehensive FAQ and troubleshooting information