### PR TITLE
docs: Clarify browser namespaces for data retention

### DIFF
--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -681,10 +681,9 @@ In this section are details about a few different types of data, including some 
   >
     All browser namespaces have the same default retention period. Here are details about the events in each browser namespace:
 
-    * `Browser` namespace: `PageView`, `PageAction`
-    * `Browser events` namespace: `AjaxRequest`, `BrowserInteraction`, `BrowserTiming (deprecated)`
+    * `Browser` namespace: `BrowserPerformance`, `PageAction`, `PageView`, `UserAction`
+    * `Browser events` namespace: `AjaxRequest`, `BrowserInteraction`, `PageViewTiming`
     * `Browser JS errors` namespace: `JavaScriptError`
-    * `Browser page view timing` namespace: `PageViewTiming`
 
     For more about these events, see [the browser events in the data dictionary](/attribute-dictionary/?dataSource=Browser+agent).
   </Collapser>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Clarifies the namespaces used for browser events in our "View and manage data retention" docs. It assigns browser events to the proper browser namespaces and removes a non-existing "page view timing" namespace.

<img width="977" height="510" alt="View_and_manage_data_retention___New_Relic_Documentation" src="https://github.com/user-attachments/assets/c7ae9613-5f74-4e2d-888f-c4d004882bf0" />

JIRA: https://new-relic.atlassian.net/browse/NR-504891