### PR TITLE
docs: Added a section in Node.js agent for setting up instrumentation for Next.js

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation.mdx
@@ -8,17 +8,17 @@ metaDescription: The New Relic Node.js agent can intercept native Next.js OpenTe
 freshnessValidatedDate: never
 ---
 
-The recommended way to monitor a Next.js application is to rely on the native OpenTelemetry spans emitted by Next.js together with the Node.js agent's hybrid agent feature, rather than the agent's built-in Next.js instrumentation. This page explains how to enable the hybrid agent, points to example applications, and covers common questions about injecting the browser agent and deploying to cloud providers.
+The recommended way to monitor a <DNT>Next.js</DNT> application is to rely on the native <DNT>OpenTelemetry</DNT> spans emitted by <DNT>Next.js</DNT> together with the <DNT>Node.js</DNT> agent's hybrid agent feature, rather than the agent's built-in <DNT>Next.js</DNT> instrumentation. This page explains how to enable the hybrid agent, points to example applications, and covers common questions about injecting the browser agent and deploying to cloud providers.
 
 <Callout variant="important">
-  Native Next.js OpenTelemetry support requires Node.js agent version [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0) or later. The hybrid agent only instruments the Node.js runtime; the Next.js edge runtime is not supported, which is why the `register()` example below exits early unless `NEXT_RUNTIME` is `nodejs`.
+  Native <DNT>Next.js OpenTelemetry</DNT> support requires <DNT>Node.js</DNT> agent version [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0) or later. The hybrid agent only instruments the <DNT>Node.js</DNT> runtime; the <DNT>Next.js</DNT> edge runtime is not supported, which is why the `register()` example below exits early unless `NEXT_RUNTIME` is `nodejs`.
 </Callout>
 
