### PR TITLE
iOS Release Notes v6.9.28

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6110.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6110.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Mobile app for iOS
-releaseDate: '2026-06-13'
+releaseDate: '2026-06-15'
 version: '6.9.28'
 downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
 redirects:

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6110.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6110.mdx
@@ -1,0 +1,14 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2026-06-13'
+version: '6.9.28'
+downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
+redirects:
+  - /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6110
+---
+
+### Features, Improvements & Fixes
+
+- Japan region support for the New Relic iOS app
+- Fixed dashboard page dropdown not appearing on iPad iOS 18
+- Bug fixes and performance improvements


### PR DESCRIPTION
## iOS App 6.9.28 Release Notes

**Build:** 6110
**Release Date:** 2026-06-13

### Features
- Japan region support for the New Relic iOS app

### Bug Fixes
- Fixed dashboard page dropdown not appearing on iPad iOS 18
- Bug fixes and performance improvements