### PR TITLE
docs: clarify server-side log config is Java-only (v8.19.0+)

### DIFF
--- a/src/content/docs/logs/logs-context/disable-automatic-logging.mdx
+++ b/src/content/docs/logs/logs-context/disable-automatic-logging.mdx
@@ -28,6 +28,12 @@ Note that if an APM agent has [high-security mode](/docs/apm/agents/manage-apm-a
 
 You can disable (or re-enable) automatic log forwarding across your entire account via the APM log settings UI or the API. You can also enable or disable log collection for specific agents via agent configuration.
 
+<Callout variant="important">
+  Server-side configuration for application log forwarding is currently **only supported by the Java agent (version 8.19.0 or later)**. For more information, see  [Server-side agent configuration](/docs/apm/agents/manage-apm-agents/configuration/server-side-agent-configuration). 
+  
+  For all other APM agents, you must manage log settings via [client-side configuration](#disable-config).
+</Callout>
+
 <CollapserGroup>
   <Collapser
     className="freq-link"


### PR DESCRIPTION
## Description
Updated the "Options to manage automatic logging settings" section to clarify that server-side configuration for application log forwarding is currently exclusive to the Java agent (v8.19.0 or later).

## Why is this change needed?
While the UI and API suggest account-wide control, the server-side setting actually only impacts Java agents. This update prevents confusion for users of other APM agents (Python, Node.js, Ruby, etc.) who might expect these settings to work for them.

This change was prompted by a discussion regarding the current limitations of server-side configuration. For more context, please refer to the internal Slack discussion: https://newrelic.slack.com/archives/CEQGKUQ80/p1770656453277249

## Changes
- Added an "Important" note before the CollapserGroup to highlight the Java-only requirement.
- Included a link to the "Server-side agent configuration" documentation for further technical context.
- Directed non-Java users to the client-side configuration section for managing their log settings.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.