### PR TITLE
iOS Release Notes v6.9.22

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6106.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6106.mdx
@@ -1,0 +1,12 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2026-04-22'
+version: '6.9.22'
+downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
+redirects:
+  - /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6106
+---
+
+### Features, Improvements & Fixes
+- Dashboard summary filter now dynamically extracts event types from widget NRQL queries instead of hardcoding "MobileBreadcrumb", aligning iOS filter behavior with Android and Web
+


### PR DESCRIPTION
## iOS App 6.9.22 Release Notes

**Build:** 6106
**Release Date:** 2026-04-22

### Bug Fixes
- Dashboard summary filter now dynamically extracts event types from widget NRQL queries instead of hardcoding "MobileBreadcrumb", aligning iOS filter behavior with Android and Web

**Jira:** [NR-553652](https://new-relic.atlassian.net/browse/NR-553652)

[NR-553652]: https://new-relic.atlassian.net/browse/NR-553652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