### PR TITLE
docs(dashboards): update export PDF/PNG docs and add NerdGraph API section

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api.mdx
@@ -4,66 +4,15 @@ tags:
   - APIs
   - NerdGraph
   - Examples
-metaDescription: Use New Relic NerdGraph to understand how entities are related.
+metaDescription: Use New Relic NerdGraph to export dashboards as PDF or PNG files programmatically.
 redirects:
   - /docs/apis/nerdgraph/examples/export-dashboards-pdfpng-api-tutorial
 freshnessValidatedDate: never
 ---
 
-Do you need to schedule reports that contain charts or dashboards? Do you want to automate how you share dashboards? You can obtain your <InlinePopover type="dashboards"/> as PDF or PNG files programmatically with a [GraphQL](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) mutation. You can also [export dashboards as PDF files using the UI](/docs/dashboards/manage-your-dashboard/manage-your-dashboard#dash-export).
+You can export your <InlinePopover type="dashboards"/> as PDF or PNG files programmatically using the NerdGraph `dashboardCreateSnapshotUrl` mutation. You can also [export dashboards using the UI](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#export-dashboards-pdf).
 
-For example, you can generate static, [snapshot versions](/docs/apis/nerdgraph/examples/nerdgraph-dashboards/#other-operations) of your New Relic dashboards and send them to [Slack](/docs/alerts-applied-intelligence/notifications/notification-integrations/#slack) or [download as files](/docs/apis/nerdgraph/examples/export-dashboards-pdfpng-using-api/).
-
-## Export dashboard pages [#dash-multiple]
-
-1. Obtain the dashboard's GUID: Click the <Icon name="fe-more-horizontal"/> icon by the dashboard's name to access the metadata widget and see the dashboard's GUID.
-
-2. Get the individual pages' GUIDs using the query below:
-
-   ```graphql
-   {
-    actor {
-       entitySearch(query: "id ='YOUR_PAGE_GUID' OR parentId ='YOUR_PAGE_GUID' AND tags.isDashboardPage = 'true'" ) {
-         results {
-           entities {
-             guid
-             name
-             ... on DashboardEntityOutline {
-               guid
-               name
-               dashboardParentGuid
-             }
-           }
-         }
-       }
-     }
-   }
-   ```
-
-3. Run the <DNT>**dashboardCreateSnapshotURL**</DNT> mutation in the [NerdGraphQL explorer](https://api.newrelic.com/graphiql) as many times as dashboard pages you want to export. You just need to provide the desired dashboard page GUID as a parameter.
-
-4. Get the link to retrieve your dashboard page as a PDF. The link looks similar to:
-
-   ```
-   https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
-   ```
-
-5. [Configure](#configure) the exported file, if necessary.
-
-## Configure the file you retrieve [#configure]
-
-Edit the returned link to change the format of your export (PDF or PNG), or resize it.
-
-For example, if you obtain the link:
-
-```
-https://gorgon.nr-assets.net/image/e0c22263-2d88-40bc-940a-b885dbc1d98d?format=PDF&width=2000&height=2000
-```
-
-You could:
-
-* Substitute `PDF` for `PNG` to get an image.
-* Modify the width and height fields to adjust the size to your needs. The maximum value is `2000`.
+For full documentation of the mutation, all available parameters, and examples — including variable overrides, custom dimensions, and per-widget chart image export — see [Export dashboards and charts via NerdGraph API](/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data/#export-api).
 
 ## Troubleshooting [#troubleshooting]
 
@@ -71,8 +20,8 @@ Here's what to do if you experience any of the following errors while trying to 
 
 * From New Relic UI: <DNT>**We ran into an error while creating the PDF. Please try again**</DNT>
 
-* From New Relic NerdGraph: <DNT>**Operation on dashboard entity failed with guid:YOUR_GUID with cause: Error 504 calling Gorgon with url [https://chart-image.service.newrelic.com/dashboard-url-from-guid/YOUR_GUID](https://chart-image.service.newrelic.com/dashboard-url-from-guid/YOUR_GUID): upstream request timeout**</DNT>
+* From New Relic NerdGraph: <DNT>**Operation on dashboard entity failed with guid:YOUR_GUID with cause: Error 504: upstream request timeout**</DNT>
 
-These errors can be caused if the generation of the PDF exceeds the API max response time. If you encounter these errors, check if any of the widgets on your dashboard have a large time window. For example, you might compare data from an entire month versus previous months. If you see a large time window, try decreasing the window.
+These errors can occur if the export exceeds the API max response time. Check if any widgets on your dashboard use a large time window — for example, comparing data across an entire month. If so, try reducing the time window.
 
-Another possible cause of these errors is that your dashboard may have a large number of widgets. If you have widgets you don't use, you might try removing some to see if this resolves the error.
+Another possible cause is a dashboard with a large number of widgets. Try removing unused widgets to see if this resolves the error.

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
@@ -32,9 +32,9 @@ To import a dashboard as JSON:
 
 7. Click <DNT>**Save**</DNT>.
 
-## Export a dashboard as PDF or PNG [#export-dashboards-pdf]
+## Export a dashboard as PDF [#export-dashboards-pdf]
 
-To export your dashboard as a PDF or PNG file, in the dashboard's top right corner, click the <DNT>**...**</DNT> icon and select <DNT>**Export dashboard as PDF**</DNT> or <DNT>**Export dashboard as PNG**</DNT>.
+To export your dashboard as a PDF file, in the dashboard's top right corner, click the <DNT>**...**</DNT> icon and select <DNT>**Export dashboard as PDF**</DNT>.
 
 <img
   title="Export dashboard as PDF"
@@ -46,15 +46,11 @@ To export your dashboard as a PDF or PNG file, in the dashboard's top right corn
   Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Dashboards**</DNT> and open an existing dashboard.
 </figcaption>
 
-Consider the following when exporting a dashboard as PDF or PNG via the UI:
+Consider the following when exporting a dashboard as PDF via the UI:
 
 * [Custom visualizations](/docs/query-your-data/explore-query-data/dashboards/add-custom-visualizations-your-dashboards/) aren't supported.
 
-* [Billboard charts](/docs/query-your-data/explore-query-data/use-charts/chart-types/#widget-billboard) that use the [`COMPARE WITH`](/docs/nrql/nrql-syntax-clauses-functions/#sel-compare) clause won't show percentages or render correctly with public chart links, exported images, and PDFs.
-
-* Markdown widgets with large images may not display correctly or may not be fully visible.
-
-* Latest visualization features such as data sorting in tables, chart data formatting, and emojis and symbols are not supported in UI exports. To export with full visualization support, use the [NerdGraph API](#export-api).
+To export as PDF or PNG with additional options such as custom dimensions and template variable overrides, use the [NerdGraph API](#export-api).
 
 ## Export dashboards and charts via NerdGraph API [#export-api]
 
@@ -243,7 +239,7 @@ enum SnapshotUrlFormat {
 </CollapserGroup>
 
 <Callout variant="important">
-  Snapshot URLs are publicly accessible without authentication and expire after 90 days. Share them carefully in accordance with your organization's data policies.
+  Snapshot URLs are publicly accessible without authentication and expire after 3 months. Share them carefully in accordance with your organization's data policies.
 </Callout>
 
 ### Get a chart image [#api-widget-snapshot]

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboards-charts-import-export-data.mdx
@@ -32,9 +32,9 @@ To import a dashboard as JSON:
 
 7. Click <DNT>**Save**</DNT>.
 
-## Export a dashboard as PDF [#export-dashboards-pdf]
+## Export a dashboard as PDF or PNG [#export-dashboards-pdf]
 
-To export your dashboard as a PDF file, in the dashboard's top right corner, click the <DNT>**...**</DNT> icon and select <DNT>**Export dashboard as PDF**</DNT>.
+To export your dashboard as a PDF or PNG file, in the dashboard's top right corner, click the <DNT>**...**</DNT> icon and select <DNT>**Export dashboard as PDF**</DNT> or <DNT>**Export dashboard as PNG**</DNT>.
 
 <img
   title="Export dashboard as PDF"
@@ -46,9 +46,7 @@ To export your dashboard as a PDF file, in the dashboard's top right corner, cli
   Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Dashboards**</DNT> and open an existing dashboard.
 </figcaption>
 
-Consider the following when exporting a dashboard as PDF:
-
-* [Template variables](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables/#requirements) aren't supported.
+Consider the following when exporting a dashboard as PDF or PNG via the UI:
 
 * [Custom visualizations](/docs/query-your-data/explore-query-data/dashboards/add-custom-visualizations-your-dashboards/) aren't supported.
 
@@ -56,7 +54,351 @@ Consider the following when exporting a dashboard as PDF:
 
 * Markdown widgets with large images may not display correctly or may not be fully visible.
 
-* Latest visualizations features such as (but not limited to) data sorting in tables, chart data format, and emojis and symbols are not supported and will not be reflected in the resulting PDF.
+* Latest visualization features such as data sorting in tables, chart data formatting, and emojis and symbols are not supported in UI exports. To export with full visualization support, use the [NerdGraph API](#export-api).
+
+## Export dashboards and charts via NerdGraph API [#export-api]
+
+Use the NerdGraph API to programmatically export dashboards and individual chart widgets as snapshot images. The API supports options not available in the UI, including custom dimensions, template variable overrides, and entity filters.
+
+### Export a dashboard as PDF or PNG [#api-dashboard-snapshot]
+
+The `dashboardCreateSnapshotUrl` mutation generates a snapshot URL for a full dashboard page.
+
+<Callout variant="tip">
+  The `guid` parameter requires the **page** GUID, not the dashboard GUID. A dashboard can have multiple pages. To find page GUIDs, use the `entitySearch` query or open the dashboard page and select <DNT>**Manage JSON**</DNT> from the <DNT>**...**</DNT> menu.
+
+  ```graphql
+  {
+    actor {
+      entitySearch(query: "parentId ='YOUR_DASHBOARD_GUID' AND tags.isDashboardPage = 'true'") {
+        results {
+          entities {
+            guid
+            name
+          }
+        }
+      }
+    }
+  }
+  ```
+</Callout>
+
+**Mutation schema:**
+
+```graphql
+mutation {
+  dashboardCreateSnapshotUrl(
+    guid: EntityGuid!
+    params: SnapshotUrlInput
+  ): String
+}
+
+input SnapshotUrlInput {
+  timeWindow: SnapshotUrlTimeWindowInput
+  display: SnapshotUrlDisplayInput
+  variables: [SnapshotUrlVariableInput!]
+  filter: String
+  format: SnapshotUrlFormat
+}
+
+input SnapshotUrlTimeWindowInput {
+  beginTime: EpochMilliseconds
+  endTime: EpochMilliseconds
+  duration: Milliseconds
+}
+
+input SnapshotUrlDisplayInput {
+  width: Int
+  height: Int
+}
+
+input SnapshotUrlVariableInput {
+  name: String!
+  values: [String!]!
+}
+
+enum SnapshotUrlFormat {
+  PDF
+  PNG
+}
+```
+
+**Parameter reference:**
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`guid`</td>
+      <td>`EntityGuid!`</td>
+      <td>—</td>
+      <td>Required. The entity GUID of the dashboard page.</td>
+    </tr>
+    <tr>
+      <td>`params.timeWindow.beginTime`</td>
+      <td>`EpochMilliseconds`</td>
+      <td>Dashboard's current time window</td>
+      <td>Start of the data window (epoch ms).</td>
+    </tr>
+    <tr>
+      <td>`params.timeWindow.endTime`</td>
+      <td>`EpochMilliseconds`</td>
+      <td>Dashboard's current time window</td>
+      <td>End of the data window (epoch ms).</td>
+    </tr>
+    <tr>
+      <td>`params.timeWindow.duration`</td>
+      <td>`Milliseconds`</td>
+      <td>—</td>
+      <td>Relative time window, alternative to `beginTime`/`endTime`.</td>
+    </tr>
+    <tr>
+      <td>`params.display.width`</td>
+      <td>`Int`</td>
+      <td>1920</td>
+      <td>Width in pixels for the snapshot.</td>
+    </tr>
+    <tr>
+      <td>`params.display.height`</td>
+      <td>`Int`</td>
+      <td>1080</td>
+      <td>Height in pixels for the snapshot.</td>
+    </tr>
+    <tr>
+      <td>`params.variables`</td>
+      <td>`[SnapshotUrlVariableInput!]`</td>
+      <td>Dashboard's current variable values</td>
+      <td>Pin specific values for dashboard template variables.</td>
+    </tr>
+    <tr>
+      <td>`params.filter`</td>
+      <td>`String`</td>
+      <td>No filter</td>
+      <td>NRQL-style entity filter applied at snapshot time.</td>
+    </tr>
+    <tr>
+      <td>`params.format`</td>
+      <td>`SnapshotUrlFormat`</td>
+      <td>`PDF`</td>
+      <td>Output format: `PDF` or `PNG`.</td>
+    </tr>
+  </tbody>
+</table>
+
+**Examples:**
+
+<CollapserGroup>
+  <Collapser id="basic-export" title="Basic export (PDF, default settings)">
+    ```graphql
+    mutation {
+      dashboardCreateSnapshotUrl(
+        guid: "YOUR_DASHBOARD_PAGE_GUID"
+      )
+    }
+    ```
+  </Collapser>
+
+  <Collapser id="png-custom-dimensions" title="Export as PNG with custom dimensions">
+    ```graphql
+    mutation {
+      dashboardCreateSnapshotUrl(
+        guid: "YOUR_DASHBOARD_PAGE_GUID"
+        params: {
+          format: PNG
+          display: {
+            width: 1920
+            height: 1080
+          }
+        }
+      )
+    }
+    ```
+  </Collapser>
+
+  <Collapser id="variables-filter" title="Export with variable overrides and a filter">
+    Use this to pin specific variable values and filters into the snapshot, useful for scheduled report automation.
+
+    ```graphql
+    mutation {
+      dashboardCreateSnapshotUrl(
+        guid: "YOUR_DASHBOARD_PAGE_GUID"
+        params: {
+          variables: [
+            { name: "environment", values: ["production"] }
+            { name: "region", values: ["us-east-1", "eu-west-1"] }
+          ]
+          filter: "env = 'production' AND service = 'checkout'"
+        }
+      )
+    }
+    ```
+  </Collapser>
+</CollapserGroup>
+
+<Callout variant="important">
+  Snapshot URLs are publicly accessible without authentication and expire after 90 days. Share them carefully in accordance with your organization's data policies.
+</Callout>
+
+### Get a chart image [#api-widget-snapshot]
+
+The `dashboardWidgetCreateSnapshotUrl` mutation generates a PNG snapshot URL for a single chart widget. The widget does not need to exist on a dashboard — you can define it inline, which makes this useful for generating chart images programmatically.
+
+**Mutation schema:**
+
+```graphql
+mutation {
+  dashboardWidgetCreateSnapshotUrl(
+    widget: DeclarativeUiWidget!
+  ): WidgetSnapshotResult
+}
+
+type WidgetSnapshotResult {
+  url: String!
+}
+```
+
+The `widget` parameter accepts a `DeclarativeUiWidget` — a JSON object with three nested layers:
+
+```
+declarative/widget envelope
+└── widget node        ← title and widget-level props
+    └── visualization  ← visualization type and configuration
+```
+
+```json
+{
+  "type": "declarative/widget",
+  "version": 1,
+  "content": {
+    "type": "widget",
+    "props": {
+      "title": "My Chart Title"
+    },
+    "content": {
+      "type": "visualization",
+      "id": "viz.line",
+      "props": {
+        // visualization-specific config (nrqlQueries, colors, thresholds, etc.)
+      }
+    }
+  }
+}
+```
+
+If you're building the widget definition from a dashboard you've exported as JSON, use this field mapping:
+
+<table>
+  <thead>
+    <tr>
+      <th>Dashboard JSON field</th>
+      <th>DeclarativeUiWidget field</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`title`</td>
+      <td>`content.props.title`</td>
+    </tr>
+    <tr>
+      <td>`visualization.id`</td>
+      <td>`content.content.id`</td>
+    </tr>
+    <tr>
+      <td>`rawConfiguration.*`</td>
+      <td>`content.content.props.*` (same field names)</td>
+    </tr>
+    <tr>
+      <td>`layout`, `id`, `linkedEntityGuids`</td>
+      <td>Not included — not needed for standalone snapshots</td>
+    </tr>
+  </tbody>
+</table>
+
+**Examples:**
+
+<CollapserGroup>
+  <Collapser id="line-chart-snapshot" title="Export a line chart">
+    ```graphql
+    mutation {
+      dashboardWidgetCreateSnapshotUrl(
+        widget: {
+          version: 1
+          type: "declarative/widget"
+          content: {
+            type: "widget"
+            props: { title: "Throughput by environment" }
+            content: {
+              type: "visualization"
+              id: "viz.line"
+              props: {
+                nrqlQueries: [
+                  {
+                    accountIds: [YOUR_ACCOUNT_ID]
+                    query: "SELECT count(*) FROM Transaction TIMESERIES"
+                  }
+                ]
+                legend: { enabled: true }
+              }
+            }
+          }
+        }
+      ) {
+        url
+      }
+    }
+    ```
+  </Collapser>
+
+  <Collapser id="billboard-snapshot" title="Export a billboard chart with thresholds">
+    ```graphql
+    mutation {
+      dashboardWidgetCreateSnapshotUrl(
+        widget: {
+          version: 1
+          type: "declarative/widget"
+          content: {
+            type: "widget"
+            props: { title: "Error rate" }
+            content: {
+              type: "visualization"
+              id: "viz.billboard"
+              props: {
+                nrqlQueries: [
+                  {
+                    accountIds: [YOUR_ACCOUNT_ID]
+                    query: "SELECT percentage(count(*), WHERE error IS true) AS 'Error rate' FROM Transaction SINCE 1 hour ago"
+                  }
+                ]
+                thresholds: [
+                  { alertSeverity: "WARNING", value: 1 }
+                  { alertSeverity: "CRITICAL", value: 5 }
+                ]
+              }
+            }
+          }
+        }
+      ) {
+        url
+      }
+    }
+    ```
+  </Collapser>
+</CollapserGroup>
+
+<Callout variant="tip">
+  The legacy `actor.account.nrql.staticChartUrl` field in NerdGraph remains available but does not support the latest visualization features such as thresholds, color formatting, and newer chart types. `dashboardWidgetCreateSnapshotUrl` is the recommended approach going forward.
+</Callout>
+
+<Callout variant="important">
+  Snapshot URLs generated by `dashboardWidgetCreateSnapshotUrl` are PNG images, publicly accessible without authentication, and expire after 3 months.
+</Callout>
 
 ## Export a chart as CSV [#export-charts-csv]
 


### PR DESCRIPTION
## Summary

- Updates the **Export a dashboard as PDF** UI section to cover PNG (now available) and removes the stale template-variables limitation
- Adds a new **Export via NerdGraph API** section to `dashboards-charts-import-export-data` covering:
  - `dashboardCreateSnapshotUrl` — full `SnapshotUrlInput` schema, parameter reference table, and collapsible examples (basic, PNG with custom dimensions, variable overrides + filter)
  - `dashboardWidgetCreateSnapshotUrl` — widget structure diagram, dashboard JSON field mapping table, collapsible examples (line chart, billboard with thresholds), and legacy `staticChartUrl` deprecation note
- Slims down `export-dashboards-pdfpng-using-api.mdx` to a redirect stub pointing to the canonical dashboards page; troubleshooting content retained

Closes NR-578390

