### PR TITLE
chore [role creation]: Fixed logical order in role creation documentation

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-manage-groups.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-manage-groups.mdx
@@ -283,7 +283,7 @@ Before you create a custom role, you have to identify the permissions you want t
 Use the following query to retrieve the list of account-scoped permissions:
 
 ```graphql
-mutation {
+query {
   customerAdministration {
     permissions {
       items {
@@ -302,7 +302,7 @@ mutation {
 For permissions scoped to an organization, run the following query instead:
 
 ```graphql
-{
+query {
   customerAdministration {
     permissions(filter: {scope: {eq: "organization"}}) {
       items {


### PR DESCRIPTION
Reorganized the "Create a role" section to follow the correct workflow:
1. First, retrieve permission IDs (moved to beginning)
2. Then, create the custom role with those IDs

This ensures users fetch available permissions before attempting to create a role, making the documentation flow logical and easier to follow.
