### PR TITLE
feat(aim): Add OpenTelemetry GenAI traces setup guide

### DIFF
--- a/src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx
@@ -48,104 +48,7 @@ You will need:
   </Step>
 
   <Step>
-    ### Mark your service as AI-enabled [#step-2]
-
-    New Relic's AI monitoring view only lists services that carry the entity tag `aiEnabledApp = true`. Traces without this tag still arrive in New Relic, but the service will not surface in the AI monitoring UI. Set the tag using whichever of the following options best fits your deployment.
-
-    <CollapserGroup>
-      <Collapser
-        id="option-a"
-        title="Option A — Resource attribute on the OpenTelemetry SDK (recommended)"
-      >
-        Resource attributes on OTel data are promoted to entity tags in New Relic automatically. Add `aiEnabledApp=true` to your resource, either via environment variable:
-
-        ```sh
-        # If you already set OTEL_RESOURCE_ATTRIBUTES elsewhere, merge with a comma.
-        export OTEL_RESOURCE_ATTRIBUTES="aiEnabledApp=true"
-        ```
-
-        Or in code when you configure the OTel SDK:
-
-        ```python
-        from opentelemetry.sdk.resources import Resource
-
-        resource = Resource.create({
-            "service.name": "my-genai-service",
-            "aiEnabledApp": "true",  # string, not boolean
-        })
-        ```
-      </Collapser>
-
-      <Collapser
-        id="option-b"
-        title="Option B — OpenTelemetry Collector resource processor"
-      >
-        If your traces pass through an OpenTelemetry Collector before reaching New Relic, add the attribute in a `resource` processor:
-
-        ```yaml
-        processors:
-          resource/ai_enabled:
-            attributes:
-              - key: aiEnabledApp
-                value: "true"
-                action: upsert
-
-        service:
-          pipelines:
-            traces:
-              receivers: [otlp]
-              processors: [resource/ai_enabled, batch]
-              exporters: [otlphttp/newrelic]
-        ```
-
-        Because the processor is attached only to the traces pipeline, data flowing through separate metrics or logs pipelines is not affected. `action: upsert` sets the attribute whether or not incoming spans already have it.
-
-        **Tag only services that actually emit GenAI data.** The config above tags every trace passing through the pipeline, including traces from non-GenAI services that happen to share the same collector. To tag only spans that carry OpenTelemetry GenAI attributes, use a `transform` processor instead:
-
-        ```yaml
-        processors:
-          transform/ai_enabled:
-            trace_statements:
-              - context: span
-                statements:
-                  - set(resource.attributes["aiEnabledApp"], "true")
-                    where attributes["gen_ai.system"] != nil
-                       or attributes["gen_ai.provider.name"] != nil
-
-        service:
-          pipelines:
-            traces:
-              receivers: [otlp]
-              processors: [transform/ai_enabled, batch]
-              exporters: [otlphttp/newrelic]
-        ```
-
-        This adds the tag only when a span carries `gen_ai.system` or `gen_ai.provider.name` — the same attributes the AI monitoring UI uses to identify GenAI data. Non-GenAI spans are left untouched.
-
-        Note that resource attributes are shared across all spans from the same service in a batch, so once any GenAI span is seen, the whole service is tagged — which is what you want.
-      </Collapser>
-
-      <Collapser
-        id="option-c"
-        title="Option C — Add the tag manually in New Relic"
-      >
-        If you cannot change the SDK or collector configuration (for example, during a quick evaluation), you can tag the entity by hand after it first appears in New Relic:
-
-        1. Open the service in <DNT>**APM & Services**</DNT>.
-
-        2. Click <DNT>**See metadata and tags**</DNT>.
-
-        3. Add a tag with key `aiEnabledApp` and value `true`.
-
-           Manual tags apply to a single entity only. Prefer options A or B if you operate more than a handful of services.
-      </Collapser>
-    </CollapserGroup>
-
-    After your application sends a few traces, open the service in APM and verify `aiEnabledApp:true` is listed under <DNT>**Tags**</DNT>. The service should also now appear in the AI monitoring service picker.
-  </Step>
-
-  <Step>
-    ### Add the right instrumentation package [#step-3]
+    ### Add the right instrumentation package [#step-2]
 
     Pick the section that matches what your application uses. You can combine more than one — for example, a LangChain app that calls Bedrock would install both.
 
