### PR TITLE
eBPF release v1.4.1

### DIFF
--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -234,12 +234,6 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`""`</td>
         </tr>
         <tr>
-            <td>`customOtlpEndpointTlsEnabled`</td>
-            <td>Whether TLS is enabled on the OTLP endpoint. Only overridden when both `customOtlpEndpoint` and this field are explicitly set.</td>
-            <td>`Boolean`</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
             <td>`customOtlpEndpointTlsCertSecret`</td>
             <td>Name of the Kubernetes secret containing the CA certificate for the custom OTLP endpoint. Only used when `customOtlpEndpoint` is set. Must be provided together with `customOtlpEndpointTlsCertSecretKey`.</td>
             <td>`String`</td>
@@ -252,6 +246,48 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`""`</td>
         </tr>
         <tr>
+            <td>`otlpProxy.host`</td>
+            <td>HTTP/HTTPS proxy hostname for routing OTLP telemetry data through a corporate proxy. If empty, no proxy is used.</td>
+            <td>`String`</td>
+            <td>`"proxy.example.com"`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.port`</td>
+            <td>Proxy port for the OTLP proxy.</td>
+            <td>`Integer`</td>
+            <td>`8080`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.scheme`</td>
+            <td>Proxy URL scheme. Accepted values: `http`, `https`.</td>
+            <td>`String`</td>
+            <td>`"http"`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.user`</td>
+            <td>Username for proxy Basic Authentication. If empty, no authentication is used.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.password`</td>
+            <td>Password for proxy Basic Authentication. Only used together with `otlpProxy.user`. For security, prefer `otlpProxy.existingSecret` instead of setting the password directly.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.url`</td>
+            <td>Complete proxy URL. When set, this overrides the individual `otlpProxy.host`, `port`, `scheme`, `user`, and `password` settings. Format: `http://[user:pass@]host:port`.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.existingSecret`</td>
+            <td>Name of an existing Kubernetes secret containing proxy credentials. The secret must contain the keys `proxy-user` and `proxy-password`.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
             <td>`entityLabels`</td>
             <td>Custom labels to be added to all entities reported by the eBPF agent. These labels are sent as the `NEW_RELIC_LABELS` environment variable in the format `"key1:value1;key2:value2"`.</td>
             <td>`Map`</td>
@@ -259,6 +295,12 @@ These parameters control the core identity and data destination for the eBPF age
         </tr>
     </tbody>
 </table>
+
+<Callout variant="important">
+
+HTTPS proxy is not supported for gRPC traffic. However, TLS traffic remains secure because the TLS tunnel is established directly between the client and the endpoint.
+
+</Callout>
 
 </Collapser>
 

--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -255,7 +255,7 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`otlpProxy.port`</td>
             <td>Proxy port for the OTLP proxy.</td>
             <td>`Integer`</td>
-            <td>`8080`</td>
+            <td>`""`</td>
         </tr>
         <tr>
             <td>`otlpProxy.scheme`</td>

--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -234,6 +234,12 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`""`</td>
         </tr>
         <tr>
+            <td>`customOtlpEndpointTlsEnabled`</td>
+            <td>Whether TLS is enabled on the OTLP endpoint. Only overridden when both `customOtlpEndpoint` and this field are explicitly set.</td>
+            <td>`Boolean`</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
             <td>`customOtlpEndpointTlsCertSecret`</td>
             <td>Name of the Kubernetes secret containing the CA certificate for the custom OTLP endpoint. Only used when `customOtlpEndpoint` is set. Must be provided together with `customOtlpEndpointTlsCertSecretKey`.</td>
             <td>`String`</td>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -166,14 +166,44 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`""`</td>
         </tr>
         <tr>
