### PR TITLE
Add documentation release notes for May 25 - May 29, 2026

### DIFF
--- a/src/content/docs/release-notes/docs-release-notes/docs-5-29-2026.mdx
+++ b/src/content/docs/release-notes/docs-release-notes/docs-5-29-2026.mdx
@@ -1,0 +1,82 @@
+---
+subject: "Docs"
+releaseDate: '2026-05-29'
+version: 'May 25 - May 29, 2026'
+---
+
+### New docs
+
+* Added [eBPF attributes reference](/docs/ebpf/attributes-reference) to provide comprehensive documentation for all attributes collected by the New Relic eBPF agent.
+* Added [Install gateway without Flux](/docs/new-relic-control/pipeline-control/gateway/install-gateway-without-flux) to provide guidance for deploying the Pipeline Control Gateway without full automation, allowing users to manage gateway infrastructure using Kubernetes tools while still using the UI for pipeline configuration.
+
+
+### Major changes
+
+* Updated [Pipeline Control Gateway documentation](/docs/new-relic-control/pipeline-control/gateway/overview) with Fluxless installation mode support and improved configuration guidance.
+* Updated [Agent Control setup](/docs/new-relic-control/agent-control/setup) documentation with Fluxless installation instructions for deploying Agent Control without Flux CD dependency.
+* Updated [ECS EC2 monitoring](/docs/opentelemetry/integrations/ecs-monitoring/ecs-ec2) and [ECS Fargate monitoring](/docs/opentelemetry/integrations/ecs-monitoring/ecs-fargate) documentation with enhanced OpenTelemetry configuration examples and deployment options.
+* Updated MySQL and MariaDB integration install wizard with MariaDB compatibility updates, new configuration options, and improved query performance metrics guidance.
+
+
+### Minor changes
+
+* Updated [Browser API interaction](/docs/browser/new-relic-browser/browser-apis/interaction) documentation with new options and detailed return value descriptions for SPA interaction tracking.
+* Updated [Node.js VM measurements](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-vm-measurements) documentation to clarify differences between default and native samplers.
+* Updated [User management UI and tasks](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks) with name field validation requirements for user names.
+* Updated [Knowledge integration overview](/docs/agentic-ai/knowledge-integration/overview) to improve navigation and clarify knowledge base integration features.
+* Updated [Install Node.js agent](/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent) documentation with simplified installation instructions.
+* Updated [OpenTelemetry APM UI](/docs/opentelemetry/get-started/apm-monitoring/opentelemetry-apm-ui) with `OtelMessagingConsumer1_24` fallback behavior when `messaging.operation` is `NULL`.
+* Removed deprecated RDS instance logs support from [AWS logs in context](/docs/logs/logs-context/aws-logs-in-context).
+
+
+### Release notes
+
+* Stay up-to-date with our latest releases:
+
+  * [Java agent v9.3.0](/docs/release-notes/agent-release-notes/java-release-notes/java-agent-930):
+    * Added support for AI Model Context Protocol (MCP) 1.0.0 and above.
+    * Added instrumentation for Spring AI completion and embedding clients for versions 1.0.0 and up.
+    * Added support for Apache Camel 3.9.0+, Kafka Clients 4.0.0+, and Micronaut Http Clients 3.5.0+.
+    * Added AWS DAX support starting from 2.0.0 to latest.
+    * Added Solr 9 JMX module and JDBC batch operations support.
+    * Fixed coroutines instrumentation with improved async behavior tracking.
+    * Resolved Mule 4.9 IllegalAccessError.
+
+  * [iOS agent v7.7.2](/docs/release-notes/mobile-release-notes/ios-release-notes/ios-agent-772):
+    * Fixed hasReplay getting added to errorMode before fullMode.
+    * Added UIColor safety to MSR to resolve reported crash.
+    * Fixed multiple crash issues in NRMAHarvester, hex library, NRMAMethodProfiler, and HexStore.
+
+  * [Flutter agent v1.2.6](/docs/release-notes/mobile-release-notes/flutter-release-notes/flutter-agent-126):
+    * Updated native iOS agent to version 7.7.2.
+    * Added support for Swift Package Manager.
+
+  * [Browser agent v1.315.0](/docs/release-notes/new-relic-browser-release-notes/browser-agent-release-notes/browser-agent-v1.315.0):
+    * Enhanced SPA API to support targetPageLoad option for binding interactions to the initial page load event.
+
+  * [Infrastructure agent v1.76.0](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1760):
+    * Added support for Unicode.Encoding option for tail input plugin for fluent-bit.
+    * Added support for JP region endpoints.
+
+  * [Infrastructure agent v1.76.1](/docs/release-notes/agent-release-notes/infrastructure-release-notes/infrastructure-agent-1-76-1):
+    * Fixed set-service-account for local users.
+    * Bumped containerd version to 1.7.32.
+    * Bumped nri-flex version to 1.18.4.
+
+  * [Job Manager release 539](/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-539):
+    * Fixed underlying OS vulnerabilities including multiple CVEs.
+
+  * [Ping runtime v1.69.0](/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.69.0):
+    * Fixed underlying OS vulnerabilities including multiple CVEs.
+
+  * [Node API runtime rc1.22](/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-rc1.22):
+    * Applied security patches for libarchive13t64, libgnutls30t64, and qs packages.
+
+  * [Node browser runtime rc1.22](/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-rc1.22):
+    * Applied security patches for libarchive13t64, brace-expansion, qs, and ws packages.
+
+  * [Mobile app for Android v5.42.0](/docs/release-notes/mobile-apps-release-notes/new-relic-android-release-notes/new-relic-android-5420):
+    * Bug fixes and improvements.
+
+  * [Mobile app for iOS v6.9.26](/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6109):
+    * Bug fixes and performance improvements.


### PR DESCRIPTION
## Summary
- Added weekly documentation release notes for May 25 - May 29, 2026
- Includes 2 new docs, 4 major changes, 7 minor changes, and 12 product release notes



🤖 Generated with [Claude Code](https://claude.com/claude-code)