### PR TITLE
chore(.net agent): Updating latest supported framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -520,7 +520,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                   Minimum supported version: 2.3.0
 
-                  Latest verified compatible version: 3.8.0
+                  Latest verified compatible version: 3.8.1
 
                   Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -575,7 +575,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.12.14
+            Latest verified compatible version: 2.13.1
                 </td>
                 </tr>
 
@@ -646,7 +646,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.17.8
+                  * Latest verified compatible version: 4.0.18.3
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -667,7 +667,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                 Use [System.Data.Odbc](https://www.nuget.org/packages/System.Data.Odbc/).
                     * Minimum supported version: 8.0.0
-                    * Latest verified compatible version: 10.0.6
+                    * Latest verified compatible version: 10.0.8
                     * Minimum agent version required: 10.35.0
                     
 
@@ -774,7 +774,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.17.5
+                    4.0.17.8
                 </td>
                 </tr>
                 <tr>
@@ -880,7 +880,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    6.1.2
+                    6.1.3
                 </td>
                 </tr>
 
@@ -895,7 +895,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0
                 </td>
                 <td>
-                    10.0.7
+                    10.0.8
                 </td>
                 </tr>
             </tbody>
@@ -1006,7 +1006,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.2.25
+                  * Latest verified compatible version: 4.0.2.30
                 </td>
                 </tr>
 
@@ -1020,7 +1020,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.8.11
+                  * Latest verified compatible version: 4.0.8.16
                 </td>
                 </tr>
 
@@ -1034,7 +1034,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.24
+                  * Latest verified compatible version: 4.0.3.29
                 </td>
                 </tr>
 
@@ -1639,7 +1639,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     <td>
                       Minimum supported version: 2.3.0
 
-                      Latest verified compatible version: 3.8.0
+                      Latest verified compatible version: 3.8.1
 
                       Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -1752,7 +1752,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.12.14
+                        * Latest verified compatible version: 2.13.1
                     </td>
                     </tr>
 
@@ -1824,7 +1824,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.17.8
+                  * Latest verified compatible version: 4.0.18.3
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1992,7 +1992,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.17.5
+                        4.0.17.8
                     </td>
                     </tr>
                     <tr>
@@ -2233,7 +2233,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.2.25
+                        * Latest verified compatible version: 4.0.2.30
                     </td>
                     </tr>
 
@@ -2247,7 +2247,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.8.11
+                    * Latest verified compatible version: 4.0.8.16
                     </td>
                     </tr>
 
@@ -2261,7 +2261,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.3.24
+                    * Latest verified compatible version: 4.0.3.29
                     </td>
                     </tr>
 


### PR DESCRIPTION
Updates .NET agent compatibility docs with latest verified versions from Dotty PR newrelic/newrelic-dotnet-agent#3589.

Packages updated:
- MongoDB.Driver: 3.8.0 → 3.8.1
- StackExchange.Redis: 2.12.14 → 2.13.1
- AWSSDK.DynamoDBv2: 4.0.17.8 → 4.0.18.3
- System.Data.Odbc: 10.0.6 → 10.0.8 (.NET Core)
- AWSSDK.BedrockRuntime: 4.0.17.5 → 4.0.17.8
- NLog: 6.1.2 → 6.1.3
- Microsoft.Extensions.Logging: 10.0.7 → 10.0.8
- AWSSDK.SQS: 4.0.2.25 → 4.0.2.30
- AWSSDK.Kinesis: 4.0.8.11 → 4.0.8.16
- AWSSDK.KinesisFirehose: 4.0.3.24 → 4.0.3.29