### PR TITLE
chore: added date when we dropped support for Node 18. Also preemptively added EOL date of Node 24

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -172,6 +172,19 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
       <tbody>
         <tr>
           <td>
+            24
+          </td>
+
+          <td>
+            April 2028
+          </td>
+
+          <td>
+            TBD
+          </td>
+        </tr>
+        <tr>
+          <td>
             22
           </td>
 
@@ -208,7 +221,7 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
           </td>
 
           <td>
-            TBD
+            As of July 23, 2025, we have discontinued support for Node.js 18 with v13 of the Node.js agent.
           </td>
         </tr>
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
 * We dropped support for Node 18 and forgot to include the date in this table.
 * We also want to broadcast future EOL dates ahead of the release. This adds the EOL date for node 24 as well
