### PR TITLE
chore(.net agent): Updating latest supported framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -415,7 +415,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                   * Minimum supported version: 3.17.0
-                  * Latest verified compatible version: 3.59.0
+                  * Latest verified compatible version: 3.60.0
                   * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                 </td>
                 </tr>
@@ -520,7 +520,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                   Minimum supported version: 2.3.0
 
-                  Latest verified compatible version: 3.8.1
+                  Latest verified compatible version: 3.9.0
 
                   Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -575,7 +575,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.13.1
+            Latest verified compatible version: 2.13.17
                 </td>
                 </tr>
 
@@ -626,7 +626,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [EnyimMemcachedCore](https://www.nuget.org/packages/EnyimMemcachedCore).
 
                   * Minimum supported version: 2.0.0
-                  * Latest verified compatible version: 3.5.0
+                  * Latest verified compatible version: 3.5.1
                 </td>
                 </tr>
 
@@ -646,7 +646,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.18.3
+                  * Latest verified compatible version: 4.0.18.6
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -774,7 +774,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.17.8
+                    4.0.20.1
                 </td>
                 </tr>
                 <tr>
@@ -952,7 +952,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 5.0
 
-                    * Latest verified compatible version: 10.1.4
+                    * Latest verified compatible version: 10.2.4
                 </td>
                 </tr>
 
@@ -1006,7 +1006,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.2.30
+                  * Latest verified compatible version: 4.0.2.33
                 </td>
                 </tr>
 
@@ -1020,7 +1020,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.8.16
+                  * Latest verified compatible version: 4.0.8.19
                 </td>
                 </tr>
 
@@ -1034,7 +1034,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.29
+                  * Latest verified compatible version: 4.0.3.32
                 </td>
                 </tr>
 
@@ -1512,7 +1512,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                         * Minimum supported version: 3.17.0
-                        * Latest verified compatible version: 3.59.0
+                        * Latest verified compatible version: 3.60.0
                         * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                       </td>
                     </tr>
@@ -1639,7 +1639,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     <td>
                       Minimum supported version: 2.3.0
 
-                      Latest verified compatible version: 3.8.1
+                      Latest verified compatible version: 3.9.0
 
                       Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -1752,7 +1752,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.13.1
+                        * Latest verified compatible version: 2.13.17
                     </td>
                     </tr>
 
@@ -1824,7 +1824,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.18.3
+                  * Latest verified compatible version: 4.0.18.6
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1992,7 +1992,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.17.8
+                        4.0.20.1
                     </td>
                     </tr>
                     <tr>
@@ -2233,7 +2233,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.2.30
+                        * Latest verified compatible version: 4.0.2.33
                     </td>
                     </tr>
 
@@ -2247,7 +2247,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.8.16
+                    * Latest verified compatible version: 4.0.8.19
                     </td>
                     </tr>
 
@@ -2261,7 +2261,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.3.29
+                    * Latest verified compatible version: 4.0.3.32
                     </td>
                     </tr>
 


### PR DESCRIPTION
Updates the .NET agent compatibility & requirements documentation to reflect the latest supported package versions verified by [Dotty PR #3609](https://github.com/newrelic/newrelic-dotnet-agent/pull/3609).

Packages updated (latest verified compatible version):

| Package | Old → New |
|---|---|
| Microsoft.Azure.Cosmos (Cosmos DB) | 3.59.0 → 3.60.0 |
| MongoDB.Driver (MongoDB, modern) | 3.8.1 → 3.9.0 |
| StackExchange.Redis | 2.13.1 → 2.13.17 |
| EnyimMemcachedCore (Memcached) | 3.5.0 → 3.5.1 |
| AWSSDK.DynamoDBv2 (DynamoDB) | 4.0.18.3 → 4.0.18.6 |
| AWSSDK.BedrockRuntime (AWS Bedrock) | 4.0.17.8 → 4.0.20.1 |
| NServiceBus | 10.1.4 → 10.2.4 |
| AWSSDK.SQS | 4.0.2.30 → 4.0.2.33 |
| AWSSDK.Kinesis | 4.0.8.16 → 4.0.8.19 |
| AWSSDK.KinesisFirehose | 4.0.3.29 → 4.0.3.32 |

Both the .NET Core and .NET Framework sections were updated where the package applies to that runtime. No major version bumps.
