### PR TITLE
feat: add NRDOT Collector option to ECS on EC2 and Fargate monitoring

### DIFF
--- a/src/content/docs/opentelemetry/integrations/ecs-monitoring/ecs-ec2.mdx
+++ b/src/content/docs/opentelemetry/integrations/ecs-monitoring/ecs-ec2.mdx
@@ -625,7 +625,110 @@ The following parameters can be customized in the OpenTelemetry Collector config
 
 ### Create task definition [#create-task-definition]
 
-Create a new ECS task definition that includes the OpenTelemetry Collector sidecar container. Choose the appropriate task definition for your container platform:
+Create a new ECS task definition that includes the collector sidecar container. Choose between NRDOT Collector (New Relic's distribution) or OpenTelemetry Collector, then select the task definition for your container platform:
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="ec2-nrdot">NRDOT Collector</TabsBarItem>
+    <TabsBarItem id="ec2-otel">OpenTelemetry Collector</TabsBarItem>
+  </TabsBar>
+
+  <TabsPages>
+    <TabsPageItem id="ec2-nrdot">
+
+<Callout variant="tip">
+  **NRDOT Collector** is New Relic's distribution of the OpenTelemetry Collector with New Relic support for assistance. It bundles the `awsecscontainermetrics` and `hostmetrics` receivers used by this configuration, so it runs with the same collector config you stored in the previous step.
+</Callout>
+
+<Callout variant="important">
+  NRDOT Collector publishes Linux container images only. To monitor Windows containers, use the **OpenTelemetry Collector** tab.
+</Callout>
+
+```json
+{
+  "family": "otel-ecs-ec2-sidecar-metrics",
+  "executionRoleArn": "arn:aws:iam::YOUR_ACCOUNT:role/NewRelicECSTaskExecutionRole",
+  "networkMode": "host",
+  "requiresCompatibilities": ["EC2"],
+  "cpu": "<TASK_CPU>",
+  "memory": "<TASK_MEMORY>",
+  "containerDefinitions": [
+    {
+      "name": "your-application",
+      "image": "your-app:latest",
+      "cpu": <APP_CPU>,
+      "memory": <APP_MEMORY>,
+      "essential": true,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "<APP_LOG_GROUP>",
+          "awslogs-create-group": "true",
+          "awslogs-region": "<AWS_REGION>",
+          "awslogs-stream-prefix": "<APP_LOG_STREAM_PREFIX>"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "newrelic/nrdot-collector:latest",
+      "cpu": <COLLECTOR_CPU>,
+      "memory": <COLLECTOR_MEMORY>,
+      "essential": true,
+      "command": ["--config=env:OTEL_CONFIG"],
+      "mountPoints": [
+        {
+          "sourceVolume": "proc",
+          "containerPath": "/proc",
+          "readOnly": true
+        },
+        {
+          "sourceVolume": "sys",
+          "containerPath": "/sys",
+          "readOnly": true
+        }
+      ],
+      "secrets": [
+        {
+          "name": "OTEL_CONFIG",
+          "valueFrom": "arn:aws:ssm:us-east-1:YOUR_ACCOUNT:parameter/ecs/otel-collector/ec2-config"
+        },
+        {
+          "name": "NEW_RELIC_LICENSE_KEY",
+          "valueFrom": "arn:aws:ssm:us-east-1:YOUR_ACCOUNT:parameter/newrelic-infra/ecs/license-key"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "<COLLECTOR_LOG_GROUP>",
+          "awslogs-create-group": "true",
+          "awslogs-region": "<AWS_REGION>",
+          "awslogs-stream-prefix": "<COLLECTOR_LOG_STREAM_PREFIX>"
+        }
+      }
+    }
+  ],
+  "volumes": [
+    {
+      "name": "proc",
+      "host": {
+        "sourcePath": "/proc"
+      }
+    },
+    {
+      "name": "sys",
+      "host": {
+        "sourcePath": "/sys"
+      }
+    }
+  ]
+}
+```
+
+    </TabsPageItem>
+
+    <TabsPageItem id="ec2-otel">
 
 <CollapserGroup>
   <Collapser id="linux-task-definition" title="Linux containers">
@@ -779,6 +882,10 @@ Create a new ECS task definition that includes the OpenTelemetry Collector sidec
 
   </Collapser>
 </CollapserGroup>
+
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>
 
 #### Task definition parameters
 

--- a/src/content/docs/opentelemetry/integrations/ecs-monitoring/ecs-fargate.mdx
+++ b/src/content/docs/opentelemetry/integrations/ecs-monitoring/ecs-fargate.mdx
@@ -427,7 +427,118 @@ The following parameters can be customized in the OpenTelemetry Collector config
 
 ### Create task definition [#create-task-definition]
 
-Create a new ECS task definition for Fargate that includes the OpenTelemetry Collector sidecar container. Choose the appropriate task definition for your container platform:
+Create a new ECS task definition for Fargate that includes the collector sidecar container. Choose between NRDOT Collector (New Relic's distribution) or OpenTelemetry Collector, then select the task definition for your container platform:
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="fargate-nrdot">NRDOT Collector</TabsBarItem>
+    <TabsBarItem id="fargate-otel">OpenTelemetry Collector</TabsBarItem>
+  </TabsBar>
+
+  <TabsPages>
+    <TabsPageItem id="fargate-nrdot">
+
+<Callout variant="tip">
+  **NRDOT Collector** is New Relic's distribution of the OpenTelemetry Collector with New Relic support for assistance. It bundles the `awsecscontainermetrics` receiver used by this configuration, so it runs with the same collector config you stored in the previous step.
+</Callout>
+
+<Callout variant="important">
+  NRDOT Collector publishes Linux container images only. To monitor Windows containers, use the **OpenTelemetry Collector** tab.
+</Callout>
+
+```json
+{
+  "family": "otel-ecs-fargate-metrics",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "<TASK_CPU>",
+  "memory": "<TASK_MEMORY>",
+  "executionRoleArn": "arn:aws:iam::YOUR_ACCOUNT:role/NewRelicECSTaskExecutionRole",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "containerDefinitions": [
+    {
+      "name": "busybox",
+      "image": "busybox:latest",
+      "cpu": <APP_CPU>,
+      "memory": <APP_MEMORY>,
+      "essential": true,
+      "command": [
+        "sh",
+        "-c",
+        "while true; do echo 'Hello from BusyBox'; sleep 30; done"
+      ],
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "<APP_LOG_GROUP>",
+          "awslogs-create-group": "true",
+          "awslogs-region": "<AWS_REGION>",
+          "awslogs-stream-prefix": "<APP_LOG_STREAM_PREFIX>"
+        }
+      }
+    },
+    {
+      "name": "otel-collector",
+      "image": "newrelic/nrdot-collector:latest",
+      "cpu": <COLLECTOR_CPU>,
+      "memoryReservation": <COLLECTOR_MEMORY_RESERVATION>,
+      "essential": true,
+      "command": ["--config=env:OTEL_CONFIG"],
+      "environment": [
+        {
+          "name": "NRIA_IS_FORWARD_ONLY",
+          "value": "true"
+        },
+        {
+          "name": "NRIA_PASSTHROUGH_ENVIRONMENT",
+          "value": "ECS_CONTAINER_METADATA_URI,ECS_CONTAINER_METADATA_URI_V4,FARGATE"
+        },
+        {
+          "name": "FARGATE",
+          "value": "true"
+        },
+        {
+          "name": "NRIA_OVERRIDE_HOST_ROOT",
+          "value": ""
+        }
+      ],
+      "secrets": [
+        {
+          "name": "OTEL_CONFIG",
+          "valueFrom": "arn:aws:ssm:us-east-1:YOUR_ACCOUNT:parameter/ecs/otel-collector/fargate-config"
+        },
+        {
+          "name": "NEW_RELIC_LICENSE_KEY",
+          "valueFrom": "arn:aws:ssm:us-east-1:YOUR_ACCOUNT:parameter/newrelic-infra/ecs/license-key"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "<COLLECTOR_LOG_GROUP>",
+          "awslogs-create-group": "true",
+          "awslogs-region": "<AWS_REGION>",
+          "awslogs-stream-prefix": "<COLLECTOR_LOG_STREAM_PREFIX>"
+        }
+      }
+    }
+  ]
+}
+```
+
+    </TabsPageItem>
+
+    <TabsPageItem id="fargate-otel">
 
 <CollapserGroup>
   <Collapser id="linux-task-definition" title="Linux containers">
@@ -617,6 +728,10 @@ Create a new ECS task definition for Fargate that includes the OpenTelemetry Col
 ```
   </Collapser>
 </CollapserGroup>
+
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>
 
 #### Task definition parameters
 


### PR DESCRIPTION
## Give us some context

### What problems does this PR solve?

New Relic recently launched OpenTelemetry-based monitoring for Amazon ECS, documented on the [Monitor ECS on EC2](https://docs.newrelic.com/docs/opentelemetry/integrations/ecs-monitoring/ecs-ec2/#create-task-definition) and [Monitor ECS Fargate](https://docs.newrelic.com/docs/opentelemetry/integrations/ecs-monitoring/ecs-fargate/#create-task-definition) pages. Both guides show only the upstream **OpenTelemetry Collector Contrib** image for the sidecar container.

The `awsecscontainermetrics` receiver is now bundled in the [NRDOT Collector](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-collector/) (New Relic's OpenTelemetry distribution), so customers can run the ECS monitoring sidecar with NRDOT — and get New Relic support — instead of Contrib. The pages didn't offer that choice.

This PR adds an **NRDOT Collector / OpenTelemetry Collector** tab selector to the **Create task definition** step on both pages, matching the tab pattern already used across the on-host OpenTelemetry integrations (for example, Kafka self-hosted).

### What changed

* Wrapped the existing task-definition content in a `<Tabs>` selector on both pages.
* **NRDOT Collector** tab (new): a Linux task definition using `newrelic/nrdot-collector:latest`, reusing the same SSM-stored collector config from the previous step and the same `--config=env:OTEL_CONFIG` command (the image's `ENTRYPOINT` is `/nrdot-collector`).
* **OpenTelemetry Collector** tab: the prior Linux + Windows task definitions, unchanged.
* Windows containers stay only under the OpenTelemetry Collector tab, since NRDOT publishes Linux container images only (Windows is host install via `.msi`). A callout notes this.

### Testing notes

* Verified JSX tag balance (`Tabs` / `TabsBar` / `TabsPages` / `TabsPageItem` / `CollapserGroup`) in both files.
* Both `.mdx` files compile cleanly through the repo's `@mdx-js/mdx` compiler with no parse or nesting errors.
* NRDOT image, entrypoint, and Linux-only availability confirmed against Docker Hub (`newrelic/nrdot-collector`) and the `nrdot-collector-releases` Dockerfile (`ENTRYPOINT ["/nrdot-collector"]`).

### Related docs

* [Monitor ECS on EC2 with OpenTelemetry](https://docs.newrelic.com/docs/opentelemetry/integrations/ecs-monitoring/ecs-ec2/)
* [Monitor ECS Fargate with OpenTelemetry](https://docs.newrelic.com/docs/opentelemetry/integrations/ecs-monitoring/ecs-fargate/)
* [NRDOT Collector](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-collector/)

### Related GitHub issue

N/A
