### PR TITLE
Update php-agent-compatibility-requirements.mdx

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -32,6 +32,11 @@ Before you [install the PHP agent](/docs/apm/agents/php-agent/installation), mak
   </thead>
   <tbody>
     <tr>
+      <td>8.5</td>
+      <td>&ge; [12.4.0.29](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-4-0-29/)</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
       <td>8.4</td>
       <td>&ge; [11.5.0.18](/docs/release-notes/agent-release-notes/php-release-notes/php-agent-11-5-0-18/)</td>
       <td>Yes</td>
@@ -322,7 +327,7 @@ Based on the information above the PHP agent, can be installed on operating syst
       </td>
 
       <td>
-        11, 12
+        11, 12, 13
       </td>
 
       <td>
@@ -340,7 +345,7 @@ Based on the information above the PHP agent, can be installed on operating syst
       </td>
 
       <td>
-        11, 12
+        11, 12, 13
       </td>
 
       <td>


### PR DESCRIPTION
The PHP agent team would like to make these changes to the compatibility page related to the release of the PHP 8.5 agent and support for Debian 13 (Trixie).