### PR TITLE
Update SAI permissions docs: Catalogs and Maps require no extra roles

### DIFF
--- a/src/content/docs/service-architecture-intelligence/catalogs/applications-catalog.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/applications-catalog.mdx
@@ -91,7 +91,7 @@ The <DNT>Applications</DNT> catalog page has multiple columns that display vario
         </tr>
         <tr>
             <td><DNT>Last reporting</DNT></td>
-            <td>The last time an entity reported data to New Relic. Users can use this information for detection of failures, freshness, and data reliability.</td>
+            <td>The last time an entity reported data to New Relic. Users can use this information to detect failures, monitor freshness, and ensure data reliability.</td>
         </tr>
         <tr>
             <td><DNT>Repositories</DNT></td>

--- a/src/content/docs/service-architecture-intelligence/catalogs/applications-catalog.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/applications-catalog.mdx
@@ -90,6 +90,10 @@ The <DNT>Applications</DNT> catalog page has multiple columns that display vario
             <td>The date and time of the last deployment. Click the link to view details of the change and its impact. For more information, see [Change tracking](/docs/change-tracking/change-tracking-introduction/).</td>
         </tr>
         <tr>
+            <td><DNT>Last reporting</DNT></td>
+            <td>The last time an entity reported data to New Relic. Users can use this information for detection of failures, freshness, and data reliability.</td>
+        </tr>
+        <tr>
             <td><DNT>Repositories</DNT></td>
             <td>The number of repositories associated with the entity. Hover the mouse over the number to see a list of related repositories. You can click links in the pop-up to navigate to those repositories, or click <DNT>**See in Repositories catalog**</DNT> to navigate to the corresponding catalog and view additional details about them.</td>
         </tr>

