### PR TITLE
docs: add GCP API Gateway integration with WIF dimensional metric

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration.mdx
@@ -1,0 +1,123 @@
+---
+title: Google Cloud API Gateway monitoring integration
+tags:
+  - Integrations
+  - Google Cloud Platform integrations
+  - GCP integrations list
+metaDescription: 'New Relic Google Cloud API Gateway integration: the data it reports and how to enable it.'
+redirects:
+  - /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration
+freshnessValidatedDate: never
+---
+
+[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include one that reports [Google Cloud API Gateway](https://cloud.google.com/api-gateway) data to New Relic. This document explains how to activate the GCP API Gateway integration and describes the data it reports.
+
+## Features
+
+Google Cloud API Gateway is a fully managed service for creating, securing, and monitoring APIs in front of Google Cloud backend services. New Relic's API Gateway integration collects request traffic and response-code metrics for each gateway, with breakdowns by API config and response-code class.
+
+## Activate integration [#activate]
+
+To enable the integration, follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure):
+
+* [Connect with Workload Identity Federation (recommended)](/docs/connect-google-cloud-platform-services-infrastructure)
+* [Connect with service account or user account](/docs/connect-google-cloud-platform-services-infrastructure)
+
+## Polling frequency [#polling]
+
+New Relic integrations query your GCP services according to a polling interval that varies by integration. The polling frequency for Google Cloud API Gateway is 5 minutes. The resolution is 1 data point every minute.
+
+<Callout variant="important">
+  Workload Identity Federation for metrics, and service account or user account authentication for samples, are not yet supported.
+</Callout>
+
+## Workload Identity Federation [#wif]
+
+### Find and use data [#find-data-wif]
+
+After you enable the integration, your API Gateway resources appear as entities in the New Relic entity explorer. To see dashboards and manage services, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP</DNT>.
+
+All API Gateway metrics available in GCP Cloud Monitoring are collected as dimensional metrics in the `Metric` event type. Additional metrics beyond this table are collected automatically. See [Google's API Gateway metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-apigateway) for the complete list.
+
+#### Entities
+
+<CollapserGroup>
+  <Collapser
+    id="entities-table"
+    title="API Gateway entities"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Entity
+          </th>
+
+          <th style={{ width: "260px" }}>
+            Entity type
+          </th>
+
+          <th>
+            Resource type
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Gateway
+          </td>
+
+          <td>
+            `GCPAPIGATEWAY`
+          </td>
+
+          <td>
+            `apigateway_gateway`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+</CollapserGroup>
+
+### Metric data [#metrics-wif]
+
+#### Key metrics — Gateway
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.apigateway.proxy.request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of requests served by the API gateway, faceted by `response_code_class` (1xx, 2xx, 3xx, 4xx, 5xx) and `api_config`.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of API Gateway metrics, see [Google's API Gateway metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-apigateway).


### PR DESCRIPTION
## Summary

- New `google-cloud-api-gateway-monitoring-integration.mdx` page for GCP v2
- Single entity: `GCPAPIGATEWAY` (resource type `apigateway_gateway`)
- Single dimensional metric: `gcp.apigateway.proxy.request_count` faceted by `response_code_class` (1xx–5xx) and `api_config`
- Applies the wording conventions established in PR #24377:
  - Locked intro / activate / polling phrasing
  - `<Callout variant=\"important\">` (no \"Coming soon\")
  - Period-then-See (no em-dash)
  - No bold inside `<DNT>`
  - Entities table wrapped in `<CollapserGroup>`

Replaces the earlier closed PR #23989 with V2 dimensional-metric structure.

## Test plan

- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm anchor links resolve (`#wif`, `#polling`, `#activate`, `#find-data-wif`)
- [ ] Confirm the entity appears in the Entities collapser

🤖 Generated with [Claude Code](https://claude.com/claude-code)