### PR TITLE
docs [IAM]: Update NerdGraph manage groups API documentation for multi-scope roles and grants

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-manage-groups.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-manage-groups.mdx
@@ -1,9 +1,9 @@
 ---
-title: "NerdGraph tutorial: Manage user groups"
+title: "NerdGraph tutorial: Manage groups and users"
 tags:
   - APIs
   - NerdGraph
-metaDescription: "How to use New Relic's NerdGraph API to manage user groups and query information about groups."
+metaDescription: "How to use New Relic's NerdGraph API to manage groups and users, and grant access to roles."
 redirects: 
   - /docs/apis/nerdgraph/examples/nerdgraph-user-mgmt
 freshnessValidatedDate: never
@@ -727,9 +727,13 @@ Response for failure:
 }
 ```
 
-## Grant access to a group [#grant-access]
+## Grant access to a group or user [#grant-access]
 
-Access grants connect groups to roles and define what those groups can access. When you create an access grant, you're giving users in a group the permissions defined in a role, applied to a specific target (organization, accounts, entities, or other groups).
+Access grants connect groups or users to roles and define what they can access. When you create an access grant, you're giving users or groups the permissions defined in a role, applied to a specific target (organization, accounts, entities, or other groups).
+
+To specify who receives the access grant:
+- **For users**: Use the `grantee` parameter with `id` and `type: USER`
+- **For groups**: Replace `grantee` with `groupId: "YOUR_GROUP_ID"`
 
 ### Account-scoped grant
 
@@ -743,6 +747,10 @@ mutation {
         accountId: YOUR_ACCOUNT_ID
         dataAccessPolicyId: "YOUR_DATA_ACCESS_POLICY_ID"
         roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -766,6 +774,10 @@ mutation {
     grantAccessOptions: {
       organizationAccessGrants: {
         roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -793,6 +805,10 @@ mutation {
           type: "YOUR_ENTITY_TYPE"
         }
         roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -815,8 +831,12 @@ mutation {
   authorizationManagementGrantAccess(
     grantAccessOptions: {
       groupAccessGrants: {
-        groupId: "YOUR_GROUP_ID"
+        groupId: "YOUR_TARGET_GROUP_ID"
         roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -880,6 +900,33 @@ Response for failure:
 }
 ```
 
+## Update access grants [#update-grants]
+
+You can update existing account access grants to change the data access policy. Use the `authorizationManagementUpdateAccess` mutation with the grant IDs you want to update.
+
+<Callout variant="important">
+  Updating access grants is currently only available for account-scoped grants.
+</Callout>
+
+Here's an example of updating an account access grant:
+
+```graphql
+mutation {
+  authorizationManagementUpdateAccess(
+    updateAccessOptions: {
+      accountAccessGrant: {
+        dataAccessPolicyId: "YOUR_NEW_DATA_ACCESS_POLICY_ID"
+      }
+      ids: "YOUR_ACCESS_GRANT_ID"
+    }
+  ) {
+    grants {
+      id
+    }
+  }
+}
+```
+
 ## Find a role ID [#role-id]
 
 For some use cases, like granting access to a group, you may need a role's ID: the numeric ID representing that role in New Relic.
@@ -927,9 +974,9 @@ Here's a query for finding the ID of a custom role:
 }
 ```
 
-## Revoke grants from group [#revoke-grants]
+## Revoke grants from group or user [#revoke-grants]
 
-Revoking access grants removes the connection between groups and roles, taking away the permissions that users in those groups had. You can revoke grants at organization, account, entity, or group level.
+Revoking access grants removes the connection between groups or users and roles, taking away the permissions they had. You can revoke grants at organization, account, entity, or group level. When revoking, specify who is losing access using either `grantee` (for users) or `groupId` (for groups), similar to granting access.
 
 ### Account-scoped revoke
 
@@ -943,6 +990,10 @@ mutation {
         accountId: YOUR_ACCOUNT_ID
         dataAccessPolicyId: "YOUR_DATA_ACCESS_POLICY_ID"
         roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -966,6 +1017,10 @@ mutation {
     revokeAccessOptions: {
       organizationAccessGrants: {
         roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -992,6 +1047,11 @@ mutation {
           id: "YOUR_ENTITY_ID"
           type: "YOUR_ENTITY_TYPE"
         }
+        roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
       }
     }
   ) {
@@ -1013,7 +1073,14 @@ Here's an example of revoking access to a group-scoped role:
 mutation {
   authorizationManagementRevokeAccess(
     revokeAccessOptions: {
-      groupAccessGrants: {}
+      groupAccessGrants: {
+        groupId: "YOUR_TARGET_GROUP_ID"
+        roleId: "YOUR_ROLE_ID"
+        grantee: {
+          id: "YOUR_USER_ID"
+          type: USER
+        }
+      }
     }
   ) {
     accessGrants {


### PR DESCRIPTION
…

Added comprehensive examples for creating and managing roles and grants at organization, account, entity, and group scopes using the NerdGraph API.

Changes:
- Updated role creation section with separate examples for account, organization, and entity-scoped roles
- Expanded grant access section to include all four grant types: account, organization, entity, and group-scoped grants
- Expanded revoke access section to include all four revoke types with proper API structure
- Updated response examples to use new accessGrants structure
- Added dataAccessPolicyId field to account-scoped grants and revokes
- Clarified that permission IDs must match the scope being created

This documentation update enables users to fully leverage the API for managing roles and permissions programmatically at different scope levels.

Resolves: NR-495990
