### PR TITLE
docs(gcp): Update AlloyDB integration for GCP v2 metrics

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
@@ -50,7 +50,7 @@ Data is attached to the following [event types](/docs/data-apis/understand-data/
       </td>
 
       <td>
-        `GcpAlloydbClusterSample`
+        `Metric`
       </td>
 
       <td>
@@ -119,7 +119,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
       <tbody>
         <tr>
           <td>
-            cluster.storage.Usage
+            `gcp.alloydb.cluster.storage.usage`
           </td>
 
           <td>
@@ -127,7 +127,21 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
           </td>
 
           <td>
-            The total AlloyDB storage in bytes across the entire cluster.
+            Total AlloyDB storage in bytes across the cluster.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.cluster.backup.last_backup_time`
+          </td>
+
+          <td>
+            Timestamp
+          </td>
+
+          <td>
+            Creation timestamp of the latest backup. Label: `metric.backup_type`.
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
## Summary

- Updates AlloyDB Cluster "Find and use data" table: event type `GcpAlloydbClusterSample` → `Metric`
- Updates `alloydb-cluster` collapser to list GCP v2 NR metric names with correct naming conventions

## Metric names (GCP v2)

| GCP Metric | NR Metric Name | Unit |
|-----------|---------------|------|
| `cluster/storage/usage` | `gcp.alloydb.cluster.storage.usage` | bytes |
| `cluster/backup/last_backup_time` | `gcp.alloydb.cluster.backup.last_backup_time` | seconds (epoch) |

`metric.backup_type` label available as a facet on `last_backup_time`.

## Test plan

- [ ] Verify AlloyDB Cluster section renders correctly in docs
- [ ] Confirm metric names match what's flowing in NR (validated: `gcp.alloydb.cluster.storage.usage` confirmed in account 10876283)

🤖 Generated with [Claude Code](https://claude.com/claude-code)