### PR TITLE
fix: add 10x guide to nav

### DIFF
--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1041,6 +1041,8 @@ pages:
                 path: /docs/apm/agents/ruby-agent/getting-started/migration-8x-guide
               - title: Ruby agent 9x migration guide
                 path: /docs/apm/agents/ruby-agent/getting-started/migration-9x-guide
+              - title: Ruby agent 10x migration guide
+                path: /docs/apm/agents/ruby-agent/getting-started/migration-10x-guide
           - title: Configuration
             path: /docs/apm/agents/ruby-agent/installation
             pages:


### PR DESCRIPTION
The Ruby agent migration guide for our 10.0 release should be added to the navigation.