### PR TITLE
fix: Remove contradictory, irrelevant callout in alert event attributes doc

### DIFF
--- a/src/content/docs/alerts/create-alert/condition-details/alert-event-attributes.mdx
+++ b/src/content/docs/alerts/create-alert/condition-details/alert-event-attributes.mdx
@@ -21,10 +21,6 @@ For more about the definition of alert events and other terms, see [our glossary
 
 An [alert event](/docs/new-relic-solutions/get-started/glossary#alert-event) is an event where a condition threshold defined in an alert policy is breached. This event has various attributes (metadata) attached to it and different attributes can be used by different features.
 
-<Callout variant="important">
-  The alert event is a concept used to determine alerting features. While you can query some of its associated attributes via NerdGraph, you cannot directly query the alert event.
-</Callout>
-
 ## `NrAiIncident` event attributes [#NrAiIncident-attributes]
 
 This table shows incident event attributes. The incident event data type is collected in [NrAiIncident](/attribute-dictionary/?event=NrAiIncident).


### PR DESCRIPTION
We should remove the **IMPORTANT** callout on this page, as the two sentences contained therein do not make any sense:

> The alert event is a concept used to determine alerting features.

I have no idea what this could possibly mean. That is certainly not the definition of an alert event — which, I should note, is *correctly* defined under the **What is an alert event?** header).

> While you can query some of its associated attributes via NerdGraph, you cannot directly query the alert event.

This is untrue and contradictory, especially in the context of a document that gives you tips on querying alert events.

Given the above, I have just removed the callout altogether. I think it may be a vestige of a much older version of this doc.