### PR TITLE
docs: add array support for .NET agent custom attributes

### DIFF
--- a/src/content/docs/apm/agents/net-agent/attributes/custom-attributes-net.mdx
+++ b/src/content/docs/apm/agents/net-agent/attributes/custom-attributes-net.mdx
@@ -98,6 +98,16 @@ When adding custom attribute values to transactions, custom events, spans, and e
 
     <tr>
       <td>
+        `arrays`, `Lists`, and other `IEnumerable` types
+      </td>
+
+      <td>
+        Serialized as a JSON array. Individual elements within the array follow the same type conversion rules listed above. Null elements are filtered out and not included in the serialized array. Empty arrays and arrays containing only null values are not recorded. Requires .NET agent version 10.50.0 or later.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         everything else
       </td>
 

--- a/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
+++ b/src/content/docs/apm/agents/net-agent/net-agent-api/net-agent-api.mdx
@@ -921,6 +921,16 @@ The following list contains the different calls you can make with the API, inclu
 
             <tr>
               <td>
+                `arrays`, `Lists`, and other `IEnumerable` types
+              </td>
+
+              <td>
+                Serialized as a JSON array. Individual elements follow the same type conversion rules above. Null elements are filtered out. Empty arrays and arrays containing only null values are not recorded. Requires .NET agent version 10.50.0 or later.
+              </td>
+            </tr>
+
+            <tr>
+              <td>
                 everything else
               </td>
 
@@ -947,7 +957,9 @@ The following list contains the different calls you can make with the API, inclu
         transaction.AddCustomAttribute("customerName","Bob Smith")
             .AddCustomAttribute("currentAge",31)
             .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
-            .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+            .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842))
+            .AddCustomAttribute("colors", new[] { "red", "green", "blue" })
+            .AddCustomAttribute("ids", new List<int> { 1, 2, 3 });
         ```
       </Collapser>
 
@@ -1346,6 +1358,16 @@ The following list contains the different calls you can make with the API, inclu
 
                     <tr>
                       <td>
+                        `arrays`, `Lists`, and other `IEnumerable` types
+                      </td>
+
+                      <td>
+                        Serialized as a JSON array. Individual elements follow the same type conversion rules above. Null elements are filtered out. Empty arrays and arrays containing only null values are not recorded. Requires .NET agent version 10.50.0 or later.
+                      </td>
+                    </tr>
+
+                    <tr>
+                      <td>
                         everything else
                       </td>
 
@@ -1371,14 +1393,16 @@ The following list contains the different calls you can make with the API, inclu
         ### Examples
 
         ```cs
-        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent(); 
-        ISpan currentSpan = agent.CurrentSpan; 
+        IAgent agent = NewRelic.Api.Agent.NewRelic.GetAgent();
+        ISpan currentSpan = agent.CurrentSpan;
 
         currentSpan
             .AddCustomAttribute("customerName","Bob Smith")
             .AddCustomAttribute("currentAge",31)
             .AddCustomAttribute("birthday", new DateTime(2000, 02, 14))
-            .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842));
+            .AddCustomAttribute("waitTime", TimeSpan.FromMilliseconds(93842))
+            .AddCustomAttribute("colors", new[] { "red", "green", "blue" })
+            .AddCustomAttribute("ids", new List<int> { 1, 2, 3 });
         ```
       </Collapser>
 


### PR DESCRIPTION
## Give us some context

* Documents the new array/`IEnumerable` support for `AddCustomAttribute()` in the .NET agent API, added in [agent PR #3456](https://github.com/newrelic/newrelic-dotnet-agent/pull/3456).
* Updates three locations to add array type documentation and code examples:
  - **`custom-attributes-net.mdx`** — Added `arrays`, `Lists`, and other `IEnumerable` types to the .NET type table
  - **`net-agent-api.mdx` (ITransaction.AddCustomAttribute)** — Added array type row and array examples
  - **`net-agent-api.mdx` (ISpan.AddCustomAttribute)** — Added array type row and array examples
* Key behaviors documented:
  - Arrays are serialized as JSON arrays
  - Null elements are filtered out
  - Empty arrays and null-only arrays are not recorded
  - Requires .NET agent version 10.50.0 or later