### PR TITLE
docs: clarify SAI capabilities are free with no consumption cost

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-pricing-billing/new-relic-one-pricing-billing.mdx
@@ -163,7 +163,7 @@ The following table compares capabilities supported by two alternative pricing m
     <tr>
       <th style={{textAlign:"left"}}>Existing product capability</th>
       <th style={{textAlign:"center"}}>Data + User</th>
-      <th style={{textAlign:"center"}}>Data + Core Compute *</th>
+      <th style={{textAlign:"center"}}>Data + Core Compute <sup>*</sup></th>
       <th style={{textAlign:"center"}}>&#43; Advanced Compute</th>
     </tr>
   </thead>
@@ -343,31 +343,31 @@ The following table compares capabilities supported by two alternative pricing m
       <td style={{textAlign:"center"}}>✅</td>
     </tr>
     <tr>
-      <td style={{textAlign:"left"}}>E&R via NRQL</td>
+      <td style={{textAlign:"left"}}>E&R via NRQL <sup>**</sup></td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>❌</td>
     </tr>
     <tr>
-      <td style={{textAlign:"left"}}>Scorecards</td>
+      <td style={{textAlign:"left"}}>Scorecards <sup>**</sup></td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>❌</td>
     </tr>
     <tr>
-      <td style={{textAlign:"left"}}>Teams</td>
+      <td style={{textAlign:"left"}}>Teams <sup>**</sup></td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>❌</td>
     </tr>
     <tr>
-      <td style={{textAlign:"left"}}>Catalogs</td>
+      <td style={{textAlign:"left"}}>Catalogs <sup>**</sup></td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>❌</td>
     </tr>
     <tr>
-      <td style={{textAlign:"left"}}>Maps</td>
+      <td style={{textAlign:"left"}}>Maps <sup>**</sup></td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>✅</td>
       <td style={{textAlign:"center"}}>❌</td>
@@ -386,7 +386,9 @@ The following table compares capabilities supported by two alternative pricing m
     </tr>
   </tbody>
 </table>
-*****Core Compute is currently in Public Preview and serves as an alternative to our User and data-based billing options for some capabilities.
+<sup>*</sup>Core Compute is currently in Public Preview and serves as an alternative to our User and data-based billing options for some capabilities.
+
+<sup>**</sup>[Service Architecture Intelligence (SAI)](/docs/service-architecture-intelligence/getting-started/) capabilities (E&R via NRQL, Scorecards, Teams, Catalogs, and Maps) are included at no additional cost for all [Full platform users](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities). Usage of these capabilities does not consume Core CCUs or count toward your monthly data ingestion limits.
 
 ### Billing for add-on features [#add-on-billing]
 

--- a/src/content/docs/service-architecture-intelligence/getting-started.mdx
+++ b/src/content/docs/service-architecture-intelligence/getting-started.mdx
@@ -8,6 +8,10 @@ freshnessValidatedDate: never
 
 Service Architecture Intelligence is New Relic's Internal Developer Portal (IDP) which provides a centralized view of your organization's services and operations. Available for all [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities), it enhances productivity by offering tools for effective resource management, operational optimization, and compliance assurance. Service Architecture Intelligence integrates various capabilities—including team management, system observability, performance evaluation, and infrastructure visualization—to streamline processes and improve collaboration across teams.
 
+<Callout variant="tip">
+Service Architecture Intelligence (SAI) capabilities are included at no additional cost for all [Full platform users](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities). Usage of these capabilities does not consume Core CCUs or count toward your monthly data ingestion limits.
+</Callout>
+
 ## Capabilities [#capabilities]
 
 The Service Architecture Intelligence offers the following capabilities:


### PR DESCRIPTION
## Summary

- Add ** footnote markers to SAI capabilities in the pricing table (E&R via NRQL, Scorecards, Teams, Catalogs, Maps)
- Add footnote explaining SAI is included at no additional cost for Full platform users with no Core CCU or data ingestion consumption
- Update SAI getting-started page with a callout about no consumption cost
- Add hyperlinks to SAI getting-started page and Full platform users documentation

## Context

This PR addresses feedback to make it clearer in the documentation that SAI capabilities are free with no consumption cost. While the docs currently state "SAI is available for all Full platform users," it wasn't explicit that there is zero consumption cost for these capabilities.

The changes add a footnote to the pricing page:
> **Service Architecture Intelligence (SAI) capabilities (E&R via NRQL, Scorecards, Teams, Catalogs, and Maps) are included at no additional cost for all Full platform users. Usage of these capabilities does not consume Core CCUs or count toward your monthly data ingestion limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)