### PR TITLE
chore: Update Node agent AIM support message

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -420,7 +420,7 @@ The Node.js agent integrates with other features to give you observability acros
       </td>
 
       <td>
-        If you have version 11.13.0 of the Node.js agent, you can collect AI data from certain AI libraries and frameworks. See AI Monitoring Support above for the current compatibility list.
+        If you have version 11.13.0 of the Node.js agent, you can collect AI data from certain AI libraries and frameworks. See [AI Monitoring Support](#ai-monitoring-support) above for the current compatibility list.
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

In #22743, I updated the main AIM supportability page for the Node agent, but I also noticed that there is another place where this information is duplicated (on the Node-specific compatibility page). To prevent maintaining multiple sources of truth, I edited this message to just refer to the `AI Monitoring Support` section, which is kept up-to-date by our bot every release. 