### PR TITLE
docs: add AlloyDB Instance Node metrics to AlloyDB integration page

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration.mdx
@@ -617,4 +617,211 @@ This integration collects GCP AlloyDB data for cluster, database, and instance.
       </tbody>
     </table>
   </Collapser>
+
+  <Collapser
+    id="alloydb-instancenode"
+    title="AlloyDB Instance Node data"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Metric
+          </th>
+
+          <th>
+            Unit
+          </th>
+
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `gcp.alloydb.node.cpu.usage_time`
+          </td>
+
+          <td>
+            Percent
+          </td>
+
+          <td>
+            CPU usage for the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.memory.available_memory`
+          </td>
+
+          <td>
+            Bytes
+          </td>
+
+          <td>
+            Available memory on the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.network.received_bytes_count`
+          </td>
+
+          <td>
+            Bytes
+          </td>
+
+          <td>
+            Network bytes received by the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.network.sent_bytes_count`
+          </td>
+
+          <td>
+            Bytes
+          </td>
+
+          <td>
+            Network bytes sent by the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.backends`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Total connections per node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.backends_by_state`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Number of connections to the node per connection state.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.deadlock_count`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Number of deadlocks on the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.replay_lag`
+          </td>
+
+          <td>
+            Milliseconds
+          </td>
+
+          <td>
+            Replication lag for the node derived from replay_lag value.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.transaction_count`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Number of transactions on the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.ultrafastcache_hitrate`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Ultra Fast Cache hit rate per node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.uptime`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Node database availability.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.wait_count`
+          </td>
+
+          <td>
+            Count
+          </td>
+
+          <td>
+            Total number of times processes waited for each wait event on the node.
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `gcp.alloydb.node.postgres.wait_time`
+          </td>
+
+          <td>
+            Microseconds
+          </td>
+
+          <td>
+            Total wait time for each wait event on the node.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
 </CollapserGroup>


### PR DESCRIPTION
## Summary

- Adds a new `AlloyDB Instance Node data` collapsible section to the AlloyDB monitoring integration docs
- Documents 13 `gcp.alloydb.node.*` dimensional Metric attributes for the `GCPALLOYDBINSTANCENODE` entity type

## Metrics documented

CPU usage, available memory, network I/O, total connections, connections by state, deadlocks, replication lag, transaction count, Ultra Fast Cache hit rate, node uptime, and wait events.

## Test plan
- [ ] Verify metric names match attributes from gcp-polling-v2 `alloydb.googleapis.com/InstanceNode` resource type

🤖 Generated with [Claude Code](https://claude.com/claude-code)