### PR TITLE
chore(.net agent): Updating latest supported framework versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -415,7 +415,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                   * Minimum supported version: 3.17.0
-                  * Latest verified compatible version: 3.60.0
+                  * Latest verified compatible version: 3.61.0
                   * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                 </td>
                 </tr>
@@ -557,7 +557,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
-                      * Latest verified compatible version: 2.5.0
+                      * Latest verified compatible version: 2.6.0
                 </td>
                 </tr>
 
@@ -575,7 +575,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 2.13.17
+            Latest verified compatible version: 3.0.0
                 </td>
                 </tr>
 
@@ -646,7 +646,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.18.6
+                  * Latest verified compatible version: 4.0.21.3
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -667,7 +667,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                 Use [System.Data.Odbc](https://www.nuget.org/packages/System.Data.Odbc/).
                     * Minimum supported version: 8.0.0
-                    * Latest verified compatible version: 10.0.8
+                    * Latest verified compatible version: 10.0.9
                     * Minimum agent version required: 10.35.0
                     
 
@@ -774,7 +774,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.20.1
+                    4.0.20.6
                 </td>
                 </tr>
                 <tr>
@@ -895,7 +895,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0
                 </td>
                 <td>
-                    10.0.8
+                    10.0.9
                 </td>
                 </tr>
             </tbody>
@@ -938,7 +938,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 1.4.0
 
-                    * Latest verified compatible version: 2.14.0
+                    * Latest verified compatible version: 2.14.2
                 </td>
                 </tr>
 
@@ -952,7 +952,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 5.0
 
-                    * Latest verified compatible version: 10.2.4
+                    * Latest verified compatible version: 10.2.5
                 </td>
                 </tr>
 
@@ -1006,7 +1006,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.2.33
+                  * Latest verified compatible version: 4.0.3.4
                 </td>
                 </tr>
 
@@ -1020,7 +1020,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.8.19
+                  * Latest verified compatible version: 4.0.9.4
                 </td>
                 </tr>
 
@@ -1034,7 +1034,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.32
+                  * Latest verified compatible version: 4.0.5
                 </td>
                 </tr>
 
@@ -1512,7 +1512,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                         * Minimum supported version: 3.17.0
-                        * Latest verified compatible version: 3.60.0
+                        * Latest verified compatible version: 3.61.0
                         * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                       </td>
                     </tr>
@@ -1676,7 +1676,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
-                      * Latest verified compatible version: 2.5.0
+                      * Latest verified compatible version: 2.6.0
                     </td>
                     </tr>
 
@@ -1992,7 +1992,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.20.1
+                        4.0.20.6
                     </td>
                     </tr>
                     <tr>
@@ -2113,7 +2113,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        10.0.7
+                        10.0.9
                     </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Updates latest verified compatible versions for the .NET agent based on Dotty PR #3640 (2026-Jun-15):

- AWSSDK.BedrockRuntime: 4.0.20.1 -> 4.0.20.6 (Core + FW)
- AWSSDK.DynamoDBv2: 4.0.18.6 -> 4.0.21.3 (Core)
- AWSSDK.Kinesis: 4.0.8.19 -> 4.0.9.4 (Core)
- AWSSDK.KinesisFirehose: 4.0.3.32 -> 4.0.5 (Core)
- AWSSDK.SQS: 4.0.2.33 -> 4.0.3.4 (Core)
- Confluent.Kafka: 2.14.0 -> 2.14.2 (Core)
- Microsoft.Azure.Cosmos: 3.60.0 -> 3.61.0 (Core + FW)
- Microsoft.Extensions.Logging: 10.0.8 -> 10.0.9 (Core), 10.0.7 -> 10.0.9 (FW)
- MySqlConnector: 2.5.0 -> 2.6.0 (Core + FW)
- NServiceBus: 10.2.4 -> 10.2.5 (Core)
- StackExchange.Redis: 2.13.17 -> 3.0.0 (Core + FW) [major version bump]
- System.Data.Odbc: 10.0.8 -> 10.0.9 (Core)