### PR TITLE
Removed docs about unsupported enrichers

### DIFF
--- a/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
+++ b/src/content/docs/logs/logs-context/configure-logs-context-nodejs.mdx
@@ -113,8 +113,6 @@ If you're not using a supported framework, you may instead use the agent's log f
 
     This option should not be used with in-agent forwarding. Using an [external log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding) to send logs to New Relic while in-agent forwarding is enabled will cause your logs to be sent up twice to New Relic. Depending on your account, this may result in double billing.
 
-    This option should also not be used with [the manual log decorating formatter](#3-old-formatter). If you have references to the manual formatter in your codebase, please remove them before enabling this option.
-
     1. If you want to use this option, make sure you have the in-agent forwarding configuration option disabled.
 
        newrelic.js:
@@ -159,19 +157,6 @@ If you're not using a supported framework, you may instead use the agent's log f
        The output log message will be an empty string.
 
        Some attributes may be empty if the log occurred outside a transaction or if they are not applicable to your application's context.
-
-       We recommend this option over manually using one of our log enrichers.
-  </Collapser>
-
-  <Collapser
-    id="3-old-formatter"
-    title="Option 3: Use the manual process to forward and decorate logs."
-  >
-    Before language agents had the ability to forward and decorate logs, you could enable logs in context by updating your application to use a framework-specific log enricher. This option is still supported, but is no longer encouraged. For instructions to use this approach, see [Manual logs in context option](#configure-nodejs).
-
-    Also, this method requires that you install a log forwarder before enabling logs in context. If you do not have a log forwarder, the New Relic UI will prompt you to use our [infrastructure agent](/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/).
-
-    If you decide to use your existing log forwarding solution and later decide to update your agent to use automatic logs in context, be sure to <DNT>**disable your manual log forwarder**</DNT>. Otherwise, your app will be sending double log lines. Depending on your account, this could result in double billing. For more information, follow the procedures to disable your [specific log forwarder](/docs/logs/forward-logs/enable-log-management-new-relic#log-forwarding).
   </Collapser>
 </CollapserGroup>
 
@@ -203,76 +188,6 @@ If you don't see any logs for errors or traces, there may not be any for your ap
 ## Disable automatic logging [#disable-automatic]
 
 APM logs in context automatically forwards APM agent log data. It is enabled by default. If you do enable application logging, it can have a negative impact on your security, compliance, billing, or system performance. For more information, or if you need to adjust the default setting, follow the procedures to [disable automatic logging](/docs/logs/logs-context/disable-automatic-logging).
-
-## Manual logs in context option [#configure-nodejs]
-
-To enable logs in context for <InlinePopover type="apm"/> apps monitored by Node.js, you can use our manual installation option.
-
-1. Make sure you have already [set up logging in New Relic](/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/enable-log-management-new-relic/). This includes configuring a supported log forwarder that collects your application logs and extends the metadata that is forwarded to New Relic.
-
-2. [Install](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/) or [update](/docs/agents/nodejs-agent/installation-configuration/update-nodejs-agent/) to the latest Node.js agent version, and [enable distributed tracing](/docs/distributed-tracing/enable-configure/quick-start/). Use [Node.js agent version 6.2.0 or higher](/docs/release-notes/agent-release-notes/nodejs-release-notes/) for logs in context.
-
-3. Install [a supported framework](#automatic) to enrich your log data, or directly use [the agent's log forwarding API](https://newrelic.github.io/node-newrelic/API.html#recordLogEvent).
-
-4. In your agent configuration, set `application_logging.enabled` to `false`. (Otherwise, the agent will automatically instrument your logger and calling these enrichers yourself will do nothing.)
-
-5. Configure logs in context for Node.js using the appropriate log extension.
-
-   <CollapserGroup>
-     <Collapser
-       id="nodejs-winston"
-       title="Node.js configuration with Winston"
-     >
-       1. To install the Winston log enricher, enter the following command into your terminal or command line interface:
-
-          ```bash
-          npm install @newrelic/winston-enricher
-          ```
-       2. In your application code, update your logging configuration to add the `newrelicFormatter`:
-
-          ```js
-          // index.js
-          require('newrelic')
-          const winston = require('winston')
-          const newrelicFormatter = require('@newrelic/winston-enricher')(winston)
-          ```
-
-          The New Relic formatter can be used individually or combined with other formatters as the final format.
-
-          ```js
-          format: winston.format.combine(
-            winston.format.label({label: 'test'}),
-            newrelicFormatter()
-          )
-          ```
-     </Collapser>
-
-     <Collapser
-       id="nodejs-pino"
-       title="Node.js configuration with Pino"
-     >
-       1. To install the Pino log enricher, enter the following command into your terminal or command line interface:
-
-          ```bash
-          npm install @newrelic/pino-enricher
-          ```
-       2. In your application code, update your logging configuration to add the New Relic Pino plugin:
-
-          ```js
-          // index.js
-          require('newrelic')
-          const nrPino = require('@newrelic/pino-enricher')
-          const pino = require('pino')
-          const logger = pino(nrPino())
-          ```
-
-          The New Relic formatter can be used individually or combined with other formatters as the final format.
-     </Collapser>
-   </CollapserGroup>
-
-6. To verify that you have configured the log appender correctly, run your application, then check your [logs data in New Relic](/docs/logs/log-management/ui-data/use-logs-ui/) using the query operator `has:span.id has:trace.id`.
-
-If everything is configured correctly and your data is being forwarded to New Relic with the enriched metadata, your logs should now be emitted as JSON and contain `trace.id` and `span.id` fields. If you don't see log data in the UI, follow the [troubleshooting procedures](/docs/logs/log-management/troubleshooting/no-log-data-appears-ui/).  If you'd like to see a working example of logs in context, take a look at our [example application](https://github.com/newrelic/newrelic-node-examples/blob/main/logs-in-context/README.md).
 
 ## What's next? [#what-next]
 


### PR DESCRIPTION
This PR removes documentation around logs-in-context enrichers for the Node.js agent that are no longer maintained nor supported.