### PR TITLE
fix: added old docs redirect

### DIFF
--- a/src/content/docs/change-tracking/change-tracking-webhooks.mdx
+++ b/src/content/docs/change-tracking/change-tracking-webhooks.mdx
@@ -5,8 +5,7 @@ tags:
 metaDescription: "After you set up the changes you want to monitor, you can use a webhook to notify your colleagues about the impacts of those changes."
 redirects:
   - /docs/change-tracking/change-tracking-webhooks
-  - /docs/change-tracking/change-tracking-slack/
-  - /docs/change-tracking/change-tracking-webhooks/
+  - /docs/change-tracking/change-tracking-slack
 freshnessValidatedDate: 2023-08-29
 ---
 


### PR DESCRIPTION
This PR adds the redirect link to change tracking docs for older slack doc which is merge into Notify your team doc.