### PR TITLE
Go Agent Release 3.43.1

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-43-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-43-1.mdx
@@ -1,0 +1,22 @@
+---
+subject: Go agent
+releaseDate: '2026-04-09'
+version: 3.43.1
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.43.1'
+features: []
+bugs: ["Fixed a bug where we were importing the incorrect version of the `nrsecureagent` in our `nrgrpc` integration"]
+security: []
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from updating to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+
+## 3.43.1
+### Fixed
+  * Fixed a bug where we were importing the incorrect version of the `nrsecureagent` in our `nrgrpc` integration
+  
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.


### PR DESCRIPTION
## Go Agent 3.43.1
## Fixed
  * Fixed a bug where we were importing the incorrect version of the `nrsecureagent` in our `nrgrpc` integration

### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](https://docs.newrelic.com/docs/apm/agents/go-agent/get-started/go-agent-eol-policy/) for details about supported versions of the Go agent and third-party components.