### PR TITLE
docs(synthetics): re-add scripted API Node.js 22 transition guide from closed PR #23296

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-api-monitors-to-node-22.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-api-monitors-to-node-22.mdx
@@ -1,0 +1,416 @@
+---
+title: "Transition Guide: Upgrading Scripted API Monitors to Latest Node.js Runtime"
+tags:
+  - Synthetics
+  - Synthetic monitoring
+  - Scripting monitors
+  - API monitoring
+translate:
+  - jp
+metaDescription: Guide for upgrading scripted API monitors to the latest Node.js runtime (Node.js 22), including important changes and migration steps.
+freshnessValidatedDate: never
+---
+
+We are introducing our latest scripted API monitor runtime, featuring the **Latest** Node.js version (currently Node.js 22). The "Latest" runtime automatically uses the most current Node.js release that New Relic supports, ensuring your API monitors run in an environment that matches modern Node.js standards, providing enhanced security, stability, and performance.
+
+**Important note:** As part of the upgrade from Node.js 16 to Node.js 22, the runtime is stricter about process lifecycles. If your monitor scripts contain unhandled "open handles" (such as unresolved promises, lingering timers, or unclosed network connections), you might begin to see monitor failures. We strongly recommend validating your scripts against the new runtime to handle these changes.
+
+<Callout variant="important">
+  ## Node 22 Upgrade Impact
+
+  With the update to the Latest Node.js runtime (currently Node.js 22), customers might experience monitor failures if their scripts contain unhandled open handles (e.g., hanging promises, lingering network requests, or unclosed timers).
+
+  To avoid interruptions, validate your monitor scripts against the latest runtime to ensure all handles are properly closed before the script finishes executing. Failed validations will appear in the Runtime Upgrades UI.
+</Callout>
+
+<Callout variant="tip">
+  ## Public and Hybrid Location Support
+
+  New Relic will handle the upgrade process for scripted browser and API monitors running on public locations, as well as monitors configured to run on both public and private locations. The automated validation and upgrade process applies to all location configurations.
+</Callout>
+
+## What is "Latest"?
+
+The "Latest" runtime option in the monitor create/upgrade dropdown automatically uses the most recent Node.js version that New Relic supports. Instead of pinning to a specific Node.js version (like Node.js 16 or Node.js 20), "Latest" ensures your monitors always run on the newest available Node.js release with the latest features, performance improvements, and security updates.
+
+## How to upgrade via NerdGraph
+
+To upgrade your monitor runtimes programmatically, use the following NerdGraph mutation. You will need to supply your monitor's specific entity GUID.
+
+### For Scripted API Monitors
+
+```graphql
+mutation {
+  syntheticsUpdateScriptApiMonitor(
+    guid: "YOUR_MONITOR_GUID",
+    monitor: {
+      runtime: {
+        runtimeType: "NODE_API",
+        runtimeTypeVersion: "22.22.0",
+      }
+    }
+  ) {
+    errors {
+      description
+      type
+    }
+  }
+}
+```
+
+<Callout variant="tip">
+  For Scripted Browser monitors, use `runtimeType: "CHROME_BROWSER"` and `runtimeTypeVersion: "LATEST"` instead.
+</Callout>
+
+## The automated upgrade process
+
+To make the transition to the Latest Node.js runtime as smooth as possible, New Relic performs proactive testing on your existing monitors. Here is the process we follow:
+
+### 1. Backend validation
+
+We automatically test your existing scripted API monitors against the new Latest Node.js runtime (currently Node.js 22) in the backend.
+
+<Callout variant="tip">
+  This validation does not consume your synthetic checks or affect your production results.
+</Callout>
+
+### 2. Automatic upgrades
+
+If your monitor script validates successfully against the latest version without any breaking changes, we will directly upgrade the monitor to the newest runtime on your behalf.
+
+### 3. Handling failures
+
+If the validation fails (often due to the strictness of Node.js 22 regarding open handles), we will not force the upgrade. Instead, monitors that failed validation will be flagged and displayed in the **Runtime Upgrades** feature in your Synthetics Nerdlet UI.
+
+You can review the failures there, troubleshoot your script syntax, and manually validate and upgrade the monitor once the script is fixed.
+
+## Common issues and solutions
+
+### Unhandled open handles
+
+The most common issue when upgrading to Node.js 22 is unhandled open handles. These include:
+
+- **Unresolved promises**: Ensure all promises are properly awaited or handled
+- **Lingering timers**: Clear all `setTimeout` and `setInterval` calls
+- **Unclosed connections**: Close all network connections, HTTP requests, database connections, and file handles
+- **Event listeners**: Remove event listeners when they're no longer needed
+
+### Example: Unhandled promises
+
+```javascript
+// ❌ Problematic code - Promise not awaited
+const $http = require('request');
+
+$http.get('https://api.example.com/data', (error, response, body) => {
+  console.log('Response:', body);
+  // Script ends before response is processed
+});
+```
+
+Fix by properly awaiting the response:
+
+```javascript
+// ✅ Better approach - Using async/await
+const $http = require('request');
+const { promisify } = require('util');
+const httpGet = promisify($http.get);
+
+async function checkAPI() {
+  try {
+    const response = await httpGet('https://api.example.com/data');
+    console.log('Response:', response.body);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+await checkAPI();
+```
+
+### Example: Consume the data event (http/https)
+
+When using `http` or `https`, you must listen to the `data` event. Otherwise, the HTTPS connection may remain open.
+
+```javascript
+const https = require('https');
+
+https.get('https://example.com/api/data', (res) => {
+  console.log('Status Code:', res.statusCode);
+  // It is necessary to consume the response data
+  res.on('data', (d) => {
+    process.stdout.write(d);
+  });
+}).on('error', (e) => {
+  console.error('Error:', e);
+});
+```
+
+### Example: Disable keepAlive
+
+Set the `keepAlive` option to `false` to close HTTP connections after the request is complete.
+
+```javascript
+const https = require('https');
+const { Agent } = require('https'); // or http for HTTP requests
+
+const options = {
+  hostname: 'api.example.com',
+  path: '/users',
+  method: 'GET',
+  agent: new Agent({ keepAlive: false }), // Disable Keep-Alive for this request
+};
+
+const req = https.request(options, (res) => {
+  console.log(`Status: ${res.statusCode}`);
+  res.on('data', (d) => {
+    process.stdout.write(d);
+  });
+});
+
+req.on('error', (e) => {
+  console.error(e);
+});
+
+req.end();
+```
+
+### Example: Stream cleanup
+
+Always clean up streams in a `finally` block to ensure proper resource disposal.
+
+```javascript
+const got = require('got');
+
+let downloadStream = got.stream("https://api.example.com/download/data.json");
+
+try {
+  // Your stream processing logic here
+  downloadStream.on('data', (chunk) => {
+    console.log('Received chunk:', chunk.length);
+  });
+} finally {
+  if (downloadStream) {
+    downloadStream.destroy();
+  }
+}
+```
+
+### Example: HTTPS request cleanup with certificate check
+
+When working with sockets, ensure they are properly destroyed in all code paths.
+
+```javascript
+const https = require('https');
+
+// ❌ Problematic code - Socket not closed in success case
+const req = https.request(options, (res) => {
+  try {
+    const cert = res.socket.getPeerCertificate();
+
+    if (cert && Object.keys(cert).length > 0) {
+      const validTo = cert.valid_to || cert.validTo;
+      console.log("Raw certificate valid_to:", validTo);
+      resolve({ validTo: validTo });
+    } else {
+      reject(new Error("Could not get certificate information"));
+    }
+  } catch (err) {
+    res.destroy();
+    if (res.socket) res.socket.destroy();
+    reject(err);
+  }
+});
+```
+
+Fix by adding cleanup functionality for all code paths:
+
+```javascript
+// ✅ Better approach - Proper cleanup in all cases
+const req = https.request(options, (res) => {
+  try {
+    const cert = res.socket.getPeerCertificate();
+
+    // Always destroy the response and socket
+    const cleanup = () => {
+      try {
+        res.destroy();
+        if (res.socket && !res.socket.destroyed) {
+          res.socket.destroy();
+        }
+      } catch (e) {
+        console.log("Cleanup warning:", e.message);
+      }
+    };
+
+    if (cert && Object.keys(cert).length > 0) {
+      const validTo = cert.valid_to || cert.validTo;
+      console.log("Raw certificate valid_to:", validTo);
+      cleanup();
+      resolve({ validTo: validTo });
+    } else {
+      cleanup();
+      reject(new Error("Could not get certificate information"));
+    }
+  } catch (err) {
+    res.destroy();
+    if (res.socket) res.socket.destroy();
+    reject(err);
+  }
+});
+```
+
+### Example: Lingering timers
+
+```javascript
+// ❌ Problematic code - Timer not cleared
+setTimeout(() => {
+  console.log('This might cause issues');
+}, 5000);
+// Script ends but timer is still active
+```
+
+Make sure to clear timers or use them properly:
+
+```javascript
+// ✅ Better approach - Clear timer when done
+const timerId = setTimeout(() => {
+  console.log('This is properly handled');
+}, 1000);
+
+// Clear it if needed
+clearTimeout(timerId);
+
+// Or use async/await for delays
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+await sleep(1000);
+console.log('Delay completed');
+```
+
+### Example: Unclosed HTTP connections
+
+```javascript
+// ❌ Problematic code - Connection pool not cleaned up
+const $http = require('request');
+
+// Multiple requests without cleanup
+for (let i = 0; i < 10; i++) {
+  $http.get(`https://api.example.com/item/${i}`);
+}
+```
+
+Properly await and handle connections:
+
+```javascript
+// ✅ Better approach - Properly handle connections
+const $http = require('request');
+const { promisify } = require('util');
+const httpGet = promisify($http.get);
+
+async function fetchItems() {
+  const promises = [];
+
+  for (let i = 0; i < 10; i++) {
+    promises.push(httpGet(`https://api.example.com/item/${i}`));
+  }
+
+  try {
+    const results = await Promise.all(promises);
+    console.log('All requests completed');
+  } catch (error) {
+    console.error('Request failed:', error);
+  }
+}
+
+await fetchItems();
+```
+
+## Node.js 22 breaking changes
+
+In addition to stricter open handle management, Node.js 22 includes other changes you should be aware of:
+
+### Updated module support
+
+- **ES Modules**: Better support for ES modules, but ensure your imports are properly configured
+- **CommonJS**: CommonJS modules still work but may have stricter validation
+
+### Deprecated APIs
+
+Some APIs deprecated in earlier Node.js versions have been removed in Node.js 22. Check the [Node.js 22 changelog](https://nodejs.org/en/blog/release/) for details on removed features.
+
+### Performance improvements
+
+Node.js 22 includes performance improvements that may affect timing-sensitive tests. Consider reviewing timeouts if your monitors rely on specific timing behavior.
+
+## Best practices for Node.js 22
+
+To ensure your scripted API monitors work smoothly with Node.js 22:
+
+1. **Use async/await**: Convert callback-based code to async/await for better error handling
+2. **Clean up resources**: Always close connections, clear timers, and remove event listeners
+3. **Handle all promises**: Never create a promise without awaiting it or handling its result
+4. **Set appropriate timeouts**: Use reasonable timeouts for API calls to prevent hanging
+5. **Test locally**: Test your scripts with Node.js 22 locally before upgrading production monitors
+
+### Example: Complete API monitor
+
+```javascript
+const assert = require('assert');
+const $http = require('request');
+const { promisify } = require('util');
+
+// Promisify request methods
+const httpGet = promisify($http.get);
+const httpPost = promisify($http.post);
+
+async function runAPITest() {
+  try {
+    // 1. Test GET endpoint
+    console.log('Testing GET endpoint...');
+    const getResponse = await httpGet('https://api.example.com/users');
+    assert.equal(getResponse.statusCode, 200, 'GET request failed');
+
+    // 2. Parse and validate response
+    const users = JSON.parse(getResponse.body);
+    assert(Array.isArray(users), 'Response is not an array');
+    assert(users.length > 0, 'No users returned');
+
+    // 3. Test POST endpoint
+    console.log('Testing POST endpoint...');
+    const postResponse = await httpPost({
+      url: 'https://api.example.com/users',
+      json: true,
+      body: {
+        name: 'Test User',
+        email: 'test@example.com'
+      }
+    });
+    assert.equal(postResponse.statusCode, 201, 'POST request failed');
+
+    console.log('All tests passed!');
+  } catch (error) {
+    console.error('Test failed:', error.message);
+    throw error; // Fail the monitor
+  }
+}
+
+// Run the test
+await runAPITest();
+```
+
+## Need help?
+
+If you encounter issues during the upgrade process:
+
+1. Check the Runtime Upgrades UI in your Synthetics Nerdlet for specific error messages
+2. Review your monitor scripts for unhandled promises and open connections
+3. Test your scripts locally with Node.js 22 before upgrading
+4. Use `console.log()` statements to debug timing and execution flow
+5. Contact New Relic Support if you need assistance troubleshooting validation failures
+
+## Related documentation
+
+For more information about scripted API monitors, see:
+- [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests)
+- [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules)
+- [Scripted monitor runtime environment](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment)
+- [Synthetic monitor runtime upgrades](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/)

--- a/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-api-monitors-to-node-22.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-api-monitors-to-node-22.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Transition Guide: Upgrading Scripted API Monitors to Latest Node.js Runtime"
+title: "Upgrade scripted API monitors to Node.js 22"
 tags:
   - Synthetics
   - Synthetic monitoring
@@ -11,33 +11,35 @@ metaDescription: Guide for upgrading scripted API monitors to the latest Node.js
 freshnessValidatedDate: never
 ---
 
-We are introducing our latest scripted API monitor runtime, featuring the **Latest** Node.js version (currently Node.js 22). The "Latest" runtime automatically uses the most current Node.js release that New Relic supports, ensuring your API monitors run in an environment that matches modern Node.js standards, providing enhanced security, stability, and performance.
+We're introducing our latest scripted API monitor runtime, featuring the **Latest** Node.js version (currently Node.js 22). The **Latest** runtime automatically uses the most current Node.js release that New Relic supports, ensuring your API monitors run in an environment that matches modern Node.js standards, providing enhanced security, stability, and performance.
 
-**Important note:** As part of the upgrade from Node.js 16 to Node.js 22, the runtime is stricter about process lifecycles. If your monitor scripts contain unhandled "open handles" (such as unresolved promises, lingering timers, or unclosed network connections), you might begin to see monitor failures. We strongly recommend validating your scripts against the new runtime to handle these changes.
+## Action required: Node.js 22 upgrade impact
+
+As part of the upgrade from Node.js 16 to Node.js 22, the runtime is stricter about process lifecycles. If your monitor scripts contain **unhandled open handles** (such as unresolved promises, lingering timers, or unclosed network connections), your monitors will fail.
+
+**To resolve this:** Validate your monitor scripts against the **Latest** runtime to ensure all handles are properly closed before the script finishes executing. Failed validations appear in the Runtime Upgrades UI. See [Troubleshoot runtime upgrade errors](/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting).
+
+## Who is affected
+
+New Relic automatically handles the upgrade process for:
+- Scripted API monitors on public locations
+- Scripted API monitors on both public and private locations (hybrid)
+
+New Relic applies automated validation and upgrade to all location configurations.
 
 <Callout variant="important">
-  ## Node 22 Upgrade Impact
-
-  With the update to the Latest Node.js runtime (currently Node.js 22), customers might experience monitor failures if their scripts contain unhandled open handles (e.g., hanging promises, lingering network requests, or unclosed timers).
-
-  To avoid interruptions, validate your monitor scripts against the latest runtime to ensure all handles are properly closed before the script finishes executing. Failed validations will appear in the Runtime Upgrades UI.
+  Monitors running exclusively on private locations require manual upgrade.
 </Callout>
 
-<Callout variant="tip">
-  ## Public and Hybrid Location Support
+## What is Latest?
 
-  New Relic will handle the upgrade process for scripted browser and API monitors running on public locations, as well as monitors configured to run on both public and private locations. The automated validation and upgrade process applies to all location configurations.
-</Callout>
+The **Latest** runtime option in the monitor create/upgrade dropdown automatically uses the most recent Node.js version that New Relic supports. Instead of pinning to a specific Node.js version (like Node.js 16 or Node.js 20), **Latest** ensures your monitors always run on the newest available Node.js release with the latest features, performance improvements, and security updates.
 
-## What is "Latest"?
+## Upgrade monitors via NerdGraph
 
-The "Latest" runtime option in the monitor create/upgrade dropdown automatically uses the most recent Node.js version that New Relic supports. Instead of pinning to a specific Node.js version (like Node.js 16 or Node.js 20), "Latest" ensures your monitors always run on the newest available Node.js release with the latest features, performance improvements, and security updates.
+To upgrade your monitor runtimes programmatically, use the NerdGraph mutation below. You need your monitor's entity GUID (available in the monitor settings).
 
-## How to upgrade via NerdGraph
-
-To upgrade your monitor runtimes programmatically, use the following NerdGraph mutation. You will need to supply your monitor's specific entity GUID.
-
-### For Scripted API Monitors
+### Scripted API monitors
 
 ```graphql
 mutation {
@@ -46,7 +48,7 @@ mutation {
     monitor: {
       runtime: {
         runtimeType: "NODE_API",
-        runtimeTypeVersion: "22.22.0",
+        runtimeTypeVersion: "LATEST",
       }
     }
   ) {
@@ -59,270 +61,42 @@ mutation {
 ```
 
 <Callout variant="tip">
-  For Scripted Browser monitors, use `runtimeType: "CHROME_BROWSER"` and `runtimeTypeVersion: "LATEST"` instead.
+  For scripted browser monitors, use `runtimeType: "CHROME_BROWSER"` and `runtimeTypeVersion: "LATEST"` instead.
 </Callout>
 
 ## The automated upgrade process
 
-To make the transition to the Latest Node.js runtime as smooth as possible, New Relic performs proactive testing on your existing monitors. Here is the process we follow:
+To ensure a smooth transition to the latest Node.js runtime, New Relic proactively tests your existing monitors. The process includes:
 
-### 1. Backend validation
+<Steps>
+  <Step>
+    ## Backend validation
 
-We automatically test your existing scripted API monitors against the new Latest Node.js runtime (currently Node.js 22) in the backend.
+    New Relic automatically tests your existing scripted API monitors against the latest Node.js runtime (currently Node.js 22) in the backend.
 
-<Callout variant="tip">
-  This validation does not consume your synthetic checks or affect your production results.
-</Callout>
+    <Callout variant="tip">
+      This validation does not consume your synthetic checks or affect your production results.
+    </Callout>
+  </Step>
 
-### 2. Automatic upgrades
+  <Step>
+    ## Automatic upgrade
 
-If your monitor script validates successfully against the latest version without any breaking changes, we will directly upgrade the monitor to the newest runtime on your behalf.
+    **If validation succeeds:** New Relic upgrades the monitor to the newest runtime on your behalf.
+  </Step>
 
-### 3. Handling failures
+  <Step>
+    ## Manual review for failures
 
-If the validation fails (often due to the strictness of Node.js 22 regarding open handles), we will not force the upgrade. Instead, monitors that failed validation will be flagged and displayed in the **Runtime Upgrades** feature in your Synthetics Nerdlet UI.
+    **If validation fails:** New Relic does not force the upgrade. This often happens due to Node.js 22's strict handling of open handles. Instead, New Relic flags monitors that failed validation and displays them in the **Runtime Upgrades** feature in your Synthetics Nerdlet UI.
 
-You can review the failures there, troubleshoot your script syntax, and manually validate and upgrade the monitor once the script is fixed.
+    You can review the failure details there, troubleshoot your script syntax, and manually validate and upgrade the monitor after fixing the script.
+  </Step>
+</Steps>
 
-## Common issues and solutions
+## Troubleshooting upgrade issues
 
-### Unhandled open handles
-
-The most common issue when upgrading to Node.js 22 is unhandled open handles. These include:
-
-- **Unresolved promises**: Ensure all promises are properly awaited or handled
-- **Lingering timers**: Clear all `setTimeout` and `setInterval` calls
-- **Unclosed connections**: Close all network connections, HTTP requests, database connections, and file handles
-- **Event listeners**: Remove event listeners when they're no longer needed
-
-### Example: Unhandled promises
-
-```javascript
-// ❌ Problematic code - Promise not awaited
-const $http = require('request');
-
-$http.get('https://api.example.com/data', (error, response, body) => {
-  console.log('Response:', body);
-  // Script ends before response is processed
-});
-```
-
-Fix by properly awaiting the response:
-
-```javascript
-// ✅ Better approach - Using async/await
-const $http = require('request');
-const { promisify } = require('util');
-const httpGet = promisify($http.get);
-
-async function checkAPI() {
-  try {
-    const response = await httpGet('https://api.example.com/data');
-    console.log('Response:', response.body);
-  } catch (error) {
-    console.error('Error:', error);
-  }
-}
-
-await checkAPI();
-```
-
-### Example: Consume the data event (http/https)
-
-When using `http` or `https`, you must listen to the `data` event. Otherwise, the HTTPS connection may remain open.
-
-```javascript
-const https = require('https');
-
-https.get('https://example.com/api/data', (res) => {
-  console.log('Status Code:', res.statusCode);
-  // It is necessary to consume the response data
-  res.on('data', (d) => {
-    process.stdout.write(d);
-  });
-}).on('error', (e) => {
-  console.error('Error:', e);
-});
-```
-
-### Example: Disable keepAlive
-
-Set the `keepAlive` option to `false` to close HTTP connections after the request is complete.
-
-```javascript
-const https = require('https');
-const { Agent } = require('https'); // or http for HTTP requests
-
-const options = {
-  hostname: 'api.example.com',
-  path: '/users',
-  method: 'GET',
-  agent: new Agent({ keepAlive: false }), // Disable Keep-Alive for this request
-};
-
-const req = https.request(options, (res) => {
-  console.log(`Status: ${res.statusCode}`);
-  res.on('data', (d) => {
-    process.stdout.write(d);
-  });
-});
-
-req.on('error', (e) => {
-  console.error(e);
-});
-
-req.end();
-```
-
-### Example: Stream cleanup
-
-Always clean up streams in a `finally` block to ensure proper resource disposal.
-
-```javascript
-const got = require('got');
-
-let downloadStream = got.stream("https://api.example.com/download/data.json");
-
-try {
-  // Your stream processing logic here
-  downloadStream.on('data', (chunk) => {
-    console.log('Received chunk:', chunk.length);
-  });
-} finally {
-  if (downloadStream) {
-    downloadStream.destroy();
-  }
-}
-```
-
-### Example: HTTPS request cleanup with certificate check
-
-When working with sockets, ensure they are properly destroyed in all code paths.
-
-```javascript
-const https = require('https');
-
-// ❌ Problematic code - Socket not closed in success case
-const req = https.request(options, (res) => {
-  try {
-    const cert = res.socket.getPeerCertificate();
-
-    if (cert && Object.keys(cert).length > 0) {
-      const validTo = cert.valid_to || cert.validTo;
-      console.log("Raw certificate valid_to:", validTo);
-      resolve({ validTo: validTo });
-    } else {
-      reject(new Error("Could not get certificate information"));
-    }
-  } catch (err) {
-    res.destroy();
-    if (res.socket) res.socket.destroy();
-    reject(err);
-  }
-});
-```
-
-Fix by adding cleanup functionality for all code paths:
-
-```javascript
-// ✅ Better approach - Proper cleanup in all cases
-const req = https.request(options, (res) => {
-  try {
-    const cert = res.socket.getPeerCertificate();
-
-    // Always destroy the response and socket
-    const cleanup = () => {
-      try {
-        res.destroy();
-        if (res.socket && !res.socket.destroyed) {
-          res.socket.destroy();
-        }
-      } catch (e) {
-        console.log("Cleanup warning:", e.message);
-      }
-    };
-
-    if (cert && Object.keys(cert).length > 0) {
-      const validTo = cert.valid_to || cert.validTo;
-      console.log("Raw certificate valid_to:", validTo);
-      cleanup();
-      resolve({ validTo: validTo });
-    } else {
-      cleanup();
-      reject(new Error("Could not get certificate information"));
-    }
-  } catch (err) {
-    res.destroy();
-    if (res.socket) res.socket.destroy();
-    reject(err);
-  }
-});
-```
-
-### Example: Lingering timers
-
-```javascript
-// ❌ Problematic code - Timer not cleared
-setTimeout(() => {
-  console.log('This might cause issues');
-}, 5000);
-// Script ends but timer is still active
-```
-
-Make sure to clear timers or use them properly:
-
-```javascript
-// ✅ Better approach - Clear timer when done
-const timerId = setTimeout(() => {
-  console.log('This is properly handled');
-}, 1000);
-
-// Clear it if needed
-clearTimeout(timerId);
-
-// Or use async/await for delays
-const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-await sleep(1000);
-console.log('Delay completed');
-```
-
-### Example: Unclosed HTTP connections
-
-```javascript
-// ❌ Problematic code - Connection pool not cleaned up
-const $http = require('request');
-
-// Multiple requests without cleanup
-for (let i = 0; i < 10; i++) {
-  $http.get(`https://api.example.com/item/${i}`);
-}
-```
-
-Properly await and handle connections:
-
-```javascript
-// ✅ Better approach - Properly handle connections
-const $http = require('request');
-const { promisify } = require('util');
-const httpGet = promisify($http.get);
-
-async function fetchItems() {
-  const promises = [];
-
-  for (let i = 0; i < 10; i++) {
-    promises.push(httpGet(`https://api.example.com/item/${i}`));
-  }
-
-  try {
-    const results = await Promise.all(promises);
-    console.log('All requests completed');
-  } catch (error) {
-    console.error('Request failed:', error);
-  }
-}
-
-await fetchItems();
-```
+The most common issue when upgrading to Node.js 22 is unhandled open handles, including unresolved promises, lingering timers, unclosed connections, and HTTP/HTTPS connections. For detailed solutions and code examples for each issue type, see [Troubleshoot runtime upgrade errors](/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting).
 
 ## Node.js 22 breaking changes
 
@@ -330,8 +104,8 @@ In addition to stricter open handle management, Node.js 22 includes other change
 
 ### Updated module support
 
-- **ES Modules**: Better support for ES modules, but ensure your imports are properly configured
-- **CommonJS**: CommonJS modules still work but may have stricter validation
+- **ES modules:** Better support for ES modules, but ensure your imports are properly configured
+- **CommonJS:** CommonJS modules still work but may have stricter validation
 
 ### Deprecated APIs
 
@@ -345,11 +119,11 @@ Node.js 22 includes performance improvements that may affect timing-sensitive te
 
 To ensure your scripted API monitors work smoothly with Node.js 22:
 
-1. **Use async/await**: Convert callback-based code to async/await for better error handling
-2. **Clean up resources**: Always close connections, clear timers, and remove event listeners
-3. **Handle all promises**: Never create a promise without awaiting it or handling its result
-4. **Set appropriate timeouts**: Use reasonable timeouts for API calls to prevent hanging
-5. **Test locally**: Test your scripts with Node.js 22 locally before upgrading production monitors
+1. **Use async/await:** Convert callback-based code to async/await for better error handling.
+2. **Clean up resources:** Always close connections, clear timers, and remove event listeners.
+3. **Handle all promises:** Never create a promise without awaiting it or handling its result.
+4. **Set appropriate timeouts:** Use reasonable timeouts for API calls to prevent hanging.
+5. **Test locally:** Test your scripts with Node.js 22 locally before upgrading production monitors.
 
 ### Example: Complete API monitor
 
@@ -397,20 +171,32 @@ async function runAPITest() {
 await runAPITest();
 ```
 
+## Frequently asked questions
+
+**What monitor types are affected?**
+Scripted API monitors. Scripted browser monitors are affected separately — see [Upgrade synthetic monitors to the latest Chrome and Node.js 22](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-monitors-to-chrome-latest). Simple browser and ping monitors are not affected.
+
+**Can I test my scripts locally before upgrading?**
+Yes. Install Node.js 22 locally and test your monitor scripts to identify issues before the upgrade.
+
+**Can I rollback if my monitor fails after upgrade?**
+Yes. You can change the runtime version back in the monitor settings or via NerdGraph.
+
+**When will my monitors be automatically upgraded?**
+New Relic performs validation first. If validation succeeds, New Relic automatically upgrades monitors. If validation fails, you see the failure in the Runtime Upgrades UI and must manually fix and upgrade.
+
 ## Need help?
 
 If you encounter issues during the upgrade process:
 
-1. Check the Runtime Upgrades UI in your Synthetics Nerdlet for specific error messages
-2. Review your monitor scripts for unhandled promises and open connections
-3. Test your scripts locally with Node.js 22 before upgrading
-4. Use `console.log()` statements to debug timing and execution flow
-5. Contact New Relic Support if you need assistance troubleshooting validation failures
+1. Check the **Runtime Upgrades UI** in your Synthetics Nerdlet for specific error messages.
+2. Review your monitor scripts for unhandled promises and open connections.
+3. Test your scripts locally with Node.js 22 before upgrading.
+4. Contact New Relic Support for assistance troubleshooting validation failures.
 
-## Related documentation
-
-For more information about scripted API monitors, see:
+**Related documentation:**
 - [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests)
 - [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules)
 - [Scripted monitor runtime environment](/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment)
-- [Synthetic monitor runtime upgrades](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui/)
+- [Runtime upgrade UI](/docs/synthetics/synthetic-monitoring/using-monitors/runtime-upgrade-ui)
+- [Troubleshoot runtime upgrade errors](/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting)

--- a/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/troubleshooting/runtime-upgrade-troubleshooting.mdx
@@ -210,7 +210,86 @@ clearTimeout(timerId);
 **Symptom:** Script appears to finish but validation fails
 **Cause:** Promises not properly awaited or handled
 
-**Solution:** Ensure all promises have `.then()`, `.catch()`, or are `await`ed.
+Ensure all promises have `.then()`, `.catch()`, or are `await`ed.
+
+#### Problematic code
+
+```javascript
+// ❌ Problematic code - Promise not awaited
+const $http = require('request');
+
+$http.get('https://api.example.com/data', (error, response, body) => {
+  console.log('Response:', body);
+  // Script ends before response is processed
+});
+```
+
+#### Recommended approach
+
+Properly await the response using async/await:
+
+```javascript
+// ✅ Better approach - Using async/await
+const $http = require('request');
+const { promisify } = require('util');
+const httpGet = promisify($http.get);
+
+async function checkAPI() {
+  try {
+    const response = await httpGet('https://api.example.com/data');
+    console.log('Response:', response.body);
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+await checkAPI();
+```
+
+### Unclosed HTTP connections [#unclosed-http]
+
+**Symptom:** Monitor validation fails with open handle errors
+**Cause:** HTTP connections made in loops without awaiting or cleanup
+
+#### Problematic code
+
+```javascript
+// ❌ Problematic code - Connection pool not cleaned up
+const $http = require('request');
+
+// Multiple requests without cleanup
+for (let i = 0; i < 10; i++) {
+  $http.get(`https://api.example.com/item/${i}`);
+}
+```
+
+#### Recommended approach
+
+Properly await and handle connections:
+
+```javascript
+// ✅ Better approach - Properly handle connections
+const $http = require('request');
+const { promisify } = require('util');
+const httpGet = promisify($http.get);
+
+async function fetchItems() {
+  const promises = [];
+
+  for (let i = 0; i < 10; i++) {
+    promises.push(httpGet(`https://api.example.com/item/${i}`));
+  }
+
+  try {
+    const results = await Promise.all(promises);
+    console.log('All requests completed');
+  } catch (error) {
+    console.error('Request failed:', error);
+  }
+}
+
+await fetchItems();
+```
 
 ## Chrome runtime upgrade issues
 

--- a/src/nav/synthetics.yml
+++ b/src/nav/synthetics.yml
@@ -49,6 +49,8 @@ pages:
         path: /docs/synthetics/synthetic-monitoring/scripting-monitors/custom-timing-details
       - title: Transition guide to Chrome latest and Node.js 22
         path: /docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-browser-monitors-to-chrome-latest
+      - title: Transition guide for scripted API monitors to Node.js 22
+        path: /docs/synthetics/synthetic-monitoring/scripting-monitors/synthetics-scripted-api-monitors-to-node-22
       - title: Scripted browser reference (Chrome 100 and higher)
         path: /docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100
       - title: Scripted browser reference (0.5.0+)


### PR DESCRIPTION
## Summary
- Re-adds `synthetics-scripted-api-monitors-to-node-22.mdx` ("Transition Guide: Upgrading Scripted API Monitors to Latest Node.js Runtime") sourced from commit `ee9199008e` of the closed PR #23296
- Adds the corresponding nav entry under **Scripting monitors** in `src/nav/synthetics.yml`

## Context
The file was originally authored by @maharjunNewRelic in [PR #23296](https://github.com/newrelic/docs-website/pull/23296), which was closed before merge. The companion file (`synthetics-scripted-browser-monitors-to-chrome-latest.mdx`) was re-introduced via @keegoid-nr's [PR #23706](https://github.com/newrelic/docs-website/pull/23706), but the scripted API Node.js 22 transition guide was never re-added. This PR restores it so the guide is available to users.

## Test plan
- [ ] Verify the transition guide renders correctly on the Netlify preview
- [ ] Verify the new nav entry appears under **Scripting monitors** alongside the Chrome/Node.js 22 browser transition guide
- [ ] Verify no broken links in the restored content