### PR TITLE
docs: add explanation about metric level

### DIFF
--- a/src/content/docs/opentelemetry/collector-observability/collector-observability.mdx
+++ b/src/content/docs/opentelemetry/collector-observability/collector-observability.mdx
@@ -91,7 +91,7 @@ The tag <DNT>`newrelic.service.type: otel_collector`</DNT> acts as an opt-in to 
 
 The default configuration exposes additional environment variables of the form `INTERNAL_TELEMETRY_...` to tweak common options such as detail levels and sampling. Refer to the [configuration itself](https://github.com/newrelic/nrdot-collector-releases/blob/main/examples/internal-telemetry-config.yaml) for more details.
 
-We recommend using the default configuration to monitor your collector. However, you can modify the example configuration to meet your needs, such as reducing sampling or data collection rates. Refer to the [official documentation](https://opentelemetry.io/docs/collector/internal-telemetry/) for more details. Keep in mind that changes to the configuration may cause certain parts of the UI to not display data. Also refer to [Limitations](#limitations). The collector's internal telemetry configuration options change as the OTel community evolves. You have full control over your configuration, including whether to use the provided defaults.
+We recommend using the default configuration to monitor your collector. However, you can modify the example configuration to meet your needs, such as reducing detail level, sampling or data collection rates. Refer to the [official documentation](https://opentelemetry.io/docs/collector/internal-telemetry/) for more details. Keep in mind that changes to the configuration may cause certain parts of the UI to not display data. Also refer to [Limitations](#limitations). The collector's internal telemetry configuration options change as the OTel community evolves. You have full control over your configuration, including whether to use the provided defaults.
 
 #### Overhead considerations
 
@@ -99,6 +99,8 @@ Like all telemetry, the collector's internal telemetry increases your data inges
 
 **Metrics**
 Creates constant overhead for the collector and all active components, regardless of throughput. Metrics are emitted at a constant interval (60 seconds by default). Any component can emit custom metrics, as indicated by the respective [metadata.yaml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/metadata.yaml#L20), which may add to the overhead.
+
+If you need to reduce the amount of metrics your collector emits, we recommend setting the metric level to <DNT>`normal`</DNT>, e.g. via the environment variable <DNT>`INTERNAL_TELEMETRY_METRICS_LEVEL`</DNT> in the example config, as only a subset of the <DNT>`detailed`</DNT> metrics are used by the UI and are typically metrics intended for fine-tuning performance or network issues, so you can re-enable them as needed.
 
 **Logs**
 Has minimal impact during normal operation. Higher overhead can occur when error logs increase rapidly, but this is reduced because logs are sampled by default. The sampling algorithm allows a constant number of logs per defined interval and then samples at a static rate. Refer to [service::telemetry::logs::sampling](https://github.com/newrelic/nrdot-collector-releases/blob/main/examples/internal-telemetry-config.yaml).


### PR DESCRIPTION
## Context
- Follow-up to #23412 to clarify the remaining use of `detailed` level metrics for Collector Observability.