### PR TITLE
chore(PHP): Add compatibility for Drupal 11.1 and 11.2

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -442,7 +442,7 @@ The following frameworks are supported:
         Drupal
       </td>
       <td>
-        7.x, 9.x, 10.x, 11.0
+        7.x, 9.x, 10.x, 11.0, 11.1, 11.2
       </td>
       <td>
         [Drupal specific functionality](/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality)<br></br>


### PR DESCRIPTION
The PHP team would like to update its compatibility page to include support for Drupal 11.1 and 11.2.