### PR TITLE
Remove scriptLanguage from monitor runtime details

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/synthetics-api/step-monitor.mdx
@@ -76,12 +76,6 @@ You can create a step monitor using the `syntheticsCreateStepMonitor` mutation. 
       <td>The runtime type version used by your monitor. `100` is the only accepted value.</td>
     </tr>
     <tr>
-      <td>`monitor.runtime.scriptLanguage`</td>
-      <td>String</td>
-      <td>Yes</td>
-      <td>The language used in your monitor. `JAVASCRIPT` is the only accepted value.</td>
-    </tr>
-    <tr>
       <td>`monitor.status`</td>
       <td>Enum</td>
       <td>Yes</td>
@@ -123,7 +117,6 @@ mutation {
       runtime: {
         runtimeType: "RUNTIME_TYPE"
         runtimeTypeVersion: "RUNTIME_TYPE_VERSION"
-        scriptLanguage: "SCRIPT_LANGUAGE"
       }
       status: STATUS
       steps: [
@@ -230,12 +223,6 @@ You can update an existing step monitor using the `syntheticsUpdateStepMonitor` 
       <td>The runtime type version used by your monitor. `100` is the only accepted value.</td>
     </tr>
     <tr>
-      <td>`monitor.runtime.scriptLanguage`</td>
-      <td>String</td>
-      <td>No</td>
-      <td>The language used in your monitor. `JAVASCRIPT` is the only accepted value.</td>
-    </tr>
-    <tr>
       <td>`monitor.status`</td>
       <td>Enum</td>
       <td>No</td>
@@ -277,7 +264,6 @@ mutation {
       runtime: {
         runtimeType: "RUNTIME_TYPE"
         runtimeTypeVersion: "RUNTIME_TYPE_VERSION"
-        scriptLanguage: "SCRIPT_LANGUAGE"
       }
       status: STATUS
       steps: [


### PR DESCRIPTION
Removed 'scriptLanguage' field from monitor runtime configuration in multiple sections. This field is marked as required even though fro step monitor it is not a valid nerdgraph field.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.