### PR TITLE
Update domain validation docs: real TLD detection replaces structural regex

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -288,7 +288,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No bare domain names
+        No real domain names (for example, `evil.com`, `phish.co.uk`)
       </td>
 
       <td>
@@ -296,7 +296,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
       </td>
 
       <td>
-        Allowed
+        Blocked
       </td>
     </tr>
 
@@ -359,7 +359,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 </table>
 
 <Callout variant="tip">
-  Names with hyphens, apostrophes, accented characters (like ñ or ü), periods, spaces, and non-Latin scripts are all valid.
+  Names with hyphens, apostrophes, accented characters (like ñ or ü), periods, spaces, and non-Latin scripts are all valid. Dot-separated names such as `firstname.lastname` are allowed because the domain check only blocks strings ending in a registered top-level domain (like `.com`, `.net`, or `.co.uk`).
 </Callout>
 
 These rules apply across the UI, [SCIM API](/docs/accounts/accounts/automated-user-management/scim-support-automated-user-management), and [NerdGraph API](/docs/apis/nerdgraph/examples/nerdgraph-manage-users). Validation runs when a user is created or when a name field is updated. Existing users with non-conforming data are not affected unless they update the validated field.


### PR DESCRIPTION
## Summary

Updates the name field validation documentation to reflect an improvement to domain detection:

- The domain check now uses [Mozilla's Public Suffix List](https://publicsuffix.org/) to identify **real** top-level domains, rather than blocking any dot-separated string that structurally resembles a domain.
- The domain check now applies uniformly to `name`, `given_name`, and `family_name` (previously `given_name`/`family_name` skipped this check entirely).
- Dot-separated names like `firstname.lastname` are explicitly called out as allowed.

<img width="1285" height="808" alt="image" src="https://github.com/user-attachments/assets/d77a4d43-dd17-4a33-a4fc-caa31569727f" />


## Context

The previous regex-based approach blocked legitimate non-English names that use dots for clarity (e.g., Japanese romanized names). This caused provisioning failures for real users. The improved detection only blocks strings ending in registered TLDs (`.com`, `.net`, `.co.uk`, `.app`, etc.), eliminating false positives on surnames.

Related: user-service PR [#1385](https://source.datanerd.us/account-auth-and-access/user-service/pull/1385)

## Changes

- `user-management-ui-and-tasks.mdx`: Updated "No bare domain names" row to "No real domain names" with examples, changed `given_name`/`family_name` column from "Allowed" to "Blocked", expanded the tip callout to explain that dot-separated names are valid when the suffix is not a real TLD.