### PR TITLE
[chore] Fix table language and remove example domain names in user management doc

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -344,7 +344,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        Equals sign (`=`)
+        Equal sign (`=`)
       </td>
 
       <td>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks.mdx
@@ -260,7 +260,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No URLs
+        URLs
       </td>
 
       <td>
@@ -274,7 +274,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No email addresses
+        Email addresses
       </td>
 
       <td>
@@ -288,7 +288,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No real domain names (for example, `evil.com`, `phish.co.uk`)
+        Domain names
       </td>
 
       <td>
@@ -302,7 +302,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No emoji
+        Emoji
       </td>
 
       <td>
@@ -316,7 +316,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No control characters
+        Control characters
       </td>
 
       <td>
@@ -330,7 +330,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No invisible Unicode
+        Invisible Unicode
       </td>
 
       <td>
@@ -344,7 +344,7 @@ When creating or updating a user, the `name`, `given_name`, and `family_name` fi
 
     <tr>
       <td>
-        No equals sign (`=`)
+        Equals sign (`=`)
       </td>
 
       <td>


### PR DESCRIPTION
## Summary
- Remove example domain names (`evil.com`, `phish.co.uk`) from name field requirements table
- Fix double-negative language in table rows (e.g., "No URLs - Blocked" → "URLs - Blocked") for clearer communication

## Test plan
- [ ] Verify the table renders correctly on the docs site
- [ ] Confirm the language is now clear and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)