### PR TITLE
docs: clarify parent-account cancellation cascades to sub-accounts

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -61,11 +61,17 @@ There are two options for downgrading your [edition](https://newrelic.com/pricin
 
 If you have more than one account in your organization, and are not looking to close all of them at this time, you can cancel one or more accounts while keeping your organization.
 
+<Callout variant="important">
+  If the account you're cancelling is a parent account, cancelling it also cancels every sub-account beneath it. This action can't be reversed from the UI. If you only want to remove a single account, cancel that account directly instead of its parent. To close every account in your organization, see [Delete your organization](#delete-org).
+</Callout>
+
 When you cancel an account:
 
 * It is disabled, but it's still present in your organization in **Accounts > Cancelled accounts**.
 * Users, groups, and custom roles remain, but access grants that are assigned to that cancelled account lose all connections to the account. You should also remove any access grant associated with this account, otherwise users may see errors when they try to view it.
 * Any API keys associated with a cancelled account become inactive and can't be reassigned to another account.
+* If the account is a parent account, all of its sub-accounts are also cancelled at the same time. The effects above (disabled state, severed access grants, and inactive API keys) apply to each sub-account that is cancelled as part of the cascade. Any active trials on the parent are expired, and the parent's subscription is cancelled if the parent owns it.
+* Cancelling a sub-account does not cancel its parent account or any sibling sub-accounts. The sub-account is detached from its parent and cancelled on its own.
 
 ### Who can cancel an account [#who-cancel]
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -62,7 +62,7 @@ There are two options for downgrading your [edition](https://newrelic.com/pricin
 If you have more than one account in your organization, and are not looking to close all of them at this time, you can cancel one or more accounts while keeping your organization.
 
 <Callout variant="important">
-  If the account you're cancelling is a parent account, cancelling it also cancels every sub-account beneath it. This action can't be reversed from the UI. If you only want to remove a single account, cancel that account directly instead of its parent. To close every account in your organization, see [Delete your organization](#delete-org).
+  If the account you're cancelling is a parent account, cancelling it also cancels every sub-account beneath it. This action can't be reversed from the UI. If you only want to remove a single account, cancel that account directly instead of its parent. To close every account in your organization, see [Delete your organization](#delete-org). If you are unsure whether your account has sub-accounts beneath it or need assistance with account deletion, please [file a ticket with our global technical support team](https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/find-help-get-support).
 </Callout>
 
 When you cancel an account:

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -62,7 +62,7 @@ There are two options for downgrading your [edition](https://newrelic.com/pricin
 If you have more than one account in your organization, and are not looking to close all of them at this time, you can cancel one or more accounts while keeping your organization.
 
 <Callout variant="important">
-  If the account you're cancelling is a parent account, cancelling it also cancels every sub-account beneath it. This action can't be reversed from the UI. If you only want to remove a single account, cancel that account directly instead of its parent. To close every account in your organization, see [Delete your organization](#delete-org). If you are unsure whether your account has sub-accounts beneath it or need assistance with account deletion, please [file a ticket with our global technical support team](https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/find-help-get-support).
+  If the account you're cancelling is a parent account, cancelling it may also cancel some or all sub-accounts beneath it depending on your account configuration. This action can't be reversed from the UI. If you only want to remove a single account, cancel that account directly instead of its parent. To close every account in your organization, see [Delete your organization](#delete-org). If you have sub-accounts and aren't sure how cancelling the parent will affect them, please [file a ticket with our global technical support team](https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/find-help-get-support) before proceeding.
 </Callout>
 
 When you cancel an account:
@@ -70,7 +70,7 @@ When you cancel an account:
 * It is disabled, but it's still present in your organization in **Accounts > Cancelled accounts**.
 * Users, groups, and custom roles remain, but access grants that are assigned to that cancelled account lose all connections to the account. You should also remove any access grant associated with this account, otherwise users may see errors when they try to view it.
 * Any API keys associated with a cancelled account become inactive and can't be reassigned to another account.
-* If the account is a parent account, all of its sub-accounts are also cancelled at the same time. The effects above (disabled state, severed access grants, and inactive API keys) apply to each sub-account that is cancelled as part of the cascade. Any active trials on the parent are expired, and the parent's subscription is cancelled if the parent owns it.
+* If the account is a parent account, some or all of its sub-accounts may also be cancelled at the same time, depending on how the accounts and subscriptions are set up. Where a sub-account is cancelled as part of this, the effects above (disabled state, severed access grants, and inactive API keys) apply to it. Any active trials on the parent are expired, and the parent's subscription is cancelled if the parent owns it.
 * Cancelling a sub-account does not cancel its parent account or any sibling sub-accounts. The sub-account is detached from its parent and cancelled on its own.
 
 ### Who can cancel an account [#who-cancel]

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -62,7 +62,12 @@ There are two options for downgrading your [edition](https://newrelic.com/pricin
 If you have more than one account in your organization, and are not looking to close all of them at this time, you can cancel one or more accounts while keeping your organization.
 
 <Callout variant="important">
-  If the account you're cancelling is a parent account, cancelling it may also cancel some or all sub-accounts beneath it depending on your account configuration. This action can't be reversed from the UI. If you only want to remove a single account, cancel that account directly instead of its parent. To close every account in your organization, see [Delete your organization](#delete-org). If you have sub-accounts and aren't sure how cancelling the parent will affect them, please [file a ticket with our global technical support team](https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/find-help-get-support) before proceeding.
+  If the account you're canceling is a parent account, canceling it may also cancel some or all sub-accounts beneath it depending on your account configuration. This action cannot be reversed from the UI.
+
+  * **To remove a single sub-account:** Cancel that specific account directly instead of its parent.
+  * **To close every account in your organization:** See [Delete your organization](#delete-org).
+
+  If you have sub-accounts and are unsure how canceling the parent will affect them, please [file a ticket with our support team](https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/find-help-get-support) before proceeding.
 </Callout>
 
 When you cancel an account:

--- a/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/downgradecancel-account.mdx
@@ -75,8 +75,10 @@ When you cancel an account:
 * It is disabled, but it's still present in your organization in **Accounts > Cancelled accounts**.
 * Users, groups, and custom roles remain, but access grants that are assigned to that cancelled account lose all connections to the account. You should also remove any access grant associated with this account, otherwise users may see errors when they try to view it.
 * Any API keys associated with a cancelled account become inactive and can't be reassigned to another account.
-* If the account is a parent account, some or all of its sub-accounts may also be cancelled at the same time, depending on how the accounts and subscriptions are set up. Where a sub-account is cancelled as part of this, the effects above (disabled state, severed access grants, and inactive API keys) apply to it. Any active trials on the parent are expired, and the parent's subscription is cancelled if the parent owns it.
-* Cancelling a sub-account does not cancel its parent account or any sibling sub-accounts. The sub-account is detached from its parent and cancelled on its own.
+* **Canceling a parent account**: Depending on your account and subscription configuration, canceling a parent account may also cancel some or all of its sub-accounts.
+  * If a sub-account is canceled as a result, it also experiences the same effects (disabled state, severed access grants, and inactive API keys).
+  * Any active trials on the parent expire, and the parent's subscription is canceled if the parent owns it.
+* **Canceling a sub-account**: Canceling a sub-account does not cancel its parent account or any sibling sub-accounts. The sub-account is detached from its parent and canceled individually.
 
 ### Who can cancel an account [#who-cancel]
 


### PR DESCRIPTION
**What problems does this PR solve?**

The "Cancel an account" section did not mention that cancelling a parent account also cancels every sub-account beneath it. Customers had no way to know from the docs that one click on a parent would take down all of its children.

**What this PR changes:**
  - Adds an `important` callout warning that cancelling a parent account cancels every sub-account beneath it, is not reversible from the UI, and pointing to "Delete your organization" for whole-org closure.
  - Adds a bullet documenting the parent → sub-account cascade and that the per-account effects (disabled state, severed access grants, inactive API keys) apply to each cascaded sub-account, plus that the parent's active trials and parent-owned subscription are also cancelled.
  - Adds a bullet clarifying that cancelling a sub-account does **not** cascade upward to its parent or siblings.

* **Related issue:** IR-39222