### PR TITLE
docs: update mobile logging defaults and auto-collection requirement

### DIFF
--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-logs.mdx
@@ -13,12 +13,14 @@ You can use our APIs to send your mobile apps logs to New Relic. Your logs will 
 
 ## Enable mobile logs [#enable-mobile-logs]
 
-By default, our mobile agent doesn't collect logs. To enable mobile logs:
+For newly created mobile entities, mobile logging is enabled by default with a 100% sample rate and a log level of `WARN`. 
+
+For existing entities where logging was previously disabled , or to verify your settings:
 
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities)**</DNT>.
 2. Click <DNT>**Mobile**</DNT>.
 3. Click on your mobile app.
-4. In the left pane under <DNT>**Settings**</DNT>, click <DNT>**Application**</DNT>.
+4. In the left pane under <DNT>**Settings**</DNT>, click <DNT>**Application Settings**</DNT>.
 5. Toggle <DNT>**Mobile Logs**</DNT> on.
 6. Click <DNT>**Save**</DNT>.
 
@@ -27,9 +29,33 @@ By default, our mobile agent doesn't collect logs. To enable mobile logs:
 To configure the sampling rate or log level:
 
 1. In New Relic, navigate to your mobile app.
-2. In the left pane under <DNT>**Settings**</DNT>, click <DNT>**Application**</DNT>.
+2. In the left pane under <DNT>**Settings**</DNT>, click <DNT>**Application Settings**</DNT>.
 3. To change the sample rate, select a new value in the field under **Sample rate of total sessions**.
-4. To change the log level, select your preferred log level in the dropdown under **Logs verbosity**. The debug log level should only be used if you want to see agent debugging logs.
+4. To change the log level, select your preferred log level in the dropdown under **Logs verbosity**. 
+
+You can adjust the log level to control the volume of data ingested. Supported levels include
+
+* `ERROR`
+* `WARN` (Default for new apps)
+* `INFO`
+* `VERBOSE`
+* `DEBUG`
+
+<Callout variant="tip">
+  Only increase the log level to `VERBOSE` or `DEBUG` for temporary troubleshooting, as these levels significantly increase data ingest. We recommend using `WARN` or `ERROR` for release builds.
+</Callout>
+
+<Callout variant="important">
+  **Server-side Configuration:** Mobile log settings are controlled server-side. This means you **do not need to deploy a new version** of your app for changes to the toggle, sample rate, or log level to take effect. The agent will pick up the new configuration on the next app launch or configuration fetch.
+</Callout>
+
+## How logs are collected [#collection-methods]
+
+* **Manual API collection (Recommended):** Use our API to send specific **log messages, attributes, and exceptions.**
+* **Automatic collection:** The agent can automatically capture logs sent to standard output (`stdout`) and standard error (`stderr`).
+  * **Requirement:** Automatic collection is **off by default**. To enable it:
+      1. You must enable the `NRFeatureFlag_AutoCollectLogs` feature flag in your app's initialization code.
+      2. The **Mobile Logs** toggle is turned **On** in the New Relic UI.
 
 ## View logs in New Relic [#view-logs-in-new-relic]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
This PR updates the Mobile Logs documentation to reflect recent product changes and clarify common points of confusion regarding log collection:
Updated Defaults: Clarifies that new mobile entities now have logging enabled by default with a 100% sample rate and WARN log level.
Server-side Configuration: Explicitly states that UI toggle and log level changes are server-side and do not require an app redeploy.
Auto-collection Requirements: Adds the necessary NRFeatureFlag_AutoCollectLogs feature flag requirement

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
These changes align the documentation with current agent behavior and backend defaults

* If your issue relates to an existing GitHub issue, please link to it.