### PR TITLE
docs: add guide to disable User Script Sandboxing for iOS agent

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot/dSYM-upload-tools.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot/dSYM-upload-tools.mdx
@@ -1,0 +1,34 @@
+---
+title: Automatic dSYM Upload Failures (Xcode 15.3+)
+type: troubleshooting
+tags:
+  - Mobile monitoring
+  - New Relic Mobile iOS
+  - Troubleshoot
+metaDescription: 'Disable User Script Sandboxing in Xcode 15.3+ to fix dSYM upload failures for the New Relic iOS agent.'
+freshnessValidatedDate: never
+---
+
+## Problem
+
+When integrating the New Relic iOS agent using Swift Package Manager (SPM) in Xcode 15.3 or later, the `run-symbol-tool` may fail to upload dSYMs automatically. This is caused by an Xcode build setting that restricts script access to the network and file system.
+
+Known errors:
+* Failure to capture or upload dSYMs, resulting in unsymbolicated crashes in the New Relic dashboard.
+* Build log error: `run-symbol-tool: upload_dsym_results.log: Operation not permitted`
+
+## Solution
+
+To resolve these errors, you must disable the **User Script Sandboxing** build setting. This allows the New Relic post-build script the necessary permissions to locate your dSYM files and upload them to New Relic servers.
+
+Follow these steps to update your configuration:
+
+1.  In the Xcode **Project Navigator**, select your project.
+2.  Select your application **Target**.
+3.  Click on the **Build Settings** tab.
+4.  Search for **User Script Sandboxing** (or `ENABLE_USER_SCRIPT_SANDBOXING`).
+5.  Set the value to **No**.
+
+Once this setting is disabled, we recommend performing a clean build (**Product > Clean Build Folder**) to ensure the `run-symbol-tool` executes correctly on the next build cycle.
+
+If you need additional help, get support at [support.newrelic.com](https://support.newrelic.com).


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
-This PR adds a troubleshooting guide to address dSYM upload failures specifically occurring in Xcode 15.3 and later. The introduction of User Script Sandboxing by Apple prevents the New Relic run-symbol-tool from writing its log file and accessing the network, resulting in the error: run-symbol-tool: line 25: upload_dsym_results.log: Operation not permitted.

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
 -Instructs users to set ENABLE_USER_SCRIPT_SANDBOXING to NO in Build Settings.This is a high-frequency issue for developers migrating to newer Xcode environments using Swift Package Manager.

* If your issue relates to an existing GitHub issue, please link to it.