### PR TITLE
Fix HAProxy install page showing nri-apache config

### DIFF
--- a/src/install/haproxy/default-configuration.mdx
+++ b/src/install/haproxy/default-configuration.mdx
@@ -3,11 +3,11 @@ componentType: default
 headingText: Configure the integration 
 ---
 
-Edit the `nri-apache-config.yml` file to configure your integration as needed. The following example config fills in all the required options and reports all metrics the integration pulls:
+Edit the `haproxy-config.yml` file to configure your integration as needed. The following example config fills in all the required options and reports all metrics the integration pulls:
 
 ```yml
 integrations:
-  - name: nri-apache
+  - name: nri-haproxy
     env:
       METRICS: "true"
       STATUS_URL: http://127.0.0.1/server-status?auto
@@ -17,7 +17,7 @@ integrations:
       env: production
       role: load_balancer
 
-  - name: nri-apache
+  - name: nri-haproxy
     env:
       INVENTORY: "true"
       STATUS_URL: http://127.0.0.1/server-status?auto
@@ -26,5 +26,5 @@ integrations:
     labels:
       env: production
       role: load_balancer
-    inventory_source: config/apache
+    inventory_source: config/haproxy
 ```

--- a/src/install/haproxy/default-install-linux.mdx
+++ b/src/install/haproxy/default-install-linux.mdx
@@ -19,7 +19,7 @@ headingText: Configure the  integration
 
    ```yml
    integrations:
-     - name: nri-apache
+     - name: nri-haproxy
        env:
          METRICS: "true"
          STATUS_URL: http://127.0.0.1/server-status?auto
@@ -29,7 +29,7 @@ headingText: Configure the  integration
          env: production
          role: load_balancer
 
-     - name: nri-apache
+     - name: nri-haproxy
        env:
          INVENTORY: "true"
          STATUS_URL: http://127.0.0.1/server-status?auto
@@ -38,7 +38,7 @@ headingText: Configure the  integration
        labels:
          env: production
          role: load_balancer
-       inventory_source: config/apache
+       inventory_source: config/haproxy
    ```
 
    You can find all the config options at the bottom of this doc along with more complex config examples.

--- a/src/install/haproxy/linux/install-linux.mdx
+++ b/src/install/haproxy/linux/install-linux.mdx
@@ -19,7 +19,7 @@ headingText: Download the  integration
 
    ```yml
    integrations:
-     - name: nri-apache
+     - name: nri-haproxy
        env:
          METRICS: "true"
          STATUS_URL: http://127.0.0.1/server-status?auto
@@ -29,7 +29,7 @@ headingText: Download the  integration
          env: production
          role: load_balancer
 
-     - name: nri-apache
+     - name: nri-haproxy
        env:
          INVENTORY: "true"
          STATUS_URL: http://127.0.0.1/server-status?auto
@@ -38,7 +38,7 @@ headingText: Download the  integration
        labels:
          env: production
          role: load_balancer
-       inventory_source: config/apache
+       inventory_source: config/haproxy
    ```
 
 You can find all the config options at the bottom of this doc along with more complex config examples.


### PR DESCRIPTION
## Summary
- The HAProxy install page (`/install/haproxy/`) incorrectly showed `nri-apache` config references in step 5
- Updated integration name from `nri-apache` to `nri-haproxy` and `inventory_source` from `config/apache` to `config/haproxy` across all three Linux install files
- Note: environment variables still reference Apache-style parameters — pending confirmation from Kai Steinbach on the correct HAProxy config values

## Files changed
- `src/install/haproxy/default-configuration.mdx`
- `src/install/haproxy/default-install-linux.mdx`
- `src/install/haproxy/linux/install-linux.mdx`

## Test plan
- [ ] Verify `/install/haproxy/` page shows `nri-haproxy` in step 5 config
- [ ] Confirm correct HAProxy environment variables with Kai Steinbach