### PR TITLE
Update vector-output-sink-log-forwarding.mdx

### DIFF
--- a/src/content/docs/logs/forward-logs/vector-output-sink-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/vector-output-sink-log-forwarding.mdx
@@ -32,24 +32,24 @@ To forward your logs from Vector to New Relic:
    ```yaml
    # Ingest data by tailing one or more files
 
-sources:
-  my_source_id:
-    type: file
-    ignore_older_secs: 86400
-    host_key: "ip-111-11-11-11.internal"
-    include:
-      - /tmp/error*.log
+   sources:
+     my_source_id:
+       type: file
+       ignore_older_secs: 86400
+       host_key: "ip-111-11-11-11.internal"
+       include:
+         - /tmp/error*.log
 
    # Configure sink to forward events to New Relic
 
-sinks:
-  dotnet_logs:
-    type: new_relic
-    inputs:
-      - my_source_id
-    account_id: "12345"
-    api: logs
-    license_key: "YOUR_LICENSE_KEY"
+   sinks:
+     dotnet_logs:
+       type: new_relic
+       inputs:
+         - my_source_id
+       account_id: "12345"
+       api: logs
+       license_key: "YOUR_LICENSE_KEY"
 
    # OPTIONAL
    #healthcheck = true                   # default

--- a/src/content/docs/logs/forward-logs/vector-output-sink-log-forwarding.mdx
+++ b/src/content/docs/logs/forward-logs/vector-output-sink-log-forwarding.mdx
@@ -27,30 +27,32 @@ To forward your logs from Vector to New Relic:
 
 2. Follow the procedures to [configure the Vector logs sink for New Relic](https://vector.dev/docs/reference/configuration/sinks/new_relic/).
 
-3. Add a snippet to your `vector.toml` file (located in `/etc/vector` by default), replacing `YOUR_LICENSE_KEY` with your New Relic <InlinePopover type="licenseKey"/>:
+3. Add a snippet to your `vector.yaml` file (located in `/etc/vector` by default), replacing `YOUR_LICENSE_KEY` with your New Relic <InlinePopover type="licenseKey"/>:
 
-   ```toml
+   ```yaml
    # Ingest data by tailing one or more files
 
-   [sources.mylog]
-   type          = "file"
-   include       = ["/path/to/file"] # Specify file or files to be tailed
-   ignore_older  = 86400             # Ignore events older than 1 day
-   file_key      = "file"            # Add filename to log events
-   host_key      = "host"            # Add hostname to log events
+sources:
+  my_source_id:
+    type: file
+    ignore_older_secs: 86400
+    host_key: "ip-111-11-11-11.internal"
+    include:
+      - /tmp/error*.log
 
    # Configure sink to forward events to New Relic
 
-   [sinks.new_relic_logs]
-   # REQUIRED
-   type            = "new_relic_logs"   # must be: "new_relic_logs"
-   inputs          = ["mylog"]          # example - value must be one or more source IDs
-   license_key     = "YOUR_LICENSE_KEY"
-   region          = "us"               # Enum, must be one of: "us" "eu" depending on your New Relic account region
-   encoding.codec  = "json"
+sinks:
+  dotnet_logs:
+    type: new_relic
+    inputs:
+      - my_source_id
+    account_id: "12345"
+    api: logs
+    license_key: "YOUR_LICENSE_KEY"
 
    # OPTIONAL
-   healthcheck = true                   # default
+   #healthcheck = true                   # default
    ```
 
 4. Restart the Vector service to ensure your changes are applied.


### PR DESCRIPTION
In 2023 yaml became the default and not toml. I tested this weekend and have screenshots. new_relic_logs is also no longer valid and it should be type: new_relic

<!-- Thanks for contributing to our docs! -->


## Give us some context

* What problems does this PR solve?
* Vector working configuration example.
* Documentation to reference:

- https://vector.dev/highlights/2023-08-30-yaml-default-format/
- https://vector.dev/docs/reference/configuration/sinks/new_relic/

I am an internal New Relic Employee.

<img width="2270" height="842" alt="Screenshot from 2026-05-24 16-35-36" src="https://github.com/user-attachments/assets/c1ddfd4d-0d11-4316-b5e4-d2737f92c78c" />
<img width="2267" height="392" alt="Screenshot from 2026-05-24 16-36-50" src="https://github.com/user-attachments/assets/def05922-1348-4446-bafa-46216aba5066" />
