### PR TITLE
feat: Diagnostics CLI 3.7.0 release notes

### DIFF
--- a/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/diagnostics-cli-370.mdx
+++ b/src/content/docs/release-notes/diagnostics-release-notes/diagnostics-cli-release-notes/diagnostics-cli-370.mdx
@@ -1,0 +1,14 @@
+---
+subject: Diagnostics CLI (nrdiag)
+releaseDate: '2026-03-09'
+version: 3.7.0
+downloadLink: 'https://download.newrelic.com/nrdiag/nrdiag_3.7.0.zip'
+---
+
+## Fixes
+
+* Sensitive values such as License Keys and passwords are now obfuscated in all task outputs including in the JSON file and any config files that are collected ([#260](https://github.com/newrelic/newrelic-diagnostics-cli/pull/260)).
+
+## Task Updates
+
+* Updated `Infra/Agent/Connect` to handle additional success responses from the endpoints ([#260](https://github.com/newrelic/newrelic-diagnostics-cli/pull/260)).


### PR DESCRIPTION
These are the release notes for the Diagnostics CLI version 3.7.0