### PR TITLE
Update Workflow Automation link for user permissions

### DIFF
--- a/src/content/docs/nrql/using-nrql/schedule-nrql-searches.mdx
+++ b/src/content/docs/nrql/using-nrql/schedule-nrql-searches.mdx
@@ -36,7 +36,7 @@ Scheduled NRQL searches let you:
 
 To use scheduled NRQL searches, you need:
 
-* **User permissions**: [Workflow Automation](/docs/alerts-applied-intelligence/applied-intelligence/incident-workflows/incident-workflows/#requirements) permissions are required to create and manage scheduled searches.
+* **User permissions**: [Workflow Automation](/docs/workflow-automation/create-a-workflow-automation/managing-workflow/#before-you-begin) permissions are required to create and manage scheduled searches.
 * **Account access**: Access to the account where you want to schedule searches.
 * **Data access**: Appropriate permissions to query the data you want to schedule. For example, if scheduling a query against log data, you need access to that log data.
 


### PR DESCRIPTION
Changing the hyperlink, from the Alerts Workflows to the correct link which should be Workflow Automation.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.