### PR TITLE
Left nav update

### DIFF
--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -119,8 +119,6 @@ pages:
         path: /docs/mobile-monitoring/new-relic-mobile-unity/monitor-your-unity-application
       - title: Unreal Engine
         path: /docs/mobile-monitoring/new-relic-mobile-unreal-engine/monitor-your-unreal-engine-application
-      - title: Xamarin
-        path: /docs/mobile-monitoring/new-relic-mobile-xamarin/monitor-your-xamarin-application
 
   - title: View data in New Relic
     pages:


### PR DESCRIPTION
Removed Xamarin from the left nav as it was it's [EOL'd](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy/#xamarin-eol) and the files were deleted in this [PR](https://github.com/newrelic/docs-website/pull/23015).