### PR TITLE
Add infrastructure agent v1.74.4 release notes

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1744.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1744.mdx
@@ -8,4 +8,4 @@ A new version of the agent has been released. Follow standard procedures to [upd
 New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [Infrastructure agent 1.64.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1640/).
 
 ## Changed
-* Updated dependency newrelic/nri-flex to v1.18.2 to address [CVE-2026-29181](https://github.com/advisories/GHSA-mh2q-q3fh-2475) [#2235](https://github.com/newrelic/infrastructure-agent/pull/2235)
+* Updated dependency `newrelic/nri-flex` to v1.18.2 to address [CVE-2026-29181](https://github.com/advisories/GHSA-mh2q-q3fh-2475) [#2235](https://github.com/newrelic/infrastructure-agent/pull/2235)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1744.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1744.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Infrastructure agent
-releaseDate: '2026-05-07'
+releaseDate: '2026-05-11'
 version: 1.74.4
 ---
 

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1744.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1744.mdx
@@ -1,0 +1,11 @@
+---
+subject: Infrastructure agent
+releaseDate: '2026-05-07'
+version: 1.74.4
+---
+
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [Infrastructure agent 1.64.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1640/).
+
+## Changed
+* Updated dependency newrelic/nri-flex to v1.18.2 to address [CVE-2026-29181](https://github.com/advisories/GHSA-mh2q-q3fh-2475) [#2235](https://github.com/newrelic/infrastructure-agent/pull/2235)


### PR DESCRIPTION
## Summary
- Adds release notes for infrastructure agent v1.74.4
- Updated dependency newrelic/nri-flex to v1.18.2 to address CVE-2026-29181