@@ -232,7 +135,7 @@ You will need:
   </Step>
 
   <Step>
-    ### Verify that your data is arriving [#step-4]
+    ### Verify that your data is arriving [#step-3]
 
     1. Restart your application so the new environment variables and instrumentation take effect.
 
@@ -288,7 +191,7 @@ If you only need latency, token, and error visibility — not message bodies —
   <tbody>
     <tr>
       <td>
-        The query in step 4 returns zero rows
+        The query in step 3 returns zero rows
       </td>
 
       <td>
@@ -302,7 +205,7 @@ If you only need latency, token, and error visibility — not message bodies —
       </td>
 
       <td>
-        The entity is missing the `aiEnabledApp:true` tag. Revisit [Step 2](#step-2).
+        New Relic automatically enables the AI monitoring view for services whose spans carry GenAI attributes. If the service doesn't appear, confirm its spans include `gen_ai.system` or `gen_ai.provider.name`, and upgrade the instrumentation package if they don't.
       </td>
     </tr>
 

--- a/src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx
@@ -1,22 +1,22 @@
 ---
-title: 'Send your GenAI traces to New Relic with OpenTelemetry'
+title: 'Send Your GenAI Traces to New Relic with OpenTelemetry'
 metaDescription: 'Learn how to send OpenTelemetry GenAI traces to New Relic so the AI monitoring view shows every LLM call, tool call, and agent step your service makes.'
 freshnessValidatedDate: never
 ---
 
-Once your application is sending OpenTelemetry (OTel) GenAI traces to New Relic, the AI monitoring view shows:
+After your application is sending OpenTelemetry (OTel) GenAI traces to New Relic, the AI monitoring view shows:
 
-* Every LLM call made by your service — prompt, completion, model, latency, token counts, finish reason.
+* Every LLM call made by your service — prompt, completion, model, latency, token counts, and finish reason.
 * Tool calls and agent steps as part of the full request trace, so you can see why a model made a decision.
 * Errors, rate-limit failures, and slow calls surfaced alongside the rest of your APM data.
 
-No New Relic agent is required. If your app already emits OpenTelemetry traces, you are most of the way there.
+No New Relic agent is required. If your app already emits OpenTelemetry traces, you're most of the way there.
 
 ## Before you start
 
 You will need:
 
-* A New Relic account with AI monitoring enabled. If you are not sure whether it is turned on, contact your New Relic account team.
+* A New Relic account with AI monitoring enabled. If you're not sure whether it's turned on, contact your New Relic account team.
 * A New Relic ingest license key. Go to <DNT>**Account settings > API keys > Ingest - License**</DNT>.
 * An application that calls an LLM. Python examples for OpenAI, Anthropic, LangChain, and AWS Bedrock are shown below. Other languages with OpenTelemetry GenAI instrumentation work the same way.
 * Network egress from your app to `otlp.nr-data.net` (US) or `otlp.eu01.nr-data.net` (EU) on port 443.
@@ -79,7 +79,7 @@ You will need:
         id="anthropic"
         title="Anthropic"
       >
-        Install an OpenTelemetry Anthropic instrumentation (available from the OpenTelemetry contrib registry and from community distributions such as OpenLLMetry). Then:
+        Install an OpenTelemetry Anthropic instrumentation (available from the OpenTelemetry contrib registry and from community distributions such as OpenLLMetry). Then enable it:
 
         ```python
         from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
@@ -156,7 +156,7 @@ You will need:
   </Step>
 </Steps>
 
-## Controlling what prompts and completions are sent [#controlling-content]
+## Control what prompts and completions are sent [#controlling-content]
 
 By default, most OpenTelemetry GenAI instrumentations do not capture the text of prompts or completions. Spans will include the model, token counts, latency, and status, but not the message bodies.
 
@@ -165,11 +165,11 @@ To make message content visible in AI monitoring, opt in explicitly. The flag na
 * `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` for OpenTelemetry-maintained instrumentations.
 * `TRACELOOP_TRACE_CONTENT=true` for community (OpenLLMetry-family) instrumentations.
 
-Before enabling content capture in production:
+Before you enable content capture in production, do the following:
 
 * Review the data your prompts contain. If your users submit PII, credentials, or regulated data, that content will be stored in New Relic.
 * Consider drop filters or attribute-level obfuscation to strip or hash specific fields before they leave your environment. See [New Relic's data-handling documentation](/docs/ai-monitoring/drop-sensitive-data).
-* Check your organization's retention and compliance requirements (GDPR, HIPAA, PCI, etc.).
+* Check your organization's retention and compliance requirements (for example, GDPR, HIPAA, or PCI).
 
 If you only need latency, token, and error visibility — not message bodies — leave content capture disabled.
 
@@ -251,7 +251,7 @@ If you only need latency, token, and error visibility — not message bodies —
 
     <tr>
       <td>
-        You expect AI monitoring to be available but the view does not appear
+        You expect AI monitoring to be available but the view doesn't appear
       </td>
 
       <td>
@@ -261,10 +261,10 @@ If you only need latency, token, and error visibility — not message bodies —
   </tbody>
 </table>
 
-## Getting help
+## Get help
 
-If you are stuck after working through the steps above:
+If you're stuck after working through the steps above:
 
 * File a New Relic support case and include a sample span payload and your service name.
 * Reach out to your New Relic account team for account-level configuration questions.
-* For general OpenTelemetry GenAI questions, the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are the authoritative reference.
+* For general OpenTelemetry GenAI questions, see the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/), the authoritative reference.

--- a/src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx
+++ b/src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx
@@ -1,0 +1,367 @@
+---
+title: 'Send your GenAI traces to New Relic with OpenTelemetry'
+metaDescription: 'Learn how to send OpenTelemetry GenAI traces to New Relic so the AI monitoring view shows every LLM call, tool call, and agent step your service makes.'
+freshnessValidatedDate: never
+---
+
+Once your application is sending OpenTelemetry (OTel) GenAI traces to New Relic, the AI monitoring view shows:
+
+* Every LLM call made by your service — prompt, completion, model, latency, token counts, finish reason.
+* Tool calls and agent steps as part of the full request trace, so you can see why a model made a decision.
+* Errors, rate-limit failures, and slow calls surfaced alongside the rest of your APM data.
+
+No New Relic agent is required. If your app already emits OpenTelemetry traces, you are most of the way there.
+
+## Before you start
+
+You will need:
+
+* A New Relic account with AI monitoring enabled. If you are not sure whether it is turned on, contact your New Relic account team.
+* A New Relic ingest license key. Go to <DNT>**Account settings > API keys > Ingest - License**</DNT>.
+* An application that calls an LLM. Python examples for OpenAI, Anthropic, LangChain, and AWS Bedrock are shown below. Other languages with OpenTelemetry GenAI instrumentation work the same way.
+* Network egress from your app to `otlp.nr-data.net` (US) or `otlp.eu01.nr-data.net` (EU) on port 443.
+
+<Callout variant="important">
+  OTel GenAI instrumentations can capture the exact prompts and completions your users send and receive. That may include PII, credentials, or regulated data. Content capture is off by default. Before turning it on, review your organization's data-handling policies and see [Controlling what prompts and completions are sent](#controlling-content).
+</Callout>
+
+<Steps>
+  <Step>
+    ### Point your OpenTelemetry exporter at New Relic [#step-1]
+
+    Set these environment variables on the process running your application:
+
+    ```sh
+    # US datacenter. For EU use https://otlp.eu01.nr-data.net:443
+    export OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.nr-data.net:443"
+    export OTEL_EXPORTER_OTLP_HEADERS="api-key=$NEW_RELIC_LICENSE_KEY"
+
+    # Name that will identify this service in New Relic
+    export OTEL_SERVICE_NAME="my-genai-service"
+
+    # Allow long prompts and completions through without truncation
+    export OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
+    export OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT=4095
+    ```
+
+    For the current list of New Relic OTLP endpoints, supported ports, and ingest limits, see the [New Relic OpenTelemetry documentation](/docs/opentelemetry/best-practices/opentelemetry-best-practices-overview).
+  </Step>
+
+  <Step>
+    ### Mark your service as AI-enabled [#step-2]
+
+    New Relic's AI monitoring view only lists services that carry the entity tag `aiEnabledApp = true`. Traces without this tag still arrive in New Relic, but the service will not surface in the AI monitoring UI. Set the tag using whichever of the following options best fits your deployment.
+
+    <CollapserGroup>
+      <Collapser
+        id="option-a"
+        title="Option A — Resource attribute on the OpenTelemetry SDK (recommended)"
+      >
+        Resource attributes on OTel data are promoted to entity tags in New Relic automatically. Add `aiEnabledApp=true` to your resource, either via environment variable:
+
+        ```sh
+        # If you already set OTEL_RESOURCE_ATTRIBUTES elsewhere, merge with a comma.
+        export OTEL_RESOURCE_ATTRIBUTES="aiEnabledApp=true"
+        ```
+
+        Or in code when you configure the OTel SDK:
+
+        ```python
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({
+            "service.name": "my-genai-service",
+            "aiEnabledApp": "true",  # string, not boolean
+        })
+        ```
+      </Collapser>
+
+      <Collapser
+        id="option-b"
+        title="Option B — OpenTelemetry Collector resource processor"
+      >
+        If your traces pass through an OpenTelemetry Collector before reaching New Relic, add the attribute in a `resource` processor:
+
+        ```yaml
+        processors:
+          resource/ai_enabled:
+            attributes:
+              - key: aiEnabledApp
+                value: "true"
+                action: upsert
+
+        service:
+          pipelines:
+            traces:
+              receivers: [otlp]
+              processors: [resource/ai_enabled, batch]
+              exporters: [otlphttp/newrelic]
+        ```
+
+        Because the processor is attached only to the traces pipeline, data flowing through separate metrics or logs pipelines is not affected. `action: upsert` sets the attribute whether or not incoming spans already have it.
+
+        **Tag only services that actually emit GenAI data.** The config above tags every trace passing through the pipeline, including traces from non-GenAI services that happen to share the same collector. To tag only spans that carry OpenTelemetry GenAI attributes, use a `transform` processor instead:
+
+        ```yaml
+        processors:
+          transform/ai_enabled:
+            trace_statements:
+              - context: span
+                statements:
+                  - set(resource.attributes["aiEnabledApp"], "true")
+                    where attributes["gen_ai.system"] != nil
+                       or attributes["gen_ai.provider.name"] != nil
+
+        service:
+          pipelines:
+            traces:
+              receivers: [otlp]
+              processors: [transform/ai_enabled, batch]
+              exporters: [otlphttp/newrelic]
+        ```
+
+        This adds the tag only when a span carries `gen_ai.system` or `gen_ai.provider.name` — the same attributes the AI monitoring UI uses to identify GenAI data. Non-GenAI spans are left untouched.
+
+        Note that resource attributes are shared across all spans from the same service in a batch, so once any GenAI span is seen, the whole service is tagged — which is what you want.
+      </Collapser>
+
+      <Collapser
+        id="option-c"
+        title="Option C — Add the tag manually in New Relic"
+      >
+        If you cannot change the SDK or collector configuration (for example, during a quick evaluation), you can tag the entity by hand after it first appears in New Relic:
+
+        1. Open the service in <DNT>**APM & Services**</DNT>.
+
+        2. Click <DNT>**See metadata and tags**</DNT>.
+
+        3. Add a tag with key `aiEnabledApp` and value `true`.
+
+           Manual tags apply to a single entity only. Prefer options A or B if you operate more than a handful of services.
+      </Collapser>
+    </CollapserGroup>
+
+    After your application sends a few traces, open the service in APM and verify `aiEnabledApp:true` is listed under <DNT>**Tags**</DNT>. The service should also now appear in the AI monitoring service picker.
+  </Step>
+
+  <Step>
+    ### Add the right instrumentation package [#step-3]
+
+    Pick the section that matches what your application uses. You can combine more than one — for example, a LangChain app that calls Bedrock would install both.
+
+    <Callout variant="tip">
+      Exact package names and versions evolve quickly in the OpenTelemetry GenAI ecosystem. Always check the OpenTelemetry Python contrib registry and the New Relic AI monitoring docs for the package your team currently supports.
+    </Callout>
+
+    <CollapserGroup>
+      <Collapser
+        id="openai"
+        title="OpenAI"
+      >
+        Install the official OpenAI GenAI instrumentation from the OpenTelemetry project, then either run your app with `opentelemetry-instrument` or call the instrumentor explicitly:
+
+        ```python
+        from opentelemetry.instrumentation.openai_v2 import OpenAIInstrumentor
+        OpenAIInstrumentor().instrument()
+
+        from openai import OpenAI
+        OpenAI().chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        ```
+      </Collapser>
+
+      <Collapser
+        id="anthropic"
+        title="Anthropic"
+      >
+        Install an OpenTelemetry Anthropic instrumentation (available from the OpenTelemetry contrib registry and from community distributions such as OpenLLMetry). Then:
+
+        ```python
+        from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
+        AnthropicInstrumentor().instrument()
+
+        import anthropic
+        anthropic.Anthropic().messages.create(
+            model="claude-sonnet-4-5",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        ```
+      </Collapser>
+
+      <Collapser
+        id="langchain"
+        title="LangChain"
+      >
+        LangChain instrumentation covers the chain, any tool calls, and the underlying model client in one package. Install the community LangChain instrumentation of your choice and enable it at startup:
+
+        ```python
+        from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+        LangchainInstrumentor().instrument()
+        ```
+
+        Your existing `ChatOpenAI`, `ChatAnthropic`, or similar chains will be traced automatically. Tool and agent steps appear as child spans under the parent chain invocation.
+      </Collapser>
+
+      <Collapser
+        id="aws-bedrock"
+        title="AWS Bedrock"
+      >
+        Bedrock traffic goes through the AWS SDK. Install the AWS SDK (botocore) OpenTelemetry instrumentation and enable it:
+
+        ```python
+        from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+        BotocoreInstrumentor().instrument()
+
+        import boto3, json
+        boto3.client("bedrock-runtime", region_name="us-east-1").invoke_model(
+            modelId="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            body=json.dumps({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 256,
+                "messages": [{"role": "user", "content": "Hello"}],
+            }),
+        )
+        ```
+
+        Verify that your installed version emits GenAI attributes (`gen_ai.system`, `gen_ai.request.model`, and token usage) for Bedrock calls — support has landed incrementally across versions.
+      </Collapser>
+    </CollapserGroup>
+  </Step>
+
+  <Step>
+    ### Verify that your data is arriving [#step-4]
+
+    1. Restart your application so the new environment variables and instrumentation take effect.
+
+    2. Trigger a small amount of real traffic — a handful of chat completions is enough.
+
+    3. In New Relic, open <DNT>**Query Your Data**</DNT> and run:
+
+       ```sql
+       SELECT count(*) FROM Span
+       WHERE gen_ai.system IS NOT NULL OR gen_ai.provider.name IS NOT NULL
+       SINCE 30 minutes ago
+       FACET service.name, gen_ai.operation.name
+       ```
+
+    4. Within one to two minutes you should see rows faceted by your service name and operation (`chat`, `completion`, `embeddings`).
+
+    5. Go to <DNT>**APM & Services > AI monitoring**</DNT> and select your service to see the GenAI view populate.
+  </Step>
+</Steps>
+
+## Controlling what prompts and completions are sent [#controlling-content]
+
+By default, most OpenTelemetry GenAI instrumentations do not capture the text of prompts or completions. Spans will include the model, token counts, latency, and status, but not the message bodies.
+
+To make message content visible in AI monitoring, opt in explicitly. The flag name depends on the instrumentation package you installed — check the documentation for that specific package. Common examples include:
+
+* `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` for OpenTelemetry-maintained instrumentations.
+* `TRACELOOP_TRACE_CONTENT=true` for community (OpenLLMetry-family) instrumentations.
+
+Before enabling content capture in production:
+
+* Review the data your prompts contain. If your users submit PII, credentials, or regulated data, that content will be stored in New Relic.
+* Consider drop filters or attribute-level obfuscation to strip or hash specific fields before they leave your environment. See [New Relic's data-handling documentation](/docs/ai-monitoring/drop-sensitive-data).
+* Check your organization's retention and compliance requirements (GDPR, HIPAA, PCI, etc.).
+
+If you only need latency, token, and error visibility — not message bodies — leave content capture disabled.
+
+## Troubleshooting
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        What you see
+      </th>
+
+      <th>
+        What to try
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        The query in step 4 returns zero rows
+      </td>
+
+      <td>
+        Confirm your OTLP endpoint matches your account's region, and that the `api-key` header holds a valid ingest license key (not a user key).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Traces arrive in New Relic but the service does not appear in AI monitoring
+      </td>
+
+      <td>
+        The entity is missing the `aiEnabledApp:true` tag. Revisit [Step 2](#step-2).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Spans arrive but the AI monitoring view is empty for your service
+      </td>
+
+      <td>
+        The spans may not be tagged with the expected GenAI attributes. Upgrade the instrumentation package, or contact New Relic support with a sample span.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Long prompts are cut off
+      </td>
+
+      <td>
+        Raise `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` and `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` on the application side.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Token counts are missing
+      </td>
+
+      <td>
+        The LLM provider returned them, but your instrumentation version does not record them yet. Upgrade the instrumentation package.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        AI monitoring shows traces but prompts/completions are blank
+      </td>
+
+      <td>
+        Content capture is disabled. See [Controlling what prompts and completions are sent](#controlling-content).
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        You expect AI monitoring to be available but the view does not appear
+      </td>
+
+      <td>
+        Contact your New Relic account team to confirm AI monitoring is enabled on your account.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Getting help
+
+If you are stuck after working through the steps above:
+
+* File a New Relic support case and include a sample span payload and your service name.
+* Reach out to your New Relic account team for account-level configuration questions.
+* For general OpenTelemetry GenAI questions, the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) are the authoritative reference.

--- a/src/nav/ai-monitoring.yml
+++ b/src/nav/ai-monitoring.yml
@@ -7,6 +7,8 @@ pages:
     path: /docs/ai-monitoring/compatibility-requirements-ai-monitoring
   - title: Install AI monitoring
     path: /install/ai-monitoring
+  - title: Send GenAI traces with OpenTelemetry
+    path: /docs/ai-monitoring/opentelemetry-ai-monitoring
   - title: Explore your AI data
     pages:
       - title: Analyze model data


### PR DESCRIPTION
## What problems does this PR solve?

New Relic AI monitoring only surfaces GenAI services that arrive via New Relic agents, but many teams already instrument their apps with OpenTelemetry (OTel) GenAI conventions and had no clear path to get those traces into the AI monitoring view. There was no doc explaining:

- How to point an OTel exporter at New Relic's OTLP endpoints for GenAI data.
- Which instrumentation packages to use for common LLM stacks (OpenAI, Anthropic, LangChain, AWS Bedrock).
- How to control prompt/completion content capture (off by default) and the data-privacy implications.

This PR adds a step-by-step guide that closes those gaps, so users can send GenAI traces to New Relic over OpenTelemetry, no New Relic agent required.

## What changed

- **New page:** `src/content/docs/ai-monitoring/opentelemetry-ai-monitoring.mdx`
  - Prerequisites, 3-step setup (exporter config  → instrumentation package → verification), content-capture controls, troubleshooting table, and a "Getting help" section.
- **Nav:** added the page to `src/nav/ai-monitoring.yml` (currently placed after **Install AI monitoring**).

Published path: `/docs/ai-monitoring/opentelemetry-ai-monitoring`