### PR TITLE
docs(logs): add Ubuntu 26.04 to infrastructure agent log forwarding supported OS list

### DIFF
--- a/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
+++ b/src/content/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent.mdx
@@ -57,7 +57,7 @@ How you forward your logs depends on how you installed the infrastructure agent,
 * RedHat version 8 and 9
 * Debian version 11 (Bullseye) and 12 (Bookworm).
 * SUSE Linux Enterprise Server (SLES) version 12 and 15 (ARM64 not supported).
-* Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x (LTS versions).
+* Ubuntu versions 16.04.x, 18.04.x, 20.04.x, 22.04.x, 24.04.x, 26.04.x (LTS versions).
 * Windows Server 2016, 2019, and 2022, and their service packs.
 * Windows 10, Windows 11.
 


### PR DESCRIPTION
## Give us some context

**What problems does this PR solve?**
New Relic now supports log forwarding on Ubuntu 26.04 (Resolute), but the docs didn't list it. This adds Ubuntu 26.04.x to the supported OS list on the "Forward your logs using the infrastructure agent" page.

**Context**
Ubuntu 26.04 support was added in the underlying packages and install recipe:
- Fluent Bit package: https://github.com/newrelic/fluent-bit-package/pull/243 (released)
- Logging install recipe: https://github.com/newrelic/open-install-library/pull/1380

Verified end-to-end on a real Ubuntu 26.04 host — the infrastructure agent + Fluent Bit install successfully and logs flow to New Relic.

**Change**
Added `26.04.x` to the Ubuntu versions line under System requirements.
