### PR TITLE
.NET agent install: update example dockerfiles with info about installing specific versions

### DIFF
--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -24,7 +24,13 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0
 # Publish your application.
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
-# Install the agent
+# Download and install the latest version of the New Relic .NET Agent via the apt package manager.
+#
+# To use a specific version instead, modify the apt-get install command to reference a specific version
+#
+# For example, to use v10.52.0 of the .NET agent, you would use the following apt-get install command:
+#  apt-get install -y newrelic-dotnet-agent=10.52.0
+
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
 && echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
 && curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /etc/apt/keyrings/newrelic-apt.gpg \
@@ -59,7 +65,13 @@ RUN dotnet publish -c Release -o /app ./YOUR_APP_NAME
 # The runtime tag version should match the SDK tag version
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
-# Install the agent
+# Download and install the latest version of the New Relic .NET Agent via the apt package manager.
+#
+# To use a specific version instead, modify the apt-get install command to reference a specific version
+#
+# For example, to use v10.52.0 of the .NET agent, you would use the following apt-get install command:
+#  apt-get install -y newrelic-dotnet-agent=10.52.0
+
 RUN apt-get update && apt-get install -y curl ca-certificates gnupg \
 && echo 'deb [signed-by=/etc/apt/keyrings/newrelic-apt.gpg] http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list \
 && curl -fsSL https://download.newrelic.com/NEWRELIC_APT_2DAD550E.public | gpg --dearmor > /etc/apt/keyrings/newrelic-apt.gpg \

--- a/src/install/dotnet/installation/dockerLinux.mdx
+++ b/src/install/dotnet/installation/dockerLinux.mdx
@@ -26,7 +26,7 @@ COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
 # Download and install the latest version of the New Relic .NET Agent via the apt package manager.
 #
-# To use a specific version instead, modify the apt-get install command to reference a specific version
+# To use a specific version instead, modify the apt-get install command to reference a specific version.
 #
 # For example, to use v10.52.0 of the .NET agent, you would use the following apt-get install command:
 #  apt-get install -y newrelic-dotnet-agent=10.52.0
@@ -67,7 +67,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 
 # Download and install the latest version of the New Relic .NET Agent via the apt package manager.
 #
-# To use a specific version instead, modify the apt-get install command to reference a specific version
+# To use a specific version instead, modify the apt-get install command to reference a specific version.
 #
 # For example, to use v10.52.0 of the .NET agent, you would use the following apt-get install command:
 #  apt-get install -y newrelic-dotnet-agent=10.52.0

--- a/src/install/dotnet/installation/dockerWindows.mdx
+++ b/src/install/dotnet/installation/dockerWindows.mdx
@@ -32,7 +32,7 @@ FROM mcr.microsoft.com/dotnet/framework/aspnet
 COPY YOUR_APP_TO_BE_PUBLISHED /inetpub/wwwroot
 
 # Download the latest New Relic .NET agent installer
-# To install a specific version instead, modify the Invoke-WebRequest command to download a specific version
+# To install a specific version instead, modify the Invoke-WebRequest command to download a specific version.
 # For example, to install version 10.52.0, the URL should be "https://download.newrelic.com/dot_net_agent/previous_releases/10.52.0/NewRelicDotNetAgent_x64.msi"
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
@@ -59,7 +59,7 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
 # Download the latest New Relic .NET agent installer
-# To install a specific version instead, modify the Invoke-WebRequest command to download a specific version
+# To install a specific version instead, modify the Invoke-WebRequest command to download a specific version.
 # For example, to install version 10.52.0, the URL should be "https://download.newrelic.com/dot_net_agent/previous_releases/10.52.0/NewRelicDotNetAgent_x64.msi"
 
 RUN powershell.exe [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\

--- a/src/install/dotnet/installation/dockerWindows.mdx
+++ b/src/install/dotnet/installation/dockerWindows.mdx
@@ -31,7 +31,10 @@ FROM mcr.microsoft.com/dotnet/framework/aspnet
 # Publish your application.
 COPY YOUR_APP_TO_BE_PUBLISHED /inetpub/wwwroot
 
-# Download the New Relic .NET agent installer
+# Download the latest New Relic .NET agent installer
+# To install a specific version instead, modify the Invoke-WebRequest command to download a specific version
+# For example, to install version 10.52.0, the URL should be "https://download.newrelic.com/dot_net_agent/previous_releases/10.52.0/NewRelicDotNetAgent_x64.msi"
+
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
  Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
  -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"
@@ -55,7 +58,10 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 # Publish your application.
 COPY INSERT_NAME_OF_APP_TO_BE_PUBLISHED /app
 
-# Download the New Relic .NET agent installer
+# Download the latest New Relic .NET agent installer
+# To install a specific version instead, modify the Invoke-WebRequest command to download a specific version
+# For example, to install version 10.52.0, the URL should be "https://download.newrelic.com/dot_net_agent/previous_releases/10.52.0/NewRelicDotNetAgent_x64.msi"
+
 RUN powershell.exe [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;\
  Invoke-WebRequest "https://download.newrelic.com/dot_net_agent/latest_release/NewRelicDotNetAgent_x64.msi"\
  -UseBasicParsing -OutFile "NewRelicDotNetAgent_x64.msi"


### PR DESCRIPTION
Previously, the .NET agent example install Dockerfiles only described how to install the latest version of the agent.  This PR adds comments to the examples indicating how to install a specific version instead.
