### PR TITLE
[NR-521141] Documentation update for AWS Autodiscovery

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/connect/set-up-auto-discovery-of-aws-entities.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/connect/set-up-auto-discovery-of-aws-entities.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 <Callout title="preview">
   We're still working on this feature, but we'd love for you to try it out!
 
-  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy). The public preview includes access to AWS Auto-Discovery.<br/>
+  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).<br/>
 </Callout>
 
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/) in your commit messages and pull request title.

## Give us some context

What problems does this PR solve?
Updates outdated documentation for the AWS Auto-Discovery feature to reflect current UI changes and decouple it from the Maps/Transaction 360 preview bundle.

Changes made:
1. Updated preview callout text - Removed references to "New Map experience" and "Transaction 360" bundle. AWS Auto-Discovery is now described as its own standalone preview feature.
2. Updated enrollment instructions - Changed enrollment text from "New experiences: Maps, Transaction 360, and Auto-Discovery" to "AWS Auto-Discovery".
3. Updated "Edit account" section - Renamed to "Manage AWS Integrations" and updated the steps:                                                                                                            
    - Changed "Manage Auto-Discovery" → "Manage AWS Integrations"                                                                                                                                            
    - Changed "Enable" → "Install"                                                                                                                                                                           
    - Added step for clicking "Install" for Auto Discovery
    
Related Jira ticket: https://new-relic.atlassian.net/browse/NR-521141                                                                                                                                      
                                                                                  