### PR TITLE
Integrate query examples into synthetics API monitor pages

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/_deprecated-query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/_deprecated-query-synthetics-data.mdx
@@ -1,15 +1,24 @@
 ---
-title: "Query synthetic monitoring data"
+title: "[DEPRECATED] Query synthetic monitoring data"
 tags:
   - Synthetics
   - APIs
   - NerdGraph
   - Examples
-metaDescription: How to use New Relic NerdGraph API to query synthetic monitoring data including monitors, private locations, secure credentials, and downtimes.
+metaDescription: "[DEPRECATED] This page has been superseded by query examples integrated into each monitor type page."
 freshnessValidatedDate: never
 ---
 
-After setting up your monitoring infrastructure, you can use queries to retrieve information about your synthetic entities. Queries make requests to fetch data about monitors, private locations, credentials, and downtimes. This tutorial provides examples of how to use the NerdGraph API to query synthetic monitoring data.
+<Callout variant="important">
+  **This page is deprecated.** Query examples have been moved to their respective monitor type and entity pages for better user experience:
+
+  - Monitor queries: See individual monitor type pages ([ping](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor), [simple browser](/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor), [scripted browser](/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor), [scripted API](/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor), [step](/docs/apis/nerdgraph/examples/synthetics-api/step-monitor), [certificate check](/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor), [broken links](/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor))
+  - Private location queries: [Private locations page](/docs/apis/nerdgraph/examples/synthetics-api/private-locations)
+  - Secure credential queries: [Secure credentials page](/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials)
+  - Monitor downtime queries: [Monitor downtimes page](/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes)
+</Callout>
+
+~~After setting up your monitoring infrastructure, you can use queries to retrieve information about your synthetic entities. Queries make requests to fetch data about monitors, private locations, credentials, and downtimes. This tutorial provides examples of how to use the NerdGraph API to query synthetic monitoring data.~~
 
 To learn additional query capabilities available to your synthetic entities, check out [NerdGraph entities API tutorial](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/).
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
@@ -233,3 +233,81 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 When a broken links monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query broken links monitors [#query-broken-links-monitors]
+
+You can query your broken links monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including broken links monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters like `monitorType = 'BROKEN_LINKS'` to find only broken links monitors.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR' AND tags.monitorType = 'BROKEN_LINKS'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
@@ -236,11 +236,9 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query broken links monitors [#query-broken-links-monitors]
 
-<Callout variant="tip">
-  **Need to query your broken links monitors?** All query examples for broken links monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your broken links monitors?** All query examples for broken links monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including broken links monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including broken links monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
@@ -236,9 +236,11 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query broken links monitors [#query-broken-links-monitors]
 
-**Need to query your broken links monitors?** All query examples for broken links monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, map IDs, or check the status of your broken links monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including broken links monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
@@ -233,3 +233,14 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 When a broken links monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query broken links monitors [#query-broken-links-monitors]
+
+<Callout variant="tip">
+  **Need to query your broken links monitors?** All query examples for broken links monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including broken links monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [broken links monitors](/docs/synth
 
 ## Create a broken links monitor [#create-broken-links]
 
-You can create a broken links monitor using the `syntheticsCreateBrokenLinksMonitor` mutation. This mutation allows you to set up monitoring for broken links on any webpage.
+You can create a broken links monitor using the <DNT>`syntheticsCreateBrokenLinksMonitor`</DNT> mutation. This mutation allows you to set up monitoring for broken links on any webpage.
 
 ### Input parameters
 
@@ -120,7 +120,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a broken links monitor [#update-broken-links]
 
-You can update an existing broken links monitor using the `syntheticsUpdateBrokenLinksMonitor` mutation. This allows you to modify the configuration of a broken links monitor that has already been created.
+You can update an existing broken links monitor using the <DNT>`syntheticsUpdateBrokenLinksMonitor`</DNT> mutation. This allows you to modify the configuration of a broken links monitor that has already been created.
 
 ### Input parameters
 
@@ -230,7 +230,7 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 
 ## Delete a broken links monitor [#delete-monitor]
 
-When a broken links monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
+When a broken links monitor is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
@@ -230,3 +230,14 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 When a certificate check monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query certificate check monitors [#query-certificate-check-monitors]
+
+<Callout variant="tip">
+  **Need to query your certificate check monitors?** All query examples for certificate check monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including certificate check monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
@@ -230,3 +230,81 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 When a certificate check monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query certificate check monitors [#query-certificate-check-monitors]
+
+You can query your certificate check monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including certificate check monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters like `monitorType = 'CERT_CHECK'` to find only certificate check monitors.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR' AND tags.monitorType = 'CERT_CHECK'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
@@ -233,11 +233,9 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query certificate check monitors [#query-certificate-check-monitors]
 
-<Callout variant="tip">
-  **Need to query your certificate check monitors?** All query examples for certificate check monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your certificate check monitors?** All query examples for certificate check monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including certificate check monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including certificate check monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
@@ -233,9 +233,11 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query certificate check monitors [#query-certificate-check-monitors]
 
-**Need to query your certificate check monitors?** All query examples for certificate check monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, map IDs, or check the status of your certificate check monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including certificate check monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [certificate check monitors](/docs/
 
 ## Create a certificate check monitor [#create-certificate-check]
 
-You can create a certificate check monitor using the `syntheticsCreateCertCheckMonitor` mutation. This mutation allows you to set up monitoring for SSL certificate expiration on any domain.
+You can create a certificate check monitor using the <DNT>`syntheticsCreateCertCheckMonitor`</DNT> mutation. This mutation allows you to set up monitoring for SSL certificate expiration on any domain.
 
 ### Input parameters
 
@@ -120,7 +120,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a certificate check monitor [#update-certificate-check]
 
-You can update an existing certificate check monitor using the `syntheticsUpdateCertCheckMonitor` mutation. This allows you to modify the configuration of a certificate check monitor that has already been created.
+You can update an existing certificate check monitor using the <DNT>`syntheticsUpdateCertCheckMonitor`</DNT> mutation. This allows you to modify the configuration of a certificate check monitor that has already been created.
 
 ### Input parameters
 
@@ -227,7 +227,7 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 
 ## Delete a certificate check monitor [#delete-monitor]
 
-When a certificate check monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
+When a certificate check monitor is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
@@ -569,7 +569,9 @@ mutation {
 
 ## Query monitor downtimes [#query-monitor-downtimes]
 
-**Need to query your monitor downtimes?** All query examples for monitor downtimes, including how to retrieve downtime schedules, configurations, and metadata, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve downtime schedules, configurations, and metadata.
 
-**Quick links to relevant sections:**
-- [Query monitor downtimes](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-downtimes) - Get all scheduled monitor downtimes with their configurations
+For more information, refer to:
+- [Query monitor downtimes](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-downtimes) - Get all scheduled monitor downtimes with their configurations.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
@@ -566,3 +566,12 @@ mutation {
   }
 }
 ```
+
+## Query monitor downtimes [#query-monitor-downtimes]
+
+<Callout variant="tip">
+  **Need to query your monitor downtimes?** All query examples for monitor downtimes, including how to retrieve downtime schedules, configurations, and metadata, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query monitor downtimes](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-downtimes) - Get all scheduled monitor downtimes with their configurations
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
@@ -569,9 +569,7 @@ mutation {
 
 ## Query monitor downtimes [#query-monitor-downtimes]
 
-<Callout variant="tip">
-  **Need to query your monitor downtimes?** All query examples for monitor downtimes, including how to retrieve downtime schedules, configurations, and metadata, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your monitor downtimes?** All query examples for monitor downtimes, including how to retrieve downtime schedules, configurations, and metadata, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query monitor downtimes](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-downtimes) - Get all scheduled monitor downtimes with their configurations
-</Callout>
+**Quick links to relevant sections:**
+- [Query monitor downtimes](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-downtimes) - Get all scheduled monitor downtimes with their configurations

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
@@ -566,3 +566,90 @@ mutation {
   }
 }
 ```
+
+## Query monitor downtimes [#query-monitor-downtimes]
+
+You can query your monitor downtimes to retrieve information about their configuration, status, and metadata. This query retrieves all monitor downtimes in your account, returning essential information including the downtime's GUID, name, account ID, and associated tags. Monitor downtimes are scheduled periods when synthetic monitors stop running, useful during planned maintenance or known outages. Configuration details such as schedule type, timezone, and recurrence patterns are stored in tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'` to retrieve all monitor downtimes.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'") {
+      results {
+        entities {
+          accountId
+          guid
+          name
+          tags {
+            key
+            values
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "entitySearch": {
+        "results": {
+          "entities": [
+            {
+              "accountId": 2520528,
+              "guid": "MjUyMDUyOHxTWU5USHxNT05JVE9SX0RPV05USU1FfDEyMzQ1",
+              "name": "Weekly Maintenance Window",
+              "tags": [
+                {
+                  "key": "timezone",
+                  "values": ["America/New_York"]
+                },
+                {
+                  "key": "scheduleType",
+                  "values": ["WEEKLY"]
+                },
+                {
+                  "key": "startTime",
+                  "values": ["02:00:00"]
+                },
+                {
+                  "key": "endTime",
+                  "values": ["04:00:00"]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes.mdx
@@ -17,7 +17,7 @@ Monitor downtimes let you schedule periods when your synthetic monitors stop run
 
 ## Create a one-time monitor downtime [#create-once-downtime]
 
-You can create a one-time monitor downtime using the `syntheticsCreateOnceMonitorDowntime` mutation. Use this for planned maintenance or events that happen only once.
+You can create a one-time monitor downtime using the <DNT>`syntheticsCreateOnceMonitorDowntime`</DNT> mutation. Use this for planned maintenance or events that happen only once.
 
 ### Input parameters
 
@@ -95,7 +95,7 @@ mutation {
 
 ## Create a daily recurring monitor downtime [#create-daily-downtime]
 
-You can create a daily recurring monitor downtime using the `syntheticsCreateDailyMonitorDowntime` mutation. Use this for regular maintenance windows that occur every day.
+You can create a daily recurring monitor downtime using the <DNT>`syntheticsCreateDailyMonitorDowntime`</DNT> mutation. Use this for regular maintenance windows that occur every day.
 
 ### Input parameters
 
@@ -187,7 +187,7 @@ mutation {
 
 ## Create a weekly recurring monitor downtime [#create-weekly-downtime]
 
-You can create a weekly recurring monitor downtime using the `syntheticsCreateWeeklyMonitorDowntime` mutation. Use this for maintenance windows that occur on specific days of the week.
+You can create a weekly recurring monitor downtime using the <DNT>`syntheticsCreateWeeklyMonitorDowntime`</DNT> mutation. Use this for maintenance windows that occur on specific days of the week.
 
 ### Input parameters
 
@@ -287,7 +287,7 @@ mutation {
 
 ## Create a monthly recurring monitor downtime [#create-monthly-downtime]
 
-You can create a monthly recurring monitor downtime using the `syntheticsCreateMonthlyMonitorDowntime` mutation. Use this for maintenance windows that occur on specific days each month.
+You can create a monthly recurring monitor downtime using the <DNT>`syntheticsCreateMonthlyMonitorDowntime`</DNT> mutation. Use this for maintenance windows that occur on specific days each month.
 
 ### Input parameters
 
@@ -399,7 +399,7 @@ mutation {
 
 ## Update a monitor downtime [#update-downtime]
 
-You can update an existing monitor downtime using the `syntheticsEditMonitorDowntime` mutation. This allows you to modify any downtime type (once, daily, weekly, or monthly) using this single mutation.
+You can update an existing monitor downtime using the <DNT>`syntheticsEditMonitorDowntime`</DNT> mutation. This allows you to modify any downtime type (once, daily, weekly, or monthly) using this single mutation.
 
 ### Input parameters
 
@@ -532,7 +532,7 @@ mutation {
 
 ## Delete a monitor downtime [#delete-downtime]
 
-You can delete a monitor downtime using the `syntheticsDeleteMonitorDowntime` mutation. Once deleted, the scheduled downtime will be removed and monitors will resume their normal schedule.
+You can delete a monitor downtime using the <DNT>`syntheticsDeleteMonitorDowntime`</DNT> mutation. Once deleted, the scheduled downtime will be removed and monitors will resume their normal schedule.
 
 ### Input parameters
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
@@ -117,15 +117,12 @@ In addition to monitors, you can manage supporting infrastructure and configurat
 
 ## Query operations [#query-operations]
 
-Use [query operations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) to retrieve information about your synthetic monitoring setup:
+Each monitor type and supporting entity page includes query examples to retrieve information about your synthetic monitoring setup:
 
-* Query all monitors in your account
-* Retrieve private location configurations
-* List secure credentials (metadata only)
-* View scheduled monitor downtimes
-* Get monitor scripts and step configurations
-* Map monitor IDs to entity GUIDs
-* Check runtime upgrade status for legacy monitors
+* **Monitor queries**: Each monitor type page includes examples for querying monitors, retrieving scripts/steps, and mapping monitor IDs to entity GUIDs
+* **Private location queries**: The [private locations](/docs/apis/nerdgraph/examples/synthetics-api/private-locations) page includes examples for querying location configurations
+* **Secure credential queries**: The [secure credentials](/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials) page includes examples for listing credential metadata
+* **Monitor downtime queries**: The [monitor downtimes](/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes) page includes examples for viewing scheduled downtimes
 
 ## Related resources [#related-resources]
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
@@ -117,15 +117,16 @@ In addition to monitors, you can manage supporting infrastructure and configurat
 
 ## Query operations [#query-operations]
 
+<Callout variant="tip">
+  **Comprehensive Query Documentation**: All query examples for synthetic monitoring are centralized in the [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page. Each monitor type page also includes quick links to relevant query sections.
+</Callout>
+
 Use [query operations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) to retrieve information about your synthetic monitoring setup:
 
-* Query all monitors in your account
-* Retrieve private location configurations
-* List secure credentials (metadata only)
-* View scheduled monitor downtimes
-* Get monitor scripts and step configurations
-* Map monitor IDs to entity GUIDs
-* Check runtime upgrade status for legacy monitors
+* **General queries**: Query all monitors in your account with filtering options
+* **Monitor-specific queries**: Get scripts from scripted monitors and steps from step monitors
+* **Supporting entity queries**: Retrieve private location configurations, secure credential metadata, and scheduled monitor downtimes
+* **Advanced queries**: Map legacy monitor IDs to entity GUIDs and check runtime upgrade status for legacy monitors
 
 ## Related resources [#related-resources]
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
@@ -117,10 +117,6 @@ In addition to monitors, you can manage supporting infrastructure and configurat
 
 ## Query operations [#query-operations]
 
-<Callout variant="tip">
-  **Comprehensive Query Documentation**: All query examples for synthetic monitoring are centralized in the [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page. Each monitor type page also includes quick links to relevant query sections.
-</Callout>
-
 Use [query operations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) to retrieve information about your synthetic monitoring setup:
 
 * **General queries**: Query all monitors in your account with filtering options

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/overview.mdx
@@ -124,7 +124,7 @@ In addition to monitors, you can manage supporting infrastructure and configurat
 Use [query operations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) to retrieve information about your synthetic monitoring setup:
 
 * **General queries**: Query all monitors in your account with filtering options
-* **Monitor-specific queries**: Get scripts from scripted monitors and steps from step monitors
+* **Monitor-specific queries**: Retrieve the script from a scripted monitor, or the ordered steps from a step monitor
 * **Supporting entity queries**: Retrieve private location configurations, secure credential metadata, and scheduled monitor downtimes
 * **Advanced queries**: Map legacy monitor IDs to entity GUIDs and check runtime upgrade status for legacy monitors
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
@@ -322,13 +322,11 @@ If there are any issues deleting the monitor, an error will be returned with det
 
 ## Query ping monitors [#query-ping-monitors]
 
-<Callout variant="tip">
-  **Need to query your ping monitors?** All query examples for ping monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your ping monitors?** All query examples for ping monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including ping monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including ping monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
 
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
@@ -320,4 +320,119 @@ A successful deletion returns the GUID of the deleted monitor:
 
 If there are any issues deleting the monitor, an error will be returned with details about what went wrong.
 
+## Query ping monitors [#query-ping-monitors]
+
+You can query your ping monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including ping monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters to narrow results.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "entitySearch": {
+        "results": {
+          "entities": [
+            {
+              "guid": "MjUyMDUyOHxTWU5USHxNT05JVE9SfDMwNDg1",
+              "name": "Example Ping Monitor",
+              "accountId": 2520528,
+              "monitorType": "SIMPLE",
+              "tags": [
+                {
+                  "key": "language",
+                  "values": ["en"]
+                },
+                {
+                  "key": "runState",
+                  "values": ["ENABLED"]
+                },
+                {
+                  "key": "uri",
+                  "values": ["https://example.com"]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.
+
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
@@ -320,4 +320,15 @@ A successful deletion returns the GUID of the deleted monitor:
 
 If there are any issues deleting the monitor, an error will be returned with details about what went wrong.
 
+## Query ping monitors [#query-ping-monitors]
+
+<Callout variant="tip">
+  **Need to query your ping monitors?** All query examples for ping monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including ping monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>
+
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
@@ -322,11 +322,13 @@ If there are any issues deleting the monitor, an error will be returned with det
 
 ## Query ping monitors [#query-ping-monitors]
 
-**Need to query your ping monitors?** All query examples for ping monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, map IDs, or check the status of your ping monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including ping monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.
 
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [ping monitors](/docs/synthetics/sy
 
 ## Create a ping monitor [#create-ping-monitor]
 
-You can create a ping monitor using the `syntheticsCreateSimpleMonitor` mutation. This mutation allows you to configure monitoring for any publicly accessible URL or endpoint.
+You can create a ping monitor using the <DNT>`syntheticsCreateSimpleMonitor`</DNT> mutation. This mutation allows you to configure monitoring for any publicly accessible URL or endpoint.
 
 ### Input parameters
 
@@ -132,7 +132,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a ping monitor [#update-ping-monitor]
 
-You can update an existing ping monitor using the `syntheticsUpdateSimpleMonitor` mutation. This allows you to modify the configuration of a ping monitor that has already been created.
+You can update an existing ping monitor using the <DNT>`syntheticsUpdateSimpleMonitor`</DNT> mutation. This allows you to modify the configuration of a ping monitor that has already been created.
 
 ### Input parameters
 
@@ -269,7 +269,7 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 
 ## Delete a synthetic monitor [#delete-monitor]
 
-This API allows you to delete an existing monitor using the `syntheticsDeleteMonitor` mutation with the guid parameter.
+This API allows you to delete an existing monitor using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation with the guid parameter.
 
 ### Input parameters
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
@@ -304,9 +304,7 @@ If there are any issues deleting the private location, the `errors` array will c
 
 ## Query private locations [#query-private-locations]
 
-<Callout variant="tip">
-  **Need to query your private locations?** All query examples for private locations, including how to retrieve location metadata and configuration details, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your private locations?** All query examples for private locations, including how to retrieve location metadata and configuration details, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query private locations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-private-locations) - Get all private locations with their configuration details
-</Callout>
+**Quick links to relevant sections:**
+- [Query private locations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-private-locations) - Get all private locations with their configuration details

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
@@ -301,3 +301,12 @@ A successful response returns `null` for errors:
 ```
 
 If there are any issues deleting the private location, the `errors` array will contain objects with `description` and `type` fields explaining what went wrong.
+
+## Query private locations [#query-private-locations]
+
+<Callout variant="tip">
+  **Need to query your private locations?** All query examples for private locations, including how to retrieve location metadata and configuration details, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query private locations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-private-locations) - Get all private locations with their configuration details
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
@@ -301,3 +301,82 @@ A successful response returns `null` for errors:
 ```
 
 If there are any issues deleting the private location, the `errors` array will contain objects with `description` and `type` fields explaining what went wrong.
+
+## Query private locations [#query-private-locations]
+
+You can query your private locations to retrieve information about their configuration, status, and metadata. This query retrieves all private locations in your account, returning essential information like the location's GUID, name, account ID, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'` to retrieve all private locations.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'") {
+      results {
+        entities {
+          accountId
+          guid
+          name
+          tags {
+            key
+            values
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "entitySearch": {
+        "results": {
+          "entities": [
+            {
+              "accountId": 2520528,
+              "guid": "MjUyMDUyOHxTWU5USHxQUklWQVRFX0xPQ0FUSU9OfDEyMzQ1",
+              "name": "My Private Location",
+              "tags": [
+                {
+                  "key": "description",
+                  "values": ["Internal datacenter monitoring"]
+                },
+                {
+                  "key": "verified",
+                  "values": ["true"]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
@@ -304,7 +304,9 @@ If there are any issues deleting the private location, the `errors` array will c
 
 ## Query private locations [#query-private-locations]
 
-**Need to query your private locations?** All query examples for private locations, including how to retrieve location metadata and configuration details, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve location metadata and configuration details.
 
-**Quick links to relevant sections:**
-- [Query private locations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-private-locations) - Get all private locations with their configuration details
+For more information, refer to:
+- [Query private locations](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-private-locations) - Get all private locations with their configuration details.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/private-locations.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 
 ## Create a private location [#create-private-location]
 
-You can create a private location using the `syntheticsCreatePrivateLocation` mutation. This mutation allows you to set up a new private location in your monitoring infrastructure where you can deploy private minions or job managers.
+You can create a private location using the <DNT>`syntheticsCreatePrivateLocation`</DNT> mutation. This mutation allows you to set up a new private location in your monitoring infrastructure where you can deploy private minions or job managers.
 
 ### Input parameters
 
@@ -99,7 +99,7 @@ If there are any issues creating the private location, the `errors` array will c
 
 ## Update a private location [#update-private-location]
 
-You can update an existing private location using the `syntheticsUpdatePrivateLocation` mutation. This allows you to modify the configuration of a private location that has already been created.
+You can update an existing private location using the <DNT>`syntheticsUpdatePrivateLocation`</DNT> mutation. This allows you to modify the configuration of a private location that has already been created.
 
 <Callout variant="important">
   If a location is shared and used by other accounts in your organization to run synthetic monitors, you cannot unshare this private location until those monitors are disabled.
@@ -184,7 +184,7 @@ If there are any issues updating the private location, the `errors` array will c
 
 ## Purge a private location job queue [#purge-private-location]
 
-You can clear the job queue for a private location using the `syntheticsPurgePrivateLocationQueue` mutation. This is useful when you need to remove a backlog of queued synthetic monitor jobs that may have accumulated due to performance issues or temporary connectivity problems.
+You can clear the job queue for a private location using the <DNT>`syntheticsPurgePrivateLocationQueue`</DNT> mutation. This is useful when you need to remove a backlog of queued synthetic monitor jobs that may have accumulated due to performance issues or temporary connectivity problems.
 
 <Callout variant="tip">
   Use this operation carefully as it will permanently remove all queued jobs. Jobs currently running will not be affected.
@@ -244,7 +244,7 @@ If there are any issues purging the queue, the `errors` array will contain objec
 
 ## Delete a private location [#delete-private-location]
 
-When a private location is no longer needed, you can permanently remove it using the `syntheticsDeletePrivateLocation` mutation.
+When a private location is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeletePrivateLocation`</DNT> mutation.
 
 <Callout variant="important">
   Before deleting a private location, ensure no monitors are assigned to it. Deleting a private location that has active monitors assigned will cause those monitors to fail.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -21,186 +21,101 @@ After setting up your monitoring infrastructure, you can use queries to retrieve
 
 To learn additional query capabilities available to your synthetic entities, check out [NerdGraph entities API tutorial](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/).
 
-## Query monitors [#query-monitors]
+## General monitor queries [#general-monitor-queries]
 
-This query retrieves all synthetic monitors in your account, returning essential information including the monitor's GUID, name, account ID, monitor type, and associated tags. The tags contain additional configuration details and metadata about each monitor.
+<CollapserGroup>
+<Collapser
+  id="query-monitors"
+  title="Query monitors">
 
-### Input parameters
+  This query retrieves all synthetic monitors in your account, returning essential information including the monitor's GUID, name, account ID, monitor type, and associated tags. The tags contain additional configuration details and metadata about each monitor.
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors.</td>
-    </tr>
-  </tbody>
-</table>
+  #### Input parameters
 
-### Sample query
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors.</td>
+      </tr>
+    </tbody>
+  </table>
 
-```graphql
-{
-  actor {
-    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR'") {
-      results {
-        entities {
-          ... on SyntheticMonitorEntityOutline {
-            guid
-            name
-            accountId
-            monitorType
-            tags {
-              key
-              values
+  #### Sample query
+
+  ```graphql
+  {
+    actor {
+      entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR'") {
+        results {
+          entities {
+            ... on SyntheticMonitorEntityOutline {
+              guid
+              name
+              accountId
+              monitorType
+              tags {
+                key
+                values
+              }
             }
           }
         }
       }
     }
   }
-}
-```
+  ```
+</Collapser>
+</CollapserGroup>
 
 ## Supporting entity queries [#supporting-entity-queries]
 
-## Query private locations [#query-private-locations]
+<CollapserGroup>
+<Collapser
+  id="query-private-locations"
+  title="Query private locations">
 
-This query retrieves all private locations in your account, returning essential information including the location's GUID, name, account ID, and associated tags. Private locations allow you to monitor applications behind your firewall, and their configuration details are accessible through the tags.
+  This query retrieves all private locations in your account, returning essential information including the location's GUID, name, account ID, and associated tags. Private locations allow you to monitor applications behind your firewall, and their configuration details are accessible through the tags.
 
-### Input parameters
+  #### Input parameters
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'` to retrieve all private locations.</td>
-    </tr>
-  </tbody>
-</table>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'` to retrieve all private locations.</td>
+      </tr>
+    </tbody>
+  </table>
 
-### Sample query
+  #### Sample query
 
-```graphql
-{
-  actor {
-    entitySearch(query: "domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'") {
-      results {
-        entities {
-          accountId
-          guid
-          name
-          tags {
-            key
-            values
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-## Query monitor downtimes [#query-monitor-downtimes]
-
-This query retrieves all monitor downtimes in your account, returning essential information including the downtime's GUID, name, account ID, and associated tags. Monitor downtimes are scheduled periods when synthetic monitors stop running, useful during planned maintenance or known outages. Configuration details such as schedule type, timezone, and recurrence patterns are stored in tags.
-
-### Input parameters
-
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'` to retrieve all monitor downtimes.</td>
-    </tr>
-  </tbody>
-</table>
-
-### Sample query
-
-```graphql
-{
-  actor {
-    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'") {
-      results {
-        entities {
-          accountId
-          guid
-          name
-          tags {
-            key
-            values
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-## Query secure credentials [#query-secure-credentials]
-
-This query retrieves all secure credentials in your account, returning metadata information including the credential's GUID, name, account ID, tags, and last update timestamp. Secure credentials help store, protect, and centrally manage sensitive information like passwords, API keys, or encoded certificates. For security reasons, querying secure credentials returns metadata only, but not the actual credential values themselves.
-
-### Input parameters
-
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'SECURE_CRED'` to retrieve all secure credentials.</td>
-    </tr>
-  </tbody>
-</table>
-
-### Sample query
-
-```graphql
-{
-  actor {
-    entitySearch(query: "domain = 'SYNTH' AND type = 'SECURE_CRED'") {
-      results {
-        entities {
-          ... on SecureCredentialEntityOutline {
+  ```graphql
+  {
+    actor {
+      entitySearch(query: "domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'") {
+        results {
+          entities {
             accountId
             guid
             name
@@ -208,254 +123,376 @@ This query retrieves all secure credentials in your account, returning metadata 
               key
               values
             }
-            updatedAt
           }
         }
       }
     }
   }
-}
-```
+  ```
+</Collapser>
+
+<Collapser
+  id="query-monitor-downtimes"
+  title="Query monitor downtimes">
+
+  This query retrieves all monitor downtimes in your account, returning essential information including the downtime's GUID, name, account ID, and associated tags. Monitor downtimes are scheduled periods when synthetic monitors stop running, useful during planned maintenance or known outages. Configuration details such as schedule type, timezone, and recurrence patterns are stored in tags.
+
+  #### Input parameters
+
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'` to retrieve all monitor downtimes.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  #### Sample query
+
+  ```graphql
+  {
+    actor {
+      entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'") {
+        results {
+          entities {
+            accountId
+            guid
+            name
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+  ```
+</Collapser>
+
+<Collapser
+  id="query-secure-credentials"
+  title="Query secure credentials">
+
+  This query retrieves all secure credentials in your account, returning metadata information including the credential's GUID, name, account ID, tags, and last update timestamp. Secure credentials help store, protect, and centrally manage sensitive information like passwords, API keys, or encoded certificates. For security reasons, querying secure credentials returns metadata only, but not the actual credential values themselves.
+
+  #### Input parameters
+
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'SECURE_CRED'` to retrieve all secure credentials.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  #### Sample query
+
+  ```graphql
+  {
+    actor {
+      entitySearch(query: "domain = 'SYNTH' AND type = 'SECURE_CRED'") {
+        results {
+          entities {
+            ... on SecureCredentialEntityOutline {
+              accountId
+              guid
+              name
+              tags {
+                key
+                values
+              }
+              updatedAt
+            }
+          }
+        }
+      }
+    }
+  }
+  ```
+</Collapser>
+</CollapserGroup>
 
 ## Monitor-specific queries [#monitor-specific-queries]
 
-## Query monitor script [#query-monitor-script]
+<CollapserGroup>
+<Collapser
+  id="query-monitor-script"
+  title="Query monitor script">
 
-This query retrieves the script content used in a scripted API or scripted browser monitor. The script contains the JavaScript code that defines the monitor's behavior, such as API calls, browser interactions, or custom validation logic. This query only works with scripted monitor types - other monitor types (simple, ping, step, certificate check, broken links) will return an error since they don't use custom scripts.
+  This query retrieves the script content used in a scripted API or scripted browser monitor. The script contains the JavaScript code that defines the monitor's behavior, such as API calls, browser interactions, or custom validation logic. This query only works with scripted monitor types - other monitor types (simple, ping, step, certificate check, broken links) will return an error since they don't use custom scripts.
 
-### Input parameters
+  #### Input parameters
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`id` (account)</td>
-      <td>Integer</td>
-      <td>Yes</td>
-      <td>The New Relic account ID that contains the monitor.</td>
-    </tr>
-    <tr>
-      <td>`monitorGuid`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The unique entity GUID of the scripted monitor whose script you want to retrieve.</td>
-    </tr>
-  </tbody>
-</table>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`id` (account)</td>
+        <td>Integer</td>
+        <td>Yes</td>
+        <td>The New Relic account ID that contains the monitor.</td>
+      </tr>
+      <tr>
+        <td>`monitorGuid`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The unique entity GUID of the scripted monitor whose script you want to retrieve.</td>
+      </tr>
+    </tbody>
+  </table>
 
-### Sample query
+  #### Sample query
 
-```graphql
-{
-  actor {
-    account(id: ACCOUNT_ID) {
-      synthetics {
-        script(monitorGuid: "ENTITY_GUID") {
-          text
+  ```graphql
+  {
+    actor {
+      account(id: ACCOUNT_ID) {
+        synthetics {
+          script(monitorGuid: "ENTITY_GUID") {
+            text
+          }
         }
       }
     }
   }
-}
-```
+  ```
+</Collapser>
 
-## Query monitor steps [#query-monitor-steps]
+<Collapser
+  id="query-monitor-steps"
+  title="Query monitor steps">
 
-This query retrieves the steps configured for a step monitor. Step monitors provide codeless, multi-step browser-based monitoring through a sequence of predefined actions like navigation, clicks, form inputs, and assertions. Each step has an ordinal position, a type that defines the action, and values that contain the step's configuration data. This query only works with step monitors - other monitor types will return an error since they don't use step-based configurations.
+  This query retrieves the steps configured for a step monitor. Step monitors provide codeless, multi-step browser-based monitoring through a sequence of predefined actions like navigation, clicks, form inputs, and assertions. Each step has an ordinal position, a type that defines the action, and values that contain the step's configuration data. This query only works with step monitors - other monitor types will return an error since they don't use step-based configurations.
 
-### Input parameters
+  #### Input parameters
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`id` (account)</td>
-      <td>Integer</td>
-      <td>Yes</td>
-      <td>The New Relic account ID that contains the monitor.</td>
-    </tr>
-    <tr>
-      <td>`monitorGuid`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The unique entity GUID of the step monitor whose steps you want to retrieve.</td>
-    </tr>
-  </tbody>
-</table>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`id` (account)</td>
+        <td>Integer</td>
+        <td>Yes</td>
+        <td>The New Relic account ID that contains the monitor.</td>
+      </tr>
+      <tr>
+        <td>`monitorGuid`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The unique entity GUID of the step monitor whose steps you want to retrieve.</td>
+      </tr>
+    </tbody>
+  </table>
 
-### Sample query
+  #### Sample query
 
-```graphql
-{
-  actor {
-    account(id: ACCOUNT_ID) {
-      synthetics {
-        steps(monitorGuid: "ENTITY_GUID") {
-          ordinal
-          type
-          values
+  ```graphql
+  {
+    actor {
+      account(id: ACCOUNT_ID) {
+        synthetics {
+          steps(monitorGuid: "ENTITY_GUID") {
+            ordinal
+            type
+            values
+          }
         }
       }
     }
   }
-}
-```
+  ```
+</Collapser>
+</CollapserGroup>
 
 ## Advanced queries [#advanced-queries]
 
-## Query to map monitor ID to entity GUID [#query-guid-mapping]
+<CollapserGroup>
+<Collapser
+  id="query-guid-mapping"
+  title="Query to map monitor ID to entity GUID">
 
-This query retrieves the entity GUID for a synthetic monitor using the monitor ID. This is useful when you have the legacy numeric monitor ID and need to convert it to the entity GUID format required for most NerdGraph operations. The entity GUID is the modern identifier used for updates, deletions, and other monitor management tasks, while the monitor ID is the older numeric identifier that may appear in URLs or legacy integrations.
+  This query retrieves the entity GUID for a synthetic monitor using the monitor ID. This is useful when you have the legacy numeric monitor ID and need to convert it to the entity GUID format required for most NerdGraph operations. The entity GUID is the modern identifier used for updates, deletions, and other monitor management tasks, while the monitor ID is the older numeric identifier that may appear in URLs or legacy integrations.
 
-### Input parameters
+  #### Input parameters
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to find the monitor. Use `domainId = 'MONITOR_ID'` where MONITOR_ID is the numeric ID of the monitor you want to find.</td>
-    </tr>
-  </tbody>
-</table>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to find the monitor. Use `domainId = 'MONITOR_ID'` where MONITOR_ID is the numeric ID of the monitor you want to find.</td>
+      </tr>
+    </tbody>
+  </table>
 
-### Sample query
+  #### Sample query
 
-```graphql
-{
-  actor {
-    entitySearch(
-      query: "(domainId = 'MONITOR_ID')"
-    ) {
-      results {
-        entities {
-          ... on SyntheticMonitorEntityOutline {
+  ```graphql
+  {
+    actor {
+      entitySearch(
+        query: "(domainId = 'MONITOR_ID')"
+      ) {
+        results {
+          entities {
+            ... on SyntheticMonitorEntityOutline {
+              guid
+              name
+              monitorId
+            }
+          }
+        }
+      }
+    }
+  }
+  ```
+</Collapser>
+
+<Collapser
+  id="query-runtime-upgrade-all"
+  title="Query runtime upgrade status (all monitors)">
+
+  This query retrieves the status of all runtime upgrade tests for legacy runtime monitors in your account. These tests validate whether monitors using older runtimes (like Chrome 72 or Node.js API legacy) can successfully run on newer runtimes (Chrome 100+ or Node.js 16.10). The results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) and help you identify which monitors are ready for upgrade. The test result is stored in the `validationStatus` tag, and if the upgrade test failed, detailed error information is available in the `validationError` tag.
+
+  #### Input parameters
+
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'` to retrieve all runtime upgrade test results.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  #### Sample query
+
+  ```graphql
+  {
+    actor {
+      entitySearch(query: "domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'") {
+        results {
+          entities {
+            accountId
             guid
             name
-            monitorId
+            tags {
+              key
+              values
+            }
           }
         }
       }
     }
   }
-}
-```
+  ```
+</Collapser>
 
-## Query runtime upgrade status (all monitors) [#query-runtime-upgrade-all]
+<Collapser
+  id="query-runtime-upgrade-specific"
+  title="Query runtime upgrade status (specific monitor)">
 
-This query retrieves the status of all runtime upgrade tests for legacy runtime monitors in your account. These tests validate whether monitors using older runtimes (like Chrome 72 or Node.js API legacy) can successfully run on newer runtimes (Chrome 100+ or Node.js 16.10). The results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) and help you identify which monitors are ready for upgrade. The test result is stored in the `validationStatus` tag, and if the upgrade test failed, detailed error information is available in the `validationError` tag.
+  This query retrieves the status of a runtime upgrade test for a specific legacy runtime monitor using the monitor ID. This is useful when you want to check the upgrade readiness of a particular monitor rather than all monitors in your account. The test validates whether the monitor can successfully run on newer runtimes and these results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/). The test result is stored in the `validationStatus` tag, and if the upgrade test failed, detailed error information is available in the `validationError` tag.
 
-### Input parameters
+  #### Input parameters
 
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'` to retrieve all runtime upgrade test results.</td>
-    </tr>
-  </tbody>
-</table>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Data Type</th>
+        <th>Is it Required?</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>`query`</td>
+        <td>String</td>
+        <td>Yes</td>
+        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'` where MONITOR_ID is the numeric ID of the specific monitor.</td>
+      </tr>
+    </tbody>
+  </table>
 
-### Sample query
+  #### Sample query
 
-```graphql
-{
-  actor {
-    entitySearch(query: "domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'") {
-      results {
-        entities {
-          accountId
-          guid
-          name
-          tags {
-            key
-            values
+  ```graphql
+  {
+    actor {
+      entitySearch(
+        query: "domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'"
+      ) {
+        results {
+          entities {
+            accountId
+            guid
+            name
+            tags {
+              key
+              values
+            }
           }
         }
       }
     }
   }
-}
-```
-
-## Query runtime upgrade status (specific monitor) [#query-runtime-upgrade-specific]
-
-This query retrieves the status of a runtime upgrade test for a specific legacy runtime monitor using the monitor ID. This is useful when you want to check the upgrade readiness of a particular monitor rather than all monitors in your account. The test validates whether the monitor can successfully run on newer runtimes and these results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/). The test result is stored in the `validationStatus` tag, and if the upgrade test failed, detailed error information is available in the `validationError` tag.
-
-### Input parameters
-
-<table>
-  <thead>
-    <tr>
-      <th>Parameter</th>
-      <th>Data Type</th>
-      <th>Is it Required?</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`query`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'` where MONITOR_ID is the numeric ID of the specific monitor.</td>
-    </tr>
-  </tbody>
-</table>
-
-### Sample query
-
-```graphql
-{
-  actor {
-    entitySearch(
-      query: "domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'"
-    ) {
-      results {
-        entities {
-          accountId
-          guid
-          name
-          tags {
-            key
-            values
-          }
-        }
-      }
-    }
-  }
-}
-```
+  ```
+</Collapser>
+</CollapserGroup>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -11,6 +11,14 @@ freshnessValidatedDate: never
 
 After setting up your monitoring infrastructure, you can use queries to retrieve information about your synthetic entities. Queries make requests to fetch data about monitors, private locations, credentials, and downtimes. This tutorial provides examples of how to use the NerdGraph API to query synthetic monitoring data.
 
+<Callout variant="tip">
+  **Quick Navigation**: Use the links below to jump to specific query types:
+  - [General monitor queries](#query-monitors) - Query all monitors or specific types
+  - [Monitor-specific queries](#query-monitor-script) - Get scripts and steps for specific monitors
+  - [Supporting entity queries](#query-private-locations) - Private locations, secure credentials, downtimes
+  - [Advanced queries](#query-guid-mapping) - ID mapping and runtime upgrade status
+</Callout>
+
 To learn additional query capabilities available to your synthetic entities, check out [NerdGraph entities API tutorial](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/).
 
 ## Query monitors [#query-monitors]
@@ -62,6 +70,8 @@ This query retrieves all synthetic monitors in your account, returning essential
   }
 }
 ```
+
+## Supporting entity queries [#supporting-entity-queries]
 
 ## Query private locations [#query-private-locations]
 
@@ -207,6 +217,8 @@ This query retrieves all secure credentials in your account, returning metadata 
 }
 ```
 
+## Monitor-specific queries [#monitor-specific-queries]
+
 ## Query monitor script [#query-monitor-script]
 
 This query retrieves the script content used in a scripted API or scripted browser monitor. The script contains the JavaScript code that defines the monitor's behavior, such as API calls, browser interactions, or custom validation logic. This query only works with scripted monitor types - other monitor types (simple, ping, step, certificate check, broken links) will return an error since they don't use custom scripts.
@@ -302,6 +314,8 @@ This query retrieves the steps configured for a step monitor. Step monitors prov
   }
 }
 ```
+
+## Advanced queries [#advanced-queries]
 
 ## Query to map monitor ID to entity GUID [#query-guid-mapping]
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -1,24 +1,15 @@
 ---
-title: "[DEPRECATED] Query synthetic monitoring data"
+title: "Query synthetic monitoring data"
 tags:
   - Synthetics
   - APIs
   - NerdGraph
   - Examples
-metaDescription: "[DEPRECATED] This page has been superseded by query examples integrated into each monitor type page."
+metaDescription: How to use New Relic NerdGraph API to query synthetic monitoring data including monitors, private locations, secure credentials, and downtimes.
 freshnessValidatedDate: never
 ---
 
-<Callout variant="important">
-  **This page is deprecated.** Query examples have been moved to their respective monitor type and entity pages for better user experience:
-
-  - Monitor queries: See individual monitor type pages ([ping](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor), [simple browser](/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor), [scripted browser](/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor), [scripted API](/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor), [step](/docs/apis/nerdgraph/examples/synthetics-api/step-monitor), [certificate check](/docs/apis/nerdgraph/examples/synthetics-api/certificate-check-monitor), [broken links](/docs/apis/nerdgraph/examples/synthetics-api/broken-links-monitor))
-  - Private location queries: [Private locations page](/docs/apis/nerdgraph/examples/synthetics-api/private-locations)
-  - Secure credential queries: [Secure credentials page](/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials)
-  - Monitor downtime queries: [Monitor downtimes page](/docs/apis/nerdgraph/examples/synthetics-api/monitor-downtimes)
-</Callout>
-
-~~After setting up your monitoring infrastructure, you can use queries to retrieve information about your synthetic entities. Queries make requests to fetch data about monitors, private locations, credentials, and downtimes. This tutorial provides examples of how to use the NerdGraph API to query synthetic monitoring data.~~
+After setting up your monitoring infrastructure, you can use queries to retrieve information about your synthetic entities. Queries make requests to fetch data about monitors, private locations, credentials, and downtimes. This tutorial provides examples of how to use the NerdGraph API to query synthetic monitoring data.
 
 <Callout variant="tip">
   **Quick Navigation**: Use the links below to jump to specific query types:

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -46,7 +46,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'MONITOR'`</DNT> to retrieve all synthetic monitors.</td>
       </tr>
     </tbody>
   </table>
@@ -103,7 +103,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'` to retrieve all private locations.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'PRIVATE_LOCATION'`</DNT> to retrieve all private locations.</td>
       </tr>
     </tbody>
   </table>
@@ -153,7 +153,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'` to retrieve all monitor downtimes.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'MONITOR_DOWNTIME'`</DNT> to retrieve all monitor downtimes.</td>
       </tr>
     </tbody>
   </table>
@@ -203,7 +203,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'SECURE_CRED'` to retrieve all secure credentials.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'SECURE_CRED'`</DNT> to retrieve all secure credentials.</td>
       </tr>
     </tbody>
   </table>
@@ -366,7 +366,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to find the monitor. Use `domainId = 'MONITOR_ID'` where MONITOR_ID is the numeric ID of the monitor you want to find.</td>
+        <td>The search query to find the monitor. Use <DNT>`domainId = 'MONITOR_ID'`</DNT> where MONITOR_ID is the numeric ID of the monitor you want to find.</td>
       </tr>
     </tbody>
   </table>
@@ -416,7 +416,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'` to retrieve all runtime upgrade test results.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION'`</DNT> to retrieve all runtime upgrade test results.</td>
       </tr>
     </tbody>
   </table>
@@ -466,7 +466,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'` where MONITOR_ID is the numeric ID of the specific monitor.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'`</DNT> where MONITOR_ID is the numeric ID of the specific monitor.</td>
       </tr>
     </tbody>
   </table>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -13,10 +13,10 @@ After setting up your monitoring infrastructure, you can use queries to retrieve
 
 <Callout variant="tip">
   **Quick Navigation**: Use the links below to jump to specific query types:
-  - [General monitor queries](#query-monitors) - Query all monitors or specific types
-  - [Monitor-specific queries](#query-monitor-script) - Retrieve the script from a scripted monitor, or the ordered steps from a step monitor
-  - [Supporting entity queries](#query-private-locations) - Private locations, secure credentials, downtimes
-  - [Advanced queries](#query-guid-mapping) - ID mapping and runtime upgrade status
+  - [General monitor queries](#query-monitors): Query all monitors or specific types
+  - [Monitor-specific queries](#query-monitor-script): Retrieve the script from a scripted monitor, or the ordered steps from a step monitor
+  - [Supporting entity queries](#query-private-locations): Private locations, secure credentials, downtimes
+  - [Advanced queries](#query-guid-mapping): ID mapping and runtime upgrade status
 </Callout>
 
 To learn additional query capabilities available to your synthetic entities, check out [NerdGraph entities API tutorial](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/).

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -30,7 +30,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves all synthetic monitors in your account, returning essential information including the monitor's GUID, name, account ID, monitor type, and associated tags. The tags contain additional configuration details and metadata about each monitor.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -51,7 +51,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -87,7 +87,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves all private locations in your account, returning essential information including the location's GUID, name, account ID, and associated tags. Private locations allow you to monitor applications behind your firewall, and their configuration details are accessible through the tags.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -108,7 +108,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -137,7 +137,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves all monitor downtimes in your account, returning essential information including the downtime's GUID, name, account ID, and associated tags. Monitor downtimes are scheduled periods when synthetic monitors stop running, useful during planned maintenance or known outages. Configuration details such as schedule type, timezone, and recurrence patterns are stored in tags.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -158,7 +158,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -187,7 +187,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves all secure credentials in your account, returning metadata information including the credential's GUID, name, account ID, tags, and last update timestamp. Secure credentials help store, protect, and centrally manage sensitive information like passwords, API keys, or encoded certificates. For security reasons, querying secure credentials returns metadata only, but not the actual credential values themselves.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -208,7 +208,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -244,7 +244,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves the script content used in a scripted API or scripted browser monitor. The script contains the JavaScript code that defines the monitor's behavior, such as API calls, browser interactions, or custom validation logic. This query only works with scripted monitor types: other monitor types (simple, ping, step, certificate check, broken links) will return an error since they don't use custom scripts.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -271,7 +271,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -294,7 +294,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves the steps configured for a step monitor. Step monitors provide codeless, multi-step browser-based monitoring through a sequence of predefined actions like navigation, clicks, form inputs, and assertions. Each step has an ordinal position, a type that defines the action, and values that contain the step's configuration data. This query only works with step monitors: other monitor types will return an error since they don't use step-based configurations.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -321,7 +321,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -350,7 +350,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves the entity GUID for a synthetic monitor using the monitor ID. This is useful when you have the legacy numeric monitor ID and need to convert it to the entity GUID format required for most NerdGraph operations. The entity GUID is the modern identifier used for updates, deletions, and other monitor management tasks, while the monitor ID is the older numeric identifier that may appear in URLs or legacy integrations.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -371,7 +371,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -400,7 +400,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves the status of all runtime upgrade tests for legacy runtime monitors in your account. These tests validate whether monitors using older runtimes (like Chrome 72 or Node.js API legacy) can successfully run on newer runtimes (Chrome 100+ or Node.js 16.10). The results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/) and help you identify which monitors are ready for upgrade. The test result is stored in the `validationStatus` tag, and if the upgrade test failed, detailed error information is available in the `validationError` tag.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -421,7 +421,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {
@@ -450,7 +450,7 @@ To learn additional query capabilities available to your synthetic entities, che
 
   This query retrieves the status of a runtime upgrade test for a specific legacy runtime monitor using the monitor ID. This is useful when you want to check the upgrade readiness of a particular monitor rather than all monitors in your account. The test validates whether the monitor can successfully run on newer runtimes and these results populate the [runtime upgrades UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/). The test result is stored in the `validationStatus` tag, and if the upgrade test failed, detailed error information is available in the `validationError` tag.
 
-  #### Input parameters
+  ### Input parameters
 
   <table>
     <thead>
@@ -471,7 +471,7 @@ To learn additional query capabilities available to your synthetic entities, che
     </tbody>
   </table>
 
-  #### Sample query
+  ### Sample query
 
   ```graphql
   {

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -242,7 +242,7 @@ To learn additional query capabilities available to your synthetic entities, che
   id="query-monitor-script"
   title="Query monitor script">
 
-  This query retrieves the script content used in a scripted API or scripted browser monitor. The script contains the JavaScript code that defines the monitor's behavior, such as API calls, browser interactions, or custom validation logic. This query only works with scripted monitor types - other monitor types (simple, ping, step, certificate check, broken links) will return an error since they don't use custom scripts.
+  This query retrieves the script content used in a scripted API or scripted browser monitor. The script contains the JavaScript code that defines the monitor's behavior, such as API calls, browser interactions, or custom validation logic. This query only works with scripted monitor types: other monitor types (simple, ping, step, certificate check, broken links) will return an error since they don't use custom scripts.
 
   #### Input parameters
 
@@ -292,7 +292,7 @@ To learn additional query capabilities available to your synthetic entities, che
   id="query-monitor-steps"
   title="Query monitor steps">
 
-  This query retrieves the steps configured for a step monitor. Step monitors provide codeless, multi-step browser-based monitoring through a sequence of predefined actions like navigation, clicks, form inputs, and assertions. Each step has an ordinal position, a type that defines the action, and values that contain the step's configuration data. This query only works with step monitors - other monitor types will return an error since they don't use step-based configurations.
+  This query retrieves the steps configured for a step monitor. Step monitors provide codeless, multi-step browser-based monitoring through a sequence of predefined actions like navigation, clicks, form inputs, and assertions. Each step has an ordinal position, a type that defines the action, and values that contain the step's configuration data. This query only works with step monitors: other monitor types will return an error since they don't use step-based configurations.
 
   #### Input parameters
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -78,7 +78,7 @@ To learn additional query capabilities available to your synthetic entities, che
 </Collapser>
 </CollapserGroup>
 
-## Supporting entity queries [#supporting-entity-queries]
+## Entity support queries [#supporting-entity-queries]
 
 <CollapserGroup>
 <Collapser

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -15,8 +15,8 @@ After setting up your monitoring infrastructure, you can use queries to retrieve
   **Quick Navigation**: Use the links below to jump to specific query types:
   - [General monitor queries](#query-monitors): Query all monitors or specific types
   - [Monitor-specific queries](#query-monitor-script): Retrieve the script from a scripted monitor, or the ordered steps from a step monitor
-  - [Supporting entity queries](#query-private-locations): Private locations, secure credentials, downtimes
-  - [Advanced queries](#query-guid-mapping): ID mapping and runtime upgrade status
+  - [Supporting entity queries](#query-private-locations): Query private locations, secure credentials, and monitor downtimes
+  - [Advanced queries](#query-guid-mapping): Map legacy monitor IDs and check runtime upgrade status
 </Callout>
 
 To learn additional query capabilities available to your synthetic entities, check out [NerdGraph entities API tutorial](/docs/apis/nerdgraph/examples/nerdgraph-entities-api-tutorial/).

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -14,7 +14,7 @@ After setting up your monitoring infrastructure, you can use queries to retrieve
 <Callout variant="tip">
   **Quick Navigation**: Use the links below to jump to specific query types:
   - [General monitor queries](#query-monitors) - Query all monitors or specific types
-  - [Monitor-specific queries](#query-monitor-script) - Get scripts and steps for specific monitors
+  - [Monitor-specific queries](#query-monitor-script) - Retrieve the script from a scripted monitor, or the ordered steps from a step monitor
   - [Supporting entity queries](#query-private-locations) - Private locations, secure credentials, downtimes
   - [Advanced queries](#query-guid-mapping) - ID mapping and runtime upgrade status
 </Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data.mdx
@@ -366,7 +366,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to find the monitor. Use <DNT>`domainId = 'MONITOR_ID'`</DNT> where MONITOR_ID is the numeric ID of the monitor you want to find.</td>
+        <td>The search query to find the monitor. Use <DNT>`domainId = 'MONITOR_ID'`</DNT> where `MONITOR_ID` is the numeric ID of the monitor you want to find.</td>
       </tr>
     </tbody>
   </table>
@@ -466,7 +466,7 @@ To learn additional query capabilities available to your synthetic entities, che
         <td>`query`</td>
         <td>String</td>
         <td>Yes</td>
-        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'`</DNT> where MONITOR_ID is the numeric ID of the specific monitor.</td>
+        <td>The search query to filter entities. Use <DNT>`domain = 'SYNTH' AND type = 'RUNTIME_VALIDATION' AND domainId = 'MONITOR_ID'`</DNT> where `MONITOR_ID` is the numeric ID of the specific monitor.</td>
       </tr>
     </tbody>
   </table>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
@@ -523,3 +523,15 @@ If there are any issues moving the monitor, the `errors` array will contain obje
 When a scripted API monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query scripted API monitors [#query-scripted-api-monitors]
+
+<Callout variant="tip">
+  **Need to query your scripted API monitors?** All query examples for scripted API monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted API monitors
+  - [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
@@ -526,10 +526,12 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query scripted API monitors [#query-scripted-api-monitors]
 
-**Need to query your scripted API monitors?** All query examples for scripted API monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, scripts, map IDs, or check the status of your scripted API monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted API monitors
-- [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+- [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
@@ -526,12 +526,10 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query scripted API monitors [#query-scripted-api-monitors]
 
-<Callout variant="tip">
-  **Need to query your scripted API monitors?** All query examples for scripted API monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your scripted API monitors?** All query examples for scripted API monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted API monitors
-  - [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted API monitors
+- [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
@@ -523,3 +523,146 @@ If there are any issues moving the monitor, the `errors` array will contain obje
 When a scripted API monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query scripted API monitors [#query-scripted-api-monitors]
+
+You can query your scripted API monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including scripted API monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters like `monitorType = 'SCRIPT_API'` to find only scripted API monitors.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR' AND tags.monitorType = 'SCRIPT_API'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Query monitor script [#query-monitor-script]
+
+To retrieve the JavaScript code used in your scripted API monitor, use this query. This is useful for reviewing or backing up your monitor scripts.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`id` (account)</td>
+      <td>Integer</td>
+      <td>Yes</td>
+      <td>The New Relic account ID that contains the monitor.</td>
+    </tr>
+    <tr>
+      <td>`monitorGuid`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The unique entity GUID of the scripted API monitor whose script you want to retrieve.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    account(id: ACCOUNT_ID) {
+      synthetics {
+        script(monitorGuid: "ENTITY_GUID") {
+          text
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "account": {
+        "synthetics": {
+          "script": {
+            "text": "var assert = require('assert');\nvar request = require('request');\nrequest.get('https://api.example.com/health', function(error, response, body) {\n  assert.equal(response.statusCode, 200);\n});"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-api-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [scripted API monitors](/docs/synth
 
 ## Create a scripted API monitor [#create-scripted-api]
 
-You can create a scripted API monitor using the `syntheticsCreateScriptApiMonitor` mutation. This mutation allows you to set up custom API testing that executes your JavaScript code to validate API endpoints.
+You can create a scripted API monitor using the <DNT>`syntheticsCreateScriptApiMonitor`</DNT> mutation. This mutation allows you to set up custom API testing that executes your JavaScript code to validate API endpoints.
 
 ### Input parameters
 
@@ -136,7 +136,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a scripted API monitor [#update-scripted-api]
 
-You can update an existing scripted API monitor using the `syntheticsUpdateScriptApiMonitor` mutation. This allows you to modify the configuration of a scripted API monitor that has already been created.
+You can update an existing scripted API monitor using the <DNT>`syntheticsUpdateScriptApiMonitor`</DNT> mutation. This allows you to modify the configuration of a scripted API monitor that has already been created.
 
 ### Input parameters
 
@@ -520,7 +520,7 @@ If there are any issues moving the monitor, the `errors` array will contain obje
 
 ## Delete a scripted API monitor [#delete-monitor]
 
-When a scripted API monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
+When a scripted API monitor is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -49,7 +49,7 @@ You can create a scripted browser monitor using the `syntheticsCreateScriptBrows
       <td>`monitor.locations`</td>
       <td>Object</td>
       <td>Yes</td>
-      <td>Locations where the monitor will run checks. `monitor.locations` allows two values: `private` for private location GUIDs and `public` for public location identifiers (e.g., `{ private: ["PRIVATE_LOCATION_GUID"] }` or `{ public: ["US_EAST_1", "US_WEST_1"] }`).</td>
+      <td>The geographic locations where the monitor will execute. `monitor.location` allows two values: private locations and public locations. You can select either private locations, public locations, or both:<br/>• `private`: Private location GUIDs (e.g., `{ private: ["PRIVATE_LOCATION_GUID"] }`)<br/>• `public`: Public location identifiers (e.g., `{ public: ["US_EAST_1", "US_WEST_1"] }`)</td>
     </tr>
     <tr>
       <td>`monitor.name`</td>
@@ -193,7 +193,7 @@ You can update an existing scripted browser monitor using the `syntheticsUpdateS
       <td>`monitor.locations`</td>
       <td>Object</td>
       <td>No</td>
-      <td>Locations where the monitor will run checks. `monitor.locations` allows two values: `private` for private location GUIDs and `public` for public location identifiers (e.g., `{ private: ["PRIVATE_LOCATION_GUID"] }` or `{ public: ["US_EAST_1", "US_WEST_1"] }`).</td>
+      <td>The geographic locations where the monitor will execute. `monitor.location` allows two values. 1. is private locations and 2. is public locations. You can select either private locations, public locations, or both:<br/>• `private`: Private location GUIDs (e.g., `{ private: ["PRIVATE_LOCATION_GUID"] }`)<br/>• `public`: Public location identifiers (e.g., `{ public: ["US_EAST_1", "US_WEST_1"] }`)</td>
     </tr>
     <tr>
       <td>`monitor.name`</td>
@@ -473,10 +473,12 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query scripted browser monitors [#query-scripted-browser-monitors]
 
-**Need to query your scripted browser monitors?** All query examples for scripted browser monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, scripts, map IDs, or check the status of your scripted browser monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted browser monitors
-- [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+- [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -470,3 +470,15 @@ If there are any issues downgrading the monitor runtime, the `errors` array will
 When a scripted browser monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query scripted browser monitors [#query-scripted-browser-monitors]
+
+<Callout variant="tip">
+  **Need to query your scripted browser monitors?** All query examples for scripted browser monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted browser monitors
+  - [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -46,10 +46,10 @@ You can create a scripted browser monitor using the `syntheticsCreateScriptBrows
       <td>Devices that the monitor will use to execute jobs. Supported devices: `DESKTOP`, `MOBILE_LANDSCAPE`, `MOBILE_PORTRAIT`, `TABLET_LANDSCAPE`, `TABLET_PORTRAIT`.</td>
     </tr>
     <tr>
-      <td>`monitor.locations.public`</td>
-      <td>Array</td>
+      <td>`monitor.locations`</td>
+      <td>Object</td>
       <td>Yes</td>
-      <td>Array of [public location](/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors/#setting-location) identifiers where the monitor will run checks (e.g., `["US_EAST_1", "US_WEST_1"]`).</td>
+      <td>Locations where the monitor will run checks. `monitor.locations` allows two values: `private` for private location GUIDs and `public` for public location identifiers (e.g., `{ private: ["PRIVATE_LOCATION_GUID"] }` or `{ public: ["US_EAST_1", "US_WEST_1"] }`).</td>
     </tr>
     <tr>
       <td>`monitor.name`</td>
@@ -190,10 +190,10 @@ You can update an existing scripted browser monitor using the `syntheticsUpdateS
       <td>Devices that the monitor will use to execute jobs. Supported devices: `DESKTOP`, `MOBILE_LANDSCAPE`, `MOBILE_PORTRAIT`, `TABLET_LANDSCAPE`, `TABLET_PORTRAIT`.</td>
     </tr>
     <tr>
-      <td>`monitor.locations.public`</td>
-      <td>Array</td>
+      <td>`monitor.locations`</td>
+      <td>Object</td>
       <td>No</td>
-      <td>Array of [public location](/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors/#setting-location) identifiers where the monitor will run checks (e.g., `["US_EAST_1", "US_WEST_1"]`).</td>
+      <td>Locations where the monitor will run checks. `monitor.locations` allows two values: `private` for private location GUIDs and `public` for public location identifiers (e.g., `{ private: ["PRIVATE_LOCATION_GUID"] }` or `{ public: ["US_EAST_1", "US_WEST_1"] }`).</td>
     </tr>
     <tr>
       <td>`monitor.name`</td>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -470,3 +470,146 @@ If there are any issues downgrading the monitor runtime, the `errors` array will
 When a scripted browser monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query scripted browser monitors [#query-scripted-browser-monitors]
+
+You can query your scripted browser monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including scripted browser monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters like `monitorType = 'SCRIPT_BROWSER'` to find only scripted browser monitors.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR' AND tags.monitorType = 'SCRIPT_BROWSER'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Query monitor script [#query-monitor-script]
+
+To retrieve the JavaScript code used in your scripted browser monitor, use this query. This is useful for reviewing or backing up your monitor scripts.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`id` (account)</td>
+      <td>Integer</td>
+      <td>Yes</td>
+      <td>The New Relic account ID that contains the monitor.</td>
+    </tr>
+    <tr>
+      <td>`monitorGuid`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The unique entity GUID of the scripted browser monitor whose script you want to retrieve.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    account(id: ACCOUNT_ID) {
+      synthetics {
+        script(monitorGuid: "ENTITY_GUID") {
+          text
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "account": {
+        "synthetics": {
+          "script": {
+            "text": "$browser.get('https://example.com');\n$browser.waitForAndFindElement($driver.By.css('h1'), 10000);"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -473,12 +473,10 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query scripted browser monitors [#query-scripted-browser-monitors]
 
-<Callout variant="tip">
-  **Need to query your scripted browser monitors?** All query examples for scripted browser monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your scripted browser monitors?** All query examples for scripted browser monitors, including how to retrieve monitor metadata, scripts, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted browser monitors
-  - [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including scripted browser monitors
+- [Query monitor script](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-script) - Retrieve JavaScript code from scripted monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [scripted browser monitors](/docs/s
 
 ## Create a scripted browser monitor [#create-scripted-browser]
 
-You can create a scripted browser monitor using the `syntheticsCreateScriptBrowserMonitor` mutation. This mutation allows you to set up custom scripted monitoring that executes your JavaScript code in a browser.
+You can create a scripted browser monitor using the <DNT>`syntheticsCreateScriptBrowserMonitor`</DNT> mutation. This mutation allows you to set up custom scripted monitoring that executes your JavaScript code in a browser.
 
 ### Input parameters
 
@@ -157,7 +157,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a scripted browser monitor [#update-scripted-browser]
 
-You can update an existing scripted browser monitor using the `syntheticsUpdateScriptBrowserMonitor` mutation. This allows you to modify the configuration of a scripted browser monitor that has already been created.
+You can update an existing scripted browser monitor using the <DNT>`syntheticsUpdateScriptBrowserMonitor`</DNT> mutation. This allows you to modify the configuration of a scripted browser monitor that has already been created.
 
 ### Input parameters
 
@@ -467,7 +467,7 @@ If there are any issues downgrading the monitor runtime, the `errors` array will
 
 ## Delete a scripted browser monitor [#delete-monitor]
 
-When a scripted browser monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
+When a scripted browser monitor is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
@@ -238,7 +238,9 @@ If there are any issues deleting the secure credential, the `errors` array will 
 
 ## Query secure credentials [#query-secure-credentials]
 
-**Need to query your secure credentials?** All query examples for secure credentials, including how to retrieve credential metadata (values are not returned for security), are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve credential metadata.
 
-**Quick links to relevant sections:**
-- [Query secure credentials](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-secure-credentials) - Get secure credential metadata (names, GUIDs, last updated)
+For more information, refer to:
+- [Query secure credentials](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-secure-credentials) - Get secure credential metadata (names, GUIDs, last updated).
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
@@ -235,3 +235,12 @@ A successful response returns `null` for errors:
 ```
 
 If there are any issues deleting the secure credential, the `errors` array will contain objects with `description` and `type` fields explaining what went wrong.
+
+## Query secure credentials [#query-secure-credentials]
+
+<Callout variant="tip">
+  **Need to query your secure credentials?** All query examples for secure credentials, including how to retrieve credential metadata (values are not returned for security), are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query secure credentials](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-secure-credentials) - Get secure credential metadata (names, GUIDs, last updated)
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
@@ -235,3 +235,82 @@ A successful response returns `null` for errors:
 ```
 
 If there are any issues deleting the secure credential, the `errors` array will contain objects with `description` and `type` fields explaining what went wrong.
+
+## Query secure credentials [#query-secure-credentials]
+
+You can query your secure credentials to retrieve metadata information about them. For security reasons, querying secure credentials returns metadata only, not the actual credential values. This query retrieves all secure credentials in your account, returning essential information like the credential's GUID, name, account ID, tags, and last update timestamp.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'SECURE_CRED'` to retrieve all secure credentials.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'SECURE_CRED'") {
+      results {
+        entities {
+          ... on SecureCredentialEntityOutline {
+            accountId
+            guid
+            name
+            tags {
+              key
+              values
+            }
+            updatedAt
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "entitySearch": {
+        "results": {
+          "entities": [
+            {
+              "accountId": 2520528,
+              "guid": "MjUyMDUyOHxTWU5USHxTRUNVUkVfQ1JFRF8xMjM0NQ",
+              "name": "API_KEY_PROD",
+              "tags": [
+                {
+                  "key": "description",
+                  "values": ["Production API key for external service"]
+                }
+              ],
+              "updatedAt": "2023-12-01T10:30:00Z"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
@@ -238,9 +238,7 @@ If there are any issues deleting the secure credential, the `errors` array will 
 
 ## Query secure credentials [#query-secure-credentials]
 
-<Callout variant="tip">
-  **Need to query your secure credentials?** All query examples for secure credentials, including how to retrieve credential metadata (values are not returned for security), are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your secure credentials?** All query examples for secure credentials, including how to retrieve credential metadata (values are not returned for security), are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query secure credentials](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-secure-credentials) - Get secure credential metadata (names, GUIDs, last updated)
-</Callout>
+**Quick links to relevant sections:**
+- [Query secure credentials](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-secure-credentials) - Get secure credential metadata (names, GUIDs, last updated)

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 
 ## Create a secure credential [#create-secure-credential]
 
-You can create a secure credential using the `syntheticsCreateSecureCredential` mutation. This mutation allows you to securely store sensitive information that your synthetic monitors can access during script execution.
+You can create a secure credential using the <DNT>`syntheticsCreateSecureCredential`</DNT> mutation. This mutation allows you to securely store sensitive information that your synthetic monitors can access during script execution.
 
 ### Input parameters
 
@@ -90,7 +90,7 @@ If there are any issues creating the secure credential, the `errors` array will 
 
 ## Update a secure credential [#update-secure-credential]
 
-You can update an existing secure credential using the `syntheticsUpdateSecureCredential` mutation. This allows you to modify the value and description while keeping the same key name.
+You can update an existing secure credential using the <DNT>`syntheticsUpdateSecureCredential`</DNT> mutation. This allows you to modify the value and description while keeping the same key name.
 
 ### Input parameters
 
@@ -171,7 +171,7 @@ If there are any issues updating the secure credential, the `errors` array will 
 
 ## Delete a secure credential [#delete-secure-credential]
 
-You can delete a secure credential using the `syntheticsDeleteSecureCredential` mutation. Once deleted, any monitors referencing this credential will fail until updated.
+You can delete a secure credential using the <DNT>`syntheticsDeleteSecureCredential`</DNT> mutation. Once deleted, any monitors referencing this credential will fail until updated.
 
 <Callout variant="caution">
   Before deleting a secure credential, make sure no active monitors are using it. Deleting a credential that's in use will cause those monitors to fail.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
@@ -519,11 +519,9 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query simple browser monitors [#query-simple-browser-monitors]
 
-<Callout variant="tip">
-  **Need to query your simple browser monitors?** All query examples for simple browser monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your simple browser monitors?** All query examples for simple browser monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including simple browser monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including simple browser monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
@@ -519,9 +519,11 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query simple browser monitors [#query-simple-browser-monitors]
 
-**Need to query your simple browser monitors?** All query examples for simple browser monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, map IDs, or check the status of your simple browser monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including simple browser monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
@@ -516,3 +516,14 @@ If there are any issues downgrading the monitor runtime, the `errors` array will
 When a simple browser monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query simple browser monitors [#query-simple-browser-monitors]
+
+<Callout variant="tip">
+  **Need to query your simple browser monitors?** All query examples for simple browser monitors, including how to retrieve monitor metadata, map monitor IDs to GUIDs, and check runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including simple browser monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
@@ -516,3 +516,126 @@ If there are any issues downgrading the monitor runtime, the `errors` array will
 When a simple browser monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query simple browser monitors [#query-simple-browser-monitors]
+
+You can query your simple browser monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including simple browser monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters like `monitorType = 'BROWSER'` to find only simple browser monitors.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR' AND tags.monitorType = 'BROWSER'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "actor": {
+      "entitySearch": {
+        "results": {
+          "entities": [
+            {
+              "guid": "MjUyMDUyOHxTWU5USHxNT05JVE9SfDMwNDg2",
+              "name": "Example Simple Browser Monitor",
+              "accountId": 2520528,
+              "monitorType": "BROWSER",
+              "tags": [
+                {
+                  "key": "language",
+                  "values": ["en"]
+                },
+                {
+                  "key": "runState",
+                  "values": ["ENABLED"]
+                },
+                {
+                  "key": "uri",
+                  "values": ["https://example.com"]
+                },
+                {
+                  "key": "browsers",
+                  "values": ["CHROME"]
+                },
+                {
+                  "key": "devices",
+                  "values": ["DESKTOP"]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/simple-browser-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [simple browser monitors](/docs/syn
 
 ## Create a simple browser monitor [#create-simple-browser]
 
-You can create a simple browser monitor using the `syntheticsCreateSimpleBrowserMonitor` mutation.
+You can create a simple browser monitor using the <DNT>`syntheticsCreateSimpleBrowserMonitor`</DNT> mutation.
 
 ### Input parameters
 
@@ -180,7 +180,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a simple browser monitor [#update-simple-browser]
 
-You can update an existing simple browser monitor using the `syntheticsUpdateSimpleBrowserMonitor` mutation. This allows you to modify the configuration of a simple browser monitor that has already been created.
+You can update an existing simple browser monitor using the <DNT>`syntheticsUpdateSimpleBrowserMonitor`</DNT> mutation. This allows you to modify the configuration of a simple browser monitor that has already been created.
 
 ### Input parameters
 
@@ -513,7 +513,7 @@ If there are any issues downgrading the monitor runtime, the `errors` array will
 
 ## Delete a simple browser monitor [#delete-monitor]
 
-When a simple browser monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
+When a simple browser monitor is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
 

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -325,3 +325,15 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 When a step monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query step monitors [#query-step-monitors]
+
+<Callout variant="tip">
+  **Need to query your step monitors?** All query examples for step monitors, including how to retrieve monitor metadata, steps configuration, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+
+  **Quick links to relevant sections:**
+  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including step monitors
+  - [Query monitor steps](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-steps) - Retrieve step configurations from step monitors
+  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+</Callout>

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -325,3 +325,130 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 When a step monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
+
+## Query step monitors [#query-step-monitors]
+
+You can query your step monitors to retrieve information about their configuration, status, and metadata. This query retrieves all synthetic monitors in your account, including step monitors, returning essential information like the monitor's GUID, name, account ID, monitor type, and associated tags.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`query`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The search query to filter entities. Use `domain = 'SYNTH' AND type = 'MONITOR'` to retrieve all synthetic monitors, or add additional filters like `monitorType = 'STEP_MONITOR'` to find only step monitors.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(query: "domain = 'SYNTH' AND type = 'MONITOR' AND tags.monitorType = 'STEP_MONITOR'") {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            accountId
+            monitorType
+            tags {
+              key
+              values
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Query monitor steps [#query-monitor-steps]
+
+To retrieve the steps configured for your step monitor, use this query. Step monitors use predefined actions and this query returns the sequence of steps with their configuration.
+
+### Input parameters
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Data Type</th>
+      <th>Is it Required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`id` (account)</td>
+      <td>Integer</td>
+      <td>Yes</td>
+      <td>The New Relic account ID that contains the monitor.</td>
+    </tr>
+    <tr>
+      <td>`monitorGuid`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The unique entity GUID of the step monitor whose steps you want to retrieve.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample query
+
+```graphql
+{
+  actor {
+    account(id: ACCOUNT_ID) {
+      synthetics {
+        steps(monitorGuid: "ENTITY_GUID") {
+          ordinal
+          type
+          values
+        }
+      }
+    }
+  }
+}
+```
+
+## Map monitor ID to entity GUID [#map-monitor-id]
+
+If you have a legacy numeric monitor ID and need to convert it to the entity GUID format required for updates and deletions, use this query:
+
+### Sample query
+
+```graphql
+{
+  actor {
+    entitySearch(
+      query: "(domainId = 'MONITOR_ID')"
+    ) {
+      results {
+        entities {
+          ... on SyntheticMonitorEntityOutline {
+            guid
+            name
+            monitorId
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Replace `MONITOR_ID` with your numeric monitor ID. The response will include the entity GUID you need for other operations.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -328,12 +328,10 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query step monitors [#query-step-monitors]
 
-<Callout variant="tip">
-  **Need to query your step monitors?** All query examples for step monitors, including how to retrieve monitor metadata, steps configuration, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+**Need to query your step monitors?** All query examples for step monitors, including how to retrieve monitor metadata, steps configuration, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
 
-  **Quick links to relevant sections:**
-  - [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including step monitors
-  - [Query monitor steps](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-steps) - Retrieve step configurations from step monitors
-  - [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-  - [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
-</Callout>
+**Quick links to relevant sections:**
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including step monitors
+- [Query monitor steps](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-steps) - Retrieve step configurations from step monitors
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -328,10 +328,12 @@ To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgrap
 
 ## Query step monitors [#query-step-monitors]
 
-**Need to query your step monitors?** All query examples for step monitors, including how to retrieve monitor metadata, steps configuration, and runtime upgrade status, are available on the centralized [Query synthetic monitoring data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) page.
+Use NerdGraph to retrieve metadata, steps configuration, map IDs, or check the status of your step monitors.
 
-**Quick links to relevant sections:**
-- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors) - Get all synthetic monitors including step monitors
-- [Query monitor steps](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-steps) - Retrieve step configurations from step monitors
-- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping) - Convert legacy monitor IDs to entity GUIDs
-- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all) - Check upgrade readiness for legacy monitors
+For more information, refer to:
+- [Query all monitors](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitors): To list all synthetic monitors and their configurations.
+- [Map monitor ID to entity GUID](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-guid-mapping): To migrate legacy monitor IDs to entity GUIDs.
+- [Runtime upgrade status](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-runtime-upgrade-all): To check if your monitors are ready for the latest runtime upgrades.
+- [Query monitor steps](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data#query-monitor-steps) - Retrieve step configurations from step monitors.
+
+To view complete list of query examples, refer to the [Query synthetics data](/docs/apis/nerdgraph/examples/synthetics-api/query-synthetics-data) document.

--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -13,7 +13,7 @@ New Relic allows you use NerdGraph to create [step monitors](/docs/synthetics/sy
 
 ## Create a step monitor [#create-step-monitor]
 
-You can create a step monitor using the `syntheticsCreateStepMonitor` mutation. This mutation allows you to set up multi-step browser monitoring with a series of predefined actions.
+You can create a step monitor using the <DNT>`syntheticsCreateStepMonitor`</DNT> mutation. This mutation allows you to set up multi-step browser monitoring with a series of predefined actions.
 
 ### Input parameters
 
@@ -167,7 +167,7 @@ If there are any issues creating the monitor, the `errors` array will contain ob
 
 ## Update a step monitor [#update-step-monitor]
 
-You can update an existing step monitor using the `syntheticsUpdateStepMonitor` mutation. This allows you to modify the configuration of a step monitor that has already been created.
+You can update an existing step monitor using the <DNT>`syntheticsUpdateStepMonitor`</DNT> mutation. This allows you to modify the configuration of a step monitor that has already been created.
 
 ### Input parameters
 
@@ -322,7 +322,7 @@ If there are any issues updating the monitor, the `errors` array will contain ob
 
 ## Delete a step monitor [#delete-monitor]
 
-When a step monitor is no longer needed, you can permanently remove it using the `syntheticsDeleteMonitor` mutation.
+When a step monitor is no longer needed, you can permanently remove it using the <DNT>`syntheticsDeleteMonitor`</DNT> mutation.
 
 To delete a monitor, refer to the [Delete Synthetic monitor](/docs/apis/nerdgraph/examples/synthetics-api/ping-monitor/#delete-monitor) section.
 


### PR DESCRIPTION
- Added query sections to all monitor type pages (ping, simple browser, scripted browser, scripted API, step, certificate check, broken links)
- Added query sections to supporting entity pages (private locations, secure credentials, monitor downtimes)
- Updated overview.mdx to reference integrated query examples instead of separate page
- Deprecated standalone query-synthetics-data.mdx file with clear migration guidance
- Improved user experience by keeping creation and query operations together on each page
- Added appropriate GraphQL query examples with proper filtering for each monitor type
- Included monitor ID to entity GUID mapping queries where relevant