### PR TITLE
fix(redirects): repair 404s for setuserId and process-integration-runtime old URLs

### DIFF
--- a/src/content/docs/sap-solutions/install-and-configure/obtain-service-key/process-integration-runtime.mdx
+++ b/src/content/docs/sap-solutions/install-and-configure/obtain-service-key/process-integration-runtime.mdx
@@ -3,6 +3,7 @@ title: "From BTP - process integration runtime instance"
 metaDescription: "Obtain service key from BTP - process integration runtime instance"
 redirects:
   - /docs/sap-solutions/additional-resources/obtain-service-key
+  - /docs/sap-solutions/additional-resources/obtain-service-key/process-integration-runtime
 freshnessValidatedDate: never
 ---
 

--- a/src/content/docs/streaming-video-&-ads/installation/roku/agent-api/user-identification/setuserId.mdx
+++ b/src/content/docs/streaming-video-&-ads/installation/roku/agent-api/user-identification/setuserId.mdx
@@ -6,6 +6,7 @@ tags:
 metaDescription: Sets userId.
 redirects:
   - /docs/streaming-video-&-ads/installation/roku/agent-api/setuserid
+  - /docs/streaming-video-&-ads/installation/roku/agent-api/setuserId
 freshnessValidatedDate: never
 ---
 


### PR DESCRIPTION
Adds redirects for two moved pages whose old URLs 404. Redirect-only; both pages already in nav. Hero: clear cache after merge. NR-582855