### PR TITLE
Update eBPF agent docs for YAML config migration and v1.4.0 field changes

### DIFF
--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -228,24 +228,6 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`"auto"`</td>
         </tr>
         <tr>
-            <td>`reportLogs`</td>
-            <td>Controls log reporting. When enabled, the agent collects and reports logs. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when APM is not attached).</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
-        </tr>
-        <tr>
-            <td>`reportAiMetrics`</td>
-            <td>Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
-        </tr>
-        <tr>
-            <td>`genAICaptureMessageContent`</td>
-            <td>Enable GenAI capture message content. When enabled, the agent captures message content for GenAI interactions. Use with caution.</td>
-            <td>`Boolean`</td>
-            <td>`false`</td>
-        </tr>
-        <tr>
             <td>`customOtlpEndpoint`</td>
             <td>Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.</td>
             <td>`String`</td>
@@ -433,64 +415,6 @@ Configure filters to drop/keep Network metrics data based on config provided
             <td>List of entity names to always keep Network metrics data. By default all entities are kept/enabled. This config bypasses `dropEntityName` filter.</td>
             <td>`List`</td>
             <td>`[]`</td>
-        </tr>
-    </tbody>
-</table>
-
-</Collapser>
-
-    <Collapser
-        id="log-data-filters"
-        title="Log data filters"
-    >
-
-Configure filters to drop/keep log data based on the config provided.
-
-<table>
-    <thead>
-        <tr>
-            <th>Parameter</th>
-            <th>Description</th>
-            <th>Data Type</th>
-            <th>Example</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.enabled`</td>
-            <td>Enable log reporting for entities monitored by the eBPF agent.</td>
-            <td>`Boolean`</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.fileRegex`</td>
-            <td>Regex to match log file path to include for entity log reporting.</td>
-            <td>`String`</td>
-            <td>`".*.log$"`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.logLevelThreshold`</td>
-            <td>Minimum log level to report. Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.</td>
-            <td>`String`</td>
-            <td>`"INFO"`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.maxSamplesPerMinute`</td>
-            <td>Maximum number of log samples to collect per minute from an entity. Once this limit is reached, events are sampled to maintain an even distribution across the harvest cycle.</td>
-            <td>`Integer`</td>
-            <td>`10000`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.keepStdStreamEntityRegex`</td>
-            <td>The eBPF agent collects and reports STDOUT/STDERR stream logs to New Relic for entities that match this regex. The entities are identified by their `NEW_RELIC_APP_NAME` (if provided) or their Kubernetes service name.</td>
-            <td>`String`</td>
-            <td>`".*"`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.keepFileEntityRegex`</td>
-            <td>The eBPF agent collects and reports file logs to New Relic for entities that match this regex. The entities are identified by their `NEW_RELIC_APP_NAME` (if provided) or their Kubernetes service name.</td>
-            <td>`String`</td>
-            <td>`".*"`</td>
         </tr>
     </tbody>
 </table>

--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -288,37 +288,37 @@ This section configure filters to drop all types of Network Metrics and APM data
         </tr>
         <tr>
             <td>`allDataFilters.dropNamespaces`</td>
-            <td>List of Kubernetes namespaces for which all data should be dropped by the agent. This field is renamed from `dropDataForNamespaces`. The old name is deprecated but remains supported for backward compatibility.</td>
+            <td>List of Kubernetes namespaces for which all data should be dropped by the agent. Use either dropNamespaces or keepNamespaces to filter namespaces, not both. If both are provided, keepNamespaces takes precedence.</td>
             <td>`List`</td>
             <td>`["kube-system"]`</td>
         </tr>
         <tr>
             <td>`allDataFilters.keepNamespaces`</td>
-            <td>List of Kubernetes namespaces for which all data should be sent by the agent.</td>
+            <td>List of Kubernetes namespaces for which all data should be sent by the agent. Use either dropNamespaces or keepNamespaces to filter namespaces, not both. If both are provided, keepNamespaces takes precedence.</td>
             <td>`List`</td>
             <td>`[]`</td>
         </tr>
         <tr>
             <td>`allDataFilters.dropPodLabels`</td>
-            <td>Pod labels to match for filtering all data. Empty map means no label-based filtering. For example: `{ "app": "frontend", "env": "production" }`</td>
+            <td>Pod labels to match for filtering all data. Empty map means no label-based filtering. For example: `{ "app": "frontend", "env": "production" }`. Use either dropPodLabels or keepPodLabels to filter based on pod labels, not both. If both are provided, keepPodLabels takes precedence.</td>
             <td>`Map`</td>
             <td>`{}`</td>
         </tr>
         <tr>
             <td>`allDataFilters.keepPodLabels`</td>
-            <td>Pod labels to match for keeping all data. Empty map means no label-based filtering. For example: `{ "app": "frontend", "env": "production" }`</td>
+            <td>Pod labels to match for keeping all data. Empty map means no label-based filtering. For example: `{ "app": "frontend", "env": "production" }`. Use either dropPodLabels or keepPodLabels to filter based on pod labels, not both. If both are provided, keepPodLabels takes precedence.</td>
             <td>`Map`</td>
             <td>`{}`</td>
         </tr>
         <tr>
             <td>`allDataFilters.dropServiceNameRegex`</td>
-            <td>Define a regex to match k8s service names to drop. For example `"kube-dns|otel-collector|\\bblah\\b"` This field is renamed from `dropDataServiceNameRegex`. The old name is deprecated but remains supported for backward compatibility.</td>
+            <td>Define a regex to match k8s service names to drop. For example `"kube-dns|otel-collector|\\bblah\\b"`. Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both. If both are provided, keepServiceNameRegex takes precedence.</td>
             <td>`String`</td>
             <td>`""`</td>
         </tr>
         <tr>
             <td>`allDataFilters.keepServiceNameRegex`</td>
-            <td>This config acts as a bypass for the `dropServiceNameRegex` config. Service names that match this regex will not have their data dropped by the `dropServiceNameRegex`. This field is renamed from `allowServiceNameRegex`. The old name is deprecated but remains supported for backward compatibility.</td>
+            <td>This config acts as a bypass for the `dropServiceNameRegex` config. Service names that match this regex will not have their data dropped by the `dropServiceNameRegex`. Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both. If both are provided, keepServiceNameRegex takes precedence. This field is renamed from `allowServiceNameRegex`. The old name is deprecated but remains supported for backward compatibility.</td>
             <td>`String`</td>
             <td>`""`</td>
         </tr>

--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -50,7 +50,7 @@ To install the eBPF agent:
     3. Click <DNT>**Continue**</DNT>.
 
     <Callout variant="tip">
-    If you choose a custom namespace for your New Relic instrumentation (instead of the default <DNT>`newrelic`</DNT>), we recommend excluding that namespace from monitoring by adding it to the <DNT>`dropDataForNamespaces`</DNT> configuration parameter. This prevents the eBPF agent from monitoring the instrumentation pods themselves. For example, if you use <DNT>`newrelic-mon`</DNT> as your namespace, set: <DNT>`dropDataForNamespaces: ["kube-system", "newrelic-mon"]`</DNT>.
+    If you choose a custom namespace for your New Relic instrumentation (instead of the default <DNT>`newrelic`</DNT>), we recommend excluding that namespace from monitoring by adding it to the <DNT>`allDataFilters.dropNamespaces`</DNT> configuration parameter. This prevents the eBPF agent from monitoring the instrumentation pods themselves. For example, if you use <DNT>`newrelic-mon`</DNT> as your namespace, set: <DNT>`allDataFilters.dropNamespaces: ["kube-system", "newrelic-mon"]`</DNT>.
     </Callout>
 
 7. On the <DNT>Install the Kubernetes integration</DNT> screen:
