### PR TITLE
[DO NOT MERGE]docs: update GCP Pub/Sub integration with WIF metrics and v2 structure

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
@@ -87,6 +87,20 @@ All Pub/Sub metrics available in GCP Cloud Monitoring are collected as dimension
         `pubsub_subscription`
       </td>
     </tr>
+
+    <tr>
+      <td>
+        Snapshot
+      </td>
+
+      <td>
+        `GCPPUBSUBSNAPSHOT`
+      </td>
+
+      <td>
+        `pubsub_snapshot`
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -573,6 +587,128 @@ For the complete list of topic metrics, see [Google's Pub/Sub metrics documentat
 </table>
 
 For the complete list of subscription metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub).
+
+#### Key metrics — Snapshots
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.num_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages retained in a snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.oldest_message_age`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest message retained in a snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.backlog_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of the messages retained in a snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.config_updates_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of configuration changes for each snapshot, grouped by operation type and result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.num_messages_by_region`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages retained in a snapshot, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.oldest_message_age_by_region`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest message retained in a snapshot, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.backlog_bytes_by_region`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of the messages retained in a snapshot, broken down by Cloud region.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of snapshot metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub).
 
 #### Dimensions
 
@@ -1077,6 +1213,96 @@ Query `GcpPubSubSubscriptionSample` events in New Relic to view data for the fol
 
       <td>
         Total byte size of the unacknowledged messages in a subscription, broken down by Cloud region.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### GcpPubSubSnapshotSample [#gcp-pubsub-snapshot-sample]
