### PR TITLE
Update monitor-your-net-maui-application.mdx

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-maui-dotnet/monitor-your-net-maui-application.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-maui-dotnet/monitor-your-net-maui-application.mdx
@@ -45,7 +45,6 @@ If you need to install the agent manually, follow these steps:
     * For Android-native apps: Android 7 (API 24) or higher
     * For iOS-native apps:
       * iOS 16 or higher, using the latest release of Xcode
-
   </Step>
 
   <Step>
@@ -61,6 +60,7 @@ If you need to install the agent manually, follow these steps:
     ### Copy your application token from the UI [#app-token]
 
     The application token is used for New Relic to authenticate your .NET MAUI app's data.
+
     To view and copy your application token in the New Relic UI:
 
     1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com/all-capabilities)**</DNT>, click <DNT>**Integrations & Agents**</DNT>, then click <DNT>**Mobile**</DNT>.
@@ -77,8 +77,8 @@ If you need to install the agent manually, follow these steps:
 
     ```csharp
     using NewRelic.MAUI.Plugin;
-    ...
 
+    ...
       public static MauiApp CreateMauiApp()
       {
         var builder = MauiApp.CreateBuilder();
@@ -103,13 +103,13 @@ If you need to install the agent manually, follow these steps:
           }));
           #endif
         });
+
         return builder.Build();
       }
 
       private static void StartNewRelic()
       {
         CrossNewRelic.Current.HandleUncaughtException();
-
         // Set optional agent configuration
         // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, 
         // crashCollectorAddress, analyticsEventEnabled, networkErrorRequestEnabled, 
@@ -138,14 +138,33 @@ If you need to install the agent manually, follow these steps:
   <Step>
     ### Screen tracking events [#screen-tracking-events]
 
-    The .NET MAUI mobile plugin allows you to track navigation events within the [.NET MAUI Shell](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation). To do so, you only need to call the following in `App.xaml.cs`:
+    The .NET MAUI mobile plugin allows you to track navigation events within the [.NET MAUI Shell](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation). There are two ways to initialize this depending on your app's startup timing in `App.xaml.cs`.
+
+    <DNT>**Option 1: In the App Constructor**</DNT>
+    You can call the tracking method directly in the constructor immediately after setting the `MainPage`.
 
     ```C#
     public App()
     {
       InitializeComponent();
-
       MainPage = new AppShell();
+      CrossNewRelic.Current.TrackShellNavigatedEvents();
+    }
+    ```
+
+    <DNT>**Option 2: In the OnStart Method (Recommended for timing/NullReferenceException issues)**</DNT>
+    If your application shell is not fully initialized during the constructor execution, calling the navigation tracker may result in a `System.NullReferenceException`. To avoid this, move the call into the MAUI `OnStart()` lifecycle method:
+
+    ```C#
+    public App()
+    {
+      InitializeComponent();
+      MainPage = new AppShell();
+    }
+
+    protected override void OnStart()
+    {
+      base.OnStart();
       CrossNewRelic.Current.TrackShellNavigatedEvents();
     }
     ```
@@ -162,7 +181,6 @@ If you need to install the agent manually, follow these steps:
     * `Source`: The type of navigation that occurred.
     * `Previous`: The URI of the previous page. This won't exist if the previous page was null.
   </Step>
-
 </Steps>
 
 ## Customize the agent instrumentation [#mobile-sdk]
@@ -177,64 +195,52 @@ The following customizations are available for the .NET MAUI agent.
       <th style={{ width: "300px" }}>
         If you want to...
       </th>
-
       <th>
         Use this method
       </th>
     </tr>
   </thead>
-
   <tbody>
     <tr>
       <td id="crash-analysis">
         Record breadcrumbs to track app activity that may be helpful for troubleshooting crashes.
       </td>
-
       <td>
         [Record breadcrumbs](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-breadcrumb)
       </td>
     </tr>
-
     <tr>
       <td id="creating">
         Track a method as an interaction.
       </td>
-
       <td>
         [Start interactions](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/start-interaction)
-
+        <br/>
         [Stop interactions](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/stop-interaction)
       </td>
     </tr>
-
     <tr>
       <td id="create-custom">
         Record custom metrics.
       </td>
-
       <td>
         [Record custom metrics](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-custom-metrics/)
       </td>
     </tr>
-
     <tr>
       <td id="create-custom">
         Record handled exceptions.
       </td>
-
       <td>
         [Record handled exceptions](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/record-handled-exceptions)
       </td>
     </tr>
-
     <tr>
       <td id="attributes-events-insights">
         Record custom attributes and events.
       </td>
-
       <td>
         There are several ways to report custom attributes and events:
-
         * [Record custom attributes](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/create-attribute)
         * [Increment session attribute count](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/increment-session-attribute-count)
         * [Remove an attribute](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/remove-attribute)
@@ -248,44 +254,36 @@ The following customizations are available for the .NET MAUI agent.
           For more about which would be the best method to use and why, see [Report mobile monitoring custom events and attributes](/docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes/).
       </td>
     </tr>
-
     <tr>
       <td id="track-custom">
         Track custom network requests and failures.
       </td>
-
       <td>
         [Track HTTP requests](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-success)
-
+        <br/>
         [Track failing HTTP requests](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-failures)
       </td>
     </tr>
-
     <tr>
       <td>
         Shut down the agent.
       </td>
-
       <td>
         [Shut down the agent](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/shut-down-agent)
       </td>
     </tr>
-
     <tr>
       <td>
         Enable/disable default mobile monitoring settings.
       </td>
-
       <td>
         [Enable/disable monitoring features](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/configure-settings)
       </td>
     </tr>
-
     <tr>
       <td>
         Run a test crash report.
       </td>
-
       <td>
         [Test crash reporting](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/test-crash-reporting)
       </td>
@@ -293,14 +291,15 @@ The following customizations are available for the .NET MAUI agent.
   </tbody>
 </table>
 
-## Troubleshoot HTTP errors [#http-errors]
+## Troubleshooting [#troubleshooting]
+
+### Troubleshoot HTTP errors [#http-errors]
 
 Missing HTTP data in the UI?
 
 After installing the .NET MAUI agent, wait at least 5 minutes. If no HTTP data appears on the HTTP errors and HTTP requests UI pages, make sure you used `HttpMessageHandler` in `HttpClient`.
 
-
-### Missing Distributed Tracing Data in the UI
+### Missing Distributed Tracing Data in the UI [#missing-distributed-tracing]
 
 Distributed Tracing does not work when you use static methods to report HTTP data. To enable Distributed Tracing, you must use `HttpMessageHandler` with `HttpClient`.
 
@@ -316,3 +315,7 @@ HttpClient myClient = new HttpClient(CrossNewRelic.Current.GetHttpMessageHandler
         Console.WriteLine("Http request failed");
     }
 ```
+
+### App crashes with TrackShellNavigatedEvents [#track-shell-crash]
+
+If you experience a `System.NullReferenceException` when calling `CrossNewRelic.Current.TrackShellNavigatedEvents()` in the `App()` constructor, it is likely because the application shell is not fully bootstrapped yet. To resolve this, move the call out of the constructor and into the MAUI `OnStart()` lifecycle method within your `App.xaml.cs` file (see the [Screen tracking events](#screen-tracking-events) section for code examples).


### PR DESCRIPTION
add documentation for System.NullReferenceException when calling CrossNewRelic.Current.TrackShellNavigatedEvents() in the App() constructor


## Give us some context

* Customer reported that they cannot use the .net maui plugin and followed the docs. The solution is to move the `TrackShellNavigationEvents()` function call to the OnStart() override.
* I created a PR in the source repo: https://github.com/newrelic/newrelic-maui-plugin/pull/81

cc @JustinRush-NR 