@@ -174,12 +174,6 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`"8356...FFFFNRAL"`</td>
         </tr>
         <tr>
-            <td>`nrStaging`</td>
-            <td>If `true`, sends data to New Relic's staging environment.</td>
-            <td>`Boolean`</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
             <td>`customSecretName`</td>
             <td>Specifies the name of a Kubernetes secret that contains your license key. Use this to avoid providing the key directly.</td>
             <td>`String`</td>
@@ -222,22 +216,64 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`"/host/usr/src/linux-headers-6.8.0-pl"`</td>
         </tr>
         <tr>
-            <td>`tableStoreDataLimitMB`</td>
-            <td>Defines the memory limit in Megabytes (MiB) for the agent's internal data store. This is the primary control for RAM usage.</td>
+            <td>`reportApmData`</td>
+            <td>Controls APM data reporting. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when neither APM nor OTel agent is attached).</td>
             <td>`String`</td>
-            <td>`"250"`</td>
+            <td>`"auto"`</td>
         </tr>
         <tr>
-            <td>`apmDataReporting`</td>
-            <td>Enable APM data reporting. When enabled, the agent collects and reports application performance monitoring data.</td>
+            <td>`reportNetworkMetrics`</td>
+            <td>Controls network metrics reporting. When enabled, the agent collects and reports network metrics including TCP statistics. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"`.</td>
+            <td>`String`</td>
+            <td>`"auto"`</td>
+        </tr>
+        <tr>
+            <td>`reportLogs`</td>
+            <td>Controls log reporting. When enabled, the agent collects and reports logs. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when APM is not attached).</td>
+            <td>`String`</td>
+            <td>`"false"`</td>
+        </tr>
+        <tr>
+            <td>`reportAiMetrics`</td>
+            <td>Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data.</td>
+            <td>`String`</td>
+            <td>`"false"`</td>
+        </tr>
+        <tr>
+            <td>`genAICaptureMessageContent`</td>
+            <td>Enable GenAI capture message content. When enabled, the agent captures message content for GenAI interactions. Use with caution.</td>
+            <td>`Boolean`</td>
+            <td>`false`</td>
+        </tr>
+        <tr>
+            <td>`customOtlpEndpoint`</td>
+            <td>Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`customOtlpEndpointTlsEnabled`</td>
+            <td>Whether TLS is enabled on the OTLP endpoint. Only overridden when both `customOtlpEndpoint` and this field are explicitly set.</td>
             <td>`Boolean`</td>
             <td>`true`</td>
         </tr>
         <tr>
-            <td>`networkMetricsReporting`</td>
-            <td>Enable network metrics reporting. When enabled, the agent collects and reports network metrics including TCP statistics. This field is renamed from `tcpStatsReporting`. The old name is deprecated but remains supported for backward compatibility.</td>
-            <td>`Boolean`</td>
-            <td>`true`</td>
+            <td>`customOtlpEndpointTlsCertSecret`</td>
+            <td>Name of the Kubernetes secret containing the CA certificate for the custom OTLP endpoint. Only used when `customOtlpEndpoint` is set. Must be provided together with `customOtlpEndpointTlsCertSecretKey`.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`customOtlpEndpointTlsCertSecretKey`</td>
+            <td>Key within the secret that contains the CA certificate. Only used when `customOtlpEndpoint` is set. Must be provided together with `customOtlpEndpointTlsCertSecret`.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`entityLabels`</td>
+            <td>Custom labels to be added to all entities reported by the eBPF agent. These labels are sent as the `NEW_RELIC_LABELS` environment variable in the format `"key1:value1;key2:value2"`.</td>
+            <td>`Map`</td>
+            <td>`{}`</td>
         </tr>
     </tbody>
 </table>
@@ -273,6 +309,24 @@ This section configure filters to drop all types of Network Metrics and APM data
             <td>List of Kubernetes namespaces for which all data should be dropped by the agent. This field is renamed from `dropDataForNamespaces`. The old name is deprecated but remains supported for backward compatibility.</td>
             <td>`List`</td>
             <td>`["kube-system"]`</td>
+        </tr>
+        <tr>
+            <td>`allDataFilters.keepNamespaces`</td>
+            <td>List of Kubernetes namespaces for which all data should be sent by the agent.</td>
+            <td>`List`</td>
+            <td>`[]`</td>
+        </tr>
+        <tr>
+            <td>`allDataFilters.dropPodLabels`</td>
+            <td>Pod labels to match for filtering all data. Empty map means no label-based filtering. For example: `{ "app": "frontend", "env": "production" }`</td>
+            <td>`Map`</td>
+            <td>`{}`</td>
+        </tr>
+        <tr>
+            <td>`allDataFilters.keepPodLabels`</td>
+            <td>Pod labels to match for keeping all data. Empty map means no label-based filtering. For example: `{ "app": "frontend", "env": "production" }`</td>
+            <td>`Map`</td>
+            <td>`{}`</td>
         </tr>
         <tr>
             <td>`allDataFilters.dropServiceNameRegex`</td>
@@ -316,15 +370,9 @@ Configure filters to drop ebpf APM data based on config provided
     </thead>
     <tbody>
         <tr>
-            <td>`apmDataFilters.dropEapmForApmEnabledEntity`</td>
-            <td> Drop eBPF APM data for applications/entities that have NewRelic APM/OTel agents running.</td>
-            <td>`Boolean`</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
             <td>`apmDataFilters.dropPodLabels`</td>
             <td>Pod labels to match for filtering APM data. Empty map means no label-based filtering. For example: dropPodLabels: `{ "app": "frontend", "env": "production" }`</td>
-            <td>`String`</td>
+            <td>`Map`</td>
             <td>`{}`</td>
         </tr>
         <tr>
@@ -371,7 +419,7 @@ Configure filters to drop/keep Network metrics data based on config provided
         <tr>
             <td>`networkMetricsDataFilter.dropPodLabels`</td>
             <td>Pod labels to match for filtering Network metrics data. Empty map means no label-based filtering. For example: dropPodLabels: `{ "app": "frontend", "env": "production" }`</td>
-            <td>`String`</td>
+            <td>`Map`</td>
             <td>`{}`</td>
         </tr>
         <tr>
@@ -385,6 +433,64 @@ Configure filters to drop/keep Network metrics data based on config provided
             <td>List of entity names to always keep Network metrics data. By default all entities are kept/enabled. This config bypasses `dropEntityName` filter.</td>
             <td>`List`</td>
             <td>`[]`</td>
