### PR TITLE
docs: add GCP AlloyDB Database dimensional metrics to AlloyDB integration page

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
@@ -618,3 +618,151 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
     </table>
   </Collapser>
 </CollapserGroup>
+
+### Database (`GcpAlloydbDatabaseSample`) [#database-sample]
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "275px" }}>
+        Metric
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `database/conn_pool/client_connections`
+      </td>
+
+      <td>
+        Number of client connections per database grouped by status.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/conn_pool/client_connection_wait_time`
+      </td>
+
+      <td>
+        Time a client connection request waits for a server connection to become available from the pool.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/conn_pool/server_connections`
+      </td>
+
+      <td>
+        Number of server connections per database grouped by state.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/committed_transactions_for_top_databases`
+      </td>
+
+      <td>
+        Number of committed transactions for top databases.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/rolledback_transactions_for_top_databases`
+      </td>
+
+      <td>
+        Number of rolled-back transactions for top databases.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/insights/aggregate/execution_time`
+      </td>
+
+      <td>
+        Accumulated query execution time since the last sample. This is the sum of CPU time, IO wait time, lock wait time, process context switch, and scheduling for all the processes involved in the query execution.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/insights/aggregate/latencies`
+      </td>
+
+      <td>
+        Query latency distribution.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/blks_hit_for_top_databases`
+      </td>
+
+      <td>
+        Number of times disk blocks were found already in the buffer cache for top databases, so that a read was not necessary.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/blks_read_for_top_databases`
+      </td>
+
+      <td>
+        Number of disk blocks read for top databases.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/deadlock_count_for_top_databases`
+      </td>
+
+      <td>
+        Number of deadlocks detected for top databases.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/inserted_tuples_count_for_top_databases`
+      </td>
+
+      <td>
+        Number of rows inserted for top databases.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/updated_tuples_count_for_top_databases`
+      </td>
+
+      <td>
+        Number of rows updated for top databases.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `database/postgresql/deleted_tuples_count_for_top_databases`
+      </td>
+
+      <td>
+        Number of rows deleted for top databases.
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary

- Adds a new **Database** metrics section to the AlloyDB integration page documenting 13 gcp-polling-v2 dimensional metrics for the `GCPALLOYDBDATABASE` entity type
- Metrics cover connection pool, transaction counts, query insights (latency, execution time), buffer cache, deadlocks, and row operation counts

## Related

- Entity definition: newrelic/entity-definitions#2843
- gcp-polling-v2 synthesis: beyond/gcp-polling-v2#51

## Test plan

- [ ] Verify the new Database section renders correctly on the docs page
- [ ] Confirm metric names match what gcp-polling-v2 reports in NR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)