### PR TITLE
Remove Go Easy Experimental tags

### DIFF
--- a/src/content/docs/apm/agents/go-agent/installation/install-automation-new-relic-go.mdx
+++ b/src/content/docs/apm/agents/go-agent/installation/install-automation-new-relic-go.mdx
@@ -81,7 +81,6 @@ go install github.com/newrelic/go-easy-instrumentation@latest
     </Collapser>
 </CollapserGroup>
 
-The Go easy instrumentation tool provides suggestions for instrumenting your Go application. Review these suggestions carefully to decide which ones you wish to implement.
 
 <Callout title="suggestion generation">
 The Go easy instrumentation tool provides suggestions for instrumenting your Go application. Review the outputted diff file carefully to verify correctness of instrumentation.


### PR DESCRIPTION
Removed preview tags from go easy page. We are launching in GA