### PR TITLE
docs(lens): add nrlens- prefix requirement for AWS connectors

### DIFF
--- a/src/content/docs/new-relic-lens/set-up-connectors.mdx
+++ b/src/content/docs/new-relic-lens/set-up-connectors.mdx
@@ -80,7 +80,7 @@ To set up a <DNT>data connector</DNT>:
 5. To grant this connector access to users or groups who don't have RBAC permissions, configure fine-grained access control from the <DNT>**Access control**</DNT> section:
    1. Select the <DNT>**Auth domain**</DNT> containing the users or groups.
    2. Select the <DNT>**User or group**</DNT>.
-   3. Select the<DNT>**Lens Viewer**</DNT>role.
+   3. Select the <DNT>**Lens Viewer**</DNT> role.
    4. To add more users or groups, click <DNT>**Add**</DNT> and repeat the steps above.
 
 6. Click <DNT>**Create**</DNT>.
@@ -203,8 +203,8 @@ Select your <DNT>connector</DNT> type to view the required fields.
       <tbody>
         <tr>
           <td>**Name**</td>
-          <td>A unique name to identify this <DNT>connector</DNT> when writing queries.</td>
-          <td>`CostDB`, `Customermetadata`</td>
+          <td>A unique name to identify this <DNT>connector</DNT> when writing queries. The name must start with `nrlens-`.</td>
+          <td>`nrlens-CostDB`, `nrlens-Customermetadata`</td>
         </tr>
         <tr>
           <td>**aws_region**</td>
@@ -636,8 +636,8 @@ Select your <DNT>connector</DNT> type to view the required fields.
       <tbody>
         <tr>
           <td>**Name**</td>
-          <td>A unique name to identify this <DNT>connector</DNT> when writing queries.</td>
-          <td>`cloudwatch-metrics`</td>
+          <td>A unique name to identify this <DNT>connector</DNT> when writing queries. The name must start with `nrlens-`.</td>
+          <td>`nrlens-cloudwatch-metrics`</td>
         </tr>
         <tr>
           <td>**aws_region**</td>


### PR DESCRIPTION
## Summary
- Updated Iceberg connector documentation to specify that catalog names must start with `nrlens-` prefix
- Updated AWS CloudWatch connector documentation to specify that catalog names must start with `nrlens-` prefix
- Fixed spacing issue in access control instructions

Resolves https://new-relic.atlassian.net/browse/NR-561563

🤖 Generated with [Claude Code](https://claude.com/claude-code)