### PR TITLE
Added release notes for fluent-bit 5.0.8 and NR output plugin 3.7.0

### DIFF
--- a/src/content/docs/release-notes/fluentbit-release-notes/fluentbit-26-06-30.mdx
+++ b/src/content/docs/release-notes/fluentbit-release-notes/fluentbit-26-06-30.mdx
@@ -1,0 +1,108 @@
+---
+subject: Fluent Bit
+releaseDate: '2026-06-30'
+version: 5.0.8
+metaDescription: Release notes for Fluent Bit version 5.0.8
+features: []
+bugs: []
+supportedOperatingSystems:
+  - osName: debian
+    osVersions:
+      - versionName: bullseye
+        architectures:
+          - amd64
+          - arm64
+      - versionName: bookworm
+        architectures:
+          - amd64
+          - arm64
+  - osName: centos
+    osVersions:
+      - versionName: '7'
+        architectures:
+          - x86_64
+          - aarch64
+      - versionName: '8'
+        architectures:
+          - x86_64
+          - aarch64
+      - versionName: '9'
+        architectures:
+          - x86_64
+          - aarch64
+  - osName: rockylinux
+    osVersions:
+      - versionName: '10'
+        architectures:
+          - x86_64
+          - aarch64
+  - osName: amazonlinux
+    osVersions:
+      - versionName: '2'
+        architectures:
+          - x86_64
+          - aarch64
+      - versionName: '2023'
+        architectures:
+          - x86_64
+          - aarch64
+  - osName: ubuntu
+    osVersions:
+      - versionName: jammy
+        architectures:
+          - amd64
+          - arm64
+      - versionName: noble
+        architectures:
+          - amd64
+          - arm64
+  - osName: sles
+    osVersions:
+      - versionName: '15.3'
+        architectures:
+          - x86_64
+      - versionName: '15.4'
+        architectures:
+          - x86_64
+      - versionName: '15.5'
+        architectures:
+          - x86_64
+      - versionName: '15.6'
+        architectures:
+          - x86_64
+      - versionName: '15.7'
+        architectures:
+          - x86_64
+  - osName: windows-server
+    osVersions:
+      - versionName: '2019'
+        architectures:
+          - win64
+          - win32
+      - versionName: '2022'
+        architectures:
+          - win64
+          - win32
+---
+
+### Support for Fluent Bit 5.0.8
+
+Users will now receive Fluent Bit version 5.0.8. For more details, refer to the [Fluent Bit announcements](https://fluentbit.io/announcements/).
+
+This release includes [New Relic Fluent Bit Output Plugin 3.7.0](https://github.com/newrelic/newrelic-fluent-bit-output/releases/tag/v3.7.0).
+
+### Added
+
+* New Relic Fluent Bit Output Plugin 3.7.0 integration
+
+### Changed
+
+* Go version upgraded to 1.26.4 for CVE fixes
+* The Infrastructure agent recommends Fluent Bit 5.0.8 packages (Linux) and 5.0.7 (Windows)
+* [Fluent Bit Output Plugin Docker image](https://hub.docker.com/r/newrelic/newrelic-fluentbit-output) uses Fluent Bit 5.0.8 with output plugin 3.7.0
+* [New Relic Logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) installs the new plugin image
+* Windows Docker image uses Fluent Bit 5.0.7 (5.0.8 Windows image not yet available upstream)
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).

--- a/src/content/docs/release-notes/logs-release-notes/logs-26-06-30.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-26-06-30.mdx
@@ -1,0 +1,27 @@
+---
+subject: Logs
+releaseDate: '2026-06-30'
+version: '260630'
+---
+
+### Support for Fluent Bit 5.0.8
+
+Users will now receive Fluent Bit version 5.0.8. For more details, refer to the [Fluent Bit announcements](https://fluentbit.io/announcements/).
+
+This release includes [New Relic Fluent Bit Output Plugin 3.7.0](https://github.com/newrelic/newrelic-fluent-bit-output/releases/tag/v3.7.0).
+
+### Added
+
+* New Relic Fluent Bit Output Plugin 3.7.0 integration
+
+### Changed
+
+* Go version upgraded to 1.26.4 for CVE fixes
+* The Infrastructure agent recommends Fluent Bit 5.0.8 packages (Linux) and 5.0.7 (Windows)
+* [Fluent Bit Output Plugin Docker image](https://hub.docker.com/r/newrelic/newrelic-fluentbit-output) uses Fluent Bit 5.0.8 with output plugin 3.7.0
+* [New Relic Logging Helm chart](https://github.com/newrelic/helm-charts/tree/master/charts/newrelic-logging) installs the new plugin image
+* Windows Docker image uses Fluent Bit 5.0.7 (5.0.8 Windows image not yet available upstream)
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
## Summary                                                         
                                                                                                                                                                                                                 
  Adds release notes for Fluent Bit 5.0.8 (New Relic Fluent Bit Output Plugin 3.7.0).                                                                                                                            
                                                                                                                                                                                                                 
  ### New files:                                                                                                                                                                                                 
  - fluentbit-release-notes/fluentbit-26-06-30.mdx — release notes with supported OS matrix                                                                                                                      
  - logs-release-notes/logs-26-06-30.mdx — companion Logs feed entry                                                                                                                                             
                                                                                                                                                                                                                 
  ### Highlights:                                                                                                                                                                                                
  - Fluent Bit upgraded to 5.0.8 (Linux) / 5.0.7 (Windows)                                                                                                                                                       
  - New Relic Fluent Bit Output Plugin upgraded to 3.7.0                                                                                                                                                         
  - Go version upgraded to 1.26.4 for CVE fixes