### PR TITLE
docs(mcp): correct New Relic API key header casing

### DIFF
--- a/src/content/docs/agentic-ai/mcp/setup.mdx
+++ b/src/content/docs/agentic-ai/mcp/setup.mdx
@@ -27,7 +27,7 @@ You can dynamically filter the tools your AI agent accesses by sending the `incl
         "url": "https://mcp.newrelic.com/mcp/",
         "type": "http",
         "headers": {
-            "api-key": "NRAK-****",
+            "Api-Key": "NRAK-****",
             "include-tags": "discovery,alerting"
         }
     }


### PR DESCRIPTION
**What problem does this PR solve?**  
The documentation previously used the incorrect API key header casing (`api-key`).
New Relic expects the header to be `Api-Key`, and the mismatch could cause authentication issues or confusion for users following the docs.

**Additional context / review notes**  
- Documentation-only change; no functional or code updates.
- Aligns examples with New Relic’s expected header format.
- Helps prevent setup errors when configuring the New Relic MCP server.

**Related issues**  
- N/A
