### PR TITLE
Fix otlp hostname

### DIFF
--- a/src/content/docs/opentelemetry/integrations/kafka/kubernetes-strimzi.mdx
+++ b/src/content/docs/opentelemetry/integrations/kafka/kubernetes-strimzi.mdx
@@ -414,7 +414,7 @@ Create a Kubernetes secret containing your New Relic license key and OTLP endpoi
     kubectl create secret generic newrelic-otlp-secret \
       --namespace newrelic \
       --from-literal=NEW_RELIC_LICENSE_KEY='your-license-key-here' \
-      --from-literal=NEW_RELIC_OTLP_ENDPOINT='https://eu01-otlp.nr-data.net:4317'
+      --from-literal=NEW_RELIC_OTLP_ENDPOINT='https://otlp.eu01.nr-data.net:4317'
     ```
   </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
This is the correct hostname or customers will misconfigure their systems. Note that this hostname is available on the linked document immediately below.