### PR TITLE
Add callout for AWS region-specific sink setup

### DIFF
--- a/src/install/aws-cloudwatch/intro.mdx
+++ b/src/install/aws-cloudwatch/intro.mdx
@@ -11,6 +11,12 @@ Amazon CloudWatch Metric Streams is an AWS service that creates a real-time stre
     src="/images/infrastructure_screenshot-full_CloudWatch-Metric-Streams.webp" 
 />
 
+    <Callout variant="important">
+        Each account can have one sink per region, so if you need to monitor multiple regions, you need to set up a sink for each region.
+    </Callout>
+
+You're [Collecting data from multiple AWS accounts](https://docs.newrelic.com/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account/) you may need to have one sink per region, so if you need to monitor multiple regions, you need to set up a sink for each region..
+
 <figcaption>
     Once you forward your AWS data to New Relic, you can view your data in a dashboard. 
 </figcaption>


### PR DESCRIPTION
Added important callout about region-specific sinks for AWS monitoring.

We should link out to this documentation and add a caution banner so customers know before they start doing initial setup.

https://docs.newrelic.com/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account/


## Give us some context

* What problems does this PR solve?
* Confusion with sending multiple metric streams to New Relic.
