### PR TITLE
Remove EDGE from supported browsers in step-monitor.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -37,7 +37,7 @@ You can create a step monitor using the `syntheticsCreateStepMonitor` mutation. 
       <td>`monitor.browsers`</td>
       <td>Array</td>
       <td>Yes</td>
-      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `EDGE`, `FIREFOX`.</td>
+      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `FIREFOX`.</td>
     </tr>
     <tr>
       <td>`monitor.devices`</td>
@@ -191,7 +191,7 @@ You can update an existing step monitor using the `syntheticsUpdateStepMonitor` 
       <td>`monitor.browsers`</td>
       <td>Array</td>
       <td>No</td>
-      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `EDGE`, `FIREFOX`.</td>
+      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `FIREFOX`.</td>
     </tr>
     <tr>
       <td>`monitor.devices`</td>


### PR DESCRIPTION
We don't support EDGE browser but see our docs has references to the same in some places.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.