### PR TITLE
fix: correct .NET Lambda auto-instrumentation scope and remove incorrect SQS outbound DT limitation

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda.mdx
@@ -157,17 +157,19 @@ In a Lambda function, the agent will switch into a "serverless mode" that will d
 
 Since the agent automatically instruments most lambda functions, you can use the [agent NuGet package](https://www.nuget.org/packages/NewRelic.Agent#readme-body-tab) to monitor your lambda functions. You need to manually configure environment variables for your chosen deployment method (see our [installation guide](/install/dotnet/?deployment=nuget#nuget-linux)). This still requires that you set up either the [New Relic Lambda Extension or CloudWatch integration](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/introduction-lambda/#how) to send your data to New Relic.
 
-Automatic instrumentation is available for the following AWS Lambda function types (as of agent version 10.29.0):
+The following AWS Lambda function types are automatically detected and instrumented without any additional configuration (as of agent version 10.29.0):
 * `Amazon.Lambda.AspNetCoreServer.APIGatewayProxyFunction`
 * `Amazon.Lambda.AspNetCoreServer.APIGatewayHttpApiV2ProxyFunction`
 * `Amazon.Lambda.AspNetCoreServer.ApplicationLoadBalancerFunction`
+
+Other handler types (such as SQS, SNS, Kinesis, S3, DynamoDB triggers, and custom handlers) are also instrumented when you set the `NEW_RELIC_LAMBDA_HANDLER` environment variable to the fully qualified handler path (for example, `MyAssembly::MyNamespace.MyClass::MyMethod`). This includes any handler method that accepts an `ILambdaContext` parameter.
 
 Limitations:
 
 * Generic lambda Methods are not instrumented automatically. If your lambda method is a generic method, such as `Task<TResponse> MyMethod<TRequest, TResponse>(TRequest, ILambdaContext)`, the .NET agent is currently not able to instrument that method.
 * The [Lambda Annotations Framework](https://aws.amazon.com/blogs/developer/net-lambda-annotations-framework/) is currently not supported.
 * [ApiGatewayV2](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format) events are missing some context required for distributed tracing.
-* Outbound distributed tracing for different AWS SDK calls (such as SQS) are not supported.
+* Inbound distributed tracing from SQS requires the upstream producer to inject W3C trace headers (`traceparent`, `tracestate`) as SQS message attributes. The agent reads these automatically when present.
 * If your Lambda function handler does not include an [`ILambdaContext`](https://docs.aws.amazon.com/lambda/latest/dg/csharp-context.html) parameter, the .NET agent will not be able to gather all of the expected information about your Lambda function.
 * .NET Lambda functions built with the [Native AOT deployment method](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net7%2Cwindows) are not supported.
 


### PR DESCRIPTION
## Summary

Corrects two inaccuracies in the .NET Lambda agent approaches documentation.

### Fix 1 — Auto-instrumented handler types are not exhaustive

The existing text lists three `Amazon.Lambda.AspNetCoreServer.*` handler types under "Automatic instrumentation is available for the following", implying these are the only supported types. This is misleading.

**Actual behavior:** Any handler method with an `ILambdaContext` parameter is instrumented when `NEW_RELIC_LAMBDA_HANDLER` is set to the fully qualified handler path. This includes SQS, SNS, Kinesis, S3, DynamoDB trigger handlers, and custom handlers. The three listed types are simply those that are detected automatically without any configuration.

**Evidence:** Confirmed via live testing with a `StartProcess(SQSEvent sqsEvent, ILambdaContext lambdaContext)` handler — `HandlerMethodWrapper` correctly wrapped the method and full transaction/span data appeared in New Relic Serverless UI.

### Fix 2 — Remove "Outbound DT for SQS not supported" limitation

The line `Outbound distributed tracing for different AWS SDK calls (such as SQS) are not supported` is factually incorrect.

**Actual behavior:** `SQSRequestHandler.HandleSQSRequest` (in `src/Agent/NewRelic/Agent/Extensions/Providers/Wrapper/AwsSdk/RequestHandlers/SQSRequestHandler.cs`) calls `SqsHelper.InsertDistributedTraceHeaders` for both `SendMessageRequest` and `SendMessageBatchRequest`, injecting `traceparent`, `tracestate`, and `newrelic` headers into outgoing SQS `MessageAttributes`.

**Evidence:** Confirmed via sandbox testing — SQS messages sent by a .NET Lambda function contained all three W3C trace headers, and the corresponding `MessageBroker/SQS/Queue/Produce` span appeared in New Relic with the correct traceId.

Replaced with an accurate note about inbound distributed tracing requirements (upstream producer must inject W3C headers as SQS MessageAttributes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
