### PR TITLE
feat(nginx): add nginx otel basic optimized config

### DIFF
--- a/src/content/docs/opentelemetry/nginx-plus/nginx-plus-otel.mdx
+++ b/src/content/docs/opentelemetry/nginx-plus/nginx-plus-otel.mdx
@@ -157,12 +157,12 @@ Configure the OpenTelemetry Collector to scrape metrics from your NGINX Plus Pro
                - "nginxplus_connections_.*"
                - "nginxplus_http_requests_.*"
                - "nginxplus_ssl_.*"
-               - "nginxplus_server_.*"
-               - "nginxplus_location_zone_.*"
-               - "nginxplus_cache_.*"
            exclude:
              match_type: regexp
              metric_names:
+               - "nginxplus_server_.*"
+               - "nginxplus_location_zone_.*"
+               - "nginxplus_cache_.*"
                - "nginxplus_stream_server_.*"
                - "nginxplus_upstream_.*"
                - "nginxplus_stream_upstream_.*"
@@ -196,8 +196,14 @@ Configure the OpenTelemetry Collector to scrape metrics from your NGINX Plus Pro
            - context: resource
              statements:
                - delete_key(attributes, "service.name")
+       transform/metadata_nullify:
+         metric_statements:
+           - context: metric
+             statements:
+               - set(description, "")
+               - set(unit, "")
      exporters:
-       otlphttp/newrelic:
+       otlp_http/newrelic:
          endpoint: ${env:NEWRELIC_OTLP_ENDPOINT}
          headers:
            api-key: ${env:NEWRELIC_LICENSE_KEY}
@@ -205,11 +211,57 @@ Configure the OpenTelemetry Collector to scrape metrics from your NGINX Plus Pro
        pipelines:
          metrics/nginx:
            receivers: [prometheus]
-           processors: [batch, filter/nginx_metrics, resourcedetection, resource/nginx, transform/nginx]
-           exporters: [otlphttp/newrelic]
+           processors: [batch, filter/nginx_metrics, resourcedetection, resource/nginx, transform/nginx, transform/metadata_nullify]
+           exporters: [otlp_http/newrelic]
      ```
 
     Save the file and ensure the `otelcol-contrib` system user can read it.
+  </Collapser>
+  <Collapser id="step2-enable-additional-metrics-otelcol" title="(Optional) Enable additional metrics">
+    By default, the configuration collects only core metrics (connections, HTTP requests, and SSL). To enable additional metric categories like server zones, location zones, or cache metrics:
+
+    1. **Identify the metrics you want to enable** from the [metrics list](#metrics) below. Note which category they belong to (e.g., HTTP Server Zones, Location Zones, Cache).
+
+    2. **Move the corresponding metric prefix from `exclude` to `include`** in the `filter/nginx_metrics` processor.
+
+      **Example: Enable HTTP Server Zones metrics**
+
+      Find this line in the `exclude` section:
+      ```yaml
+      filter/nginx_metrics:
+        metrics:
+          include:
+          # existing include metrics
+          exclude:
+            match_type: regexp
+            metric_names:
+              - "nginxplus_server_.*"
+      ```
+
+      Move it to the `include` section:
+      ```yaml
+      filter/nginx_metrics:
+        metrics:
+          include:
+            match_type: regexp
+            metric_names:
+              - "nginxplus_connections_.*"
+              - "nginxplus_http_requests_.*"
+              - "nginxplus_ssl_.*"
+              - "nginxplus_server_.*"  # Added to enable server zone metrics
+          exclude:
+            match_type: regexp
+            metric_names:
+              # Remove "nginxplus_server_.*" from here
+              - "nginxplus_location_zone_.*"
+              - "nginxplus_cache_.*"
+              # ... rest of exclude list
+      ```
+
+    3. **Restart the collector** after making changes:
+       ```bash
+       sudo systemctl restart otelcol-contri.service
+       ```
   </Collapser>
 </CollapserGroup>
 
@@ -334,16 +386,16 @@ Before forwarding logs, configure NGINX Plus to use a structured log format. Ref
      pipelines:
        metrics/nginx:
          receivers: [prometheus]
-         processors: [batch, filter/nginx_metrics, resourcedetection, resource/nginx, transform/nginx_metrics]
-         exporters: [otlphttp/newrelic]
+         processors: [batch, filter/nginx_metrics, resourcedetection, resource/nginx, transform/nginx_metrics, transform/metadata_nullify]
+         exporters: [otlp_http/newrelic]
        logs/nginx-access:
          receivers: [filelog/nginx_access_logs]
          processors: [batch, resource/nginx, transform/nginx_access_logs]
-         exporters: [otlphttp/newrelic]
+         exporters: [otlp_http/newrelic]
        logs/nginx-error:
          receivers: [filelog/nginx_error_logs]
          processors: [batch, resource/nginx, transform/nginx_error_logs]
-         exporters: [otlphttp/newrelic]
+         exporters: [otlp_http/newrelic]
    ```
 
 3. Grant the `otelcol-contrib` user read access to the log files:
@@ -549,6 +601,11 @@ Below are the available NGINX Plus metrics:
     id="plus-server-zone"
     title="HTTP Server Zones"
   >
