### PR TITLE
Update php-agent-compatibility-requirements.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -446,7 +446,8 @@ The following frameworks are supported:
       </td>
       <td>
         [Drupal specific functionality](/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality)<br></br>
-        [Drupal browser instrumentation](/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality/#page-load-timing-rum)
+        [Drupal browser instrumentation](/docs/apm/agents/php-agent/frameworks-libraries/drupal-specific-functionality/#page-load-timing-rum)<br></br>
+        Drupal 11.3 Notice: The upcoming Drupal release changes their hook implementations and is incompatible with current PHP Agent versions. We’re actively working on a solution, but Drupal 11.3+ isn’t supported yet and will remain so until early 2026.
       </td>
     </tr>
 


### PR DESCRIPTION
Adding restrictions to Drupal 11.3

Drupal 11.3 Notice: The upcoming Drupal release changes their hook implementations and is incompatible with current PHP Agent versions. We’re actively working on a solution, but Drupal 11.3+ isn’t supported yet and will remain so until early 2026.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.