### PR TITLE
chore(.net agent): Update compatibility docs for latest supported library versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -457,7 +457,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   <DNT>**Microsoft.Data.SqlClient**</DNT>
                       * Minimum supported version: 1.0.19239.1
-                      * Latest verified compatible version: 7.0.1
+                      * Latest verified compatible version: 7.0.2
                 </td>
                 </tr>
 
@@ -557,7 +557,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
-                      * Latest verified compatible version: 2.6.0
+                      * Latest verified compatible version: 2.6.1
                 </td>
                 </tr>
 
@@ -575,7 +575,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 3.0.0
+            Latest verified compatible version: 3.0.11
                 </td>
                 </tr>
 
@@ -646,7 +646,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.21.3
+                  * Latest verified compatible version: 4.0.100
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -774,7 +774,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.20.6
+                    4.0.100
                 </td>
                 </tr>
                 <tr>
@@ -849,7 +849,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    3.3.1
+                    3.3.2
                 </td>
 
                 </tr>
@@ -938,7 +938,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 1.4.0
 
-                    * Latest verified compatible version: 2.14.2
+                    * Latest verified compatible version: 2.15.0
                 </td>
                 </tr>
 
@@ -952,7 +952,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 5.0
 
-                    * Latest verified compatible version: 10.2.5
+                    * Latest verified compatible version: 10.2.7
                 </td>
                 </tr>
 
@@ -1006,7 +1006,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.3.4
+                  * Latest verified compatible version: 4.0.100
                 </td>
                 </tr>
 
@@ -1020,7 +1020,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.9.4
+                  * Latest verified compatible version: 4.0.100
                 </td>
                 </tr>
 
@@ -1034,7 +1034,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.5
+                  * Latest verified compatible version: 4.0.100
                 </td>
                 </tr>
 
@@ -1578,7 +1578,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**Microsoft.Data.SqlClient**</DNT>
                       * Minimum supported version: 1.0.19239.1
-                      * Latest verified compatible version: 7.0.1
+                      * Latest verified compatible version: 7.0.2
 
                       <DNT>**System.Data**</DNT>
                       * Minimum supported version: .NET Framework 4.6.2
@@ -1676,7 +1676,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
-                      * Latest verified compatible version: 2.6.0
+                      * Latest verified compatible version: 2.6.1
                     </td>
                     </tr>
 
@@ -1752,7 +1752,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 2.13.17
+                        * Latest verified compatible version: 3.0.11
                     </td>
                     </tr>
 
@@ -1824,7 +1824,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.18.6
+                  * Latest verified compatible version: 4.0.100
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1992,7 +1992,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.20.6
+                        4.0.100
                     </td>
                     </tr>
                     <tr>
@@ -2068,7 +2068,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        3.3.1
+                        3.3.2
                     </td>
                     </tr>
 
@@ -2233,7 +2233,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.2.33
+                        * Latest verified compatible version: 4.0.100
                     </td>
                     </tr>
 
@@ -2247,7 +2247,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.8.19
+                    * Latest verified compatible version: 4.0.100
                     </td>
                     </tr>
 
@@ -2261,7 +2261,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.3.32
+                    * Latest verified compatible version: 4.0.100
                     </td>
                     </tr>
 


### PR DESCRIPTION
Updates the .NET agent compatibility docs with the latest verified library versions:

- AWSSDK.BedrockRuntime -> 4.0.100
- AWSSDK.DynamoDBv2 -> 4.0.100
- AWSSDK.Kinesis -> 4.0.100
- AWSSDK.KinesisFirehose -> 4.0.100
- AWSSDK.SQS -> 4.0.100
- Confluent.Kafka -> 2.15.0
- log4net -> 3.3.2
- Microsoft.Data.SqlClient -> 7.0.2
- MySqlConnector -> 2.6.1
- NServiceBus -> 10.2.7
- StackExchange.Redis -> 3.0.11