+
+<Callout variant="important">
+**Note:** These metrics are disabled by default. To enable them, see [(Optional) Enable additional metrics](#step2-enable-additional-metrics-otelcol) for OpenTelemetry Collector Contrib.
+</Callout>
+
     <table>
       <thead>
         <tr>
@@ -682,6 +739,9 @@ Below are the available NGINX Plus metrics:
     id="plus-location-zones"
     title="Location Zones"
   >
+<Callout variant="important">
+**Note:** These metrics are disabled by default. To enable them, see [(Optional) Enable additional metrics](#step2-enable-additional-metrics-otelcol) for OpenTelemetry Collector Contrib.
+</Callout>
     <table>
       <thead>
         <tr>
@@ -771,6 +831,9 @@ Below are the available NGINX Plus metrics:
     id="plus-cache"
     title="Cache"
   >
+<Callout variant="important">
+**Note:** These metrics are disabled by default. To enable them, see [(Optional) Enable additional metrics](#step2-enable-additional-metrics-otelcol) for OpenTelemetry Collector Contrib.
+</Callout>
     <table>
       <thead>
         <tr>

--- a/src/content/docs/opentelemetry/nginx/nginx-otel-host.mdx
+++ b/src/content/docs/opentelemetry/nginx/nginx-otel-host.mdx
@@ -192,13 +192,20 @@ Configure the OpenTelemetry Collector to scrape metrics from your NGINX stub sta
             statements:
               # Customize the display name as needed for your New Relic dashboard
               - set(attributes["nginx.display.name"], Concat(["server", attributes["nginx.deployment.name"]], ":"))
+      
+      transform/metadata_nullify:
+        metric_statements:
+          - context: metric
+            statements:
+              - set(description, "")
+              - set(unit, "")
     ```
 
     **3. Configure the New Relic exporter:**
     ```yaml
     exporters:
       # Send metrics to New Relic via OTLP
-      otlphttp/newrelic:
+      otlp_http/newrelic:
         endpoint: ${env:NEWRELIC_OTLP_ENDPOINT}
         headers:
           api-key: ${env:NEWRELIC_LICENSE_KEY}
@@ -210,8 +217,8 @@ Configure the OpenTelemetry Collector to scrape metrics from your NGINX stub sta
       pipelines:
         metrics:
           receivers: [nginx]
-          processors: [resourcedetection, resource, batch, transform/nginx_metrics]
-          exporters: [otlphttp/newrelic]
+          processors: [resourcedetection, resource, batch, transform/nginx_metrics, transform/metadata_nullify]
+          exporters: [otlp_http/newrelic]
     ```
   </Collapser>
 
@@ -397,19 +404,19 @@ In addition to metrics, you can send NGINX [access and error logs](https://docs.
         # Your existing metrics pipeline...
         metrics:
           receivers: [nginx]
-          processors: [resourcedetection, resource, batch, transform/nginx_metrics]
-          exporters: [otlphttp/newrelic]
+          processors: [resourcedetection, resource, batch, transform/nginx_metrics, transform/metadata_nullify]
+          exporters: [otlp_http/newrelic]
 
         # Add log pipelines
         logs/nginx-access:
           receivers: [filelog/nginx_access]
           processors: [resource, batch, transform/nginx_access_logs]
-          exporters: [otlphttp/newrelic]
+          exporters: [otlp_http/newrelic]
 
         logs/nginx-error:
           receivers: [filelog/nginx_error]
           processors: [resource, batch, transform/nginx_error_logs]
-          exporters: [otlphttp/newrelic]
+          exporters: [otlp_http/newrelic]
     ```
   </Collapser>
 

--- a/src/content/docs/opentelemetry/nginx/nginx-otel-kubernetes.mdx
+++ b/src/content/docs/opentelemetry/nginx/nginx-otel-kubernetes.mdx
@@ -142,8 +142,15 @@ Deploy the OpenTelemetry Collector to your Kubernetes cluster using Helm. The co
                       ], ":"))
                   - set(attributes["nginx.deployment.name"], attributes["k8s.pod.name"])
 
+          transform/metadata_nullify:
+            metric_statements:
+              - context: metric
+                statements:
+                  - set(description, "")
+                  - set(unit, "")
+
         exporters:
-          otlphttp:
+          otlp_http:
             endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
             headers:
               api-key: "${env:NEWRELIC_LICENSE_KEY}"
@@ -153,8 +160,8 @@ Deploy the OpenTelemetry Collector to your Kubernetes cluster using Helm. The co
           pipelines:
             metrics/nginx:
               receivers: [receiver_creator/nginx]
-              processors: [batch, resource/cluster, transform/nginx]
-              exporters: [otlphttp]
+              processors: [batch, resource/cluster, transform/nginx, transform/metadata_nullify]
+              exporters: [otlp_http]
     ```
   </Collapser>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?


* Update the nginx & nginx plus otel config to reduce default ingest size
  - Removed descriptions/units from each metric metadata in OTel
  - Disabled unused metrics  in our NR UI to reduce overhead. (cache, location zone, http server zone metrics will not be ingested by default. But, customers can choose to enable it by updating the config)
* `otlphttp` is deprecated use `otlp_http` instead of `otlphttp` ([reference](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlphttpexporter/README.md))

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

* If your issue relates to an existing GitHub issue, please link to it.