+        </tr>
+    </tbody>
+</table>
+
+</Collapser>
+
+    <Collapser
+        id="log-data-filters"
+        title="Log data filters"
+    >
+
+Configure filters to drop/keep log data based on the config provided.
+
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Description</th>
+            <th>Data Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.enabled`</td>
+            <td>Enable log reporting for entities monitored by the eBPF agent.</td>
+            <td>`Boolean`</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.fileRegex`</td>
+            <td>Regex to match log file path to include for entity log reporting.</td>
+            <td>`String`</td>
+            <td>`".*.log$"`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.logLevelThreshold`</td>
+            <td>Minimum log level to report. Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.</td>
+            <td>`String`</td>
+            <td>`"INFO"`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.maxSamplesPerMinute`</td>
+            <td>Maximum number of log samples to collect per minute from an entity. Once this limit is reached, events are sampled to maintain an even distribution across the harvest cycle.</td>
+            <td>`Integer`</td>
+            <td>`10000`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.keepStdStreamEntityRegex`</td>
+            <td>The eBPF agent collects and reports STDOUT/STDERR stream logs to New Relic for entities that match this regex. The entities are identified by their `NEW_RELIC_APP_NAME` (if provided) or their Kubernetes service name.</td>
+            <td>`String`</td>
+            <td>`".*"`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.keepFileEntityRegex`</td>
+            <td>The eBPF agent collects and reports file logs to New Relic for entities that match this regex. The entities are identified by their `NEW_RELIC_APP_NAME` (if provided) or their Kubernetes service name.</td>
+            <td>`String`</td>
+            <td>`".*"`</td>
         </tr>
     </tbody>
 </table>
@@ -425,9 +531,15 @@ This section allows you to enable monitoring for specific network protocols and 
     <tbody>
         <tr>
             <td>`protocols.global.max_unlinked_spans`</td>
-            <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit</td>
+            <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit.</td>
             <td>`String`</td>
             <td>`"100"`</td>
+        </tr>
+        <tr>
+            <td>`protocols.global.unlinked_spans_error_quota_percentage`</td>
+            <td>Reserves a configurable percentage of the unlinked span quota for error spans, ensuring error visibility even when normal spans arrive first.</td>
+            <td>`String`</td>
+            <td>`"30"`</td>
         </tr>
         <tr>
             <td>`protocols.<protocol-name>.enabled`</td>

--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -531,7 +531,7 @@ This section allows you to enable monitoring for specific network protocols and 
     <tbody>
         <tr>
             <td>`protocols.global.max_unlinked_spans`</td>
-            <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit.</td>
+            <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit. Unlinked spans are spans that the eBPF agent captures but cannot associate with its parent.</td>
             <td>`String`</td>
             <td>`"100"`</td>
         </tr>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -57,7 +57,7 @@ To install the eBPF agent:
 
     <Callout variant="tip">
 
-        You can customize the eBPF agent configuration by editing the <DNT>`newrelic-ebpf-agent.conf`</DNT> file available at <DNT>`/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.conf`</DNT>. For more information on the configuration parameters, refer to [Configuration parameters](#config-params).
+        You can customize the eBPF agent configuration by editing the <DNT>`newrelic-ebpf-agent.yaml`</DNT> file available at <DNT>`/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.yaml`</DNT>. For more information on the configuration parameters, refer to [Configuration parameters](#config-params).
 
     </Callout>
 
@@ -106,7 +106,7 @@ To get the latest installation command:
 
 ## Configuration parameters [#config-params]
 
-The `newrelic-ebpf-agent.conf` file contains the following configuration parameters:
+The `newrelic-ebpf-agent.yaml` file contains the following configuration parameters:
 
 <Callout variant="tip">
 
@@ -140,357 +140,429 @@ Assigning custom name to applications:
     </thead>
     <tbody>
         <tr>
-            <td>`NEW_RELIC_LICENSE_KEY`</td>
+            <td>`licenseKey`</td>
             <td>Specifies your New Relic license key, which is required to send data.</td>
-            <td>`String`</td>
-            <td>`22387565c...FFFFNRAL`</td>
+            <td>String</td>
+            <td>`"22387565c...FFFFNRAL"`</td>
         </tr>
         <tr>
-            <td>`DEPLOYMENT_NAME`</td>
+            <td>`deploymentName`</td>
             <td>Specifies a unique name for your deployment to help identify its data in New Relic.</td>
-            <td>`String`</td>
-            <td>`fe`</td>
+            <td>String</td>
+            <td>`"my-deployment"`</td>
         </tr>
         <tr>
-            <td>`OTLP_ENDPOINT`</td>
-            <td>Defines the OTLP endpoint where the agent sends telemetry data.</td>
-            <td>`String (Host:Port)`</td>
-            <td>`otlp.nr-data.net:443`</td>
+            <td>`region`</td>
+            <td>If using a customSecretLicenseKey, you must supply your region `"US"`/`"EU"`. Otherwise, leave this value as an empty string.</td>
+            <td>String</td>
+            <td>`""`</td>
         </tr>
         <tr>
-            <td>`NEW_RELIC_LOG_LEVEL`</td>
+            <td>`customOtlpEndpoint`</td>
+            <td>Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`customOtlpEndpointTlsEnabled`</td>
+            <td>Whether TLS is enabled on the custom OTLP endpoint. Only applicable when `customOtlpEndpoint` is set.</td>
+            <td>Boolean</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
+            <td>`customOtlpEndpointTlsCertPath`</td>
+            <td>Path to custom CA certificates for OTLP endpoint TLS validation. If empty, system default CA certificates are used.</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`logLevel`</td>
             <td>Sets the agent's log level. Options are `OFF`, `FATAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` in increasing order of verbosity.</td>
-            <td>`String`</td>
-            <td>`INFO`</td>
+            <td>String</td>
+            <td>`"INFO"`</td>
         </tr>
         <tr>
-            <td>`NEW_RELIC_LOG_FILE_PATH`</td>
+            <td>`logFilePath`</td>
             <td>Specifies the file path for agent logs. If empty or the path is invalid, logs are sent to standard output (stdout).</td>
-            <td>`String (Path)`</td>
-            <td>`""`</td>
+            <td>String</td>
+            <td>`"/var/log/newrelic-ebpf-agent"`</td>
         </tr>
         <tr>
-            <td>`APM_DATA_REPORTING`</td>
-            <td>Enable APM data reporting. When enabled, the agent collects and reports application performance monitoring data.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>`reportApmData`</td>
+            <td>Controls APM data reporting. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when neither APM nor OTel agent is attached).</td>
+            <td>String</td>
+            <td>`"auto"`</td>
         </tr>
         <tr>
-            <td>`NETWORK_METRICS_REPORTING`</td>
-            <td>Enable TCP statistics reporting. When enabled, the agent collects and reports low level tcp metrics and starts network monitoring.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>`reportNetworkMetrics`</td>
+            <td>Controls network metrics reporting. When enabled, the agent collects and reports network metrics including TCP statistics. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"`.</td>
+            <td>String</td>
+            <td>`"auto"`</td>
         </tr>
         <tr>
-            <td>`JVM_METRICS_REPORTING`</td>
-            <td>Enable JVM metrics reporting. When enabled, the agent collects and reports JVM metrics for Java applications.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
-        </tr>
-        <tr>
-            <td>`DROP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME`</td>
-            <td>Comma-separated list of entity names for dropping Network metrix data. For example: `"kube-dns,otel-collector,service1"`.</td>
-            <td>`String`</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`KEEP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME`</td>
-            <td>Comma-separated list of entity names to always keep Network metrix data. default all entity is keepd/enabled. This bypasses DROP_NETWORK_METRICS_DATA_FOR_ENTITY_NAME filter. For example: `"critical-service,important-app,must-monitor"`.</td>
-            <td>`String`</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`DROP_APM_DATA_FOR_ENTITY_NAME`</td>
-            <td>Comma-separated list of entity names for dropping eBPF APM data. For example: `"kube-dns,otel-collector,service1"`.</td>
-            <td>`String`</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`KEEP_APM_DATA_FOR_ENTITY_NAME`</td>
-            <td>Comma-separated list of entity names to always keep eBPF APM data. default all entity is keepd/enabled. This bypasses `DROP_APM_DATA_FOR_ENTITY_NAME` filter. For example: `"critical-service,important-app,must-monitor"`.</td>
-            <td>`String`</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`DROP_EAPM_DATA_FOR_APM_AGENT_ENABLED_ENTITY`</td>
-            <td>Drop eBPF APM data for applications/entities that have NewRelic/OpenTelemetry APM agents running</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
-        </tr>
-        <tr>
-            <td>`DROP_ALL_DATA_FOR_ENTITY_NAME_REGEX`</td>
-            <td>Regular expression pattern to match entity names for dropping ALL data (TCP stats + APM data). For example: `"java-app|otel-collector|\\bservice1\\b"`</td>
-            <td>`String`</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`KEEP_ALL_DATA_FOR_ENTITY_NAME_REGEX`</td>
-            <td>Regular expression pattern to match entity names to always keep ALL data for. This bypasses all drop filters. For example: `"critical-service|important-app|\\bmust-monitor\\b"`</td>
-            <td>`String`</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`DROP_ALL_DATA_FOR_APM_AGENT_ENABLED_ENTITY`</td>
-            <td>Drop all data for applications/entities that have NewRelic/OpenTelemetry APM agents running.</td>
-            <td>`String`</td>
+            <td>`reportLogs`</td>
+            <td>Controls log reporting. When enabled, the agent collects and reports logs. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when APM is not attached).</td>
+            <td>String</td>
             <td>`"false"`</td>
         </tr>
         <tr>
