### PR TITLE
Update WebLogic compatibility range to 14.1.x

### DIFF
--- a/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
+++ b/src/content/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent.mdx
@@ -154,7 +154,7 @@ The agent automatically instruments these frameworks and libraries:
     * Spray 1.3.1 to latest
     * Tomcat 7.0.0 to latest
     * Undertow 1.1.0.Final to latest
-    * WebLogic 12.1.2.1 to 14.1.1
+    * WebLogic 12.1.2.1 to 14.1.x
     * WebSphere 8 to 9 (exclusive)
     * WebSphere Liberty 8.5 to latest
     * Wildfly 8.0.0.Final to latest


### PR DESCRIPTION
Java agent instrumentation should apply to versions beyond 14.1.1.

