### PR TITLE
PHP Agent 12.7.0.36 release notes

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -479,7 +479,7 @@ The following frameworks are supported:
       <td>
         Laravel
       </td>
-      <td>11.x, 12.x</td>
+      <td>11.x, 12.x, 13.x</td>
       <td></td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-7-0-35.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-7-0-35.mdx
@@ -1,0 +1,45 @@
+---
+subject: PHP agent
+releaseDate: '2026-05-11'
+version: 12.7.0.35
+downloadLink: 'https://download.newrelic.com/php_agent/archive/12.7.0.35'
+features: []
+bugs: ['Changed log level of transaction truncation fiber messages', 'Ensure unnamed spans are not recorded for infinite tracing', 'Correct daemon seen/sent metric generation', 'Allow mysqli parameter binding in execute']
+security: ['Bump go version to 1.26.2']
+---
+
+## New Relic PHP agent v12.7.0.35
+
+### Security updates
+
+* Bump go version to 1.26.2 ([#1205](https://github.com/newrelic/newrelic-php-agent/pull/1205)). Addresses [#1201](https://github.com/newrelic/newrelic-php-agent/issues/1201).
+
+### Bug Fixes
+
+* Changed log level of transaction truncation fiber messages ([#1207](https://github.com/newrelic/newrelic-php-agent/pull/1207)). Addresses [#1200](https://github.com/newrelic/newrelic-php-agent/issues/1200).
+* Ensure unnamed spans are not recorded for infinite tracing ([#1197](https://github.com/newrelic/newrelic-php-agent/pull/1197)).
+* Correct daemon seen/sent metric generation ([#1174](https://github.com/newrelic/newrelic-php-agent/pull/1174)).
+* Allow mysqli parameter binding in execute ([#1172](https://github.com/newrelic/newrelic-php-agent/pull/1172)).
+
+### Support Statement
+
+* As [previously communicated](https://docs.newrelic.com/docs/apm/agents/php-agent/installation/php-agent-installation-rpm-key-rotation/), for best practices and security, the rpm signing key has been rotated and the [rpm installation](https://docs.newrelic.com/docs/apm/agents/php-agent/installation/php-agent-installation-aws-linux-redhat-centos/) page reflects the up to date changes.
+
+* PHP Agent support for the following library & framework versions will be discontinued and New Relic recommends you upgrade to the latest version supported by the vendor:
+    * Drupal 7 support will be discontinued in all PHP Agent Versions after September 30, 2026
+    * Drupal 9 support will be discontinued in all PHP Agent Versions after September 30, 2026
+    * Laravel 11 support will be discontinued in all PHP Agent Versions after September 30, 2026
+    * Joomla 3 support will be discontinued in all PHP Agent Versions after September 30, 2026
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [New Relic PHP Agent EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+  **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
+  The PHP agent packages that are affected are:
+
+* newrelic-php5
+* newrelic-php5-common
+* newrelic-daemon
+</Callout>

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-7-0-36.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-7-0-36.mdx
@@ -1,18 +1,18 @@
 ---
 subject: PHP agent
-releaseDate: '2026-05-11'
-version: 12.7.0.35
-downloadLink: 'https://download.newrelic.com/php_agent/archive/12.7.0.35'
+releaseDate: '2026-05-12'
+version: 12.7.0.36
+downloadLink: 'https://download.newrelic.com/php_agent/archive/12.7.0.36'
 features: []
 bugs: ['Changed log level of transaction truncation fiber messages', 'Ensure unnamed spans are not recorded for infinite tracing', 'Correct daemon seen/sent metric generation', 'Allow mysqli parameter binding in execute']
-security: ['Bump go version to 1.26.2']
+security: ['Bump go version to 1.26.3']
 ---
 
-## New Relic PHP agent v12.7.0.35
+## New Relic PHP agent v12.7.0.36
 
 ### Security updates
 
-* Bump go version to 1.26.2 ([#1205](https://github.com/newrelic/newrelic-php-agent/pull/1205)). Addresses [#1201](https://github.com/newrelic/newrelic-php-agent/issues/1201).
+* Bump go version to 1.26.3 ([#1220](https://github.com/newrelic/newrelic-php-agent/pull/1220)). Addresses [#1201](https://github.com/newrelic/newrelic-php-agent/issues/1201).
 
 ### Bug Fixes
 


### PR DESCRIPTION
This PR does the following:

- Adds PHP Agent 12.7.0.36 release notes.
- Adds 13.x as supported laravel version. 