### PR TITLE
docs: restructure Vertex AI integration with WIF dimensional metrics for 5 entity types

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-vertexai-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-vertexai-monitoring-integration.mdx
@@ -10,23 +10,1003 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) include an integration for reporting your GCP Run data to our products. Here, we explain how to activate the integration and what data it collects.
+[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include one that reports [Google Cloud Vertex AI](https://cloud.google.com/vertex-ai) data to New Relic. This document explains how to activate the GCP Vertex AI integration and describes the data it reports.
+
+## Features
+
+Vertex AI is Google Cloud's unified platform for building, deploying, and managing machine-learning models and generative-AI applications. New Relic's Vertex AI integration collects performance, throughput, latency, and resource utilization metrics across locations, endpoints, indexes, feature stores, and feature online stores.
 
 ## Activate integration [#activate]
 
-To enable the integration, follow the standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+To enable the integration, follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure):
 
-## Configuration and polling [#polling]
+* [Connect with Workload Identity Federation (recommended)](/docs/connect-google-cloud-platform-services-infrastructure)
+* [Connect with service account or user account](/docs/connect-google-cloud-platform-services-infrastructure)
 
-You can change the polling frequency and filter data using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+## Polling frequency [#polling]
 
-Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations) information for the GCP Run integration:
+New Relic integrations query your GCP services according to a polling interval that varies by integration. The polling frequency for Google Cloud Vertex AI is 5 minutes. The resolution is 1 data point every minute.
 
-* New Relic polling interval: 5 minutes
+<Callout variant="important">
+  Workload Identity Federation for metrics, and service account or user account authentication for samples, are not yet supported.
+</Callout>
 
-## Find and use data [#find-data]
+## Workload Identity Federation [#wif]
 
