### PR TITLE
docs(nodejs-agent): clarify which Node.js VM metrics are collected by default vs require native module

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements.mdx
@@ -9,14 +9,17 @@ redirects:
   - /docs/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements
   - /docs/agents/nodejs-agent/supported-features/node-vm-measurements
   - /docs/agents/nodejs-agent/supported-features/nodejs-vm-measurements
-freshnessValidatedDate: never
+freshnessValidatedDate: 2026-05-22
 ---
 
 New Relic's Node.js agent collects key [metric timeslice data](/docs/data-analysis/metrics/analyze-your-metrics/data-collection-metric-timeslice-event-data) from the Node.js virtual machine (V8). These metrics give you insight into Node.js VM behavior and help you improve your application's performance. The agent also collects CPU metrics, which are often analyzed together with garbage collection (GC) metrics.
 
 ## What you need [#requirements]
 
-New Relic requires an [additional native module](https://www.npmjs.com/package/@newrelic/native-metrics) to collect Node.js VM metric timeslice data related to garbage collection, memory, and CPU. As of Node.js v6.1.0 the native module is not required to collect CPU metrics, as the New Relic Node.js agent collects them with `process.cpuUsage()`.
+Some Node.js VM metrics are collected by default using built-in Node.js APIs, while others require the optional [`@newrelic/native-metrics`](https://www.npmjs.com/package/@newrelic/native-metrics) package:
+
+* **Default samplers (no native module required):** Memory (`Memory/*`), event loop queue wait time (`Events/wait`), and CPU (`CPU/*`) are always collected using `process.memoryUsage()`, `setTimeout` lag measurement, and `process.cpuUsage()` respectively.
+* **Native module samplers:** Garbage collection (`GC/*`) and precise event loop CPU usage (`Nodejs/EventLoop/CPU/Usage`) require `@newrelic/native-metrics`. If the module is not installed or fails to load, these metrics will not appear and the agent will continue running with default samplers only.
 
 The native module can be used with:
 
@@ -178,6 +181,8 @@ The data is also available in [metrics and events](/docs/query-your-data/explore
     id="time-in-garbage-collection"
     title="Time in garbage collection"
   >
+    <Callout variant="important">Requires `@newrelic/native-metrics`. This metric is not collected by default.</Callout>
+
     Available on:
 
     * Node.js agent v1.35.1 or higher
@@ -253,6 +258,8 @@ The data is also available in [metrics and events](/docs/query-your-data/explore
     id="memory"
     title="Memory"
   >
+    <Callout variant="tip">Collected by default. No native module required.</Callout>
+
     Available on:
 
     * Node.js agent v1.36.0 or higher
@@ -335,6 +342,8 @@ The data is also available in [metrics and events](/docs/query-your-data/explore
     id="cpu"
     title="CPU"
   >
+    <Callout variant="tip">Collected by default on Node.js v6.1.0 or higher. No native module required.</Callout>
+
     Available on:
 
     * Node.js >= v6.1.0, Agent v1.34.0 or higher
@@ -409,6 +418,8 @@ The data is also available in [metrics and events](/docs/query-your-data/explore
     id="event-loop"
     title="Event Loop"
   >
+    <Callout variant="important">Requires `@newrelic/native-metrics`. This metric is not collected by default.</Callout>
+    
     Available on:
 
     * Node.js agent v1.37.0 or higher


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

**What problems does this PR solve?**

The `## What you need` [section](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements/#requirements) currently states the native module is required for "garbage collection, memory, and CPU" metrics. This is partially incorrect — memory and CPU are collected by default via built-in Node.js APIs with no native module needed. Only GC and precise event loop metrics require `@newrelic/native-metrics`.

This causes real confusion: developers see flat GC and event loop panels in the Node VMs UI and cannot tell from the docs whether it is a traffic issue or a missing dependency.

**Changes made**

- Updated the opening of `## What you need` to clearly distinguish between default samplers and native module samplers
- Added inline `<Callout>` labels inside each measurement collapser so users can immediately see whether a metric requires the native module or not
- Updated `freshnessValidatedDate` from `never` to `2026-05-22`

No existing content was removed.

**Verification**

Confirmed against agent source code:  
https://github.com/newrelic/node-newrelic/blob/main/lib/system-metrics-sampler.js

- `sampleMemory`, `checkEvents`, and `sampleCpu` always register regardless of native module availability
- `sampleGc` and `sampleLoop` only register when `@newrelic/native-metrics` loads successfully under `agent.config.plugins.native_metrics.enabled`

<img width="911" height="502" alt="image" src="https://github.com/user-attachments/assets/2f797c1b-78fa-4fe6-b98c-7a1f0d46ff0d" />

<img width="978" height="898" alt="image" src="https://github.com/user-attachments/assets/94cc84b2-1e5f-4bc8-a872-250593c79519" />
