### PR TITLE
Release notes for node-api and node-browser runtime rc1.16

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-rc1.16.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-rc1.16.mdx
@@ -1,0 +1,17 @@
+---
+subject: Node API runtime
+releaseDate: '2026-04-20'
+version: 3.0.12
+---
+
+### Features
+* Fixed the following vulnerabilities:
+
+ * CVE-2026-39983
+ * CVE-2025-62718
+ * CVE-2026-40175
+ * CVE-2026-5758
+ * GHSA-6v7q-wjvx-w8wg
+ * GHSA-rp42-5vxx-qpwr
+ * GHSA-r4q5-vmmm-2653
+ * GHSA-vvjj-xcjg-gr5g

--- a/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-rc1.16.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-rc1.16.mdx
@@ -1,0 +1,22 @@
+---
+subject: Node browser runtime
+releaseDate: '2026-04-20'
+version: 3.0.12
+---
+
+### Features
+  * Updated Chrome to version 147
+  * Added AWS SDK DynamoDB package support
+
+  * Fixed the following vulnerabilities:
+
+  * CVE-2026-39983
+  * GHSA-6v7q-wjvx-w8wg
+  * GHSA-rp42-5vxx-qpwr
+  * CVE-2026-4800
+  * CVE-2026-33151
+  * CVE-2025-62718
+  * CVE-2026-40175
+  * GHSA-r4q5-vmmm-2653
+  * CVE-2026-2950
+  * GHSA-vvjj-xcjg-gr5g


### PR DESCRIPTION


## Give us some context

 This PR adds release notes for the rc1.16 release of the Node API and Node Browser Synthetics runtimes (version 3.0.12, released 2026-04-20).
  Node Browser Runtime rc1.16:
  - Updated Chrome to version 147
  - Added AWS SDK DynamoDB package support
  - Fixed vulnerabilities: CVE-2026-39983, CVE-2026-4800, CVE-2026-33151, CVE-2025-62718, CVE-2026-40175, CVE-2026-2950, GHSA-6v7q-wjvx-w8wg, GHSA-rp42-5vxx-qpwr,
  GHSA-r4q5-vmmm-2653, GHSA-vvjj-xcjg-gr5g

  Node API Runtime rc1.16:
  - Fixed vulnerabilities: CVE-2026-39983, CVE-2025-62718, CVE-2026-40175, CVE-2026-5758, GHSA-6v7q-wjvx-w8wg, GHSA-rp42-5vxx-qpwr, GHSA-r4q5-vmmm-2653,
  GHSA-vvjj-xcjg-gr5g