### PR TITLE
Add NR25-02 security bulletin to security bulletins index page

### DIFF
--- a/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
+++ b/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx
@@ -410,6 +410,19 @@ Security bulletins for [infrastructure monitoring](/docs/infrastructure/new-reli
   <tbody>
     <tr>
       <td>
+        [NR25-02](/docs/security/new-relic-security/security-bulletins/security-bulletin-nr25-02), 12/11/25
+      </td>
+
+      <td>
+        New Relic has released new versions of several log forwarding services to address Fluent Bit plugin vulnerabilities (CVE-2025-12969, CVE-2025-12970, CVE-2025-12972, CVE-2025-12977, CVE-2025-12978).
+      </td>
+
+      <td>
+        High
+      </td>
+    </tr>
+    <tr>
+      <td>
         [NR25-01](/docs/security/new-relic-security/security-bulletins/security-bulletin-nr25-01), 3/1/25
       </td>
 


### PR DESCRIPTION
## Summary
- Added NR25-02 security bulletin to the Infrastructure monitoring section of the security bulletins index page
- NR25-02 addresses Fluent Bit plugin vulnerabilities (CVE-2025-12969, CVE-2025-12970, CVE-2025-12972, CVE-2025-12977, CVE-2025-12978)
- Released on 12/11/25 with High priority rating
- Positioned correctly in chronological order after NR25-01

## Changes Made
- Updated `/src/content/docs/security/security-privacy/information-security/security-bulletins.mdx`
- Added table row with NR25-02 entry including:
  - Link to the detailed bulletin page
  - Release date (12/11/25)
  - Summary of the vulnerabilities addressed
  - High priority rating

## Test plan
- [ ] Verify the link to NR25-02 bulletin works correctly
- [ ] Confirm the entry appears in the correct chronological order in the Infrastructure monitoring section
- [ ] Check that the formatting is consistent with other entries
- [ ] Ensure the page builds successfully without errors

