### PR TITLE
fix: Data dictionary reload/crash bug

### DIFF
--- a/src/hooks/useActiveHash.js
+++ b/src/hooks/useActiveHash.js
@@ -33,7 +33,7 @@ const useActiveHash = (ids) => {
 
       if (element && element.id !== activeHashRef.current) {
         setActiveHash(element.id);
-        activeHashRef.current = element.idj;
+        activeHashRef.current = element.id;
       }
     };
 


### PR DESCRIPTION
👋 Hello! Former NR docs person here. Realized the data dictionary is broken on mobile and it's a one-character fix.

Line 36 has `element.idj` (typo — idj instead of id), so `activeHashRef.current` is always set to undefined. That means the guard on line 34:                        

```         
if (element && element.id !== activeHashRef.current) {                           
```

is always true on every scroll event, so `setActiveHash` fires on every single scroll tick, triggering a re-render every time. On desktop that's just wasteful,but on iOS Safari:

- Re-renders can trigger layout recalculations
- The data dictionary page is large (lots of events/attributes)
- Each re-render may cause the scroll handler to fire again
- iOS Safari has a much lower memory ceiling and will kill the tab when it gets overwhelmed