### PR TITLE
chore(nodejs): Updated node migration guide with version 14 docs

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
@@ -434,7 +434,3 @@ Below is an example of a batch query and what that may look like in NR One.
 `post /batch/query/GetBookForLibrary/library.books/mutation/<anonymous>/addThing`
 
 Here you see `batch/` followed by `query/GetBookForLibrary/library.books` and `mutation/<anonymous>/addThing`.
-
-## GitHub documentation [#github]
-
-For detailed information about installation, configuration, transaction details, metrics, segments, errors, testing, troubleshooting, and more, see New Relic's [Apollo Server plugin documentation on GitHub](https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/main/README.md).

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
@@ -11,6 +11,13 @@ redirects:
 freshnessValidatedDate: never
 ---
 
+## Using Apollo Server Instrumentation Without the Plugin
+Starting with 14.0.0 of the agent, apollo server customers will no longer need to install and use @newrelic/apollo-server-plugin. The instrumentation will be automatically applied to every apollo server instance. 
+
+See our [Apollo Server Migration Guide](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/#apollo-server-migration-guide) for more details.
+
+## Using the New Relic Apollo Server Plugin
+
 The New Relic Apollo Server plugin instruments your Apollo Server applications to give visibility into your GraphQL payloads. This helps you uncover and diagnose the cause of your slow [GraphQL queries](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph). The supported Apollo Server version is 2.14 or later.
 
 Our plugin records overall timings for queries and uses [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works) to uncover the route problem. Use this instrumentation to see if the problem arises from resolving a piece of requested data or if it stems from work done on other services or databases.

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
@@ -39,6 +39,402 @@ The New Relic plugin works with the following Apollo Server modules:
 
 Other plugins may work, depending on their underlying implementation, but they have not been verified.
 
+## Metrics
+
+Two new metrics have been introduced to understand the behavior of your GraphQL operations within and across transactions. Read more on those below or jump down to the [Visualizations](#visualizations) section to see some recommended ways to use this data.
+
+For more information on querying metrics and creating charts, see the [Resources](#resources) section.
+
+### Operation Metrics
+
+`/GraphQL/operation/ApolloServer/[operation-type]/[operation-name]/[deepest-unique-path]`
+
+Operation metrics include the operation type, operation name and deepest-path. These metrics represent the durations of the individual queries or mutations and can be used to compare outside of the context of individual transactions which may have multiple queries.
+
+**Operation Type:** Indicates if the operation was a query or a mutation.
+
+**Operation Name:** The operation name when provided or `<anonymous>`.
+
+**Deepest Unique Path:** The deepest path included in the selection set of a query where only one field was selected at each level. Since operation names may be reused, this helps further determine uniqueness of a given operation. See the description on the [transactions](#deepest-unique-path) section for more details.
+
+### Field Resolve Metrics
+
+`/GraphQL/resolve/ApolloServer/[parent-type].[field-name]`
+
+Resolve metrics capture the duration spent resolving a particular piece of requested GraphQL data. These can be useful to find specific resolvers that may contribute to slowing down incoming queries. It can be helpful for distinguishing field resolvers that happen to have the same name but are on different types. It can also be can be helpful in case of the same resolver being used across different types. 
+
+These differ slightly in naming from their segment/span counterparts. To better visualize relationships, the full path to a field is represented in segments/spans (e.g. libraries.books.title). To understand the duration aggregated across all usages and transactions, these metrics use the field name without the full path.
+
+### Field and Argument Metrics
+
+`/GraphQL/field/ApolloServer/[parent-type].[field-name]`
+`/GraphQL/arg/ApolloServer/[parent-type].[field-name]/[arg-name]`
+
+Field metrics are only captured when `config.apollo_server.field_metrics` is `true`.  Unlike the Field Resolve Metrics, this will capture every time a field or resolver argument is seen.
+The intent of these metrics is to determine if a field in a GraphQL schema is still in use and is safe to remove.
+
+
+#### All fields and args that have been requested within the last day
+
+```
+FROM Metric SELECT count(newrelic.timeslice.value) where appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/{kind}/ApolloServer/{field}' where kind = 'arg' or kind = 'field' FACET kind, field limit max since 1 day ago 
+```
+
+### Visualizations [#visualizations]
+
+Here is a collection of useful queries that leverage these new metrics to better understand the behaviors of your Apollo GraphQL applications.
+
+#### Top 10 Operations
+
+If you would like to have a list of the top 10 slowest operations, the following query can be used to pull the data on demand or as a part of a dashboard.
+
+```
+FROM Metric SELECT average(newrelic.timeslice.value) * 1000 WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{operation}' FACET operation LIMIT 10
+```
+
+The 'Bar' chart type makes a nice visualization similar to the transaction overview you may be used to.
+
+A 'Table' chart type may also be useful showing a breakdown of operations. For this scenario, we recommend leveraging the METRIC_FORMAT to give further sorting and visualization flexibility. The following query will generate columns of operation type, operation name, deepest-path and 'AVG Duration (MS)' to sort and examine as you wish.
+
+```
+FROM Metric SELECT average(newrelic.timeslice.value) * 1000 as 'AVG Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{type}/{name}/{deepest-path}' FACET type, name, `deepest-path` LIMIT 20
+```
+
+#### Average Operation Time
+
+You may also wish to track the average duration over time for operations. To do this, a very similar query may be used leveraging `TIMESERIES`.
+
+```
+FROM Metric SELECT average(newrelic.timeslice.value) WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{operation}' TIMESERIES FACET operation
+```
+
+This is best viewed with the 'Line' chart type which allows for viewing all operations or toggling visualization of individual operations.
+
+#### Top 10 Resolvers
+
+If you would like to have a list of the top 10 slowest resolves, the following query can be used to pull the data on demand or as a part of a dashboard.
+
+```
+FROM Metric
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{type}.{field}' FACET field LIMIT 20
+```
+
+If you would like to include the parent type.
+
+```
+FROM Metric
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field LIMIT 20
+```
+
+The 'Bar' chart type makes a nice visualization similar to the transaction overview you may be used to. The 'Table' chart type may also be useful showing a breakdown of field and 'Average Duration (MS)' in a table.
+
+#### Average Resolver Time
+
+You may also wish to track the average duration over time for resolvers. To do this, a very similar query may be used leveraging `TIMESERIES`.
+
+```
+FROM Metric
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' TIMESERIES WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field
+```
+
+This is best viewed with the 'Line' chart type which allows for viewing all operations or toggling visualization of individual operations.
+
+### Resources [#resources]
+
+* [Query APM metric timeslice data with NRQL](/docs/data-apis/understand-data/metric-data/query-apm-metric-timeslice-data-nrql/)
+
+* [Add and customize metric charts](/docs/nrql/get-started/introduction-nrql-new-relics-query-language/)
+
+## Segments and Spans
+
+Segments and spans (when Distributed Tracing enabled) are captured for GraphQL operations, field resolution and additional work (when instrumented) that occurs as a part of field resolution such as making a query to a database.
+
+### Operation Segments/Spans
+
+`/GraphQL/operation/ApolloServer/[operation-type]/[operation-name]/[deepest-unique-path]`
+
+Operation segments/spans include the operation type, operation name and deepest unique path. These represent the individual duration and attributes of a specific invocation within a transaction or trace.
+
+For more details on the parts, see the [transactions](#details) section.
+
+**Attributes**
+
+| Name                   | Description      | Default  |
+| ---------------------- | ---------------- | -------- |
+| graphql.operation.type | query or mutation| included |
+| graphql.operation.name | Name given to the operation or anonymous | included |
+| graphql.operation.query | The original GraphQL query with arguments obfuscated | included |
+
+To exclude capture of the query attribute (or any attribute), the attribute name will need to be added to the 'attributes' exclude list or segment/span attributes exclude lists individually.
+
+For more information on including/excluding attributes, please see the [attributes documentation](/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes/#configure-attributes).
+
+### Field Resolve Segments/Spans
+
+`/GraphQL/resolve/ApolloServer/[path]`
+
+Resolve segments/spans leverage the resolution path of the individual field to best differentiate within a given trace or transaction. For example, `libraries.books` might be used instead of just `books`. These represent the individual duration and attributes of a specific field being resolved as a part of the GraphQL operation.
+
+**Attributes**
+| Name                     | Description                | Default  |
+| ------------------------ | -------------------------- | -------- |
+| graphql.field.name       | Name of the resolved field | included |
+| graphql.field.returnType | Return type (`Book!`, `[String]`, etc. ) of the resolved field | included |
+| graphql.field.parentType | Type of the parent of this field (`[Book]`) | included |
+| graphql.field.path | Full resolve path of the field (`libraries.books`) | included |
+| graphql.field.args | Arg passed to the GraphQL query or mutation for this resolver captured as key/value pairs | excluded |
+
+To include capture of args attributes, `graphql.field.args.*` (to capture all) will need to be added to the 'attributes' include list or segment/span attributes include lists individually.
+
+For more information on including/excluding attributes, please see the [attributes documentation](/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes/#configure-attributes).
+
+## Transactions
+
+```
+query {
+  libraries {
+    books {
+      title
+      author {
+        name
+      }
+    }
+  }
+}
+```
+
+`post /query/<anonymous>/libraries.books`
+
+---
+
+Transactions are captured as web transactions, associated with the underlying framework (Express, Koa, etc.), and named based on the GraphQL operations executed.
+
+We leverage several details in a transaction name to attempt to mostly group unique query representations: http method, operation type, operation name and the deepest path resolved (the first, if multiple).
+
+The raw representation of a transaction looks like the following: `/WebTransaction/{framework-name}/POST//{operation-type}/{operation-name}/{deepest-unique-path}`
+
+For an Express usage of Apollo Server, that may look like: `/WebTransaction/Expressjs/POST//query/<anonymous>/libraries.books`
+
+The transaction on New Relic One will ultimately display similar to: `post /query/<anonymous>/libraries.books`.
+
+### Details [#details]
+
+#### Http Method
+
+Http method/verb for the web request. Data may be requested via GET or POST and is surfaced to differentiate similar to other web transactions.
+
+#### Operation Type
+
+Indicates if the operation was a query or a mutation.
+
+#### Operation Name
+
+The operation name when provided or `<anonymous>`.
+
+`query { libraries }` would use the operation name `<anonymous>` because a name was not provided.
+
+A named query such as `query GetLibraries { libraries }` would use the operation name `GetLibraries'.
+
+#### Deepest Unique Path [#deepest-unique-path]
+
+The deepest path included in the selection set of a query where only one field was selected at each level. Since operation names may be reused, this helps further determine uniqueness of a given operation.
+
+We use the deepest unique path (instead of deepest path like prior) to avoid making arbitrary decision in naming, which may imply/hide details of what could cause slowness for an application.
+
+For the query:
+
+```
+query {
+  libraries {
+    branch
+    booksInStock {
+      isbn,
+      title,
+      author
+    }
+    magazinesInStock {
+      issue,
+      title
+    }
+  }
+}
+```
+
+We will select a deepest unique path of 'libraries' as we select multiple fields beyond that point. Any resolver executed beyond that point may contribute to the performance characteristics of the transaction.
+
+If the query were to only select one field per resolver, we select the full path as each selection set is unique.
+
+The query:
+
+```
+query {
+  libraries {
+    booksInStock {
+      title
+    }
+  }
+}
+```
+
+Will result in the deepest unique path: 'libraries.booksInStock.title'.
+
+`id` and `__typename` fields are automatically excluded from the naming decision.
+
+For example, a federated sub graph query:
+
+```
+query {
+  libraries {
+    branch
+    __typename
+    id
+  }
+}
+```
+
+Would result in the deepest unique path of: 'libraries.branch'.
+
+### Union Types and Inline Fragments
+
+For Union types which utilize Inline Fragments, the transaction name will use `< ... >` brackets to indicate the underlying selected field for the Union query if only one result is specified in the query.
+
+For the following schema:
+```
+union SearchResult = Book | Author
+
+type Book {
+  title: String!
+}
+
+type Author {
+  name: String!
+}
+
+type Query {
+  search(contains: String): [SearchResult!]
+}
+```
+
+and the following query:
+
+```
+query example {
+  search(contains: "author") {
+    __typename
+    ... on Author {
+      name
+    }
+  }
+}
+```
+
+Would result in the following transaction name:
+
+`post /query/example/search<Author>.name`
+
+However, if the query is returning both Book and Author:
+
+```
+query example {
+  search(contains: "author") {
+    __typename
+    ... on Author {
+      name
+    }
+    ... on Book {
+      title
+    }
+  }
+}
+```
+
+The resulting transaction name would be:
+
+`post /query/example/search`
+
+### Naming on Error
+
+Errors parsing or validating a GraphQL request can impact transaction naming.
+
+#### Validation Errors
+
+If a request was able to parse, but was not able to validate, we will name the transaction off what was attempted to be queried. For example: when a field in the incoming GraphQL query does not exist.
+
+In this situation, we'll leverage the parsed document to indicate each of the intended pieces including calculating the deepest path intended.
+
+Below is an example of querying for a field that does not exist (`doesnotexist`) and what that may look like in NR One.
+
+```
+query GetBooksByLibrary {
+  libraries {
+    books {
+      doesnotexist {
+        name
+      }
+    }
+  }
+}
+```
+
+`post /query/GetBooksByLibrary/libraries.books.doesnotexist.name`
+
+#### Parsing Errors
+
+If a requested operation cannot be parsed, we will name the transaction using a wildcard (*) in place of the usual operation pieces. In this situation, the query is invalid and we do not know if we have any tangible pieces to safely go off of.
+
+Below is an example missing a closing `}` that cannot parse and what that may look like in NR One.
+
+```
+query GetBooksByLibrary {
+  libraries {
+    books {
+      title
+      author {
+        name
+      }
+    }
+  }
+// missing closing }
+```
+
+`post /*`
+
+In these situations, the `query` attribute on the operation span associated with the error is the best way to identify the particular offender.
+
+#### Batch Queries
+
+Apollo Server allows the sending of batch queries. In these situations, there are multiple operation/queries in play to impact naming.
+
+To continue to best uniquely identify transaction groupings, we aggregate the operation names after an additional `/batch` indicator. These names are likely to be quite long. We are considering dropping the deepest unique path from these names but are currently maintaining consistency.
+
+Below is an example of a batch query and what that may look like in NR One.
+
+```
+[
+  {
+    query: query GetBookForLibrary {
+      library(branch: "downtown") {
+        books {
+          title
+          author {
+            name
+          }
+        }
+      }
+    }
+  },
+  {
+    query: mutation {
+      addThing(name: "added thing!")
+    }
+  }
+]
+```
+
+`post /batch/query/GetBookForLibrary/library.books/mutation/<anonymous>/addThing`
+
+Here you see `batch/` followed by `query/GetBookForLibrary/library.books` and `mutation/<anonymous>/addThing`.
+
 ## GitHub documentation [#github]
 
 For detailed information about installation, configuration, transaction details, metrics, segments, errors, testing, troubleshooting, and more, see New Relic's [Apollo Server plugin documentation on GitHub](https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/main/README.md).

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
@@ -11,10 +11,11 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-## Using Apollo Server Instrumentation Without the Plugin
-Starting with 14.0.0 of the agent, apollo server customers will no longer need to install and use @newrelic/apollo-server-plugin. The instrumentation will be automatically applied to every apollo server instance. 
+<Callout variant="important">
+  Starting with 14.0.0 of the Node.js agent, Apollo Server customers no longer need to install and use `@newrelic/apollo-server-plugin`. The instrumentation is automatically applied to every Apollo Server instance.
 
-See our [Apollo Server Migration Guide](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/#apollo-server-migration-guide) for more details.
+  See our [Apollo Server Migration Guide](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/#apollo-server-migration-guide) for more details.
+</Callout>
 
 ## Using the New Relic Apollo Server Plugin
 

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs.mdx
@@ -17,11 +17,9 @@ freshnessValidatedDate: never
   See our [Apollo Server Migration Guide](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/#apollo-server-migration-guide) for more details.
 </Callout>
 
-## Using the New Relic Apollo Server Plugin
-
 The New Relic Apollo Server plugin instruments your Apollo Server applications to give visibility into your GraphQL payloads. This helps you uncover and diagnose the cause of your slow [GraphQL queries](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph). The supported Apollo Server version is 2.14 or later.
 
-Our plugin records overall timings for queries and uses [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works) to uncover the route problem. Use this instrumentation to see if the problem arises from resolving a piece of requested data or if it stems from work done on other services or databases.
+The plugin records overall timings for queries and uses [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works) to uncover route problems. Use this instrumentation to see whether the problem arises from resolving a piece of requested data or from work done on other services or databases.
 
 ## Compatibility
 
@@ -49,7 +47,7 @@ For more information on querying metrics and creating charts, see the [Resources
 
 `/GraphQL/operation/ApolloServer/[operation-type]/[operation-name]/[deepest-unique-path]`
 
-Operation metrics include the operation type, operation name and deepest-path. These metrics represent the durations of the individual queries or mutations and can be used to compare outside of the context of individual transactions which may have multiple queries.
+Operation metrics include the operation type, operation name, and deepest path. These metrics represent the durations of individual queries or mutations. Use them to compare performance outside the context of individual transactions, which may contain multiple queries.
 
 **Operation Type:** Indicates if the operation was a query or a mutation.
 
@@ -61,83 +59,81 @@ Operation metrics include the operation type, operation name and deepest-path. T
 
 `/GraphQL/resolve/ApolloServer/[parent-type].[field-name]`
 
-Resolve metrics capture the duration spent resolving a particular piece of requested GraphQL data. These can be useful to find specific resolvers that may contribute to slowing down incoming queries. It can be helpful for distinguishing field resolvers that happen to have the same name but are on different types. It can also be can be helpful in case of the same resolver being used across different types. 
+Resolve metrics capture the duration spent resolving a particular piece of requested GraphQL data. Use them to find specific resolvers that may contribute to slowing down incoming queries, to distinguish field resolvers with the same name on different types, or to identify the same resolver applied across different types.
 
-These differ slightly in naming from their segment/span counterparts. To better visualize relationships, the full path to a field is represented in segments/spans (e.g. libraries.books.title). To understand the duration aggregated across all usages and transactions, these metrics use the field name without the full path.
+These differ slightly in naming from their segment and span counterparts. To better visualize relationships, the full path to a field is represented in segments and spans (for example, `libraries.books.title`). To understand the duration aggregated across all usages and transactions, these metrics use the field name without the full path.
 
 ### Field and Argument Metrics
 
 `/GraphQL/field/ApolloServer/[parent-type].[field-name]`
 `/GraphQL/arg/ApolloServer/[parent-type].[field-name]/[arg-name]`
 
-Field metrics are only captured when `config.apollo_server.field_metrics` is `true`.  Unlike the Field Resolve Metrics, this will capture every time a field or resolver argument is seen.
-The intent of these metrics is to determine if a field in a GraphQL schema is still in use and is safe to remove.
-
+Field metrics are only captured when `config.apollo_server.field_metrics` is `true`. Unlike field resolve metrics, this captures every time a field or resolver argument is seen. Use these metrics to determine whether a field in a GraphQL schema is still in use and safe to remove.
 
 #### All fields and args that have been requested within the last day
 
-```
-FROM Metric SELECT count(newrelic.timeslice.value) where appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/{kind}/ApolloServer/{field}' where kind = 'arg' or kind = 'field' FACET kind, field limit max since 1 day ago 
+```sql
+FROM Metric SELECT count(newrelic.timeslice.value) where appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/{kind}/ApolloServer/{field}' where kind = 'arg' or kind = 'field' FACET kind, field limit max since 1 day ago
 ```
 
 ### Visualizations [#visualizations]
 
-Here is a collection of useful queries that leverage these new metrics to better understand the behaviors of your Apollo GraphQL applications.
+The following queries use these metrics to help you understand the behavior of your Apollo GraphQL applications.
 
 #### Top 10 Operations
 
-If you would like to have a list of the top 10 slowest operations, the following query can be used to pull the data on demand or as a part of a dashboard.
+To get a list of the top 10 slowest operations, use the following query on demand or as part of a dashboard.
 
+```sql
+FROM Metric SELECT average(newrelic.timeslice.value) * 1000 WHERE appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{operation}' FACET operation LIMIT 10
 ```
-FROM Metric SELECT average(newrelic.timeslice.value) * 1000 WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{operation}' FACET operation LIMIT 10
-```
 
-The 'Bar' chart type makes a nice visualization similar to the transaction overview you may be used to.
+The **Bar** chart type gives a visualization similar to the transaction overview.
 
-A 'Table' chart type may also be useful showing a breakdown of operations. For this scenario, we recommend leveraging the METRIC_FORMAT to give further sorting and visualization flexibility. The following query will generate columns of operation type, operation name, deepest-path and 'AVG Duration (MS)' to sort and examine as you wish.
+A **Table** chart type is also useful for showing a breakdown of operations. Use the `METRIC_FORMAT` for additional sorting and visualization flexibility. The following query generates columns for operation type, operation name, deepest path, and **AVG Duration (MS)**.
 
-```
-FROM Metric SELECT average(newrelic.timeslice.value) * 1000 as 'AVG Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{type}/{name}/{deepest-path}' FACET type, name, `deepest-path` LIMIT 20
+```sql
+FROM Metric SELECT average(newrelic.timeslice.value) * 1000 as 'AVG Duration (MS)' WHERE appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{type}/{name}/{deepest-path}' FACET type, name, `deepest-path` LIMIT 20
 ```
 
 #### Average Operation Time
 
-You may also wish to track the average duration over time for operations. To do this, a very similar query may be used leveraging `TIMESERIES`.
+To track the average duration over time for operations, use a similar query with `TIMESERIES`.
 
-```
-FROM Metric SELECT average(newrelic.timeslice.value) WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{operation}' TIMESERIES FACET operation
+```sql
+FROM Metric SELECT average(newrelic.timeslice.value) WHERE appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/operation/ApolloServer/{operation}' TIMESERIES FACET operation
 ```
 
-This is best viewed with the 'Line' chart type which allows for viewing all operations or toggling visualization of individual operations.
+View this with the **Line** chart type, which lets you see all operations or toggle individual ones.
 
 #### Top 10 Resolvers
 
-If you would like to have a list of the top 10 slowest resolves, the following query can be used to pull the data on demand or as a part of a dashboard.
+To get a list of the top 10 slowest resolvers, use the following query on demand or as part of a dashboard.
 
-```
+```sql
 FROM Metric
-SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{type}.{field}' FACET field LIMIT 20
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{type}.{field}' FACET field LIMIT 20
 ```
 
-If you would like to include the parent type.
+If you would like to include the parent type:
 
-```
+```sql
 FROM Metric
-SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field LIMIT 20
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field LIMIT 20
 ```
 
-The 'Bar' chart type makes a nice visualization similar to the transaction overview you may be used to. The 'Table' chart type may also be useful showing a breakdown of field and 'Average Duration (MS)' in a table.
+The **Bar** chart type gives a visualization similar to the transaction overview. The **Table** chart type is also useful for showing a breakdown of field and **Average Duration (MS)**.
 
 #### Average Resolver Time
 
-You may also wish to track the average duration over time for resolvers. To do this, a very similar query may be used leveraging `TIMESERIES`.
+To track the average duration over time for resolvers, use a similar query with `TIMESERIES`.
 
-```
+```sql
 FROM Metric
-SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' TIMESERIES WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' TIMESERIES WHERE appName = 'YOUR_APP_NAME' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field
 ```
 
-This is best viewed with the 'Line' chart type which allows for viewing all operations or toggling visualization of individual operations.
+View this with the **Line** chart type, which lets you see all resolvers or toggle individual ones.
 
 ### Resources [#resources]
 
@@ -147,50 +143,161 @@ This is best viewed with the 'Line' chart type which allows for viewing all oper
 
 ## Segments and Spans
 
-Segments and spans (when Distributed Tracing enabled) are captured for GraphQL operations, field resolution and additional work (when instrumented) that occurs as a part of field resolution such as making a query to a database.
+Segments and spans (when distributed tracing is enabled) are captured for GraphQL operations, field resolution, and additional instrumented work that occurs as part of field resolution, such as making a query to a database.
 
 ### Operation Segments/Spans
 
 `/GraphQL/operation/ApolloServer/[operation-type]/[operation-name]/[deepest-unique-path]`
 
-Operation segments/spans include the operation type, operation name and deepest unique path. These represent the individual duration and attributes of a specific invocation within a transaction or trace.
+Operation segments and spans include the operation type, operation name, and deepest unique path. These represent the individual duration and attributes of a specific invocation within a transaction or trace.
 
 For more details on the parts, see the [transactions](#details) section.
 
 **Attributes**
 
-| Name                   | Description      | Default  |
-| ---------------------- | ---------------- | -------- |
-| graphql.operation.type | query or mutation| included |
-| graphql.operation.name | Name given to the operation or anonymous | included |
-| graphql.operation.query | The original GraphQL query with arguments obfuscated | included |
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        **Name**
+      </th>
+      <th>
+        **Description**
+      </th>
+      <th>
+        **Default**
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        `graphql.operation.type`
+      </td>
+      <td>
+        `query` or `mutation`
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `graphql.operation.name`
+      </td>
+      <td>
+        Name given to the operation or `anonymous`
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `graphql.operation.query`
+      </td>
+      <td>
+        The original GraphQL query with arguments obfuscated
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-To exclude capture of the query attribute (or any attribute), the attribute name will need to be added to the 'attributes' exclude list or segment/span attributes exclude lists individually.
+To exclude the query attribute (or any attribute), add the attribute name to the `attributes` exclude list or to the segment and span attributes exclude lists individually.
 
-For more information on including/excluding attributes, please see the [attributes documentation](/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes/#configure-attributes).
+For more information on including and excluding attributes, see the [attributes documentation](/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes/#configure-attributes).
 
 ### Field Resolve Segments/Spans
 
 `/GraphQL/resolve/ApolloServer/[path]`
 
-Resolve segments/spans leverage the resolution path of the individual field to best differentiate within a given trace or transaction. For example, `libraries.books` might be used instead of just `books`. These represent the individual duration and attributes of a specific field being resolved as a part of the GraphQL operation.
+Resolve segments and spans use the resolution path of the individual field to best differentiate within a given trace or transaction. For example, the path `libraries.books` is used instead of just `books`. These represent the individual duration and attributes of a specific field being resolved as part of the GraphQL operation.
 
 **Attributes**
-| Name                     | Description                | Default  |
-| ------------------------ | -------------------------- | -------- |
-| graphql.field.name       | Name of the resolved field | included |
-| graphql.field.returnType | Return type (`Book!`, `[String]`, etc. ) of the resolved field | included |
-| graphql.field.parentType | Type of the parent of this field (`[Book]`) | included |
-| graphql.field.path | Full resolve path of the field (`libraries.books`) | included |
-| graphql.field.args | Arg passed to the GraphQL query or mutation for this resolver captured as key/value pairs | excluded |
 
-To include capture of args attributes, `graphql.field.args.*` (to capture all) will need to be added to the 'attributes' include list or segment/span attributes include lists individually.
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        **Name**
+      </th>
+      <th>
+        **Description**
+      </th>
+      <th>
+        **Default**
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        `graphql.field.name`
+      </td>
+      <td>
+        Name of the resolved field
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `graphql.field.returnType`
+      </td>
+      <td>
+        Return type (`Book!`, `[String]`, etc.) of the resolved field
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `graphql.field.parentType`
+      </td>
+      <td>
+        Type of the parent of this field (`[Book]`)
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `graphql.field.path`
+      </td>
+      <td>
+        Full resolve path of the field (`libraries.books`)
+      </td>
+      <td>
+        Included
+      </td>
+    </tr>
+    <tr>
+      <td>
+        `graphql.field.args`
+      </td>
+      <td>
+        Arg passed to the GraphQL query or mutation for this resolver captured as key/value pairs
+      </td>
+      <td>
+        Excluded
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-For more information on including/excluding attributes, please see the [attributes documentation](/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes/#configure-attributes).
+To capture args attributes, add `graphql.field.args.*` to the `attributes` include list or to the segment and span attributes include lists individually.
+
+For more information on including and excluding attributes, see the [attributes documentation](/docs/apm/agents/nodejs-agent/attributes/nodejs-agent-attributes/#configure-attributes).
 
 ## Transactions
 
-```
+```graphql
 query {
   libraries {
     books {
@@ -205,11 +312,9 @@ query {
 
 `post /query/<anonymous>/libraries.books`
 
----
-
 Transactions are captured as web transactions, associated with the underlying framework (Express, Koa, etc.), and named based on the GraphQL operations executed.
 
-We leverage several details in a transaction name to attempt to mostly group unique query representations: http method, operation type, operation name and the deepest path resolved (the first, if multiple).
+The agent uses several details to group unique query representations in a transaction name: HTTP method, operation type, operation name, and the deepest path resolved (the first, if multiple).
 
 The raw representation of a transaction looks like the following: `/WebTransaction/{framework-name}/POST//{operation-type}/{operation-name}/{deepest-unique-path}`
 
@@ -219,9 +324,9 @@ The transaction on New Relic One will ultimately display similar to: `post /quer
 
 ### Details [#details]
 
-#### Http Method
+#### HTTP method
 
-Http method/verb for the web request. Data may be requested via GET or POST and is surfaced to differentiate similar to other web transactions.
+The HTTP method for the web request. Requests can arrive via GET or POST, surfacing them similarly to other web transactions.
 
 #### Operation Type
 
@@ -233,17 +338,17 @@ The operation name when provided or `<anonymous>`.
 
 `query { libraries }` would use the operation name `<anonymous>` because a name was not provided.
 
-A named query such as `query GetLibraries { libraries }` would use the operation name `GetLibraries'.
+A named query such as `query GetLibraries { libraries }` would use the operation name `GetLibraries`.
 
 #### Deepest Unique Path [#deepest-unique-path]
 
 The deepest path included in the selection set of a query where only one field was selected at each level. Since operation names may be reused, this helps further determine uniqueness of a given operation.
 
-We use the deepest unique path (instead of deepest path like prior) to avoid making arbitrary decision in naming, which may imply/hide details of what could cause slowness for an application.
+The agent uses the deepest unique path (instead of the deepest path) to avoid making an arbitrary naming decision that might imply or hide details about what causes slowness in an application.
 
 For the query:
 
-```
+```graphql
 query {
   libraries {
     branch
@@ -260,13 +365,13 @@ query {
 }
 ```
 
-We will select a deepest unique path of 'libraries' as we select multiple fields beyond that point. Any resolver executed beyond that point may contribute to the performance characteristics of the transaction.
+The deepest unique path resolves to `libraries` because multiple fields are selected beyond that point. Any resolver executed beyond that point may contribute to the performance characteristics of the transaction.
 
-If the query were to only select one field per resolver, we select the full path as each selection set is unique.
+If the query selects only one field per resolver, the full path is used because each selection set is unique.
 
 The query:
 
-```
+```graphql
 query {
   libraries {
     booksInStock {
@@ -276,13 +381,13 @@ query {
 }
 ```
 
-Will result in the deepest unique path: 'libraries.booksInStock.title'.
+Results in the deepest unique path: `libraries.booksInStock.title`.
 
 `id` and `__typename` fields are automatically excluded from the naming decision.
 
-For example, a federated sub graph query:
+For example, a federated subgraph query:
 
-```
+```graphql
 query {
   libraries {
     branch
@@ -292,14 +397,15 @@ query {
 }
 ```
 
-Would result in the deepest unique path of: 'libraries.branch'.
+Results in the deepest unique path: `libraries.branch`.
 
 ### Union Types and Inline Fragments
 
-For Union types which utilize Inline Fragments, the transaction name will use `< ... >` brackets to indicate the underlying selected field for the Union query if only one result is specified in the query.
+For union types that use inline fragments, the transaction name uses `< ... >` brackets to indicate the underlying selected field when only one result type is specified in the query.
 
 For the following schema:
-```
+
+```graphql
 union SearchResult = Book | Author
 
 type Book {
@@ -315,9 +421,9 @@ type Query {
 }
 ```
 
-and the following query:
+And the following query:
 
-```
+```graphql
 query example {
   search(contains: "author") {
     __typename
@@ -328,13 +434,13 @@ query example {
 }
 ```
 
-Would result in the following transaction name:
+Results in the following transaction name:
 
 `post /query/example/search<Author>.name`
 
-However, if the query is returning both Book and Author:
+However, if the query returns both Book and Author:
 
-```
+```graphql
 query example {
   search(contains: "author") {
     __typename
@@ -348,7 +454,7 @@ query example {
 }
 ```
 
-The resulting transaction name would be:
+The resulting transaction name is:
 
 `post /query/example/search`
 
@@ -358,13 +464,13 @@ Errors parsing or validating a GraphQL request can impact transaction naming.
 
 #### Validation Errors
 
-If a request was able to parse, but was not able to validate, we will name the transaction off what was attempted to be queried. For example: when a field in the incoming GraphQL query does not exist.
+If a request parsed but failed validation, the agent names the transaction based on what was attempted. For example, this occurs when a field in the incoming GraphQL query does not exist.
 
-In this situation, we'll leverage the parsed document to indicate each of the intended pieces including calculating the deepest path intended.
+In this situation, the agent uses the parsed document to indicate each intended piece, including calculating the deepest intended path.
 
-Below is an example of querying for a field that does not exist (`doesnotexist`) and what that may look like in NR One.
+Here is an example of querying for a field that does not exist (`doesnotexist`) and what that looks like in NR One.
 
-```
+```graphql
 query GetBooksByLibrary {
   libraries {
     books {
@@ -380,11 +486,11 @@ query GetBooksByLibrary {
 
 #### Parsing Errors
 
-If a requested operation cannot be parsed, we will name the transaction using a wildcard (*) in place of the usual operation pieces. In this situation, the query is invalid and we do not know if we have any tangible pieces to safely go off of.
+If a requested operation can't be parsed, the agent names the transaction using a wildcard (`*`) in place of the usual operation pieces. In this situation, the query is invalid and there are no identifiable pieces to go on.
 
-Below is an example missing a closing `}` that cannot parse and what that may look like in NR One.
+Here is an example missing a closing `}` that cannot parse and what that looks like in NR One.
 
-```
+```graphql
 query GetBooksByLibrary {
   libraries {
     books {
@@ -403,11 +509,11 @@ In these situations, the `query` attribute on the operation span associated with
 
 #### Batch Queries
 
-Apollo Server allows the sending of batch queries. In these situations, there are multiple operation/queries in play to impact naming.
+Apollo Server supports batch queries. In these situations, there are multiple operations in play that affect naming.
 
-To continue to best uniquely identify transaction groupings, we aggregate the operation names after an additional `/batch` indicator. These names are likely to be quite long. We are considering dropping the deepest unique path from these names but are currently maintaining consistency.
+To best identify transaction groupings, the agent aggregates operation names after an additional `/batch` indicator. These names can be quite long.
 
-Below is an example of a batch query and what that may look like in NR One.
+Here is an example of a batch query and what that looks like in NR One.
 
 ```
 [

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -24,6 +24,98 @@ Recommendation: Test your updated version before moving it into production. If y
 
 If you need to uninstall the agent and install a specific version of the agent, follow this uninstallation [guide](/docs/apm/agents/nodejs-agent/installation-configuration/uninstall-nodejs-agent/) and then reinstall a specific agent version with `npm install newrelic@LIST_VERSION_HERE` or update the version in your package.json and run `npm install`. 
 
+## Upgrade to Node.js agent version 14 [#node-agent-v14]
+
+Before upgrading to Node.js version 14, review this information for major changes.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "250px" }}>
+        <DNT>
+          **Major changes with Node.js agent v14**
+        </DNT>
+      </th>
+
+      <th>
+        <DNT>
+          **Comments**
+        </DNT>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Dropped Node.js 20 support.
+      </td>
+
+      <td>
+        * For further information see our [support policy](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Migrated `@apollo/server` instrumentation from a plugin `@newrelic/apollo-server-plugin` to traditional instrumentation.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Removed instrumentation for `koa-router` and `koa-route`.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Removed support for License, Application, and Security Policies (`LASP`).
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Removed support for Cross Application Tracing (`CAT`) functionality.
+      </td>
+
+      <td>
+        CAT was deprecated back in agent v8.4.0 and replaced with distributed tracing to propogate context between services.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Updated `config.distributed_tracing.exclude_newrelic_header` to be set to `true` by default.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Removed `shim.argsToArray` API method in favor of rest parameters.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Removed `shim.prefixRouteParameters` API method.
+      </td>
+
+      <td>
+        * Fastify instrumentation was updated to use tracing channel diagnostics so this method is no longer needed.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Dropped static `MySQL` `Pool#query` segments in `mysql` and `mysql2`.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Updated how exclusive time and trace total time is calculated.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <DNT>**BREAKING**</DNT>: Updated min supported version for `@nestjc/cli` and `@nestjs/core` to 10.0.0, `bluebird` to 3.0.0, `mysql2` to 3.0.0, `next` to 14.0.0, `cassandra-driver` to 4.0.0 and `fastify` to 4.0.0.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Upgrade to Node.js agent version 13 [#node-agent-v13]
 
 Before upgrading to Node.js version 13, review this information for major changes.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -166,7 +166,7 @@ Starting with 14.0.0 of the agent, apollo server customers will no longer need t
 * `captureIntrospectionQueries` is now `config.apollo_server.introspection_queries` or `NEW_RELIC_APOLLO_SERVER_INTROSPECTION_QUERIES`
 * `captureServiceDefinitionQueries` is now `config.apollo_server.service_definition_queries` or `NEW_RELIC_APOLLO_SERVER_SERVICE_DEFINITION_QUERIES`
 * `captureHealthCheckQueries` is now `config.apollo_server.health_check_queries` or `NEW_RELIC_APOLLO_SERVER_HEALTH_CHECK_QUERIES`
-* `captureFieldMetrics`  is now config.apollo_server.field_metrics` or `NEW_RELIC_APOLLO_SERVER_FIELD_METRICS`
+* `captureFieldMetrics` is now `config.apollo_server.field_metrics` or `NEW_RELIC_APOLLO_SERVER_FIELD_METRICS`
 
 ### API calls
 There were two previous configurations that registered functions to be called that added the key/values as custom attributes on either the operation or resolver segments.  The agent follows a pattern where customers can register callbacks via api methods, and these two use cases fit that.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -61,13 +61,15 @@ Before upgrading to Node.js version 14, review this information for major change
       </td>
 
       <td>
-        * For further information, see the `apollo-server` (documentation)[https://github.com/newrelic/node-newrelic/tree/main/documentation/apollo-server].
+        * Apollo server users will no longer need to install and use `@newrelic/apollo-server-plugin`. The instrumentation will be automatically applied to every apollo server instance.
+        * For further information, see the [Apollo Server migration guide](#apollo-server-migration-guide).
       </td>
     </tr>
     <tr>
       <td>
         <DNT>**BREAKING**</DNT>: Removed instrumentation for `koa-router` and `koa-route`.
       </td>
+      <td/>
     </tr>
     <tr>
       <td>
@@ -100,6 +102,7 @@ Before upgrading to Node.js version 14, review this information for major change
       <td>
         <DNT>**BREAKING**</DNT>: Removed `shim.argsToArray` API method in favor of rest parameters.
       </td>
+      <td/>
     </tr>
     <tr>
       <td>
@@ -121,16 +124,106 @@ Before upgrading to Node.js version 14, review this information for major change
     </tr>
     <tr>
       <td>
-        <DNT>**BREAKING**</DNT>: Updated how exclusive time and trace total time is calculated.
+        <DNT>**BREAKING**</DNT>: Updated minimum supported version for the following libraries:
+      </td>
+      <td>
+        * `@nestjc/cli` and `@nestjs/core` to 10.0.0
+        * `bluebird` to 3.0.0
+        * `mysql2` to 3.0.0
+        * `next` to 14.0.0
+        * `cassandra-driver` to 4.0.0
+        * `fastify` to 4.0.0
       </td>
     </tr>
     <tr>
       <td>
-        <DNT>**BREAKING**</DNT>: Updated min supported version for `@nestjc/cli` and `@nestjs/core` to 10.0.0, `bluebird` to 3.0.0, `mysql2` to 3.0.0, `next` to 14.0.0, `cassandra-driver` to 4.0.0 and `fastify` to 4.0.0.
+        Updated how exclusive time and trace total time is calculated.
       </td>
+      <td/>
     </tr>
   </tbody>
 </table>
+
+### Apollo Server Migration Guide
+
+Starting with 14.0.0 of the agent, apollo server customers will no longer need to install and use `@newrelic/apollo-server-plugin`.  The instrumentation will be automatically applied to every apollo server instance.  Howerver, if customers configured the plugin, this will detail the migration plan.
+
+### Plugin Configuration
+```js
+  const createPlugin = require('@newrelic/apollo-server-plugin')
+  const plugin = createPlugin({
+    captureScalars: true,
+    captureIntrospectionQueries: true,
+    captureServiceDefinitionQueries: true,
+    captureHealthCheckQueries: true,
+    captureFieldMetrics: true,
+    customResolverAttributes: () => { return { exampleAttribute: 'exampleValue' }},
+    customOperationAttributes: () => { return { exampleAttribute: 'exampleValue' }}
+  })
+```
+### Agent Configuration
+* `captureScalars` is now `config.apollo_server.scalars` or `NEW_RELIC_APOLLO_SERVER_SCALARS`
+* `captureIntrospectionQueries` is now `config.apollo_server.introspection_queries` or `NEW_RELIC_APOLLO_SERVER_INTROSPECTION_QUERIES`
+* `captureServiceDefinitionQueries` is now `config.apollo_server.service_definition_queries` or `NEW_RELIC_APOLLO_SERVER_SERVICE_DEFINITION_QUERIES`
+* `captureHealthCheckQueries` is now `config.apollo_server.health_check_queries` or `NEW_RELIC_APOLLO_SERVER_HEALTH_CHECK_QUERIES`
+* `captureFieldMetrics`  is now config.apollo_server.field_metrics` or `NEW_RELIC_APOLLO_SERVER_FIELD_METRICS`
+
+### API calls
+There were two previous configurations that registered functions to be called that added the key/values as custom attributes on either the operation or resolver segments.  The agent follows a pattern where customers can register callbacks via api methods, and these two use cases fit that.
+
+#### customOperationAttributes
+
+This is now `newrelic.setApolloOperationAttributesCallback`. It takes a callback and when present the callback gets passed the same argument as before `requestContext`
+
+**Previous**:
+```js
+  createPlugin({
+    customOperationAttributes: (requestContext) => { 
+      return {
+        clientName: requestContext.request.http.headers.get('graphql-client-name')
+      }
+    }
+  })
+```
+**Now**:
+```js
+  function operationAttributes(requestContext) {
+  return {
+    clientName: requestContext.request.http.headers.get('graphql-client-name')
+  }
+  }
+  newrelic.setApolloOperationAttributesCallback(operationAttributes)
+```
+
+#### customResolverAttributes
+This is now `newrelic.setApolloResolverAttributesCallback`. It takes a callback and when present the callback gets passed the same argument as before `{ source, args, contextValue, info }`
+
+**Previous**:
+```js
+  createPlugin({
+    customResolverAttributes: ({ source, args, context, info }) => { 
+      return {
+        allArgs: Object.keys(args).join(','),
+        returnType: info.returnType.name,
+        sourceBranch: source?.branch
+        stage: context.event.requestContext.stage
+      }
+    }
+  })
+```
+
+**Now**:
+```js
+  function customResolverAttributes({ source, args, contextValue, info }) {
+    return {
+      allArgs: Object.keys(args).join(','),
+      returnType: info.returnType.name,
+      sourceBranch: source?.branch
+      stage: contextValue.event.requestContext.stage
+    }
+  }
+  newrelic.setApolloResolverAttributesCallback(customResolverAttributes)
+```
 
 ## Upgrade to Node.js agent version 13 [#node-agent-v13]
 
@@ -165,13 +258,15 @@ Before upgrading to Node.js version 13, review this information for major change
     </tr>
     <tr>
       <td>
-        <DNT>**BREAKING**</DNT>: Updated min supported version for `fastify` to 3.0.0, `pin`o` to 8.0.0, and `koa-route`r` to 12.0.0.
+        <DNT>**BREAKING**</DNT>: Updated min supported version for `fastify` to 3.0.0, `pino` to 8.0.0, and `koa-router` to 12.0.0.
       </td>
     </tr>
     <tr>
       <td>
         Updated AI Monitoring compatibility docs with new AWS Bedrock APIs
       </td>
+
+      <td/>
     </tr>
   </tbody>
 </table>
@@ -251,11 +346,14 @@ Before upgrading to Node.js version 12, review this information for major change
       Added producer and consumer metrics to kafkajs instrumentation
     </tr>
     <tr>
-      Updated `@newrelic/native-metrics` to 11.0.0
+      <td>
+        Updated `@newrelic/native-metrics` to 11.0.0
+      </td>
+
       <td/>
     </tr>
     <tr>
-      Verified MySQL host:port metric is recorded
+      Verified `MySQL` `host:port` metric is recorded
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -59,6 +59,10 @@ Before upgrading to Node.js version 14, review this information for major change
       <td>
         <DNT>**BREAKING**</DNT>: Migrated `@apollo/server` instrumentation from a plugin `@newrelic/apollo-server-plugin` to traditional instrumentation.
       </td>
+
+      <td>
+        * For further information, see the `apollo-server` (documentation)[https://github.com/newrelic/node-newrelic/tree/main/documentation/apollo-server].
+      </td>
     </tr>
     <tr>
       <td>
@@ -69,6 +73,10 @@ Before upgrading to Node.js version 14, review this information for major change
       <td>
         <DNT>**BREAKING**</DNT>: Removed support for License, Application, and Security Policies (`LASP`).
       </td>
+
+      <td>
+        * This feature was deprecated and was configurable with `config.security_policies_token`.
+      </td>
     </tr>
     <tr>
       <td>
@@ -76,12 +84,16 @@ Before upgrading to Node.js version 14, review this information for major change
       </td>
 
       <td>
-        CAT was deprecated back in agent v8.4.0 and replaced with distributed tracing to propogate context between services.
+        * CAT was deprecated back in agent v8.4.0 and replaced with distributed tracing to propogate context between services.
       </td>
     </tr>
     <tr>
       <td>
         <DNT>**BREAKING**</DNT>: Updated `config.distributed_tracing.exclude_newrelic_header` to be set to `true` by default.
+      </td>
+
+      <td>
+        * This was replaced by W3C headers by default.
       </td>
     </tr>
     <tr>
@@ -101,6 +113,10 @@ Before upgrading to Node.js version 14, review this information for major change
     <tr>
       <td>
         <DNT>**BREAKING**</DNT>: Dropped static `MySQL` `Pool#query` segments in `mysql` and `mysql2`.
+      </td>
+
+      <td>
+        * This created unnecessary segment since `Database/*` segments are more useful.
       </td>
     </tr>
     <tr>

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent.mdx
@@ -144,11 +144,11 @@ Before upgrading to Node.js version 14, review this information for major change
   </tbody>
 </table>
 
-### Apollo Server Migration Guide
+### Apollo Server Migration Guide [#apollo-server-migration-guide]
 
 Starting with 14.0.0 of the agent, apollo server customers will no longer need to install and use `@newrelic/apollo-server-plugin`.  The instrumentation will be automatically applied to every apollo server instance.  Howerver, if customers configured the plugin, this will detail the migration plan.
 
-### Plugin Configuration
+#### Plugin Configuration
 ```js
   const createPlugin = require('@newrelic/apollo-server-plugin')
   const plugin = createPlugin({
@@ -161,17 +161,17 @@ Starting with 14.0.0 of the agent, apollo server customers will no longer need t
     customOperationAttributes: () => { return { exampleAttribute: 'exampleValue' }}
   })
 ```
-### Agent Configuration
+#### Agent Configuration
 * `captureScalars` is now `config.apollo_server.scalars` or `NEW_RELIC_APOLLO_SERVER_SCALARS`
 * `captureIntrospectionQueries` is now `config.apollo_server.introspection_queries` or `NEW_RELIC_APOLLO_SERVER_INTROSPECTION_QUERIES`
 * `captureServiceDefinitionQueries` is now `config.apollo_server.service_definition_queries` or `NEW_RELIC_APOLLO_SERVER_SERVICE_DEFINITION_QUERIES`
 * `captureHealthCheckQueries` is now `config.apollo_server.health_check_queries` or `NEW_RELIC_APOLLO_SERVER_HEALTH_CHECK_QUERIES`
 * `captureFieldMetrics` is now `config.apollo_server.field_metrics` or `NEW_RELIC_APOLLO_SERVER_FIELD_METRICS`
 
-### API calls
+#### API calls
 There were two previous configurations that registered functions to be called that added the key/values as custom attributes on either the operation or resolver segments.  The agent follows a pattern where customers can register callbacks via api methods, and these two use cases fit that.
 
-#### customOperationAttributes
+##### customOperationAttributes
 
 This is now `newrelic.setApolloOperationAttributesCallback`. It takes a callback and when present the callback gets passed the same argument as before `requestContext`
 
@@ -195,7 +195,7 @@ This is now `newrelic.setApolloOperationAttributesCallback`. It takes a callback
   newrelic.setApolloOperationAttributesCallback(operationAttributes)
 ```
 
-#### customResolverAttributes
+##### customResolverAttributes
 This is now `newrelic.setApolloResolverAttributesCallback`. It takes a callback and when present the callback gets passed the same argument as before `{ source, args, contextValue, info }`
 
 **Previous**:


### PR DESCRIPTION
Added node agent version 14 docs to the node migration/upgrade guide.