### PR TITLE
Docs: Updated expired link on Synthetics page

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/using-monitors/intro-synthetic-monitoring.mdx
@@ -303,7 +303,7 @@ Synthetic monitoring includes the following features:
       <td>
         Synthetic monitoring specifically excludes scripts for [popular analytics services](https://s3.amazonaws.com/nr-synthetics-assets/default-hostnames-blacklist/production/default-hostnames-blacklist.txt), like Google Analytics. This ensures your analytics tools continue to receive the exact same data, even with thousands of monitors checking your website each month.
 
-        You can [unblock](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers#unblock-service) any of the services blocked by default, or [block](/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference#browser-addHostnameToBlacklist) additional services.
+        You can [unblock](/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers#unblock-service) any of the services blocked by default, or [block](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100/#wildcard-use) additional services.
       </td>
     </tr>
 


### PR DESCRIPTION
Updated the link for blocking services to point to the $urlFilter.addToDenyList() function as the previous URL no longer exists.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.