### PR TITLE
Nr 552376 remove metric dpm limit

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes.mdx
@@ -50,16 +50,6 @@ The following default limits apply for all Metric data:
 
     <tr>
       <td>
-        Max data points per minute (DPM)
-      </td>
-
-      <td>
-        3-15 million DPM [(learn more)](#additional-considerations)
-      </td>
-    </tr>
-
-    <tr>
-      <td>
         Max unique time series (cardinality) per account per day
       </td>
 
@@ -245,26 +235,13 @@ The following default limits apply only to data collected via the Prometheus Rem
 
 ### Additional account conditions [#additional-considerations]
 
-Metric API limits apply at the individual account level. The default limits for DPM and cardinality range from 3M for organizations on our [Free edition](https://newrelic.com/pricing), up to 10.2M for some paying organizations. To understand your organization's limits, see the [Limits UI](/docs/data-apis/manage-data/view-system-limits). DPM and cardinality can be increased to 15M on request for paying organizations. Max payloads per minute can be adjusted above 100k on a case-by-case basis. To request changes to your metric rate limits, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com/).
+Metric API limits apply at the individual account level. The default cardinality limit ranges from 3M for organizations on our [Free edition](https://newrelic.com/pricing), up to 10.2M for some paying organizations. To understand your organization's limits, see the [Limits UI](/docs/data-apis/manage-data/view-system-limits). Cardinality can be increased to 15M on request for paying organizations. Max payloads per minute can be adjusted above 100k on a case-by-case basis. To request changes to your metric rate limits, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com/).
 
 ## Rate limit incidents [#rate-limit-incidents]
 
 This section describes how the Metric API behaves when you exceed the rate limits, and how to respond if limits are exceeded.
 
 <CollapserGroup>
-  <Collapser
-    id="incident-dpm-exceeded"
-    title="Max data points per minute (DPM)"
-  >
-    Data points per minute refers to the per minute rate at which individual metric values are sent to the Metric API.
-
-    When the maximum DPM limit is exceeded for an account, the New Relic Metric API returns a `429` response for the remainder of the minute. The response will include a `Retry-After` header indicating how long to wait in seconds before resubmitting or sending new data.
-
-    To resolve this issue, either reduce the number of data points you are sending, or request a rate limit change. Subsequent subscription changes do not impact modified rate limits. If an account change impacts your rate limit, you must notify us to adjust your rate limit.
-
-    To request rate limit changes, contact your New Relic account representative, or visit our [Support portal](http://support.newrelic.com).
-  </Collapser>
-
   <Collapser
     id="incident-unique-timeseries"
     title="Max unique time series per account per day"

--- a/src/content/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events.mdx
+++ b/src/content/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events.mdx
@@ -81,20 +81,6 @@ The `category` indicates the type of error and the `message` provides more detai
       </td>
 
       <td>
-        `DatapointsPerMinute`
-      </td>
-
-      <td>
-        You are sending too many datapoints per minute. If you get this error, you can either send data less frequently, or request changes to your metric rate limits by contacting your New Relic account representative, or visiting our [Support portal](https://support.newrelic.com/).
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        `RateLimit`
-      </td>
-
-      <td>
         `UniqueTimeseriesPerDay`
       </td>
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/remote-write-errors-error-messages.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure-remote-write/remote-write-errors-error-messages.mdx
@@ -38,7 +38,7 @@ If you receive an integration error message from New Relic or error messages in 
   </Collapser>
 
   <Collapser title="429: rate limit error">
-    This means you have hit a [rate limit](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/#rate-limit-incidents) on the amount of data being sent at one time (for example cardinality or data points per minute). You can troubleshoot by reducing the amount of Prometheus or general metric data you are sending, or by requesting a rate-limit increase.
+    This means you have hit a [rate limit](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes/#rate-limit-incidents) on the amount of data being sent at one time (for example cardinality). You can troubleshoot by reducing the amount of Prometheus or general metric data you are sending, or by requesting a rate-limit increase.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
+++ b/src/content/docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide.mdx
@@ -1264,22 +1264,16 @@ spec:
         cpu: 1000m
 ```
 
-### POMI: estimating DPM and cardinality
+### POMI: estimating cardinality
 
-Although cardinality is not associated directly with billable per GB ingest, New Relic does maintain certain rate limits on cardinality and data points per minute. Being able to visualize cardinality and DPM from a Prometheus cluster can be very important.
+Although cardinality is not associated directly with billable per GB ingest, New Relic does maintain certain rate limits on cardinality. Being able to visualize cardinality from a Prometheus cluster can be very important.
 
 <Callout variant="tip">
-New Relic accounts have a 1M DPM and 1M cardinality limit, but you can request up to 15M DPM and 15M cardinality. To request changes, contact your New Relic account representative. For more information, see [Metric API limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes).
+New Relic accounts have a 1M cardinality limit, but you can request up to 15M cardinality. To request changes, contact your New Relic account representative. For more information, see [Metric API limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes).
 </Callout>
 
-If you're already running Prometheus Server, you can run DPM and cardinality estimates there prior to enabling POMI or `remote_write`.
+If you're already running Prometheus Server, you can run cardinality estimates there prior to enabling POMI or `remote_write`.
 
-**Data points per minute (DPM):**
-
-```promql
-rate(prometheus_tsdb_head_samples_appended_total[10m]) * 60
-```
-    
 **Top 20 metrics (highest cardinality):**
 
 ```promql

--- a/src/content/docs/tutorial-optimize-telemetry/data-optimize-techniques.mdx
+++ b/src/content/docs/tutorial-optimize-telemetry/data-optimize-techniques.mdx
@@ -1075,23 +1075,15 @@ This section includes various ways to configure New Relic features to optimize d
             cpu: 1000m
     ```
 
-    ### POMI: estimating DPM and cardinality
+    ### POMI: estimating cardinality
 
-    Although cardinality is not associated directly with billable per GB ingest, New Relic does maintain certain rate limits on cardinality and data points per minute. Being able to visualize cardinality and DPM from a Prometheus cluster can be very important.
+    Although cardinality is not associated directly with billable per GB ingest, New Relic does maintain certain rate limits on cardinality. Being able to visualize cardinality from a Prometheus cluster can be very important.
 
     <Callout variant="tip">
-      New Relic accounts have a 1M DPM and 1M cardinality limit, but you can request up to 15M DPM and 15M cardinality. To request changes, contact your New Relic account representative. For more information, see [Metric API limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes).
+      New Relic accounts have a 1M cardinality limit, but you can request up to 15M cardinality. To request changes, contact your New Relic account representative. For more information, see [Metric API limits](/docs/data-apis/ingest-apis/metric-api/metric-api-limits-restricted-attributes).
     </Callout>
 
-    If you're already running Prometheus Server, you can run DPM and cardinality estimates prior to enabling POMI or `remote_write`.
-
-    <DNT>
-      **Data points per minute (DPM):**
-    </DNT>
-
-    ```promql
-    rate(prometheus_tsdb_head_samples_appended_total[10m]) * 60
-    ```
+    If you're already running Prometheus Server, you can run cardinality estimates prior to enabling POMI or `remote_write`.
 
     <DNT>
       **Top 20 metrics (highest cardinality):**


### PR DESCRIPTION
## Give us some context                                                                    
                                                                                             
  **What problems does this PR solve?**                                                      
  Removes Metric API data points per minute (DPM) limit references from public docs as part  
  of the DPM limit EOL (NR-552376 / parent NR-533796). The limit has been removed, so        
  references to it should not remain in public-facing documentation.                         
                                                                                             
  **Changes:**                                                                               
  - `metric-api-limits-restricted-attributes.mdx` — removed DPM table row, DPM rate limit    
  incident collapser, and DPM references from additional-considerations paragraph            
  (cardinality content preserved)                                                            
  - `troubleshoot-nrintegrationerror-events.mdx` — removed `DatapointsPerMinute` rate limit  
  error entry                                                                                
  - `data-governance-optimize-ingest-guide.mdx` — renamed POMI section, removed DPM          
  callout/prose/PromQL (cardinality content preserved)                                       
  - `data-optimize-techniques.mdx` — same as above                                           
  - `remote-write-errors-error-messages.mdx` — removed DPM from 429 error example  