### PR TITLE
fix: Update first-sentence in databricks-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/other-infrastructure-integrations/databricks-integration.mdx
+++ b/src/content/docs/infrastructure/other-infrastructure-integrations/databricks-integration.mdx
@@ -8,7 +8,7 @@ metaDescription: Use the Databricks integration to collect telemetry from the Da
 freshnessValidatedDate: 2026-01-26
 ---
 
-The Databricks Integration is a standalone application that collects telemetry from the Databricks Data Intelligence Platform, to be used in troubleshooting and optimizing Databricks workloads.
+The Databricks Integration is an open-source community project that provides a comprehensive suite of telemetry collection capabilities across your Databricks estate. These capabilities ensure you have the full, in-context data you need for deep analysis and optimization.
 
 The integration collects the following types of telemetry:
 


### PR DESCRIPTION
Update the first sentence in the databricks-integration.mdx to make it very clear that the integration is an open-source community project and no a product supported project.

## Give us some context

* It is not clear in the current documentation that the Databricks Integration is an open-source community project versus a product-supported project
* This PR makes the clear.