### PR TITLE
Go Agent Release v3.44.1

### DIFF
--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-44-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-44-1.mdx
@@ -1,0 +1,27 @@
+---
+subject: Go agent
+releaseDate: '2026-06-22'
+version: 3.44.1
+downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.44.1'
+features: []
+bugs: ["Corrected incorrect tag for previous release"]
+security: ["Dependabot bumps for nrgochi, nrmongo, nrmongo-v2, and nrnats]
+---
+
+<Callout variant="important">
+We recommend updating to the latest agent version as soon as it's available. If your organization has established practices that prevent you from upgrading to the latest version, ensure that your agents are regularly updated to a version that's at most 90 days old. Read more about [keeping your agent up to date](/docs/new-relic-solutions/new-relic-one/install-configure/update-new-relic-agent/).
+</Callout>
+
+## 3.44.1
+### Fixed
+  * Corrected incorrect tag for previous release
+### Security
+  * Dependabot security bumps
+    * nrgochi (integration will be bumped to v5.2.4)
+    * nrmongo (integration will be bumped to v1.17.7)
+    * nrmongo-v2 (integration will be bumped to v2.4.2)
+    * nrnats (integration will be bumped to v2.11.15)
+    
+### Support statement
+We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.

--- a/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-44-1.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/go-release-notes/go-agent-3-44-1.mdx
@@ -5,7 +5,7 @@ version: 3.44.1
 downloadLink: 'https://github.com/newrelic/go-agent/tree/v3.44.1'
 features: []
 bugs: ["Corrected incorrect tag for previous release"]
-security: ["Dependabot bumps for nrgochi, nrmongo, nrmongo-v2, and nrnats]
+security: ["Dependabot bumps for nrgochi, nrmongo, nrmongo-v2, and nrnats"]
 ---
 
 <Callout variant="important">
@@ -16,12 +16,12 @@ We recommend updating to the latest agent version as soon as it's available. If 
 ### Fixed
   * Corrected incorrect tag for previous release
 ### Security
-  * Dependabot security bumps
-    * nrgochi (integration will be bumped to v5.2.4)
-    * nrmongo (integration will be bumped to v1.17.7)
-    * nrmongo-v2 (integration will be bumped to v2.4.2)
-    * nrnats (integration will be bumped to v2.11.15)
+  * Dependabot security updates
+    * `nrgochi` integration updated to v5.2.4
+    * `nrmongo` integration updated to v1.17.7
+    * `nrmongo-v2` integration updated to v2.4.2
+    * `nrnats` integration updated to v2.11.15
     
 ### Support statement
-We use the latest version of the Go language. At minimum, you should be using no version of Go older than what is supported by the Go team themselves.
+We use the latest version of the Go language. At a minimum, use a version of Go that the Go team still supports.
 See the [Go agent EOL Policy](/docs/apm/agents/go-agent/get-started/go-agent-eol-policy) for details about supported versions of the Go agent and third-party components.


### PR DESCRIPTION
Go Agent Release Notes
## 3.44.1
### Fixed
  * Corrected incorrect tag for previous release
### Security
  * Dependabot security bumps
    * nrgochi (integration will be bumped to v5.2.4)
    * nrmongo (integration will be bumped to v1.17.7)
    * nrmongo-v2 (integration will be bumped to v2.4.2)
    * nrnats (integration will be bumped to v2.11.15)
    