### PR TITLE
Added release notes for fluent-bit and logs for fluent bit 5.0.6

### DIFF
--- a/src/content/docs/release-notes/fluentbit-release-notes/fluentbit-26-06-09.mdx
+++ b/src/content/docs/release-notes/fluentbit-release-notes/fluentbit-26-06-09.mdx
@@ -1,0 +1,107 @@
+---
+subject: Fluent Bit
+releaseDate: '2026-06-09'
+version: 5.0.6
+metaDescription: Release notes for Fluent Bit version 5.0.6
+features: []
+bugs: []
+supportedOperatingSystems:
+  - osName: debian
+    osVersions:
+      - versionName: bullseye
+        architectures:
+          - amd64
+          - arm64
+      - versionName: bookworm
+        architectures:
+          - amd64
+          - arm64
+  - osName: centos
+    osVersions:
+      - versionName: '7'
+        architectures:
+          - x86_64
+          - aarch64
+      - versionName: '8'
+        architectures:
+          - x86_64
+          - aarch64
+      - versionName: '9'
+        architectures:
+          - x86_64
+          - aarch64
+  - osName: rockylinux
+    osVersions:
+      - versionName: '10'
+        architectures:
+          - x86_64
+          - aarch64
+  - osName: amazonlinux
+    osVersions:
+      - versionName: '2'
+        architectures:
+          - x86_64
+          - aarch64
+      - versionName: '2023'
+        architectures:
+          - x86_64
+          - aarch64
+  - osName: ubuntu
+    osVersions:
+      - versionName: jammy
+        architectures:
+          - amd64
+          - arm64
+      - versionName: noble
+        architectures:
+          - amd64
+          - arm64
+  - osName: sles
+    osVersions:
+      - versionName: '15.3'
+        architectures:
+          - x86_64
+      - versionName: '15.4'
+        architectures:
+          - x86_64
+      - versionName: '15.5'
+        architectures:
+          - x86_64
+      - versionName: '15.6'
+        architectures:
+          - x86_64
+      - versionName: '15.7'
+        architectures:
+          - x86_64
+  - osName: windows-server
+    osVersions:
+      - versionName: '2019'
+        architectures:
+          - win64
+          - win32
+      - versionName: '2022'
+        architectures:
+          - win64
+          - win32
+---
+
+### Support for Fluent Bit 5.0.6
+
+Users will now receive Fluent Bit version 5.0.6. For more details, refer to the [Fluent Bit announcements](https://fluentbit.io/announcements/).
+
+This release includes [New Relic Fluent Bit Output Plugin 3.6.0](https://github.com/newrelic/newrelic-fluent-bit-output/releases/tag/v3.6.0).
+
+### Added
+
+* New Relic Fluent Bit Output Plugin 3.6.0 integration
+
+### Changed
+
+* The Infrastructure agent recommends Fluent Bit 5.0.6 packages
+* [Fluent Bit Output Plugin Docker image](https://hub.docker.com/r/newrelic/newrelic-fluentbit-output) uses Fluent Bit 5.0.6 with output plugin 3.6.0
+* [New Relic Logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) installs the new plugin image
+* aws-for-fluent-bit base image (Firelens) updated from 3.2.5 to 3.4.0 (bundles Fluent Bit 5.0.5; will move to 5.0.6 when AWS publishes a matching tag)
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).

--- a/src/content/docs/release-notes/logs-release-notes/logs-26-06-09.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-26-06-09.mdx
@@ -1,0 +1,26 @@
+---
+subject: Logs
+releaseDate: '2026-06-09'
+version: '260609'
+---
+
+### Support for Fluent Bit 5.0.6
+
+Users will now receive Fluent Bit version 5.0.6. For more details, refer to the [Fluent Bit announcements](https://fluentbit.io/announcements/).
+
+This release includes [New Relic Fluent Bit Output Plugin 3.6.0](https://github.com/newrelic/newrelic-fluent-bit-output/releases/tag/v3.6.0).
+
+### Added
+
+* New Relic Fluent Bit Output Plugin 3.6.0 integration
+
+### Changed
+
+* The Infrastructure agent recommends Fluent Bit 5.0.6 packages
+* [Fluent Bit Output Plugin Docker image](https://hub.docker.com/r/newrelic/newrelic-fluentbit-output) uses Fluent Bit 5.0.6 with output plugin 3.6.0
+* [New Relic Logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) installs the new plugin image
+* aws-for-fluent-bit base image (Firelens) updated from 3.2.5 to 3.4.0 (bundles Fluent Bit 5.0.5; will move to 5.0.6 when AWS publishes a matching tag)
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

Adds release notes for Fluent Bit 5.0.6 (New Relic Fluent Bit Output Plugin 3.6.0) 

Adds two new MDX files:
- `fluentbit-release-notes/fluentbit-26-06-03.mdx` — release notes page with supported OS matrix
- `logs-release-notes/logs-26-06-03.mdx` — companion Logs feed entry

Highlights:
- Fluent Bit upgraded to 5.0.6
- New Relic Fluent Bit Output Plugin upgraded to 3.6.0
- aws-for-fluent-bit base image (Firelens) updated from 3.2.5 to 3.4.0 (bundles Fluent Bit 5.0.5; will move to 5.0.6 when AWS publishes a matching tag)



* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.