### PR TITLE
fix: add iam.managed.allowedPolicyMembers guidance to GCP integration docs

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic.mdx
@@ -125,7 +125,10 @@ Integrating your GCP project with New Relic requires you to authorize New Relic 
 
     New Relic manages a specific Google service account for your New Relic account; you do not need to create it or manage the associated private key. Just add the service account ID as a member with viewing permissions in your project.
 
-    If your organization uses a [domain restriction constraint](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains), you will have to update the policy to allow the New Relic domain, `C02x1gp26`.
+    If your organization uses a [domain restriction constraint](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains), you will have to update the policy to allow New Relic, depending on which constraint your organization enforces:
+
+    * **`iam.allowedPolicyMemberDomains`**: Allow the New Relic domain ID `C02x1gp26`.
+    * **`iam.managed.allowedPolicyMembers`**: Allow the New Relic GCP Organization ID `740422149647` or GCP Project Number `397727728820`.
 
     This authorization method is recommended, especially if your GCP project is managed by a team. It also guarantees that New Relic will collect tags and other attributes whenever possible.
   </Collapser>


### PR DESCRIPTION
## Summary

- Expands the GCP domain restriction constraint guidance in the service account authorization section to cover both constraint types
- Adds `iam.managed.allowedPolicyMembers` entry with New Relic's GCP Organization ID (`740422149647`) and Project Number (`397727728820`) for enterprise customers who cannot use domain-based allowlisting

## Context

Enterprise customers using `iam.managed.allowedPolicyMembers` (principal-based constraint) were blocked from connecting GCP to New Relic because the existing docs only documented the `iam.allowedPolicyMemberDomains` Domain ID (`C02x1gp26`), which is insufficient for the stricter principal-based policy.

Jira: [NR-551162](https://new-relic.atlassian.net/browse/NR-551162)

## Test plan

- [ ] Verify rendered output of updated collapser section at `/docs/infrastructure/google-cloud-platform-integrations/get-started/connect-google-cloud-platform-services-new-relic`
- [ ] Confirm both constraint bullets display correctly

[NR-551162]: https://new-relic.atlassian.net/browse/NR-551162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