### PR TITLE
docs: Add GCP AI Platform Index integration documentation

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-aiplatform-index-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-aiplatform-index-integration.mdx
@@ -1,0 +1,37 @@
+---
+title: Google AI Platform Index monitoring integration
+tags:
+  - Integrations
+  - Google Cloud integrations
+  - GCP integrations list
+metaDescription: 'New Relic''s Google AI Platform Index integration: how to install it, configure it, and understand the data it reports.'
+freshnessValidatedDate: never
+---
+
+Use New Relic's [Google Cloud Platform (GCP) integrations](/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations) to report data from [GCP AI Platform Index](https://cloud.google.com/vertex-ai/docs/matching-engine/overview) to New Relic. This document explains how to activate this integration and describes the data that can be reported.
+
+## Activate integration [#activate]
+
+To enable this integration, follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+
+## Configuration and polling [#polling]
+
+You can change the polling frequency and filter data using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+
+## Find and use data [#find-data]
+
+To find your integration data in New Relic, go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP** and select an integration.
+
+For more information on how to find and use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
+
+## Metric data [#metrics]
+
+This integration reports the following metric data.
+
+### Available metrics [#available-metrics]
+
+| Metric Name | Description |
+|-------------|-------------|
+| `gcp.aiplatform.matching_engine.stream_update.request_count` | Number of stream update requests received by the index. |
+| `gcp.aiplatform.matching_engine.stream_update.latencies` | Latency (in milliseconds) between the user receiving a stream update response and the update taking effect on the index. |
+| `gcp.aiplatform.matching_engine.stream_update.datapoint_count` | Number of datapoints successfully upserted or removed from the index via stream update. |


### PR DESCRIPTION
## Give us some context

Adding documentation for the GCP AI Platform Index (Matching Engine) integration.

This PR adds:
- Integration overview and requirements
- Configuration and polling instructions
- Available metrics table (stream update request count, latency, datapoint count)

Metrics source: https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform