### PR TITLE
fix(nav): point find-help nav entry at canonical slug

### DIFF
--- a/src/nav/new-relic-solutions.yml
+++ b/src/nav/new-relic-solutions.yml
@@ -610,7 +610,7 @@ pages:
   - title: Troubleshooting
     pages:
       - title: Our support portal
-        path: /docs/new-relic-solutions/solve-common-issues/find-help-use-support-portal
+        path: /docs/new-relic-solutions/solve-common-issues/find-help-get-support
       - title: Our diagnostics tool
         pages:
           - title: Diagnostics CLI (nrdiag)

--- a/src/nav/opentelemetry.yml
+++ b/src/nav/opentelemetry.yml
@@ -25,8 +25,6 @@ pages:
         path: /docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro
       - title: Collector for data processing
         path: /docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro
-      - title: Collector for Kubernetes monitoring
-        path: /docs/opentelemetry/get-started/collector-k8s-monitoring/opentelemetry-collector-k8s-intro
       - title: ATP
         pages:
           - title: Overview

--- a/src/nav/opentelemetry.yml
+++ b/src/nav/opentelemetry.yml
@@ -25,6 +25,8 @@ pages:
         path: /docs/opentelemetry/get-started/collector-infra-monitoring/opentelemetry-collector-infra-intro
       - title: Collector for data processing
         path: /docs/opentelemetry/get-started/collector-processing/opentelemetry-collector-processing-intro
+      - title: Collector for Kubernetes monitoring
+        path: /docs/opentelemetry/get-started/collector-k8s-monitoring/opentelemetry-collector-k8s-intro
       - title: ATP
         pages:
           - title: Overview


### PR DESCRIPTION
Updates the 'Our support portal' nav entry from the old redirected slug find-help-use-support-portal to the canonical find-help-get-support (renamed in PR #18484 but nav was never updated). Nav-only. NR-582852.

Note: the OTel Kubernetes collector intro was dropped from this PR — it's an intentional orphan (retained but not added to nav).