-            <td>`customOtlpEndpointTlsEnabled`</td>
-            <td>Whether TLS is enabled on the custom OTLP endpoint. Only applicable when `customOtlpEndpoint` is set.</td>
-            <td>Boolean</td>
-            <td>`true`</td>
-        </tr>
-        <tr>
             <td>`customOtlpEndpointTlsCertPath`</td>
             <td>Path to custom CA certificates for OTLP endpoint TLS validation. If empty, system default CA certificates are used.</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.host`</td>
+            <td>HTTP/HTTPS proxy hostname for routing OTLP telemetry data through a corporate proxy. If empty, no proxy is used.</td>
+            <td>String</td>
+            <td>`"proxy.example.com"`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.port`</td>
+            <td>Proxy port for the OTLP proxy.</td>
+            <td>Integer</td>
+            <td>`8080`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.scheme`</td>
+            <td>Proxy URL scheme. Accepted values: `http`, `https`.</td>
+            <td>String</td>
+            <td>`"http"`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.user`</td>
+            <td>Username for proxy Basic Authentication. If empty, no authentication is used.</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.password`</td>
+            <td>Password for proxy Basic Authentication. Only used together with `otlpProxy.user`.</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`otlpProxy.url`</td>
+            <td>Complete proxy URL. When set, this overrides the individual `otlpProxy.host`, `port`, `scheme`, `user`, and `password` settings. Format: `http://[user:pass@]host:port`.</td>
             <td>String</td>
             <td>`""`</td>
         </tr>
@@ -227,6 +257,12 @@ These parameters control the core identity and data destination for the eBPF age
         </tr>
     </tbody>
 </table>
+
+<Callout variant="important">
+
+HTTPS proxy is not supported for gRPC traffic. However, TLS traffic remains secure because the TLS tunnel is established directly between the client and the endpoint.
+
+</Callout>
 
 </Collapser>
 

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -181,7 +181,7 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`otlpProxy.port`</td>
             <td>Proxy port for the OTLP proxy.</td>
             <td>Integer</td>
-            <td>`8080`</td>
+            <td>`""`</td>
         </tr>
         <tr>
             <td>`otlpProxy.scheme`</td>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -166,6 +166,12 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`""`</td>
         </tr>
         <tr>
+            <td>`customOtlpEndpointTlsEnabled`</td>
+            <td>Whether TLS is enabled on the custom OTLP endpoint. Only applicable when `customOtlpEndpoint` is set.</td>
+            <td>Boolean</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
             <td>`customOtlpEndpointTlsCertPath`</td>
             <td>Path to custom CA certificates for OTLP endpoint TLS validation. If empty, system default CA certificates are used.</td>
             <td>String</td>

--- a/src/content/docs/ebpf/requirements.mdx
+++ b/src/content/docs/ebpf/requirements.mdx
@@ -67,7 +67,7 @@ The following container runtimes are supported:
 The following Linux distributions are supported:
   * CentOS `9` and above
   * Debian `11` and above
-  * Red Hat Enterprise Linux `8.1` and above
+  * Red Hat Enterprise Linux `9.0` and above
   * Ubuntu `20.04` and above
   * Amazon Linux `2` and `2023`
   * Bottle Rocket `1.51.0` and above

--- a/src/content/docs/ebpf/troubleshooting/no-ui-data.mdx
+++ b/src/content/docs/ebpf/troubleshooting/no-ui-data.mdx
@@ -91,6 +91,8 @@ Port blocking can occur at both levels simultaneously, causing connectivity issu
 
 3. **Check data filtering settings**: Verify that your entity isn't being excluded by configuration parameters like `allDataFilters.dropServiceNameRegex` or `allDataFilters.dropNamespaces`.
 
+4. **Restart applications with persistent gRPC/HTTP/2 connections**: Applications with persistent gRPC/HTTP/2 connections must be restarted after the eBPF agent starts so that the agent can correctly generate entities and monitor traffic. If your gRPC or HTTP/2 application was running before the agent came up, restart the application so the agent can hook the newly established connections.
+
 ### Additional verification steps:
 
 1. **Filter entities by host**: Use the `host.name` tag in the New Relic UI to filter entities running on a specific host.


### PR DESCRIPTION
- Add otlpProxy configuration rows (host, port, scheme, user, password, url, existingSecret) to k8s-installation.mdx and linux-installation.mdx; Linux omits existingSecret as it's K8s-only.
- Remove customOtlpEndpointTlsEnabled from both installation docs.
- Add gRPC HTTPS proxy caveat callout next to the proxy config.
- Document persistent gRPC/HTTP/2 connection restart requirement in the no-UI-data troubleshooting guide.