### PR TITLE
Fix spelling error in OpenTelemetry data overview

### DIFF
--- a/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
+++ b/src/content/docs/opentelemetry/best-practices/opentelemetry-data-overview.mdx
@@ -13,7 +13,7 @@ redirects:
   - /docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-data-overview
 ---
 
-OpenTelemetry offers a versality ecoststem for instrumentation and telemetry, which can be integrated seamlessly with New Relic through the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/). This guide provides an overview of how New Relic processes and ingests OTLP data to help you to efficiently monitor and observe your systems.
+OpenTelemetry offers a versatile ecoststem for instrumentation and telemetry, which can be integrated seamlessly with New Relic through the [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/). This guide provides an overview of how New Relic processes and ingests OTLP data to help you to efficiently monitor and observe your systems.
 
 ## Get started [#get-started]
 


### PR DESCRIPTION
Corrected the spelling of 'versality' to 'versatile' in the OpenTelemetry overview.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.