### PR TITLE
Remove APM mode from AWS Lambda monitoring instructions for Java

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/sdk-based-instrumentation.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/sdk-based-instrumentation.mdx
@@ -138,8 +138,7 @@ Select your runtime below and follow the setup instructions.
     5. [Create a ZIP deployment package](https://docs.aws.amazon.com/lambda/latest/dg/java-package.html) and upload it to AWS Lambda. Or deploy it via other means.
     6. In the AWS Lambda console, set the handler. For the [example Java Lambda](https://github.com/newrelic/newrelic-lambda-tracer-java#usage), the handler would be `com.handler.example.MyLambdaHandler::handleRequest`. Because `handleRequest` is assumed, you could also use `com.handler.example.MyLambdaHandler`.
     7. Configure the [environment variables](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda).
-    8. In your AWS Management Console, on the Configuration tab, add the `NR.Apm.Lambda.Mode: true` tag to your Lambda function.    
-    9. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
+    8. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
        Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next, you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
 


### PR DESCRIPTION
Remove a step about adding the `NR.Apm.Lambda.Mode` tag to the Lambda function configuration for Java since it relies on the OpenTracing SDK, not the New Relic Java agent, the latter of which is needed for APM mode.