### PR TITLE
Add opentelemetry config options for Java agent

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -4847,20 +4847,74 @@ Set message tracer options in the `message_tracer` section. You can [override](#
   </Collapser>
 </CollapserGroup>
 
-## Open Telemetry SDK Auto-Configuration [#otel-sdk-autoconfiguration]
+## OpenTelemetry [#opentelemetry]
 
-Configuration for the open telemetry SDK autoconfigure instrumentation under the section:
+Starting with Java agent version `9.1.0`, OpenTelemetry Tracing, Metrics, and Logs API compatibility has been added, offering a "best-of-both-worlds" experience by combining New Relic’s deep visibility with OpenTelemetry signals.
+
+With this functionality, OpenTelemetry Tracing, Metrics, and Logs APIs may be used to directly custom instrument your application, in combination with New Relic Java agent APIs, while the Java agent seemlessly combines it all together into a familiar APM experience. Additionally, some libraries that provide OpenTelemetry native or standalone library instrumentation may be used to provide enhanced visibility into your application.
+
+The following configuration options determine which OpenTelemetry signals should be captured and incorporated into the New Relic APM experience.
 
 ```yml
-opentelemetry:
-  sdk:
-    autoconfigure:
+  opentelemetry:
+    enabled: false
+    logs:
+      enabled: true
+    metrics:
+      enabled: true
+      include: "MeterName1,MeterName2"
+      exclude: "MeterName3,MeterName4"
+    traces:
+      enabled: true
+      include: "TracerName1,TracerName2"
+      exclude: "TracerName3,TracerName4"
 ```
 
 <CollapserGroup>
   <Collapser
-    id="cfg-otel-sdk-autoconfiguration-enabled"
+    id="cfg-opentelemetry-enabled"
     title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set to true to allow individual OpenTelemetry signals to be enabled, false to disable all OpenTelemetry signals.
+    Default is false.
+
+    Can be set via the system property:
+    ```ini
+    -Dnewrelic.config.opentelemetry.enabled=false
+    ```
+
+    Can be set via the environment variable:
+    ```ini
+    NEW_RELIC_OPENTELEMETRY_ENABLED
+    ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-logs-enabled"
+    title="logs.enabled"
   >
     <table>
       <tbody>
@@ -4886,13 +4940,267 @@ opentelemetry:
       </tbody>
     </table>
 
-    Allows the agent's Opentelemetry SDK autoconfiguration feature to be enabled. Can be set via the system property:
+    Set to true to enable OpenTelemetry Logs signals when `opentelemetry.enabled=true`.
+    Default is true.
 
+    Can be set via the system property:
     ```ini
-    -Dnewrelic.config.opentelemetry.sdk.autoconfigure.enabled=true
+    -Dnewrelic.config.opentelemetry.logs.enabled=true
     ```
 
+    Can be set via the environment variable:
+    ```ini
+    NEW_RELIC_OPENTELEMETRY_LOGS_ENABLED
+    ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-metrics-enabled"
+    title="metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set to true to enable OpenTelemetry Metrics signals when `opentelemetry.enabled=true`.
     Default is true.
+
+    Can be set via the system property:
+    ```ini
+    -Dnewrelic.config.opentelemetry.metrics.enabled=true
+    ```
+
+    Can be set via the environment variable:
+    ```ini
+    NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED
+    ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-metrics-include"
+    title="metrics.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    A comma-delimited string of OpenTelemetry Meters (e.g. "MeterName1,MeterName2") whose signals should be included. By default, all Meters are included. This will override any default Meter excludes in the agent, effectively re-enabling them.
+
+    Default is empty string.
+
+    Can be set via the system property:
+    ```ini
+    -Dnewrelic.config.opentelemetry.metrics.include=MeterName1,MeterName2
+    ```
+
+    Can be set via the environment variable:
+    ```ini
+    NEW_RELIC_OPENTELEMETRY_METRICS_INCLUDE
+    ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-metrics-exclude"
+    title="metrics.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    A comma-delimited string of OpenTelemetry Meters (e.g. "MeterName3,MeterName4") whose signals should be excluded.This takes precedence over all other includes/excludes sources, effectively disabling the listed Meters.
+
+    Default is empty string.
+
+    Can be set via the system property:
+    ```ini
+    -Dnewrelic.config.opentelemetry.metrics.exclude=MeterName3,MeterName4
+    ```
+
+    Can be set via the environment variable:
+    ```ini
+    NEW_RELIC_OPENTELEMETRY_METRICS_EXCLUDE
+    ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-traces-enabled"
+    title="traces.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+        Set to true to enable OpenTelemetry Traces signals when `opentelemetry.enabled=true`.
+    Default is true.
+
+        Can be set via the system property:
+        ```ini
+        -Dnewrelic.config.opentelemetry.traces.enabled=true
+        ```
+
+        Can be set via the environment variable:
+        ```ini
+        NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED
+        ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-traces-include"
+    title="traces.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+              <td>
+                String
+              </td>
+            </tr>
+
+            <tr>
+              <th>
+                Default
+              </th>
+
+              <td>
+                (none)
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        A comma-delimited string of OpenTelemetry Tracers (e.g. "TracerName1,TracerName2") whose signals should be included. By default, all Tracers are included. This will override any default Tracer excludes in the agent, effectively re-enabling them.
+
+        Default is empty string.
+
+        Can be set via the system property:
+        ```ini
+        -Dnewrelic.config.opentelemetry.traces.include=TracerName1,TracerName2
+        ```
+
+        Can be set via the environment variable:
+        ```ini
+        NEW_RELIC_OPENTELEMETRY_TRACES_INCLUDE
+        ```
+  </Collapser>
+  <Collapser
+    id="cfg-opentelemetry-traces-exclude"
+    title="traces.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+              <td>
+                String
+              </td>
+            </tr>
+
+            <tr>
+              <th>
+                Default
+              </th>
+
+              <td>
+                (none)
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+        A comma-delimited string of OpenTelemetry Tracers (e.g. "TracerName3,TracerName4") whose signals should be excluded. This takes precedence over all other includes/excludes sources, effectively disabling the listed Tracers.
+
+        Default is empty string.
+
+        Can be set via the system property:
+        ```ini
+        -Dnewrelic.config.opentelemetry.traces.exclude=TracerName3,TracerName4
+        ```
+
+        Can be set via the environment variable:
+        ```ini
+        NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE
+        ```
   </Collapser>
 </CollapserGroup>
 
@@ -5133,7 +5441,7 @@ You can set the New Relic Security agent configuration in the `security` section
 
 ## Skip Applications [#skip-applications]
 
-The agent can be selectively enabled or disabled based on the startup main class or executable jar file that is extracted from the command line. This is handy in situations where the "JAVA_TOOL_OPTIONS" environment 
+The agent can be selectively enabled or disabled based on the startup main class or executable jar file that is extracted from the command line. This is handy in situations where the "JAVA_TOOL_OPTIONS" environment
 variable is present and contains the -javaagent flag but we don't want to apply the instrumentation to all java apps in the environment - for example in a Kubernetes container.
 
 <Callout variant="important">
@@ -5218,7 +5526,7 @@ New Relic Agent is disabled by startup class/jar skip or include configuration.
     `NEW_RELIC_STARTUP_JAVA_ARTIFACT_INCLUDES=myapp.jar`. The corresponding system property is `newrelic.config.startup_java_artifact_includes`.
   </Collapser>
 </CollapserGroup>
-  
+
 
 ## Slow transaction Detection
 
@@ -5660,7 +5968,7 @@ New Relic Agent: Deleted [count] stale temporary jar files freeing up [totalByte
       </tbody>
     </table>
 
-    The value is the number of hours old a temp jar needs to be in order to be deleted (whole numbers only). 
+    The value is the number of hours old a temp jar needs to be in order to be deleted (whole numbers only).
     The default value is 0, which disables the file deletion check. The corresponding system property is `newrelic.config.temp_jarfile_age_threshold_hours`.
   </Collapser>
 </CollapserGroup>
@@ -6174,7 +6482,7 @@ Set the transaction tracer options in the `transaction_tracer` section. These op
       </tbody>
     </table>
 
-    For large SQL statements, executing the regular expressions that attempt to parse exec and call statements can take a significant amount of time. 
+    For large SQL statements, executing the regular expressions that attempt to parse exec and call statements can take a significant amount of time.
     Setting this to true will disable the execution of these complex regular expressions.
 
     This config exists in Java agent version 8.25.0+.


### PR DESCRIPTION

Adds sections detailing the `opentelemetry` config options for the Java agent (aka hybrid agent):

```yml
  opentelemetry:
    enabled: false
    logs:
      enabled: true
    metrics:
      enabled: true
      include: "MeterName1,MeterName2"
      exclude: "MeterName3,MeterName4"
    traces:
      enabled: true
      include: "TracerName1,TracerName2"
      exclude: "TracerName3,TracerName4"
```
