### PR TITLE
docs(NR-553042): update data retention for Session Replay invisible namespaces

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
@@ -19,7 +19,7 @@ redirects:
   - /docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/
   - /docs/accounts/accounts-billing/new-relic-one-pricing-billing/user-count-billing/
   - /docs/accounts/accounts-billing/new-relic-one-pricing-billing/add-on-billing/
-freshnessValidatedDate: never
+freshnessValidatedDate: 2026-04-28
 ---
 
 Whether you're thinking about using New Relic or already using it, the following information is helpful to understand how New Relic prices products and bills for your usage.
@@ -376,6 +376,6 @@ In addition to the primary billing factors of data and billable users, you can a
 
 * **Advanced Compute**: This add-on to your Data + User or Data + Core Compute plan enables access to Intelligent Observability features.
 * **EU Data Center for Original Data or Data Plus**: This add-on applies to your data option (Original Data or Data Plus) when you select the European Union as your data region, as available.
-* **Extended Retention for Original Data or Data Plus**: This add-on applies if you exceed the default length of time your data is retained. This applies to all your data—not just logs—and is a good option if you need to make a lot of small queries or make queries on large volumes of data.
+* **Extended Retention for Original Data or Data Plus**: This add-on applies if you exceed the default length of time your data is retained. This applies to all your data—not just logs—and is a good option if you need to make a lot of small queries or make queries on large volumes of data. To understand default retention periods and how to manage them, see [View and manage data retention](/docs/data-apis/manage-data/manage-data-retention/).
 * **Live Archives**: Extend your log storage duration up to seven years. Live Archives also requires Advanced Compute.
 * **New Relic Synthetic Checks**: This add-on applies if your Checks exceed the default number of synthetic monitor checks.

--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -23,6 +23,7 @@ The Data retention page has two tabs:
 * <DNT>**Account**</DNT>: Manages retention for account-scoped data
 * <DNT>**Organization**</DNT>: Manages retention for organization-scoped data (such as AI chat and collaboration data)
 
+
 To learn more about extended retention add-on options, see [Extended Retention for Original Data or Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing).
 
 ## Extend your data retention for long-term analysis and compliance

--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -731,7 +731,7 @@ In this section are details about a few different types of data, including some 
   >
     `Mobile:SessionReplay` and `Browser:SessionReplay` are invisible, non-customizable namespaces. Here's what that means for your data:
 
-    * **Not shown in the <DNT>**Data retention**</DNT> UI.** These namespaces aren't listed in the retention settings view.
+    * **Not shown in the <DNT>Data retention</DNT> UI.** These namespaces aren't listed in the retention settings view.
     * **Default retention:** 8 days for standard data plans.
     * **Data Plus retention:** 98 days (standard 8 days plus the 90-day Data Plus addition).
     * **Extended retention contracts don't apply.** Retention for invisible namespaces stays at the default value regardless of any extended retention contract in place for the organization.

--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -723,19 +723,18 @@ In this section are details about a few different types of data, including some 
 
     For more about these events, see [the browser events in the data dictionary](/attribute-dictionary/?dataSource=Browser+agent).
 