--- a/src/content/docs/service-architecture-intelligence/catalogs/catalogs.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/catalogs.mdx
@@ -43,22 +43,7 @@ Catalogs is available for all [<DNT>Full platform users</DNT>](/docs/accounts/ac
 
 ### Roles and permissions [#roles-permissions]
 
-Catalogs is a read-only experience. The following role is required to view catalog entries.
-
-<table>
-  <thead>
-    <tr>
-      <th>Action</th>
-      <th>Required role</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>View catalog entries</td>
-      <td>[<DNT>**Organization read only**</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#standard-roles)</td>
-    </tr>
-  </tbody>
-</table>
+Catalogs is a read-only experience. All [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) can access Catalogs without needing any additional roles.
 
 <Callout variant="important">
 There are no create, update, or delete operations available within Catalogs. For more information on the overall SAI role model, see [SAI Getting Started](/docs/service-architecture-intelligence/getting-started/#roles-permissions).

--- a/src/content/docs/service-architecture-intelligence/catalogs/repository-catalog.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/repository-catalog.mdx
@@ -116,7 +116,7 @@ The <DNT>Repository catalog</DNT> displays all linked repositories and related i
 
 ### Add new data [#add-new-data]
 
-To add additional data to your <DNT>Repository catalog</DNT>, click the <DNT>**+ Add GitHub repositories**</DNT> button at the top right. Follow the on-screen instructions to add data to your repositories. For additional information on adding repositories, see [GitHub integration](/docs/service-architecture-intelligence/github-integration).
+To add additional data to your <DNT>Repository catalog</DNT>, click the <DNT>**+ Add GitHub repositories**</DNT> button at the top right. Follow the on-screen instructions to add data to your repositories. For additional information on adding repositories, see [GitHub Cloud integration](/docs/service-architecture-intelligence/github-integrations/github-cloud-integration) and [GitHub Enterprise integration](/docs/service-architecture-intelligence/github-integrations/github-enterprise-integration).
 
 
 ### Limitation [#limitations]

--- a/src/content/docs/service-architecture-intelligence/catalogs/repository-catalog.mdx
+++ b/src/content/docs/service-architecture-intelligence/catalogs/repository-catalog.mdx
@@ -116,7 +116,7 @@ The <DNT>Repository catalog</DNT> displays all linked repositories and related i
 
 ### Add new data [#add-new-data]
 
-To add additional data to your <DNT>Repository catalog</DNT>, click the <DNT>**+ Add GitHub repositories**</DNT> button at the top right. Follow the on-screen instructions to add data to your repositories. For additional information on adding repositories, see [GitHub Cloud integration](/docs/service-architecture-intelligence/github-integrations/github-cloud-integration) and [GitHub Enterprise integration](/docs/service-architecture-intelligence/github-integrations/github-enterprise-integration).
+To add additional data to your <DNT>Repository catalog</DNT>, click the <DNT>**+ Add GitHub repositories**</DNT> button at the top right. Follow the on-screen instructions to add data to your repositories. For additional information on adding repositories, Refer to [GitHub Cloud integration](/docs/service-architecture-intelligence/github-integrations/github-cloud-integration) and [GitHub Enterprise integration](/docs/service-architecture-intelligence/github-integrations/github-enterprise-integration).
 
 
 ### Limitation [#limitations]

--- a/src/content/docs/service-architecture-intelligence/getting-started.mdx
+++ b/src/content/docs/service-architecture-intelligence/getting-started.mdx
@@ -30,7 +30,9 @@ The Service Architecture Intelligence offers the following capabilities:
 
 ## User roles and permissions [#roles-permissions]
 
-While [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) get access to Catalogs and Maps automatically with no extra configuration required, the remaining SAI capabilities (Teams, Scorecards, and GitHub integration) require the appropriate organization-level roles. These products require at minimum the [<DNT>**Organization read only**</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#standard-roles) role (organization-scoped) for read access, and write access (create, update, delete) varies by product.
+[<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) automatically access Catalogs and Maps with no extra permissions. Other SAI capabilities (Teams, Scorecards, and GitHub integration) require specific organization-level roles as following:
+
+
 
 <table>
   <thead>

--- a/src/content/docs/service-architecture-intelligence/getting-started.mdx
+++ b/src/content/docs/service-architecture-intelligence/getting-started.mdx
@@ -30,28 +30,31 @@ The Service Architecture Intelligence offers the following capabilities:
 
 ## User roles and permissions [#roles-permissions]
 
-To access SAI features, users must have the appropriate organization-level roles. All SAI products require at minimum the [<DNT>**Organization read only**</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#standard-roles) role (organization-scoped) for read access.
-
-Write access (create, update, delete) is available for <DNT>**Teams**</DNT>, <DNT>**Scorecards**</DNT>, and <DNT>**GitHub integration**</DNT>. See the individual product pages below for specific role requirements.
+While [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) get access to Catalogs and Maps automatically with no extra configuration required, the remaining SAI capabilities (Teams, Scorecards, and GitHub integration) require the appropriate organization-level roles. These products require at minimum the [<DNT>**Organization read only**</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#standard-roles) role (organization-scoped) for read access, and write access (create, update, delete) varies by product.
 
 <table>
   <thead>
     <tr>
+      <th>Products</th>
       <th>Access level</th>
       <th>Required role</th>
-      <th>Applies to</th>
     </tr>
   </thead>
   <tbody>
     <tr>
+      <td>Catalogs, Maps</td>
       <td>Read (view)</td>
-      <td>Organization read only</td>
-      <td>All SAI products</td>
+      <td>None</td>
     </tr>
     <tr>
+      <td>Teams, Scorecards, GitHub integration</td>
+      <td>Read (view)</td>
+      <td>Organization read only</td>
+    </tr>
+    <tr>
+      <td>Teams, Scorecards, GitHub integration</td>
       <td>Write (create, update, delete)</td>
       <td>Varies by product</td>
-      <td>Teams, Scorecards, GitHub integration</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
+++ b/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
@@ -115,7 +115,7 @@ You can access Maps from various New Relic capabilities. Some capabilities provi
 Maps is a read-only experience. All [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) can access Maps without needing any additional roles.
 
 <Callout variant="important">
-There are no create, update, or delete operations available within Maps. For more information on the overall SAI role model, see [SAI Getting Started](/docs/service-architecture-intelligence/getting-started/#roles-permissions).
+There are no create, update, or delete operations available within Maps. For more information on the overall SAI role model, refer to [SAI Getting Started](/docs/service-architecture-intelligence/getting-started/#roles-permissions).
 </Callout>
 
 ## Map components [#map-components]

--- a/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
+++ b/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
@@ -112,7 +112,7 @@ You can access Maps from various New Relic capabilities. Some capabilities provi
 
 ## Roles and permissions [#roles-permissions]
 
-Maps is a read-only experience. All [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) can access Maps without needing any additional roles.
+Maps is a read-only experience. All [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) can access Maps without any additional roles.
 
 <Callout variant="important">
 There are no create, update, or delete operations available within Maps. For more information on the overall SAI role model, refer to [SAI Getting Started](/docs/service-architecture-intelligence/getting-started/#roles-permissions).

--- a/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
+++ b/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
@@ -73,25 +73,46 @@ freshnessValidatedDate: never
 
 If you're a <DNT>Full platform user</DNT> and want to switch back to the old maps experience, click <DNT>**Switch back for now**</DNT> from the map view.
 
+### Maps access across capabilities [#maps-access-capabilities]
 
-## Roles and permissions [#roles-permissions]
-
-Maps is a read-only experience. The following role is required to view maps.
+You can access Maps from various New Relic capabilities. Some capabilities provide Maps access by default, while others require enabling additional features through the [Feature Control Manager](/docs/accounts/accounts-billing/new-relic-one-user-management/feature-control-manager).
 
 <table>
   <thead>
     <tr>
-      <th>Action</th>
-      <th>Required role</th>
+      <th>Capability</th>
+      <th>Pricing model</th>
+      <th>How to enable</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>View maps</td>
-      <td>[<DNT>**Organization read only**</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#standard-roles)</td>
+      <td>[APM](/docs/apm/new-relic-apm/getting-started/introduction-apm), [Mobile](/docs/mobile-monitoring/new-relic-mobile/getting-started/introduction-new-relic-mobile), [Browser](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring), [Infrastructure](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring), [Workloads](/docs/new-relic-solutions/new-relic-one/workloads/workloads-overview), [Alerts](/docs/alerts/overview), [Catalogs](/docs/service-architecture-intelligence/catalogs/catalogs), [Teams](/docs/service-architecture-intelligence/teams/teams)</td>
+      <td>CCU (Core)</td>
+      <td>Available by default</td>
+    </tr>
+    <tr>
+      <td>[Distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing) (Entity Map)</td>
+      <td>CCU (Core)</td>
+      <td>Available by default</td>
+    </tr>
+    <tr>
+      <td>[Distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing) ([Dynamic Flow Map](/docs/service-architecture-intelligence/maps/dynamic-flow-map))</td>
+      <td>aCCU</td>
+      <td>Enable Transaction360 via [Feature Control Manager](/docs/accounts/accounts-billing/new-relic-one-user-management/feature-control-manager)</td>
+    </tr>
+    <tr>
+      <td>[Transaction360](/docs/apm/transactions/workload-performance-monitoring/transaction-workloads) ([Dynamic Flow Map](/docs/service-architecture-intelligence/maps/dynamic-flow-map))</td>
+      <td>aCCU</td>
+      <td>Enable Transaction360 via [Feature Control Manager](/docs/accounts/accounts-billing/new-relic-one-user-management/feature-control-manager)</td>
     </tr>
   </tbody>
 </table>
+
+
+## Roles and permissions [#roles-permissions]
+
+Maps is a read-only experience. All [<DNT>Full platform users</DNT>](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities) can access Maps without needing any additional roles.
 
 <Callout variant="important">
 There are no create, update, or delete operations available within Maps. For more information on the overall SAI role model, see [SAI Getting Started](/docs/service-architecture-intelligence/getting-started/#roles-permissions).

--- a/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
+++ b/src/content/docs/service-architecture-intelligence/maps/advanced-maps.mdx
@@ -87,7 +87,7 @@ You can access Maps from various New Relic capabilities. Some capabilities provi
   </thead>
   <tbody>
     <tr>
-      <td>[APM](/docs/apm/new-relic-apm/getting-started/introduction-apm), [Mobile](/docs/mobile-monitoring/new-relic-mobile/getting-started/introduction-new-relic-mobile), [Browser](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring), [Infrastructure](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring), [Workloads](/docs/new-relic-solutions/new-relic-one/workloads/workloads-overview), [Alerts](/docs/alerts/overview), [Catalogs](/docs/service-architecture-intelligence/catalogs/catalogs), [Teams](/docs/service-architecture-intelligence/teams/teams)</td>
+      <td>[APM](/docs/apm/new-relic-apm/getting-started/introduction-apm), [Mobile monitoring](/docs/mobile-monitoring/new-relic-mobile/getting-started/introduction-new-relic-mobile), [Browser monitoring](/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring), [Infrastructure monitoring](/docs/infrastructure/infrastructure-monitoring/get-started/get-started-infrastructure-monitoring), [Workloads](/docs/new-relic-solutions/new-relic-one/workloads/workloads-overview), [Alerts](/docs/alerts/overview), [Catalogs](/docs/service-architecture-intelligence/catalogs/catalogs), [Teams](/docs/service-architecture-intelligence/teams/teams)</td>
       <td>CCU (Core)</td>
       <td>Available by default</td>
     </tr>


### PR DESCRIPTION
## Summary
- Update getting-started page to clarify Full Platform users get automatic access to Catalogs and Maps, while Teams/Scorecards/GitHub integration require organization-level roles
- Simplify Catalogs and Maps roles-permissions sections to reflect no additional roles needed for Full Platform users
- Add Maps access table showing capability entry points, pricing models, and Feature Control Manager requirements with proper hyperlinks
- Add "Last reporting" column to Applications catalog documentation
- Fix broken GitHub integration link in Repository catalog to point to both GitHub Cloud and GitHub Enterprise integration pages


🤖 Generated with [Claude Code](https://claude.com/claude-code)