### PR TITLE
docs: update AlloyDB Instance metrics to gcp-polling-v2 attribute names

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
@@ -435,7 +435,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
       <tbody>
         <tr>
           <td>
-            instance.cpu.AverageUtilization
+            `gcp.alloydb.instance.cpu.average_utilization`
           </td>
 
           <td>
@@ -449,7 +449,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.cpu.MaximumUtilization
+            `gcp.alloydb.instance.cpu.maximum_utilization`
           </td>
 
           <td>
@@ -463,7 +463,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.cpu.Vcpus
+            `gcp.alloydb.instance.cpu.vcpus`
           </td>
 
           <td>
@@ -477,7 +477,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.memory.MinAvailableMemory
+            `gcp.alloydb.instance.memory.min_available_memory`
           </td>
 
           <td>
@@ -491,7 +491,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.Abort
+            `gcp.alloydb.instance.postgres.abort_count`
           </td>
 
           <td>
@@ -505,7 +505,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.AverageConnections
+            `gcp.alloydb.instance.postgres.average_connections`
           </td>
 
           <td>
@@ -519,7 +519,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.Commit
+            `gcp.alloydb.instance.postgres.commit_count`
           </td>
 
           <td>
@@ -533,7 +533,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.ConnectionsLimit
+            `gcp.alloydb.instance.postgres.connections_limit`
           </td>
 
           <td>
@@ -547,7 +547,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.Instances
+            `gcp.alloydb.instance.postgres.instances`
           </td>
 
           <td>
@@ -561,7 +561,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.replication.MaximumLag
+            `gcp.alloydb.instance.postgres.replication.maximum_lag`
           </td>
 
           <td>
@@ -575,7 +575,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.replication.Replicas
+            `gcp.alloydb.instance.postgres.replication.replicas`
           </td>
 
           <td>
@@ -589,7 +589,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.TotalConnections
+            `gcp.alloydb.instance.postgres.total_connections`
           </td>
 
           <td>
@@ -603,7 +603,7 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
 
         <tr>
           <td>
-            instance.postgres.Transaction
+            `gcp.alloydb.instance.postgres.transaction_count`
           </td>
 
           <td>


### PR DESCRIPTION
## Summary

- Updates AlloyDB Instance metrics table to use GCP v2 dimensional Metric attribute names (`gcp.alloydb.instance.*`)
- Replaces legacy `GcpAlloydbInstanceSample` metric names (e.g., `instance.cpu.AverageUtilization`) with correct NR attribute names (e.g., `` `gcp.alloydb.instance.cpu.average_utilization` ``)

## Metrics updated (13 total)

| Before | After |
|--------|-------|
| `instance.cpu.AverageUtilization` | `` `gcp.alloydb.instance.cpu.average_utilization` `` |
| `instance.cpu.MaximumUtilization` | `` `gcp.alloydb.instance.cpu.maximum_utilization` `` |
| `instance.postgres.TotalConnections` | `` `gcp.alloydb.instance.postgres.total_connections` `` |
| `instance.memory.MinAvailableMemory` | `` `gcp.alloydb.instance.memory.min_available_memory` `` |
| ... | ... |

## Test plan
- [ ] Verify metric names match attributes returned by gcp-polling-v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)