### PR TITLE
docs: align documentation with UI change

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
@@ -49,8 +49,8 @@ We were unable to locate your dsym.
 You can easily upload your dSYM files directly from the New Relic UI. The maximum file size is 600 MB. To upload your dSYM files:
 
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile**</DNT>. Then select your app from the list.
-2. View <DNT>**Crash analysis**</DNT>.
-3. Select a specific crash from the <DNT>**Crash types**</DNT> list.
+2. View <DNT>**Crashes**</DNT>.
+3. Select a specific crash from the <DNT>**Total crashes**</DNT> in Group crashes.
 4. Click <DNT>**Upload dSYM**</DNT>. You can either drag and drop your dSYMs directly, or select the file from your computer.
 
 <Callout variant="important">


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
The New Relic UI has been updated, and some labels in the documentation no longer match the current platform. This PR updates the following UI labels to maintain consistency:
  * Changed "Crash analysis" to "Crashes".
  * Changed "Crash types" to "Total crashes" (located in the Group crashes tab).