-            <td>`INCLUDE_PORT_IN_SERVER_ENTITY_IDENTIFICATION`</td>
+            <td>`reportAiMetrics`</td>
+            <td>Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"`.</td>
+            <td>String</td>
+            <td>`"false"`</td>
+        </tr>
+        <tr>
+            <td>`genAICaptureMessageContent`</td>
+            <td>Enable GenAI capture message content. When enabled, the agent captures message content for GenAI interactions. Use with caution.</td>
+            <td>Boolean</td>
+            <td>`false`</td>
+        </tr>
+        <tr>
+            <td>`includePortInServerEntityIdentification`</td>
             <td>The configuration allows you to include or exclude ports from auto-discovered entity names. Typically, names appear as `processName:cwd/container_name:[port]`, e.g., `python:frosty_merkle:[80]`. To exclude port details, set this option to `false` for names such as `python:frosty_merkle`.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`TABLE_STORE_DATA_LIMIT_MB`</td>
-            <td>Sets the maximum memory (in MiB) that the eBPF agent can use for its internal data table store. This is the primary way to control the agent's RAM usage.</td>
-            <td>Integer</td>
-            <td>`250`</td>
+            <td>`entityLabels`</td>
+            <td>Custom labels to be added to all entities reported by the eBPF agent. These labels appear as `tags.*` attributes in New Relic (e.g., `tags.environment`, `tags.datacenter`).</td>
+            <td>Map</td>
+            <td>`{datacenter: "us-east-1", environment: "production"}`</td>
         </tr>
         <tr>
-            <td>`DOWNLOADED_PACKAGED_HEADERS_PATH`</td>
+            <td>`downloadedPackagedHeadersPath`</td>
             <td>Sets the absolute path of the complete directory where the required linux headers are manually downloaded and placed for the eBPF agent to use. This is useful under restricted environments where agent is not able to download required linux headers. The required headers are identified by the agent based on the kernel version. Use only after NR support recommendation.</td>
-            <td>`String (Path)`</td>
-            <td>`"/path/to/downloaded/headers/dir"`</td>
+            <td>String</td>
+            <td>`""`</td>
         </tr>
         <tr>
-            <td>`DISTRO_KERNEL_HEADERS_PATH`</td>
+            <td>`distroKernelHeadersPath`</td>
             <td>Sets the absolute path of the complete directory where the linux headers are present for the eBPF agent to use. This is useful where required linux headers could not be installed or path could not be determined. Use only after NR support recommendation.</td>
-            <td>`String (Path)`</td>
-            <td>`"/usr/src/kernels"`</td>
+            <td>String</td>
+            <td>`""`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_SPANS_UNLINKED_MAX`</td>
+            <td>`allDataFilters.dropServiceNameRegex`</td>
+            <td>Regular expression pattern to match entity names for dropping ALL data (network metrics + APM data). For example: `"java-app|otel-collector|\\bservice1\\b"`</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`allDataFilters.keepServiceNameRegex`</td>
+            <td>Regular expression pattern to match entity names to always keep ALL data for. This bypasses all drop filters. For example: `"critical-service|important-app|\\bmust-monitor\\b"`</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`allDataFilters.dropApmAgentEnabledEntity`</td>
+            <td>Drop all data for applications/entities that have NewRelic/OpenTelemetry APM agents running.</td>
+            <td>Boolean</td>
+            <td>`false`</td>
+        </tr>
+        <tr>
+            <td>`apmDataFilters.dropEntityName`</td>
+            <td>List of entity names for dropping eBPF APM data. For example: `["kube-dns", "otel-collector", "service1"]`.</td>
+            <td>List</td>
+            <td>`[]`</td>
+        </tr>
+        <tr>
+            <td>`apmDataFilters.keepEntityName`</td>
+            <td>List of entity names to always keep eBPF APM data. By default all entities are kept/enabled. This bypasses `apmDataFilters.dropEntityName` filter. For example: `["critical-service", "important-app"]`.</td>
+            <td>List</td>
+            <td>`[]`</td>
+        </tr>
+        <tr>
+            <td>`apmDataFilters.jvmMetricsReporting`</td>
+            <td>Enable JVM metrics reporting. When enabled, the agent collects and reports JVM metrics for Java applications.</td>
+            <td>Boolean</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
+            <td>`networkMetricsDataFilter.dropEntityName`</td>
+            <td>List of entity names for dropping network metrics data. For example: `["kube-dns", "otel-collector", "service1"]`.</td>
+            <td>List</td>
+            <td>`[]`</td>
+        </tr>
+        <tr>
+            <td>`networkMetricsDataFilter.keepEntityName`</td>
+            <td>List of entity names to always keep network metrics data. By default all entities are kept/enabled. This bypasses `networkMetricsDataFilter.dropEntityName` filter. For example: `["critical-service", "important-app"]`.</td>
+            <td>List</td>
+            <td>`[]`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.enabled`</td>
+            <td>Enable log collection from entities matching the log data filters below.</td>
+            <td>Boolean</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.fileRegex`</td>
+            <td>Regex to match log file names to include for entity log reporting.</td>
+            <td>String</td>
+            <td>`".*.log$"`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.logLevelThreshold`</td>
+            <td>Minimum log level to report. Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.</td>
+            <td>String</td>
+            <td>`"INFO"`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.maxSamplesPerMinute`</td>
+            <td>Maximum number of log samples to collect per minute from an entity. Once this limit is reached, events are sampled to maintain an even distribution across the harvest cycle.</td>
+            <td>Integer</td>
+            <td>`10000`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.keepStdStreamEntityRegex`</td>
+            <td>Regex to match entity names to keep logs from stdout and stderr.</td>
+            <td>String</td>
+            <td>`".*"`</td>
+        </tr>
+        <tr>
+            <td>`logDataFilters.applicationLogReporting.keepFileEntityRegex`</td>
+            <td>Regex to match entity names to keep logs from log files.</td>
+            <td>String</td>
+            <td>`".*"`</td>
+        </tr>
+        <tr>
+            <td>`protocols.global.max_unlinked_spans`</td>
             <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit.</td>
