### PR TITLE
docs(gcp): Add Apigee monitoring integration documentation

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-apigee-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-apigee-monitoring-integration.mdx
@@ -1,0 +1,178 @@
+---
+title: Google Apigee monitoring integration
+tags:
+  - Integrations
+  - Google Cloud Platform integrations
+  - GCP integrations list
+metaDescription: 'New Relic Google Apigee integration: the data it reports and how to enable it.'
+redirects:
+  - /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-apigee-monitoring-integration
+  - /docs/gcp-gcp_apigee-integration
+freshnessValidatedDate: never
+---
+
+We offer a cloud integration for reporting your GCP Apigee data to our platform. Here we explain how to activate the integration and what data it collects.
+
+## Activate the integration [#activate]
+
+To enable the integration follow standard procedures to [connect your GCP service](/docs/connect-google-cloud-platform-services-infrastructure).
+
+## Configuration and polling [#polling]
+
+You can change the polling frequency and filter data using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+
+Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations) information for the GCP Apigee integration:
+
+* New Relic polling interval: 5 minutes
+
+## Find and use data [#find-data]
+
+To find your integration data, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP**</DNT> and select the integration.
+
+Data is attached to the following [event types](/docs/data-apis/understand-data/new-relic-data-types/#event-data):
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Entity
+      </th>
+
+      <th>
+        Event Type
+      </th>
+
+      <th>
+        Provider
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Proxy
+      </td>
+
+      <td>
+        `GcpApigeeProxySample`
+      </td>
+
+      <td>
+        `GcpApigeeProxy`
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For more on how to use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
+
+## Metric data [#metrics]
+
+This integration collects GCP Apigee data for Proxy.
+
+### Apigee Proxy data
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "275px" }}>
+        Metric
+      </th>
+
+      <th style={{ width: "150px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of API requests processed by the proxy. Labeled by response code and fault code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `response_time`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Total time from request received to response sent.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `target_response_time`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Time spent waiting for target backend response.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `policy_error_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of policy execution errors. Labeled by policy name and fault code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `upstream_target_response_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of responses from upstream targets. Labeled by target name and response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `message_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Total number of messages processed.
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- Add documentation for GCP Apigee Proxy integration
- Document GcpApigeeProxySample entity and metrics
- Metrics: request_count, response_time, target_response_time, policy_error_count, upstream_target_response_count, message_count

## Test plan
- [ ] Verify documentation renders correctly
- [ ] Confirm metric names match backend configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**TEST MODE**: This PR is for testing the entity creation agent workflow.