### PR TITLE
chore(.net agent): Updating latest supported framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -552,7 +552,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   <DNT>**MySql.Data**</DNT>
                       * Minimum supported version: 6.10.7
-                      * Latest verified compatible version: 9.6.0
+                      * Latest verified compatible version: 9.7.0
+                      * Versions 9.7.0 and higher are supported beginning with .NET agent v10.52.0
 
                   <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
@@ -1670,7 +1671,8 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**MySql.Data**</DNT>
                       * Minimum supported version: 6.10.7
-                      * Latest verified compatible version: 9.6.0
+                      * Latest verified compatible version: 9.7.0
+                      * Versions 9.7.0 and higher are supported beginning with .NET agent v10.52.0
 
                       <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -415,7 +415,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                   * Minimum supported version: 3.17.0
-                  * Latest verified compatible version: 3.58.0
+                  * Latest verified compatible version: 3.59.0
                   * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                 </td>
                 </tr>
@@ -457,7 +457,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   <DNT>**Microsoft.Data.SqlClient**</DNT>
                       * Minimum supported version: 1.0.19239.1
-                      * Latest verified compatible version: 7.0.0
+                      * Latest verified compatible version: 7.0.1
                 </td>
                 </tr>
 
@@ -520,7 +520,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                   Minimum supported version: 2.3.0
 
-                  Latest verified compatible version: 3.7.1
+                  Latest verified compatible version: 3.8.0
 
                   Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -773,7 +773,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.17.3
+                    4.0.17.5
                 </td>
                 </tr>
                 <tr>
@@ -848,7 +848,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    3.3.0
+                    3.3.1
                 </td>
 
                 </tr>
@@ -894,7 +894,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0
                 </td>
                 <td>
-                    10.0.6
+                    10.0.7
                 </td>
                 </tr>
             </tbody>
@@ -951,7 +951,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 5.0
 
-                    * Latest verified compatible version: 10.1.2
+                    * Latest verified compatible version: 10.1.4
                 </td>
                 </tr>
 
@@ -1511,7 +1511,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                         * Minimum supported version: 3.17.0
-                        * Latest verified compatible version: 3.58.0
+                        * Latest verified compatible version: 3.59.0
                         * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                       </td>
                     </tr>
@@ -1577,7 +1577,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**Microsoft.Data.SqlClient**</DNT>
                       * Minimum supported version: 1.0.19239.1
-                      * Latest verified compatible version: 7.0.0
+                      * Latest verified compatible version: 7.0.1
 
                       <DNT>**System.Data**</DNT>
                       * Minimum supported version: .NET Framework 4.6.2
@@ -1638,7 +1638,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     <td>
                       Minimum supported version: 2.3.0
 
-                      Latest verified compatible version: 3.7.1
+                      Latest verified compatible version: 3.8.0
 
                       Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -1990,7 +1990,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.17.3
+                        4.0.17.5
                     </td>
                     </tr>
                     <tr>
@@ -2066,7 +2066,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        3.3.0
+                        3.3.1
                     </td>
                     </tr>
 
@@ -2111,7 +2111,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        10.0.6
+                        10.0.7
                     </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Updates the .NET agent compatibility & requirements docs to match the latest verified package versions from the 2026-May-01 Dotty PR (newrelic/newrelic-dotnet-agent#3556).

## Updated versions

**Both sections (.NET Core and .NET Framework):**
- Microsoft.Azure.Cosmos: 3.58.0 → 3.59.0
- Microsoft.Data.SqlClient: 7.0.0 → 7.0.1
- MongoDB.Driver: 3.7.1 → 3.8.0
- AWSSDK.BedrockRuntime: 4.0.17.3 → 4.0.17.5
- log4net: 3.3.0 → 3.3.1
- Microsoft.Extensions.Logging: 10.0.6 → 10.0.7

**.NET Core section only:**
- NServiceBus: 10.1.2 → 10.1.4 (Framework remains at 8.2.4)

MySql.Data was held at 9.6.0 pending an agent instrumentation fix for 9.7.0.