### PR TITLE
feat: Add Smart Alerts public preview documentation

### DIFF
--- a/src/content/docs/alerts/alerts-ai-overview-page.mdx
+++ b/src/content/docs/alerts/alerts-ai-overview-page.mdx
@@ -13,6 +13,10 @@ freshnessValidatedDate: never
 
 On the <InlinePopover type="alerts"/> <DNT>**Overview**</DNT> page, you'll find a consolidated view of your current alert events. The <DNT>**Issues & activity**</DNT> page has views of your active issues and recent alert events.
 
+<Callout variant="tip">
+  To analyze alert coverage gaps and manage alert quality across your accounts, see [Smart Alerts](/docs/alerts/smart-alerts) (public preview).
+</Callout>
+
 ## Why it matters [#why]
 
 The <DNT>**Overview**</DNT> and <DNT>**Issues & activity**</DNT> pages provide analytics on how your system is (or isn't) performing. You can quickly switch between the [<DNT>**Overview**</DNT>](#summary), [<DNT>**Issues**</DNT>](#issues) and [<DNT>**Alert events**</DNT>](#alert-events) to scan for critical problems affecting your systems.

--- a/src/content/docs/alerts/alerts-ai-overview-page.mdx
+++ b/src/content/docs/alerts/alerts-ai-overview-page.mdx
@@ -14,7 +14,7 @@ freshnessValidatedDate: never
 On the <InlinePopover type="alerts"/> <DNT>**Overview**</DNT> page, you'll find a consolidated view of your current alert events. The <DNT>**Issues & activity**</DNT> page has views of your active issues and recent alert events.
 
 <Callout variant="tip">
-  To analyze alert coverage gaps and manage alert quality across your accounts, see [Smart Alerts](/docs/alerts/smart-alerts) (public preview).
+  To analyze alert coverage gaps and manage alert quality from a dedicated <DNT>**Alerts Overview**</DNT> page, see [smart alerts](/docs/alerts/smart-alerts) (public preview).
 </Callout>
 
 ## Why it matters [#why]

--- a/src/content/docs/alerts/create-alert/alert-coverage-gaps.mdx
+++ b/src/content/docs/alerts/create-alert/alert-coverage-gaps.mdx
@@ -18,7 +18,7 @@ In an increasingly dynamic landscape, we know how important it's to stay on top 
 What does covering an entity mean? A covered entity means that you've set up an [alert](/docs/alerts/overview#concepts-terms) to notify you of how a particular entity is performing. For example, you might have created an alert condition that opens an alert event if the throughput of an APM entity exceeds 100 requests per minute. An uncovered entity is part of your system that is unmonitored which means there could be unhealthy behavior that goes unchecked. We created [alert coverage gaps](https://one.newrelic.com/nrai/detection-gaps/home) to highlight uncovered entities so your team doesn't miss valuable data and you can prevent alert events before they happen.
 
 <Callout variant="tip">
-  To analyze and close coverage gaps across many entities at once, instead of one entity at a time, try [Smart Alerts](/docs/alerts/smart-alerts). Smart Alerts applies condition standards and recommended thresholds at scale and is currently in public preview.
+  To analyze and close coverage gaps across many entities at once, instead of one entity at a time, try [smart alerts](/docs/alerts/smart-alerts). From the <DNT>**Alerts Overview**</DNT> page, smart alerts apply condition standards and recommended thresholds at scale. This feature is currently in public preview.
 </Callout>
 
 ## Find your coverage gaps [#find-your-coverage-gaps]

--- a/src/content/docs/alerts/create-alert/alert-coverage-gaps.mdx
+++ b/src/content/docs/alerts/create-alert/alert-coverage-gaps.mdx
@@ -17,6 +17,10 @@ In an increasingly dynamic landscape, we know how important it's to stay on top 
 
 What does covering an entity mean? A covered entity means that you've set up an [alert](/docs/alerts/overview#concepts-terms) to notify you of how a particular entity is performing. For example, you might have created an alert condition that opens an alert event if the throughput of an APM entity exceeds 100 requests per minute. An uncovered entity is part of your system that is unmonitored which means there could be unhealthy behavior that goes unchecked. We created [alert coverage gaps](https://one.newrelic.com/nrai/detection-gaps/home) to highlight uncovered entities so your team doesn't miss valuable data and you can prevent alert events before they happen.
 
+<Callout variant="tip">
+  To analyze and close coverage gaps across many entities at once, instead of one entity at a time, try [Smart Alerts](/docs/alerts/smart-alerts). Smart Alerts applies condition standards and recommended thresholds at scale and is currently in public preview.
+</Callout>
+
 ## Find your coverage gaps [#find-your-coverage-gaps]
 
 To open the alert coverage gaps page, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Alerts**</DNT> and select <DNT>**Alert coverage gaps**</DNT> in the left navigation pane. There, you will see a list of all your entitites that are not currently covered.

--- a/src/content/docs/alerts/create-alert/create-alert-condition/alert-conditions.mdx
+++ b/src/content/docs/alerts/create-alert/create-alert-condition/alert-conditions.mdx
@@ -37,6 +37,7 @@ This example demonstrates manually creating a new alert condition using the <DNT
 * [A chart](/docs/tutorial-create-alerts/create-an-alert/)
 * [A policy page](https://one.newrelic.com/nr1-core/condition-builder/policy-entity)
 * [The <DNT>**Alert coverage gaps**</DNT> page](https://one.newrelic.com/alerts-ai/detection-gaps/)
+* [Smart Alerts](/docs/alerts/smart-alerts), to apply condition standards across many entities at once (public preview)
 
 You can also use one of our alert builders:
 

--- a/src/content/docs/alerts/create-alert/create-alert-condition/alert-conditions.mdx
+++ b/src/content/docs/alerts/create-alert/create-alert-condition/alert-conditions.mdx
@@ -37,7 +37,7 @@ This example demonstrates manually creating a new alert condition using the <DNT
 * [A chart](/docs/tutorial-create-alerts/create-an-alert/)
 * [A policy page](https://one.newrelic.com/nr1-core/condition-builder/policy-entity)
 * [The <DNT>**Alert coverage gaps**</DNT> page](https://one.newrelic.com/alerts-ai/detection-gaps/)
-* [Smart Alerts](/docs/alerts/smart-alerts), to apply condition standards across many entities at once (public preview)
+* The [<DNT>**Alerts Overview**</DNT> page](/docs/alerts/smart-alerts), to apply condition standards across many entities at once with smart alerts (public preview)
 
 You can also use one of our alert builders:
 

--- a/src/content/docs/alerts/overview.mdx
+++ b/src/content/docs/alerts/overview.mdx
@@ -47,7 +47,7 @@ With alerts, you can:
 * Identify [anomalies](/docs/alerts-applied-intelligence/applied-intelligence/anomaly-detection/anomaly-detection-applied-intelligence/) before they become broader issues.
 * Route issues to the correct system or team using [notifications](/docs/alerts-applied-intelligence/notifications/intro-notifications/).
 * Enable the <DNT>[Predictive capability](/docs/alerts/create-alert/set-thresholds/predictive-alerts)</DNT> to anticipate and respond proactively to possible threshold breaches in the future. (Available with the public preview of Predictive Alerts).
-* Set up and govern alert coverage at scale with <DNT>[Smart Alerts](/docs/alerts/smart-alerts)</DNT>, which applies condition standards and recommended thresholds across your entities. (Available in public preview).
+* Set up and govern alert coverage at scale with [smart alerts](/docs/alerts/smart-alerts) from the <DNT>**Alerts Overview**</DNT> page, which applies condition standards and recommended thresholds across your entities. (Available in public preview).
 
 New Relic alerts allow you to:
 

--- a/src/content/docs/alerts/overview.mdx
+++ b/src/content/docs/alerts/overview.mdx
@@ -47,6 +47,7 @@ With alerts, you can:
 * Identify [anomalies](/docs/alerts-applied-intelligence/applied-intelligence/anomaly-detection/anomaly-detection-applied-intelligence/) before they become broader issues.
 * Route issues to the correct system or team using [notifications](/docs/alerts-applied-intelligence/notifications/intro-notifications/).
 * Enable the <DNT>[Predictive capability](/docs/alerts/create-alert/set-thresholds/predictive-alerts)</DNT> to anticipate and respond proactively to possible threshold breaches in the future. (Available with the public preview of Predictive Alerts).
+* Set up and govern alert coverage at scale with <DNT>[Smart Alerts](/docs/alerts/smart-alerts)</DNT>, which applies condition standards and recommended thresholds across your entities. (Available in public preview).
 
 New Relic alerts allow you to:
 

--- a/src/content/docs/alerts/smart-alerts.mdx
+++ b/src/content/docs/alerts/smart-alerts.mdx
@@ -1,0 +1,281 @@
+---
+title: Smart Alerts
+tags:
+  - Alerts
+  - Smart Alerts
+  - Alert coverage
+  - Condition standards
+  - Proactive detection
+metaDescription: "Set up and manage comprehensive alert coverage across your architecture with automated condition standards and dynamic thresholds."
+freshnessValidatedDate: never
+---
+
+<Callout title="preview">
+We're still working on this feature, but we'd love for you to try it out!
+
+This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
+</Callout>
+
+Smart Alerts provides a streamlined framework for configuring and governing alert coverage across your architecture. You don't need to manually configure individual signals. Smart Alerts automatically analyzes your environment to identify entities, such as services and browser applications, that currently lack monitoring coverage.
+
+Traditional alerting requires significant manual effort: you'd typically spend 20-40 clicks to create a single alert condition for one entity. If your account has 100-200 entities, this translates to thousands of clicks and hours of configuration work. Smart Alerts reduces this to just 5-6 clicks by applying industry best practices at scale.
+
+Smart Alerts is best suited for teams setting up alerting for the first time, organizations without dedicated observability specialists, or anyone managing 50 or more entities where manual configuration becomes impractical. If you're an existing New Relic customer with established alert configurations, consider testing Smart Alerts in staging or non-production environments first before applying it to critical production systems.
+
+## How Smart Alerts solves alerting problems [#problems-solved]
+
+Modern alerting systems struggle with several challenges that Smart Alerts addresses:
+
+* **Missing alert coverage:** Service incidents often go undetected due to incomplete monitoring.
+* **Coverage blindspots:** It's difficult to see what is and isn't covered by alerts, creating governance challenges.
+* **Setup and maintenance toil:** Configuring and maintaining alerts requires significant time and effort.
+* **Alert quality issues:** Noisy, misconfigured, and duplicate alerts result in alert fatigue, missed notifications, and inflated operational costs.
+
+## Key concepts [#key-concepts]
+
+* **Condition standards:** Pre-packaged alerting configurations that define what to monitor for specific entity types (for example, "Response time" for APM services, "Largest contentful paint" for browser applications, or "Failures" for synthetic monitors). These standards represent industry best practices. When you apply a condition standard, Smart Alerts automatically creates alert conditions for all matching entities.
+* **Recommended thresholds:** Smart Alerts analyzes historical metric data, such as throughput, latency, or error rates, to generate thresholds specific to each entity's baseline, reducing the operational overhead of manual configuration. You can adjust these recommended thresholds to fit your specific needs.
+
+## Requirements [#requirements]
+
+Smart Alerts is available to all paid New Relic customers. To configure alert coverage with Smart Alerts, you need to be a [full platform user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities).
+
+## Access Smart Alerts [#access]
+
+To access Smart Alerts:
+
+1. Log in to [one.newrelic.com](https://one.newrelic.com).
+2. From the left navigation menu, navigate to <DNT>**Alerts**</DNT>.
+3. Select <DNT>**Alerts Overview**</DNT>.
+
+The <DNT>**Alerts Overview**</DNT> page is your central hub for managing alert coverage and quality across all accounts in your organization.
+
+## Analyze coverage gaps [#analyze-coverage]
+
+The <DNT>**Alerts Overview**</DNT> page provides two distinct views of your alert coverage:
+
+* <DNT>**Alert standards coverage:**</DNT> Shows combined standards-based coverage across your entity types (such as Services - APM, Browser applications, and Synthetic monitors). Each entity type displays a progress bar with counts for fully covered, partially covered, and not covered entities. Click <DNT>**Manage coverage**</DNT> to drill into specific gaps.
+* <DNT>**Alert condition coverage:**</DNT> Shows a pie chart of total entities split into "With conditions" versus "Without conditions," with counts and percentages for each.
+
+<Callout title="Note">
+The standards coverage widget may not load for very large accounts with a lot of entities.
+</Callout>
+
+### Entity types and condition standards [#entity-types]
+
+New Relic groups condition standards by entity type. Here are some examples of common entity types and their standards:
+
+<table>
+  <thead>
+    <tr>
+      <th>Entity type</th>
+      <th>Condition standards</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Services (APM)</td>
+      <td>
+        * Response time
+        * Throughput (low)
+        * Error rate (%)
+      </td>
+    </tr>
+    <tr>
+      <td>Browser applications</td>
+      <td>
+        * Interaction to next paint
+        * Largest contentful paint
+        * Page load time
+        * JavaScript error rate
+      </td>
+    </tr>
+    <tr>
+      <td>Synthetic monitors</td>
+      <td>
+        * Duration
+        * Failures
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+To view detailed coverage information and see which specific entities are missing standards, on the <DNT>**Alerts Overview**</DNT> page, click <DNT>**Manage coverage**</DNT>.
+
+## Set up Smart Alerts [#setup-smart-alerts]
+
+To improve your alert coverage using Smart Alerts, refer to the following steps.
+
+<Steps>
+  <Step>
+    ## Review your alerts coverage [#review-coverage]
+
+    On the <DNT>**Alerts Overview**</DNT> page, review several key performance indicators:
+
+    * <DNT>**Issues:**</DNT> View total active issues and trends for critical and high-priority issues over the last 7 days.
+    * <DNT>**Alert standards coverage:**</DNT> Check the combined standards-based coverage across entity types, with per-entity-type breakdowns showing fully covered, partially covered, and not covered counts.
+    * <DNT>**Alert condition coverage:**</DNT> View a pie chart showing total entities with and without alert conditions.
+    * <DNT>**Noise overview:**</DNT> Identify noisy conditions generating excessive alerts and conditions that aren't producing any signals, with trend charts showing daily patterns.
+    * <DNT>**Notifications:**</DNT> Track the percentage of notifications with errors and recent failures.
+  </Step>
+
+  <Step>
+    ## Manage coverage [#manage-coverage]
+
+    To see which specific entities need alert coverage:
+
+    1. On the <DNT>**Alerts Overview**</DNT> page, click <DNT>**Manage coverage**</DNT>.
+    2. Review the <DNT>**Coverage status**</DNT> page showing collapsible entity type cards.
+    3. Each card displays:
+       * Entity type name with standard count and entity count (for example, "3 standards across 2 entities")
+       * <DNT>**Standard coverage**</DNT> percentage with progress bar
+       * A data table with three columns:
+         * <DNT>**Condition standard**</DNT>: The specific metric being monitored (for example, Response time, Throughput (low), Error rate).
+         * <DNT>**Entity status**</DNT>: Entity count, coverage percentage, progress bar, and a status badge (Fully covered, Partially covered, or Uncovered).
+         * <DNT>**Action**</DNT>: <DNT>**Configure**</DNT> button to customize that standard's coverage.
+  </Step>
+
+  <Step>
+    ## Apply alert standards [#apply-standards]
+
+    From the <DNT>**Coverage status**</DNT> page, apply alert standards by configuring individual condition standards:
+
+    1. On an entity type card, click the <DNT>**Configure**</DNT> button next to the condition standard you want to apply.
+    2. The configuration page for that standard opens (for example, <DNT>**Duration**</DNT> or <DNT>**Response time**</DNT>), where you can adjust thresholds, filters, and policy settings before clicking <DNT>**Create condition**</DNT> (see the next step for details).
+  </Step>
+
+  <Step>
+    ## Configure settings [#configure-settings]
+
+    On the configuration page for a specific condition standard, Smart Alerts auto-generates thresholds and settings based on historical data. You're required to review these defaults before creating the condition, but all adjustments are optional. Expand each collapsible section to review:
+
+    <CollapserGroup>
+      <Collapser id="thresholds" title="Thresholds">
+        <Callout title="Note">
+        Threshold generation may not work for entity types with more than 500 entities. If you encounter this limitation, use the <DNT>**Filter query**</DNT> section to reduce the number of entities.
+        </Callout>
+
+        This section displays the auto-generated thresholds for your entities:
+
+        * A histogram showing the <DNT>**CRITICAL - Threshold distribution**</DNT> across your entities.
+
+        To optionally adjust thresholds, you have the following controls:
+
+        * <DNT>**Global Thresholds Tolerance**</DNT> slider: Adjust sensitivity across all entities, ranging from "More noisy (More alerts)" to "Less noisy (Fewer alerts)."
+        * <DNT>**Thresholds values**</DNT>: Constrain the threshold range by setting <DNT>**Min value**</DNT> and <DNT>**Max value**</DNT> bounds.
+        * After adjusting the slider or threshold values, click <DNT>**Re-generate thresholds**</DNT> to apply your changes. Thresholds aren't updated until you click this button.
+
+        The <DNT>**Individual Entity Configuration**</DNT> table shows each entity with the following columns:
+
+        * <DNT>**Entity**</DNT>: Entity name with a label indicating its threshold origin — "System generated" for default thresholds, or "User override" when you've modified the threshold value or toggled Zero Noise.
+        * <DNT>**Alert Events**</DNT>: The number of times the threshold was exceeded in the last 6 hours.
+        * <DNT>**Threshold Trend (6 hours)**</DNT>: Sparkline chart showing recent threshold activity.
+        * <DNT>**Threshold Value**</DNT>: The current threshold value, which you can edit directly in the table.
+        * <DNT>**Actions**</DNT>: Contains the following controls:
+          * <DNT>**Zero Noise**</DNT> toggle: Automatically adjusts the threshold to the value that best reduces false alerts, based on the condition's recent history.
+          * <DNT>**Revert**</DNT>: Reset the entity's threshold back to the system-generated value.
+          * <DNT>**Modify**</DNT>: Opens the <DNT>**Modify Threshold**</DNT> dialog for that entity.
+
+        Additional controls in the table:
+
+        * <DNT>**Zero Noise (All)**</DNT> toggle: Suppress alerts for all entities at once by toggling this at the top of the table.
+        * <DNT>**Modify**</DNT> button: Fine-tune a specific entity's threshold by clicking <DNT>**Modify**</DNT> to open the <DNT>**Modify Threshold**</DNT> dialog. This dialog displays a sparkline chart of the entity's recent metric data along with an adjustable <DNT>**Threshold value**</DNT> field. Click <DNT>**Save**</DNT> to apply or <DNT>**Cancel**</DNT> to discard changes.
+      </Collapser>
+
+      <Collapser id="filter-query" title="Filter query (optional)">
+        A condition standard covers all entities of the selected type. To filter which entities to include or exclude:
+
+        1. In the <DNT>**Filter query**</DNT> section, click <DNT>**+**</DNT> to add a filter.
+        2. Configure your filter criteria and click <DNT>**Add**</DNT>.
+
+        For example, to exclude staging and development entities, apply the standard only where `environment = 'production'`. You can add multiple filters to further refine the scope.
+
+        This section also displays a preview of the underlying NRQL query used for the condition.
+
+        <Callout variant="important">
+        If Smart Alerts detects that some entities already have alert conditions matching the recommended standards, a <DNT>**Duplicates found**</DNT> warning appears in this section. Click <DNT>**Review duplicates**</DNT> to see which entities may receive duplicate conditions, and consider excluding them using filters.
+        </Callout>
+      </Collapser>
+
+      <Collapser id="add-details" title="Add details">
+        In the <DNT>**Add details**</DNT> section, you can customize the <DNT>**Title template**</DNT> for the alert condition name.
+      </Collapser>
+
+      <Collapser id="issue-creation-preference" title="Issue creation preference">
+        In the <DNT>**Issue creation preference**</DNT> section, configure how you want to create issues for alerts:
+
+        * <DNT>**Per condition:**</DNT> Creates a separate issue for each condition that breaches the threshold.
+        * <DNT>**Per condition and target:**</DNT> Creates a separate issue for each entity that breaches the threshold. This is the default.
+        * <DNT>**Per policy:**</DNT> Aggregates breaches into a single issue to reduce notification volume.
+      </Collapser>
+    </CollapserGroup>
+  </Step>
+
+  <Step>
+    ## Create conditions [#create-conditions]
+
+    After configuring your settings:
+
+    1. Review your thresholds, filters, and issue creation preference.
+    2. Click <DNT>**Create condition**</DNT>.
+
+    This creates the alert condition immediately and begins monitoring all matching entities. It also automatically monitors new entities that come online in the future matching your filter criteria.
+  </Step>
+</Steps>
+
+## Manage alert quality [#manage-quality]
+
+While Smart Alerts focuses on closing coverage gaps using condition standards, the <DNT>**Alerts Overview**</DNT> provides a holistic health check for your entire alerting ecosystem including conditions created manually, via API or Terraform, or through Smart Alerts.
+
+### Reduce noise [#reduce-noise]
+
+Alert fatigue is a major obstacle to fast incident resolution. The <DNT>**Noise overview**</DNT> identifies high-volume alert conditions that may be drowning out critical signals.
+
+To view and manage noisy conditions:
+
+1. To check the percentage of noisy alerts, on the <DNT>**Alerts Overview**</DNT> page, go to the <DNT>**Noise overview**</DNT> section.
+2. To view details of noisy conditions, click <DNT>**Manage**</DNT>.
+3. To edit the condition, click the <Icon name="fe-more-horizontal"/> menu and select <DNT>**Edit**</DNT>. To disable it, use the toggle switch.
+
+### Manage conditions without signals [#no-signals]
+
+Over time, alert configurations can become stale as services are deprecated, renamed, or re-architected. This leads to unused alerts that clutter your system.
+
+To clean up these conditions:
+
+1. On the <DNT>**Alerts Overview**</DNT> page, go to the <DNT>**Noise overview**</DNT> section.
+2. To view conditions without signals, click <DNT>**Manage**</DNT>.
+3. Review conditions that haven't detected or received any signal data for the past 30 days.
+4. To investigate why the signal is missing, drill down into these conditions.
+5. Depending on the root cause, you can:
+   * Edit the underlying query to fix the signal path.
+   * Disable the alert temporarily.
+   * Delete it permanently to clean up your configuration.
+
+### Address notification problems [#notification-problems]
+
+The <DNT>**Notification**</DNT> section helps you identify and fix issues with alert delivery:
+
+1. To view notification issues, click <DNT>**Manage notifications**</DNT>.
+2. Review the <DNT>**Notification failures over the last 24 hours**</DNT> table to see specific issues.
+3. To understand the error and take corrective action, click into a failed notification.
+
+## Related topics [#related-topics]
+
+<DocTiles>
+  <DocTile title="Alert coverage gaps and condition recommendations" path="/docs/alerts/create-alert/alert-coverage-gaps">
+    Identify individual uncovered entities and add recommended alert conditions.
+  </DocTile>
+  <DocTile title="Create an alert condition" path="/docs/alerts/create-alert/create-alert-condition/alert-conditions">
+    Build and customize alert conditions manually.
+  </DocTile>
+  <DocTile title="Set thresholds for alert conditions" path="/docs/alerts/create-alert/set-thresholds/set-thresholds-alert-condition">
+    Learn how thresholds determine when an alert condition triggers.
+  </DocTile>
+  <DocTile title="Alerts overview, issue, and activity" path="/docs/alerts/alerts-ai-overview-page">
+    Interpret alert events, issues, and activity across your accounts.
+  </DocTile>
+  <DocTile title="Introduction to notifications" path="/docs/alerts/get-notified/intro-notifications">
+    Route issues to the right teams and tools.
+  </DocTile>
+</DocTiles>

--- a/src/content/docs/alerts/smart-alerts.mdx
+++ b/src/content/docs/alerts/smart-alerts.mdx
@@ -1,8 +1,8 @@
 ---
-title: Smart Alerts
+title: Smart alerts
 tags:
   - Alerts
-  - Smart Alerts
+  - Smart alerts
   - Alert coverage
   - Condition standards
   - Proactive detection
@@ -16,15 +16,17 @@ We're still working on this feature, but we'd love for you to try it out!
 This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
-Smart Alerts provides a streamlined framework for configuring and governing alert coverage across your architecture. You don't need to manually configure individual signals. Smart Alerts automatically analyzes your environment to identify entities, such as services and browser applications, that currently lack monitoring coverage.
+New Relic's smart alerting gives you a streamlined way to configure and govern alert coverage across your architecture. Instead of manually configuring individual signals, New Relic automatically analyzes your environment to identify entities — such as services, browser applications, and hosts — that lack monitoring coverage, then helps you apply alerting best practices at scale.
 
-Traditional alerting requires significant manual effort: you'd typically spend 20-40 clicks to create a single alert condition for one entity. If your account has 100-200 entities, this translates to thousands of clicks and hours of configuration work. Smart Alerts reduces this to just 5-6 clicks by applying industry best practices at scale.
+You work with smart alerts from the <DNT>**Alerts Overview**</DNT> page in the New Relic UI.
 
-Smart Alerts is best suited for teams setting up alerting for the first time, organizations without dedicated observability specialists, or anyone managing 50 or more entities where manual configuration becomes impractical. If you're an existing New Relic customer with established alert configurations, consider testing Smart Alerts in staging or non-production environments first before applying it to critical production systems.
+Traditional alerting requires significant manual effort: you'd typically spend 20-40 clicks to create a single alert condition for one entity. If your account has 100-200 entities, this translates to thousands of clicks and hours of configuration work. Smart alerts reduce this to just 5-6 clicks by applying industry best practices at scale.
 
-## How Smart Alerts solves alerting problems [#problems-solved]
+Smart alerts are best suited for teams setting up alerting for the first time, organizations without dedicated observability specialists, or anyone managing 50 or more entities where manual configuration becomes impractical. If you're an existing New Relic customer with established alert configurations, consider testing in a staging or non-production environment first before applying changes to critical production systems.
 
-Modern alerting systems struggle with several challenges that Smart Alerts addresses:
+## How smart alerts solve alerting problems [#problems-solved]
+
+Modern alerting systems struggle with several challenges that smart alerts address:
 
 * **Missing alert coverage:** Service incidents often go undetected due to incomplete monitoring.
 * **Coverage blindspots:** It's difficult to see what is and isn't covered by alerts, creating governance challenges.
@@ -33,22 +35,27 @@ Modern alerting systems struggle with several challenges that Smart Alerts addre
 
 ## Key concepts [#key-concepts]
 
-* **Condition standards:** Pre-packaged alerting configurations that define what to monitor for specific entity types (for example, "Response time" for APM services, "Largest contentful paint" for browser applications, or "Failures" for synthetic monitors). These standards represent industry best practices. When you apply a condition standard, Smart Alerts automatically creates alert conditions for all matching entities.
-* **Recommended thresholds:** Smart Alerts analyzes historical metric data, such as throughput, latency, or error rates, to generate thresholds specific to each entity's baseline, reducing the operational overhead of manual configuration. You can adjust these recommended thresholds to fit your specific needs.
+* **Condition standards:** Pre-packaged alerting configurations that define what to monitor for specific entity types (for example, "Response time" for APM services, "Largest contentful paint" for browser applications, or "Failures" for synthetic monitors). These standards represent industry best practices. When you apply a condition standard, New Relic automatically creates alert conditions for all matching entities.
+* **Recommended thresholds:** New Relic generates a threshold for each entity intelligently — either from rules for well-known metrics or from the entity's own signal behavior — which reduces the operational overhead of manual configuration. You can review and adjust these recommended thresholds to fit your needs.
 
 ## Requirements [#requirements]
 
-Smart Alerts is available to all paid New Relic customers. To configure alert coverage with Smart Alerts, you need to be a [full platform user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities).
+Smart alerts are available to all paid New Relic accounts that opt into the public preview.
 
-## Access Smart Alerts [#access]
+* **View:** Any user in an opted-in account can view the <DNT>**Alerts Overview**</DNT> page.
+* **Create, manage, edit, and delete:** You need to be a [full platform user](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type/#user-type-capabilities). Access and authorization match [anomaly alert conditions](/docs/alerts/create-alert/set-thresholds/anomaly-detection) — any full platform user in the account can manage coverage, including conditions created by other users.
 
-To access Smart Alerts:
+Smart alerts are account-scoped. You can't view or manage alert coverage across multiple accounts from a single view.
 
-1. Log in to [one.newrelic.com](https://one.newrelic.com).
-2. From the left navigation menu, navigate to <DNT>**Alerts**</DNT>.
+## Access smart alerts [#access]
+
+To open the <DNT>**Alerts Overview**</DNT> page:
+
+1. Go to [one.newrelic.com](https://one.newrelic.com).
+2. From the left navigation menu, go to <DNT>**Alerts**</DNT>.
 3. Select <DNT>**Alerts Overview**</DNT>.
 
-The <DNT>**Alerts Overview**</DNT> page is your central hub for managing alert coverage and quality across all accounts in your organization.
+The <DNT>**Alerts Overview**</DNT> page is your central hub for managing alert coverage and quality for your account. It's a separate page from the existing <DNT>**Overview**</DNT> and <DNT>**Issues & activity**</DNT> pages, which continue to show your alert events and activity.
 
 ## Analyze coverage gaps [#analyze-coverage]
 
@@ -56,6 +63,8 @@ The <DNT>**Alerts Overview**</DNT> page provides two distinct views of your aler
 
 * <DNT>**Alert standards coverage:**</DNT> Shows combined standards-based coverage across your entity types (such as Services - APM, Browser applications, and Synthetic monitors). Each entity type displays a progress bar with counts for fully covered, partially covered, and not covered entities. Click <DNT>**Manage coverage**</DNT> to drill into specific gaps.
 * <DNT>**Alert condition coverage:**</DNT> Shows a pie chart of total entities split into "With conditions" versus "Without conditions," with counts and percentages for each.
+
+These two views can differ for the same entity. If an alert condition exists for an entity but doesn't match a condition standard, that entity counts as "With conditions" under <DNT>**Alert condition coverage**</DNT> but remains uncovered under <DNT>**Alert standards coverage**</DNT>.
 
 <Callout title="Note">
 The standards coverage widget may not load for very large accounts with a lot of entities.
@@ -91,20 +100,40 @@ New Relic groups condition standards by entity type. Here are some examples of c
       </td>
     </tr>
     <tr>
+      <td>Mobile applications</td>
+      <td>
+        {/* Condition standards to be confirmed with SME */}
+        _To be confirmed_
+      </td>
+    </tr>
+    <tr>
       <td>Synthetic monitors</td>
       <td>
         * Duration
         * Failures
       </td>
     </tr>
+    <tr>
+      <td>Hosts</td>
+      <td>
+        * CPU usage
+        * Memory usage
+        * Storage usage
+        * Network transmit
+      </td>
+    </tr>
   </tbody>
 </table>
 
+<Callout title="Note">
+New Relic doesn't yet have defined condition standards for every entity type. Entity types without curated standards appear under <DNT>**Under consideration**</DNT> on the <DNT>**Coverage status**</DNT> page and will gain standards over time.
+</Callout>
+
 To view detailed coverage information and see which specific entities are missing standards, on the <DNT>**Alerts Overview**</DNT> page, click <DNT>**Manage coverage**</DNT>.
 
-## Set up Smart Alerts [#setup-smart-alerts]
+## Set up smart alerts [#setup-smart-alerts]
 
-To improve your alert coverage using Smart Alerts, refer to the following steps.
+To improve your alert coverage, refer to the following steps.
 
 <Steps>
   <Step>
@@ -116,7 +145,6 @@ To improve your alert coverage using Smart Alerts, refer to the following steps.
     * <DNT>**Alert standards coverage:**</DNT> Check the combined standards-based coverage across entity types, with per-entity-type breakdowns showing fully covered, partially covered, and not covered counts.
     * <DNT>**Alert condition coverage:**</DNT> View a pie chart showing total entities with and without alert conditions.
     * <DNT>**Noise overview:**</DNT> Identify noisy conditions generating excessive alerts and conditions that aren't producing any signals, with trend charts showing daily patterns.
-    * <DNT>**Notifications:**</DNT> Track the percentage of notifications with errors and recent failures.
   </Step>
 
   <Step>
@@ -132,32 +160,28 @@ To improve your alert coverage using Smart Alerts, refer to the following steps.
        * A data table with three columns:
          * <DNT>**Condition standard**</DNT>: The specific metric being monitored (for example, Response time, Throughput (low), Error rate).
          * <DNT>**Entity status**</DNT>: Entity count, coverage percentage, progress bar, and a status badge (Fully covered, Partially covered, or Uncovered).
-         * <DNT>**Action**</DNT>: <DNT>**Configure**</DNT> button to customize that standard's coverage.
+         * <DNT>**Action**</DNT>: A <DNT>**Configure**</DNT> or <DNT>**Manage**</DNT> button. If none of a standard's entities are covered yet, the button reads <DNT>**Configure**</DNT>. Once at least one condition covers the standard, it changes to <DNT>**Manage**</DNT>.
   </Step>
 
   <Step>
-    ## Apply alert standards [#apply-standards]
+    ## Apply or manage alert standards [#apply-standards]
 
-    From the <DNT>**Coverage status**</DNT> page, apply alert standards by configuring individual condition standards:
+    From the <DNT>**Coverage status**</DNT> page, apply or manage each condition standard:
 
-    1. On an entity type card, click the <DNT>**Configure**</DNT> button next to the condition standard you want to apply.
-    2. The configuration page for that standard opens (for example, <DNT>**Duration**</DNT> or <DNT>**Response time**</DNT>), where you can adjust thresholds, filters, and policy settings before clicking <DNT>**Create condition**</DNT> (see the next step for details).
+    * If no entities are covered for a standard, click <DNT>**Configure**</DNT> to open the configuration page for that standard (for example, <DNT>**Duration**</DNT> or <DNT>**Response time**</DNT>), where you adjust thresholds, filters, and policy settings before creating the condition (see the next step for details).
+    * If at least one entity is already covered, the button reads <DNT>**Manage**</DNT>. Click <DNT>**Manage**</DNT> to view all alert conditions covering that standard, where you can create new conditions or edit existing ones.
   </Step>
 
   <Step>
     ## Configure settings [#configure-settings]
 
-    On the configuration page for a specific condition standard, Smart Alerts auto-generates thresholds and settings based on historical data. You're required to review these defaults before creating the condition, but all adjustments are optional. Expand each collapsible section to review:
+    On the configuration page for a specific condition standard, New Relic auto-generates thresholds and settings based on your data. You're required to review these defaults before creating the condition, but all adjustments are optional. Expand each collapsible section to review:
 
     <CollapserGroup>
       <Collapser id="thresholds" title="Thresholds">
-        <Callout title="Note">
-        Threshold generation may not work for entity types with more than 500 entities. If you encounter this limitation, use the <DNT>**Filter query**</DNT> section to reduce the number of entities.
-        </Callout>
+        This section displays the auto-generated thresholds for your entities. Thresholds are generated intelligently — either from rules for well-known metrics or from each entity's recent signal behavior.
 
-        This section displays the auto-generated thresholds for your entities:
-
-        * A histogram showing the <DNT>**CRITICAL - Threshold distribution**</DNT> across your entities.
+        * A histogram shows the <DNT>**CRITICAL - Threshold distribution**</DNT> across your entities.
 
         To optionally adjust thresholds, you have the following controls:
 
@@ -193,7 +217,7 @@ To improve your alert coverage using Smart Alerts, refer to the following steps.
         This section also displays a preview of the underlying NRQL query used for the condition.
 
         <Callout variant="important">
-        If Smart Alerts detects that some entities already have alert conditions matching the recommended standards, a <DNT>**Duplicates found**</DNT> warning appears in this section. Click <DNT>**Review duplicates**</DNT> to see which entities may receive duplicate conditions, and consider excluding them using filters.
+        If New Relic detects that some entities already have alert conditions matching the recommended standards, a <DNT>**Duplicates found**</DNT> warning appears in this section. Click <DNT>**Review duplicates**</DNT> to see which entities may receive duplicate conditions, and consider excluding them using filters.
         </Callout>
       </Collapser>
 
@@ -225,17 +249,17 @@ To improve your alert coverage using Smart Alerts, refer to the following steps.
 
 ## Manage alert quality [#manage-quality]
 
-While Smart Alerts focuses on closing coverage gaps using condition standards, the <DNT>**Alerts Overview**</DNT> provides a holistic health check for your entire alerting ecosystem including conditions created manually, via API or Terraform, or through Smart Alerts.
+While smart alerts focus on closing coverage gaps using condition standards, the <DNT>**Alerts Overview**</DNT> provides a holistic health check for your entire alerting ecosystem including conditions created manually, via API or Terraform, or through smart alerts.
 
 ### Reduce noise [#reduce-noise]
 
-Alert fatigue is a major obstacle to fast incident resolution. The <DNT>**Noise overview**</DNT> identifies high-volume alert conditions that may be drowning out critical signals.
+Alert fatigue is a major obstacle to fast incident resolution. The <DNT>**Noise overview**</DNT> identifies high-volume alert conditions that may be drowning out critical signals. A condition is considered noisy when it generates three or more issues per hour for at least three hours within a 24-hour span, and conditions are sorted with the noisiest at the top.
 
 To view and manage noisy conditions:
 
-1. To check the percentage of noisy alerts, on the <DNT>**Alerts Overview**</DNT> page, go to the <DNT>**Noise overview**</DNT> section.
-2. To view details of noisy conditions, click <DNT>**Manage**</DNT>.
-3. To edit the condition, click the <Icon name="fe-more-horizontal"/> menu and select <DNT>**Edit**</DNT>. To disable it, use the toggle switch.
+1. On the <DNT>**Alerts Overview**</DNT> page, go to the <DNT>**Noise overview**</DNT> section.
+2. To view details of the noisiest conditions, click <DNT>**Manage**</DNT>.
+3. To make a condition less noisy, modify its threshold. To edit a condition, click the <Icon name="fe-more-horizontal"/> menu and select <DNT>**Edit**</DNT>. To disable it, use the toggle switch. Disabling a condition stops it from evaluating its signal.
 
 ### Manage conditions without signals [#no-signals]
 
@@ -245,20 +269,12 @@ To clean up these conditions:
 
 1. On the <DNT>**Alerts Overview**</DNT> page, go to the <DNT>**Noise overview**</DNT> section.
 2. To view conditions without signals, click <DNT>**Manage**</DNT>.
-3. Review conditions that haven't detected or received any signal data for the past 30 days.
+3. Review conditions that haven't detected or received any signal data for the past 30 days. Some conditions, such as error rate or failure rate, don't produce a signal by design, so no signal isn't always a problem.
 4. To investigate why the signal is missing, drill down into these conditions.
 5. Depending on the root cause, you can:
    * Edit the underlying query to fix the signal path.
    * Disable the alert temporarily.
    * Delete it permanently to clean up your configuration.
-
-### Address notification problems [#notification-problems]
-
-The <DNT>**Notification**</DNT> section helps you identify and fix issues with alert delivery:
-
-1. To view notification issues, click <DNT>**Manage notifications**</DNT>.
-2. Review the <DNT>**Notification failures over the last 24 hours**</DNT> table to see specific issues.
-3. To understand the error and take corrective action, click into a failed notification.
 
 ## Related topics [#related-topics]
 

--- a/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
@@ -308,7 +308,7 @@ If you're new to alerts or if you want suggestions that optimize your alert cove
 
 * [Get recommended alerts by technology](https://newrelic.com/instant-observability)
 * [Let New Relic find your coverage gaps](https://one.newrelic.com/nrai/detection-gaps/home)
-* [Set up alert coverage at scale with Smart Alerts](/docs/alerts/smart-alerts) (public preview)
+* [Set up alert coverage at scale with smart alerts](/docs/alerts/smart-alerts) (public preview)
 * [Get condition recommendations](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/condition-recommendations/)
 
 ### Understand signal [#understand-signal]

--- a/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
+++ b/src/content/docs/new-relic-solutions/best-practices-guides/alerts-applied-intelligence/alerts-best-practices.mdx
@@ -308,6 +308,7 @@ If you're new to alerts or if you want suggestions that optimize your alert cove
 
 * [Get recommended alerts by technology](https://newrelic.com/instant-observability)
 * [Let New Relic find your coverage gaps](https://one.newrelic.com/nrai/detection-gaps/home)
+* [Set up alert coverage at scale with Smart Alerts](/docs/alerts/smart-alerts) (public preview)
 * [Get condition recommendations](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/condition-recommendations/)
 
 ### Understand signal [#understand-signal]

--- a/src/nav/alerts.yml
+++ b/src/nav/alerts.yml
@@ -5,6 +5,8 @@ pages:
     path: /docs/alerts/overview
   - title: Overview, issue, and activity
     path: /docs/alerts/alerts-ai-overview-page
+  - title: Smart Alerts
+    path: /docs/alerts/smart-alerts
   - title: Create an alert
     pages:
       - title: Create an alert condition

--- a/src/nav/alerts.yml
+++ b/src/nav/alerts.yml
@@ -5,7 +5,7 @@ pages:
     path: /docs/alerts/overview
   - title: Overview, issue, and activity
     path: /docs/alerts/alerts-ai-overview-page
-  - title: Smart Alerts
+  - title: Smart alerts
     path: /docs/alerts/smart-alerts
   - title: Create an alert
     pages:


### PR DESCRIPTION
## Key changes

Migrates the **Smart Alerts** documentation from the limited preview (LP) beta site into the public docs site as a public preview (PP) page, and wires it into the existing alerts information architecture.

- **New documentation:** `src/content/docs/alerts/smart-alerts.mdx` → `/docs/alerts/smart-alerts`
- **Navigation:** added `Smart Alerts` as a top-level page in `src/nav/alerts.yml` (after "Overview, issue, and activity")
- **Contextual cross-references** added where they genuinely help the reader (no existing content removed or redirected):
  - `alerts/overview.mdx` — added to the "With alerts, you can" list
  - `alerts/alerts-ai-overview-page.mdx` — tip linking to coverage/quality management
  - `alerts/create-alert/alert-coverage-gaps.mdx` — tip relating the at-scale Smart Alerts approach
  - `alerts/create-alert/create-alert-condition/alert-conditions.mdx` — added as a condition-creation entry point
  - `new-relic-solutions/best-practices-guides/.../alerts-best-practices.mdx` — added to coverage recommendations

## Content decisions

- **Preview callout** uses the standard public-preview language (LP "proprietary/confidential" wording removed).
- **Requirements** section reflects SME guidance: available to all paid customers; requires a full platform user.
- **UI labels** verified against the source PDF appendix screenshots (APM standards `Response time` / `Throughput (low)` / `Error rate (%)`, Coverage status page, Glassbox Threshold Simulator).
- **Unreleased "What's Next" features excluded** per acceptance criteria (scope-level aggregation, baking periods, unified noise reduction, duplicate-handling improvements, enhanced visualization, visual badges).
- Relationship to the existing "Alert coverage gaps" page is **coexist + cross-link** (pending SME confirmation on whether Smart Alerts supersedes the classic overview; easy to convert to redirects later).

## Open follow-up

- Infrastructure host/cloud entity types are listed as a PP coverage improvement in the scope doc but are not in the source PDF and have no product-verified condition-standard labels yet. To be confirmed from the fresh end-to-end demo and added as a follow-up if in scope.

Jira: [NR-587272](https://new-relic.atlassian.net/browse/NR-587272)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-587272]: https://new-relic.atlassian.net/browse/NR-587272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