### PR TITLE
Add name field validation rules to user management docs

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -222,6 +222,36 @@ Here are some user management tasks you might want to do:
   </Collapser>
 </CollapserGroup>
 
+## Name field requirements [#name-field-requirements]
+
+When creating or updating a user, the `name`, `given_name`, and `family_name` fields must meet these requirements:
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>Rule</th>
+      <th>`name`</th>
+      <th>`given_name` / `family_name`</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Maximum length</td><td>250 characters</td><td>250 characters</td></tr>
+    <tr><td>No URLs (`http://`, `https://`, `www.`, `mailto:`)</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>No email addresses</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>No bare domain names (for example, `example.com`)</td><td>Yes</td><td>No</td></tr>
+    <tr><td>No emoji</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>No control characters (newlines, null bytes)</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>No invisible Unicode characters (zero-width spaces, bidi overrides)</td><td>Yes</td><td>Yes</td></tr>
+    <tr><td>No `=` character</td><td>Yes</td><td>No</td></tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+Names with hyphens, apostrophes, accented characters, periods, and multi-word names are valid. Zero-width non-joiner (U+200C), required for Persian and Farsi text, is allowed. All name fields are normalized to NFKC Unicode form before validation.
+</Callout>
+
+These rules apply across the UI, [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management), and [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-manage-users). Validation runs only when the field is being changed. Existing users with non-conforming data are not affected unless they update the validated field.
+
 ## Use our API [#api]
 
 To use our API to manage accounts and users, see our [NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -233,11 +233,11 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
         Rule
       </th>
 
-      <th style={{ width: "110px" }}>
+      <th style={{ width: "100px" }}>
         `name`
       </th>
 
-      <th style={{ width: "110px" }}>
+      <th style={{ width: "200px" }}>
         `given_name` / `family_name`
       </th>
     </tr>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -286,6 +286,19 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
       </td>
     </tr>
 
+    <tr>
+      <td>
+        No bare domain names
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Allowed
+      </td>
+    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -229,20 +229,20 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 <table>
   <thead>
     <tr>
-      <th style={{ width: "400px" }}>Rule</th>
+      <th>Rule</th>
       <th>`name`</th>
       <th>`given_name` / `family_name`</th>
     </tr>
   </thead>
   <tbody>
     <tr><td>Maximum length</td><td>250 characters</td><td>250 characters</td></tr>
-    <tr><td>No URLs (`http://`, `https://`, `www.`, `mailto:`)</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>No email addresses</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>No bare domain names (for example, `example.com`)</td><td>Yes</td><td>No</td></tr>
-    <tr><td>No emoji</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>No control characters (newlines, null bytes)</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>No invisible Unicode characters (zero-width spaces, bidi overrides)</td><td>Yes</td><td>Yes</td></tr>
-    <tr><td>No `=` character</td><td>Yes</td><td>No</td></tr>
+    <tr><td>No URLs</td><td>Blocked</td><td>Blocked</td></tr>
+    <tr><td>No email addresses</td><td>Blocked</td><td>Blocked</td></tr>
+    <tr><td>No bare domain names</td><td>Blocked</td><td>Allowed</td></tr>
+    <tr><td>No emoji</td><td>Blocked</td><td>Blocked</td></tr>
+    <tr><td>No control characters</td><td>Blocked</td><td>Blocked</td></tr>
+    <tr><td>No invisible Unicode</td><td>Blocked</td><td>Blocked</td></tr>
+    <tr><td>No equals sign (`=`)</td><td>Blocked</td><td>Allowed</td></tr>
   </tbody>
 </table>
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -362,7 +362,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
   Names with hyphens, apostrophes, accented characters (like ñ or ü), periods, spaces, and non-Latin scripts are all valid.
 </Callout>
 
-These rules apply across the UI, [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management), and [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-manage-users). Validation runs only when the field is being changed. Existing users with non-conforming data are not affected unless they update the validated field.
+These rules apply across the UI, [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management), and [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-manage-users). Validation runs when a user is created or when a name field is updated. Existing users with non-conforming data are not affected unless they update the validated field.
 
 ## Use our API [#api]
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -359,7 +359,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 </table>
 
 <Callout variant="tip">
-Names with hyphens, apostrophes, accented characters, periods, and multi-word names are valid. Zero-width non-joiner (U+200C), required for Persian and Farsi text, is allowed. All name fields are normalized to NFKC Unicode form before validation.
+  Names with hyphens, apostrophes, accented characters (like ñ or ü), periods, spaces, and non-Latin scripts are all valid.
 </Callout>
 
 These rules apply across the UI, [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management), and [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-manage-users). Validation runs only when the field is being changed. Existing users with non-conforming data are not affected unless they update the validated field.

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -229,20 +229,132 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 <table>
   <thead>
     <tr>
-      <th>Rule</th>
-      <th>`name`</th>
-      <th>`given_name` / `family_name`</th>
+      <th>
+        Rule
+      </th>
+
+      <th style={{ width: "110px" }}>
+        `name`
+      </th>
+
+      <th style={{ width: "110px" }}>
+        `given_name` / `family_name`
+      </th>
     </tr>
   </thead>
+
   <tbody>
-    <tr><td>Maximum length</td><td>250 characters</td><td>250 characters</td></tr>
-    <tr><td>No URLs</td><td>Blocked</td><td>Blocked</td></tr>
-    <tr><td>No email addresses</td><td>Blocked</td><td>Blocked</td></tr>
-    <tr><td>No bare domain names</td><td>Blocked</td><td>Allowed</td></tr>
-    <tr><td>No emoji</td><td>Blocked</td><td>Blocked</td></tr>
-    <tr><td>No control characters</td><td>Blocked</td><td>Blocked</td></tr>
-    <tr><td>No invisible Unicode</td><td>Blocked</td><td>Blocked</td></tr>
-    <tr><td>No equals sign (`=`)</td><td>Blocked</td><td>Allowed</td></tr>
+    <tr>
+      <td>
+        Maximum length: 250 characters
+      </td>
+
+      <td>
+        Enforced
+      </td>
+
+      <td>
+        Enforced
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No URLs
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Blocked
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No email addresses
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Blocked
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No bare domain names
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Allowed
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No emoji
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Blocked
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No control characters
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Blocked
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No invisible Unicode
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Blocked
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        No equals sign (`=`)
+      </td>
+
+      <td>
+        Blocked
+      </td>
+
+      <td>
+        Allowed
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -286,19 +286,6 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
       </td>
     </tr>
 
-    <tr>
-      <td>
-        No bare domain names
-      </td>
-
-      <td>
-        Blocked
-      </td>
-
-      <td>
-        Allowed
-      </td>
-    </tr>
 
     <tr>
       <td>

--- a/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
@@ -121,7 +121,7 @@ New Relic uses a subset of the available fields in the SCIM core schema. Other S
       </td>
 
       <td>
-        Last name of the user.
+        Last name of the user. See [name field requirements](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
       </td>
     </tr>
 
@@ -131,7 +131,7 @@ New Relic uses a subset of the available fields in the SCIM core schema. Other S
       </td>
 
       <td>
-        First name of the user.
+        First name of the user. See [name field requirements](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
       </td>
     </tr>
 

--- a/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
+++ b/src/content/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management.mdx
@@ -121,7 +121,7 @@ New Relic uses a subset of the available fields in the SCIM core schema. Other S
       </td>
 
       <td>
-        Last name of the user. See [name field requirements](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
+        Last name of the user. See [validation rules](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
       </td>
     </tr>
 
@@ -131,7 +131,7 @@ New Relic uses a subset of the available fields in the SCIM core schema. Other S
       </td>
 
       <td>
-        First name of the user. See [name field requirements](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
+        First name of the user. See [validation rules](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
       </td>
     </tr>
 

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-manage-users.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-manage-users.mdx
@@ -86,6 +86,8 @@ Here's an example query for getting the last active date and the user type for t
 
 ## Create users [#create-users]
 
+The `name` field must meet [name field validation requirements](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#name-field-requirements).
+
 Here's an example of creating a basic user:
 
 ```graphql


### PR DESCRIPTION
## Summary
- Add canonical "Name field requirements" section to the user management UI doc with a table of validation rules (max length, prohibited patterns, Unicode normalization)
- Cross-link from SCIM API page (`name.familyName`, `name.givenName` descriptions)
- Cross-link from NerdGraph create users section

This is what it looks like now: 
<img width="994" height="786" alt="image" src="https://github.com/user-attachments/assets/f6b55766-30cc-4348-8007-84dabb3bcefe" />
<img width="841" height="207" alt="image" src="https://github.com/user-attachments/assets/9f032c06-3697-456c-a65a-c95f53f20faa" />
<img width="813" height="108" alt="image" src="https://github.com/user-attachments/assets/b56f5f75-ec27-4ae3-86f2-b6feaf213018" />

In the scim table we have wrapping on `give_name` and `family_name` but those changes are unrelated and already on production so I'm leaving those as they are. 

## Context
Documents the name validation rules implemented in [NR-562190](https://new-relic.atlassian.net/browse/NR-562190). Rules enforce no URLs, emails, emoji, control characters, or invisible Unicode in user name fields.

## Test plan
- [ ] Verify Netlify preview renders the table and callout correctly
- [ ] Confirm anchor link `#name-field-requirements` resolves
- [ ] Confirm cross-links from SCIM and NerdGraph pages navigate correctly

[NR-562190]: https://new-relic.atlassian.net/browse/NR-562190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