### PR TITLE
fix: correct releaseDate year for Lambda Extension v2.4.2–v2.4.5

### DIFF
--- a/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.2.mdx
+++ b/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.2.mdx
@@ -1,6 +1,6 @@
 ---
 subject: "Lambda-Extension"
-releaseDate: '2025-01-08'
+releaseDate: '2026-01-08'
 version: 2.4.2
 ---
 

--- a/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.3.mdx
+++ b/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.3.mdx
@@ -1,6 +1,6 @@
 ---
 subject: "Lambda-Extension"
-releaseDate: '2025-01-09'
+releaseDate: '2026-01-09'
 version: 2.4.3
 ---
 

--- a/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.4.mdx
+++ b/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.4.mdx
@@ -1,6 +1,6 @@
 ---
 subject: "Lambda-Extension"
-releaseDate: '2025-01-23'
+releaseDate: '2026-01-23'
 version: 2.4.4
 ---
 

--- a/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.5.mdx
+++ b/src/content/docs/release-notes/lambda-extension-release-notes/lambda-extension-2.4.5.mdx
@@ -1,6 +1,6 @@
 ---
 subject: "Lambda-Extension"
-releaseDate: '2025-01-29'
+releaseDate: '2026-01-29'
 version: 2.4.5
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes incorrect `releaseDate` values introduced in #22898. Versions 2.4.2 through 2.4.5 had the year set to `2025` instead of `2026` — a new-year rollover mistake that causes logical ordering errors and directly impacts translation PRs.

**Flagged by Aashirwad Jain via Slack:** https://newrelic.slack.com/archives/C0DSGL3FZ/p1772091958556989

Dates were verified against the official Lambda Extension release page: https://github.com/newrelic/newrelic-lambda-extension/releases

## Changes

| File | Old `releaseDate` | Correct `releaseDate` |
|------|------------------|----------------------|
| lambda-extension-2.4.2.mdx | `2025-01-08` | `2026-01-08` |
| lambda-extension-2.4.3.mdx | `2025-01-09` | `2026-01-09` |
| lambda-extension-2.4.4.mdx | `2025-01-23` | `2026-01-23` |
| lambda-extension-2.4.5.mdx | `2025-01-29` | `2026-01-29` |

cc @Sashwatdas123 — the `releaseDate` values in your original PR #22898 for the January 2026 releases were set to `2025`, this PR corrects them. Thanks for the contribution!