### PR TITLE
chore: Update NextJs example app link for Node APM instrumentation

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -62,7 +62,7 @@ To install the Node.js agent:
 3. Use the command `npm install newrelic` for each application you want to monitor. If your app is using [one of these Apollo Server modules](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) install our Apollo plugin with `npm install @newrelic/apollo-server-plugin`. [More details about using `@newrelic/apollo-server-plugin` can be found here](https://github.com/newrelic/newrelic-node-apollo-server-plugin/tree/main#readme).
 
    <Callout variant="important">
-     If you're using Next.js, see [this example of a Next.js app](https://github.com/newrelic/newrelic-node-nextjs#example-project)
+     If you're using Next.js, see [this example of a Next.js app](https://github.com/newrelic/newrelic-node-examples/tree/main/nextjs/nextjs-app-router)
    </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.


### PR DESCRIPTION
Update Nextjs example app link to an active project instead of an archived one.