### PR TITLE
docs: Clarify custom attributes for Browser events

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/setcustomattribute.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setcustomattribute.mdx
@@ -82,7 +82,7 @@ The following Browser events are supported:
       </td>
 
       <td>
-        Attributes set using the SPA [setAttribute](/docs/browser/new-relic-browser/browser-apis/setattribute/) method will take precedence over attributes set by setCustomAttribute.
+        Attributes set using the SPA [`setAttribute`](/docs/browser/new-relic-browser/browser-apis/setattribute/) method take precedence over attributes set by `setCustomAttribute`.
       </td>
     </tr>
 
@@ -101,7 +101,7 @@ The following Browser events are supported:
       </td>
 
       <td>
-        To view or log errors for a custom attribute via API, use the browser API's [noticeError](/docs/browser/new-relic-browser/browser-apis/noticeerror/) call.
+        To view or log errors for a custom attribute via API, use the browser API [`noticeError`](/docs/browser/new-relic-browser/browser-apis/noticeerror/) call.
       </td>
     </tr>
 
@@ -111,7 +111,7 @@ The following Browser events are supported:
       </td>
 
       <td>
-        Custom attributes supplied to the [`log`](/docs/browser/new-relic-browser/browser-apis/log/) method in the options argument (options.customAttributes) will take precedence over attributes set by setCustomAttribute.
+        Custom attributes supplied to the [`log`](/docs/browser/new-relic-browser/browser-apis/log/) method in the `options.customAttributes` argument take precedence over attributes set by `setCustomAttribute`.
       </td>
     </tr>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

This PR organizes the supported Browser events for the setCustomAttribute Browser API method into a table instead of several paragraphs. This will help clarify for users to know what Browser events are supported or not.

Make sure the links in the table work; some of them used to be outdated link redirects to newer pages which do not work in local development.

<img width="1017" height="786" alt="setCustomAttribute___New_Relic_Documentation" src="https://github.com/user-attachments/assets/b7723177-5573-479a-a6d9-517b78ee0807" />

JIRA: https://new-relic.atlassian.net/browse/NR-504886