### PR TITLE
fix(agent-control): fix extra indentation in troubleshoot log config snippet

### DIFF
--- a/src/content/docs/new-relic-control/agent-control/troubleshooting.mdx
+++ b/src/content/docs/new-relic-control/agent-control/troubleshooting.mdx
@@ -266,27 +266,26 @@ This document covers the steps to troubleshoot common issues when installing or 
   1. To enable logging to a file, use the `log` setting in Agent Control configuration file:
 
 ```yml
-  # Fleet Control connection settings
-  #fleet_control:
+# Fleet Control connection settings
+#fleet_control:
 
-  # managed agents settings
-  #agents:
+# managed agents settings
+#agents:
 
-  # agent logging settings
-  log:
-    level: debug
-    file:
-      enable: true
-      # Add a custom path if needed, default path: /var/log/newrelic-agent-control/agent-control.log
-      # path: "/path/to/agent-control.log"
-    # Optional formatting settings
-    format:
-      # Include the target module (disabled by default for better readability)
-      target: true
-      # Custom timestamp format "%Y-%m-%dT%H:%M:%S"
-      timestamp: "%Y"
-
-  ```
+# agent logging settings
+log:
+  level: debug
+  file:
+    enable: true
+    # Add a custom path if needed, default path: /var/log/newrelic-agent-control/agent-control.log
+    # path: "/path/to/agent-control.log"
+  # Optional formatting settings
+  format:
+    # Include the target module (disabled by default for better readability)
+    target: true
+    # Custom timestamp format "%Y-%m-%dT%H:%M:%S"
+    timestamp: "%Y"
+```
 
     Log level possible values are:
       * `trace`


### PR DESCRIPTION
## Summary

- Removes 2 extra spaces of leading indentation from the YAML log config code block in the Agent Control troubleshoot page
- Top-level keys (`log:`, commented-out `#fleet_control:`, `#agents:`) now start at column 0, matching valid `agent-control.yml` syntax
- Users who copy-paste the snippet will no longer get malformed YAML

## Jira

NR-580630

## Test plan

- [ ] Visually verify the code block renders correctly on the staging preview
- [ ] Confirm `log:` is at column 0 in the rendered snippet