-            <td>`String`</td>
-            <td>`"100"`</td>
+            <td>Integer</td>
+            <td>`100`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_HTTP_ENABLED`</td>
+            <td>`protocols.global.unlinked_spans_error_quota_percentage`</td>
+            <td>Reserves a configurable percentage of the unlinked span quota for error spans, ensuring error visibility even when normal spans arrive first.</td>
+            <td>Integer</td>
+            <td>`30`</td>
+        </tr>
+        <tr>
+            <td>`protocols.http.enabled`</td>
             <td>Enables or disables all HTTP protocol tracing (metrics and spans).</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_HTTP_SPANS_ENABLED`</td>
+            <td>`protocols.http.spans.enabled`</td>
             <td>Enables or disables the exporting of spans for HTTP requests.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_HTTP_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.http.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting HTTP spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_HTTP_SPANS_SAMPLING_ERROR_RATE`</td>
+            <td>`protocols.http.spans.samplingErrorRate`</td>
             <td>Sets an error rate percentage (1-100) for an HTTP route. If a route's error rate exceeds this value, its corresponding spans are exported.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`""`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_THRIFT_ENABLED`</td>
+            <td>`protocols.thrift.enabled`</td>
             <td>Enables or disables all Thrift protocol tracing (metrics and spans).</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_THRIFT_SPANS_ENABLED`</td>
+            <td>`protocols.thrift.spans.enabled`</td>
             <td>Enables or disables the exporting of spans for Thrift requests.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_THRIFT_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.thrift.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting Thrift spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_THRIFT_SPANS_SAMPLING_ERROR_RATE`</td>
+            <td>`protocols.thrift.spans.samplingErrorRate`</td>
             <td>Sets an error rate percentage (1-100) for a Thrift service or method. If a service's error rate exceeds this value, its corresponding spans are exported.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`""`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MYSQL_ENABLED`</td>
+            <td>`protocols.mysql.enabled`</td>
             <td>Enables or disables all MySQL protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MYSQL_SPANS_ENABLED`</td>
+            <td>`protocols.mysql.spans.enabled`</td>
             <td>Enables or disables exporting of spans for MySQL queries.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MYSQL_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.mysql.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting MySQL spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_PGSQL_ENABLED`</td>
+            <td>`protocols.pgsql.enabled`</td>
             <td>Enables or disables all PostgreSQL protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_PGSQL_SPANS_ENABLED`</td>
+            <td>`protocols.pgsql.spans.enabled`</td>
             <td>Enables or disables exporting of spans for PostgreSQL queries.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_PGSQL_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.pgsql.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting PostgreSQL spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_CASS_ENABLED`</td>
+            <td>`protocols.cass.enabled`</td>
             <td>Enables or disables all Cassandra protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_CASS_SPANS_ENABLED`</td>
+            <td>`protocols.cass.spans.enabled`</td>
             <td>Enables or disables exporting of spans for Cassandra queries.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_CASS_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.cass.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting Cassandra spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_REDIS_ENABLED`</td>
+            <td>`protocols.redis.enabled`</td>
             <td>Enables or disables all Redis protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_REDIS_SPANS_ENABLED`</td>
+            <td>`protocols.redis.spans.enabled`</td>
             <td>Enables or disables exporting of spans for Redis commands.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_REDIS_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.redis.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting Redis spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MONGODB_ENABLED`</td>
+            <td>`protocols.mongodb.enabled`</td>
             <td>Enables or disables all MongoDB protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MONGODB_SPANS_ENABLED`</td>
+            <td>`protocols.mongodb.spans.enabled`</td>
             <td>Enables or disables exporting of spans for MongoDB queries.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MONGODB_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.mongodb.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting MongoDB spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_DYNAMODB_ENABLED`</td>
+            <td>`protocols.dynamodb.enabled`</td>
             <td>Enables or disables all DynamoDB protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_DYNAMODB_SPANS_ENABLED`</td>
+            <td>`protocols.dynamodb.spans.enabled`</td>
             <td>Enables or disables exporting of spans for DynamoDB queries.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_DYNAMODB_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.dynamodb.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting DynamoDB spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MSSQL_ENABLED`</td>
+            <td>`protocols.mssql.enabled`</td>
             <td>Enables or disables all MSSQL protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MSSQL_SPANS_ENABLED`</td>
+            <td>`protocols.mssql.spans.enabled`</td>
             <td>Enables or disables exporting of spans for MSSQL queries.</td>
-            <td>`String`</td>
-            <td>`"false"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_MSSQL_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.mssql.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting MSSQL spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_KAFKA_ENABLED`</td>
+            <td>`protocols.kafka.enabled`</td>
             <td>Enables or disables all Kafka protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_KAFKA_SPANS_ENABLED`</td>
+            <td>`protocols.kafka.spans.enabled`</td>
             <td>Enables or disables exporting of spans for Kafka messages. Note: Kafka tracing does not report metrics.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_KAFKA_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.kafka.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting Kafka spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_AMQP_ENABLED`</td>
+            <td>`protocols.amqp.enabled`</td>
             <td>Enables or disables all AMQP protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_AMQP_SPANS_ENABLED`</td>
+            <td>`protocols.amqp.spans.enabled`</td>
             <td>Enables or disables exporting of spans for AMQP (e.g., RabbitMQ) messages. Note: AMQP tracing does not report metrics.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_AMQP_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.amqp.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting AMQP spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_DNS_ENABLED`</td>
+            <td>`protocols.dns.enabled`</td>
             <td>Enables or disables all DNS protocol tracing.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_DNS_SPANS_ENABLED`</td>
+            <td>`protocols.dns.spans.enabled`</td>
             <td>Enables or disables exporting of spans for DNS queries. Note: DNS tracing does not report metrics.</td>
-            <td>`String`</td>
-            <td>`"true"`</td>
+            <td>Boolean</td>
+            <td>`true`</td>
         </tr>
         <tr>
-            <td>`PROTOCOLS_DNS_SPANS_SAMPLING_LATENCY`</td>
+            <td>`protocols.dns.spans.samplingLatency`</td>
             <td>Sets the sampling latency threshold for exporting DNS spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>`String`</td>
+            <td>String</td>
             <td>`"p50"`</td>
         </tr>
     </tbody>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -250,13 +250,13 @@ Configure filters to drop all types of data (network metrics and APM data) based
     <tbody>
         <tr>
             <td>`allDataFilters.dropServiceNameRegex`</td>
-            <td>Regular expression pattern to match entity names for dropping ALL data (network metrics + APM data). For example: `"java-app|otel-collector|\\bservice1\\b"`</td>
+            <td>Regular expression pattern to match entity names for dropping ALL data (network metrics + APM data). For example: `"java-app|otel-collector|\\bservice1\\b"`. Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both. If both are provided, keepServiceNameRegex takes precedence.</td>
             <td>String</td>
             <td>`""`</td>
         </tr>
         <tr>
             <td>`allDataFilters.keepServiceNameRegex`</td>
