### PR TITLE
Update prerequisites-to-share-dashboards-charts.mdx

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/prerequisites-to-share-dashboards-charts.mdx
@@ -138,7 +138,7 @@ As an Authentication Domain Manager, perform the following steps to grant access
            * `Delete`: Can revoke any live URL.
        * `Live Url (individual)`: Access details of live URLs owned by the user.
             * `View`: Can see own live URL details.
-           * `Modify`: Can update the properties of the live URLs.
+           * `Modify`: Can create live URLs and/or update the properties of the live URLs.
            * `Delete`: Can revoke own live URLs.
   </Step>
 


### PR DESCRIPTION
In the Add permissions to a custom role section, the description of the Modify capability is not accurate and customers believe they only need Modify to change the properties of the live URLs, when this capability is also needed to Create live urls. I have updated so it reads: 
 Modify: Can create live URLs and/or update the properties of the live urls

