### PR TITLE
chor: Added the new relic app name information in the docs

### DIFF
--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -129,6 +129,20 @@ Replace `<key>` with your New Relic license key and `<cluster-name>` with your c
 
 The [`values.yaml`](https://github.com/newrelic/helm-charts/blob/master/charts/nr-ebpf-agent/values.yaml) file contains the following configuration sections:
 
+<Callout variant="tip">
+
+The eBPF agent automatically generates entity names differently depending on the environment:
+
+    * In hosts or Docker, these names are a combination of the process name, its directory or container ID, and the listening port. For example, `ruby:/home/ubuntu/app:[5678]` or `java:f4aead533895:[8080]`.
+
+    * In Kubernetes, these names are derived from the service name for example, `mysql-database-service`.
+
+Assigning custom name to applications:
+
+    * You can assign a custom name to your application by setting the `NEW_RELIC_APP_NAME` environment variable for both Kubernetes and on-host applications.
+
+</Callout>
+
 <CollapserGroup>
 
     <Collapser

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -118,6 +118,20 @@ To get the latest installation command:
 
 The `newrelic-ebpf-agent.conf` file contains the following configuration parameters:
 
+<Callout variant="tip">
+
+The eBPF agent automatically generates entity names differently depending on the environment:
+
+    * In hosts or Docker, these names are a combination of the process name, its directory or container ID, and the listening port. For example, `ruby:/home/ubuntu/app:[5678]` or `java:f4aead533895:[8080]`.
+
+    * In Kubernetes, these names are derived from the service name for example, `mysql-database-service`.
+
+Assigning custom name to applications:
+
+    * You can assign a custom name to your application by setting the `NEW_RELIC_APP_NAME` environment variable for both Kubernetes and on-host applications.
+
+</Callout>
+
 <CollapserGroup>
 
     <Collapser

--- a/src/content/docs/ebpf/network-metrics.mdx
+++ b/src/content/docs/ebpf/network-metrics.mdx
@@ -170,9 +170,7 @@ The eBPF agent automatically generates entity names differently depending on the
 
 Assigning custom name to applications:
 
-    * You can assign a name of your choice to your application by setting the `NEW_RELIC_APP_NAME` environment variable for both docker containers and on-host applications.
-
-    * The named application will appear in the New Relic UI suffixed with `-ebpf`.
+    * You can assign a custom name to your application by setting the `NEW_RELIC_APP_NAME` environment variable for both Kubernetes and on-host applications.
 
 </Callout>
 


### PR DESCRIPTION
This PR adds the NEW_RELIC_APP_NAME environment variable information to the eBPF documentation