### PR TITLE
fix(nav): add 'Optimize your data ingest' to Observability maturity nav

### DIFF
--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -162,6 +162,8 @@ pages:
         path: /docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-coe
       - title: Observability as code
         path: /docs/new-relic-solutions/observability-maturity/operational-efficiency/observability-as-code-guide
+      - title: Optimize your data ingest
+        path: /docs/new-relic-solutions/observability-maturity/operational-efficiency/data-governance-optimize-ingest-guide
       - title: Business observability
         pages:
           - title: Introduction to business observability


### PR DESCRIPTION
Adds the orphaned Phase 3 doc **Optimize your data ingest** (`data-governance-optimize-ingest-guide`) to the left nav under **Observability maturity → Operational efficiency**, beside its two folder siblings (Observability center of excellence, Observability as code) that are already linked.

**What:** One nav entry added to `src/nav/new-relic-solutions.yml`. No content changes.
**Why:** Active, maintained doc (last updated Apr 2026) mistakenly left out of nav; ~3,424 views in the last 12 months arriving without a nav entry.
**GA status:** Content already GA/published (live since 2022) — this is navigation-only, no new or changed prose.

Ref: NR-582854