### PR TITLE
docs: Clarify the .NET agent's support for running in containers.

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -216,7 +216,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     * Windows Server 2025
                     * Windows 10
                     * Windows 11
-                    * Windows containers running on Server 2016 (NanoServer based images are not supported)
+
+                    Containerized versions of these operating systems are also supported, with the exception of `nanoserver`.
                 </td>
                 </tr>
 
@@ -226,7 +227,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
 
                 <td>
-                    All x64 Linux distributions supported by the .NET Core 2.0+/.NET 5+ runtime are supported by the .NET agent. For a full list, refer to Microsoft's documentation for the version of the runtime you are using.
+                    All x64 Linux distributions supported by the .NET Core 2.0+/.NET 5+ runtime are supported by the .NET agent (including containerized versions). For a full list, refer to Microsoft's documentation for the version of the runtime you are using.
                 </td>
                 </tr>
 
@@ -236,7 +237,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
 
                 <td>
-                    All ARM64 Linux distributions supported by the .NET 5+ runtime are supported by the .NET agent, with the following known exceptions:
+                    All ARM64 Linux distributions supported by the .NET 5+ runtime are supported by the .NET agent (including containerized versions), with the following known exceptions:
                     * Alpine Linux
                 </td>
                 </tr>
@@ -1229,7 +1230,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 * Windows 10
                 * Windows 11
                 * Windows Azure (OS Family 1, 2, and 3)
-                * Windows containers running on Windows 2016 (NanoServer based images are not supported)
+
+                The agent supports running in containerized versions of all supported Windows operating systems with the known exception of `nanoserver`.
             </Collapser>
             <Collapser
                 className="freq-link"

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -227,7 +227,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 </td>
 
                 <td>
-                    All x64 Linux distributions supported by the .NET Core 2.0+/.NET 5+ runtime are supported by the .NET agent (including containerized versions). For a full list, refer to Microsoft's documentation for the version of the runtime you are using.
+                    All x64 Linux distributions supported by the .NET Core 2.0+/.NET 5+ runtime are supported by the .NET agent (including containerized versions). For a full list, refer to [Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/core/install/linux) for the version of the runtime you are using.
                 </td>
                 </tr>
 


### PR DESCRIPTION
Update the .NET agent's compatibility and support document to indicate broad support for using the agent in containers.  We support running in containerized versions of any operating system we support running on bare metal or VM, with the known exception of Windows Nanoserver.
