### PR TITLE
Update flex-integration-tool-build-your-own-integration.mdx

### DIFF
--- a/src/content/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration.mdx
+++ b/src/content/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration.mdx
@@ -32,7 +32,7 @@ After collecting and cleaning up the data, you can then [query Flex data](/docs/
 Make sure your system meets these requirements:
 
   1. [Sign up for a free account](https://newrelic.com/signup) if you haven't already. It's free!
-  2. See our [requirements for the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) doc to make sure your system and any on-host integrations you configure meet the requirements. 
+  2. See the [requirements for the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/) document to make sure your system and any on-host integrations you configure meet the requirements. 
   3. Flex comes bundled with our [infrastructure agent](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring/) version 1.10.7 or higher running on Linux, Windows, or Kubernetes.
 
 See the [identify outdated agent versions from the UI](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent/#check-version) document to check your version or the [update the infrastructure agent](/docs/infrastructure/install-infrastructure-agent/update-or-uninstall/update-infrastructure-agent/) document if you need to update it.


### PR DESCRIPTION
It was causing customer confusion that this doc was calling the "account" to be compatible with macOS in the previous point 2 (now removed), when in the fourth (now third) point the bundling of nri-flex was correctly specified as NOT available for macOS. In a discussion with other infra wizards, we concluded that the fluff about the account's compatibility is not required.

