### PR TITLE
fix(serialization): preserve JSX comments through translation pipeline using data attributes

### DIFF
--- a/scripts/actions/serialize-mdx.mjs
+++ b/scripts/actions/serialize-mdx.mjs
@@ -11,8 +11,6 @@ import rehypeStringify from 'rehype-stringify10';
 import format from 'rehype-format';
 import customHeadingIds from '../../plugins/gatsby-remark-custom-heading-ids/utils/visitor.js';
 
-import { inspect } from 'util';
-
 const mdxElement = (state, node) => {
   const handler = handlers[node.name];
 
@@ -40,6 +38,35 @@ const mdxSpanExpression = (h, node) => {
   return h.handlers.text(h, node);
 };
 
+// Handle MDX flow expressions (e.g., JSX comments like {/* ... */})
+// Serialize them using the same pattern as imports/frontmatter - data attributes with base64
+const mdxFlowExpression = (_h, node) => {
+  // Check if this is a comment (starts with /* and ends with */)
+  if (node.value && node.value.trim().match(/^\/\*[\s\S]*?\*\/$/)) {
+    // Use the mdxComment handler for JSX comments
+    return handlers.mdxComment.serialize(null, node);
+  }
+
+  // For non-comment expressions, convert to text (default behavior)
+  return {
+    type: 'text',
+    value: `{${node.value}}`,
+  };
+};
+
+// Handle MDX text expressions (inline expressions like {value})
+const mdxTextExpression = (_h, node) => {
+  // Check if this is a comment
+  if (node.value && node.value.trim().match(/^\/\*[\s\S]*?\*\/$/)) {
+    return handlers.mdxComment.serialize(null, node);
+  }
+
+  return {
+    type: 'text',
+    value: `{${node.value}}`,
+  };
+};
+
 
 const processor = unified()
   .use(toMDAST)
@@ -55,6 +82,8 @@ const processor = unified()
       mdxJsxTextElement: mdxElement,
       mdxJsxFlowElement: mdxElement,
       mdxSpanExpression,
+      mdxFlowExpression,
+      mdxTextExpression,
       code: handlers.CodeBlock.serialize,
     },
   })

--- a/scripts/actions/utils/handlers.mjs
+++ b/scripts/actions/utils/handlers.mjs
@@ -59,6 +59,37 @@ export default {
       };
     },
   },
+  mdxComment: {
+    deserialize: (_state, node) => {
+      const value = Buffer.from(node.properties.dataValue, 'base64').toString();
+
+      return {
+        type: 'mdxFlowExpression',
+        value,
+        data: {
+          estree: {
+            type: 'Program',
+            body: [],
+            sourceType: 'module',
+            comments: [{
+              type: 'Block',
+              value: value.slice(2, -2), // Remove /* and */
+            }],
+          },
+        },
+      };
+    },
+    serialize: (_state, node) => {
+      return {
+        type: 'element',
+        tagName: 'div',
+        properties: {
+          'data-type': 'mdxComment',
+          'data-value': Buffer.from(node.value).toString('base64'),
+        },
+      };
+    },
+  },
   frontmatter: {
     deserialize: (_state, node) => {
       const data = deserializeJSValue(node.properties.dataValue);


### PR DESCRIPTION
## Summary
This PR aims to implement JSX comment preservation during MDX serialization/deserialization using HTML elements with data attributes, following the existing pattern used for CodeBlock, imports, and frontmatter.

## Problem
JSX comments like `{/* ... */}` were not passing mdx checks in the translation pipeline. Previous attempts using HTML comments with markers (`<!-- [JSX_COMMENT]... -->`) were reverted because Smartling/translation tools modify HTML comments.

## Changes
Added `mdxComment` handler that:
- Serializes JSX comments to: `<div data-type="mdxComment" data-value="base64_encoded">`
- Uses the same pattern as CodeBlock/import/frontmatter handlers
- Data attributes are preserved by translation tools

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->