### PR TITLE
NR-541709: Add Lambda Extension (Rust) licenses page

### DIFF
--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-serverless/lambda-extension-rust-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-serverless/lambda-extension-rust-licenses.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 
 We love open-source software, and use the following in the New Relic Lambda Extension (Rust). Thank you, open-source community, for making these fine tools! Some of these are listed under multiple software licenses, and in that case we have listed the license we've chosen to use.
 
-The source code and full third-party notices are also available in the [GitHub repository](https://github.com/newrelic/newrelic-lambda-extension).
+The source code and full third-party notices are also available in the [GitHub repository](https://github.com/newrelic/newrelic-lambda-extension-rust).
 
 <table>
   <thead>

--- a/src/content/docs/licenses/product-or-service-licenses/new-relic-serverless/lambda-extension-rust-licenses.mdx
+++ b/src/content/docs/licenses/product-or-service-licenses/new-relic-serverless/lambda-extension-rust-licenses.mdx
@@ -1,0 +1,271 @@
+---
+title: Lambda Extension (Rust) licenses
+tags:
+  - Licenses
+  - Product or service licenses
+  - New Relic Serverless
+metaDescription: Lambda Extension (Rust) license info.
+freshnessValidatedDate: never
+---
+
+We love open-source software, and use the following in the New Relic Lambda Extension (Rust). Thank you, open-source community, for making these fine tools! Some of these are listed under multiple software licenses, and in that case we have listed the license we've chosen to use.
+
+The source code and full third-party notices are also available in the [GitHub repository](https://github.com/newrelic/newrelic-lambda-extension).
+
+<table>
+  <thead>
+    <tr>
+      <th width={325}>
+        **Library**
+      </th>
+
+      <th>
+        **License**
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        [tokio](https://github.com/tokio-rs/tokio)
+      </td>
+
+      <td>
+        [MIT](https://github.com/tokio-rs/tokio/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [reqwest](https://github.com/seanmonstar/reqwest)
+      </td>
+
+      <td>
+        [MIT](https://github.com/seanmonstar/reqwest/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [serde](https://github.com/serde-rs/serde)
+      </td>
+
+      <td>
+        [MIT](https://github.com/serde-rs/serde/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [serde_json](https://github.com/serde-rs/json)
+      </td>
+
+      <td>
+        [MIT](https://github.com/serde-rs/json/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [tracing](https://github.com/tokio-rs/tracing)
+      </td>
+
+      <td>
+        [MIT](https://github.com/tokio-rs/tracing/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [tracing-subscriber](https://github.com/tokio-rs/tracing)
+      </td>
+
+      <td>
+        [MIT](https://github.com/tokio-rs/tracing/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [hyper](https://github.com/hyperium/hyper)
+      </td>
+
+      <td>
+        [MIT](https://github.com/hyperium/hyper/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [hyper-util](https://github.com/hyperium/hyper-util)
+      </td>
+
+      <td>
+        [MIT](https://github.com/hyperium/hyper-util/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [http-body-util](https://github.com/hyperium/http-body)
+      </td>
+
+      <td>
+        [MIT](https://github.com/hyperium/http-body/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [flate2](https://github.com/rust-lang/flate2-rs)
+      </td>
+
+      <td>
+        [MIT](https://github.com/rust-lang/flate2-rs/blob/main/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [async-trait](https://github.com/dtolnay/async-trait)
+      </td>
+
+      <td>
+        [MIT](https://github.com/dtolnay/async-trait/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [chrono](https://github.com/chronotope/chrono)
+      </td>
+
+      <td>
+        [MIT](https://github.com/chronotope/chrono/blob/main/LICENSE.txt)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [nix](https://github.com/nix-rust/nix)
+      </td>
+
+      <td>
+        [MIT](https://github.com/nix-rust/nix/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [base64](https://github.com/marshallpierce/rust-base64)
+      </td>
+
+      <td>
+        [MIT](https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [anyhow](https://github.com/dtolnay/anyhow)
+      </td>
+
+      <td>
+        [MIT](https://github.com/dtolnay/anyhow/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [once_cell](https://github.com/matklad/once_cell)
+      </td>
+
+      <td>
+        [MIT](https://github.com/matklad/once_cell/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [dashmap](https://github.com/xacrimon/dashmap)
+      </td>
+
+      <td>
+        [MIT](https://github.com/xacrimon/dashmap/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [bytes](https://github.com/tokio-rs/bytes)
+      </td>
+
+      <td>
+        [MIT](https://github.com/tokio-rs/bytes/blob/master/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [regex](https://github.com/rust-lang/regex)
+      </td>
+
+      <td>
+        [MIT](https://github.com/rust-lang/regex/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [rand](https://github.com/rust-random/rand)
+      </td>
+
+      <td>
+        [MIT](https://github.com/rust-random/rand/blob/master/LICENSE-MIT)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [aws-config](https://github.com/awslabs/aws-sdk-rust)
+      </td>
+
+      <td>
+        [Apache-2.0](https://github.com/awslabs/aws-sdk-rust/blob/main/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [aws-sdk-secretsmanager](https://github.com/awslabs/aws-sdk-rust)
+      </td>
+
+      <td>
+        [Apache-2.0](https://github.com/awslabs/aws-sdk-rust/blob/main/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [aws-sdk-ssm](https://github.com/awslabs/aws-sdk-rust)
+      </td>
+
+      <td>
+        [Apache-2.0](https://github.com/awslabs/aws-sdk-rust/blob/main/LICENSE)
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        [aws-sdk-lambda](https://github.com/awslabs/aws-sdk-rust)
+      </td>
+
+      <td>
+        [Apache-2.0](https://github.com/awslabs/aws-sdk-rust/blob/main/LICENSE)
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+The remainder of the code is covered by the [New Relic agent license agreement](/docs/licenses/license-information/other-licenses/new-relic-agent-license).

--- a/src/nav/licenses.yml
+++ b/src/nav/licenses.yml
@@ -83,6 +83,10 @@ pages:
             path: /docs/licenses/product-or-service-licenses/new-relic-developer-edition/developer-program
           - title: Developer Program resources
             path: /docs/licenses/product-or-service-licenses/new-relic-developer-edition/developer-program-resources
+      - title: New Relic Serverless
+        pages:
+          - title: Lambda Extension (Rust)
+            path: /docs/licenses/product-or-service-licenses/new-relic-serverless/lambda-extension-rust-licenses
       - title: Auto-telemetry with Pixie
         pages:
           - title: Auto-telemetry with Pixie licenses


### PR DESCRIPTION
## Summary

- Added new licenses page for the New Relic Lambda Extension (Rust) at `/docs/licenses/product-or-service-licenses/new-relic-serverless/lambda-extension-rust-licenses/`
- Lists 24 open-source libraries (20 MIT, 4 Apache-2.0) with linked library names and license files
- Added new **New Relic Serverless** section to `licenses.yml` nav
- Security approval: NR-541709 (Make Rust Layer Code Public — Review Complete)

