### PR TITLE
Add IP whitelisting note to Lens overview

### DIFF
--- a/src/content/docs/new-relic-lens/overview.mdx
+++ b/src/content/docs/new-relic-lens/overview.mdx
@@ -71,6 +71,10 @@ Using <DNT>Lens</DNT> involves the following steps:
   </Step>
 </Steps>
 
+<Callout variant="important" title="Database access requirements">
+  If your external database restricts access by IP address, you must whitelist New Relic's IP addresses to allow <DNT>Lens</DNT> to connect and query your data. Find the list of IP addresses [here](/docs/new-relic-solutions/get-started/networks/#webhooks) to add to your database's allowlist.
+</Callout>
+
 ## Use cases [#use-cases]
 
 Lens enables various data analysis scenarios:


### PR DESCRIPTION
## Summary
- Adds an important callout to the New Relic Lens overview page explaining IP whitelisting requirements
- If external databases restrict access by IP, users must whitelist New Relic IP addresses for Lens to connect
- Links to the networks documentation page with the specific IP addresses

## Test plan
- [ ] Verify the callout renders correctly on the Lens overview page
- [ ] Verify the link to the networks page works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)