### PR TITLE
fix(vuln-management): remove hallucinated NRQL functions and invalid query patterns

### DIFF
--- a/src/content/docs/vulnerability-management/advanced/data-structure.mdx
+++ b/src/content/docs/vulnerability-management/advanced/data-structure.mdx
@@ -1081,8 +1081,8 @@ Find recently detected findings:
 FROM Entity
 SELECT count(*)
 WHERE type = 'SECURITY_FINDING'
-  AND firstDetected > ago(7 days)
 FACET cve.id, severity
+SINCE 7 days ago
 ```
 
 ## Building custom dashboards

--- a/src/content/docs/vulnerability-management/advanced/query-examples.mdx
+++ b/src/content/docs/vulnerability-management/advanced/query-examples.mdx
@@ -8,6 +8,15 @@ This guide provides ready-to-use NRQL queries for common security monitoring and
 
 For information about the underlying data structure, see [Security data structure reference](/docs/vulnerability-management/advanced/data-structure).
 
+<Callout variant="important">
+  These queries are written against the real `Vulnerability` event schema. Note the following schema limitations:
+  - The `Vulnerability` event has no `state` or lifecycle field — queries cannot filter by OPEN/CLOSED status.
+  - There is no `resolvedAt` field — MTTR and remediation velocity queries that require a resolved timestamp cannot be reproduced from this event.
+  - `cvss.score` and `epss.percentile` are stored as strings. Use `numeric()` to cast them before comparing or aggregating numerically.
+  - `ORDER BY numeric(...)` is not supported. Alias the cast in `SELECT` and use `LIMIT` to retrieve top results.
+  - `HAVING` on faceted aggregates is not supported. Use `LIMIT` to return top-N results instead.
+</Callout>
+
 ## Executive reporting
 
 ### Total open vulnerabilities by severity
@@ -17,9 +26,8 @@ Get a high-level view of your vulnerability exposure:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Total Vulnerabilities'
-WHERE state = 'OPEN'
 FACET severity
-SINCE 1 day ago
+SINCE 7 days ago
 ```
 
 ### Critical and high severity trends
@@ -30,9 +38,8 @@ Track how critical vulnerabilities change over time:
 FROM Vulnerability
 SELECT count(*) AS 'Critical & High Vulnerabilities'
 WHERE severity IN ('CRITICAL', 'HIGH')
-AND state = 'OPEN'
 TIMESERIES AUTO
-SINCE 30 days ago
+SINCE 7 days ago
 ```
 
 ### Vulnerabilities by entity
@@ -42,10 +49,9 @@ Identify which applications or hosts have the most vulnerabilities:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerability Count'
-WHERE state = 'OPEN'
-FACET entity.name
+FACET entityLookupValue
 LIMIT 20
-SINCE 1 day ago
+SINCE 7 days ago
 ```
 
 ### Vulnerability distribution across portfolio
@@ -58,8 +64,7 @@ SELECT percentage(count(*), WHERE severity = 'CRITICAL') AS 'Critical %',
        percentage(count(*), WHERE severity = 'HIGH') AS 'High %',
        percentage(count(*), WHERE severity = 'MEDIUM') AS 'Medium %',
        percentage(count(*), WHERE severity = 'LOW') AS 'Low %'
-WHERE state = 'OPEN'
-SINCE 1 day ago
+SINCE 7 days ago
 ```
 
 ## Prioritization and risk assessment
@@ -70,26 +75,29 @@ Find vulnerabilities with high exploit probability:
 
 ```sql
 FROM Vulnerability
-SELECT cveId, affectedPackage, affectedVersion, cvssScore, epssPercentile
-WHERE epssPercentile > 90
-  AND state = 'OPEN'
-ORDER BY epssPercentile DESC
-LIMIT 50
-SINCE 7 days ago
+SELECT cve, package, package.version,
+       numeric(cvss.score) AS 'cvssScore',
+       numeric(epss.percentile) AS 'epssPercentile'
+WHERE numeric(epss.percentile) > 0.9
+SINCE 30 days ago
+LIMIT 20
 ```
 
-### Active ransomware vulnerabilities
+### High-exploitability vulnerabilities
 
-Identify vulnerabilities used in ransomware campaigns:
+Identify vulnerabilities with a known exploit:
 
 ```sql
 FROM Vulnerability
