### PR TITLE
docs(net-agent): clarify IBM DB2 compatibility and limitations

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -438,6 +438,28 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                 <tr>
                 <td>
+                    IBM DB2
+                </td>
+
+                <td className="fcenter">
+                    <Icon
+                    style={{color: '#328787'}}
+                    name="fe-check"
+                    />
+                </td>
+
+                <td>
+                  Use `IBM.Data.DB2`.
+
+                  * There are no specific minimum or maximum version requirements for the IBM DB2 driver or server.
+                  * Only synchronous methods (e.g., `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (e.g., `ExecuteReaderAsync`) are not supported by default.
+                  * The `.NET Core` specific package (`IBM.Data.DB2.Core`) is **not** automatically instrumented. You must use [custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation) to instrument this package.
+                </td>
+                </tr>
+
+
+                <tr>
+                <td>
                     Microsoft SQL Server
                 </td>
 
@@ -1554,8 +1576,15 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         />
                     </td>
 
-                    <td/>
+                    <td>
+                      Use `IBM.Data.DB2`.
+
+                      * There are no specific minimum or maximum version requirements for the IBM DB2 driver or server.
+                      * Only synchronous methods (e.g., `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (e.g., `ExecuteReaderAsync`) are not supported by default.
+                      * The `.NET Core` specific package (`IBM.Data.DB2.Core`) is **not** automatically instrumented.
+                    </td>
                     </tr>
+
 
                     <tr>
                     <td>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -1580,7 +1580,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       Use `IBM.Data.DB2`.
 
                       * There are no specific minimum or maximum version requirements for the IBM DB2 driver or server.
-                      * Only synchronous methods (for example, `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (e.g., `ExecuteReaderAsync`) are not supported by default.
+                      * Only synchronous methods (for example, `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (for example, `ExecuteReaderAsync`) are not supported by default.
                       * The `.NET Core` specific package (`IBM.Data.DB2.Core`) is **not** automatically instrumented.
                     </td>
                     </tr>

--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -452,7 +452,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use `IBM.Data.DB2`.
 
                   * There are no specific minimum or maximum version requirements for the IBM DB2 driver or server.
-                  * Only synchronous methods (e.g., `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (e.g., `ExecuteReaderAsync`) are not supported by default.
+                  * Only synchronous methods (for example, `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (for example, `ExecuteReaderAsync`) are not supported by default.
                   * The `.NET Core` specific package (`IBM.Data.DB2.Core`) is **not** automatically instrumented. You must use [custom instrumentation](/docs/apm/agents/net-agent/custom-instrumentation/introduction-net-custom-instrumentation) to instrument this package.
                 </td>
                 </tr>
@@ -1580,7 +1580,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                       Use `IBM.Data.DB2`.
 
                       * There are no specific minimum or maximum version requirements for the IBM DB2 driver or server.
-                      * Only synchronous methods (e.g., `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (e.g., `ExecuteReaderAsync`) are not supported by default.
+                      * Only synchronous methods (for example, `ExecuteReader`, `ExecuteNonQuery`) are automatically instrumented. Asynchronous methods (e.g., `ExecuteReaderAsync`) are not supported by default.
                       * The `.NET Core` specific package (`IBM.Data.DB2.Core`) is **not** automatically instrumented.
                     </td>
                     </tr>


### PR DESCRIPTION
Updated the Datastores compatibility tables for both .NET Core and .NET Framework to clarify the support conditions and limitations for IBM DB2.

Changes included:
- Added IBM DB2 to the .NET Core datastores compatibility table.
- Updated the empty notes for IBM DB2 in the .NET Framework datastores table.
- Clarified that there are no specific minimum or maximum version requirements for the IBM DB2 driver or server.
- Documented the limitation that only synchronous methods (e.g., ExecuteReader) are automatically instrumented, while async methods are not supported by default.
- Documented the limitation that the `.NET Core` specific package (`IBM.Data.DB2.Core`) is not automatically instrumented and requires custom instrumentation.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.