### PR TITLE
docs: update to reflect that read-only users can no longer create, update, or delete dashboards 

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -223,7 +223,7 @@ Here's a table with our standard roles. To better understand these roles, go to 
       </td>
 
       <td>
-        Provides read-only access to the New Relic platform (except for [synthetic monitor secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/) and [dashboard permissions](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/#dashboards-permissions)).
+        Provides read-only access to the New Relic platform (except for [synthetic monitor secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/)).
       </td>
 
       <td>

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard.mdx
@@ -430,6 +430,21 @@ If you delete your dashboard, you can quickly restore it with NerdGraph. To lear
   type="youtube"
 />
 
+## Recover access for users with read-only role [#recover-access-for-read-only-role]
+
+Read-only users have strictly "view-only" access for dashboards.
+If you have users who currently rely on the read-only role but still need to manage dashboards, you can easily maintain their workflow by creating a custom role.
+
+To configure continued access:
+1. Navigate to the Admin settings to add or edit a role.
+2. Locate the new Dashboards section within the role configuration.
+3. Enable the specific permissions required for your users:
+  * View: Allows users to view dashboards (enabled by default).
+  * Modify: Allows users to create and edit dashboards.
+  * Delete: Allows users to delete or restore dashboards.
+
+Note on permissions: These new role-based access controls (RBAC) work alongside existing dashboard-level permissions. For example, a user with the "Modify" role capability still cannot edit a specific dashboard that has been individually set to "read-only" at the dashboard level.
+
 ## Key visual tools [#key-visual-tools]
 
 Dashboards offer intuitive visualization features and tools for advanced data exploration and fast troubleshooting.


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Starting end of Apr 2026, Dashboards will no longer allow users with read-only roles to be able to create, update, or delete dashboards. This change is to reflect this fact in the docs and also to document the recommended action for impacted users. See [draft customer communication here](https://docs.google.com/document/d/1aFLyTCgPG9LcxgWeIsEOaA-O8XuDG3S21C0BELEQqGc/edit?tab=t.0), also more info here: https://new-relic.atlassian.net/browse/NR-453489