### PR TITLE
chore(.net agent): Updating latest supported framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -477,7 +477,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     Use [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/)
 
                     * Minimum supported version: 23.4.0
-                    * Latest verified compatible version: 23.26.100
+                    * Latest verified compatible version: 23.26.200
 
                     Older versions of `Oracle.ManagedDataAccess.Core` may be instrumented, but have not been tested and are not supported.
                 </td>
@@ -574,7 +574,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.12.8
+            Latest verified compatible version: 2.12.14
                 </td>
                 </tr>
 
@@ -625,7 +625,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [EnyimMemcachedCore](https://www.nuget.org/packages/EnyimMemcachedCore).
 
                   * Minimum supported version: 2.0.0
-                  * Latest verified compatible version: 3.4.7
+                  * Latest verified compatible version: 3.5.0
                 </td>
                 </tr>
 
@@ -645,7 +645,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.17.4
+                  * Latest verified compatible version: 4.0.17.8
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -666,7 +666,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                 Use [System.Data.Odbc](https://www.nuget.org/packages/System.Data.Odbc/).
                     * Minimum supported version: 8.0.0
-                    * Latest verified compatible version: 10.0.3
+                    * Latest verified compatible version: 10.0.6
                     * Minimum agent version required: 10.35.0
                     
 
@@ -773,7 +773,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.16.7
+                    4.0.17.3
                 </td>
                 </tr>
                 <tr>
@@ -894,7 +894,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0
                 </td>
                 <td>
-                    10.0.5
+                    10.0.6
                 </td>
                 </tr>
             </tbody>
@@ -937,7 +937,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 1.4.0
 
-                    * Latest verified compatible version: 2.13.2
+                    * Latest verified compatible version: 2.14.0
                 </td>
                 </tr>
 
@@ -951,7 +951,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 5.0
 
-                    * Latest verified compatible version: 10.1.0
+                    * Latest verified compatible version: 10.1.2
                 </td>
                 </tr>
 
@@ -1005,7 +1005,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.2.21
+                  * Latest verified compatible version: 4.0.2.25
                 </td>
                 </tr>
 
@@ -1019,7 +1019,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.8.7
+                  * Latest verified compatible version: 4.0.8.11
                 </td>
                 </tr>
 
@@ -1033,7 +1033,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.20
+                  * Latest verified compatible version: 4.0.3.24
                 </td>
                 </tr>
 
@@ -1647,7 +1647,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         Use [Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/)
 
                         * Minimum supported version: 12.1.2400
-                        * Latest verified compatible version: 23.26.100
+                        * Latest verified compatible version: 23.26.200
                     </td>
                     </tr>
                     
@@ -1703,7 +1703,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.12.8
+                        * Latest verified compatible version: 2.12.14
                     </td>
                     </tr>
 
@@ -1775,7 +1775,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.17.4
+                  * Latest verified compatible version: 4.0.17.8
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1943,7 +1943,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.16.7
+                        4.0.17.3
                     </td>
                     </tr>
                     <tr>
@@ -2064,7 +2064,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        10.0.5
+                        10.0.6
                     </td>
                     </tr>
                 </tbody>
@@ -2184,7 +2184,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.2.21
+                        * Latest verified compatible version: 4.0.2.25
                     </td>
                     </tr>
 
@@ -2198,7 +2198,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.8.7
+                    * Latest verified compatible version: 4.0.8.11
                     </td>
                     </tr>
 
@@ -2212,7 +2212,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.3.20
+                    * Latest verified compatible version: 4.0.3.24
                     </td>
                     </tr>
 


### PR DESCRIPTION
Updates the .NET agent compatibility docs with latest verified compatible versions from Dotty PR newrelic/newrelic-dotnet-agent#3542.

Updated packages:
- Oracle.ManagedDataAccess / Core: 23.26.100 → 23.26.200
- StackExchange.Redis: 2.12.8 → 2.12.14
- EnyimMemcachedCore: 3.4.7 → 3.5.0
- AWSSDK.DynamoDBv2: 4.0.17.4 → 4.0.17.8
- System.Data.Odbc: 10.0.3 → 10.0.6
- AWSSDK.BedrockRuntime: 4.0.16.7 → 4.0.17.3
- Microsoft.Extensions.Logging: 10.0.5 → 10.0.6
- Confluent.Kafka: 2.13.2 → 2.14.0
- NServiceBus: 10.1.0 → 10.1.2
- AWSSDK.SQS: 4.0.2.21 → 4.0.2.25
- AWSSDK.Kinesis: 4.0.8.7 → 4.0.8.11
- AWSSDK.KinesisFirehose: 4.0.3.20 → 4.0.3.24