### PR TITLE
docs: publish nrdot host 1.12.0 release notes

### DIFF
--- a/src/content/docs/release-notes/nrdot-release-notes/nrdot-host-2026-04-30.mdx
+++ b/src/content/docs/release-notes/nrdot-release-notes/nrdot-host-2026-04-30.mdx
@@ -1,0 +1,16 @@
+---
+subject: NRDOT
+category: Host Monitoring
+releaseDate: '2026-04-30'
+version: 1.12.0
+metaDescription: Release notes for NRDOT Host Monitoring use case version 1.12.0
+downloadLink: https://github.com/newrelic/nrdot-collector-releases/releases/tag/1.12.0
+features: ['Host use case verified to work with `nrdot-collector:1.12.0`']
+bugs: []
+security: []
+---
+## Changelog
+First dedicated release notes for the ['Host Monitoring'](https://github.com/newrelic/nrdot-collector-releases/blob/main/distributions/nrdot-collector/README.md#use-cases) use case which are scoped to relevant changes in the configuration or `nrdot-collector`. The [nrdot-collector](https://docs.newrelic.com/docs/release-notes/nrdot-release-notes/nrdot-2026-04-01/) will continue to bundle the config necessary to power this use case. However, with `nrdot-collector` supporting more and more use cases, we want to provide additional release notes that are more easily conusamble for someone using NRDOT for a specific purpose like Host Monitoring.
+
+### Features
+* Host use case verified to work with `nrdot-collector:1.12.0`


### PR DESCRIPTION
### Summary
- Initial release notes for 'Host Monitoring' category within NRDOT, see also #23567