### PR TITLE
docs: Add GCP API Gateway integration documentation

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration.mdx
@@ -26,7 +26,6 @@ You can change the polling frequency and filter data using [configuration option
 
 Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations) information for the GCP API Gateway integration:
 
-* New Relic polling interval: 5 minutes
 
 ## Find and use data [#find-data]
 

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration.mdx
@@ -1,0 +1,103 @@
+---
+title: Google Cloud API Gateway monitoring integration
+tags:
+  - Integrations
+  - Google Cloud Platform integrations
+  - GCP integrations list
+metaDescription: 'New Relic Google Cloud API Gateway integration: the data it reports and how to enable it.'
+redirects:
+  - /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration
+freshnessValidatedDate: never
+---
+
+[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) include an integration for reporting your GCP API Gateway data to our products. Here we explain how to activate the integration and what data it collects.
+
+## What is Google Cloud API Gateway? [#about]
+
+[Google Cloud API Gateway](https://cloud.google.com/api-gateway) is a fully managed service that enables you to create, secure, and monitor APIs for your Google Cloud backend services. It provides a single entry point for your APIs, handling authentication, rate limiting, and traffic management, while giving you visibility into API usage and performance.
+
+## Activate integration [#activate]
+
+To enable the integration follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+
+## Configuration and polling [#polling]
+
+You can change the polling frequency and filter data using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+
+Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations) information for the GCP API Gateway integration:
+
+* New Relic polling interval: 5 minutes
+
+## Find and use data [#find-data]
+
+To find your integration data, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP**</DNT> and select an integration.
+
+Data is attached to the following [event type](/docs/data-apis/understand-data/new-relic-data-types/#event-data):
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        Entity
+      </th>
+
+      <th>
+        Event Type
+      </th>
+
+      <th>
+        Provider
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Gateway
+      </td>
+
+      <td>
+        `Metric`
+      </td>
+
+      <td>
+        `GcpApiGateway`
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For more on how to use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
+
+## Metric data [#metrics]
+
+This integration collects GCP API Gateway data for Gateway.
+
+### API Gateway data
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "275px" }}>
+        Metric Name
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.apigateway.proxy.request_count`
+      </td>
+
+      <td>
+        Number of requests that are proxied by the API Gateway.
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Give us some context

Adding documentation for the GCP API Gateway integration.

This PR adds:
- Integration overview and requirements
- Available metrics (`gcp.apigateway.proxy.request_count`) with response_code_class and api_config dimensions
- Data sourced from `Metric` event type (GCP v2, no sample events)