### PR TITLE
Added new GPG key for Debain 13 in infra agent installation

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/linux-installation/package-manager-install.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/linux-installation/package-manager-install.mdx
@@ -138,6 +138,13 @@ To install infrastructure in Linux, follow these instructions:
        ```bash
        curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
        ```
+       <DNT>
+         **Debian 13 ("trixie")**
+       </DNT>
+
+       ```bash
+       curl -fsSL https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra-sha256.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/newrelic-infra.gpg
+       ```
      </Collapser>
 
      <Collapser


### PR DESCRIPTION
Added new GPG key for Debain 13 in infra agent installation

Please find the change below 
<img width="1917" height="953" alt="Screenshot 2026-02-18 at 10 08 31 AM" src="https://github.com/user-attachments/assets/b3b18c0b-e20a-4410-87cd-14a7af95f68f" />
