### PR TITLE
docs: AJAX deny list wildcard feature

### DIFF
--- a/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
+++ b/src/content/docs/browser/new-relic-browser/configuration/filter-ajax-request-events.mdx
@@ -8,7 +8,7 @@ In [agent version 1211](/docs/release-notes/new-relic-browser-release-notes/brow
 
 ## Using the deny list
 
-By default, we record AjaxRequest events for all network requests made by your application.
+By default, we record `AjaxRequest` events for all network requests made by your application.
 
 * To stop recording all events, add a singular `*` (asterisk) wildcard character.
   * Example: `*`


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

This PR adds information about our new AJAX deny list feature where you can use the wildcard `*` character to match portions of the string in your URL.

JIRA: https://new-relic.atlassian.net/browse/NR-491997

<img width="1944" height="1482" alt="Filter_AjaxRequest_events___New_Relic_Documentation" src="https://github.com/user-attachments/assets/a9c7f989-973c-4adb-8ce1-19777bc4b9e8" />