-            <td>Regular expression pattern to match entity names to always keep ALL data for. This bypasses all drop filters. For example: `"critical-service|important-app|\\bmust-monitor\\b"`</td>
+            <td>Regular expression pattern to match entity names to always keep ALL data for. This bypasses all drop filters. For example: `"critical-service|important-app|\\bmust-monitor\\b"`. Use either dropServiceNameRegex or keepServiceNameRegex to filter service names, not both. If both are provided, keepServiceNameRegex takes precedence.</td>
             <td>String</td>
             <td>`""`</td>
         </tr>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -125,9 +125,11 @@ Assigning custom name to applications:
 <CollapserGroup>
 
     <Collapser
-        id="configuration"
-        title="Configuration parameters"
+        id="general-configuration"
+        title="General configuration"
     >
+
+These parameters control the core identity and data destination for the eBPF agent.
 
 <table>
     <thead>
@@ -200,24 +202,6 @@ Assigning custom name to applications:
             <td>`"auto"`</td>
         </tr>
         <tr>
-            <td>`reportLogs`</td>
-            <td>Controls log reporting. When enabled, the agent collects and reports logs. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when APM is not attached).</td>
-            <td>String</td>
-            <td>`"false"`</td>
-        </tr>
-        <tr>
-            <td>`reportAiMetrics`</td>
-            <td>Enable AI monitoring. When enabled, the agent collects and reports AI monitoring data. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"`.</td>
-            <td>String</td>
-            <td>`"false"`</td>
-        </tr>
-        <tr>
-            <td>`genAICaptureMessageContent`</td>
-            <td>Enable GenAI capture message content. When enabled, the agent captures message content for GenAI interactions. Use with caution.</td>
-            <td>Boolean</td>
-            <td>`false`</td>
-        </tr>
-        <tr>
             <td>`includePortInServerEntityIdentification`</td>
             <td>The configuration allows you to include or exclude ports from auto-discovered entity names. Typically, names appear as `processName:cwd/container_name:[port]`, e.g., `python:frosty_merkle:[80]`. To exclude port details, set this option to `false` for names such as `python:frosty_merkle`.</td>
             <td>Boolean</td>
@@ -241,6 +225,29 @@ Assigning custom name to applications:
             <td>String</td>
             <td>`""`</td>
         </tr>
+    </tbody>
+</table>
+
+</Collapser>
+
+
+    <Collapser
+        id="all-data-filters"
+        title="All data filters"
+    >
+
+Configure filters to drop all types of data (network metrics and APM data) based on provided configuration.
+
+<table>
+    <thead>
+        <tr>
+        <th>Parameter name</th>
+        <th>Description</th>
+        <th>Data type</th>
+        <th>Example value</th>
+        </tr>
+    </thead>
+    <tbody>
         <tr>
             <td>`allDataFilters.dropServiceNameRegex`</td>
             <td>Regular expression pattern to match entity names for dropping ALL data (network metrics + APM data). For example: `"java-app|otel-collector|\\bservice1\\b"`</td>
@@ -259,6 +266,29 @@ Assigning custom name to applications:
             <td>Boolean</td>
             <td>`false`</td>
         </tr>
+    </tbody>
+</table>
+
+</Collapser>
+
+
+    <Collapser
+        id="apm-data-filters"
+        title="APM data filters"
+    >
+
+Configure filters to drop eBPF APM data based on provided configuration.
+
+<table>
+    <thead>
+        <tr>
+        <th>Parameter name</th>
+        <th>Description</th>
+        <th>Data type</th>
+        <th>Example value</th>
+        </tr>
+    </thead>
+    <tbody>
         <tr>
             <td>`apmDataFilters.dropEntityName`</td>
             <td>List of entity names for dropping eBPF APM data. For example: `["kube-dns", "otel-collector", "service1"]`.</td>
@@ -277,6 +307,29 @@ Assigning custom name to applications:
             <td>Boolean</td>
             <td>`true`</td>
         </tr>
+    </tbody>
+</table>
+
+</Collapser>
+
+
+    <Collapser
+        id="network-metrics-data-filters"
+        title="Network metrics data filters"
+    >
+
+Configure filters to drop/keep network metrics data based on provided configuration.
+
+<table>
+    <thead>
+        <tr>
+        <th>Parameter name</th>
+        <th>Description</th>
+        <th>Data type</th>
+        <th>Example value</th>
+        </tr>
+    </thead>
+    <tbody>
         <tr>
             <td>`networkMetricsDataFilter.dropEntityName`</td>
             <td>List of entity names for dropping network metrics data. For example: `["kube-dns", "otel-collector", "service1"]`.</td>
@@ -289,42 +342,42 @@ Assigning custom name to applications:
             <td>List</td>
             <td>`[]`</td>
         </tr>
+    </tbody>
+</table>
+
+</Collapser>
+
+
+    <Collapser
+        id="protocol-tracing"
+        title="Protocol tracing configuration"
+    >
+
+This section allows you to enable monitoring for specific network protocols and configure how trace data (spans) is collected. You can enable or disable monitoring for protocols like HTTP, MySQL, and others, and set parameters for span collection based on latency or error rates. The following protocols are supported:
+
+* HTTP
+* Thrift
+* MySQL
+* PostgreSQL
+* MongoDB
+* Apache Cassandra
+* Redis
+* DynamoDB
+* MSSQL
+* Kafka
+* AMQP
+* DNS
+
+<table>
+    <thead>
         <tr>
-            <td>`logDataFilters.applicationLogReporting.enabled`</td>
-            <td>Enable log collection from entities matching the log data filters below.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
+        <th>Parameter name</th>
+        <th>Description</th>
+        <th>Data type</th>
+        <th>Example value</th>
         </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.fileRegex`</td>
-            <td>Regex to match log file names to include for entity log reporting.</td>
-            <td>String</td>
-            <td>`".*.log$"`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.logLevelThreshold`</td>
-            <td>Minimum log level to report. Options: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.</td>
-            <td>String</td>
-            <td>`"INFO"`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.maxSamplesPerMinute`</td>
-            <td>Maximum number of log samples to collect per minute from an entity. Once this limit is reached, events are sampled to maintain an even distribution across the harvest cycle.</td>
-            <td>Integer</td>
-            <td>`10000`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.keepStdStreamEntityRegex`</td>
-            <td>Regex to match entity names to keep logs from stdout and stderr.</td>
-            <td>String</td>
-            <td>`".*"`</td>
-        </tr>
-        <tr>
-            <td>`logDataFilters.applicationLogReporting.keepFileEntityRegex`</td>
-            <td>Regex to match entity names to keep logs from log files.</td>
-            <td>String</td>
-            <td>`".*"`</td>
-        </tr>
+    </thead>
+    <tbody>
         <tr>
             <td>`protocols.global.max_unlinked_spans`</td>
             <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit. Unlinked spans are spans that the eBPF agent captures but cannot associate with its parent.</td>
@@ -338,232 +391,28 @@ Assigning custom name to applications:
             <td>`30`</td>
         </tr>
         <tr>
