### PR TITLE
feat(es-otel): Add es docs for nrdot, otel and prometheous

### DIFF
--- a/src/content/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-install.mdx
+++ b/src/content/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-install.mdx
@@ -13,9 +13,10 @@ redirects:
 
 Monitor your self-hosted Elasticsearch cluster by installing the OpenTelemetry Collector directly on servers or virtual machines. New Relic provides flexible deployment options to match your infrastructure setup and monitoring requirements.
 
-You can choose between two collector distributions:
+You can choose between three collector options:
 * **NRDOT:** New Relic Distribution of OpenTelemetry
 * **OTel Collector Contrib:** Standard OpenTelemetry Collector with community-contributed components
+* **Prometheus Receiver:** For environments already running a [Prometheus Elasticsearch exporter](https://github.com/prometheus-community/elasticsearch_exporter)
 
 ## Installation options [#installation-options]
 
@@ -25,15 +26,473 @@ Choose the collector distribution that matches your needs:
   <TabsBar>
     <TabsBarItem id="nrdot">NRDOT Collector</TabsBarItem>
     <TabsBarItem id="otel-contrib">OTel Collector Contrib</TabsBarItem>
+    <TabsBarItem id="prometheus">Prometheus Receiver</TabsBarItem>
   </TabsBar>
 
   <TabsPages>
     <TabsPageItem id="nrdot">
 
-<Callout variant="important">
-**NRDOT support for Elasticsearch monitoring is coming soon!**
-Stay tuned for updates!
+<Steps>
+
+<Step>
+
+### Before you begin [#prereq-nrdot]
+
+Before configuring Elasticsearch monitoring with NRDOT, ensure you have:
+
+**NRDOT collector installed:**
+* You must have NRDOT collector installed and running as a systemd service on your host
+* If not installed, follow the [official NRDOT installation guide](/docs/opentelemetry/nrdot/nrdot-collector/) to install the collector using the package manager (DEB/RPM) which sets up the systemd service automatically
+
+**Required access privileges:**
+* Your New Relic <InlinePopover type="licenseKey"/>
+* Root or sudo privileges on the host machine
+* Elasticsearch cluster admin privileges with `monitor` or `manage` cluster privilege (see [Elasticsearch security privileges documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html) for details)
+
+**System requirements:**
+* **Elasticsearch version 7.16 or higher** - This integration requires a modern Elasticsearch cluster
+* **Network connectivity** - Outbound HTTPS (port 443) to New Relic's [OTLP ingest endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp)
+
+**Configuration values ready:**
+* **Elasticsearch endpoint** - Your Elasticsearch cluster URL (e.g., `http://localhost:9200`)
+* **Cluster name** - A unique identifier for your cluster in New Relic
+
+</Step>
+
+<Step>
+
+### Configure Elasticsearch monitoring [#configure-es-nrdot]
+
+Once the NRDOT collector is installed, replace the collector's default configuration file with the Elasticsearch monitoring configuration. This will enable Elasticsearch metrics collection. Host metrics and logs are optional and can be added separately.
+
+The configuration file is located at: `/etc/nrdot-collector/config.yaml`
+
+<Callout variant="tip">
+**Backup your default configuration:** Before modifying the configuration file, create a backup copy to preserve the default settings:
+```bash
+sudo cp /etc/nrdot-collector/config.yaml /etc/nrdot-collector/config.yaml.backup
+```
 </Callout>
+
+To configure the collector:
+
+1. Open the configuration file with a text editor using root or sudo privileges:
+
+    ```bash
+    sudo nano /etc/nrdot-collector/config.yaml
+    ```
+
+2. Delete all existing content and replace it with the following configuration for Elasticsearch monitoring:
+
+<Callout variant="important">
+Replace the `endpoint` value with your Elasticsearch cluster endpoint and update `elasticsearch.cluster.name` in the processor block with a unique name to identify your cluster in New Relic.
+</Callout>
+
+
+```yaml
+receivers:
+  elasticsearch:
+    endpoint: "http://localhost:9200"
+    collection_interval: 15s
+    metrics:
+      elasticsearch.os.cpu.usage:
+        enabled: true
+      elasticsearch.cluster.data_nodes:
+        enabled: true
+      elasticsearch.cluster.health:
+        enabled: true
+      elasticsearch.cluster.in_flight_fetch:
+        enabled: true
+      elasticsearch.cluster.nodes:
+        enabled: true
+      elasticsearch.cluster.pending_tasks:
+        enabled: true
+      elasticsearch.cluster.shards:
+        enabled: true
+      elasticsearch.cluster.state_update.time:
+        enabled: true
+      elasticsearch.index.documents:
+        enabled: true
+      elasticsearch.index.operations.merge.current:
+        enabled: true
+      elasticsearch.index.operations.time:
+        enabled: true
+      elasticsearch.node.cache.count:
+        enabled: true
+      elasticsearch.node.cache.evictions:
+        enabled: true
+      elasticsearch.node.cache.memory.usage:
+        enabled: true
+      elasticsearch.node.shards.size:
+        enabled: true
+      elasticsearch.node.cluster.io:
+        enabled: true
+      elasticsearch.node.documents:
+        enabled: true
+      elasticsearch.node.disk.io.read:
+        enabled: true
+      elasticsearch.node.disk.io.write:
+        enabled: true
+      elasticsearch.node.fs.disk.available:
+        enabled: true
+      elasticsearch.node.fs.disk.total:
+        enabled: true
+      elasticsearch.node.http.connections:
+        enabled: true
+      elasticsearch.node.ingest.documents.current:
+        enabled: true
+      elasticsearch.node.ingest.operations.failed:
+        enabled: true
+      elasticsearch.node.open_files:
+        enabled: true
+      elasticsearch.node.operations.completed:
+        enabled: true
+      elasticsearch.node.operations.current:
+        enabled: true
+      elasticsearch.node.operations.get.completed:
+        enabled: true
+      elasticsearch.node.operations.time:
+        enabled: true
+      elasticsearch.node.shards.reserved.size:
+        enabled: true
+      elasticsearch.index.shards.size:
+        enabled: true
+      elasticsearch.os.cpu.load_avg.1m:
+        enabled: true
+      elasticsearch.os.cpu.load_avg.5m:
+        enabled: true
+      elasticsearch.os.cpu.load_avg.15m:
+        enabled: true
+      elasticsearch.os.memory:
+        enabled: true
+      jvm.gc.collections.count:
+        enabled: true
+      jvm.gc.collections.elapsed:
+        enabled: true
+      jvm.memory.heap.max:
+        enabled: true
+      jvm.memory.heap.used:
+        enabled: true
+      jvm.memory.heap.utilization:
+        enabled: true
+      jvm.threads.count:
+        enabled: true
+      elasticsearch.index.segments.count:
+        enabled: true
+      elasticsearch.index.operations.completed:
+        enabled: true
+      elasticsearch.node.script.cache_evictions:
+        enabled: false
+      elasticsearch.node.cluster.connections:
+        enabled: false
+      elasticsearch.node.pipeline.ingest.documents.preprocessed:
+        enabled: false
+      elasticsearch.node.thread_pool.tasks.queued:
+        enabled: false
+      elasticsearch.cluster.published_states.full:
+        enabled: false
+      jvm.memory.pool.max:
+        enabled: false
+      elasticsearch.node.script.compilation_limit_triggered:
+        enabled: false
+      elasticsearch.node.shards.data_set.size:
+        enabled: false
+      elasticsearch.node.pipeline.ingest.documents.current:
+        enabled: false
+      elasticsearch.cluster.state_update.count:
+        enabled: false
+      elasticsearch.node.fs.disk.free:
+        enabled: false
+      jvm.memory.nonheap.used:
+        enabled: false
+      jvm.memory.pool.used:
+        enabled: false
+      elasticsearch.node.translog.size:
+        enabled: false
+      elasticsearch.node.thread_pool.threads:
+        enabled: false
+      elasticsearch.cluster.state_queue:
+        enabled: false
+      elasticsearch.node.translog.operations:
+        enabled: false
+      elasticsearch.memory.indexing_pressure:
+        enabled: false
+      elasticsearch.node.ingest.documents:
+        enabled: false
+      jvm.classes.loaded:
+        enabled: false
+      jvm.memory.heap.committed:
+        enabled: false
+      elasticsearch.breaker.memory.limit:
+        enabled: false
+      elasticsearch.indexing_pressure.memory.total.replica_rejections:
+        enabled: false
+      elasticsearch.breaker.memory.estimated:
+        enabled: false
+      elasticsearch.cluster.published_states.differences:
+        enabled: false
+      jvm.memory.nonheap.committed:
+        enabled: false
+      elasticsearch.node.translog.uncommitted.size:
+        enabled: false
+      elasticsearch.node.script.compilations:
+        enabled: false
+      elasticsearch.node.pipeline.ingest.operations.failed:
+        enabled: false
+      elasticsearch.indexing_pressure.memory.limit:
+        enabled: false
+      elasticsearch.breaker.tripped:
+        enabled: false
+      elasticsearch.indexing_pressure.memory.total.primary_rejections:
+        enabled: false
+      elasticsearch.node.thread_pool.tasks.finished:
+        enabled: false
+processors:
+  memory_limiter:
+    check_interval: 60s
+    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB:-100}
+  cumulativetodelta: {}
+  attributes/cluster_state_aggregate:
+    include:
+      match_type: strict
+      metric_names:
+        - elasticsearch.cluster.state_update.time
+    actions:
+      - key: type
+        action: delete
+      - key: state
+        action: delete
+  filter/critical_operations:
+    metrics:
+      datapoint:
+        # Filters to keep only: query, index, get, merge
+        # Affects only 4 metrics: *.operations.completed and *.operations.time
+        # All other metrics pass through unchanged
+        - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+  resource/cluster_name_override:
+    attributes:
+      - key: elasticsearch.cluster.name
+        value: "<elasticsearch-cluster-name>"
+        action: upsert
+  resourcedetection:
+    detectors: [ system ]
+    system:
+      resource_attributes:
+        host.name:
+          enabled: true
+        host.id:
+          enabled: true
+        os.type:
+          enabled: true
+  batch:
+    timeout: 30s
+    send_batch_size: 2048
+    send_batch_max_size: 4096
+  attributes/cardinality_reduction:
+    actions:
+      - key: process.pid
+        action: delete
+      - key: process.parent_pid
+        action: delete
+  transform/metadata_nullify:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(description, "")
+          - set(unit, "")
+exporters:
+  otlphttp:
+    endpoint: ${env:NEWRELIC_OTLP_ENDPOINT}
+    headers:
+      api-key: ${env:NEWRELIC_LICENSE_KEY}
+    compression: gzip
+    timeout: 30s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+service:
+  pipelines:
+    metrics/elasticsearch:
+      receivers: [elasticsearch]
+      processors: [memory_limiter, resourcedetection, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+      exporters: [otlphttp]
+```
+
+3. *(Optional)* For secured Elasticsearch with authentication and SSL, modify the receiver configuration:
+
+    ```yaml
+    receivers:
+      elasticsearch:
+        endpoint: "https://localhost:9200"
+        username: "your_elasticsearch_username"
+        password: "your_elasticsearch_password"
+        tls:
+          ca_file: "/etc/elasticsearch/certs/http_ca.crt"
+          insecure_skip_verify: false
+        collection_interval: 15s
+    ```
+
+4. *(Optional)* To collect host metrics, add the hostmetrics receiver:
+
+    ```yaml
+    receivers:
+      hostmetrics:
+        collection_interval: 60s
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization: {enabled: true}
+              system.cpu.time: {enabled: true}
+          load:
+            metrics:
+              system.cpu.load_average.1m: {enabled: true}
+              system.cpu.load_average.5m: {enabled: true}
+              system.cpu.load_average.15m: {enabled: true}
+          memory:
+            metrics:
+              system.memory.usage: {enabled: true}
+              system.memory.utilization: {enabled: true}
+          disk:
+            metrics:
+              system.disk.io: {enabled: true}
+              system.disk.operations: {enabled: true}
+          filesystem:
+            metrics:
+              system.filesystem.usage: {enabled: true}
+              system.filesystem.utilization: {enabled: true}
+          network:
+            metrics:
+              system.network.io: {enabled: true}
+              system.network.packets: {enabled: true}
+          process:
+            metrics:
+              process.cpu.utilization:
+                enabled: true
+    ```
+
+    And add to the service pipelines:
+
+    ```yaml
+    service:
+      pipelines:
+        metrics/host:
+          receivers: [hostmetrics]
+          processors: [memory_limiter, resourcedetection, batch]
+          exporters: [otlphttp]
+    ```
+
+5. *(Optional)* To collect Elasticsearch logs, add the filelog receiver. Ensure the user running the collector service (nrdot-collector) has read access to your Elasticsearch log files:
+
+    **If running Elasticsearch on Linux (Host):**
+    ```yaml
+    receivers:
+      filelog:
+        include:
+          - /var/log/elasticsearch/elasticsearch.log
+          - /var/log/elasticsearch/*.log
+    ```
+
+    **If running Elasticsearch in Docker:**
+    ```yaml
+    receivers:
+      filelog:
+        include:
+          - /var/lib/docker/containers/*/*.log
+        operators:
+          - type: move
+            from: attributes.log
+            to: body
+    ```
+
+    And add to the service pipelines:
+
+    ```yaml
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [resource/cluster_name_override]
+          exporters: [otlphttp]
+    ```
+
+6. *(Optional)* To add custom metadata tags to your metrics, use the `resource/static_override` processor:
+
+    ```yaml
+    processors:
+      resource/static_override:
+        attributes:
+          - key: env
+            value: "production"
+            action: upsert
+    service:
+      pipelines:
+        metrics/elasticsearch:
+          receivers: [elasticsearch]
+          processors: [memory_limiter, resourcedetection, resource/cluster_name_override, resource/static_override, attributes/cardinality_reduction, cumulativetodelta, transform/metadata_nullify, batch]
+          exporters: [otlphttp]
+    ```
+
+7. Save the configuration file.
+
+8. Set the environment variables:
+
+    Create a systemd override directory:
+
+    ```bash
+    sudo mkdir -p /etc/systemd/system/nrdot-collector.service.d
+    ```
+
+    Create the environment configuration file:
+
+    ```bash
+    cat <<EOF | sudo tee /etc/systemd/system/nrdot-collector.service.d/environment.conf
+    [Service]
+    Environment="NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318"
+    Environment="NEWRELIC_LICENSE_KEY=YOUR_LICENSE_KEY_HERE"
+    Environment="NEW_RELIC_MEMORY_LIMIT_MIB=100"
+    EOF
+    ```
+
+    Update the configuration with your values:
+    * Replace `https://otlp.nr-data.net:4318` with your region's endpoint
+    * Replace `YOUR_LICENSE_KEY_HERE` with your actual New Relic license key
+    * Replace `100` with your desired memory limit in MiB for the collector (default: 100 MiB). Adjust based on your environment's needs
+
+9. Restart the NRDOT collector to apply changes:
+
+    ```bash
+    sudo systemctl daemon-reload
+    sudo systemctl restart nrdot-collector.service
+    ```
+
+</Step>
+
+<Step>
+
+### Verify data collection [#verify-nrdot]
+
+Verify that the NRDOT collector is running and collecting data without errors:
+
+1. Check the collector service status:
+
+    ```bash
+    sudo systemctl status nrdot-collector.service
+    ```
+
+2. Monitor the collector logs for any errors:
+
+    ```bash
+    sudo journalctl -u nrdot-collector.service -f
+    ```
+
+    Look for successful connections to Elasticsearch and New Relic. If you see errors, refer to the [troubleshooting guide](/docs/opentelemetry/integrations/elasticsearch/troubleshooting).
+
+</Step>
+
+</Steps>
+
 
     </TabsPageItem>
 
@@ -470,6 +929,542 @@ Verify that the OTel Collector Contrib is running and collecting data without er
     ```
 
     Look for successful connections to Elasticsearch and New Relic. If you see errors, refer to the [troubleshooting guide](/docs/opentelemetry/integrations/elasticsearch/troubleshooting).
+
+</Step>
+
+</Steps>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="prometheus">
+
+Use this approach if you already have a [Prometheus Elasticsearch exporter](https://github.com/prometheus-community/elasticsearch_exporter) running in your environment, or if you're migrating from a Prometheus-based monitoring stack.
+
+<Callout variant="tip">
+  **Recommended:** If you don't already have a Prometheus exporter running, use the **NRDOT Collector** or **OTel Collector Contrib** tabs instead. They connect directly to the Elasticsearch API without needing an additional exporter component.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Install and configure the Elasticsearch exporter [#install-exporter]
+
+The [Prometheus Elasticsearch exporter](https://github.com/prometheus-community/elasticsearch_exporter) exposes Elasticsearch metrics in Prometheus format on port `9114`.
+
+1. Download the latest release:
+
+    ```bash
+    wget https://github.com/prometheus-community/elasticsearch_exporter/releases/download/v1.8.0/elasticsearch_exporter-1.8.0.linux-amd64.tar.gz
+    tar xzf elasticsearch_exporter-*.tar.gz
+    cd elasticsearch_exporter-*
+    ```
+
+2. Start the exporter (point it to your Elasticsearch instance):
+
+    ```bash
+    ./elasticsearch_exporter --es.uri=http://localhost:9200
+    ```
+
+    <Callout variant="tip">
+      For secured Elasticsearch, use: `--es.uri=https://username:password@localhost:9200 --es.ssl-skip-verify`
+    </Callout>
+
+3. Verify the exporter is running:
+
+    ```bash
+    curl http://localhost:9114/metrics | grep elasticsearch_cluster_health
+    ```
+
+    You should see Prometheus-formatted metrics like `elasticsearch_cluster_health_status`, `elasticsearch_cluster_health_number_of_nodes`, etc.
+
+</Step>
+
+<Step>
+
+### Configure the collector [#configure-prom]
+
+This configuration works with both **NRDOT** and **OTel Collector Contrib**. Place it in the appropriate config location for your collector:
+* **NRDOT:** `/etc/nrdot-collector/config.yaml`
+* **OTel Collector Contrib:** `/etc/otelcol-contrib/config.yaml`
+
+If you don't have a collector installed yet, follow the installation steps in the **NRDOT Collector** or **OTel Collector Contrib** tabs above first, then return here to apply this configuration.
+
+This configuration scrapes metrics from the Elasticsearch exporter and translates them to OpenTelemetry-compatible metric names that power the New Relic Elasticsearch dashboard.
+
+<Collapser id="prometheus-full-config" title="Full Prometheus receiver configuration">
+
+```yaml
+receivers:
+  prometheus/elasticsearch:
+    config:
+      scrape_configs:
+        - job_name: 'elasticsearch'
+          scrape_interval: 15s
+          static_configs:
+            - targets: ['localhost:9114']  # <-- elasticsearch_exporter address
+
+processors:
+  memory_limiter:
+    check_interval: 60s
+    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB:-100}
+
+  metricstransform/prom_to_otel:
+    transforms:
+      - include: ^elasticsearch_cluster_health_number_of_data_nodes$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.data_nodes
+      - include: ^elasticsearch_cluster_health_status$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.health
+        operations:
+          - action: update_label
+            label: color
+            new_label: status
+      - include: ^elasticsearch_cluster_health_number_of_in_flight_fetch$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.in_flight_fetch
+      - include: ^elasticsearch_cluster_health_number_of_nodes$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.nodes
+      - include: ^elasticsearch_cluster_health_number_of_pending_tasks$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.pending_tasks
+      - include: ^elasticsearch_cluster_health_active_shards$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.shards
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: active
+      - include: ^elasticsearch_cluster_health_active_primary_shards$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.shards
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: active_primary
+      - include: ^elasticsearch_cluster_health_initializing_shards$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.shards
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: initializing
+      - include: ^elasticsearch_cluster_health_relocating_shards$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.shards
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: relocating
+      - include: ^elasticsearch_cluster_health_unassigned_shards$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.cluster.shards
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: unassigned
+      - include: ^elasticsearch_indices_docs$
+        match_type: regexp
+        action: insert
+        new_name: elasticsearch.node.documents
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: active
+      - include: ^elasticsearch_indices_docs$
+        match_type: regexp
+        action: insert
+        new_name: elasticsearch.index.documents
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: active
+          - action: add_label
+            new_label: aggregation
+            new_value: primary_shards
+          - action: add_label
+            new_label: elasticsearch.index.name
+            new_value: _all
+      - include: ^elasticsearch_indices_docs_deleted$
+        match_type: regexp
+        action: insert
+        new_name: elasticsearch.node.documents
+        operations:
+          - action: add_label
+            new_label: state
+            new_value: deleted
+      - include: ^elasticsearch_indices_fielddata_evictions$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.cache.evictions
+        operations:
+          - action: add_label
+            new_label: cache_name
+            new_value: fielddata
+      - include: ^elasticsearch_indices_query_cache_evictions$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.cache.evictions
+        operations:
+          - action: add_label
+            new_label: cache_name
+            new_value: query
+      - include: ^elasticsearch_indices_fielddata_memory_size_bytes$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.cache.memory.usage
+        operations:
+          - action: add_label
+            new_label: cache_name
+            new_value: fielddata
+      - include: ^elasticsearch_indices_query_cache_memory_size_bytes$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.cache.memory.usage
+        operations:
+          - action: add_label
+            new_label: cache_name
+            new_value: query
+      - include: ^elasticsearch_transport_rx_size_bytes_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.cluster.io
+        operations:
+          - action: add_label
+            new_label: direction
+            new_value: received
+      - include: ^elasticsearch_transport_tx_size_bytes_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.cluster.io
+        operations:
+          - action: add_label
+            new_label: direction
+            new_value: sent
+      - include: ^elasticsearch_filesystem_data_available_bytes$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.fs.disk.available
+      - include: ^elasticsearch_filesystem_data_size_bytes$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.fs.disk.total
+      - include: ^elasticsearch_process_open_files_count$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.open_files
+      - include: ^elasticsearch_indices_indexing_index_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.operations.completed
+        operations:
+          - action: add_label
+            new_label: operation
+            new_value: index
+      - include: ^elasticsearch_indices_search_query_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.operations.completed
+        operations:
+          - action: add_label
+            new_label: operation
+            new_value: query
+      - include: ^elasticsearch_indices_get_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.operations.completed
+        operations:
+          - action: add_label
+            new_label: operation
+            new_value: get
+      - include: ^elasticsearch_indices_merges_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.operations.completed
+        operations:
+          - action: add_label
+            new_label: operation
+            new_value: merge
+      - include: ^elasticsearch_indices_indexing_index_time_seconds_total$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.operations.time
+        operations:
+          - action: add_label
+            new_label: operation
+            new_value: index
+          - action: experimental_scale_value
+            experimental_scale: 1000
+      - include: ^elasticsearch_indices_search_query_time_seconds$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.node.operations.time
+        operations:
+          - action: add_label
+            new_label: operation
+            new_value: query
+          - action: experimental_scale_value
+            experimental_scale: 1000
+      - include: ^elasticsearch_thread_pool_active_count$
+        match_type: regexp
+        action: insert
+        new_name: elasticsearch.node.operations.current
+        operations:
+          - action: update_label
+            label: type
+            new_label: operation
+      - include: ^elasticsearch_os_cpu_percent$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.os.cpu.usage
+      - include: ^elasticsearch_os_load1$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.os.cpu.load_avg.1m
+      - include: ^elasticsearch_os_load5$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.os.cpu.load_avg.5m
+      - include: ^elasticsearch_os_load15$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.os.cpu.load_avg.15m
+      - include: ^elasticsearch_jvm_gc_collection_seconds_count$
+        match_type: regexp
+        action: update
+        new_name: jvm.gc.collections.count
+      - include: ^elasticsearch_jvm_gc_collection_seconds_sum$
+        match_type: regexp
+        action: update
+        new_name: jvm.gc.collections.elapsed
+        operations:
+          - action: experimental_scale_value
+            experimental_scale: 1000
+      - include: ^elasticsearch_jvm_memory_max_bytes$
+        match_type: regexp
+        action: update
+        new_name: jvm.memory.heap.max
+      - include: ^elasticsearch_jvm_memory_used_bytes$
+        match_type: regexp
+        action: update
+        new_name: jvm.memory.heap.used
+      - include: ^elasticsearch_thread_pool_threads_count$
+        match_type: regexp
+        action: update
+        new_name: jvm.threads.count
+        operations:
+          - action: aggregate_labels
+            label_set: [name, cluster]
+            aggregation_type: sum
+      - include: ^elasticsearch_indices_segments_count$
+        match_type: regexp
+        action: update
+        new_name: elasticsearch.index.segments.count
+
+  filter/allowed_metrics:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - elasticsearch.cluster.data_nodes
+          - elasticsearch.cluster.health
+          - elasticsearch.cluster.in_flight_fetch
+          - elasticsearch.cluster.nodes
+          - elasticsearch.cluster.pending_tasks
+          - elasticsearch.cluster.shards
+          - elasticsearch.index.documents
+          - elasticsearch.index.segments.count
+          - elasticsearch.node.cache.evictions
+          - elasticsearch.node.cache.memory.usage
+          - elasticsearch.node.cluster.io
+          - elasticsearch.node.documents
+          - elasticsearch.node.fs.disk.available
+          - elasticsearch.node.fs.disk.total
+          - elasticsearch.node.open_files
+          - elasticsearch.node.operations.completed
+          - elasticsearch.node.operations.current
+          - elasticsearch.node.operations.time
+          - elasticsearch.os.cpu.usage
+          - elasticsearch.os.cpu.load_avg.1m
+          - elasticsearch.os.cpu.load_avg.5m
+          - elasticsearch.os.cpu.load_avg.15m
+          - jvm.gc.collections.count
+          - jvm.gc.collections.elapsed
+          - jvm.memory.heap.max
+          - jvm.memory.heap.used
+          - jvm.threads.count
+
+  transform/rename_node_name:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["elasticsearch.node.name"], attributes["name"]) where attributes["name"] != nil
+          - delete_key(attributes, "name") where attributes["elasticsearch.node.name"] != nil
+
+  groupbyattrs/node:
+    keys:
+      - elasticsearch.node.name
+      - elasticsearch.cluster.name
+
+  cumulativetodelta: {}
+
+  resource/cluster_name_override:
+    attributes:
+      - key: elasticsearch.cluster.name
+        value: "<elasticsearch-cluster-name>"
+        action: upsert
+
+  transform/scope_override:
+    metric_statements:
+      - context: scope
+        statements:
+          - set(name, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver")
+          - set(version, "")
+
+  resourcedetection:
+    detectors: [system]
+    system:
+      resource_attributes:
+        host.name:
+          enabled: true
+        host.id:
+          enabled: true
+        os.type:
+          enabled: true
+
+  batch:
+    timeout: 30s
+    send_batch_size: 2048
+    send_batch_max_size: 4096
+
+  attributes/cardinality_reduction:
+    actions:
+      - key: process.pid
+        action: delete
+      - key: process.parent_pid
+        action: delete
+
+  transform/metadata_nullify:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(description, "")
+          - set(unit, "")
+
+exporters:
+  otlphttp:
+    endpoint: ${env:NEWRELIC_OTLP_ENDPOINT}
+    headers:
+      api-key: ${env:NEWRELIC_LICENSE_KEY}
+    compression: gzip
+    timeout: 30s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+
+service:
+  pipelines:
+    metrics/elasticsearch:
+      receivers: [prometheus/elasticsearch]
+      processors:
+        - memory_limiter
+        - metricstransform/prom_to_otel
+        - filter/allowed_metrics
+        - transform/rename_node_name
+        - groupbyattrs/node
+        - transform/scope_override
+        - resourcedetection
+        - resource/cluster_name_override
+        - attributes/cardinality_reduction
+        - cumulativetodelta
+        - transform/metadata_nullify
+        - batch
+      exporters: [otlphttp]
+```
+
+</Collapser>
+
+Replace the following values in the configuration:
+
+* `<elasticsearch-cluster-name>`: Your Elasticsearch cluster name for identification in New Relic.
+* `localhost:9114`: The address of your `elasticsearch_exporter` if running on a different host or port.
+
+</Step>
+
+<Step>
+
+### Set up environment variables [#env-vars-prom]
+
+Create a systemd override to inject the required environment variables. Replace `<collector-service>` with your collector service name (`nrdot-collector` or `otelcol-contrib`):
+
+```bash
+sudo mkdir -p /etc/systemd/system/<collector-service>.service.d
+```
+
+Create the file `/etc/systemd/system/<collector-service>.service.d/environment.conf`:
+
+```ini
+[Service]
+Environment="NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318"
+Environment="NEWRELIC_LICENSE_KEY=YOUR_NEWRELIC_LICENSE_KEY"
+Environment="NEW_RELIC_MEMORY_LIMIT_MIB=100"
+```
+
+Replace `YOUR_NEWRELIC_LICENSE_KEY` with your <InlinePopover type="licenseKey"/>.
+
+<Callout variant="tip">
+  For EU accounts, use `NEWRELIC_OTLP_ENDPOINT=https://otlp.eu01.nr-data.net:4318`
+</Callout>
+
+</Step>
+
+<Step>
+
+### Start the collector [#start-prom]
+
+Replace `<collector-service>` with your collector service name (`nrdot-collector` or `otelcol-contrib`):
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable <collector-service>
+sudo systemctl restart <collector-service>
+```
+
+Check the collector status:
+
+```bash
+sudo systemctl status <collector-service>
+sudo journalctl -u <collector-service> -f
+```
+
+</Step>
+
+<Step>
+
+### Verify data in New Relic [#verify-prom]
+
+After a few minutes, verify that data is flowing to New Relic:
+
+```sql
+FROM Metric SELECT count(*)
+WHERE metricName LIKE 'elasticsearch.%'
+AND elasticsearch.cluster.name = '<elasticsearch-cluster-name>'
+SINCE 10 minutes ago
+```
 
 </Step>
 

--- a/src/content/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
+++ b/src/content/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
@@ -13,9 +13,10 @@ Monitor your Elasticsearch clusters in Kubernetes by deploying the OpenTelemetry
 
 To get started, select the collector distribution that best fits your Kubernetes environment:
 
-You can choose between two collector distributions:
+You can choose between three collector options:
 * **NRDOT:** New Relic Distribution of OpenTelemetry
 * **OTel Collector Contrib:** Standard OpenTelemetry Collector with community-contributed components
+* **Prometheus Receiver:** For environments already running a [Prometheus Elasticsearch exporter](https://github.com/prometheus-community/elasticsearch_exporter)
 
 ## Installation options [#installation-options]
 
@@ -25,15 +26,858 @@ Choose the collector distribution that matches your needs:
   <TabsBar>
     <TabsBarItem id="nrdot">NRDOT Collector</TabsBarItem>
     <TabsBarItem id="otel-contrib">OTel Collector Contrib</TabsBarItem>
+    <TabsBarItem id="prometheus">Prometheus Receiver</TabsBarItem>
   </TabsBar>
 
   <TabsPages>
     <TabsPageItem id="nrdot">
 
+<Steps>
+
+<Step>
+
+### Before you begin [#prereq-nrdot]
+
+Before deploying the NRDOT collector on Kubernetes, ensure you have:
+
+**Required access privileges:**
+* Your New Relic <InlinePopover type="licenseKey"/>
+* kubectl access to your Kubernetes cluster
+* Elasticsearch cluster admin privileges with `monitor` or `manage` cluster privilege (see [Elasticsearch security privileges documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html) for details)
+
+**System requirements:**
+* **Elasticsearch version 7.16 or higher** - This integration requires a modern Elasticsearch cluster
+* **Kubernetes cluster** - A running Kubernetes cluster where Elasticsearch is deployed
+* **Network connectivity** - Outbound HTTPS (port 443) to New Relic's [OTLP ingest endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp)
+
+**Elasticsearch pod requirements:**
+* **Pod labels (Required)** - Each Elasticsearch pod must have the label `app: elasticsearch` for automatic discovery to work. Without this label, the collector will not detect or monitor your pods.
+
 <Callout variant="important">
-**NRDOT support for Elasticsearch Kubernetes monitoring is coming soon!**
-Stay tuned for updates!
+**How to add labels to Elasticsearch pods:**
+
+If you're using a StatefulSet or Deployment for Elasticsearch, add the label in the pod template:
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+spec:
+  template:
+    metadata:
+      labels:
+        app: elasticsearch  # Required for auto-discovery
+    spec:
+      containers:
+      - name: elasticsearch
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.x.x
+```
+
+For existing pods without labels, update your StatefulSet/Deployment and restart the pods:
+
+```bash
+kubectl label pods -l <your-existing-selector> app=elasticsearch -n <namespace>
+```
+
+You can verify labels are set correctly:
+
+```bash
+kubectl get pods -n <namespace> --show-labels
+```
 </Callout>
+
+</Step>
+
+<Step>
+
+### Choose your installation method [#nrdot-choose-install]
+
+You can install the NRDOT Collector using Kubernetes manifests or Helm charts. Choose the method that best fits your workflow:
+
+**Manifest install:**
+- More control over individual Kubernetes resources
+- Requires completing the base Kubernetes OpenTelemetry manifest installation first
+- Best for customized deployments
+
+**Helm install:**
+- Simpler deployment with single command
+- Easier to manage and upgrade
+- Best for standard deployments
+
+Proceed to the next step for detailed instructions for your chosen method.
+
+</Step>
+
+<Step>
+
+### Install and configure NRDOT Collector [#nrdot-install-configure]
+
+<CollapserGroup>
+
+  <Collapser id="nrdot-k8s-manifest-install" title="Manifest install">
+
+#### Complete base Kubernetes OpenTelemetry manifest installation [#nrdot-base-install]
+
+Before configuring Elasticsearch monitoring, complete the base [Kubernetes OpenTelemetry manifest installation](/docs/kubernetes-pixie/k8s-otel/install/#manifest-install).
+
+#### Update collector image to NRDOT [#nrdot-update-image]
+
+In both [`deployment.yaml`](https://github.com/newrelic/helm-charts/blob/master/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment.yaml) and [`daemonset.yaml`](https://github.com/newrelic/helm-charts/blob/master/charts/nr-k8s-otel-collector/examples/k8s/rendered/daemonset.yaml) files in your local `rendered` directory, update the image to:
+
+```yaml
+image: newrelic/nrdot-collector:latest
+```
+
+#### Configure Elasticsearch monitoring [#nrdot-configure-es]
+
+Update the [`deployment-configmap.yaml`](https://github.com/newrelic/helm-charts/blob/master/charts/nr-k8s-otel-collector/examples/k8s/rendered/deployment-configmap.yaml) for Elasticsearch monitoring.
+
+You have two options:
+
+**Option 1: Replace all existing OpenTelemetry components** (recommended for Elasticsearch-only monitoring)
+
+Replace the entire `deployment-configmap.yaml` content with the Elasticsearch-specific configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nr-k8s-otel-collector-deployment-config
+data:
+  config.yaml: |
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+        observe_nodes: true
+
+    receivers:
+      jaeger: null
+      zipkin: null
+      prometheus: null
+      otlp: null
+      receiver_creator/elasticsearch:
+        watch_observers: [k8s_observer]
+        receivers:
+          elasticsearch:
+            rule: type == "pod" && labels["app"] == "elasticsearch"
+            config:
+              endpoint: 'http://`endpoint`:9200'
+              collection_interval: 15s
+              metrics:
+                elasticsearch.os.cpu.usage:
+                  enabled: true
+                elasticsearch.cluster.data_nodes:
+                  enabled: true
+                elasticsearch.cluster.health:
+                  enabled: true
+                elasticsearch.cluster.in_flight_fetch:
+                  enabled: true
+                elasticsearch.cluster.nodes:
+                  enabled: true
+                elasticsearch.cluster.pending_tasks:
+                  enabled: true
+                elasticsearch.cluster.shards:
+                  enabled: true
+                elasticsearch.cluster.state_update.time:
+                  enabled: true
+                elasticsearch.index.documents:
+                  enabled: true
+                elasticsearch.index.operations.merge.current:
+                  enabled: true
+                elasticsearch.index.operations.time:
+                  enabled: true
+                elasticsearch.node.cache.count:
+                  enabled: true
+                elasticsearch.node.cache.evictions:
+                  enabled: true
+                elasticsearch.node.cache.memory.usage:
+                  enabled: true
+                elasticsearch.node.shards.size:
+                  enabled: true
+                elasticsearch.node.cluster.io:
+                  enabled: true
+                elasticsearch.node.documents:
+                  enabled: true
+                elasticsearch.node.disk.io.read:
+                  enabled: true
+                elasticsearch.node.disk.io.write:
+                  enabled: true
+                elasticsearch.node.fs.disk.available:
+                  enabled: true
+                elasticsearch.node.fs.disk.total:
+                  enabled: true
+                elasticsearch.node.http.connections:
+                  enabled: true
+                elasticsearch.node.ingest.documents.current:
+                  enabled: true
+                elasticsearch.node.ingest.operations.failed:
+                  enabled: true
+                elasticsearch.node.open_files:
+                  enabled: true
+                elasticsearch.node.operations.completed:
+                  enabled: true
+                elasticsearch.node.operations.current:
+                  enabled: true
+                elasticsearch.node.operations.get.completed:
+                  enabled: true
+                elasticsearch.node.operations.time:
+                  enabled: true
+                elasticsearch.node.shards.reserved.size:
+                  enabled: true
+                elasticsearch.index.shards.size:
+                  enabled: true
+                elasticsearch.os.cpu.load_avg.1m:
+                  enabled: true
+                elasticsearch.os.cpu.load_avg.5m:
+                  enabled: true
+                elasticsearch.os.cpu.load_avg.15m:
+                  enabled: true
+                elasticsearch.os.memory:
+                  enabled: true
+                jvm.gc.collections.count:
+                  enabled: true
+                jvm.gc.collections.elapsed:
+                  enabled: true
+                jvm.memory.heap.max:
+                  enabled: true
+                jvm.memory.heap.used:
+                  enabled: true
+                jvm.memory.heap.utilization:
+                  enabled: true
+                jvm.threads.count:
+                  enabled: true
+                elasticsearch.index.segments.count:
+                  enabled: true
+                elasticsearch.index.operations.completed:
+                  enabled: true
+                elasticsearch.node.script.cache_evictions:
+                  enabled: false
+                elasticsearch.node.cluster.connections:
+                  enabled: false
+                elasticsearch.node.pipeline.ingest.documents.preprocessed:
+                  enabled: false
+                elasticsearch.node.thread_pool.tasks.queued:
+                  enabled: false
+                elasticsearch.cluster.published_states.full:
+                  enabled: false
+                jvm.memory.pool.max:
+                  enabled: false
+                elasticsearch.node.script.compilation_limit_triggered:
+                  enabled: false
+                elasticsearch.node.shards.data_set.size:
+                  enabled: false
+                elasticsearch.node.pipeline.ingest.documents.current:
+                  enabled: false
+                elasticsearch.cluster.state_update.count:
+                  enabled: false
+                elasticsearch.node.fs.disk.free:
+                  enabled: false
+                jvm.memory.nonheap.used:
+                  enabled: false
+                jvm.memory.pool.used:
+                  enabled: false
+                elasticsearch.node.translog.size:
+                  enabled: false
+                elasticsearch.node.thread_pool.threads:
+                  enabled: false
+                elasticsearch.cluster.state_queue:
+                  enabled: false
+                elasticsearch.node.translog.operations:
+                  enabled: false
+                elasticsearch.memory.indexing_pressure:
+                  enabled: false
+                elasticsearch.node.ingest.documents:
+                  enabled: false
+                jvm.classes.loaded:
+                  enabled: false
+                jvm.memory.heap.committed:
+                  enabled: false
+                elasticsearch.breaker.memory.limit:
+                  enabled: false
+                elasticsearch.indexing_pressure.memory.total.replica_rejections:
+                  enabled: false
+                elasticsearch.breaker.memory.estimated:
+                  enabled: false
+                elasticsearch.cluster.published_states.differences:
+                  enabled: false
+                jvm.memory.nonheap.committed:
+                  enabled: false
+                elasticsearch.node.translog.uncommitted.size:
+                  enabled: false
+                elasticsearch.node.script.compilations:
+                  enabled: false
+                elasticsearch.node.pipeline.ingest.operations.failed:
+                  enabled: false
+                elasticsearch.indexing_pressure.memory.limit:
+                  enabled: false
+                elasticsearch.breaker.tripped:
+                  enabled: false
+                elasticsearch.indexing_pressure.memory.total.primary_rejections:
+                  enabled: false
+                elasticsearch.node.thread_pool.tasks.finished:
+                  enabled: false
+
+    processors:
+      memory_limiter:
+        check_interval: 60s
+        limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
+      cumulativetodelta: {}
+      attributes/cluster_state_aggregate:
+        include:
+          match_type: strict
+          metric_names:
+            - elasticsearch.cluster.state_update.time
+        actions:
+          - key: type
+            action: delete
+          - key: state
+            action: delete
+      filter/critical_operations:
+        metrics:
+          datapoint:
+            - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+      resource/cluster:
+        attributes:
+          - key: k8s.cluster.name
+            value: "elasticsearch-cluster"
+            action: insert
+      resource/cluster_name_override:
+        attributes:
+          - key: elasticsearch.cluster.name
+            value: "elasticsearch-cluster"
+            action: upsert
+      resourcedetection:
+        detectors: [env, system]
+        system:
+          resource_attributes:
+            host.name:
+              enabled: true
+            host.id:
+              enabled: false
+            os.type:
+              enabled: true
+      batch:
+        timeout: 30s
+        send_batch_size: 2048
+        send_batch_max_size: 4096
+      attributes/cardinality_reduction:
+        actions:
+          - key: process.pid
+            action: delete
+          - key: process.parent_pid
+            action: delete
+          - key: k8s.pod.uid
+            action: delete
+      transform/metadata_nullify:
+        metric_statements:
+          - context: metric
+            statements:
+              - set(description, "")
+              - set(unit, "")
+
+    exporters:
+      otlp_http:
+        endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
+        headers:
+          api-key: "${env:NEWRELIC_LICENSE_KEY}"
+        compression: gzip
+        timeout: 30s
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+
+    service:
+      extensions: [health_check, k8s_observer]
+      pipelines:
+        traces: null
+        logs: null
+        metrics: null
+        metrics/elasticsearch:
+          receivers: [receiver_creator/elasticsearch]
+          processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+          exporters: [otlp_http]
+```
+
+**Option 2: Merge with existing configuration** (if monitoring multiple services)
+
+Add the Elasticsearch receiver and processors to your existing configuration. Refer to the sections above and merge them with your current `deployment-configmap.yaml`.
+
+<Callout variant="tip">
+**Customize for your environment:**
+
+**Required changes:**
+* **Pod label rule** - The rule `labels["app"] == "elasticsearch"` must match your pod labels
+* **Cluster name** - Replace `elasticsearch-cluster` in both `resource/cluster` and `resource/cluster_name_override` with your unique cluster name
+
+**Optional changes:**
+* **Port** - Update `9200` if Elasticsearch runs on a different port
+* **Authentication** - Add credentials if your Elasticsearch cluster is secured (see example below)
+</Callout>
+
+**For secured Elasticsearch clusters:**
+
+```yaml
+receivers:
+  receiver_creator/elasticsearch:
+    watch_observers: [k8s_observer]
+    receivers:
+      elasticsearch:
+        rule: type == "pod" && labels["app"] == "elasticsearch"
+        config:
+          endpoint: 'https://`endpoint`:9200'
+          username: "your_elasticsearch_username"
+          password: "your_elasticsearch_password"
+          tls:
+            insecure_skip_verify: false
+```
+
+#### Apply the updated manifests [#nrdot-apply-manifests]
+
+Apply the updated manifests and restart the deployment:
+
+```bash
+kubectl apply -n newrelic -R -f rendered
+kubectl rollout restart deployment nr-k8s-otel-collector-deployment -n newrelic
+```
+
+  </Collapser>
+
+  <Collapser id="nrdot-k8s-helm-install" title="Helm install">
+
+#### Create Kubernetes secret for credentials [#nrdot-helm-create-secret]
+
+Create a Kubernetes secret to store your New Relic credentials securely:
+
+1. Create the namespace:
+
+    ```bash
+    kubectl create namespace newrelic
+    ```
+
+2. Create the secret:
+
+    ```bash
+    kubectl create secret generic newrelic-licenses \
+      --from-literal=NEWRELIC_LICENSE_KEY=YOUR_LICENSE_KEY_HERE \
+      --from-literal=NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318 \
+      --from-literal=NEW_RELIC_MEMORY_LIMIT_MIB=100 \
+      -n newrelic
+    ```
+
+    Update the values:
+    * Replace `YOUR_LICENSE_KEY_HERE` with your actual New Relic license key
+    * Replace `https://otlp.nr-data.net:4318` with your region's endpoint (refer to [OTLP endpoint documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol))
+    * Replace `100` with your desired memory limit in MiB for the collector
+
+#### Configure Elasticsearch monitoring [#nrdot-helm-configure-es]
+
+Create a `values.yaml` file for NRDOT Collector Elasticsearch monitoring:
+
+```yaml
+mode: deployment
+
+image:
+  repository: newrelic/nrdot-collector
+  tag: latest
+  pullPolicy: IfNotPresent
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+ports: {}
+
+extraEnvs:
+  - name: NEWRELIC_LICENSE_KEY
+    valueFrom:
+      secretKeyRef:
+        name: newrelic-licenses
+        key: NEWRELIC_LICENSE_KEY
+  - name: NEWRELIC_OTLP_ENDPOINT
+    valueFrom:
+      secretKeyRef:
+        name: newrelic-licenses
+        key: NEWRELIC_OTLP_ENDPOINT
+  - name: NEW_RELIC_MEMORY_LIMIT_MIB
+    valueFrom:
+      secretKeyRef:
+        name: newrelic-licenses
+        key: NEW_RELIC_MEMORY_LIMIT_MIB
+  - name: K8S_CLUSTER_NAME
+    value: "elasticsearch-cluster"
+
+clusterRole:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["apps"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
+
+config:
+  extensions:
+    health_check:
+      endpoint: 0.0.0.0:13133
+    k8s_observer:
+      auth_type: serviceAccount
+      observe_pods: true
+      observe_nodes: true
+
+  receivers:
+    jaeger: null
+    zipkin: null
+    prometheus: null
+    otlp: null
+    receiver_creator/elasticsearch:
+      watch_observers: [k8s_observer]
+      receivers:
+        elasticsearch:
+          rule: type == "pod" && labels["app"] == "elasticsearch"
+          config:
+            endpoint: 'http://`endpoint`:9200'
+            collection_interval: 15s
+            metrics:
+              elasticsearch.os.cpu.usage:
+                enabled: true
+              elasticsearch.cluster.data_nodes:
+                enabled: true
+              elasticsearch.cluster.health:
+                enabled: true
+              elasticsearch.cluster.in_flight_fetch:
+                enabled: true
+              elasticsearch.cluster.nodes:
+                enabled: true
+              elasticsearch.cluster.pending_tasks:
+                enabled: true
+              elasticsearch.cluster.shards:
+                enabled: true
+              elasticsearch.cluster.state_update.time:
+                enabled: true
+              elasticsearch.index.documents:
+                enabled: true
+              elasticsearch.index.operations.merge.current:
+                enabled: true
+              elasticsearch.index.operations.time:
+                enabled: true
+              elasticsearch.node.cache.count:
+                enabled: true
+              elasticsearch.node.cache.evictions:
+                enabled: true
+              elasticsearch.node.cache.memory.usage:
+                enabled: true
+              elasticsearch.node.shards.size:
+                enabled: true
+              elasticsearch.node.cluster.io:
+                enabled: true
+              elasticsearch.node.documents:
+                enabled: true
+              elasticsearch.node.disk.io.read:
+                enabled: true
+              elasticsearch.node.disk.io.write:
+                enabled: true
+              elasticsearch.node.fs.disk.available:
+                enabled: true
+              elasticsearch.node.fs.disk.total:
+                enabled: true
+              elasticsearch.node.http.connections:
+                enabled: true
+              elasticsearch.node.ingest.documents.current:
+                enabled: true
+              elasticsearch.node.ingest.operations.failed:
+                enabled: true
+              elasticsearch.node.open_files:
+                enabled: true
+              elasticsearch.node.operations.completed:
+                enabled: true
+              elasticsearch.node.operations.current:
+                enabled: true
+              elasticsearch.node.operations.get.completed:
+                enabled: true
+              elasticsearch.node.operations.time:
+                enabled: true
+              elasticsearch.node.shards.reserved.size:
+                enabled: true
+              elasticsearch.index.shards.size:
+                enabled: true
+              elasticsearch.os.cpu.load_avg.1m:
+                enabled: true
+              elasticsearch.os.cpu.load_avg.5m:
+                enabled: true
+              elasticsearch.os.cpu.load_avg.15m:
+                enabled: true
+              elasticsearch.os.memory:
+                enabled: true
+              jvm.gc.collections.count:
+                enabled: true
+              jvm.gc.collections.elapsed:
+                enabled: true
+              jvm.memory.heap.max:
+                enabled: true
+              jvm.memory.heap.used:
+                enabled: true
+              jvm.memory.heap.utilization:
+                enabled: true
+              jvm.threads.count:
+                enabled: true
+              elasticsearch.index.segments.count:
+                enabled: true
+              elasticsearch.index.operations.completed:
+                enabled: true
+              elasticsearch.node.script.cache_evictions:
+                enabled: false
+              elasticsearch.node.cluster.connections:
+                enabled: false
+              elasticsearch.node.pipeline.ingest.documents.preprocessed:
+                enabled: false
+              elasticsearch.node.thread_pool.tasks.queued:
+                enabled: false
+              elasticsearch.cluster.published_states.full:
+                enabled: false
+              jvm.memory.pool.max:
+                enabled: false
+              elasticsearch.node.script.compilation_limit_triggered:
+                enabled: false
+              elasticsearch.node.shards.data_set.size:
+                enabled: false
+              elasticsearch.node.pipeline.ingest.documents.current:
+                enabled: false
+              elasticsearch.cluster.state_update.count:
+                enabled: false
+              elasticsearch.node.fs.disk.free:
+                enabled: false
+              jvm.memory.nonheap.used:
+                enabled: false
+              jvm.memory.pool.used:
+                enabled: false
+              elasticsearch.node.translog.size:
+                enabled: false
+              elasticsearch.node.thread_pool.threads:
+                enabled: false
+              elasticsearch.cluster.state_queue:
+                enabled: false
+              elasticsearch.node.translog.operations:
+                enabled: false
+              elasticsearch.memory.indexing_pressure:
+                enabled: false
+              elasticsearch.node.ingest.documents:
+                enabled: false
+              jvm.classes.loaded:
+                enabled: false
+              jvm.memory.heap.committed:
+                enabled: false
+              elasticsearch.breaker.memory.limit:
+                enabled: false
+              elasticsearch.indexing_pressure.memory.total.replica_rejections:
+                enabled: false
+              elasticsearch.breaker.memory.estimated:
+                enabled: false
+              elasticsearch.cluster.published_states.differences:
+                enabled: false
+              jvm.memory.nonheap.committed:
+                enabled: false
+              elasticsearch.node.translog.uncommitted.size:
+                enabled: false
+              elasticsearch.node.script.compilations:
+                enabled: false
+              elasticsearch.node.pipeline.ingest.operations.failed:
+                enabled: false
+              elasticsearch.indexing_pressure.memory.limit:
+                enabled: false
+              elasticsearch.breaker.tripped:
+                enabled: false
+              elasticsearch.indexing_pressure.memory.total.primary_rejections:
+                enabled: false
+              elasticsearch.node.thread_pool.tasks.finished:
+                enabled: false
+
+  processors:
+    memory_limiter:
+      check_interval: 60s
+      limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
+    cumulativetodelta: {}
+    attributes/cluster_state_aggregate:
+      include:
+        match_type: strict
+        metric_names:
+          - elasticsearch.cluster.state_update.time
+      actions:
+        - key: type
+          action: delete
+        - key: state
+          action: delete
+    filter/critical_operations:
+      metrics:
+        datapoint:
+          - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+    resource/cluster:
+      attributes:
+        - key: k8s.cluster.name
+          value: "${env:K8S_CLUSTER_NAME}"
+          action: insert
+    resource/cluster_name_override:
+      attributes:
+        - key: elasticsearch.cluster.name
+          value: "${env:K8S_CLUSTER_NAME}"
+          action: upsert
+    resourcedetection:
+      detectors: [env, system]
+      system:
+        resource_attributes:
+          host.name:
+            enabled: true
+          host.id:
+            enabled: true
+          os.type:
+            enabled: true
+    batch:
+      timeout: 30s
+      send_batch_size: 2048
+      send_batch_max_size: 4096
+    attributes/cardinality_reduction:
+      actions:
+        - key: process.pid
+          action: delete
+        - key: process.parent_pid
+          action: delete
+        - key: k8s.pod.uid
+          action: delete
+    transform/metadata_nullify:
+      metric_statements:
+        - context: metric
+          statements:
+            - set(description, "")
+            - set(unit, "")
+
+  exporters:
+    otlp_http:
+      endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
+      headers:
+        api-key: "${env:NEWRELIC_LICENSE_KEY}"
+      compression: gzip
+      timeout: 30s
+      retry_on_failure:
+        enabled: true
+        initial_interval: 5s
+        max_interval: 30s
+        max_elapsed_time: 300s
+
+  service:
+    extensions: [health_check, k8s_observer]
+    pipelines:
+      traces: null
+      logs: null
+      metrics: null
+      metrics/elasticsearch:
+        receivers: [receiver_creator/elasticsearch]
+        processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+        exporters: [otlp_http]
+```
+
+<Callout variant="tip">
+**Customize for your environment:**
+
+**Required changes:**
+* **Pod label rule** - Update `labels["app"] == "elasticsearch"` to match your pod labels
+* **Cluster name** - Replace `elasticsearch-cluster` in `extraEnvs.K8S_CLUSTER_NAME` with your unique cluster name
+
+**Optional changes:**
+* **Port** - Update `9200` if Elasticsearch runs on a different port
+* **Authentication** - Add credentials if secured (see below)
+</Callout>
+
+**For secured Elasticsearch clusters:**
+
+```yaml
+receivers:
+  receiver_creator/elasticsearch:
+    watch_observers: [k8s_observer]
+    receivers:
+      elasticsearch:
+        rule: type == "pod" && labels["app"] == "elasticsearch"
+        config:
+          endpoint: 'https://`endpoint`:9200'
+          username: "your_elasticsearch_username"
+          password: "your_elasticsearch_password"
+          tls:
+            insecure_skip_verify: false
+```
+
+#### Install with Helm [#nrdot-helm-install]
+
+Install the NRDOT Collector using Helm with your `values.yaml` configuration:
+
+```bash
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+helm upgrade --install elasticsearch-nrdot-collector open-telemetry/opentelemetry-collector \
+  --namespace newrelic \
+  --create-namespace \
+  -f values.yaml
+```
+
+  </Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Verify deployment and data collection [#nrdot-verify-deployment]
+
+Verify that the NRDOT collector is running and collecting Elasticsearch data:
+
+1. Check that the collector pods are running:
+
+    ```bash
+    kubectl get pods -n newrelic --watch
+    ```
+
+    **For manifest install:** You should see pods with names like `nr-k8s-otel-collector-deployment-<hash>` in a `Running` state.
+
+    **For Helm install:** You should see pods with names like `elasticsearch-nrdot-collector-<hash>` in a `Running` state.
+
+2. Check the collector logs for any errors:
+
+    **For manifest install:**
+    ```bash
+    kubectl logs -n newrelic -l app.kubernetes.io/name=nr-k8s-otel-collector -f
+    ```
+
+    **For Helm install:**
+    ```bash
+    kubectl logs -n newrelic -l app.kubernetes.io/name=opentelemetry-collector -f
+    ```
+
+    Look for successful connections to Elasticsearch pods and New Relic. If you see errors, refer to the [troubleshooting guide](/docs/opentelemetry/integrations/elasticsearch/troubleshooting).
+
+3. Run an NRQL query in New Relic to confirm data is arriving (replace `elasticsearch-cluster` with your cluster name):
+
+    ```sql
+    FROM Metric
+    SELECT *
+    WHERE metricName LIKE 'elasticsearch.%'
+      AND instrumentation.provider = 'opentelemetry'
+      AND k8s.cluster.name = 'elasticsearch-cluster'
+    SINCE 10 minutes ago
+    ```
+
+</Step>
+
+</Steps>
+
 
     </TabsPageItem>
 
@@ -493,6 +1337,492 @@ Verify that the OpenTelemetry Collector is running and collecting Elasticsearch 
     WHERE metricName LIKE 'elasticsearch.%'
       AND instrumentation.provider = 'opentelemetry'
       AND k8s.cluster.name = 'elasticsearch-cluster'
+    SINCE 10 minutes ago
+    ```
+
+</Step>
+
+</Steps>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="prometheus">
+
+Use this approach if you already have a [Prometheus Elasticsearch exporter](https://github.com/prometheus-community/elasticsearch_exporter) running in your Kubernetes cluster, or if you're migrating from a Prometheus-based monitoring stack.
+
+<Callout variant="tip">
+  **Recommended:** If you don't already have a Prometheus exporter running, use the **NRDOT Collector** or **OTel Collector Contrib** tabs instead. They connect directly to the Elasticsearch API without needing an additional exporter component.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Deploy the Elasticsearch exporter [#deploy-exporter-k8s]
+
+If you don't already have the exporter running, deploy it using Helm:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+helm install elasticsearch-exporter prometheus-community/prometheus-elasticsearch-exporter \
+  --namespace monitoring \
+  --create-namespace \
+  --set es.uri=http://elasticsearch.default.svc.cluster.local:9200
+```
+
+Replace `elasticsearch.default.svc.cluster.local:9200` with your Elasticsearch service address.
+
+Verify the exporter is running:
+
+```bash
+kubectl get pods -n monitoring -l app=prometheus-elasticsearch-exporter
+```
+
+</Step>
+
+<Step>
+
+### Create the credentials Secret [#create-secret-prom-k8s]
+
+```bash
+kubectl create secret generic newrelic-credentials \
+  --namespace monitoring \
+  --from-literal=NEWRELIC_LICENSE_KEY=YOUR_NEWRELIC_LICENSE_KEY \
+  --from-literal=NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318
+```
+
+Replace `YOUR_NEWRELIC_LICENSE_KEY` with your <InlinePopover type="licenseKey"/>.
+
+<Callout variant="tip">
+  For EU accounts, use `NEWRELIC_OTLP_ENDPOINT=https://otlp.eu01.nr-data.net:4318`
+</Callout>
+
+</Step>
+
+<Step>
+
+### Create the collector ConfigMap [#create-configmap-prom-k8s]
+
+Create a ConfigMap with the collector configuration. This works with both **NRDOT** (`newrelic/nrdot-collector`) and **OTel Collector Contrib** (`otel/opentelemetry-collector-contrib`) container images. The configuration scrapes metrics from the Elasticsearch exporter and translates Prometheus metric names to OpenTelemetry-compatible names that power the New Relic Elasticsearch dashboard.
+
+<Collapser id="prometheus-k8s-configmap" title="Full Prometheus receiver ConfigMap">
+
+Save the following as `otel-collector-prometheus-es.yaml` and apply with `kubectl apply -f otel-collector-prometheus-es.yaml`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-prometheus-es
+  namespace: monitoring
+data:
+  config.yaml: |
+    receivers:
+      prometheus/elasticsearch:
+        config:
+          scrape_configs:
+            - job_name: 'elasticsearch'
+              scrape_interval: 15s
+              static_configs:
+                - targets: ['elasticsearch-exporter-prometheus-elasticsearch-exporter.monitoring.svc.cluster.local:9114']
+
+    processors:
+      memory_limiter:
+        check_interval: 60s
+        limit_mib: 100
+
+      metricstransform/prom_to_otel:
+        transforms:
+          - include: ^elasticsearch_cluster_health_number_of_data_nodes$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.data_nodes
+          - include: ^elasticsearch_cluster_health_status$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.health
+            operations:
+              - action: update_label
+                label: color
+                new_label: status
+          - include: ^elasticsearch_cluster_health_number_of_in_flight_fetch$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.in_flight_fetch
+          - include: ^elasticsearch_cluster_health_number_of_nodes$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.nodes
+          - include: ^elasticsearch_cluster_health_number_of_pending_tasks$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.pending_tasks
+          - include: ^elasticsearch_cluster_health_active_shards$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.shards
+            operations:
+              - action: add_label
+                new_label: state
+                new_value: active
+          - include: ^elasticsearch_cluster_health_unassigned_shards$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.cluster.shards
+            operations:
+              - action: add_label
+                new_label: state
+                new_value: unassigned
+          - include: ^elasticsearch_indices_docs$
+            match_type: regexp
+            action: insert
+            new_name: elasticsearch.node.documents
+            operations:
+              - action: add_label
+                new_label: state
+                new_value: active
+          - include: ^elasticsearch_indices_docs$
+            match_type: regexp
+            action: insert
+            new_name: elasticsearch.index.documents
+            operations:
+              - action: add_label
+                new_label: state
+                new_value: active
+              - action: add_label
+                new_label: aggregation
+                new_value: primary_shards
+              - action: add_label
+                new_label: elasticsearch.index.name
+                new_value: _all
+          - include: ^elasticsearch_indices_fielddata_evictions$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.cache.evictions
+            operations:
+              - action: add_label
+                new_label: cache_name
+                new_value: fielddata
+          - include: ^elasticsearch_indices_query_cache_evictions$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.cache.evictions
+            operations:
+              - action: add_label
+                new_label: cache_name
+                new_value: query
+          - include: ^elasticsearch_transport_rx_size_bytes_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.cluster.io
+            operations:
+              - action: add_label
+                new_label: direction
+                new_value: received
+          - include: ^elasticsearch_transport_tx_size_bytes_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.cluster.io
+            operations:
+              - action: add_label
+                new_label: direction
+                new_value: sent
+          - include: ^elasticsearch_filesystem_data_available_bytes$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.fs.disk.available
+          - include: ^elasticsearch_filesystem_data_size_bytes$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.fs.disk.total
+          - include: ^elasticsearch_indices_indexing_index_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.operations.completed
+            operations:
+              - action: add_label
+                new_label: operation
+                new_value: index
+          - include: ^elasticsearch_indices_search_query_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.operations.completed
+            operations:
+              - action: add_label
+                new_label: operation
+                new_value: query
+          - include: ^elasticsearch_indices_get_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.operations.completed
+            operations:
+              - action: add_label
+                new_label: operation
+                new_value: get
+          - include: ^elasticsearch_indices_merges_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.operations.completed
+            operations:
+              - action: add_label
+                new_label: operation
+                new_value: merge
+          - include: ^elasticsearch_indices_indexing_index_time_seconds_total$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.operations.time
+            operations:
+              - action: add_label
+                new_label: operation
+                new_value: index
+              - action: experimental_scale_value
+                experimental_scale: 1000
+          - include: ^elasticsearch_indices_search_query_time_seconds$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.node.operations.time
+            operations:
+              - action: add_label
+                new_label: operation
+                new_value: query
+              - action: experimental_scale_value
+                experimental_scale: 1000
+          - include: ^elasticsearch_os_cpu_percent$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.os.cpu.usage
+          - include: ^elasticsearch_jvm_gc_collection_seconds_count$
+            match_type: regexp
+            action: update
+            new_name: jvm.gc.collections.count
+          - include: ^elasticsearch_jvm_memory_max_bytes$
+            match_type: regexp
+            action: update
+            new_name: jvm.memory.heap.max
+          - include: ^elasticsearch_jvm_memory_used_bytes$
+            match_type: regexp
+            action: update
+            new_name: jvm.memory.heap.used
+          - include: ^elasticsearch_thread_pool_threads_count$
+            match_type: regexp
+            action: update
+            new_name: jvm.threads.count
+            operations:
+              - action: aggregate_labels
+                label_set: [name, cluster]
+                aggregation_type: sum
+          - include: ^elasticsearch_indices_segments_count$
+            match_type: regexp
+            action: update
+            new_name: elasticsearch.index.segments.count
+
+      filter/allowed_metrics:
+        metrics:
+          include:
+            match_type: strict
+            metric_names:
+              - elasticsearch.cluster.data_nodes
+              - elasticsearch.cluster.health
+              - elasticsearch.cluster.in_flight_fetch
+              - elasticsearch.cluster.nodes
+              - elasticsearch.cluster.pending_tasks
+              - elasticsearch.cluster.shards
+              - elasticsearch.index.documents
+              - elasticsearch.index.segments.count
+              - elasticsearch.node.cache.evictions
+              - elasticsearch.node.cluster.io
+              - elasticsearch.node.documents
+              - elasticsearch.node.fs.disk.available
+              - elasticsearch.node.fs.disk.total
+              - elasticsearch.node.operations.completed
+              - elasticsearch.node.operations.time
+              - elasticsearch.os.cpu.usage
+              - jvm.gc.collections.count
+              - jvm.memory.heap.max
+              - jvm.memory.heap.used
+              - jvm.threads.count
+
+      transform/rename_node_name:
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["elasticsearch.node.name"], attributes["name"]) where attributes["name"] != nil
+              - delete_key(attributes, "name") where attributes["elasticsearch.node.name"] != nil
+
+      groupbyattrs/node:
+        keys:
+          - elasticsearch.node.name
+          - elasticsearch.cluster.name
+
+      cumulativetodelta: {}
+
+      resource/cluster_name_override:
+        attributes:
+          - key: elasticsearch.cluster.name
+            value: "<elasticsearch-cluster-name>"
+            action: upsert
+
+      transform/scope_override:
+        metric_statements:
+          - context: scope
+            statements:
+              - set(name, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver")
+              - set(version, "")
+
+      resourcedetection:
+        detectors: [env]
+        env:
+          resource_attributes:
+            host.name:
+              enabled: true
+
+      batch:
+        timeout: 30s
+        send_batch_size: 2048
+        send_batch_max_size: 4096
+
+      attributes/cardinality_reduction:
+        actions:
+          - key: process.pid
+            action: delete
+          - key: process.parent_pid
+            action: delete
+
+      transform/metadata_nullify:
+        metric_statements:
+          - context: metric
+            statements:
+              - set(description, "")
+              - set(unit, "")
+
+    exporters:
+      otlphttp:
+        endpoint: ${env:NEWRELIC_OTLP_ENDPOINT}
+        headers:
+          api-key: ${env:NEWRELIC_LICENSE_KEY}
+        compression: gzip
+        timeout: 30s
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_interval: 30s
+          max_elapsed_time: 300s
+
+    service:
+      pipelines:
+        metrics/elasticsearch:
+          receivers: [prometheus/elasticsearch]
+          processors:
+            - memory_limiter
+            - metricstransform/prom_to_otel
+            - filter/allowed_metrics
+            - transform/rename_node_name
+            - groupbyattrs/node
+            - transform/scope_override
+            - resourcedetection
+            - resource/cluster_name_override
+            - attributes/cardinality_reduction
+            - cumulativetodelta
+            - transform/metadata_nullify
+            - batch
+          exporters: [otlphttp]
+```
+
+</Collapser>
+
+Replace the following values in the configuration:
+
+* `<elasticsearch-cluster-name>`: Your Elasticsearch cluster name
+* `elasticsearch-exporter-prometheus-elasticsearch-exporter.monitoring.svc.cluster.local:9114`: Your exporter's Kubernetes service address
+
+</Step>
+
+<Step>
+
+### Deploy the collector [#deploy-collector-prom-k8s]
+
+Deploy the collector using either the NRDOT or OTel Collector Contrib image. Update the `image` field below based on your choice:
+* **NRDOT:** `newrelic/nrdot-collector:latest`
+* **OTel Collector Contrib:** `otel/opentelemetry-collector-contrib:latest`
+
+Save the following as `otel-collector-deployment.yaml` and apply with `kubectl apply -f otel-collector-deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector-elasticsearch
+  namespace: monitoring
+  labels:
+    app: otel-collector-elasticsearch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector-elasticsearch
+  template:
+    metadata:
+      labels:
+        app: otel-collector-elasticsearch
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:latest
+          args:
+            - "--config=/etc/otel/config.yaml"
+          env:
+            - name: NEWRELIC_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: newrelic-credentials
+                  key: NEWRELIC_LICENSE_KEY
+            - name: NEWRELIC_OTLP_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: newrelic-credentials
+                  key: NEWRELIC_OTLP_ENDPOINT
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-prometheus-es
+```
+
+</Step>
+
+<Step>
+
+### Verify the deployment [#verify-prom-k8s]
+
+1. Check the collector pod is running:
+
+    ```bash
+    kubectl get pods -n monitoring -l app=otel-collector-elasticsearch
+    ```
+
+2. Check collector logs:
+
+    ```bash
+    kubectl logs -n monitoring -l app=otel-collector-elasticsearch -f
+    ```
+
+3. Verify data in New Relic:
+
+    ```sql
+    FROM Metric SELECT count(*)
+    WHERE metricName LIKE 'elasticsearch.%'
+    AND elasticsearch.cluster.name = '<elasticsearch-cluster-name>'
     SINCE 10 minutes ago
     ```
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

What problems does this PR solve?                                     
                                                                          
  Adds a third installation option (Prometheus Receiver) to the           
  Elasticsearch OpenTelemetry integration documentation for both
  self-hosted and Kubernetes environments. This provides customers who
  already have a Prometheus elasticsearch_exporter running in their
  environment with a supported migration path to New Relic using
  OpenTelemetry, without needing to change their existing metric
  collection infrastructure.

  Changes:
  - Added "Prometheus Receiver" as a 3rd tab in
  elasticsearch-otel-integration-install.mdx (self-hosted)
  - Added "Prometheus Receiver" as a 3rd tab in
  elasticsearch-otel-integration-k8-install.mdx (Kubernetes)
  - Added full NRDOT Collector tab implementation (replacing "coming soon"
   placeholder) in both pages
  - Updated intro text to reference three collector options

  Context:
  - The Prometheus receiver config includes a metricstransform processor
  that translates Prometheus exporter metric names to OTel-compatible
  names, enabling the existing New Relic Elasticsearch dashboard to work
  with both native and Prometheus-based data sources
  - The config works with both NRDOT and OTel Collector Contrib
  distributions
  - Self-hosted uses systemd service management; K8s uses ConfigMap +
  Deployment manifests

  Testing:
  - Validated Prometheus receiver config against a live Elasticsearch
  cluster with elasticsearch_exporter v1.8.0
  - Metrics successfully appear in New Relic with correct names and
  attributes
  - Dashboard widgets populate correctly with translated metrics