### PR TITLE
Update setuserid.mdx to correct syntax

### DIFF
--- a/src/content/docs/browser/new-relic-browser/browser-apis/setuserid.mdx
+++ b/src/content/docs/browser/new-relic-browser/browser-apis/setuserid.mdx
@@ -14,7 +14,7 @@ freshnessValidatedDate: never
 ## Syntax
 
 ```js
-newrelic.setUserId(value: string|null)
+newrelic.setUserId(value: string|null, resetSession?: boolean)
 ```
 
 Adds a user-defined identifier string to subsequent events on the page.


### PR DESCRIPTION
This PR fixes a mistake in the `.setUserId` API for the browser agent.  It should include the second argument