### PR TITLE
Add explicit New Relic install command for Containerized Azure in Python

### DIFF
--- a/src/content/docs/serverless-function-monitoring/azure-function-monitoring/container.mdx
+++ b/src/content/docs/serverless-function-monitoring/azure-function-monitoring/container.mdx
@@ -116,6 +116,9 @@ To install the New Relic Python agent, add the following lines to the final stag
   ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
       AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
+  RUN pip install newrelic
+
+  # Install any other dependencies
   COPY requirements.txt /
   RUN pip install -r /requirements.txt
   COPY . /home/site/wwwroot


### PR DESCRIPTION
This PR adds an explicit `RUN pip install newrelic` to the Azure container installation page for Python instead of implicitly assuming the user has `newrelic` in their `requirements.txt` file.