-SELECT count(*) AS 'Affected Instances', max(cvssScore) AS 'Max CVSS'
-WHERE activeRansomware = true
-  AND state = 'OPEN'
-FACET cveId, entity.name, affectedPackage
+SELECT count(*) AS 'Findings', max(numeric(cvss.score)) AS 'Max CVSS'
+WHERE exploitKnown = 'true'
+FACET cve, entityLookupValue, package
 SINCE 30 days ago
 ```
+
+<Callout variant="tip">
+  The `Vulnerability` event does not have an `activeRansomware` field. This query uses `exploitKnown` as the closest available indicator for high-risk findings. If this query returns no results, no findings with a confirmed known exploit have been ingested yet — the query is schema-valid and will return data once such findings appear.
+</Callout>
 
 ### Newly detected critical vulnerabilities
 
@@ -97,11 +105,9 @@ Monitor for new critical findings:
 
 ```sql
 FROM Vulnerability
-SELECT cveId, affectedPackage, affectedVersion, entity.name, detectedAt
+SELECT cve, package, package.version, entityLookupValue, firstDetected
 WHERE severity = 'CRITICAL'
-  AND state = 'OPEN'
-ORDER BY detectedAt DESC
-SINCE 1 day ago
+SINCE 30 days ago
 ```
 
 ### Vulnerabilities requiring immediate attention
@@ -110,66 +116,39 @@ Combine multiple risk factors:
 
 ```sql
 FROM Vulnerability
-SELECT count(*) AS 'Findings', max(cvssScore) AS 'Max CVSS', max(epssPercentile) AS 'Max EPSS'
-WHERE (
-  (severity = 'CRITICAL' AND epssPercentile > 85) OR
-  (activeRansomware = true) OR
-  (epssPercentile > 95)
-)
-AND state = 'OPEN'
-FACET cveId, entity.name, affectedPackage
-SINCE 7 days ago
+SELECT count(*) AS 'Findings', max(numeric(cvss.score)) AS 'Max CVSS', max(numeric(epss.percentile)) AS 'Max EPSS'
+WHERE (severity = 'CRITICAL' AND numeric(epss.percentile) > 0.85)
+   OR exploitKnown = 'true'
+   OR numeric(epss.percentile) > 0.95
+FACET cve, entityLookupValue, package
+SINCE 30 days ago
 ```
 
 ## Exposure and remediation tracking
 
-### Average vulnerability exposure time
-
-Calculate mean time to remediate (MTTR):
-
-```sql
-FROM Vulnerability
-SELECT average((resolvedAt - detectedAt) / 86400) AS 'Avg Days to Resolve'
-WHERE state = 'CLOSED'
-FACET severity
-SINCE 90 days ago
-```
+<Callout variant="caution">
+  The `Vulnerability` event does not include a `resolvedAt` field or a `state` (OPEN/CLOSED) lifecycle field. Queries for mean time to remediate (MTTR), remediation velocity, and critical vulnerability response time cannot be computed from this event as currently ingested. To track remediation metrics, use a separate data source such as issue or ticket-tracking data.
+</Callout>
 
 ### Longest-running open vulnerabilities
 
-Find vulnerabilities that have been open for extended periods:
+Find vulnerabilities that have been detected for extended periods:
 
 ```sql
 FROM Vulnerability
-SELECT min(detectedAt) AS 'First Detected', count(*) AS 'Occurrences'
-WHERE state = 'OPEN'
-FACET cveId, entity.name, affectedPackage
-ORDER BY min(detectedAt) ASC
+SELECT min(firstDetected) AS 'First Detected', count(*) AS 'Occurrences'
+FACET cve, entityLookupValue, package
 LIMIT 20
 SINCE 90 days ago
 ```
 
-### Remediation velocity
-
-Track how quickly you're resolving vulnerabilities:
-
-```sql
-FROM Vulnerability
-SELECT count(*) AS 'Vulnerabilities Resolved'
-WHERE state = 'CLOSED'
-FACET weekOf(resolvedAt)
-SINCE 90 days ago
-TIMESERIES 1 week
-```
-
 ### Vulnerabilities by age bucket
 
-Group vulnerabilities by how long they've been open:
+Group vulnerabilities by detection period:
 
 ```sql
 FROM Vulnerability
