### PR TITLE
correction to env var

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda.mdx
@@ -189,7 +189,7 @@ You can find more environment variables in our [Node.js configuration documentat
             <td>`NEW_RELIC_PACKAGE_REPORTING_ENABLED`</td>
             <td>`true`</td>
             <td>`true`, `false`</td>
-            <td>Improve cold start times by setting this to `true`</td>
+            <td>Improve cold start times by setting this to `false`</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
Package reporting should be disabled for Lambda monitoring to improve cold start times.