### PR TITLE
Update OpenTelemetry support documentation structure

### DIFF
--- a/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
@@ -965,7 +965,7 @@ New Relic's OpenTelemetry support model is segmented into three types, reflectin
 
     **In-Scope OpenTelemetry Components:**
 
-    * **Standard OpenTelemetry SDKs and APIs:** Issues related to core instrumentation logic in standard libraries (e.g., the base Java, Python, or Go SDKs) will be addressed in NRDOT. New Relic will contribute to fix this issue at the contrib or core OTel distribution, but the open source vetting can take some time.
+    * **Standard OpenTelemetry SDKs and APIs:** Issues related to core instrumentation logic in standard libraries (e.g., the base Java, Python, or Go SDKs).
     * **Standard OpenTelemetry Collector Components:** Troubleshooting standard receivers (e.g., hostmetrics, otlp) and standard processors (e.g., batch, memorylimiter), exporters, connectors or extensions, when not part of the official New Relic Collector Distribution.
     * **Configuration Validation:** Assisting customers with validating configurations of their standard (not customized) OpenTelemetry components.
   </Collapser>


### PR DESCRIPTION
## Summary
This PR restructures the OpenTelemetry support documentation to provide clearer guidance on the different types of support available:

- **Type 1: New Relic Community Support** - Community forum and discussion-based support
- **Type 2: New Relic Maintained OpenTelemetry Tools** - Full support for New Relic-maintained components (NRDOT, K8s Helm charts, data ingestion)
- **Type 3: Basic Troubleshooting and Upstream to OpenTelemetry Core** - Initial guidance for standard OTel components with contributions to upstream projects

## Changes
- Reorganized support information into three distinct categories
- Added detailed "General OpenTelemetry support notes" section
- Added new "Exclusions and limitations" section clarifying what is not supported
- Moved "Get help from the OpenTelemetry Community" to its own dedicated section
- Improved clarity on scope of support for different OTel components
