### PR TITLE
Add documentation release notes for February 16 - February 20, 2026

### DIFF
--- a/src/content/docs/release-notes/docs-release-notes/docs-2-20-2026.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-2-20-2026.mdx
@@ -28,15 +28,11 @@ version: 'February 16 - February 20, 2026'
 
 * Added Swift and Objective-C code samples to [iOS agent documentation](/docs/mobile-monitoring/new-relic-mobile-ios/get-started/introduction-new-relic-mobile-ios).
 * Added RPM key rotation documentation for [PHP agent installation](/docs/apm/agents/php-agent/installation/php-agent-installation-rpm-key-rotation).
-* Added SAP Monitoring tile to the integrations catalog.
 * Added NGINX OpenTelemetry basic optimized configuration to [NGINX OTel documentation](/docs/opentelemetry/integrations/nginx/nginx-otel-overview).
 * Updated [APM application linking](/docs/kubernetes-pixie/kubernetes-integration/advanced-configuration/link-apm-applications-kubernetes) instructions for Kubernetes.
 * Updated [global technical support offerings](/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings) documentation.
 * Updated [.NET agent compatibility documentation](/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements) with latest framework support.
 * Updated [Node.js agent compatibility documentation](/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent) with latest module support.
-* Updated forum.newrelic.com links to support.newrelic.com across documentation.
-* Fixed broken NGINX OpenTelemetry documentation link.
-* Fixed AWS ALB documentation redirects.
 
 ### Release notes
 


### PR DESCRIPTION
## Summary

* Added weekly documentation release notes covering February 16 - February 20, 2026
* Includes 6 new docs, 4 major changes, 1 What's New post, 11 minor changes, and 11 product release notes

## What's included

### New docs
- RabbitMQ OpenTelemetry instrumentation
- Docker OpenTelemetry monitoring
- No-Code Parsing documentation
- Adaptive Telemetry Processor (ATP) documentation
- Azure Execute actions catalog
- Media streaming release notes (Bitmovin, Shaka)

### Major changes
- Dashboard template variables with widget title examples
- OpenTelemetry Kafka Strimzi migration to Prometheus
- OpenTelemetry Kafka docs with NRDOT collector
- Alerts terminology update (incident → alert event)

### Release notes
- Python agent v11.5.0
- Node.js agent v13.13.0
- iOS agent v7.6.2
- Browser agent v1.310.0
- Kubernetes integration v3.54.0
- Fluent Bit v4.2.2
- Logs v260217
- Ping Runtime v1.61.0
- Job Manager release 509
- React Native agent v1.7.0
- Capacitor agent v1.5.16

## Test plan

- [ ] Verify the release notes file renders correctly
- [ ] Verify all links are valid
- [ ] Review content accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)