### PR TITLE
Removing references to EDGE browser

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/scripted-browser-monitor.mdx
@@ -37,7 +37,7 @@ You can create a scripted browser monitor using the `syntheticsCreateScriptBrows
       <td>`monitor.browsers`</td>
       <td>Array</td>
       <td>Yes</td>
-      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `EDGE`, `FIREFOX`.</td>
+      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `FIREFOX`.</td>
     </tr>
     <tr>
       <td>`monitor.devices`</td>
@@ -181,7 +181,7 @@ You can update an existing scripted browser monitor using the `syntheticsUpdateS
       <td>`monitor.browsers`</td>
       <td>Array</td>
       <td>No</td>
-      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `EDGE`, `FIREFOX`.</td>
+      <td>Browser(s) that the monitor will use to execute jobs. Supported browsers: `CHROME`, `FIREFOX`.</td>
     </tr>
     <tr>
       <td>`monitor.devices`</td>


### PR DESCRIPTION
Hi, We don't support EDGE browser but see our docs has references to the same in some places.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.