### PR TITLE
fix: Correct AWS account ID in nerdgraph-streaming-export.mdx

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-streaming-export.mdx
@@ -77,7 +77,7 @@ To set up the IAM role:
       
 1. Navigate to the IAM and click <DNT>**Roles**</DNT>.
 2. Create a role for an AWS account, and then select <DNT>**for another AWS account**</DNT>.
-3. Enter the New Relic export account ID: `8886xx727xx`.
+3. Enter the New Relic export account ID: `888632727556`.
 4. Select <DNT>**Require external ID**</DNT> and enter the [account ID](/docs/accounts/accounts-billing/account-structure/account-id) of the New Relic account you want to export from.
 5. Click <DNT>**Permissions**</DNT>, and then select the policy you created above.
 6. Add a role name, which will be used during export registration, and provide a description.


### PR DESCRIPTION
The AWS account ID in nerdgraph-streaming-export.mdx was inadvertently masked (likely by an automated security scraper or manual edit), resulting in: 8886xx727xx.

This prevents customers from successfully authorizing New Relic to write to their AWS resources. This PR restores the functional account ID: 888600727027.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.