-To find your integration data, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP**</DNT> and select an integration.
+### Find and use data [#find-data-wif]
+
+After you enable the integration, your Vertex AI resources appear as entities in the New Relic entity explorer. To see dashboards and manage services, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP</DNT>.
+
+All Vertex AI metrics available in GCP Cloud Monitoring are collected as dimensional metrics in the `Metric` event type. Additional metrics beyond this table are collected automatically. See [Google's Vertex AI metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform) for the complete list.
+
+#### Entities
+
+<CollapserGroup>
+  <Collapser
+    id="entities-table"
+    title="Vertex AI entities"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Entity
+          </th>
+
+          <th style={{ width: "260px" }}>
+            Entity type
+          </th>
+
+          <th>
+            Resource type
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Location
+          </td>
+
+          <td>
+            `GCPAIPLATFORMLOCATION`
+          </td>
+
+          <td>
+            `aiplatform_location`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Endpoint
+          </td>
+
+          <td>
+            `GCPAIPLATFORMENDPOINT`
+          </td>
+
+          <td>
+            `aiplatform_endpoint`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Index
+          </td>
+
+          <td>
+            `GCPAIPLATFORMINDEX`
+          </td>
+
+          <td>
+            `aiplatform_index`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Featurestore
+          </td>
+
+          <td>
+            `GCPAIPLATFORMFEATURESTORE`
+          </td>
+
+          <td>
+            `aiplatform_featurestore`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Feature Online Store
+          </td>
+
+          <td>
+            `GCPAIPLATFORMFEATUREONLINESTORE`
+          </td>
+
+          <td>
+            `aiplatform_featureonlinestore`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+</CollapserGroup>
+
+### Metric data [#metrics-wif]
+
+#### Key metrics — Location
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.aiplatform.executing_vertexai_pipeline_jobs`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of pipeline jobs currently being executed in the location.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.executing_vertexai_pipeline_tasks`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of pipeline tasks currently being executed in the location.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.online_prediction_requests_per_base_model`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of online prediction requests per project per base model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.quota.online_prediction_requests_per_base_model.usage`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Current quota usage for online prediction requests per base model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.quota.online_prediction_requests_per_base_model.limit`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Current quota limit for online prediction requests per base model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.quota.online_prediction_requests_per_base_model.exceeded`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of attempts that exceeded the online prediction requests quota.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.online_prediction_input_tokens_per_minute_per_base_model`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Online prediction input tokens per minute per project per base model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.online_prediction_output_tokens_per_minute_per_base_model`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Online prediction output tokens per minute per project per base model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.publisher.online_serving.token_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Total tokens served by publisher models in the location.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.publisher.online_serving.first_token_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Latency to first response token from publisher models.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of location metrics, see [Google's Vertex AI metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform).
+
+#### Key metrics — Endpoint
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.accelerator.duty_cycle`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Average fraction of time over the past sample period during which the accelerators were actively processing.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.accelerator.memory.bytes_used`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Accelerator memory allocated by the deployed model replica.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.cpu.utilization`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        CPU utilization of the deployed model replica.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.memory.bytes_used`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Memory in use by the deployed model replica.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.network.received_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Network bytes received by the deployed model replica.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.network.sent_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Network bytes sent by the deployed model replica.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.prediction_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of online predictions served by the endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.prediction_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Online prediction latency of the deployed model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.error_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of online prediction errors returned by the endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.response_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of online prediction responses returned by the endpoint, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.replicas`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of active replicas serving the deployed model.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.prediction.online.target_replicas`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Target number of active replicas for the deployed model.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of endpoint metrics, see [Google's Vertex AI metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform).
+
+#### Key metrics — Index
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.current_replicas`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Current number of replicas serving the index endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.current_shards`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Current number of shards backing the index.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.cpu.request_utilization`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        CPU utilization driven by request traffic to the index endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.memory.used_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Memory in use by the index endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.query.request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of query requests served by the index endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.query.latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Query request latency at the index endpoint.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.stream_update.request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of stream-update requests sent to the index.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.stream_update.datapoint_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of datapoints successfully upserted or removed via stream update.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.matching_engine.stream_update.latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Latency between a stream-update response and the update taking effect.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of index metrics, see [Google's Vertex AI metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform).
+
+#### Key metrics — Featurestore
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.cpu_load`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Average CPU load across nodes in the Featurestore online storage.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.cpu_load_hottest_node`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        CPU load on the hottest node in the Featurestore online storage.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.node_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of nodes provisioned for the Featurestore online storage.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.online_entities_updated`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of entities updated in the Featurestore online storage.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.online_serving.request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of online serving requests handled by the Featurestore, faceted by EntityType.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.online_serving.latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Online serving request latency at the Featurestore, faceted by EntityType.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.online_serving.request_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Online serving request size at the Featurestore, faceted by EntityType.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.online_serving.response_size`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Online serving response size at the Featurestore, faceted by EntityType.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.storage.stored_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total data stored in the Featurestore.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.storage.billable_processed_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Billable bytes processed for Featurestore offline data.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.streaming_write.offline_processed_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of streaming-write requests processed into offline storage.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featurestore.streaming_write.offline_write_delays`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Time from when the streaming-write API is called until the record reaches offline storage.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of featurestore metrics, see [Google's Vertex AI metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform).
+
+#### Key metrics — Feature Online Store
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.online_serving.request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of online serving requests handled by the Feature Online Store, faceted by FeatureView.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.online_serving.serving_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Online serving request latency at the Feature Online Store, faceted by FeatureView.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.online_serving.serving_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Online serving response size at the Feature Online Store, faceted by FeatureView.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.running_sync`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of syncs currently running at the Feature Online Store.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.serving_data_ages`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age of the data being served by the Feature Online Store.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.serving_data_by_sync_time`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Breakdown of records in the Feature Online Store by synced timestamp.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.storage.bigtable_cpu_load`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Average CPU load across Bigtable nodes backing the Feature Online Store.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.storage.bigtable_cpu_load_hottest_node`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        CPU load on the hottest Bigtable node backing the Feature Online Store.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.storage.bigtable_nodes`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of Bigtable nodes backing the Feature Online Store.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.aiplatform.featureonlinestore.storage.stored_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total data stored in the Feature Online Store.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of feature online store metrics, see [Google's Vertex AI metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform).
+
+## Service account or user account [#service-account]
+
+### Find and use data [#find-data]
+
+After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your <InlinePopover type="dashboards"/> and alert settings, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP > (select an integration)</DNT>.
 
 Data is attached to the following [event types](/docs/data-apis/understand-data/new-relic-data-types/#event-data):
 
@@ -135,10 +1115,6 @@ Data is attached to the following [event types](/docs/data-apis/understand-data/
 </table>
 
 For more on how to use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
-
-## Metric data [#metrics]
-
-This integration collects GCP data for VertexAI.
 
 ### VertexAI Endpoint data
 


### PR DESCRIPTION
## Summary

- Adds a **Workload Identity Federation** section with dimensional `Metric` event queries covering 5 Vertex AI entity types:
  - `GCPAIPLATFORMLOCATION` — 10 key metrics
  - `GCPAIPLATFORMENDPOINT` — 12 key metrics
  - `GCPAIPLATFORMINDEX` — 9 key metrics (`matching_engine.*`)
  - `GCPAIPLATFORMFEATURESTORE` — 12 key metrics
  - `GCPAIPLATFORMFEATUREONLINESTORE` — 10 key metrics
- Entities table wrapped in `<CollapserGroup>` for scannability
- **Service account or user account** section preserved with all existing `GcpVertexAi*Sample` tables (Endpoint, Featurestore, FeatureOnlineStore, Location, Index, PipelineJob)
- Applies wording conventions from PR #24377 review: locked intro/activate/polling phrasing, `<Callout variant="important">` (no "Coming soon"), period-then-See (no em-dash), no bold inside `<DNT>`

## Test plan

- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm all 5 entities appear in the Entities collapser
- [ ] Check all anchor links resolve (`#wif`, `#service-account`, `#polling`, `#activate`, `#find-data-wif`, `#find-data`)
- [ ] Confirm existing sample-event tables are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)