-The Node.js agent has had Next.js instrumentation since 2022 through [@newrelic/next](https://github.com/newrelic/newrelic-node-nextjs/releases/tag/v0.1.0), and that instrumentation was bundled into the agent in [12.0.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.0.0). However, it was limited and didn't work when deploying to cloud providers like [Vercel](https://vercel.com/frameworks/nextjs), [AWS Amplify](https://aws.amazon.com/amplify/), [Netlify](https://www.netlify.com/with/nextjs/), or [Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static). With the introduction of the [hybrid agent](/docs/apm/agents/manage-apm-agents/opentelemetry-api-support), the Node.js agent can intercept OpenTelemetry spans and synthesize the telemetry that drives the New Relic experience. Native Next.js OpenTelemetry instrumentation was added in [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0).
+The <DNT>Node.js</DNT> agent has had <DNT>Next.js</DNT> instrumentation since 2022 through [@newrelic/next](https://github.com/newrelic/newrelic-node-nextjs/releases/tag/v0.1.0), and that instrumentation was bundled into the agent in [12.0.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.0.0). However, it was limited and didn't work when deploying to cloud providers like <DNT>[Vercel](https://vercel.com/frameworks/nextjs)</DNT>, <DNT>[AWS Amplify](https://aws.amazon.com/amplify/)</DNT>, <DNT>[Netlify](https://www.netlify.com/with/nextjs/)</DNT>, or <DNT>[Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static)</DNT>. With the introduction of the [hybrid agent](/docs/apm/agents/manage-apm-agents/opentelemetry-api-support), the <DNT>Node.js</DNT> agent can intercept <DNT>OpenTelemetry</DNT> spans and synthesize the telemetry that drives the New Relic experience. Native <DNT>Next.js OpenTelemetry</DNT> instrumentation was added in [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0).
 
 ## Enable the hybrid agent [#enable]
 
-To enable the hybrid agent and disable the agent instrumentations that conflict with Next.js, set the following configuration in `newrelic.js`:
+To enable the hybrid agent and disable the agent instrumentations that conflict with <DNT>Next.js</DNT>, set the following configuration in `newrelic.js`:
 
 ```js
 'use strict'
@@ -44,7 +44,7 @@ exports.config = {
 ```
 
 <Callout variant="tip">
-  If you make native `fetch` calls, you must disable `undici` instrumentation as shown above. Next.js wraps `fetch` and creates its own client spans, so leaving `undici` enabled produces duplicate client spans in your traces.
+  If you make native `fetch` calls, you must disable `undici` instrumentation as shown above. <DNT>Next.js</DNT> wraps `fetch` and creates its own client spans, so leaving `undici` enabled produces duplicate client spans in your traces.
 </Callout>
 
 If you prefer to use environment variables:
@@ -58,7 +58,7 @@ NEW_RELIC_INSTRUMENTATION_HTTP_ENABLED=false
 NEW_RELIC_INSTRUMENTATION_UNDICI_ENABLED=false
 ```
 
-You must also add an `instrumentation.js` file (or `instrumentation.ts` for TypeScript) to load the agent before the rest of your application:
+You must also add an `instrumentation.js` file (or `instrumentation.ts` for <DNT>TypeScript</DNT>) to load the agent before the rest of your application:
 
 ```js
 async function loadNewRelicAgent() {
@@ -91,11 +91,11 @@ export async function register() {
 }
 ```
 
-Check out the Next.js App Router [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
+Check out the <DNT>Next.js App Router</DNT> [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
 
-## Next.js instrumentation in Vercel [#vercel]
+## <DNT>Next.js</DNT> instrumentation in <DNT>Vercel</DNT> [#vercel]
 
-Deploying to Vercel splits static and dynamic pages into different environments. Instead of relying on `.env` and `newrelic.js` to load agent configuration, define the following [environment variables](https://vercel.com/docs/environment-variables) in the Vercel console under **Environment Variables**:
+Deploying to <DNT>Vercel</DNT> splits static and dynamic pages into different environments. Instead of relying on `.env` and `newrelic.js` to load agent configuration, define the following [environment variables](https://vercel.com/docs/environment-variables) in the <DNT>Vercel</DNT> console under <DNT>**Environment Variables**</DNT>:
 
 ```ini
 NEW_RELIC_LICENSE_KEY=<your-license-key>
@@ -106,13 +106,13 @@ NEW_RELIC_INSTRUMENTATION_HTTP_ENABLED=false
 NEW_RELIC_INSTRUMENTATION_UNDICI_ENABLED=false
 ```
 
-You still need the `instrumentation.js` file described above; only the source of the configuration changes on Vercel.
+You still need the `instrumentation.js` file described above; only the source of the configuration changes on <DNT>Vercel</DNT>.
 
-Check out the Next.js App Router [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
+Check out the <DNT>Next.js App Router</DNT> [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
 
 ## Inject the browser agent [#browser-agent]
 
-Since Next.js is a full-stack framework, most customers want observability on both the client and the server. The following example shows how to inject the New Relic browser agent into every page.
+Since <DNT>Next.js</DNT> is a full-stack framework, most customers want observability on both the client and the server. The following example shows how to inject the New Relic browser agent into every page.
 
 Edit the root layout file within `app/` and add the following:
 
@@ -170,4 +170,4 @@ export default async function RootLayout({
 }
 ```
 
-Check out the Next.js App Router [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
+Check out the <DNT>Next.js App Router</DNT> [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.

--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation.mdx
@@ -1,0 +1,173 @@
+---
+title: Next.js instrumentation with the hybrid agent
+tags:
+  - Agents
+  - Nodejs agent
+  - Extend your instrumentation
+metaDescription: The New Relic Node.js agent can intercept native Next.js OpenTelemetry spans and produce necessary telemetry within New Relic.
+freshnessValidatedDate: never
+---
+
+The recommended way to monitor a Next.js application is to rely on the native OpenTelemetry spans emitted by Next.js together with the Node.js agent's hybrid agent feature, rather than the agent's built-in Next.js instrumentation. This page explains how to enable the hybrid agent, points to example applications, and covers common questions about injecting the browser agent and deploying to cloud providers.
+
+<Callout variant="important">
+  Native Next.js OpenTelemetry support requires Node.js agent version [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0) or later. The hybrid agent only instruments the Node.js runtime; the Next.js edge runtime is not supported, which is why the `register()` example below exits early unless `NEXT_RUNTIME` is `nodejs`.
+</Callout>
+
+The Node.js agent has had Next.js instrumentation since 2022 through [@newrelic/next](https://github.com/newrelic/newrelic-node-nextjs/releases/tag/v0.1.0), and that instrumentation was bundled into the agent in [12.0.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.0.0). However, it was limited and didn't work when deploying to cloud providers like [Vercel](https://vercel.com/frameworks/nextjs), [AWS Amplify](https://aws.amazon.com/amplify/), [Netlify](https://www.netlify.com/with/nextjs/), or [Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static). With the introduction of the [hybrid agent](/docs/apm/agents/manage-apm-agents/opentelemetry-api-support), the Node.js agent can intercept OpenTelemetry spans and synthesize the telemetry that drives the New Relic experience. Native Next.js OpenTelemetry instrumentation was added in [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0).
+
+## Enable the hybrid agent [#enable]
+
+To enable the hybrid agent and disable the agent instrumentations that conflict with Next.js, set the following configuration in `newrelic.js`:
+
+```js
+'use strict'
+
+exports.config = {
+  app_name: ['Your application name'],
+  license_key: 'your-license-key',
+  opentelemetry: {
+    enabled: true
+  },
+  instrumentation: {
+    http: {
+      enabled: false
+    },
+    next: {
+      enabled: false
+    },
+    undici: {
+      enabled: false
+    }
+  }
+}
+```
+
+<Callout variant="tip">
+  If you make native `fetch` calls, you must disable `undici` instrumentation as shown above. Next.js wraps `fetch` and creates its own client spans, so leaving `undici` enabled produces duplicate client spans in your traces.
+</Callout>
+
+If you prefer to use environment variables:
+
+```ini
+NEW_RELIC_LICENSE_KEY=<your-license-key>
+NEW_RELIC_APP_NAME=<your-application-name>
+NEW_RELIC_OPENTELEMETRY_ENABLED=true
+NEW_RELIC_INSTRUMENTATION_NEXT_ENABLED=false
+NEW_RELIC_INSTRUMENTATION_HTTP_ENABLED=false
+NEW_RELIC_INSTRUMENTATION_UNDICI_ENABLED=false
+```
+
+You must also add an `instrumentation.js` file (or `instrumentation.ts` for TypeScript) to load the agent before the rest of your application:
+
+```js
+async function loadNewRelicAgent() {
+  const { default: newrelic } = await import('newrelic')
+  const agent = newrelic?.agent
+  if (!agent || agent.collector?.isConnected?.()) {
+    return
+  }
+
+  await new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer)
+      agent.removeListener('started', done)
+      agent.removeListener('errored', done)
+      resolve()
+    }
+    const timer = setTimeout(done, 8000)
+    agent.once('started', done)
+    agent.once('errored', done)
+  })
+}
+
+export async function register() {
+  // The agent only instruments the Node.js runtime, not the edge runtime.
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return
+  }
+
+  await loadNewRelicAgent()
+}
+```
+
+Check out the Next.js App Router [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
+
+## Next.js instrumentation in Vercel [#vercel]
+
+Deploying to Vercel splits static and dynamic pages into different environments. Instead of relying on `.env` and `newrelic.js` to load agent configuration, define the following [environment variables](https://vercel.com/docs/environment-variables) in the Vercel console under **Environment Variables**:
+
+```ini
+NEW_RELIC_LICENSE_KEY=<your-license-key>
+NEW_RELIC_APP_NAME=<your-application-name>
+NEW_RELIC_OPENTELEMETRY_ENABLED=true
+NEW_RELIC_INSTRUMENTATION_NEXT_ENABLED=false
+NEW_RELIC_INSTRUMENTATION_HTTP_ENABLED=false
+NEW_RELIC_INSTRUMENTATION_UNDICI_ENABLED=false
+```
+
+You still need the `instrumentation.js` file described above; only the source of the configuration changes on Vercel.
+
+Check out the Next.js App Router [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.
+
+## Inject the browser agent [#browser-agent]
+
+Since Next.js is a full-stack framework, most customers want observability on both the client and the server. The following example shows how to inject the New Relic browser agent into every page.
+
+Edit the root layout file within `app/` and add the following:
+
+```js
+import Script from 'next/script';
+
+async function loadNewRelicAgent() {
+  const { default: newrelic } = await import('newrelic')
+  const agent = newrelic?.agent
+  if (!agent || agent.collector?.isConnected?.()) {
+    return newrelic
+  }
+
+  await new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer)
+      agent.removeListener('started', done)
+      agent.removeListener('errored', done)
+      resolve()
+    }
+    const timer = setTimeout(done, 8000)
+    agent.once('started', done)
+    agent.once('errored', done)
+  })
+
+  return newrelic
+}
+
+export default async function RootLayout({
+  children,
+}){
+  // Wait for the agent to connect before requesting the browser timing header.
+  const newrelic = await loadNewRelicAgent()
+  const browserTimingHeader = newrelic.getBrowserTimingHeader({
+    hasToRemoveScriptWrapper: true,
+    allowTransactionlessInjection: true,
+  })
+
+  return (
+    <html lang="en">
+      <body className="min-h-full flex flex-col">{children}</body>
+      <Script
+        // Inline scripts require an id.
+        // See https://nextjs.org/docs/app/building-your-application/optimizing/scripts#inline-scripts
+        id='nr-browser-agent'
+        // "beforeInteractive" loads the script before the page becomes interactive.
+        strategy='beforeInteractive'
+        // The script body is the browser timing header generated above. Because
+        // `hasToRemoveScriptWrapper` is true, the header is raw JavaScript with no
+        // surrounding <script> tag, so we inject it with `dangerouslySetInnerHTML`.
+        dangerouslySetInnerHTML={{ __html: browserTimingHeader }}
+      />
+    </html>
+  );
+}
+```
+
+Check out the Next.js App Router [example application](https://github.com/newrelic/newrelic-node-examples/tree/9fa74c516926014fa33758cbd6e3737334ed4f98/nextjs/nextjs-app-router) for a more complete example of this setup.

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -159,7 +159,7 @@ pages:
                 path: /docs/new-relic-solutions/best-practices-guides/full-stack-observability/browser-monitoring-best-practices-java
               - title: Instrument Kafka message queues
                 path: /docs/apm/agents/java-agent/instrumentation/java-agent-instrument-kafka-message-queues
-              - title: Instrument Amazon SQS 
+              - title: Instrument Amazon SQS
                 path: /docs/apm/agents/java-agent/instrumentation/instrument-aws-sqs-message-queues
               - title: Use RabbitMQ or JMS for message queues
                 path: /docs/apm/agents/java-agent/instrumentation/use-rabbitmq-or-jms-message-queues
@@ -479,6 +479,8 @@ pages:
                 path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-instrumentation
               - title: Node.js custom metrics
                 path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/nodejs-custom-metrics
+              - title: Next.js instrumentation
+                path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation
               - title: Apollo Server plugin
                 path: /docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs
               - title: Node.js VMs statistics page


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Provides the recommended way to setup the Node.js agent with Next.js. We did some investigation and found that we can support native Next.js otel spans with 14.1.0 of the agent as well as deploy to vercel. Historically this has been an issue for customers, and discovered this while working on https://github.com/newrelic/node-newrelic/issues/3188

