### PR TITLE
fix: Add explanation of how PHP agent collects errors and exceptions

### DIFF
--- a/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/php-agent/configuration/php-agent-configuration.mdx
@@ -3153,7 +3153,15 @@ The values of these settings are used to control various tracer features.
       </tbody>
     </table>
 
-    Enable or disable the error collector. When enabled, the agent collects and reports PHP errors to the New Relic UI.
+    Enable or disable the error collector. When enabled, the agent collects and reports PHP errors and exceptions to the New Relic UI.
+
+    ### How the PHP agent collects errors and exceptions
+
+    The PHP agent automatically collects errors and exceptions in the following ways:
+
+    * **Uncaught exceptions**: The agent automatically captures any uncaught exceptions (instances of `Exception` in PHP 5, or `Throwable` in PHP 7+) that occur during transaction execution.
+    * **PHP errors**: The agent captures PHP errors based on the configured error levels (see [`error_collector.ignore_errors`](#inivar-err-ignore-errors) below).
+    * **Manual error reporting**: Use the [`newrelic_notice_error()`](/docs/agents/php-agent/php-agent-api/newrelic_notice_error) API to manually report errors or exceptions that are not captured automatically, such as handled exceptions or custom error conditions.
 
     The agent records only the single most severe error for each transaction, and up to 20 errors per [harvest cycle](/docs/apm/new-relic-apm/getting-started/glossary#harvest-cycle).
 


### PR DESCRIPTION
Address customer feedback from NR-485555 by adding detailed explanation of error and exception collection mechanisms in the error_collector.enabled configuration section.

Changes:
- Clarify that agent collects both errors and exceptions
- Add subsection explaining automatic collection of uncaught exceptions
- Document PHP error collection based on configured levels
- Link to newrelic_notice_error() API for manual error reporting
- Distinguish between Exception (PHP 5) and Throwable (PHP 7+)