-            <td>`protocols.http.enabled`</td>
-            <td>Enables or disables all HTTP protocol tracing (metrics and spans).</td>
+            <td>`protocols.<protocol-name>.enabled`</td>
+            <td>If `true`, enables monitoring for the specified protocol (for example, `http`, `mysql`, and any others).</td>
             <td>Boolean</td>
             <td>`true`</td>
         </tr>
         <tr>
-            <td>`protocols.http.spans.enabled`</td>
-            <td>Enables or disables the exporting of spans for HTTP requests.</td>
+            <td>`protocols.<protocol-name>.spans.enabled`</td>
+            <td>If `true`, exports trace spans for the enabled protocol.</td>
             <td>Boolean</td>
             <td>`true`</td>
         </tr>
         <tr>
-            <td>`protocols.http.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting HTTP spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
+            <td>`protocols.<protocol-name>.spans.samplingLatency`</td>
+            <td>Defines the latency-based sampling threshold for exporting spans. Valid options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
             <td>String</td>
             <td>`"p50"`</td>
         </tr>
         <tr>
-            <td>`protocols.http.spans.samplingErrorRate`</td>
-            <td>Sets an error rate percentage (1-100) for an HTTP route. If a route's error rate exceeds this value, its corresponding spans are exported.</td>
+            <td>`protocols.<protocol-name>.spans.samplingErrorRate`</td>
+            <td>For HTTP and Thrift only. Exports spans from any route where the error rate exceeds the specified percentage (1-100).</td>
             <td>String</td>
             <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`protocols.thrift.enabled`</td>
-            <td>Enables or disables all Thrift protocol tracing (metrics and spans).</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.thrift.spans.enabled`</td>
-            <td>Enables or disables the exporting of spans for Thrift requests.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.thrift.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting Thrift spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.thrift.spans.samplingErrorRate`</td>
-            <td>Sets an error rate percentage (1-100) for a Thrift service or method. If a service's error rate exceeds this value, its corresponding spans are exported.</td>
-            <td>String</td>
-            <td>`""`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mysql.enabled`</td>
-            <td>Enables or disables all MySQL protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mysql.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for MySQL queries.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mysql.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting MySQL spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.pgsql.enabled`</td>
-            <td>Enables or disables all PostgreSQL protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.pgsql.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for PostgreSQL queries.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.pgsql.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting PostgreSQL spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.cass.enabled`</td>
-            <td>Enables or disables all Cassandra protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.cass.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for Cassandra queries.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.cass.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting Cassandra spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.redis.enabled`</td>
-            <td>Enables or disables all Redis protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.redis.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for Redis commands.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.redis.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting Redis spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mongodb.enabled`</td>
-            <td>Enables or disables all MongoDB protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mongodb.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for MongoDB queries.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mongodb.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting MongoDB spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.dynamodb.enabled`</td>
-            <td>Enables or disables all DynamoDB protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.dynamodb.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for DynamoDB queries.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.dynamodb.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting DynamoDB spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mssql.enabled`</td>
-            <td>Enables or disables all MSSQL protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mssql.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for MSSQL queries.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.mssql.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting MSSQL spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.kafka.enabled`</td>
-            <td>Enables or disables all Kafka protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.kafka.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for Kafka messages. Note: Kafka tracing does not report metrics.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.kafka.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting Kafka spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.amqp.enabled`</td>
-            <td>Enables or disables all AMQP protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.amqp.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for AMQP (e.g., RabbitMQ) messages. Note: AMQP tracing does not report metrics.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.amqp.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting AMQP spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
-        </tr>
-        <tr>
-            <td>`protocols.dns.enabled`</td>
-            <td>Enables or disables all DNS protocol tracing.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.dns.spans.enabled`</td>
-            <td>Enables or disables exporting of spans for DNS queries. Note: DNS tracing does not report metrics.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
-            <td>`protocols.dns.spans.samplingLatency`</td>
-            <td>Sets the sampling latency threshold for exporting DNS spans. Spans for requests slower than this percentile are exported. Options: `p1`, `p10`, `p50`, `p90`, `p99`.</td>
-            <td>String</td>
-            <td>`"p50"`</td>
         </tr>
     </tbody>
 </table>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -327,7 +327,7 @@ Assigning custom name to applications:
         </tr>
         <tr>
             <td>`protocols.global.max_unlinked_spans`</td>
-            <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit.</td>
+            <td>Controls maximum unlinked spans reported per protocol. Set to 0 to disable limit. Unlinked spans are spans that the eBPF agent captures but cannot associate with its parent.</td>
             <td>Integer</td>
             <td>`100`</td>
         </tr>

--- a/src/content/docs/ebpf/network-metrics.mdx
+++ b/src/content/docs/ebpf/network-metrics.mdx
@@ -132,7 +132,7 @@ When network metrics-only mode is enabled, the eBPF agent automatically detects 
 Run the following command to enable network metrics-only mode in new Kubernetes installations:
 
 ```bash
-KSM_IMAGE_VERSION="v2.13.0" && helm repo add newrelic https://helm-charts.newrelic.com && helm repo update && kubectl create namespace "newrelic" ; helm upgrade --install nr-ebpf-agent newrelic/nr-ebpf-agent --set licenseKey=<your-license-key> --set cluster="cluster-name-ebpf" --set apmDataReporting=false --namespace=newrelic
+KSM_IMAGE_VERSION="v2.13.0" && helm repo add newrelic https://helm-charts.newrelic.com && helm repo update && kubectl create namespace "newrelic" ; helm upgrade --install nr-ebpf-agent newrelic/nr-ebpf-agent --set licenseKey=<your-license-key> --set cluster="cluster-name-ebpf" --set reportApmData=false --namespace=newrelic
 ```
 
     </Collapser>
@@ -145,10 +145,10 @@ KSM_IMAGE_VERSION="v2.13.0" && helm repo add newrelic https://helm-charts.newrel
 
 Follow the below steps to enable network metrics-only mode in existing Kubernetes installations:
 
-1. Add the following `apmDataReporting` key with a value of `false` to your `values.yaml` file:
+1. Set the `reportApmData` key to `"false"` in your `values.yaml` file:
 
     ```yaml
-    apmDataReporting: false
+    reportApmData: "false"
     ```
 
 2. Apply the configuration:
@@ -189,10 +189,10 @@ curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh |
 
 Follow the below steps to enable network metrics-only mode in existing Linux host installations:
 
-1. Add the following `apmDataReporting` key with a value of `false` to your `newrelic-ebpf-agent.conf` file:
+1. Set the `reportApmData` key to `"false"` in your `newrelic-ebpf-agent.yaml` file:
 
-    ```bash
-    APM_DATA_REPORTING="false"
+    ```yaml
+    reportApmData: "false"
     ```
 
 

--- a/src/content/docs/ebpf/requirements.mdx
+++ b/src/content/docs/ebpf/requirements.mdx
@@ -33,6 +33,7 @@ The following Kubernetes environments are supported:
   * Google Kubernetes Engine (GKE)
   * Azure Kubernetes Service (AKS)
   * Red Hat OpenShift
+  * Microk8s
 
 ### Container runtime support [#container-runtime]
 
@@ -68,8 +69,7 @@ The following Linux distributions are supported:
   * Debian `11` and above
   * Red Hat Enterprise Linux `8.1` and above
   * Ubuntu `20.04` and above
