### PR TITLE
Add documentation release notes for April 5-10, 2026

### DIFF
--- a/src/content/docs/release-notes/docs-release-notes/docs-4-10-2026.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-4-10-2026.mdx
@@ -65,7 +65,7 @@ version: 'April 5 - April 10, 2026'
   * [Capacitor Agent v1.6.2](/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-162):
     * Bug fixes and improvements.
 
-  * [Cordova Agent v7.1.0, v7.1.1](/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-710):
+  * [Cordova Agent v7.1.0, v7.1.1](/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-711):
     * Bug fixes and improvements for Cordova mobile monitoring.
 
   * [Flutter Agent v1.12.2](/docs/release-notes/mobile-release-notes/flutter-release-notes/flutter-agent-1122):

--- a/src/content/docs/release-notes/docs-release-notes/docs-4-10-2026.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-4-10-2026.mdx
@@ -1,0 +1,81 @@
+---
+subject: "Docs"
+releaseDate: '2026-04-10'
+version: 'April 5 - April 10, 2026'
+---
+
+### New docs
+
+* Added [Grafana dashboard translator REST API](/docs/infrastructure/prometheus-integrations/view-query-data/grafana-to-nr-dashboard-translation-rest-api/) for converting Grafana dashboards to New Relic dashboards.
+* Added [Java agent approaches for AWS Lambda](/docs/apm/agents/java-agent/getting-started/java-agent-approaches-lambda/) documenting serverless monitoring options with the Java agent.
+
+### Major changes
+
+* Restructured [Streaming Video & Ads documentation](/docs/streaming-video-&-ads/introduction-to-streaming-video-&-ads/) with new platform-specific installation guides for Android, iOS, Browser, and Roku, along with updated API reference documentation and improved navigation.
+* Restructured [Data ingest budgets documentation](/docs/data-apis/manage-data/data-ingest-budgets/overview/) into separate pages for account-level and organization-level budgets with multi-tenant support.
+
+### Minor changes
+
+* Updated [Kubernetes cluster explorer documentation](/docs/kubernetes-pixie/kubernetes-integration/understand-use-data/kubernetes-cross-cluster/) with revised metric names to match UI changes.
+* Updated [Account email settings](/docs/accounts/accounts/account-maintenance/account-email-settings/) with restructured SSO/SAML email change instructions as proper subsection.
+* Updated [NRDOT collector documentation](/docs/opentelemetry/nrdot/nrdot-collector/) to simplify docs to single distro model.
+* Updated [Workflow automation introduction](/docs/workflow-automation/introduction-to-workflow/) with RBAC permissions information.
+* Updated [Node.js agent compatibility requirements](/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/) with updated package versions.
+* Updated [Java agent compatibility requirements](/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent/) with latest verified compatible versions.
+* Updated [Supported PromQL features](/docs/infrastructure/prometheus-integrations/view-query-data/supported-promql-features/) with additional Grafana translation support information.
+* Updated [Errors inbox browser tab](/docs/errors-inbox/browser-tab/) with `SecurityPolicyViolation` event handling section.
+* Updated [New Relic Lens query data](/docs/new-relic-lens/query-data/) to clarify that `FROM` clause cannot be used before `SELECT` in ANSI SQL.
+* Updated [Confluent Cloud integration](/docs/message-queues-streaming/installation/confluent-cloud-integration/) with Compute Pool (Flink) data table.
+* Updated [NRDOT MSSQL](/docs/opentelemetry/database/otel-mssql/) and [Oracle DB](/docs/opentelemetry/database/otel-oracledb/) documentation with database configuration updates.
+* Updated [PHP agent installation RPM key rotation](/docs/apm/agents/php-agent/installation/php-agent-installation-rpm-key-rotation/) with key rotation updates.
+* Updated [PHP agent installation for AWS Linux/RedHat/CentOS](/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos/) with additional installation guidance.
+* Updated [Kubernetes integration compatibility requirements](/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements/) with bullet point formatting fixes.
+* Updated [Streaming Video & Ads application views](/docs/streaming-video-&-ads/view-data-in-newrelic/streaming-video-&-ads-all-platform-view/application/) with QoE index image and callout.
+
+### Release notes
+
+* Stay up-to-date with our latest releases:
+
+  * [Java Agent v9.2.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-920):
+    * Added Java 26 support and AWS Lambda serverless monitoring mode.
+    * Added `log_level_denylist` configuration for log forwarding.
+    * Added auto app naming support for logs, trace samplers, and entity supportability metrics.
+    * Added instrumentation for OpenTelemetry 1.59.0+ and Reactor Netty HTTP client.
+    * Fixed NPE with distributed tracing payload and memory leak in `ThreadTracker` cache.
+
+  * [Ruby Agent v10.3.0](/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-10-3-0):
+    * Added database query naming via SQL comments with `/* NewRelicQueryName: CustomName */`.
+    * Added Semantic Logger instrumentation for log forwarding (versions 4.6.0+).
+    * Added `ignored_middleware_classes` configuration option.
+    * Added `NewRelic::Agent.add_transaction_log_attributes` API.
+    * Fixed ActionCable broadcast metrics cardinality and FIPS/FedRAMP compliance issues.
+
+  * [Go Agent v3.43.1](/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-43-1):
+    * Fixed bug importing incorrect version of `nrsecureagent` in `nrgrpc` integration.
+
+  * [Kubernetes Integration v4.0.0](/docs/release-notes/infrastructure-release-notes/kubernetes-integration-release-notes/kubernetes-integration-4-0-0):
+    * Major version release included in `newrelic-infrastructure-4.0.0` and `nri-bundle-7.0.0`.
+
+  * [React Native Agent v1.8.0](/docs/release-notes/mobile-release-notes/react-native-release-notes/react-native-agent-180):
+    * New features and improvements for React Native mobile monitoring.
+
+  * [Unity Agent v1.5.0](/docs/release-notes/mobile-release-notes/unity-release-notes/unity-agent-150):
+    * New features and improvements for Unity mobile monitoring.
+
+  * [Capacitor Agent v1.6.2](/docs/release-notes/mobile-release-notes/capacitor-release-notes/capacitor-agent-162):
+    * Bug fixes and improvements.
+
+  * [Cordova Agent v7.1.0, v7.1.1](/docs/release-notes/mobile-release-notes/cordova-release-notes/cordova-agent-710):
+    * Bug fixes and improvements for Cordova mobile monitoring.
+
+  * [Flutter Agent v1.12.2](/docs/release-notes/mobile-release-notes/flutter-release-notes/flutter-agent-1122):
+    * Bug fixes and improvements.
+
+  * [.NET MAUI Agent v1.2.1](/docs/release-notes/mobile-release-notes/net-maui-release-notes/net-maui-agent-121):
+    * Bug fixes and improvements.
+
+  * [Synthetics Job Manager v519](/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-519):
+    * Updates for synthetic monitoring job management.
+
+  * [Ping Runtime v1.64.0](/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.64.0):
+    * Updates for synthetic ping monitoring.


### PR DESCRIPTION
## Summary

- Added weekly documentation release notes covering April 5-10, 2026
- Covers 29 PRs merged during the release period

### New docs
- Grafana dashboard translator REST API
- Java agent approaches for AWS Lambda

### Major changes
- Restructured Streaming Video & Ads documentation
- Restructured Data ingest budgets documentation with multi-tenant support

### Minor changes
- 15 updates including Kubernetes metrics, SSO/SAML docs, NRDOT simplification, workflow automation RBAC, and various compatibility updates

### Release notes
- Java Agent v9.2.0, Ruby Agent v10.3.0, Go Agent v3.43.1
- Kubernetes Integration v4.0.0
- Mobile agents: React Native v1.8.0, Unity v1.5.0, Capacitor v1.6.2, Cordova v7.1.0/v7.1.1, Flutter v1.12.2, .NET MAUI v1.2.1
- Synthetics Job Manager v519, Ping Runtime v1.64.0

## Test plan

- [ ] Verify the release notes page renders correctly
- [ ] Confirm all links work as expected
- [ ] Check that the content flows logically

🤖 Generated with [Claude Code](https://claude.com/claude-code)