### PR TITLE
Restore notebooks section to navigation

### DIFF
--- a/src/nav/dashboards.yml
+++ b/src/nav/dashboards.yml
@@ -51,12 +51,12 @@ pages:
         path: /docs/query-your-data/explore-query-data/dashboards/add-custom-visualizations-your-dashboards
       - title: Troubleshooting chart errors
         path: /docs/query-your-data/explore-query-data/dashboards/troubleshooting-chart-errors
-  # - title: Notebooks
-  #   pages:
-  #     - title: Get started with notebooks
-  #       path: /docs/query-your-data/explore-query-data/notebooks/introduction-notebooks
-  #     - title: Blocks in notebook
-  #       path: /docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks
+  - title: Notebooks
+    pages:
+      - title: Get started with notebooks
+        path: /docs/query-your-data/explore-query-data/notebooks/introduction-notebooks
+      - title: Blocks in notebook
+        path: /docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks
   - title: Grafana integrations
     pages:
       - title: Grafana support with Prometheus and PromQL


### PR DESCRIPTION
Uncommented the Notebooks section in the dashboards navigation to make it accessible to users again.

