### PR TITLE
feat(search): migrate /search-results to SearchGPT

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.15.0",
+    "@newrelic/gatsby-theme-newrelic": "9.16.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.16.0",
+    "@newrelic/gatsby-theme-newrelic": "9.17.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/src/pages/search-results.js
+++ b/src/pages/search-results.js
@@ -9,72 +9,78 @@ import {
   search,
   Spinner,
   Surface,
-  useLocale,
+  highlightText,
   useQueryParams,
 } from '@newrelic/gatsby-theme-newrelic';
 import { navigate } from '@reach/router';
 
-import { usePagination, DOTS } from '../hooks/usePagination';
-
-const SearchResultPageView = ({ pageContext }) => {
+const SearchResultPageView = () => {
   const { queryParams } = useQueryParams();
   const query = queryParams.get('query');
-  const page = Number(queryParams.get('page') ?? 1);
-  const locale = useLocale();
-  const [results, setResults] = useState({ loading: true });
-  const { records, pageCount, loading, error } = results;
-  const { slug } = pageContext;
 
-  const totalPages = pageCount;
-  const totalResults = totalPages * 5;
-  const prevPage = page - 1;
-  const nextPage = page + 1;
-  const hasNextPage = nextPage <= totalPages;
-  const hasPrevPage = prevPage >= 1;
+  const [state, setState] = useState({ loading: true });
+  // SearchGPT paginates with opaque cursors (no random access to a page
+  // number), so we track the cursor for the current page plus a stack of the
+  // cursors for previously-visited pages to support "Previous".
+  const [cursor, setCursor] = useState(undefined);
+  const [cursorStack, setCursorStack] = useState([]);
 
-  const paginationRange = usePagination({
-    totalPageCount: totalPages,
-    siblingCount: 1,
-    currentPage: page,
-  });
+  const { results, totalCount, nextCursor, loading, error } = state;
+
+  // reset pagination whenever the query changes
+  useEffect(() => {
+    setCursor(undefined);
+    setCursorStack([]);
+  }, [query]);
 
   useEffect(() => {
     if (!query) {
       navigate('/');
+      return;
     }
+
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true }));
+
     (async () => {
-      const defaultSources = locale.isDefault
-        ? ['developer', 'docs', 'opensource', 'quickstarts']
-        : [
-            `developer-${locale.locale}`,
-            `docs-${locale.locale}`,
-            `opensource-${locale.locale}`,
-            `quickstarts`,
-          ];
       try {
-        const results = await search({
-          searchTerm: query,
-          defaultSources,
-          filters: [
-            { type: 'source', defaultFilters: [] },
-            { type: 'searchBy', defaultFilters: [] },
-          ],
-          page,
-          perPage: 5,
-        });
-        setResults({
-          pageCount: results.info.page.num_pages,
-          records: results.records.page,
+        const res = await search({ searchTerm: query, cursor });
+        if (cancelled) return;
+        setState({
+          results: res.results,
+          totalCount: res.totalCount,
+          nextCursor: res.nextCursor,
           loading: false,
         });
       } catch {
-        setResults({
+        setState({
           error: 'Unable to get search results, an error has occurred',
           loading: false,
         });
       }
     })();
-  }, [locale, page, query]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [query, cursor]);
+
+  const goNext = () => {
+    if (!nextCursor) return;
+    setCursorStack((stack) => [...stack, cursor]);
+    setCursor(nextCursor);
+  };
+
+  const goPrev = () => {
+    setCursorStack((stack) => {
+      const next = stack.slice(0, -1);
+      setCursor(stack[stack.length - 1]);
+      return next;
+    });
+  };
+
+  const hasPrevPage = cursorStack.length > 0;
+  const hasNextPage = Boolean(nextCursor);
 
   return (
     <PageContainer>
@@ -90,82 +96,51 @@ const SearchResultPageView = ({ pageContext }) => {
           />
         </LoadingContainer>
       )}
-      {records && (
+      {results && !loading && (
         <>
           <h2>
-            {totalResults} results for "{query}"
+            {totalCount} results for "{query}"
           </h2>
-          {records.map((result, i) => (
-            <Result key={`${i}-${result.title}`} result={result} />
+          {results.map((result, i) => (
+            <Result
+              key={`${i}-${result.title}`}
+              result={result}
+              query={query}
+            />
           ))}
           <PaginationContainer>
-            <Link
+            <PaginationButton
               disabled={!hasPrevPage}
-              to={`${slug}/?query=${query}&page=${prevPage}`}
+              onClick={goPrev}
+              css={css`
+                padding: 0.25rem 0.35rem;
+                margin-right: 0.5rem;
+              `}
             >
-              <PaginationButton
-                disabled={!hasPrevPage}
+              <Icon
+                name="fe-arrow-left"
                 css={css`
-                  padding: 0.25rem 0.35rem;
-                  margin-right: 0.5rem;
+                  margin-right: 0.25rem;
                 `}
-              >
-                <Icon
-                  name="fe-arrow-left"
-                  css={css`
-                    margin-right: 0.25rem;
-                  `}
-                />
-                Previous
-              </PaginationButton>
-            </Link>
-            {paginationRange.map((pageNumber) => {
-              if (pageNumber === DOTS) {
-                return <span>{DOTS}</span>;
-              }
-              return (
-                <Link
-                  key={`searchpage-${pageNumber}`}
-                  disabled={pageNumber === page}
-                  to={`${slug}/?query=${query}&page=${pageNumber}`}
-                >
-                  <PaginationButton
-                    disabled={pageNumber === page}
-                    css={css`
-                      padding: 0.25rem 0.35rem;
-                      ${pageNumber === page &&
-                      css`
-                        background: var(--primary-text-color);
-                        color: var(--primary-background-color);
-                        opacity: 1;
-                      `}
-                    `}
-                  >
-                    {pageNumber}
-                  </PaginationButton>
-                </Link>
-              );
-            })}
-            <Link
+              />
+              Previous
+            </PaginationButton>
+            <PaginationButton
               disabled={!hasNextPage}
-              to={`${slug}/?query=${query}&page=${nextPage}`}
+              onClick={goNext}
+              css={css`
+                padding: 0.25rem 0.35rem;
+                margin-left: 0.5rem;
+              `}
             >
-              <PaginationButton
-                disabled={!hasNextPage}
+              Next
+              <Icon
+                name="fe-arrow-right"
                 css={css`
-                  padding: 0.25rem 0.35rem;
-                  margin-left: 0.5rem;
+                  margin-left: 0.25rem;
                 `}
-              >
-                Next
-                <Icon
-                  name="fe-arrow-right"
-                  css={css`
-                    margin-left: 0.25rem;
-                  `}
-                />
-              </PaginationButton>
-            </Link>
+              />
+            </PaginationButton>
           </PaginationContainer>
         </>
       )}
@@ -232,13 +207,17 @@ const PaginationButton = ({ children, ...props }) => (
   </Button>
 );
 
-const Result = ({ result }) => {
+PaginationButton.propTypes = {
+  children: PropTypes.node,
+};
+
+const Result = ({ result, query }) => {
   return (
     <Surface
       as={Link}
       to={result.url}
       css={css`
-        em {
+        .highlight {
           color: #00ac69;
           font-style: normal;
         }
@@ -267,16 +246,21 @@ const Result = ({ result }) => {
           margin-bottom: 0;
           font-weight: 500;
         `}
-        dangerouslySetInnerHTML={{ __html: result.highlight.title }}
+        dangerouslySetInnerHTML={{
+          __html: highlightText(result.title, query),
+        }}
       />
-      <p dangerouslySetInnerHTML={{ __html: result.highlight.body }} />
+      <p dangerouslySetInnerHTML={{ __html: result.summary }} />
     </Surface>
   );
 };
 
-SearchResultPageView.propTypes = {
-  pageContext: PropTypes.shape({
-    slug: PropTypes.string,
+Result.propTypes = {
+  query: PropTypes.string,
+  result: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    summary: PropTypes.string,
   }).isRequired,
 };
 

--- a/src/pages/search-results.js
+++ b/src/pages/search-results.js
@@ -44,7 +44,7 @@ const SearchResultPageView = () => {
 
     (async () => {
       try {
-        const res = await search({ searchTerm: query, cursor });
+        const res = await search({ searchTerm: query, cursor, limit: 5 });
         if (cancelled) return;
         setState({
           results: res.results,

--- a/src/pages/search-results.js
+++ b/src/pages/search-results.js
@@ -10,18 +10,30 @@ import {
   Spinner,
   Surface,
   highlightText,
+  useLocale,
+  localeToSearchLanguage,
   useQueryParams,
 } from '@newrelic/gatsby-theme-newrelic';
 import { navigate } from '@reach/router';
+
+const LIMIT = 5;
 
 const SearchResultPageView = () => {
   const { queryParams } = useQueryParams();
   const query = queryParams.get('query');
 
+  // Scope results to the site's language (jp→ja, kr→ko, pt→pt-br); English
+  // site = en. undefined for an unmapped locale, which searches all languages.
+  const { locale } = useLocale() || {};
+  const language = localeToSearchLanguage(locale);
+
   const [state, setState] = useState({ loading: true });
   // SearchGPT paginates with opaque cursors (no random access to a page
   // number), so we track the cursor for the current page plus a stack of the
-  // cursors for previously-visited pages to support "Previous".
+  // cursors for previously-visited pages to support "Previous". The current
+  // page number is just the stack depth + 1, and the total is estimated
+  // upfront from totalCount — shown as "Page N of ~M" (approximate because the
+  // hit count is an estimate and the walk ends when nextCursor goes null).
   const [cursor, setCursor] = useState(undefined);
   const [cursorStack, setCursorStack] = useState([]);
 
@@ -44,7 +56,12 @@ const SearchResultPageView = () => {
 
     (async () => {
       try {
-        const res = await search({ searchTerm: query, cursor, limit: 5 });
+        const res = await search({
+          searchTerm: query,
+          cursor,
+          limit: LIMIT,
+          language,
+        });
         if (cancelled) return;
         setState({
           results: res.results,
@@ -52,9 +69,13 @@ const SearchResultPageView = () => {
           nextCursor: res.nextCursor,
           loading: false,
         });
-      } catch {
+      } catch (err) {
+        if (cancelled) return;
         setState({
-          error: 'Unable to get search results, an error has occurred',
+          error:
+            err.name === 'RateLimitError'
+              ? `Rate limited. Try again in ${err.rateLimit?.resetInSeconds}s.`
+              : 'Unable to get search results, an error has occurred',
           loading: false,
         });
       }
@@ -63,7 +84,7 @@ const SearchResultPageView = () => {
     return () => {
       cancelled = true;
     };
-  }, [query, cursor]);
+  }, [query, cursor, language]);
 
   const goNext = () => {
     if (!nextCursor) return;
@@ -81,6 +102,11 @@ const SearchResultPageView = () => {
 
   const hasPrevPage = cursorStack.length > 0;
   const hasNextPage = Boolean(nextCursor);
+  // Cursor walk is seek-based, so the full result set is reachable — no
+  // 100/source clamp. Current page is the stack depth + 1; total is an
+  // upfront estimate from the hit count.
+  const currentPage = cursorStack.length + 1;
+  const totalPages = totalCount != null ? Math.ceil(totalCount / LIMIT) : null;
 
   return (
     <PageContainer>
@@ -125,6 +151,10 @@ const SearchResultPageView = () => {
               />
               Previous
             </PaginationButton>
+            <PageIndicator>
+              Page {currentPage}
+              {totalPages != null && ` of ~${totalPages}`}
+            </PageIndicator>
             <PaginationButton
               disabled={!hasNextPage}
               onClick={goNext}
@@ -179,7 +209,7 @@ const PaginationContainer = styled.div`
   display: flex;
   max-width: 760px;
   justify-content: center;
-  align-items: flex-end;
+  align-items: center;
   margin: 3rem auto 0;
   a {
     margin: 0 0.25rem 0;
@@ -199,6 +229,13 @@ const PaginationContainer = styled.div`
       }
     }
   }
+`;
+
+const PageIndicator = styled.span`
+  margin: 0 0.75rem;
+  font-size: 1rem;
+  white-space: nowrap;
+  color: var(--secondary-text-color);
 `;
 
 const PaginationButton = ({ children, ...props }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,10 +3383,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.15.0":
-  version "9.15.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.15.0.tgz#4f5b73bc1a945965edcba1580b78e9e9d604b6b2"
-  integrity sha512-zloCeu58N5umAeKqwF2yh+GuVJplUhPVORhJBThUsAS/JDUqdyJyZZRecYUjsN1XSWprD47gThuTpi/4XYZLTA==
+"@newrelic/gatsby-theme-newrelic@9.16.0":
+  version "9.16.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.16.0.tgz#f1db15d1c9d2d5386c31f990673143b2237734c8"
+  integrity sha512-RjuEnSRriJPMNtdsTx2eF3Mq03/B66mpB9zQFm7zstDQowVON8KH/cfrj4yii1Y8VOYusjR7tAAuxW8oKu7RNw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"
@@ -3401,7 +3401,7 @@
     gatsby-plugin-portal "^1.0.7"
     gatsby-plugin-react-helmet "^5.4.0"
     gatsby-plugin-robots-txt "^1.6.8"
-    gatsby-plugin-sharp "4.25.0"
+    gatsby-plugin-sharp "^4.25.1"
     gatsby-plugin-sitemap "^4.6.0"
     gatsby-plugin-use-dark-mode "^1.3.0"
     gatsby-source-filesystem "^4.25.0"
@@ -3410,11 +3410,11 @@
     i18next "^20.2.1"
     js-cookie "^2.2.1"
     katex "^0.13.24"
-    lodash "^4.17.21"
+    lodash "^4.18.1"
     path-browserify "^1.0.1"
     polished "^4.1.1"
     prism-react-renderer "^1.2.0"
-    prismjs "^1.29.0"
+    prismjs "^1.30.0"
     prop-types "^15.5.7"
     react-i18next "^11.8.13"
     react-live "^2.2.3"
@@ -3428,8 +3428,8 @@
     rehype-katex "^5.0.0"
     remark-math "^3.0.1"
     stream-browserify "^3.0.0"
-    terser "^5.6.1"
-    ua-parser-js "^0.7.28"
+    terser "^5.14.2"
+    ua-parser-js "^0.7.33"
     use-dark-mode "^2.3.1"
     use-local-storage-state "^9.0.2"
     use-media "^1.4.0"
@@ -5229,6 +5229,11 @@ acorn@^8.14.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+acorn@^8.15.0:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
+  integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
+
 acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
@@ -5239,7 +5244,7 @@ acorn@^8.2.4, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
-acorn@^8.5.0, acorn@^8.8.2:
+acorn@^8.5.0:
   version "8.14.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
   integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
@@ -10135,25 +10140,7 @@ gatsby-plugin-robots-txt@^1.6.8:
     "@babel/runtime" "^7.17.9"
     generate-robotstxt "^8.0.3"
 
-gatsby-plugin-sharp@4.25.0:
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-4.25.0.tgz#9af5e1be2b82c67aa64711675850f0ba4e7e3b0e"
-  integrity sha512-8XiSKibQyp6pOFHEkEdRCpoDA3Ywcq5PKftNMExZ51MormT0+WqRC7ynuU+0fzktDTbbSyREvblKa+21Id+rRA==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    async "^3.2.4"
-    bluebird "^3.7.2"
-    debug "^4.3.4"
-    filenamify "^4.3.0"
-    fs-extra "^10.1.0"
-    gatsby-core-utils "^3.25.0"
-    gatsby-plugin-utils "^3.19.0"
-    lodash "^4.17.21"
-    probe-image-size "^7.2.3"
-    semver "^7.3.7"
-    sharp "^0.30.7"
-
-gatsby-plugin-sharp@4.25.1:
+gatsby-plugin-sharp@4.25.1, gatsby-plugin-sharp@^4.25.1:
   version "4.25.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-4.25.1.tgz#dcc31bdc698511501acc9b95ba277844c15a7576"
   integrity sha512-cGRb8lmwJkzwT1Qze0R+VL+55BIb9weM17m+dUf6gs5Z++lQltqge+L8a1qWWsGL6KfLQN7+bIqjhmTTscIPMQ==
@@ -17492,7 +17479,7 @@ prism-react-renderer@^1.2.0, prism-react-renderer@^1.2.1:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz#786bb69aa6f73c32ba1ee813fbe17a0115435085"
   integrity sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==
 
-prismjs@^1.29.0:
+prismjs@^1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
@@ -20439,6 +20426,16 @@ terser-webpack-plugin@^5.5.0:
     schema-utils "^4.3.0"
     terser "^5.31.1"
 
+terser@^5.14.2:
+  version "5.48.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.48.0.tgz#8b391171cfbb7ac4a88f9f04ba1cfabc54f643db"
+  integrity sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.15.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
 terser@^5.2.0:
   version "5.14.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
@@ -20456,16 +20453,6 @@ terser@^5.31.1:
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.14.0"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
-
-terser@^5.6.1:
-  version "5.39.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.39.0.tgz#0e82033ed57b3ddf1f96708d123cca717d86ca3a"
-  integrity sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
@@ -21000,10 +20987,15 @@ typescript@^4.2.4, typescript@^4.5.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
   integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
-ua-parser-js@^0.7.28, ua-parser-js@^0.7.30:
+ua-parser-js@^0.7.30:
   version "0.7.40"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.40.tgz#c87d83b7bb25822ecfa6397a0da5903934ea1562"
   integrity sha512-us1E3K+3jJppDBa3Tl0L3MOJiGhe1C6P0+nIvQAFYbxlMAx0h81eOwLmU57xgqToduDDPx3y5QsdjPfDu+FgOQ==
+
+ua-parser-js@^0.7.33:
+  version "0.7.41"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.41.tgz#9f6dee58c389e8afababa62a4a2dc22edb69a452"
+  integrity sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==
 
 unbox-primitive@^1.0.2, unbox-primitive@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,10 +3383,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.16.0":
-  version "9.16.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.16.0.tgz#f1db15d1c9d2d5386c31f990673143b2237734c8"
-  integrity sha512-RjuEnSRriJPMNtdsTx2eF3Mq03/B66mpB9zQFm7zstDQowVON8KH/cfrj4yii1Y8VOYusjR7tAAuxW8oKu7RNw==
+"@newrelic/gatsby-theme-newrelic@9.17.0":
+  version "9.17.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.17.0.tgz#9539b298e1966cc8f3f5ef61291a2c822c44a9ff"
+  integrity sha512-xFZEchex+j1GlfsL1EdBl6doizUZhHlBCaRTJAmpTZygAR+/H/2YpD6rlNpbQdyMWCx/h1smzLY424nuNBjTKw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Summary

Migrates the `/search-results` page from **Swiftype** to **SearchGPT** (New Relic's internal search service, REST API v2), consuming the `search()` / `highlightText()` / `useLocale()` / `localeToSearchLanguage()` exports from `@newrelic/gatsby-theme-newrelic`.

Depends on theme **9.17.0** (published with the SearchGPT v2 client + `localeToSearchLanguage` + `useLocale` re-export); this PR bumps the dep from 9.15.0.

## Changes

- **`src/pages/search-results.js`** — rewritten against the SearchGPT `search()` contract:
  - `search({ searchTerm, cursor, limit, language })` replaces the old Swiftype `{ searchTerm, defaultSources, filters, page, perPage }`.
  - Reads `results` / `totalCount` / `nextCursor` from the normalized hybrid-search shape.
  - **Cursor-based Prev/Next pagination.** SearchGPT paginates with opaque seek cursors (`search_after`), so there is no random page access. The page tracks the current cursor plus a stack of previously-visited cursors to support "Previous". Because the walk is seek-based, the full result set is reachable — it is **not** clamped to the 100-results-per-source window.
  - **Upfront "Page N of ~M" estimate.** Current page = cursor-stack depth + 1; total = `Math.ceil(totalCount / LIMIT)`, shown as approximate (`~M`) since the hit count is an estimate and the walk terminates when `nextCursor` goes null.
  - **Language scoping.** `useLocale()` + `localeToSearchLanguage()` scope results to the site language (jp→ja, kr→ko, pt→pt-br; English site = en). An unmapped locale yields `undefined`, which omits the param and searches all languages. Pagination resets when the query changes.
  - **Result rendering.** `result.title` highlighted client-side via `highlightText()`; `result.summary` is server-highlighted. Emphasis markup renders as `<span class='highlight'>` (styled green).
  - **Rate-limit handling.** A `RateLimitError` surfaces "Rate limited. Try again in Ns." from `err.rateLimit.resetInSeconds`; other failures show a generic error.
  - Pagination controls use the theme `Button` (`variant=OUTLINE`, `size=SMALL`) with native `disabled`, avoiding a disabled-`<Link>` a11y regression.
- **`package.json` / `yarn.lock`** — `@newrelic/gatsby-theme-newrelic` 9.15.0 → 9.17.0.

## Verification

- Confirmed the installed 9.17.0 `search()` return shape (`{ results, nextCursor, prevCursor, totalCount }`; results carry `url` / `title` / `summary`) and `highlightText()` markup (`<span class='highlight'>`) match the page's expectations.
- Lint passes.
- ⚠️ Runtime search can't be exercised from `localhost` — the SearchGPT service whitelists `docs.newrelic.com` (CORS), not localhost. **Verify exact `totalCount`, highlighted titles + summaries, Prev/Next cursor walk (including the reset-on-new-query behavior), language scoping on localized sites, and error/empty/rate-limited states on the deploy preview / production.**

## Env vars (build env + local `.env`)

```
GATSBY_SEARCHGPT_API_KEY=NRAK-...                                     # required
GATSBY_SEARCHGPT_BASE_URL=https://support-search.service.newrelic.com # optional (default)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)