### PR TITLE
Revise Java release notes to add link to OpenTelemetry API compatibil…

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-910.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-910.mdx
@@ -19,10 +19,8 @@ security: []
 
 ## New features and improvements
 
-- The Java Hybrid Agent: offering a "best-of-both-worlds" experience by combining New Relic’s deep visibility with OpenTelemetry API compatibility. This release includes comprehensive support for the OpenTelemetry Tracing, Metrics, and Logs APIs, as well as standalone library and native framework instrumentation. Key enhancements like Span Links and Events on Spans are now available, ensuring seamless interoperability in mixed-mode environments.
-  - Update hybrid agent config based on spec changes by @jasonjkeller in [2738](https://github.com/newrelic/newrelic-java-agent/pull/2738)
+- The Java Hybrid Agent: offering a "best-of-both-worlds" experience by combining New Relic’s deep visibility with [OpenTelemetry API compatibility](https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/opentelemetry-api-support/). This release includes comprehensive support for the OpenTelemetry Tracing, Metrics, and Logs APIs, as well as standalone library and native framework instrumentation. Key enhancements like Span Links and Events on Spans are now available, ensuring seamless interoperability in mixed-mode environments.
   - Hybrid Agent OpenTelemetry API Support by @jasonjkeller in [2711](https://github.com/newrelic/newrelic-java-agent/pull/2711)
-  - OTel Bridge API support by @sdaubin in [1886](https://github.com/newrelic/newrelic-java-agent/pull/1886)
 - Enhancements to coroutine ignores by @dhilpipre in [2726](https://github.com/newrelic/newrelic-java-agent/pull/2726)
 - Add agent metadata action - @mvicknr in [2732](https://github.com/newrelic/newrelic-java-agent/pull/2732)
 [2745](https://github.com/newrelic/newrelic-java-agent/pull/2745)


### PR DESCRIPTION
…ity doc

Updated the description of the Java Hybrid Agent to include a link to OpenTelemetry API compatibility doc and removed some unnecessary PR links.
