### PR TITLE
Add documentation release notes for January 26 - January 30, 2026

### DIFF
--- a/src/content/docs/release-notes/docs-release-notes/docs-1-30-2026.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-1-30-2026.mdx
@@ -6,25 +6,25 @@ version: 'January 26 - January 30, 2026'
 
 ### New docs
 
-* Added [Elasticsearch OpenTelemetry integration overview](/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-otel-integration-overview) to provide comprehensive guidance for monitoring Elasticsearch with OpenTelemetry.
-* Added [Elasticsearch OpenTelemetry integration installation](/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/elasticsearch-otel-integration-install) to provide step-by-step installation instructions for the Elasticsearch OpenTelemetry integration.
-* Added [Elasticsearch troubleshooting](/docs/infrastructure/host-integrations/host-integrations-list/elasticsearch/troubleshooting) to provide troubleshooting guidance for Elasticsearch monitoring.
+* Added [Elasticsearch OpenTelemetry integration overview](/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-overview) to provide comprehensive guidance for monitoring Elasticsearch with OpenTelemetry.
+* Added [Elasticsearch OpenTelemetry integration installation](/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-install) to provide step-by-step installation instructions for the Elasticsearch OpenTelemetry integration.
+* Added [Elasticsearch troubleshooting](/docs/opentelemetry/integrations/elasticsearch/troubleshooting) to provide troubleshooting guidance for Elasticsearch monitoring.
 * Added [Automatic dSYM Upload Failures (Xcode 15.3+)](/docs/mobile-monitoring/new-relic-mobile-ios/troubleshoot/dSYM-upload-tools) to provide troubleshooting guidance for iOS agent dSYM upload failures in Xcode 15.3 and later.
 
 ### Major changes
 
-* Restructured [Cloud Cost Intelligence (CCI) documentation](/docs/cci) to improve organization and discoverability of features including budgets, recommendations, and integrations.
-* Updated [Workflow automation actions catalog](/docs/workflow-automation/workflow-automation-features/actions-catalog/actions-catalog) with extensive revisions to action documentation and added two new actions for New Relic data ingest and NRDB queries.
+* Restructured [Cloud Cost Intelligence (CCI) documentation](/docs/cci/overview) to improve organization and discoverability of features including budgets, recommendations, and integrations.
+* Updated [Workflow automation actions catalog](/docs/workflow-automation/setup-and-configuration/actions-catalog/actions-catalog) with extensive revisions to action documentation and added two new actions for New Relic data ingest and NRDB queries.
 * Updated [Global Technical Support offerings](/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings) with improved OpenTelemetry support documentation structure and added Account and Billing support section.
 * Updated [Bring your own cache](/docs/distributed-tracing/infinite-tracing-on-premise/bring-your-own-cache) with simplified configuration examples and improved documentation structure.
 * Updated [Databricks integration](/docs/infrastructure/other-infrastructure-integrations/databricks-integration) to reflect latest version changes.
 
 ### Minor changes
 
-* Updated [Infrastructure agent configuration settings](/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings) with new configuration options for Infrastructure agent v1.72.1.
+* Updated [Infrastructure agent configuration settings](/docs/infrastructure/infrastructure-agent/configuration/infrastructure-agent-configuration-settings) with new configuration options for Infrastructure agent v1.72.1.
 * Updated [Node.js agent compatibility requirements](/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent) for Node.js agent v13.11.0.
-* Enhanced [OpenTelemetry integrations list](/docs/infrastructure/host-integrations/host-integrations-list/opentelemetry-integrations-list) with Elasticsearch integration information.
-* Updated [Introduction to dashboards](/docs/explore-query-data/dashboards/introduction-dashboards) with improved content clarity.
+* Enhanced [OpenTelemetry integrations list](/docs/opentelemetry/opentelemetry-integrations-list) with Elasticsearch integration information.
+* Updated [Introduction to dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) with improved content clarity.
 * Updated [VMware Tanzu service broker integration](/docs/infrastructure/other-infrastructure-integrations/cloudfoundry-integrations/vmware-tanzu-service-broker-integration) with corrections.
 * Added MFA setup instructions to [Authentication domains](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more).
 * Updated [iOS agent compatibility requirements](/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements) to reflect iOS agent v7.6.0 requires iOS 16 or higher.


### PR DESCRIPTION
## Summary
Documentation release notes for the week of January 26 - January 30, 2026.

## Changes included

### New docs (3)
- Elasticsearch OpenTelemetry integration overview, installation, and troubleshooting

### Major changes (4)
- CCI documentation restructure
- Workflow automation actions catalog updates with new actions
- OpenTelemetry support documentation structure improvements
- Bring your own cache documentation simplification

### Minor changes (5)
- Infrastructure agent configuration updates
- Node.js agent compatibility requirements
- OpenTelemetry integrations list enhancements
- Dashboard and VMware Tanzu documentation corrections

### Release notes (5 agents)
- .NET agent v10.48.1
- Cordova agent v7.0.13
- Unity agent v1.4.13
- Node.js agent v13.11.0
- Infrastructure agent v1.72.1