### PR TITLE
chore: Update AIM library support page to redirect for Nodejs agent

### DIFF
--- a/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
@@ -65,11 +65,7 @@ AI monitoring is compatible with these agent versions and AI libraries:
       </td>
 
       <td>
-        * [OpenAI Node.js API library](https://www.npmjs.com/package/openai) versions 4.0.0 and above. If your model uses streaming, the Node.js agent supports versions 4.12.2 and above
-        * [AWS SDK for JavaScript BedrockRuntime Client](https://www.npmjs.com/package/@aws-sdk/client-bedrock-runtime) versions 3.474.0 and above
-        * [LangChain.js](https://www.npmjs.com/package/langchain) versions 0.2.0 and above
-        * [Google Gen AI SDK](https://www.npmjs.com/package/@google/genai) versions 1.1.0 and above
-        * [MCP SDK](https://www.npmjs.com/package/@modelcontextprotocol/sdk) versions 1.13.0 and above
+        Please see the full list of supported AIM libraries on the [Node.js agent's compatibility requirements page](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#ai-monitoring-support).
       </td>
     </tr>
 

--- a/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/compatibility-requirements-ai-monitoring.mdx
@@ -65,7 +65,7 @@ AI monitoring is compatible with these agent versions and AI libraries:
       </td>
 
       <td>
-        Please see the full list of supported AIM libraries on the [Node.js agent's compatibility requirements page](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#ai-monitoring-support).
+        For full list of supported AIM libraries, refer to the [Node.js agent's compatibility requirements page](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#ai-monitoring-support).
       </td>
     </tr>
 


### PR DESCRIPTION
## Give us some context

* This page is out-of-date with the current AIM libraries the Node.js APM agent supports. Now, it is just a simple redirect to the automatically-updated page that is our source of truth.