### PR TITLE
docs(otel-apm): fix misaligned table headers

### DIFF
--- a/src/content/docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui.mdx
+++ b/src/content/docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui.mdx
@@ -982,10 +982,7 @@ The following resource attributes are copied from source data on to APM metrics:
             **[Instrument Type](https://docs.newrelic.com/docs/data-apis/understand-data/metric-data/metric-data-type/)**
             </th>
             <th>
-            **Unit**
-            </th>
-            <th>
-            **([UCUM](https://ucum.org/ucum))**
+            **Unit ([UCUM](https://ucum.org/ucum))**
             </th>
             <th>
             **Description**
@@ -995,7 +992,7 @@ The following resource attributes are copied from source data on to APM metrics:
     <tbody>
         <tr>
             <td>
-            `apm.service.external.host.duration` |  |  | 
+            `apm.service.external.host.duration`
             </td>
             <td>
             Distribution
@@ -1005,9 +1002,6 @@ The following resource attributes are copied from source data on to APM metrics:
             </td>
             <td>
             Duration of external calls.
-            </td>
-            <td>
-            
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
## Give us some context
- Merges Unit and UCUM into a single column (as they are intended to be a single column, see other tables) as it breaks the formatting of the table. 