### PR TITLE
docs: add mTLS configuration for infra agent

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings.mdx
@@ -1960,7 +1960,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
     id="http-server-cert"
     title="http_server_cert"
   >
-    Path to a PEM-encoded certificate to listen for integration payloads over HTTPS. When configured along with `http_server_key`, the agent will use HTTPS for the integration payload server.
+    The path to a PEM-encoded certificate used to listen for integration payloads over HTTPS. When configured with `http_server_key`, the agent uses HTTPS for the integration payload server.
 
     <table>
       <thead>
@@ -2018,7 +2018,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
     id="http-server-key"
     title="http_server_key"
   >
-    Path to a PEM-encoded key to listen for integration payloads over HTTPS. When configured along with `http_server_cert`, the agent will use HTTPS for the integration payload server.
+    The path to a PEM-encoded key used to listen for integration payloads over HTTPS. When configured with `http_server_cert`, the agent uses HTTPS for the integration payload server.
 
     <table>
       <thead>
@@ -2076,7 +2076,7 @@ Metrics can also be enriched with extended cloud metadata (including custom reso
     id="http-server-ca"
     title="http_server_ca"
   >
-    Path to a PEM-encoded CA certificate to enforce client certificate validation for HTTPS requests. When configured, the agent will verify client certificates against this CA, enabling mutual TLS (mTLS) authentication for the integration payload server.
+    The path to a PEM-encoded CA certificate used to enforce client certificate validation for HTTPS requests. When configured, the agent verifies client certificates against this CA to enable mutual TLS (mTLS) authentication for the integration payload server.
 
     <table>
       <thead>


### PR DESCRIPTION
Add documentation for three new configuration settings that enable Mutual TLS (mTLS) authentication for the agent's local HTTP server. These settings allow the agent to securely receive integration payloads (e.g., StatsD) over HTTPS.

New configuration parameters include:
- http_server_cert: Path to the PEM-encoded certificate used to listen for payloads over HTTPS.
- http_server_key: Path to the PEM-encoded key for the HTTPS listener.
- http_server_ca: Path to the PEM-encoded CA certificate used to enforce client certificate validation for incoming requests.

These settings were introduced in version 1.24.0.


<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.