### PR TITLE
chore(.net agent): Updating latest supported library versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -518,7 +518,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                   Minimum supported version: 2.3.0
 
-                  Latest verified compatible version: 3.6.0
+                  Latest verified compatible version: 3.7.0
 
                   Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -572,7 +572,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.11.8
+            Latest verified compatible version: 2.12.1
                 </td>
                 </tr>
 
@@ -643,7 +643,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.15
+                  * Latest verified compatible version: 4.0.15.2
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -771,7 +771,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.16.1
+                    4.0.16.3
                 </td>
                 </tr>
                 <tr>
@@ -892,7 +892,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0
                 </td>
                 <td>
-                    10.0.3
+                    10.0.5
                 </td>
                 </tr>
             </tbody>
@@ -935,7 +935,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 1.4.0
 
-                    * Latest verified compatible version: 2.13.1
+                    * Latest verified compatible version: 2.13.2
                 </td>
                 </tr>
 
@@ -1003,7 +1003,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.2.15
+                  * Latest verified compatible version: 4.0.2.17
                 </td>
                 </tr>
 
@@ -1017,7 +1017,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.8.1
+                  * Latest verified compatible version: 4.0.8.3
                 </td>
                 </tr>
 
@@ -1031,7 +1031,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.14
+                  * Latest verified compatible version: 4.0.3.16
                 </td>
                 </tr>
 
@@ -1588,7 +1588,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     <td>
                       Minimum supported version: 2.3.0
 
-                      Latest verified compatible version: 3.6.0
+                      Latest verified compatible version: 3.7.0
 
                       Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -1700,7 +1700,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.11.8
+                        * Latest verified compatible version: 2.12.1
                     </td>
                     </tr>
 
@@ -1772,7 +1772,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.15
+                  * Latest verified compatible version: 4.0.15.2
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1940,7 +1940,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.16.1
+                        4.0.16.3
                     </td>
                     </tr>
                     <tr>
@@ -2061,7 +2061,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        10.0.3
+                        10.0.5
                     </td>
                     </tr>
                 </tbody>
@@ -2181,7 +2181,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.2.15
+                        * Latest verified compatible version: 4.0.2.17
                     </td>
                     </tr>
 
@@ -2195,7 +2195,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.8.1
+                    * Latest verified compatible version: 4.0.8.3
                     </td>
                     </tr>
 
@@ -2209,7 +2209,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.3.14
+                    * Latest verified compatible version: 4.0.3.16
                     </td>
                     </tr>
 


### PR DESCRIPTION
## Summary

Updates the .NET agent compatibility and requirements docs with latest tested library versions from the [Dotty PR](https://github.com/newrelic/newrelic-dotnet-agent/pull/3488):

- MongoDB.Driver: 3.6.0 → 3.7.0
- StackExchange.Redis: 2.11.8 → 2.12.1
- AWSSDK.DynamoDBv2: 4.0.15 → 4.0.15.2
- AWSSDK.BedrockRuntime: 4.0.16.1 → 4.0.16.3
- Microsoft.Extensions.Logging: 10.0.3 → 10.0.5
- AWSSDK.SQS: 4.0.2.15 → 4.0.2.17
- AWSSDK.Kinesis: 4.0.8.1 → 4.0.8.3
- AWSSDK.KinesisFirehose: 4.0.3.14 → 4.0.3.16
- Confluent.Kafka: 2.13.1 → 2.13.2 (.NET Core only)

Note: OpenAI was reverted to 2.8.0 in the Dotty PR due to a transitive dependency conflict with Azure.AI.OpenAI; docs not updated for OpenAI/Azure.AI.OpenAI.

## Test plan
- [ ] Verify version numbers match the Dotty PR package updates