### PR TITLE
docs(workflow-automation): document TRACE logLevel option

### DIFF
--- a/src/content/docs/workflow-automation/manage-workflows/monitor-workflow-execution.mdx
+++ b/src/content/docs/workflow-automation/manage-workflows/monitor-workflow-execution.mdx
@@ -258,7 +258,7 @@ If started from a schedule occurrence:
 
 For Action step type, when using `DEBUG` each action input adds an additional attribute to the log entry with the format `workflowAutomation.inputs.<inputName>: <inputValue>`.
 
-When `TRACE` log level will be implemented, the action output will also be added to the log entry with the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
+With `TRACE` log level, the action output is also added to the log entry with the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
 
 ### Example NRQL query
 

--- a/src/content/docs/workflow-automation/manage-workflows/monitor-workflow-execution.mdx
+++ b/src/content/docs/workflow-automation/manage-workflows/monitor-workflow-execution.mdx
@@ -258,7 +258,7 @@ If started from a schedule occurrence:
 
 For Action step type, when using `DEBUG` each action input adds an additional attribute to the log entry with the format `workflowAutomation.inputs.<inputName>: <inputValue>`.
 
-With `TRACE` log level, the action output is also added to the log entry with the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
+For Action step type, when using `TRACE` each action output adds an additional attribute to the log entry with the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
 
 ### Example NRQL query
 

--- a/src/content/docs/workflow-automation/workflow-automation-apis/create-schedule.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/create-schedule.mdx
@@ -68,7 +68,7 @@ The `logLevel` option controls the amount of logging information generated durin
 - `NONE` (default): No log outputs will be generated.
 - `INFO`: Outputs step level information.
 - `DEBUG`: Adds an attribute to the step started logs with all the action step inputs, using the format `workflowAutomation.inputs.<inputName>: <inputValue>`.
-- `TRACE`: In addition to `DEBUG` output, adds the action output to the log entry using the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
+- `TRACE`: In addition to `DEBUG` output, adds an attribute to the step started logs with all the action step outputs, using the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
 
 ## Sample request
 

--- a/src/content/docs/workflow-automation/workflow-automation-apis/create-schedule.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/create-schedule.mdx
@@ -67,7 +67,8 @@ The `logLevel` option controls the amount of logging information generated durin
 **Available values:**
 - `NONE` (default): No log outputs will be generated.
 - `INFO`: Outputs step level information.
-- `DEBUG`: Adds attribute to the step started logs with all the action step inputs.
+- `DEBUG`: Adds an attribute to the step started logs with all the action step inputs, using the format `workflowAutomation.inputs.<inputName>: <inputValue>`.
+- `TRACE`: In addition to `DEBUG` output, adds the action output to the log entry using the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
 
 ## Sample request
 

--- a/src/content/docs/workflow-automation/workflow-automation-apis/start-workflow-run.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/start-workflow-run.mdx
@@ -68,7 +68,7 @@ The `logLevel` option controls the amount of logging information generated durin
 - `NONE` (default): No log outputs will be generated.
 - `INFO`: Outputs step level information.
 - `DEBUG`: Adds an attribute to the step started logs with all the action step inputs, using the format `workflowAutomation.inputs.<inputName>: <inputValue>`.
-- `TRACE`: In addition to `DEBUG` output, adds the action output to the log entry using the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
+- `TRACE`: In addition to `DEBUG` output, adds an attribute to the step started logs with all the action step outputs, using the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
 
 ## Sample request
 

--- a/src/content/docs/workflow-automation/workflow-automation-apis/start-workflow-run.mdx
+++ b/src/content/docs/workflow-automation/workflow-automation-apis/start-workflow-run.mdx
@@ -55,7 +55,7 @@ Number of concurrent workflow runs, and number of steps executed in a given run 
       <td>`options.logLevel`</td>
       <td>Enum</td>
       <td>No</td>
-      <td>Controls logging during execution. Values: `NONE` (default), `INFO`, `DEBUG`.</td>
+      <td>Controls logging during execution. Values: `NONE` (default), `INFO`, `DEBUG`, `TRACE`.</td>
     </tr>
   </tbody>
 </table>
@@ -67,7 +67,8 @@ The `logLevel` option controls the amount of logging information generated durin
 **Available values:**
 - `NONE` (default): No log outputs will be generated.
 - `INFO`: Outputs step level information.
-- `DEBUG`: Adds attribute to the step started logs with all the action step inputs.
+- `DEBUG`: Adds an attribute to the step started logs with all the action step inputs, using the format `workflowAutomation.inputs.<inputName>: <inputValue>`.
+- `TRACE`: In addition to `DEBUG` output, adds the action output to the log entry using the format `workflowAutomation.outputs.<outputName>: <outputValue>`.
 
 ## Sample request
 


### PR DESCRIPTION
Add TRACE log level to StartWorkflowRun and CreateSchedule API references and update the monitor-workflow-execution Logs section to reflect that TRACE (which adds action outputs as workflowAutomation.outputs.*) is now available rather than pending implementation.