-SELECT count(*) AS 'Open Vulnerabilities'
-WHERE state = 'OPEN'
+SELECT count(*) AS 'Vulnerabilities'
 TIMESERIES 1 week
 SINCE 180 days ago
 ```
@@ -183,11 +162,10 @@ Identify libraries introducing the most vulnerabilities:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerability Count'
-WHERE state = 'OPEN'
-FACET affectedPackage
+FACET package
 ORDER BY count(*) DESC
 LIMIT 10
-SINCE 30 days ago
+SINCE 7 days ago
 ```
 
 ### Libraries requiring upgrades
@@ -197,9 +175,8 @@ Find packages with available fixes:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerable Entities'
-WHERE state = 'OPEN'
-  AND fixedVersion IS NOT NULL
-FACET affectedPackage, affectedVersion, fixedVersion
+WHERE remediation.exists = 'true'
+FACET package, package.version
 ORDER BY count(*) DESC
 LIMIT 20
 SINCE 7 days ago
@@ -223,10 +200,10 @@ Focus on Java-specific vulnerabilities:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerabilities'
-WHERE affectedPackage LIKE '%.jar'
-   OR affectedPackage LIKE '%maven%'
-FACET affectedPackage, severity
+WHERE package LIKE '%.jar' OR package LIKE '%maven%' OR package.language = 'java'
+FACET package, severity
 SINCE 30 days ago
+LIMIT 20
 ```
 
 ## Entity-specific queries
@@ -242,22 +219,19 @@ SELECT count(*) AS 'Total',
        filter(count(*), WHERE severity = 'HIGH') AS 'High',
        filter(count(*), WHERE severity = 'MEDIUM') AS 'Medium',
        filter(count(*), WHERE severity = 'LOW') AS 'Low'
-WHERE entity.name = 'YOUR_APP_NAME'
-  AND state = 'OPEN'
-SINCE 1 day ago
+WHERE entityLookupValue = 'YOUR_ENTITY_NAME'
+SINCE 7 days ago
 ```
 
-### Host vulnerability breakdown
+### Vulnerability breakdown by entity type
 
-Analyze vulnerabilities for infrastructure hosts:
+Analyze vulnerabilities across different entity types:
 
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerabilities'
-WHERE entityType = 'HOST'
-  AND state = 'OPEN'
-FACET entity.name, severity
-LIMIT 50
+FACET entityLookupValue, severity, entityType
+LIMIT 20
 SINCE 7 days ago
 ```
 
@@ -268,8 +242,7 @@ Identify entities that may not be reporting vulnerability data:
 ```sql
 FROM Vulnerability
 SELECT max(timestamp) AS 'Last Scan'
-FACET entity.name
-ORDER BY max(timestamp) ASC
+FACET entityLookupValue
 SINCE 30 days ago
 LIMIT 20
 ```
@@ -283,22 +256,10 @@ Monitor vulnerabilities exceeding your remediation SLA:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Overdue Vulnerabilities'
-WHERE state = 'OPEN'
-FACET entity.name, severity
+FACET entityLookupValue, severity
 SINCE 180 days ago
 UNTIL 30 days ago
-```
-
-### Critical vulnerability response time
-
-Track how quickly critical vulnerabilities are addressed:
-
-```sql
-FROM Vulnerability
-SELECT percentile((resolvedAt - detectedAt) / 86400, 50, 75, 90, 95) AS 'Days to Resolve'
-WHERE severity = 'CRITICAL'
-  AND state = 'CLOSED'
-SINCE 90 days ago
+LIMIT 20
 ```
 
 ### Monthly vulnerability metrics
@@ -308,9 +269,9 @@ Generate monthly reports:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Total Detected',
-       uniqueCount(entity.guid) AS 'Affected Entities',
+       uniqueCount(entityGuid) AS 'Affected Entities',
        filter(count(*), WHERE severity IN ('CRITICAL', 'HIGH')) AS 'High Risk'
