### PR TITLE
feat(lambda): restore AWS required permissions to compatibility doc

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
@@ -107,7 +107,7 @@ Based on the type of instrumentation, the following runtimes are supported.
 * Python: `python3.8`, `python3.9`, `python3.10`, `python3.11`, `python3.12`, `python3.13`, `python3.14`
 * Go: `provided.al2`, `provided.al2023`
 * Java: `java8.al2`, `java11`, `java17`, `java21`
-* Ruby: `ruby3.2`, `ruby3.3`
+* Ruby: `ruby3.2`, `ruby3.3`, `ruby3.4`
 * .NET: `dotnet6`, `dotnet8`
 
 </TabsPageItem>

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
@@ -80,7 +80,7 @@ Before running the `newrelic-lambda` CLI, grant New Relic a minimum of these per
 }
 ```
 
-For more information, see the [newrelic-lambda CLI repo](https://github.com/newrelic/newrelic-lambda-cli#installation).
+For more information, refer to the [newrelic-lambda CLI repo](https://github.com/newrelic/newrelic-lambda-cli#installation).
 
 <Callout variant="tip">
   New Relic recommends integrating your AWS account with New Relic using the [AWS integration](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/) to automatically discover and monitor your Lambda functions. This allows you to leverage the full power of New Relic APM for your serverless functions.

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
@@ -16,6 +16,72 @@ Before enabling serverless monitoring using our Lambda layer, you'll need:
 
 * An AWS account with permissions for creating IAM resources, managed secrets, and Lambdas. You also need permissions for creating CloudFormation stacks and S3 buckets.
 
+## AWS permissions [#aws-permissions]
+
+### Infrastructure integration permissions [#integration-permissions]
+
+By default, New Relic uses the AWS Managed Policy `ReadOnlyAccess`. This allows the Infrastructure integration to see all the resources in your account, rather than just your Lambda functions and CloudWatch metrics. New Relic recommends this default, but if your organization requires a strict security posture for third-party integrations, you can grant the IAM role a minimum of these permissions instead:
+
+```yaml
+Resource: "*"
+  Action:
+    - "cloudwatch:GetMetricStatistics"
+    - "cloudwatch:ListMetrics"
+    - "cloudwatch:GetMetricData"
+    - "lambda:GetAccountSettings"
+    - "lambda:ListFunctions"
+    - "lambda:ListAliases"
+    - "lambda:ListTags"
+    - "lambda:ListEventSourceMappings"
+```
+
+### CLI permissions [#cli-permissions]
+
+Before running the `newrelic-lambda` CLI, grant New Relic a minimum of these permissions in AWS:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "CLIAccessPolicy",
+      "Action": [
+        "cloudformation:CreateChangeSet",
+        "cloudformation:CreateStack",
+        "cloudformation:DescribeStacks",
+        "cloudformation:ExecuteChangeSet",
+        "iam:AttachRolePolicy",
+        "iam:CreateRole",
+        "iam:GetRole",
+        "iam:PassRole",
+        "lambda:AddPermission",
+        "lambda:CreateFunction",
+        "lambda:GetFunction",
+        "logs:DeleteSubscriptionFilter",
+        "logs:DescribeSubscriptionFilters",
+        "logs:PutSubscriptionFilter",
+        "s3:GetObject",
+        "serverlessrepo:CreateCloudFormationChangeSet",
+        "secretsmanager:CreateSecret"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Sid": "NRLogAccessPolicy",
+      "Effect": "Allow",
+      "Action": [
+        "serverlessrepo:CreateCloudFormationTemplate",
+        "serverlessrepo:GetCloudFormationTemplate"
+      ],
+      "Resource": "arn:aws:serverlessrepo:us-east-1:463657938898:applications/NewRelic-log-ingestion"
+    }
+  ]
+}
+```
+
+For more information, see the [newrelic-lambda CLI repo](https://github.com/newrelic/newrelic-lambda-cli#installation).
+
 <Callout variant="tip">
   New Relic recommends integrating your AWS account with New Relic using the [AWS integration](/docs/infrastructure/amazon-integrations/get-started/introduction-aws-integrations/) to automatically discover and monitor your Lambda functions. This allows you to leverage the full power of New Relic APM for your serverless functions.
 </Callout>

--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/compatibility-requirement-lambda-monitoring.mdx
@@ -103,8 +103,8 @@ Based on the type of instrumentation, the following runtimes are supported.
   
 
 <TabsPageItem id="1">
-* Node.js: `nodejs16.x`, `nodejs18.x`, `nodejs20.x`, `nodejs22.x`
-* Python: `python3.8`, `python3.9`, `python3.10`, `python3.11`, `python3.12`, `python3.13`
+* Node.js: `nodejs16.x`, `nodejs18.x`, `nodejs20.x`, `nodejs22.x`, `nodejs24.x`
+* Python: `python3.8`, `python3.9`, `python3.10`, `python3.11`, `python3.12`, `python3.13`, `python3.14`
 * Go: `provided.al2`, `provided.al2023`
 * Java: `java8.al2`, `java11`, `java17`, `java21`
 * Ruby: `ruby3.2`, `ruby3.3`
@@ -120,8 +120,8 @@ Based on the type of instrumentation, the following runtimes are supported.
 </TabsPageItem>
 
 <TabsPageItem id="3">
-* Node.js(OS/Arch: Linux, Windows, ARM, ARM 64, x86, x86-64) : `nodejs16.x`, `nodejs18.x`, `nodejs20.x`, `nodejs22.x`
-* Python (OS/Arch: Linux, Windows, ARM, ARM 64, x86, x86-64): `python3.7`, `python3.8`, `python3.9`, `python3.10`, `python3.11`, `python3.12`, `python3.13`
+* Node.js(OS/Arch: Linux, Windows, ARM, ARM 64, x86, x86-64) : `nodejs16.x`, `nodejs18.x`, `nodejs20.x`, `nodejs22.x`, `nodejs24.x`
+* Python (OS/Arch: Linux, Windows, ARM, ARM 64, x86, x86-64): `python3.7`, `python3.8`, `python3.9`, `python3.10`, `python3.11`, `python3.12`, `python3.13`, `python3.14`
 * Java (OS/Arch: Linux, Windows, ARM, ARM 64, x86, x86-64): `java8`, `java11`, `java17`, `java21`
 * Ruby :  `ruby3.2`, `ruby3.3`
 * .NET (OS/Arch: Linux, Windows, ARM, ARM 64, x86, x86-64): `dotnet6`, `dotnet8`     


### PR DESCRIPTION
## Summary

- Restores the AWS permissions section to the Lambda compatibility and requirements doc, covering Infrastructure integration permissions (ReadOnlyAccess / minimum cloudwatch+lambda YAML) and CLI permissions (CLIAccessPolicy + NRLogAccessPolicy JSON)
- Adds `nodejs24.x` and `python3.14` to supported runtimes for layered instrumentation
- Adds `ruby3.4` to supported runtimes for layered instrumentation
- Adds `nodejs24.x` and `python3.14` to supported runtimes for containerized instrumentation

Ported from: https://github.com/newrelic/docs-website-private/pull/129
Jira: NR-512182

## Test plan

- [ ] Verify AWS permissions section renders correctly in the doc
- [ ] Confirm runtime lists are accurate and match current Lambda layer support
- [ ] Check no broken links in the new permissions section

🤖 Generated with [Claude Code](https://claude.com/claude-code)