### PR TITLE
chore: Remove reference to `newrelic.instrumentLoadedModule`

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -96,7 +96,7 @@ To install the Node.js agent:
    More info about the [Node.js command line option `-r` here](https://nodejs.org/api/cli.html#-r---require-module).
 
    <Callout variant="important">
-     If you are unable to use the `-r` require flag, you can also use `require('newrelic')` as the first line of your app's main module. <DNT>**Note**</DNT>   If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler `require('newrelic')` will cause instrumentation issues.
+     If you are unable to use the `-r` require flag, you can also use `require('newrelic')` as the first line of your app's main module. However, if you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler, `require('newrelic')` will cause instrumentation issues.
 
      ```js
      // load the agent

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -96,22 +96,14 @@ To install the Node.js agent:
    More info about the [Node.js command line option `-r` here](https://nodejs.org/api/cli.html#-r---require-module).
 
    <Callout variant="important">
-     If you are unable to use the `-r` require flag you can also use `require('newrelic')` as the first line of your app's main module. <DNT>**Note**</DNT>   If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler `require('newrelic')` will cause instrumentation issues.
-
-     If neither of these options work for you, (for example, asynchronously loading API keys from a remote location during application bootstrapping), you may also add stock instrumentation to an already loaded [supported module](https://github.com/newrelic/node-newrelic/blob/0113eb5f0e707dc662a17d262a841503bab88841/lib/instrumentations.js#L6#L6) by using [`newrelic.instrumentLoadedModule`](https://newrelic.github.io/node-newrelic/API.html#instrumentLoadedModule):
+     If you are unable to use the `-r` require flag, you can also use `require('newrelic')` as the first line of your app's main module. <DNT>**Note**</DNT>   If you are using [Babel](https://babeljs.io/docs/en/index.html) or a similar transpiler `require('newrelic')` will cause instrumentation issues.
 
      ```js
-     // module loaded before newrelic
-     const expressModule = require('express');
-
      // load the agent
      const newrelic = require('newrelic');
 
-     // instrument express after the agent has been loaded
-     newrelic.instrumentLoadedModule(
-       'express',    // the module's name, as a string
-       expressModule // the module instance
-     );
+     // load other packages
+     const expressModule = require('express');
      ```
    </Callout>
 


### PR DESCRIPTION
We plan to remove the `instrumentLoadedModule` API in the next major version of the Node agent. This is because we have moved most of our instrumentation support to a subscriber-based model which strongly recommends using `node -r newrelic` only for loading the agent.

## Related Issues
https://github.com/newrelic/node-newrelic/issues/4031