### PR TITLE
docs: rename local auth to service principal auth for Azure log forwarding

### DIFF
--- a/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/azure-log-forwarding.mdx
@@ -46,7 +46,7 @@ Follow these steps:
 8. In the <DNT>**New Relic license key**</DNT> field, paste the previously copied API key.
 9. Ensure the [New Relic endpoint](/docs/logs/log-api/introduction-log-api/#endpoint) is set to the one corresponding to your account.
 10. Select Scaling mode. Default is `Basic`.
-11. Optional: Select <DNT>**Authentication Mode**</DNT>. Default is `Local Authentication`. Choose `Managed Identity` if your Azure environment has disabled Local Authentication (shared access keys) for security compliance. When set to `Managed Identity`, the Function App is assigned a system-assigned managed identity and granted the `Azure Event Hubs Data Receiver` role on the Event Hub namespace — no connection string is stored. See [the authentication mode information](#eventhub-authentication) for more details.
+11. Optional: Select <DNT>**Authentication Mode**</DNT>. Default is `Service Principal Authentication`. Choose `Managed Identity` if your Azure environment has disabled service principal authentication (shared access keys) for security compliance. When set to `Managed Identity`, the Function App is assigned a system-assigned managed identity and granted the `Azure Event Hubs Data Receiver` role on the Event Hub namespace — no connection string is stored. See [the authentication mode information](#eventhub-authentication) for more details.
 12. Optional: Configure EventHub batching parameters (available in v2.8.0+) to optimize performance:
     * **Max Event Batch Size**: Maximum events per batch (default: 500, minimum: 1)
     * **Min Event Batch Size**: Minimum events per batch (default: 20, minimum: 1)
@@ -99,10 +99,10 @@ The template supports configuring the Azure Functions scaling mode, allowing you
 
 Starting with version 3.2.0, the ARM template supports two authentication methods for connecting the Function App to the Event Hub:
 
-* <DNT>**Local Authentication**</DNT> (default): The Function App connects using a shared access key connection string stored in the application settings. This is the traditional approach and matches previous versions of the template.
+* <DNT>**Service Principal Authentication**</DNT> (default): The Function App connects using a shared access key connection string stored in the application settings. This is the traditional approach and matches previous versions of the template.
 
 * <DNT>**Managed Identity**</DNT>: The Function App uses a system-assigned managed identity with the `Azure Event Hubs Data Receiver` built-in role on the Event Hub namespace. No secrets or connection strings are stored. Use this option when:
-  * Your organization has disabled local authentication (shared access keys) on Event Hub namespaces for security compliance.
+  * Your organization has disabled shared access keys on Event Hub namespaces for security compliance.
   * You prefer keyless authentication managed entirely by Azure AD.
 
 When `Managed Identity` is selected, the template automatically:


### PR DESCRIPTION

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

This is a follow-up docs fix for the managed identity work from the [PR](https://github.com/newrelic/docs-website/pull/24008).
During review, we identified that the term Local Authentication was not the right label for the shared access key flow. The correct term is Service Principal Authentication.

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.