### PR TITLE
Document sql_metadata_comments configuration option

### DIFF
--- a/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
+++ b/src/content/docs/apm/agents/java-agent/configuration/java-agent-configuration-config-file.mdx
@@ -6278,6 +6278,44 @@ Set the transaction tracer options in the `transaction_tracer` section. These op
   </Collapser>
 
   <Collapser
+    id="tt-sql_metadata_comments"
+    title="sql_metadata_comments"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `(none)`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Controls the addition of comments to the beginning of executed SQL statements to be used by the New Relic Query Performance Monitoring
+    product for entity linking. An empty String disables SQL comments (default setting).
+    Allowed options are:
+
+    * `nr_service_guid` - The GUID of the New Relic entity the agent is instrumenting
+
+    A resulting comment would resemble this:
+    `/*nr_service_guid=MTE3NDc2MDB8QVBNfEFQUExJQ0FUSU9OfDI4MTc5NDEIEA*/`
+  </Collapser>
+
+  <Collapser
     id="tt-stack_based_naming"
     title="stack_based_naming (Play 2.x+ only)"
   >


### PR DESCRIPTION
Added documentation for sql_metadata_comments configuration option in the Java agent.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.