### PR TITLE
docs referenced old/legacy v1 user role admin when it should be align…

### DIFF
--- a/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/heroku-log-forwarding.mdx
@@ -25,7 +25,7 @@ Heroku Syslog drains on the counterpart doesn't allow you to add this custom met
 
 To configure this type of drain:
 
-1. Ensure you have the [All Product Admin Role](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#roles).
+1. Ensure you have the [All Product Admin Role](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#roles).
 2. Go to the [New Relic Marketplace](https://one.newrelic.com/marketplace).
 3. Under <DNT>**Logging**</DNT>, click the `Heroku` tile. You can also search for it using the search bar.
 4. If you have multiple accounts, select the account to which you want to send the logs.


### PR DESCRIPTION
…ed to the v2 user model; the comparable role would be ALl Product Admin.

This is fixing a simple error in our docs where we were referencing legacy roles when we should be referencing v2 updated roles.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.