### PR TITLE
chore: Added new supported node versions to table as well as specified when node 20 was dropped

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent.mdx
@@ -81,6 +81,19 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
       <tbody>
         <tr>
           <td>
+            26
+          </td>
+
+          <td>
+            October 2026
+          </td>
+
+          <td>
+            July 7, 2026 with Node.js agent v14.2.0
+          </td>
+        </tr>
+        <tr>
+          <td>
             24
           </td>
 
@@ -103,48 +116,6 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
 
           <td>
             June 28, 2024 with Node.js agent v11.22.0
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            20
-          </td>
-
-          <td>
-            October 2023
-          </td>
-
-          <td>
-            August 28, 2023 with Node.js agent v11.0.0
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            18
-          </td>
-
-          <td>
-            October 2022
-          </td>
-
-          <td>
-            August 3, 2022 with Node.js agent v9.0.0
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            16
-          </td>
-
-          <td>
-            October 2021
-          </td>
-
-          <td>
-            July 26, 2021 with Node.js agent v8.0.0
           </td>
         </tr>
       </tbody>
@@ -170,6 +141,19 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
       </thead>
 
       <tbody>
+        <tr>
+          <td>
+            26
+          </td>
+
+          <td>
+            April 2029
+          </td>
+
+          <td>
+            TBD
+          </td>
+        </tr>
         <tr>
           <td>
             24
@@ -207,7 +191,7 @@ Before [installing the agent](/docs/apm/agents/nodejs-agent/installation-configu
           </td>
 
           <td>
-            TBD
+            As of May 18, 2026, we have discontinued support for Node.js 20 with v14 of the Node.js agent.
           </td>
         </tr>
 


### PR DESCRIPTION
## Give us some context

* What problems does this PR solve?
Node.js agent just released support for node 26. We also forgot to update table when we dropped support for node 20. Lastly, I added node 26 to EOL table with a future date of april 2029