### PR TITLE
feat(mobile): add Mobile User Journeys docs page

### DIFF
--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys.mdx
@@ -1,0 +1,69 @@
+---
+title: Mobile User Journeys
+tags:
+  - Mobile monitoring
+  - Mobile monitoring UI
+  - Mobile app pages
+metaDescription: Mobile User Journeys visualizes how end-users navigate your mobile app in aggregate, helping you understand user behavior, identify friction points, and improve the overall app experience.
+freshnessValidatedDate: never
+---
+
+Mobile User Journeys visualizes how end-users navigate your mobile app in aggregate. It reveals critical patterns in user behavior — where users go after opening the app, where they get stuck, and which paths lead to the outcomes you care about.
+
+<Callout variant="important">
+  Mobile User Journeys is currently available within the **Errors** experience in the New Relic mobile monitoring UI. A standalone Mobile User Journeys view (similar to the [Browser User Journeys](/docs/browser/browser-monitoring/browser-pro-features/user-journeys/) feature) is planned for a future release.
+</Callout>
+
+## Why use Mobile User Journeys? [#why]
+
+Mobile User Journeys helps you answer questions like:
+
+- **Which screens do users visit most?** Understand the common paths users take through your app.
+- **Where do users drop off?** Identify screens or flows where users abandon sessions.
+- **What leads to crashes or errors?** See the navigation sequence that preceded a crash or error event.
+- **Which journeys drive conversions?** Pinpoint the in-app flows that lead to purchases, sign-ups, or other key actions.
+
+## How to access Mobile User Journeys [#access]
+
+Mobile User Journeys is currently surfaced in the context of the Errors UI:
+
+1. Go to **[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Mobile**.
+2. Select your mobile application.
+3. In the left navigation, click **Crashes**, then select **Mobile crashes** to open the errors inbox view.
+4. Select an error group to open the error detail view.
+5. In the error detail, look for the **User Journeys** tab to see the navigation paths that led to the error.
+
+## Understand the User Journeys visualization [#visualization]
+
+The User Journeys visualization uses a Sankey diagram to show the flow of users between screens. Each node represents a screen or interaction in your app, and the width of each connecting path reflects the number of users who followed that route.
+
+Key elements of the diagram:
+
+- **Nodes**: Individual screens or interactions in the app.
+- **Paths**: Connections between nodes, sized proportionally to the volume of users who followed that path.
+- **Entry points**: The screens where user sessions begin.
+- **Exit points**: The screens where users ended their session or triggered an error.
+
+## Filter and explore journeys [#filter]
+
+Within the User Journeys view, you can:
+
+- **Filter by time range**: Use the time picker to narrow the journeys to a specific window.
+- **Filter by app version**: Focus on journeys from a specific release to compare behavior before and after a deployment.
+- **Filter by user attributes**: Narrow results by device type, OS version, geography, or custom attributes you've instrumented with the [Mobile SDK](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide/).
+- **Click a path**: Select any path or node to see a list of sessions that followed it, including links to [Session Replay](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-session-replay/introduction) recordings where available.
+
+## Use journeys to diagnose errors [#diagnose-errors]
+
+One of the most powerful uses of Mobile User Journeys is understanding **what users did before an error occurred**. When you view User Journeys from within an error group:
+
+1. The visualization automatically anchors on sessions that experienced that error.
+2. You can trace back through prior screens to identify common navigation patterns that precede the crash.
+3. Use this data to reproduce the issue in development or prioritize which flows to fix first based on user impact.
+
+## Related features [#related]
+
+- [Mobile crashes](/docs/errors-inbox/mobile-tab): View and triage crash groups across your mobile app.
+- [Handled exceptions](/docs/mobile-monitoring/mobile-monitoring-ui/crashes/handled-exceptions-analyze-trends-prevent-crashes): Track non-fatal errors and trends.
+- [Session replay](/docs/mobile-monitoring/mobile-monitoring-ui/mobile-session-replay/introduction): Watch recordings of real user sessions to understand exact user behavior.
+- [Browser User Journeys](/docs/browser/browser-monitoring/browser-pro-features/user-journeys/): The equivalent User Journeys feature for web apps monitored with Browser.

--- a/src/nav/mobile-monitoring.yml
+++ b/src/nav/mobile-monitoring.yml
@@ -138,6 +138,8 @@ pages:
             path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/release-versions-page
           - title: Alerts page
             path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/alerts-page
+          - title: User Journeys
+            path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys
       - title: Session replay
         path: /docs/mobile-monitoring/mobile-monitoring-ui/mobile-session-replay
         pages:


### PR DESCRIPTION
## Summary

- Creates a new dedicated docs page for the **Mobile User Journeys** feature at `src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys.mdx`
- Adds the page to `src/nav/mobile-monitoring.yml` under **View data in New Relic > Mobile app pages**

## What's covered in the doc

- Feature overview and why to use it
- How to access User Journeys (currently surfaced within the Errors UI)
- Explanation of the Sankey diagram visualization
- Filtering and exploration options
- How to use journeys for error diagnosis
- Related features (crashes, handled exceptions, session replay, browser UJ)

## Notes

- Current state: Mobile UJ surfaces in the Errors UI context only — the standalone Mobile UJ view is planned for a future release. The doc reflects this with a callout.
- Used the [Browser User Journeys doc](https://docs.newrelic.com/docs/browser/browser-monitoring/browser-pro-features/user-journeys/) as a structural reference.

## Test plan

- [ ] Verify doc renders correctly in the preview environment
- [ ] Confirm nav entry appears under Mobile app pages in the left nav
- [ ] Check all cross-links resolve correctly

Jira: NR-572764
Original work request: NR-540666

🤖 Generated with [Claude Code](https://claude.com/claude-code)