### PR TITLE
docs: restructure Pub/Sub integration with WIF metrics for Topic, Subscription, and Snapshot

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-pubsub-monitoring-integration.mdx
@@ -11,31 +11,667 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include an integration to report [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) data to New Relic. This document explains how to activate the GCP Pub/Sub integration and describes the data that will be reported.
+[New Relic's integrations](/docs/infrastructure/introduction-infra-monitoring) with the [Google Cloud Platform (GCP)](https://cloud.google.com/) include one that reports [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/) data to New Relic. This document explains how to activate the GCP Pub/Sub integration and describes the data it reports.
 
 ## Features
 
-As part of the Google Cloud [stream analytics solution](https://cloud.google.com/solutions/stream-analytics), the Cloud Pub/Sub service ingests and delivers event streams for quick data processing and analysis.
+As part of the Google Cloud [stream analytics solution](https://cloud.google.com/solutions/stream-analytics), the Cloud Pub/Sub service ingests and delivers event streams for quick data processing and analysis. New Relic's Pub/Sub integration collects publish, delivery, backlog, and retention metrics across topics, subscriptions, and snapshots.
 
 ## Activate integration [#activate]
 
-To enable the integration follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure).
+To enable the integration, follow standard procedures to [connect your GCP service to New Relic](/docs/connect-google-cloud-platform-services-infrastructure):
+
+* [Connect with Workload Identity Federation (recommended)](/docs/connect-google-cloud-platform-services-infrastructure)
+* [Connect with service account or user account](/docs/connect-google-cloud-platform-services-infrastructure)
 
 ## Polling frequency [#polling]
 
-New Relic integrations query your GCP services according to a polling interval, which varies depending on the integration. The polling frequency for Google Cloud Pub/Sub is five minutes. The resolution is 1 data point every minute.
+New Relic integrations query your GCP services according to a polling interval that varies by integration. The polling frequency for Google Cloud Pub/Sub is 5 minutes. The resolution is 1 data point every minute.
 
-## Find and use data [#find-data]
+<Callout variant="important">
+  Workload Identity Federation for metrics, and service account or user account authentication for samples, are not yet supported.
+</Callout>
 
-After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your <InlinePopover type="dashboards"/> and alert settings, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP > (select an integration)**</DNT>.
+## Workload Identity Federation [#wif]
 
-## Metric data [#metrics]
+### Find and use data [#find-data-wif]
+
+After you enable the integration, your Pub/Sub resources appear as entities in the New Relic entity explorer. To see dashboards and manage services, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP</DNT>.
+
+All Pub/Sub metrics available in GCP Cloud Monitoring are collected as dimensional metrics in the `Metric` event type. Additional metrics beyond this table are collected automatically. See [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-pubsub) for the complete list.
+
+#### Entities
+
+<CollapserGroup>
+  <Collapser
+    id="entities-table"
+    title="Pub/Sub entities"
+  >
+    <table>
+      <thead>
+        <tr>
+          <th style={{ width: "200px" }}>
+            Entity
+          </th>
+
+          <th style={{ width: "260px" }}>
+            Entity type
+          </th>
+
+          <th>
+            Resource type
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            Topic
+          </td>
+
+          <td>
+            `GCPPUBSUBTOPIC`
+          </td>
+
+          <td>
+            `pubsub_topic`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Subscription
+          </td>
+
+          <td>
+            `GCPPUBSUBSUBSCRIPTION`
+          </td>
+
+          <td>
+            `pubsub_subscription`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            Snapshot
+          </td>
+
+          <td>
+            `GCPPUBSUBSNAPSHOT`
+          </td>
+
+          <td>
+            `pubsub_snapshot`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+</CollapserGroup>
+
+### Metric data [#metrics-wif]
+
+#### Key metrics — Topic
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.pubsub.topic.send_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of publish requests to the topic, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.send_request_latencies`
+      </td>
+
+      <td>
+        Microseconds
+      </td>
+
+      <td>
+        Publish request latency distribution at the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.publish_message_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages published to the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.message_sizes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Distribution of published message sizes at the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.byte_cost`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Byte cost of operations on the topic, used for quota accounting.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.num_retained_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages retained in the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.num_unacked_messages_by_region`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of unacknowledged messages held by the topic, faceted by region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.retained_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of messages retained in the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.oldest_retained_message_age`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age of the oldest message retained in the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.oldest_unacked_message_age_by_region`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age of the oldest unacknowledged message in the topic, faceted by region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.publish_quota_utilization`
+      </td>
+
+      <td>
+        Percent
+      </td>
+
+      <td>
+        Publish-quota utilization ratio for the topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.topic.config_updates_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of configuration changes applied to the topic, faceted by operation type and result.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of topic metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-pubsub).
+
+#### Key metrics — Subscription
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.num_undelivered_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of unacknowledged backlog messages in the subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.backlog_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of unacknowledged messages in the subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.oldest_unacked_message_age`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age of the oldest unacknowledged message in the subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.num_outstanding_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages delivered to the subscription's push endpoint but not yet acknowledged.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.ack_message_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages acknowledged on the subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.ack_latencies`
+      </td>
+
+      <td>
+        Milliseconds
+      </td>
+
+      <td>
+        Acknowledgement latency distribution at the subscription.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.pull_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of pull requests issued against the subscription, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.pull_ack_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of acknowledge requests issued against the subscription, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.push_request_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of push attempts from the subscription to its endpoint, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.push_request_latencies`
+      </td>
+
+      <td>
+        Microseconds
+      </td>
+
+      <td>
+        Push request latency distribution from the subscription to its endpoint, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.streaming_pull_response_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of StreamingPull responses returned for the subscription, faceted by response code.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.expired_ack_deadlines_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of acknowledgement deadlines that expired before the subscriber acknowledged the message.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.dead_letter_message_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages delivered from the subscription to its dead-letter topic.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.byte_cost`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Byte cost of operations on the subscription, used for quota accounting.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.subscription.delivery_latency_health_score`
+      </td>
+
+      <td>
+        Boolean
+      </td>
+
+      <td>
+        Health score indicating whether the subscription's delivery latency is within its target.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of subscription metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-pubsub).
+
+#### Key metrics — Snapshot
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.num_messages`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages held in the snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.backlog_bytes`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of messages held in the snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.oldest_message_age`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age of the oldest message in the snapshot.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.num_messages_by_region`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of messages held in the snapshot, faceted by region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.backlog_bytes_by_region`
+      </td>
+
+      <td>
+        Bytes
+      </td>
+
+      <td>
+        Total byte size of messages held in the snapshot, faceted by region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.oldest_message_age_by_region`
+      </td>
+
+      <td>
+        Seconds
+      </td>
+
+      <td>
+        Age of the oldest message in the snapshot, faceted by region.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `gcp.pubsub.snapshot.config_updates_count`
+      </td>
+
+      <td>
+        Count
+      </td>
+
+      <td>
+        Number of configuration changes applied to the snapshot, faceted by operation type and result.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of snapshot metrics, see [Google's Pub/Sub metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp_p_z#gcp-pubsub).
+
+## Service account or user account [#service-account]
+
+### Find and use data [#find-data]
+
+After activating the integration and waiting a few minutes (based on the [polling frequency](#polling)), data will appear in the New Relic UI. To [find and use your data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data), including links to your <InlinePopover type="dashboards"/> and alert settings, go to <DNT>[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > GCP > (select an integration)</DNT>.
 
 Pub/Sub topics are named entities that represent feeds of messages, and subscriptions are named entities that represent message destinations on a particular topic.
 
 To view [metric data](/docs/telemetry-data-platform/understand-data/new-relic-data-types/#metrics) for your GCP Pub/Sub integration in New Relic, [create NRQL queries](/docs/integrations/new-relic-integrations/getting-started/use-integration-data-new-relic-insights#nrql) for `GcpPubSubTopicSample` and `GcpPubSubSubscriptionSample` [events](/docs/data-apis/understand-data/new-relic-data-types/#event-data) and their related attributes.
 
-### GcpPubSubTopicSample [#gcp-app-engine-service-sample]
+### GcpPubSubTopicSample [#gcp-pubsub-topic-sample]
 
 Query `GcpPubSubTopicSample` events in New Relic to view data for the following attributes:
 
@@ -165,7 +801,7 @@ Query `GcpPubSubTopicSample` events in New Relic to view data for the following 
   </tbody>
 </table>
 
-### GcpPubSubSubscriptionSample [#gcp-app-engine-service-sample]
+### GcpPubSubSubscriptionSample [#gcp-pubsub-subscription-sample]
 
 Query `GcpPubSubSubscriptionSample` events in New Relic to view data for the following attributes:
 


### PR DESCRIPTION
## Summary

- Adds a **Workload Identity Federation** section with `Metric` event dimensional queries for three Pub/Sub entity types:
  - `GCPPUBSUBTOPIC` (resource type `pubsub_topic`) — 12 key metrics (publish, message sizes, byte cost, retention, unacked, quota utilization, config updates)
  - `GCPPUBSUBSUBSCRIPTION` (resource type `pubsub_subscription`) — 15 key metrics (backlog, undelivered, oldest unacked age, pull/push/streaming pull request and latency, ack/expired ack, dead-letter, byte cost, delivery latency health)
  - `GCPPUBSUBSNAPSHOT` (resource type `pubsub_snapshot`) — 7 key metrics (num_messages, backlog_bytes, oldest_message_age, region variants, config updates)
- Entities table wrapped in `<CollapserGroup>` for scannability
- **Service account or user account** section preserved with the existing `GcpPubSubTopicSample` and `GcpPubSubSubscriptionSample` tables intact
- Applies wording conventions from PR #24377:
  - Locked intro / activate / polling phrasing
  - `<Callout variant=\"important\">` (no \"Coming soon\")
  - Period-then-See (no em-dash)
  - No bold inside `<DNT>`

Replaces the earlier closed PR #24376 with the current locked style rules.

## Test plan

- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm all 3 entities appear in the Entities collapser
- [ ] Check anchor links resolve (`#wif`, `#service-account`, `#polling`, `#activate`, `#find-data-wif`, `#find-data`, `#gcp-pubsub-topic-sample`, `#gcp-pubsub-subscription-sample`)
- [ ] Confirm the existing GcpPubSubTopicSample and GcpPubSubSubscriptionSample tables are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)