### PR TITLE
docs(haproxy): apply style guide fixes

### DIFF
--- a/src/content/docs/opentelemetry/integrations/haproxy/find-and-query-data.mdx
+++ b/src/content/docs/opentelemetry/integrations/haproxy/find-and-query-data.mdx
@@ -14,7 +14,7 @@ After you've set up HAProxy monitoring with OpenTelemetry, your data appears in 
 
 <CollapserGroup>
 
-<Collapser id="method1-entities" title="Through the entity explorer">
+<Collapser id="method1-entities" title="Use the entity explorer">
 
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > All entities**</DNT>.
 2. Search for your HAProxy entities by name, or filter by entity type `HAPROXYINSTANCE`.
@@ -22,7 +22,7 @@ After you've set up HAProxy monitoring with OpenTelemetry, your data appears in 
 
 </Collapser>
 
-<Collapser id="method2-dashboard" title="Through Integrations & Agents">
+<Collapser id="method2-dashboard" title="Use Integrations & Agents">
 
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Integrations & Agents**</DNT>.
 2. Click <DNT>**Dashboards**</DNT>.
@@ -31,7 +31,7 @@ After you've set up HAProxy monitoring with OpenTelemetry, your data appears in 
 
 </Collapser>
 
-<Collapser id="method3-query" title="Through the query builder">
+<Collapser id="method3-query" title="Use the query builder">
 
 1. Go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Query your data**</DNT>.
 2. Run a query to find your HAProxy data:

--- a/src/content/docs/opentelemetry/integrations/haproxy/kubernetes.mdx
+++ b/src/content/docs/opentelemetry/integrations/haproxy/kubernetes.mdx
@@ -127,7 +127,7 @@ Ensure you have:
         exporters: [otlphttp/newrelic]
     ```
 
-    #### Configuration parameters
+    ### Configuration parameters
 
     The following table describes the key configuration parameters:
 
@@ -298,7 +298,7 @@ Ensure you have:
       kubectl rollout restart deployment nr-k8s-otel-collector-deployment -n newrelic
       ```
 
-  #### Configuration parameters
+  ### Configuration parameters
 
     <table>
     <thead>
@@ -444,7 +444,7 @@ Deploy the OpenTelemetry Collector Contrib to your Kubernetes cluster. The colle
               exporters: [otlp_http/newrelic]
       ```
 
-      #### Configuration parameters
+      ### Configuration parameters
 
       <table>
       <thead>
@@ -705,7 +705,7 @@ Deploy the OpenTelemetry Collector Contrib to your Kubernetes cluster. The colle
 
       You should see log lines showing `starting receiver` with your HAProxy pod IPs.
 
-  #### Configuration parameters
+  ### Configuration parameters
 
       <table>
       <thead>
@@ -970,7 +970,7 @@ Use this approach if your HAProxy pods already expose a Prometheus `/metrics` en
           exporters: [otlp_http/newrelic]
       ```
 
-      #### Configuration parameters
+      ### Configuration parameters
 
       <table>
       <thead>
@@ -1227,7 +1227,7 @@ Use this approach if your HAProxy pods already expose a Prometheus `/metrics` en
       The `/etc/machine-id` volume mount is required for entity synthesis. The `resourcedetection` processor reads this file to populate the `host.id` resource attribute. Without it, entities won't be created in New Relic.
       </Callout>
 
-      #### Configuration parameters
+      ### Configuration parameters
 
       <table>
       <thead>

--- a/src/content/docs/opentelemetry/integrations/haproxy/overview.mdx
+++ b/src/content/docs/opentelemetry/integrations/haproxy/overview.mdx
@@ -11,15 +11,15 @@ metaDescription: 'Learn about monitoring HAProxy with OpenTelemetry on self-host
 freshnessValidatedDate: never
 ---
 
-Get complete visibility into your HAProxy load balancers with OpenTelemetry. You can collect metrics from HAProxy's CSV stats endpoint (via the [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver)) or from its built-in Prometheus endpoint (HAProxy 2.0+). Both self-hosted Linux and Kubernetes deployments are supported.
+Get complete visibility into your HAProxy load balancers with OpenTelemetry. You can collect metrics from HAProxy's CSV stats endpoint (via the [haproxyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/haproxyreceiver)) or from its built-in Prometheus endpoint (HAProxy 2.0+). New Relic supports both self-hosted Linux and Kubernetes deployments.
 
-<Callout variant="important">
+{/* <Callout variant="important">
   - Running HAProxy on Linux? See [Monitor self-hosted HAProxy with OpenTelemetry](/docs/opentelemetry/integrations/haproxy/self-hosted/).
   - Running HAProxy on Kubernetes? See [Monitor HAProxy on Kubernetes with OpenTelemetry](/docs/opentelemetry/integrations/haproxy/kubernetes/).
   - For a complete list of collected metrics, see [HAProxy OTel metrics reference](/docs/opentelemetry/integrations/haproxy/metrics-reference/).
-</Callout>
+</Callout> */}
 
-## Why monitor HAProxy with OpenTelemetry? [#why-monitor]
+## Why monitor HAProxy with OpenTelemetry [#why-monitor]
 
 Monitor HAProxy to maintain load balancer performance, backend server health, and application reliability. OpenTelemetry provides a standardized, vendor-neutral approach to collect and analyze this data.
 