-  * openSUSE Leap `15.5` and above
-  * Amazon Linux `2`, 2023 
+  * Amazon Linux `2` and `2023`
   * Bottle Rocket `1.51.0` and above
   * AlmaLinux `9.7`
 

--- a/src/content/docs/ebpf/troubleshooting/file-descriptor-limit.mdx
+++ b/src/content/docs/ebpf/troubleshooting/file-descriptor-limit.mdx
@@ -95,28 +95,33 @@ If increasing resource limits is not feasible, you can reduce the agent's file d
 
 1. Reduce monitoring scope by filtering out namespaces or services:
    
-   * **For Linux hosts** (`/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.conf`):
+   * **For Linux hosts** (`/etc/newrelic-ebpf-agent/newrelic-ebpf-agent.yaml`):
 
-      ```bash
-      # Exclude specific processes or entities
-      DROP_DATA_FOR_ENTITY="process1,process2"
+      ```yaml
+      # Exclude specific entities by regex
+      allDataFilters:
+        dropServiceNameRegex: "process1|process2"
       ```
    
    * **For Kubernetes** (`values.yaml`):
 
       ```yaml
       # Exclude namespaces or services
-      dropDataForNamespaces: ["kube-system", "monitoring"]
-      dropDataServiceNameRegex: "kube-dns|system-service"
+      allDataFilters:
+        dropNamespaces: ["kube-system", "monitoring"]
+        dropServiceNameRegex: "kube-dns|system-service"
       ```
 
 2. Disable specific protocol monitoring to reduce the number of probes:
    
    * **For Linux hosts:**
       
-      ```bash
-      PROTOCOLS_MYSQL_ENABLED="false"
-      PROTOCOLS_MONGODB_ENABLED="false"
+      ```yaml
+      protocols:
+        mysql:
+          enabled: false
+        mongodb:
+          enabled: false
       ```
    
    * **For Kubernetes:**

--- a/src/content/docs/ebpf/troubleshooting/no-ui-data.mdx
+++ b/src/content/docs/ebpf/troubleshooting/no-ui-data.mdx
@@ -89,7 +89,7 @@ Port blocking can occur at both levels simultaneously, causing connectivity issu
    helm upgrade nr-ebpf-agent newrelic/nr-ebpf-agent -n newrelic --reuse-values
    ```
 
-3. **Check data filtering settings**: Verify that your entity isn't being excluded by configuration parameters like `DROP_DATA_FOR_ENTITY` or `dropDataServiceNameRegex`.
+3. **Check data filtering settings**: Verify that your entity isn't being excluded by configuration parameters like `allDataFilters.dropServiceNameRegex` or `allDataFilters.dropNamespaces`.
 
 ### Additional verification steps:
 

--- a/src/content/docs/ebpf/troubleshooting/troubleshoot-k8s.mdx
+++ b/src/content/docs/ebpf/troubleshooting/troubleshoot-k8s.mdx
@@ -54,7 +54,7 @@ eBPF agent fails to start due to insufficient privileges.
 
    ```bash
    kubectl get nodes -o wide
-   # Kernel version should be 5.4 or later
+   # Kernel version should be 5.8 or later
    ```
 
    </Collapser>
@@ -92,8 +92,9 @@ eBPF agent consuming excessive resources or causing performance degradation.
 3. Configure data filtering to reduce load:
 
       ```yaml
-      dropDataForNamespaces: ["kube-system", "monitoring"]
-      dropDataServiceNameRegex: "kube-dns|otel-collector"
+      allDataFilters:
+        dropNamespaces: ["kube-system", "monitoring"]
+        dropServiceNameRegex: "kube-dns|otel-collector"
       ```
 
 4. Limit protocol monitoring if not all protocols are needed:
@@ -191,7 +192,8 @@ Entity names not appearing correctly or data not attributed to correct services.
    
       ```yaml
       # In values.yaml
-      dropDataForNamespaces: []  # Remove namespaces you want to monitor
+      allDataFilters:
+        dropNamespaces: []  # Remove namespaces you want to monitor
       ```
 
 * In Kubernetes, entity names are derived from the Kubernetes service name for example, `mysql-database-service`. On hosts or in Docker, names are a combination of the process name, its directory or container ID, and the listening port for example, `ruby:/home/ubuntu/app:[5678]`.


### PR DESCRIPTION
## Summary
- Migrated Linux host config documentation from `.conf` (env-var `KEY=VALUE`) format to `.yaml` (structured YAML) format to match agent v1.4.0
- Added missing config fields to both Linux and K8s installation docs
- Removed deprecated/stale fields and fixed inconsistencies across troubleshooting pages

## Changes

### Linux installation (`linux-installation.mdx`)
- Updated config file references from `newrelic-ebpf-agent.conf` to `newrelic-ebpf-agent.yaml`
- Rewrote entire config parameter table with new YAML field names (camelCase, dot-notation for nested fields)
- Added new fields: `region`, `customOtlpEndpoint`, `customOtlpEndpointTlsEnabled`, `customOtlpEndpointTlsCertPath`, `reportLogs`, `reportAiMetrics`, `genAICaptureMessageContent`, `entityLabels`, `logDataFilters.*` (6 fields), `protocols.global.unlinked_spans_error_quota_percentage`
- Removed `DROP_EAPM_DATA_FOR_APM_AGENT_ENABLED_ENTITY` and `TABLE_STORE_DATA_LIMIT_MB`
- Updated data types to proper Boolean/List/Map/Integer where applicable

### K8s installation (`k8s-installation.mdx`)
- Renamed `apmDataReporting` → `reportApmData`, `networkMetricsReporting` → `reportNetworkMetrics` with updated types and defaults
- Added missing general config fields: `reportLogs`, `reportAiMetrics`, `genAICaptureMessageContent`, `customOtlpEndpoint`, `customOtlpEndpointTlsEnabled`, `customOtlpEndpointTlsCertSecret`, `customOtlpEndpointTlsCertSecretKey`, `entityLabels`
- Added missing all data filter fields: `keepNamespaces`, `dropPodLabels`, `keepPodLabels`
- Added new log data filters section with 6 fields
- Added `protocols.global.unlinked_spans_error_quota_percentage`
- Removed stale fields: `nrStaging`, `tableStoreDataLimitMB`, `dropEapmForApmEnabledEntity`
- Fixed `dropPodLabels` type from `String` to `Map` in APM and network metrics filter sections
- Updated `dropDataForNamespaces` → `allDataFilters.dropNamespaces` in tip callout

### Network metrics (`network-metrics.mdx`)
- Updated Linux config reference from `.conf`/`APM_DATA_REPORTING` to `.yaml`/`reportApmData`
- Updated K8s Helm commands and values from `apmDataReporting` to `reportApmData`

### Troubleshooting pages
- `troubleshoot-k8s.mdx`: Fixed kernel version from 5.4 to 5.8; updated `dropDataForNamespaces`/`dropDataServiceNameRegex` to `allDataFilters.dropNamespaces`/`allDataFilters.dropServiceNameRegex`
- `no-ui-data.mdx`: Updated deprecated `DROP_DATA_FOR_ENTITY`/`dropDataServiceNameRegex` references
- `file-descriptor-limit.mdx`: Updated Linux examples from `.conf` env-var format to `.yaml`; updated K8s examples from deprecated field names to `allDataFilters.*`