### PR TITLE
Add amended 9.1.0 Java agent release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-910.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-910.mdx
@@ -23,8 +23,8 @@ security: []
   - Update hybrid agent config based on spec changes by @jasonjkeller in [2738](https://github.com/newrelic/newrelic-java-agent/pull/2738)
   - Hybrid Agent OpenTelemetry API Support by @jasonjkeller in [2711](https://github.com/newrelic/newrelic-java-agent/pull/2711)
   - OTel Bridge API support by @sdaubin in [1886](https://github.com/newrelic/newrelic-java-agent/pull/1886)
+- Added support for prepending a comment to executed SQL that contains the entity GUID of the current application. This is used by the Query Performance Monitoring product for entity linking by @jtduffy in [2715](https://github.com/newrelic/newrelic-java-agent/pull/2715)
 - Enhancements to coroutine ignores by @dhilpipre in [2726](https://github.com/newrelic/newrelic-java-agent/pull/2726)
-- Add SQL metadata comments in support of QPM by @jtduffy in [2715](https://github.com/newrelic/newrelic-java-agent/pull/2715)
 - Add agent metadata action - @mvicknr in [2732](https://github.com/newrelic/newrelic-java-agent/pull/2732)
 [2745](https://github.com/newrelic/newrelic-java-agent/pull/2745)
 


### PR DESCRIPTION
Release date: 2/12/26 
Amending existing 9.1.0 docs to include alternative QPM verbiage.