### PR TITLE
feat(whats-new): mobile session replay is now GA

### DIFF
--- a/src/content/whats-new/2026/04/whats-new-04-28-mobile-session-replay-ga.md
+++ b/src/content/whats-new/2026/04/whats-new-04-28-mobile-session-replay-ga.md
@@ -1,0 +1,28 @@
+---
+title: 'Mobile Update: Session replay is now generally available'
+summary: 'Troubleshoot faster and deliver better customer experiences with full-stack visibility into your mobile app sessions'
+learnMoreLink: 'https://newrelic.com/docs/mobile-monitoring/mobile-monitoring-ui/mobile-session-replay/introduction'
+releaseDate: '2026-04-28'
+---
+
+New Relic is excited to announce that Mobile session replay has launched, a powerful feature that allows you to see what your end users were doing in an app to understand user behavior, prioritize enhancements and resolve performance issues quicker.
+
+Understanding user behavior is crucial for optimizing app usability and improving user experience. With Mobile session replay, you can:
+
+* **Troubleshoot faster with full-stack visibility:** Review replays synced to detailed telemetry data such as breadcrumbs and logs for faster troubleshooting to deliver better customer experiences.
+* **Industry-leading Privacy & Security:** No PII is collected out of the box. Fully customizable masking and sampling settings can be updated server side.
+* **Only record replays your teams care about:** Use errored-session sampling to only record sessions when something breaks, or take full control and start/pause replays with APIs.
+
+**Key Features:**
+
+* **Intuitive UX:** The session replay UI features visual markers for errors and crashes, as well as controls such as full-screen mode, skip inactivity, and multiple playback speeds to easily pinpoint and address user friction points.
+
+* **Visualize the user journey:** This feature provides a great deal of information about how your users interact with your site. And it can benefit different users and departments across your organization, including engineers, designers, customer support and product managers. You can share critical moments with our 'share a clip' feature for debugging complex user-reported issues. When sessions are long, this feature helps share out with your colleagues the most critical moment in time that you need them to watch.
+
+* **Easy configuration:** Enable session replay on your app settings page. Choose from two sample rates: overall sessions or collect just errored sessions like crashes. Custom roles can be created for more control over user permissions.
+
+* **UI frameworks:** Currently supported UI frameworks include iOS UIKit, Android XML layouts, React Native Views, iOS SwiftUI, and Android Jetpack Compose.
+
+**Get started**
+
+Mobile session replay is now generally available and included in the New Relic platform. This feature will contribute to your GB/ingest pricing. Start using today with the latest agents for iOS, Android, and React Native apps.


### PR DESCRIPTION
## Summary
- Adds What's New post announcing Mobile Session Replay general availability
- Scheduled to go live April 28, 2026

## Test plan
- [ ] Verify post renders correctly on the docs site
- [ ] Confirm `learnMoreLink` resolves to the correct page
- [ ] Confirm `releaseDate` is set to `2026-04-28`

🤖 Generated with [Claude Code](https://claude.com/claude-code)