### PR TITLE
chore: Add new JP region in upload-dsyms-bitcode-apps.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/configuration/upload-dsyms-bitcode-apps.mdx
@@ -100,6 +100,11 @@ To manually upload your dSYM files:
          ```shell
          curl -F dsym=@"~/DSYM_ZIP_PATH" -H "X-APP-LICENSE-KEY: YOUR_NEW_RELIC_APPLICATION_TOKEN" https://mobile-symbol-upload.eu01.nr-data.net/symbol
          ```
+       * For <DNT>**JP accounts**</DNT>:
+
+         ```shell
+         curl -F dsym=@"~/DSYM_ZIP_PATH" -H "X-APP-LICENSE-KEY: YOUR_NEW_RELIC_APPLICATION_TOKEN" https://mobile-symbol-upload.jp01.nr-data.net/symbol
+         ```
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

Adds new JP region endpoint to manually uploading dsyms

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.