--- a/src/content/docs/opentelemetry/integrations/haproxy/self-hosted.mdx
+++ b/src/content/docs/opentelemetry/integrations/haproxy/self-hosted.mdx
@@ -23,7 +23,7 @@ If you're currently using `nri-haproxy` and want to switch to OpenTelemetry, dis
 
 ## Before you begin [#prerequisites]
 
-Ensure you have:
+Ensure you have the following:
 
 - Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key)
 - HAProxy with the [stats endpoint](https://www.haproxy.com/blog/exploring-the-haproxy-stats-page) enabled (any version supporting stats; Prometheus path requires 2.0+)

--- a/src/content/docs/opentelemetry/integrations/haproxy/self-hosted.mdx
+++ b/src/content/docs/opentelemetry/integrations/haproxy/self-hosted.mdx
@@ -18,7 +18,7 @@ You can choose between three collector options:
 * **Prometheus Receiver:** For environments already using HAProxy's built-in Prometheus endpoint (HAProxy 2.0+)
 
 <Callout variant="tip">
-If you're currently using `nri-haproxy` and want to switch to OpenTelemetry, simply disable the legacy integration and follow the setup steps below. The OTel-based approach provides dimensional metrics with richer metadata (`haproxy.proxy_name`, `haproxy.service_name` per frontend/backend/server).
+If you're currently using `nri-haproxy` and want to switch to OpenTelemetry, disable the legacy integration and follow the setup steps below. The OTel-based approach provides dimensional metrics with richer metadata (`haproxy.proxy_name`, `haproxy.service_name` per frontend/backend/server).
 </Callout>
 
 ## Before you begin [#prerequisites]
@@ -47,7 +47,7 @@ Choose your preferred collector and follow the steps:
       OpenTelemetry Collector Contrib
     </TabsBarItem>
     <TabsBarItem id="prometheus">
-      Prometheus Receiver
+      Prometheus receiver
     </TabsBarItem>
   </TabsBar>
 
@@ -229,7 +229,7 @@ service:
       exporters: [otlphttp]
 ```
 
-#### Configuration parameters
+### Configuration parameters
 
 <table>
 <thead>
@@ -302,7 +302,7 @@ sudo journalctl -u nrdot-collector -n 50 --no-pager
 
   <Collapser id="nrdot-step5" title="Step 5: Verify data in New Relic">
 
-Allow 2-3 minutes for data to flow, then verify in New Relic:
+Allow 2 to 3 minutes for data to flow, then verify in New Relic:
 
 ```sql
 FROM Metric SELECT uniques(metricName)
@@ -444,7 +444,7 @@ receivers:
         enabled: true
 ```
 
-#### Configuration parameters
+### Configuration parameters
 
 <table>
 <thead>
@@ -517,7 +517,7 @@ sudo journalctl -u otelcol-contrib -n 50 --no-pager
 
   <Collapser id="otelcol-step6" title="Step 6: Verify data in New Relic">
 
-Allow 2-3 minutes for data to flow, then verify in New Relic:
+Allow 2 to 3 minutes for data to flow, then verify in New Relic:
 
 ```sql
 FROM Metric SELECT uniques(metricName)
@@ -581,7 +581,7 @@ Verify the Prometheus endpoint:
 curl -s http://localhost:8404/metrics | head -20
 ```
 
-You should see Prometheus-formatted metrics like `haproxy_frontend_current_sessions`, `haproxy_backend_http_responses_total`, etc. HAProxy exposes approximately 204 metrics through this endpoint.
+You should see Prometheus-formatted metrics such as `haproxy_frontend_current_sessions` and `haproxy_backend_http_responses_total`. HAProxy exposes approximately 204 metrics through this endpoint.
 
 <Callout variant="important">
 The Prometheus endpoint requires HAProxy 2.0 or later. If you're running an older version, use the **OTel Collector Contrib** tab with the haproxyreceiver instead, which uses the CSV stats endpoint and works with all HAProxy versions.
@@ -918,7 +918,7 @@ This configuration performs three key transformations:
 3. **Renames metrics** from Prometheus naming (`haproxy_frontend_*`) to OTel naming (`haproxy.*`) for consistent dashboards and alerts
 </Callout>
 
-#### Configuration parameters
+### Configuration parameters
 
 <table>
 <thead>
@@ -1056,7 +1056,7 @@ Common causes:
 
   <Collapser id="troubleshoot-no-data" title="No data appears in New Relic">
 
-- Allow 2-3 minutes for initial data ingestion
+- Allow 2 to 3 minutes for initial data ingestion
 - Verify the collector is running: `sudo systemctl status otelcol-contrib`
 - Check the stats endpoint is reachable from the collector host: `curl -s http://localhost:8404/stats`
 - Verify your license key is correct and the OTLP endpoint matches your region


### PR DESCRIPTION
Applies style guide fixes to the HAProxy OTel docs and updates `self-hosted.mdx`.

Supersedes #24683 — same content plus the additional `Update self-hosted.mdx` commit, which could not be pushed to the original branch (`feat/haproxy-otel-docs-style-fixes`) because that branch has direct-push protection enabled.

Commits:
- docs(haproxy): apply style guide fixes
- Update self-hosted.mdx