### PR TITLE
chore: Update instructions in `install-nodejs-agent.mdx`

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -66,7 +66,7 @@ To install the Node.js agent:
    </Callout>
 
    <Callout variant="important">
-     If you are using Next.js, see [this example of a Next.js app](https://github.com/newrelic/newrelic-node-examples/tree/main/nextjs/nextjs-app-router)
+     If you are using Next.js, please refer to our [Next.js instrumention guide](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation/) that utilizes the Hybrid Agent.
    </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -59,10 +59,14 @@ To install the Node.js agent:
 
 2. Ensure you meet the [system requirements](/docs/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent). In particular, make sure you use a supported Node.js version.
 
-3. Use the command `npm install newrelic` for each application you want to monitor. If your app is using [one of these Apollo Server modules](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) install our Apollo plugin with `npm install @newrelic/apollo-server-plugin`. [More details about using `@newrelic/apollo-server-plugin` can be found here](https://github.com/newrelic/newrelic-node-apollo-server-plugin/tree/main#readme).
+3. Use the command `npm install newrelic` for each application you want to monitor.
+
+  <Callout variant="important">
+     If you are using Apollo Server modules, please refer to our [Apollo Server plugin documentation](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) for further installation details.
+   </Callout>
 
    <Callout variant="important">
-     If you're using Next.js, see [this example of a Next.js app](https://github.com/newrelic/newrelic-node-examples/tree/main/nextjs/nextjs-app-router)
+     If you are using Next.js, see [this example of a Next.js app](https://github.com/newrelic/newrelic-node-examples/tree/main/nextjs/nextjs-app-router)
    </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -66,7 +66,7 @@ To install the Node.js agent:
    </Callout>
 
    <Callout variant="important">
-     If you are using Next.js, please refer to our [Next.js instrumention guide](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation/) that utilizes the Hybrid Agent.
+     If you are using Next.js, please refer to our [Next.js + Hybrid Agent instrumentation guide](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation/).
    </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/install-nodejs-agent.mdx
@@ -62,11 +62,9 @@ To install the Node.js agent:
 3. Use the command `npm install newrelic` for each application you want to monitor.
 
   <Callout variant="important">
-     If you are using Apollo Server modules, please refer to our [Apollo Server plugin documentation](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) for further installation details.
-   </Callout>
+     If you use Apollo Server modules, refer to the [Apollo Server plugin documentation](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/apollo-server-plugin-nodejs/) for installation details.
 
-   <Callout variant="important">
-     If you are using Next.js, please refer to our [Next.js + Hybrid Agent instrumentation guide](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation/).
+     If you use Next.js, refer to the [Next.js hybrid agent instrumentation guide](/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation/).
    </Callout>
 
 4. From `node_modules/newrelic`, copy `newrelic.js` into the root directory of your app.


### PR DESCRIPTION
Updates the Node.js APM agent installation doc to refer customers to our Apollo Server plugin page now that the Node agent ships with Apollo Sever support built-in.

Also updated the Next.js instructions again to link to the proper instrumentation docs.