### PR TITLE
docs: Add GCP AI Platform Endpoint integration documentation

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-aiplatform-endpoint-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-aiplatform-endpoint-integration.mdx
@@ -1,0 +1,47 @@
+---
+title: Google AI Platform Endpoint monitoring integration
+tags:
+  - Integrations
+  - Google Cloud Platform integrations
+  - GCP integrations list
+metaDescription: 'New Relic Google AI Platform Endpoint integration: the data it reports and how to enable it.'
+freshnessValidatedDate: never
+---
+
+[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) include an integration for reporting your GCP AI Platform Endpoint data to our products. Here we explain how to activate the integration and what data it collects.
+
+## Activate integration [#activate]
+
+To enable the integration, follow the standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+
+## Configuration and polling [#polling]
+
+You can change the polling frequency and filter data using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+
+Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations) information for the GCP AI Platform Endpoint integration:
+
+* New Relic polling interval: 5 minutes
+
+## Find and use data [#find-data]
+
+To find your integration data, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP**</DNT> and select an integration.
+
+Data is reported as `Metric` event type with `provider` set to `GcpAiPlatformEndpoint`.
+
+## Metric data [#metrics]
+
+This integration reports the following [metric data](/docs/telemetry-data-platform/understand-data/new-relic-data-types/#metrics).
+
+### Available metrics [#available-metrics]
+
+| Metric Name | Description | Unit |
+|-------------|-------------|------|
+| `gcp.aiplatform.prediction.online.prediction_count` | Number of online predictions served. | count |
+| `gcp.aiplatform.prediction.online.error_count` | Number of online prediction errors. | count |
+| `gcp.aiplatform.prediction.online.prediction_latencies` | Online prediction latency of the deployed model. | ms |
+| `gcp.aiplatform.prediction.online.cpu.utilization` | CPU utilization of the deployed model replica. | % |
+| `gcp.aiplatform.prediction.online.memory.bytes_used` | Memory usage of the deployed model replica. | bytes |
+| `gcp.aiplatform.prediction.online.network.sent_bytes_count` | Network bytes sent by the deployed model replica. | bytes |
+| `gcp.aiplatform.prediction.online.network.received_bytes_count` | Network bytes received by the deployed model replica. | bytes |
+| `gcp.aiplatform.prediction.online.replicas` | Number of active replicas of the deployed model. | count |
+| `gcp.aiplatform.prediction.online.target_replicas` | Target number of active replicas for the deployed model. | count |


### PR DESCRIPTION
## Give us some context

Adding dedicated documentation page for the GCP AI Platform (Vertex AI) Endpoint integration.

This PR adds:
- New integration page at `google-cloud-platform-integrations/gcp-integrations-list/google-aiplatform-endpoint-integration.mdx`
- Uses `Metric` event type (GCP v2 — no `GcpVertexAiEndpointSample` references)
- Documents all 9 metrics from `aiplatform.googleapis.com/Endpoint` resource
- Covers activation, polling configuration, and data discovery

Metrics sourced from official GCP Cloud Monitoring docs.