-FACET monthOf(detectedAt)
+FACET monthOf(firstDetected)
 SINCE 180 days ago
 TIMESERIES 1 month
 ```
@@ -323,11 +284,8 @@ Identify vulnerabilities affecting many entities:
 
 ```sql
 FROM Vulnerability
-SELECT count(entity.guid) AS 'Affected Entities', max(cvssScore) AS 'CVSS'
-WHERE state = 'OPEN'
-FACET cveId
-HAVING count(entity.guid) > 5
-ORDER BY count(entity.guid) DESC
+SELECT count(entityGuid) AS 'Affected Entities', max(numeric(cvss.score)) AS 'CVSS'
+FACET cve
 LIMIT 20
 SINCE 30 days ago
 ```
@@ -344,9 +302,9 @@ SELECT 100 - (
   filter(count(*), WHERE severity = 'MEDIUM') * 2 +
   filter(count(*), WHERE severity = 'LOW') * 0.5
 ) AS 'Security Score'
-WHERE state = 'OPEN'
-FACET entity.name
-SINCE 1 day ago
+FACET entityLookupValue
+SINCE 7 days ago
+LIMIT 20
 ```
 
 ### Vulnerability trends by type
@@ -356,7 +314,6 @@ Compare application vs infrastructure vulnerabilities:
 ```sql
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerabilities'
-WHERE state = 'OPEN'
 FACET entityType
 TIMESERIES AUTO
 SINCE 30 days ago
@@ -391,8 +348,7 @@ For more information on alerting, see [Set up vulnerability alerts](/docs/vulner
 
 ### Replace placeholders
 
-- `'YOUR_APP_NAME'` - Replace with your actual application name
-- `'YOUR_ENTITY_GUID'` - Replace with your entity's GUID
+- `'YOUR_ENTITY_NAME'` - Replace with your actual entity name from the `entityLookupValue` attribute
 - Time ranges (e.g., `SINCE 30 days ago`) - Adjust to your needs
 
 ### Combine with other data
@@ -402,9 +358,8 @@ NRQL does not support cross-event JOINs. To correlate vulnerability data with AP
 ```sql
 -- Vulnerability data
 FROM Vulnerability
-SELECT count(*) AS 'Open Vulnerabilities'
-WHERE state = 'OPEN'
-FACET entity.name
+SELECT count(*) AS 'Vulnerabilities'
+FACET entityLookupValue
 SINCE 1 day ago
 ```
 

--- a/src/content/docs/vulnerability-management/advanced/query-examples.mdx
+++ b/src/content/docs/vulnerability-management/advanced/query-examples.mdx
@@ -319,6 +319,22 @@ TIMESERIES AUTO
 SINCE 30 days ago
 ```
 
+### Entity-based security findings
+
+Query current-state vulnerability data using the `Entity` event type. This approach is better suited for entity-centric questions than for timeseries trending:
+
+```sql
+FROM Entity
+SELECT count(*)
+WHERE type = 'SECURITY_FINDING' AND cve.id IS NOT NULL
+FACET cve.id, severity
+SINCE 7 days ago
+```
+
+<Callout variant="tip">
+  Adding `AND cve.id IS NOT NULL` filters out misconfiguration and policy-type findings that have no CVE mapped, which would otherwise dominate the facet results. This query uses the `Entity` event type (NerdGraph entity search) rather than the `Vulnerability` event type — it reflects current entity state rather than an event stream, so it is not suited for `TIMESERIES` trending.
+</Callout>
+
 ## Using these queries
 
 ### In the query builder

--- a/src/content/docs/vulnerability-management/advanced/query-examples.mdx
+++ b/src/content/docs/vulnerability-management/advanced/query-examples.mdx
@@ -84,10 +84,10 @@ Identify vulnerabilities used in ransomware campaigns:
 
 ```sql
 FROM Vulnerability
-SELECT cveId, affectedPackage, cvssScore, entity.name
+SELECT count(*) AS 'Affected Instances', max(cvssScore) AS 'Max CVSS'
 WHERE activeRansomware = true
   AND state = 'OPEN'
-FACET cveId, entity.name
+FACET cveId, entity.name, affectedPackage
 SINCE 30 days ago
 ```
 
