### PR TITLE
Updating API links from REST to Nerdgraph for Secure Credentials

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests.mdx
@@ -15,7 +15,7 @@ freshnessValidatedDate: never
 
 You can use secure credentials with synthetic monitoring to store critical information, such as passwords, API keys, usernames, etc. This prevents scripted monitor users from viewing, updating, or deleting these values unless they have explicit permissions in New Relic.
 
-You can set secure credentials in New Relic or with the [API](/docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis). The credentials are securely stored using AES-GCM 256-bit encryption at rest with keys managed by [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/).
+You can set secure credentials in New Relic or with the [Nerdgraph API](/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials). The credentials are securely stored using AES-GCM 256-bit encryption at rest with keys managed by [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/).
 
 To learn how to secure sensitive information in your synthetic monitoring workflows, watch this short video (3:15 minutes):
 
@@ -76,7 +76,7 @@ Before [using secure credentials](#ui-procedures), review these requirements and
 
 ## Add or update secure credentials [#ui-procedures]
 
-You can add or update secure credentials using the UI or the [synthetic monitoring REST API](/docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis#add-secure-credential). Note, values cannot be viewed, only keys.
+You can add or update secure credentials using the UI or the [synthetic monitoring Nerdgraph API](/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials). Note, values cannot be viewed, only keys.
 
 <Callout variant="caution">
   New Relic recommends not to store secure credentials/keys on the `Description` field as it can lead to potential security issues.
@@ -87,7 +87,7 @@ To add, view, edit, or delete a secure credential key for a scripted browser or 
 1. Go to <DNT>**[one.newrelic.com > Synthetic monitoring > Secure credentials](https://one.newrelic.com/synthetics-nerdlets/secure-credential-list)**</DNT>.
 2. To add a new secure credential, look for the <DNT>**Create secure credential +**</DNT> button. If you have credentials already added, this button is at the top right.
    * Tips for creating the <DNT>**Key**</DNT>: choose a username or other meaningful key name to identify the secure credential. Use alphanumeric or underscore `_` characters. Key names must be UPPERCASE.
-   * Tips for creating the <DNT>**Value**</DNT>: Use any combination of alphanumeric or special characters. 10000 characters maximum. This field is not accessible via [the API](/docs/apis/synthetics-rest-api/secure-credentials-examples/use-synthetics-secure-credentials-apis).
+   * Tips for creating the <DNT>**Value**</DNT>: Use any combination of alphanumeric or special characters. 10000 characters maximum. This field is not accessible via [the Nerdgraph API](/docs/apis/nerdgraph/examples/synthetics-api/secure-credentials).
 3. To edit an existing credential, click the ellipsis <Icon name="fe-more-horizontal"/> icon for options.
 4. Associate the secure credential with a scripted browser or API test by [editing the script](#script-procedures).
 


### PR DESCRIPTION
An outdated link in the synthetics documentation was flagged by a wizard. This doc includes a link to the synthetics REST API for updating secure credential values. We shouldn't be pointing anyone to the REST API and instead point users to Nerdgraph API. Made changes accordingly in this doc

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.