### PR TITLE
Update set-max-event-pool-size.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
@@ -163,7 +163,7 @@ NewRelic.setMaxEventPoolSize(unsigned int $size)
       This method lets you override the maximum size of that event pool. You must set this value after `Agent.start()` is called.
 
       <Callout type="important">
-        While this method lets you override the default pool size, **1,000 is the absolute hard ceiling** supported by the SDK. Setting a value higher than 1,000 will not increase the pool capacity.
+        While you can set the event pool size greater than `1000`, the agent imposes a strict internal limit on network data. A maximum of **1,000 network transactions** will be recorded and transmitted per harvest cycle, regardless of how large you configure the event pool.
       </Callout>
 
       The default value for the event harvest cycle is 60 seconds. See also [Set max event buffer time](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time/) to change the length of the event harvest cycle.
@@ -200,7 +200,7 @@ NewRelic.setMaxEventPoolSize(unsigned int $size)
             </td>
 
             <td>
-              Required. The maximum number of events that can be buffered in memory before they are sent to New Relic.  Note: This value has a hard ceiling of 1,000 and cannot exceed it.
+              Required. The maximum number of events that can be buffered in memory before they are sent to New Relic.
             </td>
           </tr>
         </tbody>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
@@ -162,7 +162,11 @@ NewRelic.setMaxEventPoolSize(unsigned int $size)
       This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic iOS agent will begin [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
       This method lets you override the maximum size of that event pool. You must set this value after `Agent.start()` is called.
 
-      The default value for the event harvest cycle is 600 seconds. See also [Set max event buffer time](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time/) to change the length of the event harvest cycle.
+      <Callout type="important">
+        While this method lets you override the default pool size, **1,000 is the absolute hard ceiling** supported by the SDK. Setting a value higher than 1,000 will not increase the pool capacity.
+      </Callout>
+
+      The default value for the event harvest cycle is 60 seconds. See also [Set max event buffer time](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time/) to change the length of the event harvest cycle.
 
       To ensure that the new value is always applied, place this API call in the `applicationDidBecomeActive` iOS lifecycle method.
 
@@ -196,7 +200,7 @@ NewRelic.setMaxEventPoolSize(unsigned int $size)
             </td>
 
             <td>
-              Required. The maximum number of events that can be buffered in memory before they are sent to New Relic.
+              Required. The maximum number of events that can be buffered in memory before they are sent to New Relic.  Note: This value has a hard ceiling of 1,000 and cannot exceed it.
             </td>
           </tr>
         </tbody>

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
@@ -162,7 +162,7 @@ NewRelic.setMaxEventPoolSize(unsigned int $size)
       This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic iOS agent will begin [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle.
       This method lets you override the maximum size of that event pool. You must set this value after `Agent.start()` is called.
 
-      <Callout type="important">
+      <Callout variant="important">
         While you can set the event pool size greater than `1000`, the agent imposes a strict internal limit on network data. A maximum of **1,000 network transactions** will be recorded and transmitted per harvest cycle, regardless of how large you configure the event pool.
       </Callout>
 


### PR DESCRIPTION
Reduced harvest timer to 60 sec for iOS and added warning max of 1000 for event pool size.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
  Updated documentation to reflect actual features.
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.