### PR TITLE
chore: Raise the minimum Ruby version

### DIFF
--- a/src/content/docs/apm/agents/manage-apm-agents/opentelemetry-api-support.mdx
+++ b/src/content/docs/apm/agents/manage-apm-agents/opentelemetry-api-support.mdx
@@ -89,7 +89,7 @@ OpenTelemetry API support is available for the following New Relic APM agents:
     </tr>
     <tr>
       <td>Ruby</td>
-      <td>[10.2.0]</td>
+      <td>[10.6.0]</td>
       <td><Icon name="fe-check" /></td>
       <td><Icon name="fe-x" /></td>
       <td><Icon name="fe-x" /></td>


### PR DESCRIPTION
The initial hybrid agent release for Ruby didn't include support for Span Links or Span Events. Now that we have support for those, raise the displayed minimum version to that value.