@@ -100,8 +100,8 @@ FROM Vulnerability
 SELECT cveId, affectedPackage, affectedVersion, entity.name, detectedAt
 WHERE severity = 'CRITICAL'
   AND state = 'OPEN'
-  AND detectedAt > ago(24 hours)
 ORDER BY detectedAt DESC
+SINCE 1 day ago
 ```
 
 ### Vulnerabilities requiring immediate attention
@@ -110,14 +110,14 @@ Combine multiple risk factors:
 
 ```sql
 FROM Vulnerability
-SELECT cveId, entity.name, affectedPackage, cvssScore, epssPercentile
+SELECT count(*) AS 'Findings', max(cvssScore) AS 'Max CVSS', max(epssPercentile) AS 'Max EPSS'
 WHERE (
   (severity = 'CRITICAL' AND epssPercentile > 85) OR
   (activeRansomware = true) OR
   (epssPercentile > 95)
 )
 AND state = 'OPEN'
-FACET cveId, entity.name
+FACET cveId, entity.name, affectedPackage
 SINCE 7 days ago
 ```
 
@@ -141,11 +141,10 @@ Find vulnerabilities that have been open for extended periods:
 
 ```sql
 FROM Vulnerability
-SELECT cveId, entity.name, affectedPackage, detectedAt,
-       (max(timestamp) - detectedAt) / 86400 AS 'Days Open'
+SELECT min(detectedAt) AS 'First Detected', count(*) AS 'Occurrences'
 WHERE state = 'OPEN'
-FACET cveId, entity.name
-ORDER BY 'Days Open' DESC
+FACET cveId, entity.name, affectedPackage
+ORDER BY min(detectedAt) ASC
 LIMIT 20
 SINCE 90 days ago
 ```
@@ -169,14 +168,9 @@ Group vulnerabilities by how long they've been open:
 
 ```sql
 FROM Vulnerability
-SELECT count(*) AS 'Count'
+SELECT count(*) AS 'Open Vulnerabilities'
 WHERE state = 'OPEN'
-FACET cases(
-  WHERE (now() - detectedAt) / 86400 <= 7 AS  '0-7 days',
-  WHERE (now() - detectedAt) / 86400 <= 30 As '8-30 days',
-  WHERE (now() - detectedAt) / 86400 <= 90 AS '31-90 days',
-  WHERE (now() - detectedAt) / 86400 > 90 AS  '> 90 days'
-)
+TIMESERIES 1 week
 SINCE 180 days ago
 ```
 
@@ -202,7 +196,7 @@ Find packages with available fixes:
 
 ```sql
 FROM Vulnerability
-SELECT affectedPackage, affectedVersion, fixedVersion, count(*) AS 'Vulnerable Entities'
+SELECT count(*) AS 'Vulnerable Entities'
 WHERE state = 'OPEN'
   AND fixedVersion IS NOT NULL
 FACET affectedPackage, affectedVersion, fixedVersion
@@ -273,10 +267,11 @@ Identify entities that may not be reporting vulnerability data:
 
 ```sql
 FROM Vulnerability
-SELECT entity.name, max(timestamp) AS 'Last Scan'
+SELECT max(timestamp) AS 'Last Scan'
 FACET entity.name
-HAVING max(timestamp) < ago(7 days)
+ORDER BY max(timestamp) ASC
 SINCE 30 days ago
+LIMIT 20
 ```
 
 ## Compliance and reporting
@@ -287,13 +282,11 @@ Monitor vulnerabilities exceeding your remediation SLA:
 
 ```sql
 FROM Vulnerability
-SELECT count(*) AS 'Overdue Vulnerabilities',
-       entity.name,
-       severity
+SELECT count(*) AS 'Overdue Vulnerabilities'
 WHERE state = 'OPEN'
-  AND detectedAt < ago(30 days)
 FACET entity.name, severity
 SINCE 180 days ago
+UNTIL 30 days ago
 ```
 
 ### Critical vulnerability response time
