### PR TITLE
doc update[Alerts]: Add clarification for OR operator behavior in workflow filters

### DIFF
--- a/src/content/docs/alerts/get-notified/incident-workflows.mdx
+++ b/src/content/docs/alerts/get-notified/incident-workflows.mdx
@@ -198,6 +198,16 @@ The workflows feature is located under the <DNT>**Alerts **</DNT> menu.
      A warning that the filter doesn't match any past issue sometimes occurs.
    </Callout>
 
+   <Callout variant="important">
+     **When excluding multiple values:** If you need to exclude issues that contain any of several values for the same attribute, use separate <DNT>**AND**</DNT> conditions instead of combining them with <DNT>**OR**</DNT>.
+
+     For example, to exclude issues where `targetName` contains either "ServiceA" or "ServiceB":
+     * **Incorrect query:** `targetName DOES_NOT_CONTAIN "ServiceA" OR DOES_NOT_CONTAIN "ServiceB"`
+       (This matches if the issue lacks either value, even if it contains the other)
+     * **Correct query:** `targetName DOES_NOT_CONTAIN "ServiceA" AND targetName DOES_NOT_CONTAIN "ServiceB"`
+       (This only matches if the issue lacks both values)
+   </Callout>
+
 5. Recommended: filter issues by team tag so all teams can be notified when their entities are included in an issue. Steps can be found in the demo below:
 
    <Video


### PR DESCRIPTION
This update addresses a common customer confusion regarding how the OR operator works with exclusion filters (DOES_NOT_CONTAIN, DOES_NOT_EQUAL, IS_NOT) in workflow filter queries.

Added an important callout after step 4 that:
- Explains the counter-intuitive behavior of OR with exclusions
- Provides clear "Incorrect query" vs "Correct query" examples
- Shows why multiple exclusions should use AND instead of OR
- References ticket NR-481918 where this pattern was identified

Reference: https://new-relic.atlassian.net/browse/NR-481918?focusedCommentId=1468817

