### PR TITLE
Update tool-reference.mdx

### DIFF
--- a/src/content/docs/agentic-ai/mcp/tool-reference.mdx
+++ b/src/content/docs/agentic-ai/mcp/tool-reference.mdx
@@ -63,7 +63,6 @@ In this example, the AI agent will only be presented with tools categorized unde
 - `list_related_entities`: List entities 1 hop away (related) from a given entity `GUID`.
 - `list_available_new_relic_accounts`: List all account `IDs` available to the user.
 - `list_dashboards`: List all dashboards for a New Relic account.
-- `list_entity_types`: List the complete catalog of New Relic entity types with domain/type definitions.
 - `search_entity_with_tag`: Search for entities using a specific tag key and value.
 
 ## Data Access (tag: data-access) [#data-access]


### PR DESCRIPTION
**Deprecated and removed:** The `list_entity_types` tool is no longer available in the New Relic MCP Server.
> It previously returned the complete catalog of New Relic entity types (domain, type, and metric definitions)
> used to discover valid domains and types for entity searches. This tool has been deprecated by the AIR team
> and removed from the MCP Server.
