### PR TITLE
docs: add title to NRDOT host release notes

### DIFF
--- a/src/content/docs/release-notes/nrdot-release-notes/nrdot-host-2026-04-30.mdx
+++ b/src/content/docs/release-notes/nrdot-release-notes/nrdot-host-2026-04-30.mdx
@@ -1,6 +1,7 @@
 ---
 subject: NRDOT
 category: Host Monitoring
+title: NRDOT Host Monitoring v1.12.0
 releaseDate: '2026-04-30'
 version: 1.12.0
 metaDescription: Release notes for NRDOT Host Monitoring use case version 1.12.0


### PR DESCRIPTION
## Context
- Release notes with the `category: Host Monitoring` default to `$subject $version` in their page title which makes them identical to the `category: Collector` releases notes for the same version. Using the `title` based on what I see how the [Streaming Video & Ads for Browser](https://github.com/kb-newrelic/docs-website/blob/809ed1d5d97eaa35e6ce81c680ddb5105fa31fdc/src/content/docs/release-notes/streaming-browser-release-notes/streaming-browser-agent-bitmovin-25-02-23.mdx?plain=1#L3) release notes achieve to overwrite the title.