### PR TITLE
docs: add release notes for Pipeline Control Gateway v2.4.1

### DIFF
--- a/src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-13.mdx
+++ b/src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-13.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Pipeline Control gateway
+subject: Pipeline Control Gateway
 releaseDate: '2026-05-13'
 version: 2.2.0
 metaDescription: Release notes for Pipeline Control gateway 2.2.0

--- a/src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-29.mdx
+++ b/src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-29.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Pipeline Control gateway
+subject: Pipeline Control Gateway
 releaseDate: '2026-05-29'
 version: 2.4.1
 metaDescription: Release notes for Pipeline Control gateway 2.4.1
@@ -7,13 +7,13 @@ metaDescription: Release notes for Pipeline Control gateway 2.4.1
 
 ## Configuration-only mode (without Flux)
 
-- You can now install and operate Pipeline Control gateway without requiring Flux controllers in your cluster. In this mode, New Relic continues to manage your pipeline configuration (sampling, filtering, transforms) automatically through the UI, while you manage gateway infrastructure (scaling, versions) manually via Helm.
-- This reduces the permissions footprint from cluster-admin to namespace-scoped ConfigMap access only, making it suitable for security-restricted and compliance-driven environments.
-- A built-in config-watcher sidecar automatically detects configuration changes pushed from the UI and restarts gateway pods — no external operators (such as Stakater Reloader) required.
-- For installation instructions, refer to [Install gateway without Flux](/docs/new-relic-control/pipeline-control/gateway/install-gateway-without-flux/).
+* You can now install and operate Pipeline Control gateway without requiring Flux controllers in your cluster. In this mode, New Relic continues to manage your pipeline configuration (sampling, filtering, transforms) automatically through the UI, while you manage gateway infrastructure (scaling, versions) manually via Helm.
+* This reduces the permissions footprint from cluster-admin to namespace-scoped ConfigMap access only, making it suitable for security-restricted and compliance-driven environments.
+* A built-in config-watcher sidecar automatically detects configuration changes pushed from the UI and restarts gateway pods — no external operators (such as Stakater Reloader) required.
+* For installation instructions, refer to [Install gateway without Flux](/docs/new-relic-control/pipeline-control/gateway/install-gateway-without-flux/).
 
 ## DaemonSet deployment mode
 
-- Added support for deploying the gateway as a Kubernetes DaemonSet (one pod per node) instead of a Deployment with HPA. This is useful for environments that require node-level telemetry processing or consistent per-node resource allocation.
-- Enable DaemonSet mode by setting `daemonset.enabled: true` in your Helm values. The DaemonSet mode also supports the config-watcher sidecar and `customConfigMap` for configuration-only installations.
-- DaemonSet and Deployment modes are mutually exclusive — the chart uses conditional guards to ensure only one mode is active at a time.
+* Added support for deploying the gateway as a Kubernetes DaemonSet (one pod per node) instead of a Deployment with HPA. This is useful for environments that require node-level telemetry processing or consistent per-node resource allocation.
+* Enable DaemonSet mode by setting `daemonset.enabled: true` in your Helm values. The DaemonSet mode also supports the config-watcher sidecar and `customConfigMap` for configuration-only installations.
+* DaemonSet and Deployment modes are mutually exclusive — the chart uses conditional guards to ensure only one mode is active at a time.

--- a/src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-29.mdx
+++ b/src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-29.mdx
@@ -1,0 +1,19 @@
+---
+subject: Pipeline Control gateway
+releaseDate: '2026-05-29'
+version: 2.4.1
+metaDescription: Release notes for Pipeline Control gateway 2.4.1
+---
+
+## Configuration-only mode (without Flux)
+
+- You can now install and operate Pipeline Control gateway without requiring Flux controllers in your cluster. In this mode, New Relic continues to manage your pipeline configuration (sampling, filtering, transforms) automatically through the UI, while you manage gateway infrastructure (scaling, versions) manually via Helm.
+- This reduces the permissions footprint from cluster-admin to namespace-scoped ConfigMap access only, making it suitable for security-restricted and compliance-driven environments.
+- A built-in config-watcher sidecar automatically detects configuration changes pushed from the UI and restarts gateway pods — no external operators (such as Stakater Reloader) required.
+- For installation instructions, refer to [Install gateway without Flux](/docs/new-relic-control/pipeline-control/gateway/install-gateway-without-flux/).
+
+## DaemonSet deployment mode
+
+- Added support for deploying the gateway as a Kubernetes DaemonSet (one pod per node) instead of a Deployment with HPA. This is useful for environments that require node-level telemetry processing or consistent per-node resource allocation.
+- Enable DaemonSet mode by setting `daemonset.enabled: true` in your Helm values. The DaemonSet mode also supports the config-watcher sidecar and `customConfigMap` for configuration-only installations.
+- DaemonSet and Deployment modes are mutually exclusive — the chart uses conditional guards to ensure only one mode is active at a time.


### PR DESCRIPTION
## Summary

- Added release notes for Pipeline Control Gateway v2.4.1
- Two new features documented:
  - **Configuration-only mode (without Flux)** — install and operate PCG without Flux controllers
  - **DaemonSet deployment mode** — deploy gateway as DaemonSet (one pod per node)

## File added

- `src/content/docs/release-notes/pipeline-control-gateway-release-notes/pipeline-control-gateway-26-05-29.mdx`
