### PR TITLE
Go Agent v3.44.0

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-44-0.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-44-0.mdx
@@ -1,0 +1,30 @@
+---
+subject: Go agent
+releaseDate: '2026-06-11'
+version: 3.44.0
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.44.0'
+features: ["New Integration for Anthropic SDK", "New Integration for GocqlX"]
+bugs: ["Unblocked integrationsupport testing", "Fixed a bug in sqlparse to support optional INTO statements in sql integrations","Fixed a bug in rnats that caused flaky testing"]    
+security: ["Bumped nrfiber"]
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+## 3.44.0
+### Added
+  * Added Support for Anthropic SDK `nranthropic`
+  * Added Support for GocqlX `nrgocqlx`
+### Fixed
+  * Export Internal Test Types via `integrationsupport` to unblock external test consumers
+    * Thank you to community member @nitinprajwal for contributing to this solution
+  * Fixed a bug in sqlparse to support optional `INTO` statements in sql integrations
+  * Fixed a bug in `nrnats` that caused flaky testing
+### Security
+  * Dependabot Security Bumps
+    * `nrfiber`
+
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.


### PR DESCRIPTION
## 3.44.0
### Added
  * Added Support for Anthropic SDK `nranthropic`
  * Added Support for GocqlX `nrgocqlx`
### Fixed
  * Export Internal Test Types via `integrationsupport` to unblock external test consumers
    * Thank you to community member @nitinprajwal for contributing to this solution
  * Fixed a bug in sqlparse to support optional `INTO` statements in sql integrations
  * Fixed a bug in `nrnats` that caused flaky testing
### Security
  * Dependabot Security Bumps
    * `nrfiber`

### Support statement
We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.