-    Note that `Browser:SessionReplay` is an invisible namespace and isn't listed above. For details, see [Session Replay namespaces](#session-replay-namespaces).
+    Note that Browser Session Replay data isn't listed above — its retention is managed separately and isn't configurable through the UI. For details, see [Session Replay data retention](#session-replay-namespaces).
   </Collapser>
 
   <Collapser
     id="session-replay-namespaces"
-    title="Session Replay namespaces (Mobile and Browser)"
+    title="Session Replay data retention (Mobile and Browser)"
   >
-    `Mobile:SessionReplay` and `Browser:SessionReplay` are invisible, non-customizable namespaces. Here's what that means for your data:
+    Retention for Mobile Session Replay and Browser Session Replay data is managed by New Relic and isn't configurable through the <DNT>**Data retention**</DNT> UI. Here's what to expect:
 
-    * **Not shown in the <DNT>Data retention</DNT> UI.** These namespaces aren't listed in the retention settings view.
     * **Default retention:** 8 days for standard data plans.
     * **Data Plus retention:** 98 days (standard 8 days plus the 90-day Data Plus addition).
-    * **Extended retention contracts don't apply.** Retention for invisible namespaces stays at the default value regardless of any extended retention contract in place for the organization.
+    * **Extended retention contracts don't apply.** The retention period stays at the default value regardless of any extended retention contract in place for your organization.
     * **Data is deleted automatically.** When Session Replay data exceeds its retention period, it's deleted automatically — no manual deletion request is needed.
   </Collapser>
 
@@ -850,7 +849,7 @@ To view and edit your retention, go to [data retention view](https://one.newreli
 Options for increasing retention:
 
 * If you haven't already, switch to [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing), which offers significantly longer data retention and other benefits.
-* For Data Plus or original data option: add data retention. 30 days of additional data retention for your organization costs $0.05 per GB ingested per month. This option applies only to visible namespaces that appear in the <DNT>**Data retention**</DNT> UI. Invisible namespaces — such as `Mobile:SessionReplay` and `Browser:SessionReplay` — aren't affected by self-service retention adjustments. For more details, see [Session Replay namespaces](#session-replay-namespaces).
+* For Data Plus or original data option: add data retention. 30 days of additional data retention for your organization costs $0.05 per GB ingested per month. This option applies only to data types that appear in the <DNT>**Data retention**</DNT> UI. Session Replay data for Mobile and Browser isn't affected by self-service retention adjustments. For more details, see [Session Replay data retention](#session-replay-namespaces).
 
 Important points about increasing retention:
 

--- a/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
+++ b/src/content/docs/data-apis/manage-data/manage-data-retention.mdx
@@ -23,14 +23,14 @@ The Data retention page has two tabs:
 * <DNT>**Account**</DNT>: Manages retention for account-scoped data
 * <DNT>**Organization**</DNT>: Manages retention for organization-scoped data (such as AI chat and collaboration data)
 
-To learn about plans and costs for changing retention, refer to [Data options: Data Plus and original](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#upgrade-data-plus).
+To learn more about extended retention add-on options, see [Extended Retention for Original Data or Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing).
 
 ## Extend your data retention for long-term analysis and compliance
 
 Extending your data retention allows you to do long-term analysis, visualization, and alerting for all your metrics, events, logs, and traces across all of your sources. However, it's important to manage that data for cost, performance, and in some cases, compliance reasons. Our data management hub provides the tools you need to understand and control where your data is coming from, and adjust what's stored and for how long.
 
 <Callout variant="tip">
-  With [our Data Plus option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-plus), you get up to an additional 90 days of retention (for most data types) and other enterprise-grade capabilities, such as longer query durations, FedRAMP and HIPAA compliance, additional security features, and more.
+  With [our Data Plus option](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing), you get up to an additional 90 days of retention (for most data types) and other enterprise-grade capabilities, such as longer query durations, FedRAMP and HIPAA compliance, additional security features, and more.
 </Callout>
 
 ## Account-scoped vs organization-scoped retention [#account-vs-organization]
@@ -72,7 +72,7 @@ The way users manage data retention may depend on how many accounts you have in 
 
 If you are in an organization that has only one account in it, your [**Billing User**](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/) can manage the following:
 
-* **Max per contract:** This is the highest value you can set for the **Effective retention** of a data type. If you would like to increase this, see our [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-prices) plan.
+* **Max per contract:** This is the highest value you can set for the **Effective retention** of a data type. If you would like to increase this, see our [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing) plan.
 * **Effective retention:** This is the amount of time data is currently retained for a data type.  For the user to be able to edit this, the organization (account) needs to be on [Standard or a higher edition](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#how-pricing-works).
 
 If your Billing User can't perform either of these two tasks, contact support or your New Relic representative.
@@ -81,7 +81,7 @@ If your Billing User can't perform either of these two tasks, contact support or
 
 If you're in an organization that has more than one account in it, users can manage the following:
 
-* **Max per contract:** This is the highest value you can set for the **Effective retention** of a data type. If you would like to increase this, see our [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-prices) plan.
+* **Max per contract:** This is the highest value you can set for the **Effective retention** of a data type. If you would like to increase this, see our [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing) plan.
 * **Effective retention:** This is the amount of time data is currently retained for a data type. For the user to be able to edit this:
   * The organization (account) needs to be on [Pro or a higher edition](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#how-pricing-works).
   * The user type needs to be **Full platform**.
@@ -121,7 +121,7 @@ This table shows the default [namespace](/docs/glossary/glossary) retention sett
       </th>
 
       <th style={{ width: "210px" }}>
-        Retention for [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing#data-prices) (days)
+        Retention for [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing) (days)
       </th>
     </tr>
   </thead>
@@ -721,6 +721,21 @@ In this section are details about a few different types of data, including some 
     * `Browser JS errors` namespace: `JavaScriptError`
 
     For more about these events, see [the browser events in the data dictionary](/attribute-dictionary/?dataSource=Browser+agent).
+
+    Note that `Browser:SessionReplay` is an invisible namespace and isn't listed above. For details, see [Session Replay namespaces](#session-replay-namespaces).
+  </Collapser>
+
+  <Collapser
+    id="session-replay-namespaces"
+    title="Session Replay namespaces (Mobile and Browser)"
+  >
+    `Mobile:SessionReplay` and `Browser:SessionReplay` are invisible, non-customizable namespaces. Here's what that means for your data:
+
+    * **Not shown in the <DNT>**Data retention**</DNT> UI.** These namespaces aren't listed in the retention settings view.
+    * **Default retention:** 8 days for standard data plans.
+    * **Data Plus retention:** 98 days (standard 8 days plus the 90-day Data Plus addition).
+    * **Extended retention contracts don't apply.** Retention for invisible namespaces stays at the default value regardless of any extended retention contract in place for the organization.
+    * **Data is deleted automatically.** When Session Replay data exceeds its retention period, it's deleted automatically — no manual deletion request is needed.
   </Collapser>
 
   <Collapser
@@ -833,12 +848,12 @@ To view and edit your retention, go to [data retention view](https://one.newreli
 
 Options for increasing retention:
 
-* If you haven't already, switch to [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/data-ingest-billing/#data-plus), which offers significantly longer data retention and other benefits.
-* For Data Plus or original data option: add data retention. 30 days of additional data retention for your organization costs $0.05 per GB ingested per month.
+* If you haven't already, switch to [Data Plus](/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing/#add-on-billing), which offers significantly longer data retention and other benefits.
+* For Data Plus or original data option: add data retention. 30 days of additional data retention for your organization costs $0.05 per GB ingested per month. This option applies only to visible namespaces that appear in the <DNT>**Data retention**</DNT> UI. Invisible namespaces — such as `Mobile:SessionReplay` and `Browser:SessionReplay` — aren't affected by self-service retention adjustments. For more details, see [Session Replay namespaces](#session-replay-namespaces).
 
 Important points about increasing retention:
 
-* When you enable a higher retention period, retention is increased across the board for all data types listed in the [<DNT>**Data retention**</DNT> UI](#find-ui). It cannot be increased only for specific data types.
+* When you enable a higher retention period, retention is increased across the board for all data types listed in the [<DNT>**Data retention**</DNT> UI](https://one.newrelic.com/admin-portal/limits-data-retention/data-retention). It cannot be increased only for specific data types.
 * Once you enable a higher retention period, reducing retention for specific data sources has no impact on your billing. To learn about ways to reduce your data ingest and billing, see [Manage data ingest](/docs/data-apis/manage-data/manage-data-coming-new-relic).
 * When you adjust retention, it can take up to 24 hours to take effect.
 


### PR DESCRIPTION
## Summary

Resolves [NR-553042](https://new-relic.atlassian.net/browse/NR-553042)

- Adds a new **Session Replay data retention** collapser in the "Retention details" section of the data retention page, explaining that Mobile Session Replay and Browser Session Replay data have fixed retention periods managed by New Relic (8-day default / 98-day Data Plus), aren't configurable through the UI, and are deleted automatically on expiry.
- Updates the **Browser namespaces** collapser with a note that Browser Session Replay data is managed separately and links to the new section.
- Updates the **Edit data retention** section to clarify that 30-day self-service retention increments apply only to data types shown in the retention UI.
- Fixes a broken `#find-ui` internal anchor — replaced with the direct UI URL.
- Updates all **Data Plus** links in `manage-data-retention.mdx` to point to the `#add-on-billing` section of the pricing page.
- Adds a cross-link in `new-relic-one-pricing-billing.mdx` (Extended Retention bullet) pointing users to the data retention doc.

## Files changed

- `src/content/docs/data-apis/manage-data/manage-data-retention.mdx`
- `src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx`

🤖 Generated with [Claude Code](https://claude.ai/code)

[NR-553042]: https://new-relic.atlassian.net/browse/NR-553042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