### PR TITLE
fix: Update React docs URL in build-react-hooks-app.mdx

### DIFF
--- a/src/content/docs/new-relic-solutions/tutorials/build-react-hooks-app.mdx
+++ b/src/content/docs/new-relic-solutions/tutorials/build-react-hooks-app.mdx
@@ -9,7 +9,7 @@ freshnessValidatedDate: never
 
 <br/>
 
-Starting with version 2.49.1 of our `nr1` CLI, you can build New Relic applications and custom visualizations with [React hooks](https://reactjs.org/docs/hooks-intro.html). This guide gives some Nerdlet examples of React hooks in action!
+Starting with version 2.49.1 of our `nr1` CLI, you can build New Relic applications and custom visualizations with [React hooks](https://react.dev/reference/react/hooks). This guide gives some Nerdlet examples of React hooks in action!
 
 ## Before you begin
 


### PR DESCRIPTION
Changed the URL to point to the new location for React docs (https://react.dev/) as the previous URL (https://reactjs.org/docs/hooks-intro.html) redirects to https://legacy.reactjs.org where the page content states that the pages in that domain will no longer be updated.
