### PR TITLE
docs(gcp): Add Cloud Run Service entity documentation

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration.mdx
@@ -51,15 +51,29 @@ Data is attached to the following [event type](/docs/data-apis/understand-data/n
   <tbody>
     <tr>
       <td>
+        Service
+      </td>
+
+      <td>
+        `GcpCloudRunServiceSample`
+      </td>
+
+      <td>
+        `GcpCloudRunService`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         Revision
       </td>
 
       <td>
-        `GcpRunRevisionSample`
+        `GcpCloudRunRevisionSample`
       </td>
 
       <td>
-        `GcpRunRevision`
+        `GcpCloudRunRevision`
       </td>
     </tr>
   </tbody>
@@ -69,9 +83,115 @@ For more on how to use your data, see [Understand and use integration data](/doc
 
 ## Metric data [#metrics]
 
-This integration collects GCP Run data for Revision.
+This integration collects GCP Cloud Run data for Service and Revision.
 
-### Run Revision data
+### Cloud Run Service data
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "275px" }}>
+        Metric
+      </th>
+
+      <th style={{ width: "150px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of requests received by the service. Labeled by response code and response code class.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `request_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Distribution of request latencies. Labeled by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `container.cpu.utilizations`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Container CPU utilization.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `container.memory.utilizations`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Container memory utilization.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `container.instance_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of running container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `billable_instance_time`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Total billable instance time.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Cloud Run Revision data
 
 <table>
   <thead>


### PR DESCRIPTION
## Summary
- Add GcpCloudRunServiceSample entity to Cloud Run documentation
- Update Revision entity naming to match GcpCloudRunRevisionSample
- Add Service metrics documentation (request_count, latencies, CPU/memory utilization, instance_count, billable_time)

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Confirm metric names match backend configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**TEST MODE**: This PR is for testing the entity creation agent workflow.