### PR TITLE
fix: Update guided install scope docs for APM or OHI installs

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview.mdx
@@ -41,6 +41,14 @@ Ready to get started? Click the <DNT>**Guided install**</DNT> button. Or, if you
 
 Our guided install discovers the applications, infrastructure and log sources running in your environment, and recommends which ones should be instrumented. The install automates the configuration and deployment of each system you choose to instrument.
 
+<Callout variant="important">
+  **Guided Install is designed for initial installations on new hosts**
+
+  The CLI-based Guided Install provides an automated installation experience designed for new host deployments ("Day 0" installations). When run on a system with existing New Relic agents, it will reset agent configurations to default settings to ensure a clean, consistent installation.
+
+  **For upgrading existing agents:** If you have custom configurations you want to preserve (log settings, custom attributes, labels, etc.), use the [manual upgrade procedures](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent) instead. These upgrade methods are straightforward and will maintain all your custom settings.
+</Callout>
+
 <InstallFeedback/>
 
 ## Why it matters [#why-it-matters]
@@ -50,6 +58,45 @@ With our guided install, you can instrument your applications and infrastructure
 The guided install uses our command line interface (CLI), the [infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/install-infrastructure-agent) for your host environment, and a [library of installation recipes](https://github.com/newrelic/open-install-library) to instrument your applications and infrastructure for you. That means less toil for you.
 
 Because our instrumentation recipes are open source, you can modify existing recipes, or build new ones, to suit your needs.
+
+## Guided Install scope and intended use [#scope]
+
+Understanding when to use Guided Install versus manual upgrade procedures will help you choose the right approach for your situation.
+
+### Guided Install is designed for
+
+* **New host deployments**: Installing New Relic agents on hosts without existing agent installations
+* **"Day 0" installations**: Initial setup when starting to monitor new infrastructure
+* **Automated discovery**: Quickly discovering and instrumenting applications and services on fresh systems
+* **Standard configurations**: Deployments where default, out-of-the-box configurations work well
+* **Quick starts and trials**: Quickly getting started with New Relic monitoring
+
+### When to use manual upgrade procedures instead
+
+Use the manual upgrade procedures if:
+
+* **You're upgrading existing agents**: You already have New Relic agents installed and want to update to a newer version
+* **You have custom configurations**: Your agents have custom settings, log paths, attributes, or labels you want to keep
+* **You need configuration control**: You want to maintain specific agent configurations during the upgrade
+
+### How Guided Install works with existing installations
+
+If you run Guided Install on a system with existing New Relic agents:
+
+* Agent configuration files are set to default values
+* Custom settings (log paths, custom attributes, labels, etc.) are not preserved
+* This ensures a clean, consistent installation experience
+
+To avoid losing custom configurations, use the [manual upgrade procedures](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent) for your operating system.
+
+### Upgrading with configuration preservation
+
+For upgrading existing agents while preserving your custom configurations, use the [manual upgrade procedures](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent). These methods:
+
+* Are simple - usually just one or two commands per operating system
+* Preserve all your custom configurations, log settings, and manual changes
+* Are the recommended approach for production environments with existing agents
+* Are OS-specific but straightforward to follow
 
 ## CLI flags [#cli-flags]
 
@@ -344,6 +391,77 @@ For Windows:
 <Callout variant="important">
   This feature works on all Linux and Windows hosts but is not supported on macOS. When installing on macOS, the latest version will always be installed regardless of any specified version.
 </Callout>
+
+## Frequently asked questions [#faq]
+
+<CollapserGroup>
+  <Collapser
+    id="guided-install-upgrade"
+    title="Can I use Guided Install to upgrade my existing agent?"
+  >
+    While the Guided Install command will run on systems with existing agents, it's designed for new installations and will reset configurations to defaults.
+
+    For upgrades that preserve your custom configurations (log settings, custom attributes, labels, etc.), use the [manual upgrade procedures](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent) appropriate for your operating system and installation method. These upgrade steps are simple and maintain all your custom settings.
+  </Collapser>
+
+  <Collapser
+    id="why-factory-reset"
+    title="Why does Guided Install reset configuration files?"
+  >
+    Guided Install is designed to ensure a clean, consistent installation experience. It sets agent configurations to standard default values that work well for most use cases.
+
+    This approach is ideal for new installations where:
+    * No previous agent installation exists
+    * No custom configurations need to be preserved
+    * A quick, automated setup with sensible defaults is preferred
+
+    For scenarios where you need to preserve existing configurations (such as production upgrades), the manual upgrade procedures are the recommended approach.
+  </Collapser>
+
+  <Collapser
+    id="preserve-configs-during-upgrade"
+    title="How do I preserve custom configurations during agent upgrades?"
+  >
+    Use the manual upgrade procedures documented for your specific system:
+
+    * [Linux (apt, yum, zypper)](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent#update)
+    * [Windows (MSI installer)](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent#windows-update-64)
+    * [macOS (Homebrew)](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent#macos-update)
+    * [Configuration management tools](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent#config-mgmt-update)
+
+    These upgrade methods are straightforward (often just one or two commands) and will preserve all your custom configurations, log settings, and manual changes.
+  </Collapser>
+
+  <Collapser
+    id="backup-configs"
+    title="Can I back up my configurations before using Guided Install?"
+  >
+    Yes! If you want to use Guided Install on a system with existing agents, you can back up your configuration files first.
+
+    **Linux:**
+    ```bash
+    # Back up main config file
+    sudo cp /etc/newrelic-infra.yml /etc/newrelic-infra.yml.backup
+
+    # Back up integrations directory
+    sudo cp -r /etc/newrelic-infra /etc/newrelic-infra.backup
+    ```
+
+    **Windows:**
+    ```powershell
+    Copy-Item -Path "C:\Program Files\New Relic\newrelic-infra" -Destination "C:\Program Files\New Relic\newrelic-infra.backup" -Recurse
+    ```
+
+    After Guided Install completes, you can selectively restore custom settings from your backup as needed.
+  </Collapser>
+
+  <Collapser
+    id="telemetry-data"
+    title="Will my historical data in New Relic be affected?"
+  >
+    No. Guided Install only affects local agent configuration files on your host. Your historical telemetry data and dashboards in New Relic remain unchanged.
+  </Collapser>
+</CollapserGroup>
 
 ## Troubleshoot common problems [#troubleshoot]
 

--- a/src/content/docs/infrastructure/infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/update-or-uninstall/update-infrastructure-agent.mdx
@@ -24,6 +24,14 @@ If you need to install the infrastructure agent for the first time, see the inst
 
 If you need to uninstall the infrastructure agent, see [Uninstall the infrastructure agent](/docs/agents/manage-apm-agents/installation/uninstall-agent).
 
+<Callout variant="important">
+  **Note about Guided Install and agent upgrades**
+
+  [Guided Install](/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview) is designed for new host installations. When run on a system with existing agents, it will reset agent configurations to default settings.
+
+  **To upgrade your agent while preserving custom configurations** (log settings, custom attributes, labels, etc.), follow the manual upgrade procedures documented on this page for your specific operating system and installation method.
+</Callout>
+
 ## Identify the infrastructure agent version [#version]
 
 The infrastructure agent doesn't update itself automatically. To see if you have the latest agent version, see the [infrastructure agent release notes](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes).


### PR DESCRIPTION
Jira - https://new-relic.atlassian.net/browse/NR-520228 

Update documentation to clearly communicate that CLI-based Guided Install is designed for initial installations on new hosts. When run on systems with existing agents, it resets configurations to defaults.

#### Changes:
  - Add prominent callout on Guided Install overview page explaining intended use
  - Add "Scope and intended use" section with clear guidance on when to use Guided Install vs manual upgrades
  - Add FAQ section addressing common questions about upgrades and configuration preservation
  - Update "Update Infrastructure Agent" page with notice about Guided Install behavior
  - Include backup instructions for customers who need to preserve configurations
