### PR TITLE
Update APM application linking troubleshooting instructions for Kubernetes

### DIFF
--- a/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes.mdx
+++ b/src/content/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes.mdx
@@ -225,22 +225,18 @@ Follow these troubleshooting tips as needed.
 
     ### Solution
 
-    1. Verify that the environment variables are set correctly injected by following the instructions described in the [Validate the injection of metadata](/docs/integrations/kubernetes-integration/metadata-injection/kubernetes-apm-metadata-injection#validate-injection) section.
+    1. Verify that the environment variables have been correctly injected into new pods by following the instructions described in the [Validate the injection of metadata](/docs/integrations/kubernetes-integration/metadata-injection/kubernetes-apm-metadata-injection#validate-injection) section.
 
-    2. If they do not exist, get the name of the metadata injection pod by running:
+    2. If they do not exist, firstly, tail the logs of the webhook service:
 
        ```shell
-       kubectl get pods | grep newrelic-metadata-injection-deployment
-       kubectl logs -f pod/my-pod
+       kubectl logs -l app.kubernetes.io/name=nri-metadata-injection -f
        ```
 
-    3. In another terminal, create a new pod and inspect the logs of the metadata injection deployment for errors. See [Validate the injection of metadata](/docs/integrations/kubernetes-integration/metadata-injection/kubernetes-apm-metadata-injection#validate-injection) section to create a new pod. For each pod created, there should be a set of 4 new entries in the logs, such as:
+    3. In another terminal, create a new pod and inspect the logs of the metadata injection deployment for errors. See [Validate the injection of metadata](/docs/integrations/kubernetes-integration/metadata-injection/kubernetes-apm-metadata-injection#validate-injection) section to create a new pod. For each pod created, there should be log entry, assuming the [log level (logLevel)](https://github.com/newrelic/k8s-metadata-injection/blob/main/charts/nri-metadata-injection/README.md#values) is at INFO or lower:
 
        ```json
-       {"level":"info","ts":"2020-04-09T12:55:32.107Z","caller":"server/main.go:139","msg":"POST https://newrelic-metadata-injection-svc.default.svc:443/mutate?timeout=30s HTTP/2.0\" from 10.11.49.2:32836"}
-       {"level":"info","ts":"2020-04-09T12:55:32.110Z","caller":"server/webhook.go:168","msg":"received admission review","kind":"/v1, Kind=Pod","namespace":"default","name":"","pod":"busybox1","UID":"6577519b-7a61-11ea-965e-0e46d1c9335c","operation":"CREATE","userinfo":{"username":"admin","uid":"admin","groups":["system:masters","system:authenticated"]}}
-       {"level":"info","ts":"2020-04-09T12:55:32.111Z","caller":"server/webhook.go:182","msg":"admission response created","response":"[{\"op\":\"add\",\"path\":\"/spec/containers/0/env\",\"value\":[{\"name\":\"NEW_RELIC_METADATA_KUBERNETES_CLUSTER_NAME\",\"value\":\"adn_kops\"}]},{\"op\":\"add\",\"path\":\"/spec/containers/0/env/-\",\"value\":{\"name\":\"NEW_RELIC_METADATA_KUBERNETES_NODE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"spec.nodeName\"}}}},{\"op\":\"add\",\"path\":\"/spec/containers/0/env/-\",\"value\":{\"name\":\"NEW_RELIC_METADATA_KUBERNETES_NAMESPACE_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.namespace\"}}}},{\"op\":\"add\",\"path\":\"/spec/containers/0/env/-\",\"value\":{\"name\":\"NEW_RELIC_METADATA_KUBERNETES_POD_NAME\",\"valueFrom\":{\"fieldRef\":{\"fieldPath\":\"metadata.name\"}}}},{\"op\":\"add\",\"path\":\"/spec/containers/0/env/-\",\"value\":{\"name\":\"NEW_RELIC_METADATA_KUBERNETES_CONTAINER_NAME\",\"value\":\"busybox\"}},{\"op\":\"add\",\"path\":\"/spec/containers/0/env/-\",\"value\":{\"name\":\"NEW_RELIC_METADATA_KUBERNETES_CONTAINER_IMAGE_NAME\",\"value\":\"busybox\"}}]"}
-       {"level":"info","ts":"2020-04-09T12:55:32.111Z","caller":"server/webhook.go:257","msg":"writing response"}
+      {"level":"info","ts":"2026-02-16T09:58:05.934Z","caller":"server/webhook.go:160","msg":"admission review received","operation":"CREATE","kind":"Pod","namespace":"default","podGenerateName":"test-pod-2-55476b7f5c-","uid":"0b689368-5395-4cda-9b8c-61fa2705f6ee","mutate":true}
        ```
 
        If there are no new entries in the logs, it means that the API server can't communicate with the webhook service, this could be due to network rules or security groups rejecting the communication.
@@ -289,16 +285,18 @@ Follow these troubleshooting tips as needed.
 
     6. If there are no log entries in either the API server logs or the metadata injection deployment, it means that the webhook was not registered properly.
 
-    7. Ensure the metadata injection setup job ran successfully by inspecting the output of this command:
+    7. Ensure the metadata injection setup jobs ran successfully by inspecting the output of this command:
 
        ```shell
-       kubectl get job newrelic-metadata-setup
+       kubectl get job nri-metadata-injection-admission-create
+       kubectl get job nri-metadata-injection-admission-patch
        ```
 
     8. If the job isn't completed, investigate the logs of the setup job:
 
        ```shell
-       kubectl logs job/newrelic-metadata-setup
+       kubectl logs job/nri-metadata-injection-admission-create
+       kubectl logs job/nri-metadata-injection-admission-patch
        ```
 
     9. Ensure the `CertificateSigningRequest` is approved and issued by running this command:
@@ -310,20 +308,20 @@ Follow these troubleshooting tips as needed.
     10. Ensure the TLS secret is present by running this command:
 
         ```shell
-        kubectl get secret newrelic-metadata-injection-secret
+        kubectl get secret nri-metadata-injection-admission
         ```
 
     11. Ensure the CA bundle is present in the mutating webhook configuration:
 
         ```shell
-        kubectl get mutatingwebhookconfiguration newrelic-metadata-injection-cfg -o json
+        kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io nri-metadata-injection -o json
         ```
 
     12. Ensure the `TargetPort` of the <DNT>**Service**</DNT> resource matches the <DNT>**Port**</DNT> of the <DNT>**Deployment**</DNT>'s container:
 
         ```shell
-        kubectl describe service/newrelic-metadata-injection-svc
-        kubectl describe deployment/newrelic-metadata-injection-deployment
+        kubectl describe service/nri-metadata-injection
+        kubectl describe deployment/nri-metadata-injection
         ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
Depends on https://github.com/newrelic/k8s-metadata-injection/pull/701 being merged first, which updates the logging strategy of the `k8s-metadata-injection mutating` Kubernetes web hook component. In particular it makes the default logging less verbose as well as adding log level support and so I want to update these docs which reference the old logs explicitly.

I've also update a few other resource names in the same section as these are out of date based on the current Helm chart config. Looking at the old log examples the doc was generated 6 years ago.

Related PR: https://github.com/newrelic/k8s-metadata-injection/pull/701
Related issue: https://github.com/newrelic/k8s-metadata-injection/issues/700