### PR TITLE
chore(Navigation): Remove overlay APIs from SDK navigation docs

### DIFF
--- a/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/navigation.mdx
+++ b/src/content/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/navigation.mdx
@@ -90,22 +90,6 @@ const nerdlet = {
 const location = navigation.getOpenNerdletLocation(nerdlet);
 ```
 
-### `navigation.getOpenOverlayLocation`
-
-<FunctionDefinition
-  arguments={[{"defaultValue":null,"description":"Overlay you want to open.","name":"overlay","type":"Overlay"}]}
-  returnValue={{"description": null, "type": "undefined"}}
-/>
-
-```js
-const overlay = {
-  id: 'nr1-core.search',
-};
-
-
-const location = navigation.getOpenOverlayLocation(overlay);
-```
-
 ### `navigation.getOpenStackedEntityLocation`
 
 <FunctionDefinition
@@ -279,22 +263,6 @@ const nerdletWithState = {
 const location = navigation.getOpenNerdletLocation(nerdletWithState);
 ```
 
-### `navigation.openOverlay`
-
-<FunctionDefinition
-  arguments={[{"defaultValue":null,"description":"Overlay you want to open.","name":"overlay","type":"Overlay"},{"defaultValue":null,"description":"Options for the URL state.","name":"urlStateOptions","type":"UrlStateOptions"}]}
-  returnValue={{"description": null, "type": "undefined"}}
-/>
-
-```js
-const overlay = {
-  id: 'nr1-core.search',
-};
-
-
-navigation.openOverlay(overlay);
-```
-
 ### `navigation.openStackedEntity`
 
 <FunctionDefinition
@@ -396,8 +364,6 @@ navigation.replaceNerdlet(nerdlet);
 <TypeDefReference typeDef={{"name":"Nerdlet","properties":[{"description":"Id of the nerdlet. You can specify the full nerdlet id: <nerdpack-id>.<nerdlet-id> (i.e. '8ba28fe4-5362-4f7f-8f9a-4b8c6c39d8a6.my-nerdlet') or simply <nerdlet-id> (i.e. 'my-nerdlet'). In the latter case, the nerdlet will be treated as if it belongs to the current nerdpack, meaning that the nerdpack id is automatically added by the platform.","name":"id","type":"string"},{"description":"State of the nerdlet which is persisted in the url.","name":"urlState","type":"Object"}]}}/>
 
 <TypeDefReference typeDef={{"name":"UrlStateOptions","properties":[{"description":"If `true`, the current entry in the browser history will be replaced with the new one.","name":"replaceHistory","type":"boolean"}]}}/>
-
-<TypeDefReference typeDef={{"name":"Overlay","properties":[{"description":"Id of the overlay to be opened, for example `nr1-core.search`.","name":"id","type":"string"},{"description":"State of the overlay which is persisted in the url.","name":"urlState","type":"Object"}]}}/>
 
 <TypeDefReference typeDef={{"name":"Launcher","properties":[{"description":"Id of the launcher, for example `nr1-core.explorer`.","name":"id","type":"string"},{"description":"Nerdlet to be opened in the launcher. If not provided, the root nerdlet of the launcher will be opened.","name":"nerdlet","type":"Nerdlet"},{"description":"Nerdlet to be opened as stacked nerdlets.","name":"stackedNerdlets","type":"Nerdlet[]"}]}}/>
 

--- a/src/i18n/content/fr/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/navigation.mdx
+++ b/src/i18n/content/fr/docs/new-relic-solutions/build-nr-ui/sdk-component/platform-apis/navigation.mdx
@@ -82,19 +82,6 @@ const nerdlet = {
 const location = navigation.getOpenNerdletLocation(nerdlet);
 ```
 
-### `navigation.getOpenOverlayLocation`
-
-<FunctionDefinition arguments={[{"defaultValue":null,"description":"Overlay you want to open.","name":"overlay","type":"Overlay"}]} returnValue={{"description": null, "type": "undefined"}} />
-
-```js
-const overlay = {
-  id: 'nr1-core.search',
-};
-
-
-const location = navigation.getOpenOverlayLocation(overlay);
-```
-
 ### `navigation.getOpenStackedEntityLocation`
 
 <FunctionDefinition arguments={[{"defaultValue":null,"description":"GUID of the entity to open.","name":"entityGuid","type":"string"}]} returnValue={{"description": null, "type": "undefined"}} />
@@ -250,19 +237,6 @@ const nerdletWithState = {
 const location = navigation.getOpenNerdletLocation(nerdletWithState);
 ```
 
-### `navigation.openOverlay`
-
-<FunctionDefinition arguments={[{"defaultValue":null,"description":"Overlay you want to open.","name":"overlay","type":"Overlay"},{"defaultValue":null,"description":"Options for the URL state.","name":"urlStateOptions","type":"UrlStateOptions"}]} returnValue={{"description": null, "type": "undefined"}} />
-
-```js
-const overlay = {
-  id: 'nr1-core.search',
-};
-
-
-navigation.openOverlay(overlay);
-```
-
 ### `navigation.openStackedEntity`
 
 <FunctionDefinition arguments={[{"defaultValue":null,"description":"GUID of the entity to open.","name":"entityGuid","type":"string"},{"defaultValue":null,"description":"Options for the URL state.","name":"urlStateOptions","type":"UrlStateOptions"}]} returnValue={{"description": null, "type": "undefined"}} />
@@ -355,8 +329,6 @@ navigation.replaceNerdlet(nerdlet);
 <TypeDefReference typeDef={{"name":"Nerdlet","properties":[{"description":"Id of the nerdlet. You can specify the full nerdlet id: <nerdpack-id>.<nerdlet-id> (i.e. '8ba28fe4-5362-4f7f-8f9a-4b8c6c39d8a6.my-nerdlet') or simply <nerdlet-id> (i.e. 'my-nerdlet'). In the latter case, the nerdlet will be treated as if it belongs to the current nerdpack, meaning that the nerdpack id is automatically added by the platform.","name":"id","type":"string"},{"description":"State of the nerdlet which is persisted in the url.","name":"urlState","type":"Object"}]}} />
 
 <TypeDefReference typeDef={{"name":"UrlStateOptions","properties":[{"description":"If `true`, the current entry in the browser history will be replaced with the new one.","name":"replaceHistory","type":"boolean"}]}} />
-
-<TypeDefReference typeDef={{"name":"Overlay","properties":[{"description":"Id of the overlay to be opened, for example `nr1-core.search`.","name":"id","type":"string"},{"description":"State of the overlay which is persisted in the url.","name":"urlState","type":"Object"}]}} />
 
 <TypeDefReference typeDef={{"name":"Launcher","properties":[{"description":"Id of the launcher, for example `nr1-core.explorer`.","name":"id","type":"string"},{"description":"Nerdlet to be opened in the launcher. If not provided, the root nerdlet of the launcher will be opened.","name":"nerdlet","type":"Nerdlet"},{"description":"Nerdlet to be opened as stacked nerdlets.","name":"stackedNerdlets","type":"Nerdlet[]"}]}} />
 


### PR DESCRIPTION
This PR removes the overlay methods from the `navigation` platform API page because they will be removed from the SDK after all use cases have been migrated to the new `openNerdlet` method.

I made the same removals in the French translation of the page so both stay in sync. All other navigation methods and type definitions are untouched.

The methods will continue working but only for current consumers, we have a EOL allowlist so it's not possible for new consumers to use those methods.