### PR TITLE
docs: clarify in-platform case communication for email removal

### DIFF
--- a/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
+++ b/src/content/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings.mdx
@@ -785,7 +785,9 @@ If you need assistance with New Relic Products, you are in good hands with sever
     id="ticket"
     title="Support case"
   >
-    If you are eligible for a support case as shown [here](/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/#nr1plan) and would like to file a support case as provided [here](/docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal/#file-ticket), please note the following:
+    If you are eligible for a support case as shown [here](/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/#nr1plan) and would like to file a support case as provided [here](/docs/new-relic-solutions/solve-common-issues/find-help-get-support/#file-ticket), please note the following:
+
+    All case communication — including replies, updates, and file attachments — must happen through the in-product support experience. Select the <DNT>**?**</DNT> icon from the top right navigation menu in [New Relic](https://one.newrelic.com) and choose <DNT>**Your support cases**</DNT> to view and respond to your cases. You'll receive email notifications when your case is updated, but email replies are not monitored.
 
     If you request or consent to a screen-sharing session with New Relic Support for the purpose of providing you technical support within your New Relic account, New Relic will conduct the technical support at your direction. You will retain control of when and what to share and can end the call and turn off screen sharing at any time during the call by closing the program. If you are a HIPAA-enabled customer, you will be required to set up your own screen-share.
 

--- a/src/content/docs/new-relic-solutions/solve-common-issues/find-help-get-support.mdx
+++ b/src/content/docs/new-relic-solutions/solve-common-issues/find-help-get-support.mdx
@@ -26,7 +26,7 @@ freshnessValidatedDate: 2025-07-10
 
 New Relic offers a variety of support options, including online help, a troubleshooting tool, open source documentation with detailed procedures and troubleshooting tips, and support assistance in (and out) of the Platform.
 
-* [Access support resources in the our platform.](#nr-support)
+* [Access support resources in our platform.](#nr-support)
 * [Ask in New Relic's Explorers Hub.](#nr-forum)
 * [Run the New Relic Diagnostics tool.](#diagnostics)
 * [Find answers in New Relic Docs and New Relic University.](#find-answers)
@@ -103,6 +103,8 @@ If you can't find what you're looking for, and your subscription level includes 
     <Callout variant="important">
       The ability to create a support case is based on your account's [Support Plan](/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/).
     </Callout>
+
+After your case is created, all communication with New Relic Technical Support happens in the platform. You'll receive email notifications when your case is updated, but to reply or add information, return to the help sidebar by selecting the <DNT>**?**</DNT> icon from the top right navigation menu in [New Relic](https://one.newrelic.com) and then choose <DNT>**Your support cases**</DNT>.
 
 ## Check the status of our systems [#check-status]
 


### PR DESCRIPTION
## Summary

- Fixes typo in `find-help-get-support.mdx` (`in the our` → `in our`)
- Adds post-case-creation paragraph directing customers to use HelpXP for all case communication (replies, updates, attachments)
- Fixes stale internal URL in `global-technical-support-offerings.mdx` support case collapser (`find-help-use-support-portal` → `find-help-get-support`)
- Adds explicit note in support case collapser: email replies are not monitored; all communication happens in-product

## Context

Part of the GTS email removal project — removing email-to-case and email replies as support channels, directing all case communication to the in-product support experience (HelpXP). Email notifications are retained.

## Test plan

- [ ] Verify HelpXP navigation steps (`?` icon → Your support cases) are accurate
- [ ] Confirm `find-help-get-support/#file-ticket` anchor resolves correctly
- [ ] Review with GTS team before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)