### PR TITLE
docs: restructure Cloud Run integration with WIF dimensional metrics for Revision and Job

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration.mdx
@@ -4,30 +4,434 @@ tags:
   - Integrations
   - Google Cloud Platform integrations
   - GCP integrations list
-metaDescription: 'New Relic Google Cloud Datastore integration: the data it reports and how to enable it.'
+metaDescription: 'New Relic Google Cloud Run integration: the data it reports and how to enable it.'
 redirects:
   - /docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-run-monitoring-integration
   - /docs/gcp-gcp_run-integration
 freshnessValidatedDate: never
 ---
 
-[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) include an integration for reporting your GCP Run data to our products. Here we explain how to activate the integration and what data it collects.
+[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include one that reports [Google Cloud Run](https://cloud.google.com/run) data to New Relic. This document explains how to activate the GCP Cloud Run integration and describes the data it reports.
+
+## Features
+
+Cloud Run is Google Cloud's fully managed serverless container platform for running stateless services and one-off jobs. New Relic's Cloud Run integration collects request, latency, container utilization, and execution metrics across services (via revisions) and jobs.
 
 ## Activate integration [#activate]
 
-To enable the integration follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+To enable the integration, follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure):
 
-## Configuration and polling [#polling]
+* [Connect with Workload Identity Federation (recommended)](/docs/connect-google-cloud-platform-services-infrastructure)
+* [Connect with service account or user account](/docs/connect-google-cloud-platform-services-infrastructure)
 
-You can change the polling frequency and filter data using [configuration options](/docs/integrations/new-relic-integrations/getting-started/configure-polling-frequency-data-collection-cloud-integrations).
+## Polling frequency [#polling]
 
-Default [polling](/docs/integrations/google-cloud-platform-integrations/getting-started/polling-intervals-gcp-integrations) information for the GCP Run integration:
+New Relic integrations query your GCP services according to a polling interval that varies by integration. The polling frequency for Google Cloud Run is 5 minutes. The resolution is 1 data point every minute.
 
-* New Relic polling interval: 5 minutes
+<Callout variant="important">
+  Workload Identity Federation for metrics, and service account or user account authentication for samples, are not yet supported.
+</Callout>
 
-## Find and use data [#find-data]
+## Workload Identity Federation [#wif]
 
-To find your integration data, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP**</DNT> and select an integration.
+### Find and use data [#find-data-wif]
+
+After you enable the integration, your Cloud Run resources appear as entities in the New Relic entity explorer. To see dashboards and manage services, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP</DNT>.
+
+All Cloud Run metrics available in GCP Cloud Monitoring are collected as dimensional metrics in the `Metric` event type. Additional metrics beyond this table are collected automatically. See [Google's Cloud Run metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-run) for the complete list.
+
+#### Entities
+
+<CollapserGroup>
+  <Collapser
+    id="entities-table"
+    title="Cloud Run entities"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Entity
+          </th>
+
+          <th style={{ width: "260px" }}>
+            Entity type
+          </th>
+
+          <th>
+            Resource type
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Revision
+          </td>
+
+          <td>
+            `GCPCLOUDRUNREVISION`
+          </td>
+
+          <td>
+            `cloud_run_revision`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Job
+          </td>
+
+          <td>
+            `GCPCLOUDRUNJOB`
+          </td>
+
+          <td>
+            `cloud_run_job`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+</CollapserGroup>
+
+### Metric data [#metrics-wif]
+
+#### Key metrics — Revision
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.run.request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of requests reaching the revision, faceted by `response_code_class` (1xx–5xx) and `response_code`.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.request_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Request latency distribution for traffic served by the revision.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.billable_instance_time`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Billable time aggregated across all container instances of the revision.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.instance_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of container instances backing the revision, faceted by state (active, idle).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.cpu.allocation_time`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        CPU-seconds allocated to the revision's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.cpu.utilizations`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        CPU utilization distribution of the revision's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.memory.allocation_time`
+      </td>
+
+      <td>
+        GiB-seconds
+      </td>
+
+      <td>
+        Memory-seconds allocated to the revision's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.memory.utilizations`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Memory utilization distribution of the revision's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.network.received_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Network bytes received by the revision's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.network.sent_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Network bytes sent by the revision's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.max_request_concurrencies`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Maximum concurrent requests observed per container instance of the revision.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.startup_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Container startup latency distribution for the revision.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of revision metrics, see [Google's Cloud Run metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-run).
+
+#### Key metrics — Job
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.run.job.completed_execution_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of completed job executions, faceted by result (succeeded, failed, cancelled).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.job.running_executions`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of executions currently running for the job.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.job.completed_task_attempt_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of completed task attempts across all executions of the job.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.job.running_task_attempts`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of task attempts currently running across executions of the job.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.cpu.allocation_time`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        CPU-seconds allocated to the job's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.memory.allocation_time`
+      </td>
+
+      <td>
+        GiB-seconds
+      </td>
+
+      <td>
+        Memory-seconds allocated to the job's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.network.received_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Network bytes received by the job's container instances.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.run.container.network.sent_bytes_count`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Network bytes sent by the job's container instances.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of job metrics, see [Google's Cloud Run metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-run).
+
+## Service account or user account [#service-account]
+
+### Find and use data [#find-data]
+
+After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your <InlinePopover type="dashboards"/> and alert settings, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP > (select an integration)</DNT>.
 
 Data is attached to the following [event type](/docs/data-apis/understand-data/new-relic-data-types/#event-data):
 
@@ -66,10 +470,6 @@ Data is attached to the following [event type](/docs/data-apis/understand-data/n
 </table>
 
 For more on how to use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
-
-## Metric data [#metrics]
-
-This integration collects GCP Run data for Revision.
 
 ### Run Revision data
 


### PR DESCRIPTION
## Summary

- Adds a **Workload Identity Federation** section with `Metric` event dimensional queries for both Cloud Run entity types:
  - `GCPCLOUDRUNREVISION` (resource type `cloud_run_revision`) — 12 key metrics covering request, latency, CPU, memory, network, instance count, max concurrency, and startup latency
  - `GCPCLOUDRUNJOB` (resource type `cloud_run_job`) — 8 key metrics covering execution and task counts plus shared container allocation/network metrics
- Entities table wrapped in `<CollapserGroup>` for scannability
- **Service account or user account** section preserved with the existing `GcpRunRevisionSample` table intact
- Applies wording conventions from PR #24377:
  - Locked intro / activate / polling phrasing
  - `<Callout variant=\"important\">` (no \"Coming soon\")
  - Period-then-See (no em-dash)
  - No bold inside `<DNT>`

## Test plan

- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm both entities appear in the Entities collapser
- [ ] Check anchor links resolve (`#wif`, `#service-account`, `#polling`, `#activate`, `#find-data-wif`, `#find-data`)
- [ ] Confirm the existing GcpRunRevisionSample table is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)