### PR TITLE
Fix link formatting for Java agent 9.2.0 release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-920.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/java-release-notes/java-agent-920.mdx
@@ -19,26 +19,25 @@ security: []
 
 ## New features and improvements
 
-* Adds Java 26 support https://github.com/newrelic/newrelic-java-agent/pull/2734
-* Adds Serverless mode for AWS Lambda monitoring with the Java agent https://github.com/newrelic/newrelic-java-agent/pull/2609 https://github.com/newrelic/newrelic-java-agent/pull/2615 https://github.com/newrelic/newrelic-java-agent/pull/2625 https://github.com/newrelic/newrelic-java-agent/pull/2633 https://github.com/newrelic/newrelic-java-agent/pull/2640 https://github.com/newrelic/newrelic-java-agent/pull/2641 https://github.com/newrelic/newrelic-java-agent/pull/2647 https://github.com/newrelic/newrelic-java-agent/pull/2673 https://github.com/newrelic/newrelic-java-agent/pull/2716 https://github.com/newrelic/newrelic-java-agent/pull/2721 https://github.com/newrelic/newrelic-java-agent/pull/2735 https://github.com/newrelic/newrelic-java-agent/pull/2723 https://github.com/newrelic/newrelic-java-agent/pull/2740 https://github.com/newrelic/newrelic-java-agent/pull/2769 https://github.com/newrelic/newrelic-java-agent/pull/2782 https://github.com/newrelic/newrelic-java-agent/pull/2794 https://github.com/newrelic/newrelic-java-agent/pull/2797 https://github.com/newrelic/newrelic-java-agent/pull/2796 https://github.com/newrelic/newrelic-java-agent/pull/2806
-* Adds new `application_logging.forwarding.log_level_denylist` config https://github.com/newrelic/newrelic-java-agent/pull/2764
-* Implements region aware event/metric ingest URIs https://github.com/newrelic/newrelic-java-agent/pull/2749 https://github.com/newrelic/newrelic-java-agent/pull/2790 https://github.com/newrelic/newrelic-java-agent/pull/2790
-* Adds support for associating logs to corresponding entity when `enable_auto_app_naming` is `true` https://github.com/newrelic/newrelic-java-agent/pull/2627
-* Add `opentelemetry-sdk-extension-autoconfigure-1.59.0` instrumentation for OpenTelemetry 1.59.0+ https://github.com/newrelic/newrelic-java-agent/pull/2786
-* Adds support for associating adaptive sampler to corresponding entity when `enable_auto_app_naming` is `true` https://github.com/newrelic/newrelic-java-agent/pull/2805
-* Adds supportability metrics for each entity created when `enable_auto_app_naming` is `true` https://github.com/newrelic/newrelic-java-agent/pull/2808
-* Implements Cloud Metadata Bypass Proxy config https://github.com/newrelic/newrelic-java-agent/pull/2791
-* Adds support for multiple versions of Caffeine in the agent https://github.com/newrelic/newrelic-java-agent/pull/2807
-* Adds support for explain plans that utilize SQL arrays https://github.com/newrelic/newrelic-java-agent/pull/2815
-* Adds generic 'Queue' as a transport type https://github.com/newrelic/newrelic-java-agent/pull/2820
-* Adds support for Reactor Netty Http client calls https://github.com/newrelic/newrelic-java-agent/pull/2817
+* Adds Java 26 support [2734](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds Serverless mode for AWS Lambda monitoring with the Java agent [2609](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2615](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2625](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2633](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2640](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2641](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2647](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2673](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2716](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2721](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2735](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2723](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2740](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2769](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2782](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2794](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2797](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2796](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2806](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds new `application_logging.forwarding.log_level_denylist` config [2764](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Implements region aware event/metric ingest URIs [2749](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2790](https://github.com/newrelic/newrelic-java-agent/pull/2734) [2790](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds support for associating logs to corresponding entity when `enable_auto_app_naming` is `true` [2627](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Add `opentelemetry-sdk-extension-autoconfigure-1.59.0` instrumentation for OpenTelemetry 1.59.0+ [2786](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds support for associating adaptive sampler to corresponding entity when `enable_auto_app_naming` is `true` [2805](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds supportability metrics for each entity created when `enable_auto_app_naming` is `true` [2808](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Implements Cloud Metadata Bypass Proxy config [2791](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds support for multiple versions of Caffeine in the agent [2807](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds support for explain plans that utilize SQL arrays [2815](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds generic 'Queue' as a transport type [2820](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds support for Reactor Netty Http client calls [2817](https://github.com/newrelic/newrelic-java-agent/pull/2734)
 
 ## Fixes
-
-* Fixes an edge case where ill-formed payloads caused an NPE when accessing the `sampled` field on the NR payload https://github.com/newrelic/newrelic-java-agent/pull/2762
-* Expires Tokens when a Reactive Subscription is canceled https://github.com/newrelic/newrelic-java-agent/pull/2798
-* Adds logic to manually evict any dead threads from the `TheadTracker` cache to prevent a memory leak https://github.com/newrelic/newrelic-java-agent/pull/2811
-* Resolves a deadlock between harvest thread and JVM shutdown thread https://github.com/newrelic/newrelic-java-agent/pull/2539
+* Fixes an edge case where ill-formed payloads caused an NPE when accessing the `sampled` field on the NR payload [2762](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Expires Tokens when a Reactive Subscription is canceled [2798](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Adds logic to manually evict any dead threads from the `TheadTracker` cache to prevent a memory leak [2811](https://github.com/newrelic/newrelic-java-agent/pull/2734)
+* Resolves a deadlock between harvest thread and JVM shutdown thread [2539](https://github.com/newrelic/newrelic-java-agent/pull/2734)
 
 ## Update to latest version [#procedures]
 


### PR DESCRIPTION
Fixes link formatting for Java agent 9.2.0 release notes.

Please release ASAP