### PR TITLE
chore: Update Ruby hybrid agent support

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/opentelemetry-api-support.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/opentelemetry-api-support.mdx
@@ -93,8 +93,8 @@ OpenTelemetry API support is available for the following New Relic APM agents:
       <td><Icon name="fe-check" /></td>
       <td><Icon name="fe-x" /></td>
       <td><Icon name="fe-x" /></td>
-      <td><Icon name="fe-x" /></td>
-      <td><Icon name="fe-x" /></td>
+      <td><Icon name="fe-check" /></td>
+      <td><Icon name="fe-check" /></td>
     </tr>
   </tbody>
 </table>
@@ -407,7 +407,7 @@ OpenTelemetry API support is disabled by default. Enable it through your agent's
     ```
 
     <Callout variant="important">
-    When OpenTelemetry support is enabled, the agent will automatically detect if `opentelemetry-api` is installed and switch to using OpenTelemetry instrumentation for supported libraries.
+    When OpenTelemetry support is enabled, the agent will automatically detect if `opentelemetry-api` is installed. This gem must be installed to use hybrid agent features.
     </Callout>
 
     ### Manual instrumentation
@@ -439,10 +439,10 @@ OpenTelemetry API support is disabled by default. Enable it through your agent's
     ❌ **Not supported**: OpenTelemetry Logs API
 
     #### Span Links
-    ❌ **Not supported**: Span Links
+    ✅ **Supported**: Span Links using the `OpenTelemetry::Trace::Span#add_link` API
 
     #### Events on Spans
-    ❌ **Not supported**: Events on Spans
+    ✅ **Supported**: Events on Spans using the `OpenTelemetry::Trace::Span#add_event` API
 
     ### How it works
 


### PR DESCRIPTION
Ruby agent [version 10.6.0 includes support for Span Links and Events on Spans.](https://docs.newrelic.com/docs/release-notes/agent-release-notes/ruby-release-notes/ruby-agent-10-6-0/)

In addition, a callout was reworded for clarity.
