### PR TITLE
Revert verbiage to 'yanked' in Python Agent release notes

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110000.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/python-release-notes/python-agent-110000.mdx
@@ -10,7 +10,7 @@ bugs: ['Fixes a crash in psycopg', 'Ensures MCP spans are only recorded when AI 
 ## Notes
 
 <Callout variant="caution">
-  This version of the agent has been withdrawn.
+  This version of the agent has been yanked.
 </Callout>
 
 This release of the Python agent makes the following changes:


### PR DESCRIPTION
A previous release of the Python Agent's v11.0.0 notes had noted the status as "withdrawn" and this PR changes it back to the term "yanked"

It seems as though [this comment](https://github.com/newrelic/docs-website/pull/21863#issuecomment-3377794941) may have been missed before the previous merge.  The reason for this is because "yanked" is a [specific industry term](https://docs.pypi.org/project-management/yanking/) that denotes the continued presence of the specified version despite no longer being shown.  In other words, it is now hidden.  There is also the concept of deleting a release, but this is reserved for more extreme cases.  In this case, using this specific term is necessary for customers to be able to differentiate the two.