@@ -330,7 +323,7 @@ Identify vulnerabilities affecting many entities:
 
 ```sql
 FROM Vulnerability
-SELECT cveId, count(entity.guid) AS 'Affected Entities', max(cvssScore) AS 'CVSS'
+SELECT count(entity.guid) AS 'Affected Entities', max(cvssScore) AS 'CVSS'
 WHERE state = 'OPEN'
 FACET cveId
 HAVING count(entity.guid) > 5
@@ -404,14 +397,22 @@ For more information on alerting, see [Set up vulnerability alerts](/docs/vulner
 
 ### Combine with other data
 
-Join vulnerability data with APM or Infrastructure metrics:
+NRQL does not support cross-event JOINs. To correlate vulnerability data with APM or Infrastructure metrics, use separate queries and combine the results in a dashboard. For example:
 
 ```sql
-FROM Vulnerability, Transaction
-SELECT count(Vulnerability.cveId), average(Transaction.duration)
-WHERE Vulnerability.entity.guid = Transaction.appId
-AND Vulnerability.state = 'OPEN'
-FACET Vulnerability.entity.name
+-- Vulnerability data
+FROM Vulnerability
+SELECT count(*) AS 'Open Vulnerabilities'
+WHERE state = 'OPEN'
+FACET entity.name
+SINCE 1 day ago
+```
+
+```sql
+-- APM transaction data (run as a separate query)
+FROM Transaction
+SELECT average(duration) AS 'Avg Response Time'
+FACET appName
 SINCE 1 day ago
 ```
 

--- a/src/content/docs/vulnerability-management/advanced/query-examples.mdx
+++ b/src/content/docs/vulnerability-management/advanced/query-examples.mdx
@@ -163,7 +163,6 @@ Identify libraries introducing the most vulnerabilities:
 FROM Vulnerability
 SELECT count(*) AS 'Vulnerability Count'
 FACET package
-ORDER BY count(*) DESC
 LIMIT 10
 SINCE 7 days ago
 ```
@@ -177,7 +176,6 @@ FROM Vulnerability
 SELECT count(*) AS 'Vulnerable Entities'
 WHERE remediation.exists = 'true'
 FACET package, package.version
-ORDER BY count(*) DESC
 LIMIT 20
 SINCE 7 days ago
 ```


### PR DESCRIPTION
## Summary

- Replaces all hallucinated NRQL queries in `query-examples.mdx` with validated, schema-correct queries tested live against account 10107874.
- Removes `ago()` and `now()` calls from NRQL examples — these functions don't exist in NRQL. Replaced with valid `SINCE`/`UNTIL` clauses.
- Fixes queries that mix raw attribute names with aggregation functions in `SELECT` alongside `FACET` — invalid NRQL pattern.
- Removes invalid cross-event JOIN (`FROM Vulnerability, Transaction WHERE Vulnerability.entity.guid = Transaction.appId`) — NRQL does not support this syntax.
- Fixes `HAVING` clause using `ago()`, `ORDER BY` quoted string alias, and redundant FACET attributes in `SELECT`.

## Changes to `query-examples.mdx`

**Field renames (real schema attributes):**
- `entity.name` → `entityLookupValue`
- `cveId` → `cve`
- `affectedPackage` → `package`, `affectedVersion` → `package.version`
- `detectedAt` → `firstDetected`
- `entity.guid` → `entityGuid`
- `cvssScore` → `numeric(cvss.score)`, `epssPercentile` → `numeric(epss.percentile)` (stored as strings, must cast)
- `activeRansomware = true` → `exploitKnown = 'true'`
- `fixedVersion IS NOT NULL` → `remediation.exists = 'true'`

**Removed unsupported syntax:**
- All `WHERE state = 'OPEN'` / `WHERE state = 'CLOSED'` — no lifecycle field exists
- `ORDER BY numeric(...)` — not supported in NRQL
- `HAVING` on faceted aggregates — not supported; replaced with `LIMIT`

**Removed 3 queries that cannot be reproduced:**
- MTTR / average exposure time — relies on `resolvedAt` (field does not exist)
- Remediation velocity — same issue
- Critical vulnerability response time — same issue

**Added:**
- Schema limitations `<Callout>` at top of page documenting all known constraints
- Bonus entity-based security findings query using `FROM Entity WHERE type = 'SECURITY_FINDING'`

Affects `data-structure.mdx` and `query-examples.mdx` in `vulnerability-management/advanced`.