### PR TITLE
(applications-catalog): add AI assets column documentation

### DIFF
--- a/src/content/docs/service-architecture-intelligence/catalogs/applications-catalog.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/applications-catalog.mdx
@@ -127,9 +127,9 @@ You can control which data points display in the table to reduce noise and focus
 
 Use the filter bar at the top to narrow down your entities:
 
-* <DNT>**Quick filters**</DNT>: Use the pre-defined buttons to filter by entity type, AI asset, or team.
-* <DNT>**Custom filter rules**</DNT>: Click the <DNT>**+**</DNT> icon to add specific attributes. You can define rules using operators to filter for a specific attribute value. For example, filter entities where <DNT>Language</DNT> `=` `go` to get all Go services.
-* <DNT>**Global search**</DNT>: Use the <DNT>**Search by entity name**</DNT> bar to find specific services instantly.
+* **Quick filters**: Use the pre-defined buttons to filter by entity type, AI asset, or team.
+* **Custom filter rules**: Click the <DNT>**+**</DNT> icon to add specific attributes. You can define rules using operators to filter for a specific attribute value. For example, filter entities where <DNT>Language</DNT> `=` `go` to get all Go services.
+* **Global search**: Use the <DNT>**Search by entity name**</DNT> bar to find specific services instantly.
 
 ### Add new data [#add-new-data]
 


### PR DESCRIPTION
- Add AI assets column to the Applications catalog table
- Include description of AI-related libraries detection (OpenAI, Bedrock, LangChain)
- Document 24-hour data refresh frequency
- Add link to AI monitoring documentation
- Update metadata tags