+
+Query `GcpPubSubSnapshotSample` events in New Relic to view data for the following attributes:
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>
+        Attribute
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `snapshot.BacklogBytes`
+      </td>
+
+      <td>
+        Total byte size of the messages retained in a snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `snapshot.BacklogBytesByRegion`
+      </td>
+
+      <td>
+        Total byte size of the messages retained in a snapshot, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `snapshot.ConfigUpdates`
+      </td>
+
+      <td>
+        Cumulative count of configuration changes for each snapshot, grouped by operation type and result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `snapshot.NumMessages`
+      </td>
+
+      <td>
+        Number of messages retained in a snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `snapshot.NumMessagesByRegion`
+      </td>
+
+      <td>
+        Number of messages retained in a snapshot, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `snapshot.OldestMessageAge`
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest message retained in a snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `snapshot.OldestMessageAgeByRegion`
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest message retained in a snapshot, broken down by Cloud region.
       </td>
     </tr>
   </tbody>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 
 [New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include an integration to report [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) data to New Relic. This document explains how to activate the GCP Pub/Sub integration and describes the data that will be reported.
 
-## Features [#features]
+## Features
 
 As part of the Google Cloud [stream analytics solution](https://cloud.google.com/solutions/stream-analytics), the Cloud Pub/Sub service ingests and delivers event streams for quick data processing and analysis.
 

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
@@ -13,23 +13,630 @@ freshnessValidatedDate: never
 
 [New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include an integration to report [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) data to New Relic. This document explains how to activate the GCP Pub/Sub integration and describes the data that will be reported.
 
-## Features
+## Features [#features]
 
 As part of the Google Cloud [stream analytics solution](https://cloud.google.com/solutions/stream-analytics), the Cloud Pub/Sub service ingests and delivers event streams for quick data processing and analysis.
 
 ## Activate integration [#activate]
 
-To enable the integration follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+To enable the integration follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure):
+
+* [Connect with Workload Identity Federation (recommended)](/docs/connect-google-cloud-platform-services-infrastructure)
+* [Connect with service account or user account](/docs/connect-google-cloud-platform-services-infrastructure)
 
 ## Polling frequency [#polling]
 
 New Relic integrations query your GCP services according to a polling interval, which varies depending on the integration. The polling frequency for Google Cloud Pub/Sub is five minutes. The resolution is 1 data point every minute.
 
-## Find and use data [#find-data]
+<Callout variant="tip">
+  Coming soon: Workload Identity Federation for metrics, and service account or user account authentication for samples.
+</Callout>
+
+## Workload Identity Federation [#wif]
+
+### Find and use data [#find-data-wif]
+
+After activating the integration, your Pub/Sub resources appear as entities in the New Relic entity explorer. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP**</DNT> to see dashboards and manage services.
+
+All Pub/Sub metrics available in GCP Cloud Monitoring are collected as dimensional metrics in the `Metric` event type. Additional metrics beyond this table are collected automatically — see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub) for the complete list.
+
+#### Entities
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Entity
+      </th>
+
+      <th style={{ width: "200px" }}>
+        Entity type
+      </th>
+
+      <th>
+        Resource type
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        Topic
+      </td>
+
+      <td>
+        `GCPPUBSUBTOPIC`
+      </td>
+
+      <td>
+        `pubsub_topic`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Subscription
+      </td>
+
+      <td>
+        `GCPPUBSUBSUBSCRIPTION`
+      </td>
+
+      <td>
+        `pubsub_subscription`
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+### Metric data [#metrics-wif]
+
+#### Key metrics — Topics
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.pubsub.topic.send_message_operation_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of publish message operations.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.send_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of publish requests.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.message_sizes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Distribution of publish message sizes (in bytes).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.byte_cost`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Cost of operations, measured in bytes. Used to measure utilization for quotas.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.config_updates_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of configuration changes, grouped by operation type and result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.num_retained_acked_messages_by_region`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of acknowledged messages retained in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.num_unacked_messages_by_region`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of unacknowledged messages in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.oldest_retained_acked_message_age_by_region`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest acknowledged message retained in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.oldest_unacked_message_age_by_region`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest unacknowledged message in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.retained_acked_bytes_by_region`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of acknowledged messages retained in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.unacked_bytes_by_region`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of unacknowledged messages in a topic, broken down by Cloud region.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of topic metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub).
+
+#### Key metrics — Subscriptions
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "400px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.num_undelivered_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of unacknowledged messages (backlog) in a subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.oldest_unacked_message_age`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest unacknowledged message in a subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.backlog_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of the unacknowledged messages in a subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.pull_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of pull requests, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.push_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of push attempts, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.push_request_latencies`
+      </td>
+
+      <td>
+        Microseconds
+      </td>
+
+      <td>
+        Distribution of push request latencies (in microseconds), grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.num_outstanding_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages delivered to a subscription's push endpoint, but not yet acknowledged.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.num_retained_acked_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of acknowledged messages retained in a subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.oldest_retained_acked_message_age`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age (in seconds) of the oldest acknowledged message retained in a subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.byte_cost`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Cumulative cost of operations, measured in bytes. Used to measure quota utilization.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.config_updates_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of configuration changes for each subscription, grouped by operation type and result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.mod_ack_deadline_message_operation_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of ModifyAckDeadline message operations, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.mod_ack_deadline_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of ModifyAckDeadline requests, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.pull_ack_message_operation_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of acknowledge message operations, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.pull_ack_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of acknowledge requests, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.pull_message_operation_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of pull message operations, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.retained_acked_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of acknowledged messages retained in a subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.streaming_pull_ack_message_operation_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of StreamingPull acknowledge message operations, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.streaming_pull_message_operation_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of streaming pull message operations, grouped by result.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.streaming_pull_response_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Cumulative count of streaming pull responses, grouped by result.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of subscription metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-pubsub).
+
+#### Dimensions
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>
+        Dimension
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `project_id`
+      </td>
+
+      <td>
+        GCP project ID.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `topic_id`
+      </td>
+
+      <td>
+        Pub/Sub topic ID.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `subscription_id`
+      </td>
+
+      <td>
+        Pub/Sub subscription ID.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.resource.type`
+      </td>
+
+      <td>
+        Monitored resource type.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Service account or user account [#service-account]
+
+### Find and use data [#find-data]
 
 After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your <InlinePopover type="dashboards"/> and alert settings, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP > (select an integration)**</DNT>.
-
-## Metric data [#metrics]
 
 Pub/Sub topics are named entities that represent feeds of messages, and subscriptions are named entities that represent message destinations on a particular topic.
 


### PR DESCRIPTION
## Summary

- Adds a **Workload Identity Federation** section with dimensional `Metric` event queries (`gcp.pubsub.topic.*` / `gcp.pubsub.subscription.*` / `gcp.pubsub.snapshot.*`) — 11 topic metrics, 20 subscription metrics, and 7 snapshot metrics, each pointing to GCP docs for the full list
- Adds Entities table (`GCPPUBSUBTOPIC` / `GCPPUBSUBSUBSCRIPTION` / `GCPPUBSUBSNAPSHOT`) and Dimensions table
- Updates **Activate integration** section with separate WIF (recommended) and service account / user account links
- Adds `<Callout variant="tip">` coming-soon box for WIF/service-account auth paths
- Preserves all existing `GcpPubSubTopicSample` and `GcpPubSubSubscriptionSample` sample-event tables under a new **Service account or user account** section
- Adds new **`GcpPubSubSnapshotSample`** section with 7 snapshot sample-event attributes (`snapshot.BacklogBytes`, `snapshot.NumMessages`, `snapshot.OldestMessageAge`, and by-region variants)

## Test plan

- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm existing sample-event tables are unchanged
- [ ] Check all anchor links (`#wif`, `#service-account`, `#polling`, `#activate`, `#gcp-pubsub-snapshot-sample`) resolve
- [ ] Verify snapshot entity row renders in Entities table

🤖 Generated with [Claude Code](https://claude.com/claude-code)