### PR TITLE
chore(.net agent): Updating latest supported framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -413,7 +413,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                   * Minimum supported version: 3.17.0
-                  * Latest verified compatible version: 3.57.0
+                  * Latest verified compatible version: 3.57.1
                   * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                 </td>
                 </tr>
@@ -572,7 +572,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.11.0
+            Latest verified compatible version: 2.11.8
                 </td>
                 </tr>
 
@@ -623,7 +623,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [EnyimMemcachedCore](https://www.nuget.org/packages/EnyimMemcachedCore).
 
                   * Minimum supported version: 2.0.0
-                  * Latest verified compatible version: 3.4.5
+                  * Latest verified compatible version: 3.4.6
                 </td>
                 </tr>
 
@@ -643,7 +643,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.14
+                  * Latest verified compatible version: 4.0.15
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -771,7 +771,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.16
+                    4.0.16.1
                 </td>
                 </tr>
                 <tr>
@@ -846,7 +846,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    3.2.0
+                    3.3.0
                 </td>
 
                 </tr>
@@ -877,7 +877,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    6.1.0
+                    6.1.1
                 </td>
                 </tr>
 
@@ -935,7 +935,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 1.4.0
 
-                    * Latest verified compatible version: 2.13.0
+                    * Latest verified compatible version: 2.13.1
                 </td>
                 </tr>
 
@@ -1003,7 +1003,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.2.14
+                  * Latest verified compatible version: 4.0.2.15
                 </td>
                 </tr>
 
@@ -1017,7 +1017,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.8
+                  * Latest verified compatible version: 4.0.8.1
                 </td>
                 </tr>
 
@@ -1031,7 +1031,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.13
+                  * Latest verified compatible version: 4.0.3.14
                 </td>
                 </tr>
 
@@ -1461,7 +1461,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                         * Minimum supported version: 3.17.0
-                        * Latest verified compatible version: 3.57.0
+                        * Latest verified compatible version: 3.57.1
                         * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                       </td>
                     </tr>
@@ -1700,7 +1700,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.11.0
+                        * Latest verified compatible version: 2.11.8
                     </td>
                     </tr>
 
@@ -1752,7 +1752,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [EnyimMemcachedCore](https://www.nuget.org/packages/EnyimMemcachedCore).
 
                   * Minimum supported version: 2.0.0
-                  * Latest verified compatible version: 3.4.5
+                  * Latest verified compatible version: 3.4.6
                 </td>
                 </tr>
 
@@ -1772,7 +1772,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.14
+                  * Latest verified compatible version: 4.0.15
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1940,7 +1940,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.16
+                        4.0.16.1
                     </td>
                     </tr>
                     <tr>
@@ -2016,7 +2016,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        3.2.0
+                        3.3.0
                     </td>
                     </tr>
 
@@ -2046,7 +2046,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        6.1.0
+                        6.1.1
                     </td>
                     </tr>
 
@@ -2104,7 +2104,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 1.4.0
 
-                        * Latest verified compatible version: 2.13.0
+                        * Latest verified compatible version: 2.13.1
                     </td>
                     </tr>
 
@@ -2181,7 +2181,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.2.14
+                        * Latest verified compatible version: 4.0.2.15
                     </td>
                     </tr>
 
@@ -2195,7 +2195,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.8
+                    * Latest verified compatible version: 4.0.8.1
                     </td>
                     </tr>
 
@@ -2209,7 +2209,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.3.13
+                    * Latest verified compatible version: 4.0.3.14
                     </td>
                     </tr>
 


### PR DESCRIPTION
## Summary
- Updates "latest verified compatible version" for 11 packages in the .NET agent compatibility docs
- Based on Dotty PR https://github.com/newrelic/newrelic-dotnet-agent/pull/3463

### Updated packages
| Package | Old Version | New Version |
|---|---|---|
| Microsoft.Azure.Cosmos | 3.57.0 | 3.57.1 |
| StackExchange.Redis | 2.11.0 | 2.11.8 |
| EnyimMemcachedCore | 3.4.5 | 3.4.6 |
| AWSSDK.DynamoDBv2 | 4.0.14 | 4.0.15 |
| AWSSDK.BedrockRuntime | 4.0.16 | 4.0.16.1 |
| log4net | 3.2.0 | 3.3.0 |
| NLog | 6.1.0 | 6.1.1 |
| Confluent.Kafka | 2.13.0 | 2.13.1 |
| AWSSDK.SQS | 4.0.2.14 | 4.0.2.15 |
| AWSSDK.Kinesis | 4.0.8 | 4.0.8.1 |
| AWSSDK.KinesisFirehose | 4.0.3.13 | 4.0.3.14 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)