### PR TITLE
node.js: add warning about other monitoring products

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -285,6 +285,10 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
   </Collapser>
 </CollapserGroup>
 
+## Other third-party monitoring software [#other-monitoring-software]
+
+If your application uses any additional monitoring software, we cannot guarantee that our agent will work correctly and cannot offer technical support. For more information, see [Errors when using other monitoring software](/docs/apm/new-relic-apm/troubleshooting/errors-while-using-new-relic-apm-alongside-other-apm-software).
+
 {/* The content between begin: compat-table and end: compat-table is automatically updated by the Node.js agent team bot. Don't change the contents and don't change the formatting of the data between the comments.*/}
 {/* begin: compat-table */}
 ## Instrumented modules


### PR DESCRIPTION
Add a notice that matches the one used by the PHP team at https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/#other-monitoring-software