### PR TITLE
PHP Agent 12.4.0.29 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-4-0-29.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-4-0-29.mdx
@@ -1,0 +1,46 @@
+---
+subject: PHP agent
+releaseDate: '2026-01-12'
+version: 12.4.0.29
+downloadLink: 'https://download.newrelic.com/php_agent/archive/12.4.0.29'
+features: ['add support for PHP 8.5']
+bugs: ['addressed deprecation warnings in Symfony 7.4 / 8.0']
+security: []
+---
+
+## New Relic PHP agent v12.4.0.29
+
+### New Features
+
+* Added PHP 8.5 support
+
+### Bug Fixes
+
+* Addressed deprecation warnings which could be seen when using Symfony 7.4 and 8.0
+
+### Support Statement
+
+* In an upcoming release, for best practices and security, the rpm signing key will be rotated. Closer to that release, specific dates and necessary actions for rpm users will be provided.
+
+* PHP Agent support for the following library & framework versions will be discontinued in all PHP Agent releases after February 28th, 2026:
+  * For the following library & framework versions, New Relic recommends you upgrade to the latest supported version:
+    * Symfony 4.x
+    * Laravel 7.x, 9.x, 10.x
+    * Slim 3.x
+  * Support for the following libraries & frameworks will be discontinued for all versions:
+    * MediaWiki
+    * Zend Framework
+    * Lumen
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [New Relic PHP Agent EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+  **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
+  The PHP agent packages that are affected are:
+
+* newrelic-php5
+* newrelic-php5-common
+* newrelic-daemon
+</Callout>


### PR DESCRIPTION
The PHP agent team has released the 12.4.0.29 agent and these are the associated release notes.  Please merge as soon as possible.