### PR TITLE
[chore]: add UI steps to locate Include variable toggle

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables.mdx
@@ -45,9 +45,17 @@ Furthermore, you can now decide if you want to include the variable or not witho
 
 ## Include and exclude variables [#include-variable]
 
-When you enable the <DNT>**Include variable**</DNT> toggle and select a value, the dashboard data is filtered by that value. You can click <DNT>**Refresh to default value**</DNT> to restore the configured defaults. For more information, see [template variables](#create-variables).
+The <DNT>**Include variable**</DNT> toggle is a UI control in each variable's dropdown. It controls whether a template variable scopes your dashboard data, and it's on by default. When the toggle is on, the dashboard filters data to your selected value(s). When you turn it off, the dashboard shows cumulative (unscoped) data and stops filtering by that variable's selection. The toggle sets the default behavior for the dashboard, but individual viewers can adjust it for the duration of their session.
 
-For example, you may be investigating an issue that is not specific to any particular value within a variable. In such cases, the variable's existing values might be limiting query results, even when selecting all possible options. To address this, you can exclude the variable from the query. This effectively removes the variable's condition and replaces it with a neutral boolean value (true or false), ensuring query validity and returning comprehensive results.  
+Follow these steps to locate the toggle:
+
+1. From your dashboard, click the dropdown for the template variable you want to control.
+2. At the bottom of the dropdown, alongside the list of available values, find the <DNT>**Include variable**</DNT> toggle.
+3. Click the toggle to include or exclude the variable from your dashboard queries.
+
+When you enable the toggle and select a value, the dashboard data is filtered by that value. You can click <DNT>**Refresh to default value**</DNT> to restore the configured defaults. For more information, see [template variables](#create-variables).
+
+If you're investigating an issue that isn't specific to any particular value within a variable, the variable's existing values might be limiting query results, even when you select all possible options. To address this, you can exclude the variable from the query. This removes the variable's condition and replaces it with a neutral boolean value (`true` or `false`), ensuring query validity and returning comprehensive results.
 
 ### Example
 
@@ -340,8 +348,6 @@ Define a template variable that you'll use in a NRQL query to create a widget.
     5. (Optional) To customize the chart, select the <DNT>**See customization options**</DNT> icon beside the <DNT>**Chart type**</DNT> dropdown. For available options, refer [Customize your charts](/docs/query-your-data/explore-query-data/use-charts/use-your-charts#customize-charts).
 
     6. Click <DNT>**Add to dashboard**</DNT>
-
-    7. test
 
     </Step>
 </Steps>


### PR DESCRIPTION
## Summary

Closes NR-580430.

A user (Brenn Kucey, [Slack thread](https://newrelic.slack.com/archives/C0DSGL3FZ/p1781830600976469)) asked whether the "Include and exclude variables" section described an actual UI toggle or just a manual suggestion. The toggle is real but wasn't discoverable from the current docs.

**Changes:**
- Rewrote the `#include-variable` section intro with explicit step-by-step instructions for locating the **Include variable** toggle (click the variable's dropdown → toggle appears at the bottom alongside the list of available values)
- Clarified that the toggle is on by default and scopes data to the selected value(s); when off, the dashboard shows cumulative (unscoped) data
- Noted that the toggle sets the default behavior but individual viewers can adjust it for their session
- Removed a stray `7. test` artifact from the create-widget numbered steps

## What's still needed

- [ ] A dedicated screenshot showing the **Include variable** toggle in the variable dropdown. Capture and insert near the new steps before publishing.