### PR TITLE
docs: .NET agent, document new application name exclusion config and env vars

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -1870,7 +1870,7 @@ Please note that custom instrumentation cannot be ignored via the `rules` elemen
 
 ### Applications element (instrumentation) [#application-instrumentation]
 
-The `applications` element is a child of the `instrumentation` element. The `applications` element supports `application` child elements which specify which non-web apps to instrument. The `application` element contains a `name` attribute.
+The `applications` element is a child of the `instrumentation` element. The `applications` element supports `application` child elements which specify which non-web apps to instrument. The `application` element contains a `name` attribute.  Additionally, starting in agent version 10.48.0, there is an optional `include` attribute with a default value of "true".  Set this attribute to "false" to prevent the agent from instrumenting that process.
 
 <Callout variant="important">
   This is not the same as the [`application` (configuration)](#application-configuration) element, which is a [child of the `configuration`](#application) element.
@@ -1881,10 +1881,19 @@ The `applications` element is a child of the `instrumentation` element. The `app
   <applications>
     <application name="MyService1.exe" />
     <application name="MyService2.exe" />
-    <application name="MyService3.exe" />
+    <application name="MyService3.exe" include="false" />
   </applications>
 </instrumentation>
 ```
+
+Alternatively, starting in agent version 10.48.0, set the `NEW_RELIC_INCLUDED_APPLICATION_NAMES` and/or the `NEW_RELIC_EXCLUDED_APPLICATION_NAMES` environment variable(s) in the application's environment:
+
+    ```ini
+    NEW_RELIC_INCLUDED_APPLICATION_NAMES="MyService1.exe,MyService2.exe"
+    NEW_RELIC_EXCLUDED_APPLICATION_NAMES="MyService3.exe"
+    ```
+
+Note that exclude takes priority over include.
 
 ### Attributes element [#agent-attributes]
 


### PR DESCRIPTION
The .NET agent has a new feature in version 10.48.0, which lets users configure a list of application names to ignore.

See https://github.com/newrelic/newrelic-dotnet-agent/pull/3387 for more details.
