### PR TITLE
Add NR_TAGS alternative

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/upgrade-to-apm-experience.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/upgrade-to-apm-experience.mdx
@@ -82,7 +82,7 @@ Ensure that your New Relic CLI version is `0.9.8` or later. You can check your C
     2. Set the `NEW_RELIC_APM_LAMBDA_MODE` [environment variable](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda/) to `true` in your Lambda function configuration. This enables the APM mode for the New Relic Lambda layer.
     3. Deploy your Lambda function with the updated configuration.
     4. In the <DNT>Configuration</DNT> tab of your <DNT>AWS Management Console</DNT>, add the `NR.Apm.Lambda.Mode: true` tag to your Lambda function.
-
+    5. If you are not using an [AWS cloud integration](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/) (Metric Stream or API Polling) to synchronize CloudWatch tags, set the `NR_TAGS` environment variable to `NR.Apm.Lambda.Mode:true`. This allows the New Relic Lambda Extension to send the required metadata directly to New Relic.
     </Collapser>
 
     </CollapserGroup>


### PR DESCRIPTION
Added instruction to set NR_TAGS environment variable for tags synchronization if not using a cloud integration.