### PR TITLE
fix: Add port 4318 to OTLP endpoint in MS SQL Server docs

### DIFF
--- a/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -248,253 +248,367 @@ This configuration enables comprehensive database monitoring with all available 
 </Callout> 
 
 ```yaml
+# NRDOT Collector Configuration for New Relic SQL Server Integration
+extensions:
+  health_check:
+
 receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  host_metrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.time:
+            enabled: false
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: false
+          system.paging.faults:
+            enabled: false
+      disk:
+        metrics:
+          system.disk.merged:
+            enabled: false
+          system.disk.pending_operations:
+            enabled: false
+          system.disk.weighted_io_time:
+            enabled: false
+      network:
+        metrics:
+          system.network.connections:
+            enabled: false
+      processes:
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_user_error: true
+        mute_process_io_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
   nrsqlserver:
-    collection_interval: 15s
+    collection_interval: 30s
     username: <YOUR_USERNAME>
     password: <YOUR_PASSWORD>
     server: <YOUR_SERVER>
     port: <YOUR_PORT>
 
-  metrics:
-    # Database
-    sqlserver.database.count:
-      enabled: true
-    sqlserver.database.file.size:
-      enabled: true
-    sqlserver.database.io:
-      enabled: true
-    sqlserver.database.latency:
-      enabled: true
-    sqlserver.database.operations:
-      enabled: true
-    sqlserver.database.page_file.size:
-      enabled: true
-    sqlserver.database.transactions.active:
-      enabled: true
-    sqlserver.database.backup_or_restore.rate:
-      enabled: true
-    sqlserver.database.execution.errors:
-      enabled: true
-    sqlserver.database.full_scan.rate:
-      enabled: true
-    sqlserver.database.tempdb.space:
-      enabled: true
-    sqlserver.database.tempdb.version_store.size:
-      enabled: true
-      # Security / Principals
-    sqlserver.database.principals.count:
-      enabled: true
-    sqlserver.database.principals.old:
-      enabled: true
-    sqlserver.database.principals.orphaned_users:
-      enabled: true
-    sqlserver.database.principals.recently_created:
-      enabled: true
-    sqlserver.database.role.members.count:
-      enabled: true
-    sqlserver.database.role.memberships.count:
-      enabled: true
-    sqlserver.database.role.permission.risk_level:
-      enabled: true
-    sqlserver.database.role.roles.count:
-      enabled: true
-    sqlserver.database.security.role_membership.count:
-      enabled: true
-    sqlserver.server.security.principal.count:
-      enabled: true
-    sqlserver.server.security.role_membership.count:
-      enabled: true
+    # Enable comprehensive database metrics
+    metrics:
+      # Database
+      sqlserver.database.count:
+        enabled: true
+      sqlserver.database.file.size:
+        enabled: true 
+      sqlserver.database.io:
+        enabled: true
+      sqlserver.database.latency:
+        enabled: true
+      sqlserver.database.operations:
+        enabled: true
+      sqlserver.database.transactions.active:
+        enabled: true
+      sqlserver.database.backup_or_restore.rate:
+        enabled: true
+      sqlserver.database.execution.errors:
+        enabled: true
+      sqlserver.database.full_scan.rate:
+        enabled: true
+      sqlserver.database.tempdb.space:
+        enabled: true
+      sqlserver.database.tempdb.version_store.size:
+        enabled: true
       # Locks
-    sqlserver.lock.by_mode.count:
-      enabled: true
-    sqlserver.lock.by_resource.count:
-      enabled: true
-    sqlserver.lock.timeout.rate:
-      enabled: true
-    sqlserver.lock.wait.count:
-      enabled: true
-    sqlserver.lock.wait.rate:
-      enabled: true
-    sqlserver.deadlock.rate:
-      enabled: true
+      sqlserver.lock.timeout.rate:
+        enabled: true
+      sqlserver.lock.wait.count:
+        enabled: true
+      sqlserver.deadlock.rate:
+        enabled: true
       # Transactions
-    sqlserver.transaction.delay:
-      enabled: true
-    sqlserver.transaction.mirror_write.rate:
-      enabled: true
-    sqlserver.transaction.longest_running_time:
-      enabled: true
-    sqlserver.transaction.version_cleanup.rate:
-      enabled: true
-    sqlserver.transaction.version_generation.rate:
-      enabled: true
+      sqlserver.transaction.delay:
+        enabled: true
+      sqlserver.transaction.longest_running_time:
+        enabled: true
+      sqlserver.transaction.version_cleanup.rate:
+        enabled: true
+      sqlserver.transaction.version_generation.rate:
+        enabled: true
       # Memory
-    sqlserver.memory.area:
-      enabled: true
-    sqlserver.memory.cache.object.count:
-      enabled: true
-    sqlserver.memory.grants.pending.count:
-      enabled: true
-    sqlserver.memory.page.count:
-      enabled: true
-    sqlserver.memory.target:
-      enabled: true
-    sqlserver.memory.usage:
-      enabled: true
+      sqlserver.memory.area:
+        enabled: true
+      sqlserver.memory.cache.object.count:
+        enabled: true
+      sqlserver.memory.grants.pending.count:
+        enabled: true
+      sqlserver.memory.page.count:
+        enabled: true
+      sqlserver.memory.target:
+        enabled: true
+      sqlserver.memory.usage:
+        enabled: true
       # OS
-    sqlserver.os.disk.size:
-      enabled: true
-    sqlserver.os.memory.usage:
-      enabled: true
-    sqlserver.os.memory.utilization:
-      enabled: true
-    sqlserver.os.scheduler.runnable_tasks.count:
-      enabled: true
-    sqlserver.os.wait.duration:
-      enabled: true
-    sqlserver.os.wait.tasks.count:
-      enabled: true
+      sqlserver.os.memory.usage:
+        enabled: true
+      sqlserver.os.memory.utilization:
+        enabled: true
+      sqlserver.os.scheduler.runnable_tasks.count:
+        enabled: true
+      sqlserver.os.wait.duration:
+        enabled: true
+      sqlserver.os.wait.tasks.count:
+        enabled: true
       # Pages / Buffer
-    sqlserver.page.buffer_cache.hit_ratio:
-      enabled: true
-    sqlserver.page.buffer_cache.free_list.stalls.rate:
-      enabled: true
-    sqlserver.page.life_expectancy:
-      enabled: true
-    sqlserver.page.lookup.rate:
-      enabled: true
+      sqlserver.page.buffer_cache.free_list.stalls.rate:
+        enabled: true
+      sqlserver.page.lookup.rate:
+        enabled: true
       # Batch / Compilation
-    sqlserver.batch.request.rate:
-      enabled: true
-    sqlserver.batch.sql_compilation.rate:
-      enabled: true
-    sqlserver.batch.sql_recompilation.rate:
-      enabled: true
-    sqlserver.batch.compilation.utilization:
-      enabled: true
-    sqlserver.batch.page_split.utilization:
-      enabled: true
-    sqlserver.recompilation.ratio:
-      enabled: true
-    sqlserver.parameterization.rate:
-      enabled: true
-    sqlserver.plan.execution.rate:
-      enabled: true
-    sqlserver.attention.rate:
-      enabled: true
+      sqlserver.batch.compilation.utilization:
+        enabled: true
+      sqlserver.batch.page_split.utilization:
+        enabled: true
+      sqlserver.recompilation.ratio:
+        enabled: true
+      sqlserver.parameterization.rate:
+        enabled: true
+      sqlserver.plan.execution.rate:
+        enabled: true
+      sqlserver.attention.rate:
+        enabled: true
       # Processes / Connections
-    sqlserver.process.count:
-      enabled: true
-    sqlserver.processes.blocked:
-      enabled: true
-    sqlserver.user.connection.count:
-      enabled: true
-    sqlserver.login.rate:
-      enabled: true
-    sqlserver.logout.rate:
-      enabled: true
+      sqlserver.process.count:
+        enabled: true
+      sqlserver.processes.blocked:
+        enabled: true
+      sqlserver.login.rate:
+        enabled: true
+      sqlserver.logout.rate:
+        enabled: true
       # Thread Pool
-    sqlserver.thread_pool.tasks.count:
-      enabled: true
-    sqlserver.thread_pool.workers.count:
-      enabled: true
-    sqlserver.thread_pool.workers.max:
-      enabled: true
-    sqlserver.thread_pool.workers.utilization:
-      enabled: true
+      sqlserver.thread_pool.tasks.count:
+        enabled: true
+      sqlserver.thread_pool.workers.count:
+        enabled: true
+      sqlserver.thread_pool.workers.max:
+        enabled: true
+      sqlserver.thread_pool.workers.utilization:
+        enabled: true
       # TempDB
-    sqlserver.tempdb.allocation.wait_time.total:
-      enabled: true
-    sqlserver.tempdb.contention.waiters.count:
-      enabled: true
-    sqlserver.tempdb.data_files.count:
-      enabled: true
-    sqlserver.tempdb.file.size:
-      enabled: true
-    sqlserver.tempdb.space.usage:
-      enabled: true
+      sqlserver.tempdb.allocation.wait_time.total:
+        enabled: true
+      sqlserver.tempdb.contention.waiters.count:
+        enabled: true
+      sqlserver.tempdb.data_files.count:
+        enabled: true
+      sqlserver.tempdb.file.size:
+        enabled: true
+      sqlserver.tempdb.space.usage:
+        enabled: true
       # Latch
-    sqlserver.latch.superlatch.count:
-      enabled: true
-    sqlserver.latch.superlatch.transition.rate:
-      enabled: true
-    sqlserver.latch.wait.rate:
-      enabled: true
-    sqlserver.latch.wait_time.avg:
-      enabled: true
-    sqlserver.latch.wait_time.total:
-      enabled: true
+      sqlserver.latch.superlatch.count:
+        enabled: true
+      sqlserver.latch.superlatch.transition.rate:
+        enabled: true
+      sqlserver.latch.wait.rate:
+        enabled: true
+      sqlserver.latch.wait_time.avg:
+        enabled: true
+      sqlserver.latch.wait_time.total:
+        enabled: true
       # Index
-    sqlserver.index.search.rate:
-      enabled: true
+      sqlserver.index.search.rate:
+        enabled: true
       # Resource Pool
-    sqlserver.resource_pool.disk.operations:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.read.rate:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.write.rate:
-      enabled: true
+      sqlserver.resource_pool.disk.operations:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.read.rate:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.write.rate:
+        enabled: true
       # Replica / Always-On
-    sqlserver.replica.data.rate:
-      enabled: true
-    sqlserver.failover_cluster.ag.cluster_type:
-      enabled: true
-    sqlserver.failover_cluster.ag.failure_condition_level:
-      enabled: true
-    sqlserver.failover_cluster.ag.health_check_timeout:
-      enabled: true
-    sqlserver.failover_cluster.ag.required_sync_secondaries:
-      enabled: true
-    sqlserver.failover_cluster.replica.database.queue_size:
-      enabled: true
-    sqlserver.failover_cluster.replica.database.redo.rate:
-      enabled: true
-    sqlserver.failover_cluster.replica.flow_control_time:
-      enabled: true
-    sqlserver.failover_cluster.replica.role:
-      enabled: true
-    sqlserver.failover_cluster.replica.synchronization_health:
-      enabled: true
+      sqlserver.replica.data.rate:
+        enabled: true
+      sqlserver.failover_cluster.ag.cluster_type:
+        enabled: true
+      sqlserver.failover_cluster.ag.failure_condition_level:
+        enabled: true
+      sqlserver.failover_cluster.ag.health_check_timeout:
+        enabled: true
+      sqlserver.failover_cluster.ag.required_sync_secondaries:
+        enabled: true
+      sqlserver.failover_cluster.replica.database.queue_size:
+        enabled: true
+      sqlserver.failover_cluster.replica.database.redo.rate:
+        enabled: true
+      sqlserver.failover_cluster.replica.flow_control_time:
+        enabled: true
+      sqlserver.failover_cluster.replica.role:
+        enabled: true
+      sqlserver.failover_cluster.replica.synchronization_health:
+        enabled: true
       # Server Properties
-    sqlserver.computer.uptime:
-      enabled: true
-    sqlserver.cpu.count:
-      enabled: true
+      sqlserver.computer.uptime:
+        enabled: true
+      sqlserver.cpu.count:
+        enabled: true
       # Tables
-    sqlserver.table.count:
-      enabled: true
+      sqlserver.table.count:
+        enabled: true
       # Errors
-    sqlserver.kill_connection.error.rate:
-      enabled: true
+      sqlserver.kill_connection.error.rate:
+        enabled: true
 
-  events:
-    db.server.query_sample:
-      enabled: true
-    db.server.top_query:
-      enabled: true
+    # Enable top query and query sample log collection
+    events:
+      db.server.query_sample:
+        enabled: true
+      db.server.top_query:
+        enabled: true
 
-  top_query_collection:
-    lookback_time: 60s
-    max_query_sample_count: 1000
-    top_query_count: 250
-    collection_interval: 60s
+    # Top query collection configuration
+    top_query_collection:
+      lookback_time: 60s
+      max_query_sample_count: 500
+      top_query_count: 200
+      collection_interval: 60s
 
-  collect_full_query_text: true
-  allowed_comment_keys:
-    - nr_service_guid
+    collect_full_query_text: true
+    allowed_comment_keys:
+      - nr_service_guid
 
-  query_sample_collection:
-    max_rows_per_query: 100
+    # Query sample collection configuration
+    query_sample_collection:
+      max_rows_per_query: 100
 
 processors:
-  memory_limiter:
-    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  metrics_transform:
+    transforms:
+      - include: system.cpu.utilization
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [state]
+            aggregation_type: mean
+      - include: system.paging.operations
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [direction]
+            aggregation_type: sum
+
+  filter/exclude_cpu_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+  filter/exclude_memory_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+  filter/exclude_memory_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+  filter/exclude_filesystem_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+  filter/exclude_filesystem_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_filesystem_inodes_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_system_disk:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+  filter/exclude_system_paging:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
+        - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
+
+  filter/exclude_network:
+    metrics:
+      datapoint:
+        - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+  attributes/exclude_system_paging:
+    include:
+      match_type: strict
+      metric_names:
+        - system.paging.operations
+    actions:
+      - key: type
+        action: delete
+
+  cumulativetodelta:
+
+  transform/host:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
 
   batch:
 
+  resource_detection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+  resource_detection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: true
+
+  resource_detection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   otlphttp:
@@ -510,15 +624,52 @@ service:
     metrics:
       level: none
 
+  extensions: [health_check]
+
   pipelines:
-    metrics:
+    metrics/host:
+      receivers: [host_metrics, nrsqlserver]
+      processors:
+        - metrics_transform
+        - filter/exclude_cpu_utilization
+        - filter/exclude_memory_utilization
+        - filter/exclude_memory_usage
+        - filter/exclude_filesystem_utilization
+        - filter/exclude_filesystem_usage
+        - filter/exclude_filesystem_inodes_usage
+        - filter/exclude_system_disk
+        - filter/exclude_network
+        - attributes/exclude_system_paging
+        - transform/host
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - cumulativetodelta
+        - batch
+      exporters: [otlphttp]
+
+    logs/host:
       receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      processors:
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - batch
+      exporters: [otlphttp]
+
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+      exporters: [otlphttp]
+
+    metrics:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
     logs:
-      receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
 ```
@@ -537,7 +688,7 @@ The following table describes the key configuration parameters for the `nrsqlser
 | `<YOUR_USERNAME>` | Enter your database username for authentication |
 | `<YOUR_PASSWORD>` | Enter your database password for authentication |
 | `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
-| `port` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
 | `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
 | `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
 | `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
@@ -836,7 +987,7 @@ Choose your monitoring configuration based on your needs:
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+    datasource: "server=<YOUR_HOSTNAME>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
     # Enable comprehensive database metrics
     metrics:
@@ -897,9 +1048,9 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: <YOUR_NEWRELIC_OTLP_ENDPOINT>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <YOUR_NEWRELIC_LICENSE_KEY>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -921,14 +1072,6 @@ service:
       exporters: [otlphttp]
 ```
 
-<Callout variant="important">
-Replace the following values:
-
-- `<HOSTNAME-OR-RDS-ENDPOINT>`: Your server hostname (on-premises) or RDS endpoint
-- `<YOUR_NEWRELIC_OTLP_ENDPOINT>`: Your New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).
-- `<YOUR_NEWRELIC_LICENSE_KEY>`: Your New Relic license key
-</Callout>
-
   </Collapser>
 
   <Collapser
@@ -947,24 +1090,76 @@ This configuration enables comprehensive database monitoring with all available 
 2. **Add the configuration content below** to the `mssql-config.yaml` file you created in the previous step.
 
 ```yaml
-receivers:
-  nrsqlserver:
-    collection_interval: 15s
-    datasource: "server=<YOUR-HOSTNAME>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+# NRDOT Collector Configuration for New Relic SQL Server Integration
+extensions:
+  health_check:
 
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  host_metrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.time:
+            enabled: false
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: false
+          system.paging.faults:
+            enabled: false
+      disk:
+        metrics:
+          system.disk.merged:
+            enabled: false
+          system.disk.pending_operations:
+            enabled: false
+          system.disk.weighted_io_time:
+            enabled: false
+      network:
+        metrics:
+          system.network.connections:
+            enabled: false
+      processes:
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_user_error: true
+        mute_process_io_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
+  nrsqlserver:
+    collection_interval: 30s
+    datasource: "server=<YOUR_HOSTNAME>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+
+    # Enable comprehensive database metrics
     metrics:
       # Database
       sqlserver.database.count:
         enabled: true
       sqlserver.database.file.size:
-        enabled: true
+        enabled: true 
       sqlserver.database.io:
         enabled: true
       sqlserver.database.latency:
         enabled: true
       sqlserver.database.operations:
-        enabled: true
-      sqlserver.database.page_file.size:
         enabled: true
       sqlserver.database.transactions.active:
         enabled: true
@@ -978,46 +1173,15 @@ receivers:
         enabled: true
       sqlserver.database.tempdb.version_store.size:
         enabled: true
-        # Security / Principals
-      sqlserver.database.principals.count:
-        enabled: true
-      sqlserver.database.principals.old:
-        enabled: true
-      sqlserver.database.principals.orphaned_users:
-        enabled: true
-      sqlserver.database.principals.recently_created:
-        enabled: true
-      sqlserver.database.role.members.count:
-        enabled: true
-      sqlserver.database.role.memberships.count:
-        enabled: true
-      sqlserver.database.role.permission.risk_level:
-        enabled: true
-      sqlserver.database.role.roles.count:
-        enabled: true
-      sqlserver.database.security.role_membership.count:
-        enabled: true
-      sqlserver.server.security.principal.count:
-        enabled: true
-      sqlserver.server.security.role_membership.count:
-        enabled: true
       # Locks
-      sqlserver.lock.by_mode.count:
-        enabled: true
-      sqlserver.lock.by_resource.count:
-        enabled: true
       sqlserver.lock.timeout.rate:
         enabled: true
       sqlserver.lock.wait.count:
-        enabled: true
-      sqlserver.lock.wait.rate:
         enabled: true
       sqlserver.deadlock.rate:
         enabled: true
       # Transactions
       sqlserver.transaction.delay:
-        enabled: true
-      sqlserver.transaction.mirror_write.rate:
         enabled: true
       sqlserver.transaction.longest_running_time:
         enabled: true
@@ -1039,8 +1203,6 @@ receivers:
       sqlserver.memory.usage:
         enabled: true
       # OS
-      sqlserver.os.disk.size:
-        enabled: true
       sqlserver.os.memory.usage:
         enabled: true
       sqlserver.os.memory.utilization:
@@ -1052,21 +1214,11 @@ receivers:
       sqlserver.os.wait.tasks.count:
         enabled: true
       # Pages / Buffer
-      sqlserver.page.buffer_cache.hit_ratio:
-        enabled: true
       sqlserver.page.buffer_cache.free_list.stalls.rate:
-        enabled: true
-      sqlserver.page.life_expectancy:
         enabled: true
       sqlserver.page.lookup.rate:
         enabled: true
       # Batch / Compilation
-      sqlserver.batch.request.rate:
-        enabled: true
-      sqlserver.batch.sql_compilation.rate:
-        enabled: true
-      sqlserver.batch.sql_recompilation.rate:
-        enabled: true
       sqlserver.batch.compilation.utilization:
         enabled: true
       sqlserver.batch.page_split.utilization:
@@ -1083,8 +1235,6 @@ receivers:
       sqlserver.process.count:
         enabled: true
       sqlserver.processes.blocked:
-        enabled: true
-      sqlserver.user.connection.count:
         enabled: true
       sqlserver.login.rate:
         enabled: true
@@ -1164,39 +1314,146 @@ receivers:
       sqlserver.kill_connection.error.rate:
         enabled: true
 
+    # Enable top query and query sample log collection
     events:
       db.server.query_sample:
         enabled: true
       db.server.top_query:
         enabled: true
 
+    # Top query collection configuration
     top_query_collection:
       lookback_time: 60s
-      max_query_sample_count: 1000
-      top_query_count: 250
+      max_query_sample_count: 500
+      top_query_count: 200
       collection_interval: 60s
 
     collect_full_query_text: true
     allowed_comment_keys:
       - nr_service_guid
 
+    # Query sample collection configuration
     query_sample_collection:
       max_rows_per_query: 100
 
 processors:
-  memory_limiter:
-    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  metrics_transform:
+    transforms:
+      - include: system.cpu.utilization
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [state]
+            aggregation_type: mean
+      - include: system.paging.operations
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [direction]
+            aggregation_type: sum
+
+  filter/exclude_cpu_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+  filter/exclude_memory_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+  filter/exclude_memory_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+  filter/exclude_filesystem_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+  filter/exclude_filesystem_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_filesystem_inodes_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_system_disk:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+  filter/exclude_system_paging:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
+        - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
+
+  filter/exclude_network:
+    metrics:
+      datapoint:
+        - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+  attributes/exclude_system_paging:
+    include:
+      match_type: strict
+      metric_names:
+        - system.paging.operations
+    actions:
+      - key: type
+        action: delete
+
+  cumulativetodelta:
+
+  transform/host:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
 
   batch:
 
+  resource_detection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+  resource_detection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: true
+
+  resource_detection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   otlphttp:
-    endpoint: <YOUR_NEWRELIC_OTLP_ENDPOINT>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <YOUR_NEWRELIC_LICENSE_KEY>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -1206,28 +1463,73 @@ service:
     metrics:
       level: none
 
+  extensions: [health_check]
+
   pipelines:
-    metrics:
+    metrics/host:
+      receivers: [host_metrics, nrsqlserver]
+      processors:
+        - metrics_transform
+        - filter/exclude_cpu_utilization
+        - filter/exclude_memory_utilization
+        - filter/exclude_memory_usage
+        - filter/exclude_filesystem_utilization
+        - filter/exclude_filesystem_usage
+        - filter/exclude_filesystem_inodes_usage
+        - filter/exclude_system_disk
+        - filter/exclude_network
+        - attributes/exclude_system_paging
+        - transform/host
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - cumulativetodelta
+        - batch
+      exporters: [otlphttp]
+
+    logs/host:
       receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      processors:
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - batch
+      exporters: [otlphttp]
+
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+      exporters: [otlphttp]
+
+    metrics:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
     logs:
-      receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 ```
 
-<Callout variant="important">
-Replace the following values:
-
-- `<HOSTNAME-OR-RDS-ENDPOINT>`: Your server hostname (on-premises) or RDS endpoint
-- `<YOUR_NEWRELIC_OTLP_ENDPOINT>`: Your New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).
-- `<YOUR_NEWRELIC_LICENSE_KEY>`: Your New Relic license key
-</Callout>
-
   </Collapser>
 </CollapserGroup>
+
+
+#### Configuration parameters
+
+The following table describes the key configuration parameters for the `nrsqlserver` receiver:
+
+| Parameter | Description |
+|-----------|-------------|
+| `<YOUR_USERNAME>` | Enter your database username for authentication |
+| `<YOUR_PASSWORD>` | Enter your database password for authentication |
+| `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
+| `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
+| `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
+| `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
+
 
 <Callout variant="tip">
 **Note:** If you enable all available metrics, increase the `limit_mib` value (e.g., 1000) to prevent the memory limiter from dropping data.
@@ -1482,7 +1784,7 @@ This configuration focuses on essential database monitoring with core metrics.
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+    datasource: "server=<YOUR_HOSTNAME>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
     # Enable comprehensive database metrics
     metrics:
@@ -1543,9 +1845,9 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: <YOUR_NEWRELIC_OTLP_ENDPOINT>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <YOUR_NEWRELIC_LICENSE_KEY>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -1567,14 +1869,6 @@ service:
       exporters: [otlphttp]
 ```
 
-<Callout variant="important">
-Replace the following values:
-
-- `<HOSTNAME-OR-RDS-ENDPOINT>`: Your server hostname (on-premises) or RDS endpoint
-- `<YOUR_NEWRELIC_OTLP_ENDPOINT>`: Your New Relic OTLP endpoint). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).
-- `<YOUR_NEWRELIC_LICENSE_KEY>`: Your New Relic license key
-</Callout>
-
   </Collapser>
 
   <Collapser
@@ -1593,24 +1887,76 @@ This configuration enables comprehensive database monitoring with all available 
 2. **Add the configuration content below** to the `mssql-config.yaml` file you created in the previous step.
 
 ```yaml
-receivers:
-  nrsqlserver:
-    collection_interval: 15s
-    datasource: "server=<YOUR-HOSTNAME>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+# NRDOT Collector Configuration for New Relic SQL Server Integration
+extensions:
+  health_check:
 
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  host_metrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.time:
+            enabled: false
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: false
+          system.paging.faults:
+            enabled: false
+      disk:
+        metrics:
+          system.disk.merged:
+            enabled: false
+          system.disk.pending_operations:
+            enabled: false
+          system.disk.weighted_io_time:
+            enabled: false
+      network:
+        metrics:
+          system.network.connections:
+            enabled: false
+      processes:
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_user_error: true
+        mute_process_io_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
+  nrsqlserver:
+    collection_interval: 30s
+    datasource: "server=<YOUR-HOSTNAME>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;
+
+    # Enable comprehensive database metrics
     metrics:
       # Database
       sqlserver.database.count:
         enabled: true
       sqlserver.database.file.size:
-        enabled: true
+        enabled: true 
       sqlserver.database.io:
         enabled: true
       sqlserver.database.latency:
         enabled: true
       sqlserver.database.operations:
-        enabled: true
-      sqlserver.database.page_file.size:
         enabled: true
       sqlserver.database.transactions.active:
         enabled: true
@@ -1624,46 +1970,15 @@ receivers:
         enabled: true
       sqlserver.database.tempdb.version_store.size:
         enabled: true
-        # Security / Principals
-      sqlserver.database.principals.count:
-        enabled: true
-      sqlserver.database.principals.old:
-        enabled: true
-      sqlserver.database.principals.orphaned_users:
-        enabled: true
-      sqlserver.database.principals.recently_created:
-        enabled: true
-      sqlserver.database.role.members.count:
-        enabled: true
-      sqlserver.database.role.memberships.count:
-        enabled: true
-      sqlserver.database.role.permission.risk_level:
-        enabled: true
-      sqlserver.database.role.roles.count:
-        enabled: true
-      sqlserver.database.security.role_membership.count:
-        enabled: true
-      sqlserver.server.security.principal.count:
-        enabled: true
-      sqlserver.server.security.role_membership.count:
-        enabled: true
-        # Locks
-      sqlserver.lock.by_mode.count:
-        enabled: true
-      sqlserver.lock.by_resource.count:
-        enabled: true
+      # Locks
       sqlserver.lock.timeout.rate:
         enabled: true
       sqlserver.lock.wait.count:
         enabled: true
-      sqlserver.lock.wait.rate:
-        enabled: true
       sqlserver.deadlock.rate:
         enabled: true
-        # Transactions
+      # Transactions
       sqlserver.transaction.delay:
-        enabled: true
-      sqlserver.transaction.mirror_write.rate:
         enabled: true
       sqlserver.transaction.longest_running_time:
         enabled: true
@@ -1671,7 +1986,7 @@ receivers:
         enabled: true
       sqlserver.transaction.version_generation.rate:
         enabled: true
-        # Memory
+      # Memory
       sqlserver.memory.area:
         enabled: true
       sqlserver.memory.cache.object.count:
@@ -1684,9 +1999,7 @@ receivers:
         enabled: true
       sqlserver.memory.usage:
         enabled: true
-        # OS
-      sqlserver.os.disk.size:
-        enabled: true
+      # OS
       sqlserver.os.memory.usage:
         enabled: true
       sqlserver.os.memory.utilization:
@@ -1697,22 +2010,12 @@ receivers:
         enabled: true
       sqlserver.os.wait.tasks.count:
         enabled: true
-        # Pages / Buffer
-      sqlserver.page.buffer_cache.hit_ratio:
-        enabled: true
+      # Pages / Buffer
       sqlserver.page.buffer_cache.free_list.stalls.rate:
-        enabled: true
-      sqlserver.page.life_expectancy:
         enabled: true
       sqlserver.page.lookup.rate:
         enabled: true
-        # Batch / Compilation
-      sqlserver.batch.request.rate:
-        enabled: true
-      sqlserver.batch.sql_compilation.rate:
-        enabled: true
-      sqlserver.batch.sql_recompilation.rate:
-        enabled: true
+      # Batch / Compilation
       sqlserver.batch.compilation.utilization:
         enabled: true
       sqlserver.batch.page_split.utilization:
@@ -1725,18 +2028,16 @@ receivers:
         enabled: true
       sqlserver.attention.rate:
         enabled: true
-        # Processes / Connections
+      # Processes / Connections
       sqlserver.process.count:
         enabled: true
       sqlserver.processes.blocked:
-        enabled: true
-      sqlserver.user.connection.count:
         enabled: true
       sqlserver.login.rate:
         enabled: true
       sqlserver.logout.rate:
         enabled: true
-        # Thread Pool
+      # Thread Pool
       sqlserver.thread_pool.tasks.count:
         enabled: true
       sqlserver.thread_pool.workers.count:
@@ -1745,7 +2046,7 @@ receivers:
         enabled: true
       sqlserver.thread_pool.workers.utilization:
         enabled: true
-        # TempDB
+      # TempDB
       sqlserver.tempdb.allocation.wait_time.total:
         enabled: true
       sqlserver.tempdb.contention.waiters.count:
@@ -1756,7 +2057,7 @@ receivers:
         enabled: true
       sqlserver.tempdb.space.usage:
         enabled: true
-        # Latch
+      # Latch
       sqlserver.latch.superlatch.count:
         enabled: true
       sqlserver.latch.superlatch.transition.rate:
@@ -1767,17 +2068,17 @@ receivers:
         enabled: true
       sqlserver.latch.wait_time.total:
         enabled: true
-        # Index
+      # Index
       sqlserver.index.search.rate:
         enabled: true
-        # Resource Pool
+      # Resource Pool
       sqlserver.resource_pool.disk.operations:
         enabled: true
       sqlserver.resource_pool.disk.throttled.read.rate:
         enabled: true
       sqlserver.resource_pool.disk.throttled.write.rate:
         enabled: true
-        # Replica / Always-On
+      # Replica / Always-On
       sqlserver.replica.data.rate:
         enabled: true
       sqlserver.failover_cluster.ag.cluster_type:
@@ -1798,51 +2099,158 @@ receivers:
         enabled: true
       sqlserver.failover_cluster.replica.synchronization_health:
         enabled: true
-        # Server Properties
+      # Server Properties
       sqlserver.computer.uptime:
         enabled: true
       sqlserver.cpu.count:
         enabled: true
-        # Tables
+      # Tables
       sqlserver.table.count:
         enabled: true
-        # Errors
+      # Errors
       sqlserver.kill_connection.error.rate:
         enabled: true
 
+    # Enable top query and query sample log collection
     events:
       db.server.query_sample:
         enabled: true
       db.server.top_query:
         enabled: true
 
+    # Top query collection configuration
     top_query_collection:
       lookback_time: 60s
-      max_query_sample_count: 1000
-      top_query_count: 250
+      max_query_sample_count: 500
+      top_query_count: 200
       collection_interval: 60s
 
     collect_full_query_text: true
     allowed_comment_keys:
       - nr_service_guid
 
+    # Query sample collection configuration
     query_sample_collection:
       max_rows_per_query: 100
 
 processors:
-  memory_limiter:
-    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  metrics_transform:
+    transforms:
+      - include: system.cpu.utilization
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [state]
+            aggregation_type: mean
+      - include: system.paging.operations
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [direction]
+            aggregation_type: sum
+
+  filter/exclude_cpu_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+  filter/exclude_memory_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+  filter/exclude_memory_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+  filter/exclude_filesystem_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+  filter/exclude_filesystem_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_filesystem_inodes_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_system_disk:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+  filter/exclude_system_paging:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
+        - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
+
+  filter/exclude_network:
+    metrics:
+      datapoint:
+        - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+  attributes/exclude_system_paging:
+    include:
+      match_type: strict
+      metric_names:
+        - system.paging.operations
+    actions:
+      - key: type
+        action: delete
+
+  cumulativetodelta:
+
+  transform/host:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
 
   batch:
 
+  resource_detection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+  resource_detection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: true
+
+  resource_detection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   otlphttp:
-    endpoint: <YOUR_NEWRELIC_OTLP_ENDPOINT>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <YOUR_NEWRELIC_LICENSE_KEY>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -1852,28 +2260,73 @@ service:
     metrics:
       level: none
 
+  extensions: [health_check]
+
   pipelines:
-    metrics:
+    metrics/host:
+      receivers: [host_metrics, nrsqlserver]
+      processors:
+        - metrics_transform
+        - filter/exclude_cpu_utilization
+        - filter/exclude_memory_utilization
+        - filter/exclude_memory_usage
+        - filter/exclude_filesystem_utilization
+        - filter/exclude_filesystem_usage
+        - filter/exclude_filesystem_inodes_usage
+        - filter/exclude_system_disk
+        - filter/exclude_network
+        - attributes/exclude_system_paging
+        - transform/host
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - cumulativetodelta
+        - batch
+      exporters: [otlphttp]
+
+    logs/host:
       receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      processors:
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - batch
+      exporters: [otlphttp]
+
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+      exporters: [otlphttp]
+
+    metrics:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
     logs:
-      receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 ```
 
-<Callout variant="important">
-Replace the following values:
-
-- `<HOSTNAME-OR-RDS-ENDPOINT>`: Your server hostname (on-premises) or RDS endpoint
-- `<YOUR_NEWRELIC_OTLP_ENDPOINT>`: Your New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).
-- `<YOUR_NEWRELIC_LICENSE_KEY>`: Your New Relic license key
-</Callout>
-
   </Collapser>
 </CollapserGroup>
+
+
+
+#### Configuration parameters
+
+The following table describes the key configuration parameters for the `nrsqlserver` receiver:
+
+| Parameter | Description |
+|-----------|-------------|
+| `<YOUR_USERNAME>` | Enter your database username for authentication |
+| `<YOUR_PASSWORD>` | Enter your database password for authentication |
+| `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
+| `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
+| `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
+| `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
 
 <Callout variant="tip">
 **Note:** If you enable all available metrics, increase the `limit_mib` value (e.g., 1000) to prevent the memory limiter from dropping data.

--- a/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -164,7 +164,7 @@ This configuration focuses on essential database monitoring with core metrics.
       name: 'endpoint',
       label: 'New Relic OTLP Endpoint',
       codeLine: 50,
-      defaultValue: 'https://otlp.nr-data.net',
+      defaultValue: 'https://otlp.nr-data.net:4318',
       toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
     },
     {

--- a/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -1659,12 +1659,12 @@ receivers:
       max_rows_per_query: 100
 
 processors:
-    memory_limiter:
-      check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-      limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
-      spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  memory_limiter:
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
-    batch:
+  batch:
 
 exporters:
   otlphttp:

--- a/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -128,106 +128,60 @@ This configuration focuses on essential database monitoring with core metrics.
 
 2. **Add the configuration content below** to the `mssql-config.yaml` file you created in the previous step.
 
-**Enter your values below and see the configuration update in real-time:**
+```yaml
+receivers:
+  nrsqlserver:
+    collection_interval: 15s
+    username: <input1>
+    password: <input2>
+    server: <input3>
+    port: <input4>
 
-<AgentConfig
-  inputOptions={[
-    {
-      name: 'username',
-      label: 'SQL Server Username',
-      codeLine: 8,
-      defaultValue: 'newrelic',
-      toolTip: 'Enter your SQL Server username',
-    },
-    {
-      name: 'password',
-      label: 'SQL Server Password',
-      codeLine: 9,
-      defaultValue: 'your_password',
-      toolTip: 'Enter your SQL Server password',
-    },
-    {
-      name: 'server',
-      label: 'Server Hostname/IP',
-      codeLine: 10,
-      defaultValue: 'sqlserver.example.com',
-      toolTip: 'Enter your SQL Server hostname or IP address',
-    },
-    {
-      name: 'port',
-      label: 'Server Port',
-      codeLine: 11,
-      defaultValue: '1433',
-      toolTip: 'Enter your SQL Server port number (default: 1433)',
-    },
-    {
-      name: 'endpoint',
-      label: 'New Relic OTLP Endpoint',
-      codeLine: 50,
-      defaultValue: 'https://otlp.nr-data.net:4318',
-      toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
-    },
-    {
-      name: 'licenseKey',
-      label: 'New Relic License Key',
-      codeLine: 52,
-      defaultValue: 'YOUR_LICENSE_KEY',
-      toolTip: 'Enter your New Relic license key',
-    },
-  ]}
-  config={`receivers:
-nrsqlserver:
-  collection_interval: 15s
-  username: <input1>
-  password: <input2>
-  server: <input3>
-  port: <input4>
+      # Enable comprehensive database metrics
+    metrics:
+      sqlserver.database.count:
+        enabled: true
+      sqlserver.database.io:
+        enabled: true
+      sqlserver.database.latency:
+        enabled: true
+      sqlserver.database.operations:
+        enabled: true
+      sqlserver.database.tempdb.space:
+        enabled: true
+      sqlserver.database.tempdb.version_store.size:
+        enabled: true
+      sqlserver.deadlock.rate:
+        enabled: true
+      sqlserver.os.wait.duration:
+        enabled: true
+      sqlserver.processes.blocked:
+        enabled: true
+      sqlserver.memory.grants.pending.count:
+        enabled: true
+      sqlserver.database.file.size:
+        enabled: true
+      sqlserver.memory.area:
+        enabled: true
 
-    # Enable comprehensive database metrics
-  metrics:
-    sqlserver.database.count:
-      enabled: true
-    sqlserver.database.io:
-      enabled: true
-    sqlserver.database.latency:
-      enabled: true
-    sqlserver.database.operations:
-      enabled: true
-    sqlserver.database.tempdb.space:
-      enabled: true
-    sqlserver.database.tempdb.version_store.size:
-      enabled: true
-    sqlserver.deadlock.rate:
-      enabled: true
-    sqlserver.os.wait.duration:
-      enabled: true
-    sqlserver.processes.blocked:
-      enabled: true
-    sqlserver.memory.grants.pending.count:
-      enabled: true
-    sqlserver.database.file.size:
-      enabled: true
-    sqlserver.memory.area:
-      enabled: true
+    events:
+      db.server.query_sample:
+        enabled: true
+      db.server.top_query:
+        enabled: true
 
-  events:
-    db.server.query_sample:
-      enabled: true
-    db.server.top_query:
-      enabled: true
+    top_query_collection:
+      lookback_time: 60s
+      max_query_sample_count: 1000
+      top_query_count: 250
+      collection_interval: 60s
 
-  top_query_collection:
-    lookback_time: 60s
-    max_query_sample_count: 1000
-    top_query_count: 250
-    collection_interval: 60s
+    collect_full_query_text: true
+    allowed_comment_keys:
+      - nr_service_guid
 
-  collect_full_query_text: true
-  allowed_comment_keys:
-    - nr_service_guid
-
-  query_sample_collection:
-    max_rows_per_query: 100
+    query_sample_collection:
+      max_rows_per_query: 100
 
 processors:
   memory_limiter:
@@ -260,11 +214,8 @@ service:
     logs:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp]`}
-  fileName="mssql-config.yaml"
-  tipMdx={{ body: null }}
-  onChange={() => {}}
-/>
+      exporters: [otlphttp]`
+```
 
 <Callout variant="tip">
 
@@ -289,7 +240,6 @@ This configuration enables comprehensive database monitoring with all available 
 
 2. **Add the configuration content below** to the `mssql-config.yaml` file you created in the previous step.
 
-**Enter your values below and see the configuration update in real-time:**
 
 <Callout variant="important">
 
@@ -297,58 +247,14 @@ This configuration enables comprehensive database monitoring with all available 
 
 </Callout> 
 
-<AgentConfig
-  inputOptions={[
-    {
-      name: 'username',
-      label: 'SQL Server Username',
-      codeLine: 4,
-      defaultValue: 'newrelic',
-      toolTip: 'Enter your SQL Server username for authentication',
-    },
-    {
-      name: 'password',
-      label: 'SQL Server Password',
-      codeLine: 5,
-      defaultValue: 'your_password',
-      toolTip: 'Enter your SQL Server password for authentication',
-    },
-    {
-      name: 'server',
-      label: 'Server Hostname/IP',
-      codeLine: 6,
-      defaultValue: 'sqlserver.example.com',
-      toolTip: 'Enter your SQL Server hostname or IP address',
-    },
-    {
-      name: 'port',
-      label: 'Server Port',
-      codeLine: 7,
-      defaultValue: '1433',
-      toolTip: 'Enter your SQL Server port number (default: 1433)',
-    },
-    {
-      name: 'endpoint',
-      label: 'New Relic OTLP Endpoint',
-      codeLine: 177,
-      defaultValue: 'https://otlp.nr-data.net:4318',
-      toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
-    },
-    {
-      name: 'licenseKey',
-      label: 'New Relic License Key',
-      codeLine: 179,
-      defaultValue: 'YOUR_LICENSE_KEY',
-      toolTip: 'Enter your New Relic license key',
-    },
-  ]}
-  config={`receivers:
-nrsqlserver:
-  collection_interval: 15s
-  username: <input1>
-  password: <input2>
-  server: <input3>
-  port: <input4>
+```yaml
+receivers:
+  nrsqlserver:
+    collection_interval: 15s
+    username: <input1>
+    password: <input2>
+    server: <input3>
+    port: <input4>
 
   metrics:
     # Database
@@ -613,60 +519,29 @@ service:
     logs:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp]`}
-  fileName="mssql-config.yaml"
-  tipMdx={{ body: null }}
-  onChange={() => {}}
-/>
+      exporters: [otlphttp]
+
+```
 
 
   </Collapser>
 </CollapserGroup>
 
+
 #### Configuration parameters
 
 The following table describes the key configuration parameters for the `nrsqlserver` receiver:
 
-<table>
-<thead>
-  <tr>
-    <th>Parameter</th>
-    <th>Description</th>
-  </tr>
-</thead>
-<tbody>
-  <tr>
-    <td>`Username`</td>
-    <td>Enter your database username for authentication</td>
-  </tr>
-  <tr>
-    <td>`Password`</td>
-    <td>Enter your database password for authentication</td>
-  </tr>
-  <tr>
-    <td>`Server`</td>
-    <td>Enter your SQL Server hostname or IP address</td>
-  </tr>
-  <tr>
-    <td>`Port`</td>
-    <td>Enter your SQL Server port number. The default value is 1433.</td>
-  </tr>
-  <tr>
-    <td>`OTLP Endpoint`</td>
-    <td>
-    Enter the New Relic OTLP endpoint (e.g., https://otlp.nr-data.net). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).
-    </td>
-  </tr>
-  <tr>
-    <td>`License Key`</td>
-    <td>Enter your New Relic license key.</td>
-  </tr>
-  <tr>
-    <td>`collection_interval`</td>
-    <td>Interval in seconds to collect database metrics. Default: 15s</td>
-  </tr>
-</tbody>
-</table>
+| Parameter | Description |
+|-----------|-------------|
+| `<YOUR_USERNAME>` | Enter your database username for authentication |
+| `<YOUR_PASSWORD>` | Enter your database password for authentication |
+| `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
+| `port` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
+| `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
+| `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
+
 
 <Callout variant="tip">
 **Note:** If you enable all available metrics, increase the `limit_mib` value (e.g., 1000) to prevent the memory limiter from dropping data.

--- a/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -1522,9 +1522,7 @@ The following table describes the key configuration parameters for the `nrsqlser
 
 | Parameter | Description |
 |-----------|-------------|
-| `<YOUR_USERNAME>` | Enter your database username for authentication |
-| `<YOUR_PASSWORD>` | Enter your database password for authentication |
-| `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
+| `<YOUR_HOSTNAME>` | Enter your SQL Server hostname or IP address |
 | `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
 | `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
 | `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
@@ -1887,6 +1885,7 @@ This configuration enables comprehensive database monitoring with all available 
 2. **Add the configuration content below** to the `mssql-config.yaml` file you created in the previous step.
 
 ```yaml
+
 # NRDOT Collector Configuration for New Relic SQL Server Integration
 extensions:
   health_check:
@@ -1943,7 +1942,7 @@ receivers:
 
   nrsqlserver:
     collection_interval: 30s
-    datasource: "server=<YOUR-HOSTNAME>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;
+    datasource: "server=<YOUR_HOSTNAME>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
     # Enable comprehensive database metrics
     metrics:
@@ -2307,6 +2306,7 @@ service:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
+
 ```
 
   </Collapser>
@@ -2320,9 +2320,7 @@ The following table describes the key configuration parameters for the `nrsqlser
 
 | Parameter | Description |
 |-----------|-------------|
-| `<YOUR_USERNAME>` | Enter your database username for authentication |
-| `<YOUR_PASSWORD>` | Enter your database password for authentication |
-| `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
+| `<YOUR_HOSTNAME>` | Enter your SQL Server hostname or IP address |
 | `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
 | `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
 | `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |

--- a/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -132,10 +132,10 @@ This configuration focuses on essential database monitoring with core metrics.
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    username: <input1>
-    password: <input2>
-    server: <input3>
-    port: <input4>
+    username: <YOUR_USERNAME>
+    password: <YOUR_PASSWORD>
+    server: <YOUR_SERVER>
+    port: <YOUR_PORT>
 
       # Enable comprehensive database metrics
     metrics:
@@ -185,17 +185,17 @@ receivers:
 
 processors:
   memory_limiter:
-    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
-    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 
 exporters:
   otlphttp:
-    endpoint: <input5>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <input6>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -214,7 +214,7 @@ service:
     logs:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp]`
+      exporters: [otlphttp]
 ```
 
 <Callout variant="tip">
@@ -251,10 +251,10 @@ This configuration enables comprehensive database monitoring with all available 
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    username: <input1>
-    password: <input2>
-    server: <input3>
-    port: <input4>
+    username: <YOUR_USERNAME>
+    password: <YOUR_PASSWORD>
+    server: <YOUR_SERVER>
+    port: <YOUR_PORT>
 
   metrics:
     # Database
@@ -489,18 +489,18 @@ receivers:
 
 processors:
   memory_limiter:
-    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 
 
 exporters:
   otlphttp:
-    endpoint: <input5>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <input6>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -582,9 +582,9 @@ processors:
     override: true
 exporters:
   otlphttp:
-    endpoint: https://otlp.nr-data.net:443
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key:
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -180,7 +180,7 @@ This configuration focuses on essential database monitoring with core metrics.
       name: 'endpoint',
       label: 'New Relic OTLP Endpoint',
       codeLine: 69,
-      defaultValue: 'https://otlp.nr-data.net',
+      defaultValue: 'https://otlp.nr-data.net:4318',
       toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
     },
     {

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -481,9 +481,9 @@ receivers:
 
 processors:
   memory_limiter:
-    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 
@@ -1153,9 +1153,9 @@ receivers:
 
 processors:
   memory_limiter:
-    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 
@@ -1792,18 +1792,18 @@ receivers:
 
 processors:
   memory_limiter:
-    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 
 
 exporters:
   otlphttp:
-    endpoint: <input2>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <input3>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -455,24 +455,6 @@ receivers:
       # Replica / Always-On
       sqlserver.replica.data.rate:
         enabled: true
-      sqlserver.failover_cluster.ag.cluster_type:
-        enabled: true
-      sqlserver.failover_cluster.ag.failure_condition_level:
-        enabled: true
-      sqlserver.failover_cluster.ag.health_check_timeout:
-        enabled: true
-      sqlserver.failover_cluster.ag.required_sync_secondaries:
-        enabled: true
-      sqlserver.failover_cluster.replica.database.queue_size:
-        enabled: true
-      sqlserver.failover_cluster.replica.database.redo.rate:
-        enabled: true
-      sqlserver.failover_cluster.replica.flow_control_time:
-        enabled: true
-      sqlserver.failover_cluster.replica.role:
-        enabled: true
-      sqlserver.failover_cluster.replica.synchronization_health:
-        enabled: true
       # Server Properties
       sqlserver.computer.uptime:
         enabled: true
@@ -484,29 +466,24 @@ receivers:
       # Errors
       sqlserver.kill_connection.error.rate:
         enabled: true
-
     # Enable top query and query sample log collection
     events:
       db.server.query_sample:
         enabled: true
       db.server.top_query:
         enabled: true
-
     # Top query collection configuration
     top_query_collection:
       lookback_time: 60s
       max_query_sample_count: 500
       top_query_count: 200
       collection_interval: 60s
-
     collect_full_query_text: true
     allowed_comment_keys:
       - nr_service_guid
-
     # Query sample collection configuration
     query_sample_collection:
       max_rows_per_query: 100
-
 processors:
   metrics_transform:
     transforms:
@@ -522,14 +499,12 @@ processors:
           - action: aggregate_labels
             label_set: [direction]
             aggregation_type: sum
-
   filter/exclude_cpu_utilization:
     metrics:
       datapoint:
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
-
   filter/exclude_memory_utilization:
     metrics:
       datapoint:
@@ -538,30 +513,25 @@ processors:
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
-
   filter/exclude_memory_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
         - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
-
   filter/exclude_filesystem_utilization:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
-
   filter/exclude_filesystem_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
         - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
-
   filter/exclude_filesystem_inodes_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
         - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
-
   filter/exclude_system_disk:
     metrics:
       datapoint:
@@ -570,18 +540,15 @@ processors:
         - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
         - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
         - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
-
   filter/exclude_system_paging:
     metrics:
       datapoint:
         - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
         - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
-
   filter/exclude_network:
     metrics:
       datapoint:
         - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
-
   attributes/exclude_system_paging:
     include:
       match_type: strict
@@ -590,18 +557,14 @@ processors:
     actions:
       - key: type
         action: delete
-
   cumulativetodelta:
-
   transform/host:
     metric_statements:
       - context: metric
         statements:
           - set(metric.description, "")
           - set(metric.unit, "")
-
   batch:
-
   resource_detection:
     detectors: ["system"]
     system:
@@ -609,33 +572,27 @@ processors:
       resource_attributes:
         host.id:
           enabled: true
-
   resource_detection/cloud:
     detectors: ["gcp", "ec2", "azure"]
     timeout: 2s
     override: true
-
   resource_detection/env:
     detectors: ["env"]
     timeout: 2s
     override: true
-
 exporters:
   otlphttp:
-    endpoint: <YOUR_OTLP_ENDPOINT>
+    endpoint: https://otlp.nr-data.net:443
     headers:
-      api-key: <YOUR_LICENSE_KEY>
+      api-key:
     tls:
       insecure: false
     compression: gzip
-
 service:
   telemetry:
     metrics:
       level: none
-
   extensions: [health_check]
-
   pipelines:
     metrics/host:
       receivers: [host_metrics, nrsqlserver]
@@ -657,7 +614,6 @@ service:
         - cumulativetodelta
         - batch
       exporters: [otlphttp]
-
     logs/host:
       receivers: [nrsqlserver]
       processors:
@@ -666,17 +622,14 @@ service:
         - resource_detection/env
         - batch
       exporters: [otlphttp]
-
     traces:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
     metrics:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
     logs:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -203,9 +203,9 @@ receivers:
 
 processors:
   memory_limiter:
-    check_interval: $\{env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       $\{env:NR_MEM_LIMITER_LIMIT_MIB:-200}
-    spike_limit_mib: $\{env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-200}
+    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -258,27 +258,79 @@ This configuration provides comprehensive database monitoring with all available
 
 ```yaml
 
+# NRDOT Collector Configuration for New Relic SQL Server Integration
+extensions:
+  health_check:
+
 receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  host_metrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.time:
+            enabled: false
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: false
+          system.paging.faults:
+            enabled: false
+      disk:
+        metrics:
+          system.disk.merged:
+            enabled: false
+          system.disk.pending_operations:
+            enabled: false
+          system.disk.weighted_io_time:
+            enabled: false
+      network:
+        metrics:
+          system.network.connections:
+            enabled: false
+      processes:
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_user_error: true
+        mute_process_io_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
   nrsqlserver:
-    collection_interval: 15s
+    collection_interval: 30s
     username: <YOUR_USERNAME>
     password: <YOUR_PASSWORD>
     server: <YOUR_SERVER>
     port: <YOUR_PORT>
 
+    # Enable comprehensive database metrics
     metrics:
       # Database
       sqlserver.database.count:
         enabled: true
       sqlserver.database.file.size:
-        enabled: true
+        enabled: true 
       sqlserver.database.io:
         enabled: true
       sqlserver.database.latency:
         enabled: true
       sqlserver.database.operations:
-        enabled: true
-      sqlserver.database.page_file.size:
         enabled: true
       sqlserver.database.transactions.active:
         enabled: true
@@ -292,46 +344,15 @@ receivers:
         enabled: true
       sqlserver.database.tempdb.version_store.size:
         enabled: true
-      # Security / Principals
-      sqlserver.database.principals.count:
-        enabled: true
-      sqlserver.database.principals.old:
-        enabled: true
-      sqlserver.database.principals.orphaned_users:
-        enabled: true
-      sqlserver.database.principals.recently_created:
-        enabled: true
-      sqlserver.database.role.members.count:
-        enabled: true
-      sqlserver.database.role.memberships.count:
-        enabled: true
-      sqlserver.database.role.permission.risk_level:
-        enabled: true
-      sqlserver.database.role.roles.count:
-        enabled: true
-      sqlserver.database.security.role_membership.count:
-        enabled: true
-      sqlserver.server.security.principal.count:
-        enabled: true
-      sqlserver.server.security.role_membership.count:
-        enabled: true
       # Locks
-      sqlserver.lock.by_mode.count:
-        enabled: true
-      sqlserver.lock.by_resource.count:
-        enabled: true
       sqlserver.lock.timeout.rate:
         enabled: true
       sqlserver.lock.wait.count:
-        enabled: true
-      sqlserver.lock.wait.rate:
         enabled: true
       sqlserver.deadlock.rate:
         enabled: true
       # Transactions
       sqlserver.transaction.delay:
-        enabled: true
-      sqlserver.transaction.mirror_write.rate:
         enabled: true
       sqlserver.transaction.longest_running_time:
         enabled: true
@@ -353,8 +374,6 @@ receivers:
       sqlserver.memory.usage:
         enabled: true
       # OS
-      sqlserver.os.disk.size:
-        enabled: true
       sqlserver.os.memory.usage:
         enabled: true
       sqlserver.os.memory.utilization:
@@ -366,21 +385,11 @@ receivers:
       sqlserver.os.wait.tasks.count:
         enabled: true
       # Pages / Buffer
-      sqlserver.page.buffer_cache.hit_ratio:
-        enabled: true
       sqlserver.page.buffer_cache.free_list.stalls.rate:
-        enabled: true
-      sqlserver.page.life_expectancy:
         enabled: true
       sqlserver.page.lookup.rate:
         enabled: true
       # Batch / Compilation
-      sqlserver.batch.request.rate:
-        enabled: true
-      sqlserver.batch.sql_compilation.rate:
-        enabled: true
-      sqlserver.batch.sql_recompilation.rate:
-        enabled: true
       sqlserver.batch.compilation.utilization:
         enabled: true
       sqlserver.batch.page_split.utilization:
@@ -397,8 +406,6 @@ receivers:
       sqlserver.process.count:
         enabled: true
       sqlserver.processes.blocked:
-        enabled: true
-      sqlserver.user.connection.count:
         enabled: true
       sqlserver.login.rate:
         enabled: true
@@ -448,6 +455,24 @@ receivers:
       # Replica / Always-On
       sqlserver.replica.data.rate:
         enabled: true
+      sqlserver.failover_cluster.ag.cluster_type:
+        enabled: true
+      sqlserver.failover_cluster.ag.failure_condition_level:
+        enabled: true
+      sqlserver.failover_cluster.ag.health_check_timeout:
+        enabled: true
+      sqlserver.failover_cluster.ag.required_sync_secondaries:
+        enabled: true
+      sqlserver.failover_cluster.replica.database.queue_size:
+        enabled: true
+      sqlserver.failover_cluster.replica.database.redo.rate:
+        enabled: true
+      sqlserver.failover_cluster.replica.flow_control_time:
+        enabled: true
+      sqlserver.failover_cluster.replica.role:
+        enabled: true
+      sqlserver.failover_cluster.replica.synchronization_health:
+        enabled: true
       # Server Properties
       sqlserver.computer.uptime:
         enabled: true
@@ -460,33 +485,140 @@ receivers:
       sqlserver.kill_connection.error.rate:
         enabled: true
 
-      events:
-        db.server.query_sample:
-          enabled: true
-        db.server.top_query:
-          enabled: true
+    # Enable top query and query sample log collection
+    events:
+      db.server.query_sample:
+        enabled: true
+      db.server.top_query:
+        enabled: true
 
-      top_query_collection:
-        lookback_time: 60s
-        max_query_sample_count: 1000
-        top_query_count: 250
-        collection_interval: 60s
+    # Top query collection configuration
+    top_query_collection:
+      lookback_time: 60s
+      max_query_sample_count: 500
+      top_query_count: 200
+      collection_interval: 60s
 
-      collect_full_query_text: true
-      allowed_comment_keys:
-        - nr_service_guid
+    collect_full_query_text: true
+    allowed_comment_keys:
+      - nr_service_guid
 
-      query_sample_collection:
-        max_rows_per_query: 100
+    # Query sample collection configuration
+    query_sample_collection:
+      max_rows_per_query: 100
 
 processors:
-  memory_limiter:
-    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  metrics_transform:
+    transforms:
+      - include: system.cpu.utilization
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [state]
+            aggregation_type: mean
+      - include: system.paging.operations
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [direction]
+            aggregation_type: sum
+
+  filter/exclude_cpu_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+  filter/exclude_memory_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+  filter/exclude_memory_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+  filter/exclude_filesystem_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+  filter/exclude_filesystem_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_filesystem_inodes_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_system_disk:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+  filter/exclude_system_paging:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
+        - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
+
+  filter/exclude_network:
+    metrics:
+      datapoint:
+        - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+  attributes/exclude_system_paging:
+    include:
+      match_type: strict
+      metric_names:
+        - system.paging.operations
+    actions:
+      - key: type
+        action: delete
+
+  cumulativetodelta:
+
+  transform/host:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
 
   batch:
 
+  resource_detection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+  resource_detection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: true
+
+  resource_detection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   otlphttp:
@@ -502,15 +634,52 @@ service:
     metrics:
       level: none
 
+  extensions: [health_check]
+
   pipelines:
-    metrics:
+    metrics/host:
+      receivers: [host_metrics, nrsqlserver]
+      processors:
+        - metrics_transform
+        - filter/exclude_cpu_utilization
+        - filter/exclude_memory_utilization
+        - filter/exclude_memory_usage
+        - filter/exclude_filesystem_utilization
+        - filter/exclude_filesystem_usage
+        - filter/exclude_filesystem_inodes_usage
+        - filter/exclude_system_disk
+        - filter/exclude_network
+        - attributes/exclude_system_paging
+        - transform/host
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - cumulativetodelta
+        - batch
+      exporters: [otlphttp]
+
+    logs/host:
       receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      processors:
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - batch
+      exporters: [otlphttp]
+
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+      exporters: [otlphttp]
+
+    metrics:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
     logs:
-      receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
 ```
@@ -528,7 +697,7 @@ The following table describes the key configuration parameters for the nrsqlserv
 | `<YOUR_USERNAME>` | Enter your database username for authentication |
 | `<YOUR_PASSWORD>` | Enter your database password for authentication |
 | `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
-| `port` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
 | `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
 | `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
 | `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
@@ -812,7 +981,7 @@ Use the configuration below with your RDS endpoint:
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+    datasource: "server=<YOUR_RDS_ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
     # Enable comprehensive database metrics
     metrics:
@@ -873,9 +1042,9 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: <YOUR_NEWRELIC_OTLP_ENDPOINT>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <YOUR_NEWRELIC_LICENSE_KEY>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -932,25 +1101,78 @@ This configuration provides comprehensive database monitoring with all available
 
 2. **Add the configuration content below to the mssql-config.yaml file** you created in the previous step.
 
-```yaml
-receivers:
-  nrsqlserver:
-    collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
+```yaml
+# NRDOT Collector Configuration for New Relic SQL Server Integration
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  host_metrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.time:
+            enabled: false
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: false
+          system.paging.faults:
+            enabled: false
+      disk:
+        metrics:
+          system.disk.merged:
+            enabled: false
+          system.disk.pending_operations:
+            enabled: false
+          system.disk.weighted_io_time:
+            enabled: false
+      network:
+        metrics:
+          system.network.connections:
+            enabled: false
+      processes:
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_user_error: true
+        mute_process_io_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
+  nrsqlserver:
+    collection_interval: 30s
+    datasource: "server=<YOUR_RDS_ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+
+    # Enable comprehensive database metrics
     metrics:
       # Database
       sqlserver.database.count:
         enabled: true
       sqlserver.database.file.size:
-        enabled: true
+        enabled: true 
       sqlserver.database.io:
         enabled: true
       sqlserver.database.latency:
         enabled: true
       sqlserver.database.operations:
-        enabled: true
-      sqlserver.database.page_file.size:
         enabled: true
       sqlserver.database.transactions.active:
         enabled: true
@@ -964,46 +1186,15 @@ receivers:
         enabled: true
       sqlserver.database.tempdb.version_store.size:
         enabled: true
-      # Security / Principals
-      sqlserver.database.principals.count:
-        enabled: true
-      sqlserver.database.principals.old:
-        enabled: true
-      sqlserver.database.principals.orphaned_users:
-        enabled: true
-      sqlserver.database.principals.recently_created:
-        enabled: true
-      sqlserver.database.role.members.count:
-        enabled: true
-      sqlserver.database.role.memberships.count:
-        enabled: true
-      sqlserver.database.role.permission.risk_level:
-        enabled: true
-      sqlserver.database.role.roles.count:
-        enabled: true
-      sqlserver.database.security.role_membership.count:
-        enabled: true
-      sqlserver.server.security.principal.count:
-        enabled: true
-      sqlserver.server.security.role_membership.count:
-        enabled: true
       # Locks
-      sqlserver.lock.by_mode.count:
-        enabled: true
-      sqlserver.lock.by_resource.count:
-        enabled: true
       sqlserver.lock.timeout.rate:
         enabled: true
       sqlserver.lock.wait.count:
-        enabled: true
-      sqlserver.lock.wait.rate:
         enabled: true
       sqlserver.deadlock.rate:
         enabled: true
       # Transactions
       sqlserver.transaction.delay:
-        enabled: true
-      sqlserver.transaction.mirror_write.rate:
         enabled: true
       sqlserver.transaction.longest_running_time:
         enabled: true
@@ -1025,8 +1216,6 @@ receivers:
       sqlserver.memory.usage:
         enabled: true
       # OS
-      sqlserver.os.disk.size:
-        enabled: true
       sqlserver.os.memory.usage:
         enabled: true
       sqlserver.os.memory.utilization:
@@ -1038,21 +1227,11 @@ receivers:
       sqlserver.os.wait.tasks.count:
         enabled: true
       # Pages / Buffer
-      sqlserver.page.buffer_cache.hit_ratio:
-        enabled: true
       sqlserver.page.buffer_cache.free_list.stalls.rate:
-        enabled: true
-      sqlserver.page.life_expectancy:
         enabled: true
       sqlserver.page.lookup.rate:
         enabled: true
       # Batch / Compilation
-      sqlserver.batch.request.rate:
-        enabled: true
-      sqlserver.batch.sql_compilation.rate:
-        enabled: true
-      sqlserver.batch.sql_recompilation.rate:
-        enabled: true
       sqlserver.batch.compilation.utilization:
         enabled: true
       sqlserver.batch.page_split.utilization:
@@ -1069,8 +1248,6 @@ receivers:
       sqlserver.process.count:
         enabled: true
       sqlserver.processes.blocked:
-        enabled: true
-      sqlserver.user.connection.count:
         enabled: true
       sqlserver.login.rate:
         enabled: true
@@ -1132,33 +1309,140 @@ receivers:
       sqlserver.kill_connection.error.rate:
         enabled: true
 
-      events:
-        db.server.query_sample:
-          enabled: true
-        db.server.top_query:
-          enabled: true
+    # Enable top query and query sample log collection
+    events:
+      db.server.query_sample:
+        enabled: true
+      db.server.top_query:
+        enabled: true
 
-      top_query_collection:
-        lookback_time: 60s
-        max_query_sample_count: 1000
-        top_query_count: 250
-        collection_interval: 60s
+    # Top query collection configuration
+    top_query_collection:
+      lookback_time: 60s
+      max_query_sample_count: 500
+      top_query_count: 200
+      collection_interval: 60s
 
-      collect_full_query_text: true
-      allowed_comment_keys:
-        - nr_service_guid
+    collect_full_query_text: true
+    allowed_comment_keys:
+      - nr_service_guid
 
-      query_sample_collection:
-        max_rows_per_query: 100
+    # Query sample collection configuration
+    query_sample_collection:
+      max_rows_per_query: 100
 
 processors:
-  memory_limiter:
-    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  metrics_transform:
+    transforms:
+      - include: system.cpu.utilization
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [state]
+            aggregation_type: mean
+      - include: system.paging.operations
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [direction]
+            aggregation_type: sum
+
+  filter/exclude_cpu_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+  filter/exclude_memory_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+  filter/exclude_memory_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+  filter/exclude_filesystem_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+  filter/exclude_filesystem_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_filesystem_inodes_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_system_disk:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+  filter/exclude_system_paging:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
+        - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
+
+  filter/exclude_network:
+    metrics:
+      datapoint:
+        - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+  attributes/exclude_system_paging:
+    include:
+      match_type: strict
+      metric_names:
+        - system.paging.operations
+    actions:
+      - key: type
+        action: delete
+
+  cumulativetodelta:
+
+  transform/host:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
 
   batch:
 
+  resource_detection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+  resource_detection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: true
+
+  resource_detection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   otlphttp:
@@ -1174,15 +1458,52 @@ service:
     metrics:
       level: none
 
+  extensions: [health_check]
+
   pipelines:
-    metrics:
+    metrics/host:
+      receivers: [host_metrics, nrsqlserver]
+      processors:
+        - metrics_transform
+        - filter/exclude_cpu_utilization
+        - filter/exclude_memory_utilization
+        - filter/exclude_memory_usage
+        - filter/exclude_filesystem_utilization
+        - filter/exclude_filesystem_usage
+        - filter/exclude_filesystem_inodes_usage
+        - filter/exclude_system_disk
+        - filter/exclude_network
+        - attributes/exclude_system_paging
+        - transform/host
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - cumulativetodelta
+        - batch
+      exporters: [otlphttp]
+
+    logs/host:
       receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      processors:
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - batch
+      exporters: [otlphttp]
+
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+      exporters: [otlphttp]
+
+    metrics:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
     logs:
-      receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
       
 ```
@@ -1197,7 +1518,7 @@ The following table describes the key configuration parameters for the nrsqlserv
 
 | Parameter | Description |
 |-----------|-------------|
-| `<HOSTNAME-OR-RDS-ENDPOINT>` | Enter your RDS SQL Server endpoint |
+| `<YOUR_RDS_ENDPOINT>` | Enter your RDS SQL Server endpoint |
 | `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
 | `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint (e.g., https://otlp.nr-data.net). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
 | `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
@@ -1462,7 +1783,7 @@ Use the configuration below with your RDS endpoint:
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+    datasource: "server=<YOUR_RDS_ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
     # Enable comprehensive database metrics
     metrics:
@@ -1523,9 +1844,9 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: <YOUR_NEWRELIC_OTLP_ENDPOINT>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <YOUR_NEWRELIC_LICENSE_KEY>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -1571,25 +1892,78 @@ This configuration provides comprehensive database monitoring with all available
 
 2. Add the configuration content below to the `mssql-config.yaml` file you created in the previous step.
 
-```yaml
-receivers:
-  nrsqlserver:
-    collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
+```yaml
+# NRDOT Collector Configuration for New Relic SQL Server Integration
+extensions:
+  health_check:
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+  host_metrics:
+    collection_interval: 30s
+    scrapers:
+      cpu:
+        metrics:
+          system.cpu.time:
+            enabled: false
+          system.cpu.utilization:
+            enabled: true
+      load:
+      memory:
+        metrics:
+          system.memory.utilization:
+            enabled: true
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: false
+          system.paging.faults:
+            enabled: false
+      disk:
+        metrics:
+          system.disk.merged:
+            enabled: false
+          system.disk.pending_operations:
+            enabled: false
+          system.disk.weighted_io_time:
+            enabled: false
+      network:
+        metrics:
+          system.network.connections:
+            enabled: false
+      processes:
+      process:
+        mute_process_name_error: true
+        mute_process_exe_error: true
+        mute_process_user_error: true
+        mute_process_io_error: true
+        metrics:
+          process.cpu.utilization:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+
+  nrsqlserver:
+    collection_interval: 30s
+    datasource: "server=<YOUR_RDS_ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+
+    # Enable comprehensive database metrics
     metrics:
       # Database
       sqlserver.database.count:
         enabled: true
       sqlserver.database.file.size:
-        enabled: true
+        enabled: true 
       sqlserver.database.io:
         enabled: true
       sqlserver.database.latency:
         enabled: true
       sqlserver.database.operations:
-        enabled: true
-      sqlserver.database.page_file.size:
         enabled: true
       sqlserver.database.transactions.active:
         enabled: true
@@ -1603,46 +1977,15 @@ receivers:
         enabled: true
       sqlserver.database.tempdb.version_store.size:
         enabled: true
-      # Security / Principals
-      sqlserver.database.principals.count:
-        enabled: true
-      sqlserver.database.principals.old:
-        enabled: true
-      sqlserver.database.principals.orphaned_users:
-        enabled: true
-      sqlserver.database.principals.recently_created:
-        enabled: true
-      sqlserver.database.role.members.count:
-        enabled: true
-      sqlserver.database.role.memberships.count:
-        enabled: true
-      sqlserver.database.role.permission.risk_level:
-        enabled: true
-      sqlserver.database.role.roles.count:
-        enabled: true
-      sqlserver.database.security.role_membership.count:
-        enabled: true
-      sqlserver.server.security.principal.count:
-        enabled: true
-      sqlserver.server.security.role_membership.count:
-        enabled: true
       # Locks
-      sqlserver.lock.by_mode.count:
-        enabled: true
-      sqlserver.lock.by_resource.count:
-        enabled: true
       sqlserver.lock.timeout.rate:
         enabled: true
       sqlserver.lock.wait.count:
-        enabled: true
-      sqlserver.lock.wait.rate:
         enabled: true
       sqlserver.deadlock.rate:
         enabled: true
       # Transactions
       sqlserver.transaction.delay:
-        enabled: true
-      sqlserver.transaction.mirror_write.rate:
         enabled: true
       sqlserver.transaction.longest_running_time:
         enabled: true
@@ -1664,8 +2007,6 @@ receivers:
       sqlserver.memory.usage:
         enabled: true
       # OS
-      sqlserver.os.disk.size:
-        enabled: true
       sqlserver.os.memory.usage:
         enabled: true
       sqlserver.os.memory.utilization:
@@ -1677,21 +2018,11 @@ receivers:
       sqlserver.os.wait.tasks.count:
         enabled: true
       # Pages / Buffer
-      sqlserver.page.buffer_cache.hit_ratio:
-        enabled: true
       sqlserver.page.buffer_cache.free_list.stalls.rate:
-        enabled: true
-      sqlserver.page.life_expectancy:
         enabled: true
       sqlserver.page.lookup.rate:
         enabled: true
       # Batch / Compilation
-      sqlserver.batch.request.rate:
-        enabled: true
-      sqlserver.batch.sql_compilation.rate:
-        enabled: true
-      sqlserver.batch.sql_recompilation.rate:
-        enabled: true
       sqlserver.batch.compilation.utilization:
         enabled: true
       sqlserver.batch.page_split.utilization:
@@ -1708,8 +2039,6 @@ receivers:
       sqlserver.process.count:
         enabled: true
       sqlserver.processes.blocked:
-        enabled: true
-      sqlserver.user.connection.count:
         enabled: true
       sqlserver.login.rate:
         enabled: true
@@ -1771,33 +2100,140 @@ receivers:
       sqlserver.kill_connection.error.rate:
         enabled: true
 
-      events:
-        db.server.query_sample:
-          enabled: true
-        db.server.top_query:
-          enabled: true
+    # Enable top query and query sample log collection
+    events:
+      db.server.query_sample:
+        enabled: true
+      db.server.top_query:
+        enabled: true
 
-      top_query_collection:
-        lookback_time: 60s
-        max_query_sample_count: 1000
-        top_query_count: 250
-        collection_interval: 60s
+    # Top query collection configuration
+    top_query_collection:
+      lookback_time: 60s
+      max_query_sample_count: 500
+      top_query_count: 200
+      collection_interval: 60s
 
-      collect_full_query_text: true
-      allowed_comment_keys:
-        - nr_service_guid
+    collect_full_query_text: true
+    allowed_comment_keys:
+      - nr_service_guid
 
-      query_sample_collection:
-        max_rows_per_query: 100
+    # Query sample collection configuration
+    query_sample_collection:
+      max_rows_per_query: 100
 
 processors:
-  memory_limiter:
-    check_interval: ${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       ${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: ${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+  metrics_transform:
+    transforms:
+      - include: system.cpu.utilization
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [state]
+            aggregation_type: mean
+      - include: system.paging.operations
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set: [direction]
+            aggregation_type: sum
+
+  filter/exclude_cpu_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
+        - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
+
+  filter/exclude_memory_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "inactive"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
+        - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
+
+  filter/exclude_memory_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
+        - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
+
+  filter/exclude_filesystem_utilization:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
+
+  filter/exclude_filesystem_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_filesystem_inodes_usage:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
+        - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
+
+  filter/exclude_system_disk:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.disk.operations" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.merged" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
+        - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
+
+  filter/exclude_system_paging:
+    metrics:
+      datapoint:
+        - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
+        - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
+
+  filter/exclude_network:
+    metrics:
+      datapoint:
+        - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
+
+  attributes/exclude_system_paging:
+    include:
+      match_type: strict
+      metric_names:
+        - system.paging.operations
+    actions:
+      - key: type
+        action: delete
+
+  cumulativetodelta:
+
+  transform/host:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
 
   batch:
 
+  resource_detection:
+    detectors: ["system"]
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+  resource_detection/cloud:
+    detectors: ["gcp", "ec2", "azure"]
+    timeout: 2s
+    override: true
+
+  resource_detection/env:
+    detectors: ["env"]
+    timeout: 2s
+    override: true
 
 exporters:
   otlphttp:
@@ -1813,17 +2249,54 @@ service:
     metrics:
       level: none
 
+  extensions: [health_check]
+
   pipelines:
-    metrics:
+    metrics/host:
+      receivers: [host_metrics, nrsqlserver]
+      processors:
+        - metrics_transform
+        - filter/exclude_cpu_utilization
+        - filter/exclude_memory_utilization
+        - filter/exclude_memory_usage
+        - filter/exclude_filesystem_utilization
+        - filter/exclude_filesystem_usage
+        - filter/exclude_filesystem_inodes_usage
+        - filter/exclude_system_disk
+        - filter/exclude_network
+        - attributes/exclude_system_paging
+        - transform/host
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - cumulativetodelta
+        - batch
+      exporters: [otlphttp]
+
+    logs/host:
       receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      processors:
+        - resource_detection
+        - resource_detection/cloud
+        - resource_detection/env
+        - batch
+      exporters: [otlphttp]
+
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
+      exporters: [otlphttp]
+
+    metrics:
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
 
     logs:
-      receivers: [nrsqlserver]
-      processors: [memory_limiter, batch]
+      receivers: [otlp]
+      processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
+      
 ```
 
 </Collapser>
@@ -1836,7 +2309,7 @@ The following table describes the key configuration parameters for the nrsqlserv
 
 | Parameter | Description |
 |-----------|-------------|
-| `<HOSTNAME-OR-RDS-ENDPOINT>` | Enter your RDS SQL Server endpoint |
+| `<YOUR_RDS_ENDPOINT>` | Enter your RDS SQL Server endpoint |
 | `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
 | `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
 | `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -1308,29 +1308,24 @@ receivers:
       # Errors
       sqlserver.kill_connection.error.rate:
         enabled: true
-
     # Enable top query and query sample log collection
     events:
       db.server.query_sample:
         enabled: true
       db.server.top_query:
         enabled: true
-
     # Top query collection configuration
     top_query_collection:
       lookback_time: 60s
       max_query_sample_count: 500
       top_query_count: 200
       collection_interval: 60s
-
     collect_full_query_text: true
     allowed_comment_keys:
       - nr_service_guid
-
     # Query sample collection configuration
     query_sample_collection:
       max_rows_per_query: 100
-
 processors:
   metrics_transform:
     transforms:
@@ -1346,14 +1341,12 @@ processors:
           - action: aggregate_labels
             label_set: [direction]
             aggregation_type: sum
-
   filter/exclude_cpu_utilization:
     metrics:
       datapoint:
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
-
   filter/exclude_memory_utilization:
     metrics:
       datapoint:
@@ -1362,30 +1355,25 @@ processors:
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
-
   filter/exclude_memory_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
         - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
-
   filter/exclude_filesystem_utilization:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
-
   filter/exclude_filesystem_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
         - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
-
   filter/exclude_filesystem_inodes_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
         - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
-
   filter/exclude_system_disk:
     metrics:
       datapoint:
@@ -1394,18 +1382,15 @@ processors:
         - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
         - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
         - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
-
   filter/exclude_system_paging:
     metrics:
       datapoint:
         - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
         - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
-
   filter/exclude_network:
     metrics:
       datapoint:
         - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
-
   attributes/exclude_system_paging:
     include:
       match_type: strict
@@ -1414,18 +1399,14 @@ processors:
     actions:
       - key: type
         action: delete
-
   cumulativetodelta:
-
   transform/host:
     metric_statements:
       - context: metric
         statements:
           - set(metric.description, "")
           - set(metric.unit, "")
-
   batch:
-
   resource_detection:
     detectors: ["system"]
     system:
@@ -1433,17 +1414,14 @@ processors:
       resource_attributes:
         host.id:
           enabled: true
-
   resource_detection/cloud:
     detectors: ["gcp", "ec2", "azure"]
     timeout: 2s
     override: true
-
   resource_detection/env:
     detectors: ["env"]
     timeout: 2s
     override: true
-
 exporters:
   otlphttp:
     endpoint: <YOUR_OTLP_ENDPOINT>
@@ -1452,14 +1430,11 @@ exporters:
     tls:
       insecure: false
     compression: gzip
-
 service:
   telemetry:
     metrics:
       level: none
-
   extensions: [health_check]
-
   pipelines:
     metrics/host:
       receivers: [host_metrics, nrsqlserver]
@@ -1481,7 +1456,6 @@ service:
         - cumulativetodelta
         - batch
       exporters: [otlphttp]
-
     logs/host:
       receivers: [nrsqlserver]
       processors:
@@ -1490,17 +1464,14 @@ service:
         - resource_detection/env
         - batch
       exporters: [otlphttp]
-
     traces:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
     metrics:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
     logs:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
@@ -2099,29 +2070,24 @@ receivers:
       # Errors
       sqlserver.kill_connection.error.rate:
         enabled: true
-
     # Enable top query and query sample log collection
     events:
       db.server.query_sample:
         enabled: true
       db.server.top_query:
         enabled: true
-
     # Top query collection configuration
     top_query_collection:
       lookback_time: 60s
       max_query_sample_count: 500
       top_query_count: 200
       collection_interval: 60s
-
     collect_full_query_text: true
     allowed_comment_keys:
       - nr_service_guid
-
     # Query sample collection configuration
     query_sample_collection:
       max_rows_per_query: 100
-
 processors:
   metrics_transform:
     transforms:
@@ -2137,14 +2103,12 @@ processors:
           - action: aggregate_labels
             label_set: [direction]
             aggregation_type: sum
-
   filter/exclude_cpu_utilization:
     metrics:
       datapoint:
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "interrupt"'
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "nice"'
         - 'metric.name == "system.cpu.utilization" and attributes["state"] == "softirq"'
-
   filter/exclude_memory_utilization:
     metrics:
       datapoint:
@@ -2153,30 +2117,25 @@ processors:
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "cached"'
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "buffered"'
         - 'metric.name == "system.memory.utilization" and attributes["state"] == "slab_reclaimable"'
-
   filter/exclude_memory_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.memory.usage" and attributes["state"] == "slab_unreclaimable"'
         - 'metric.name == "system.memory.usage" and attributes["state"] == "inactive"'
-
   filter/exclude_filesystem_utilization:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.utilization" and attributes["type"] == "squashfs"'
-
   filter/exclude_filesystem_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.usage" and attributes["type"] == "squashfs"'
         - 'metric.name == "system.filesystem.usage" and attributes["state"] == "reserved"'
-
   filter/exclude_filesystem_inodes_usage:
     metrics:
       datapoint:
         - 'metric.name == "system.filesystem.inodes.usage" and attributes["type"] == "squashfs"'
         - 'metric.name == "system.filesystem.inodes.usage" and attributes["state"] == "reserved"'
-
   filter/exclude_system_disk:
     metrics:
       datapoint:
@@ -2185,18 +2144,15 @@ processors:
         - 'metric.name == "system.disk.io" and IsMatch(attributes["device"], "^loop.*") == true'
         - 'metric.name == "system.disk.io_time" and IsMatch(attributes["device"], "^loop.*") == true'
         - 'metric.name == "system.disk.operation_time" and IsMatch(attributes["device"], "^loop.*") == true'
-
   filter/exclude_system_paging:
     metrics:
       datapoint:
         - 'metric.name == "system.paging.usage" and attributes["state"] == "cached"'
         - 'metric.name == "system.paging.operations" and attributes["type"] == "cached"'
-
   filter/exclude_network:
     metrics:
       datapoint:
         - 'IsMatch(metric.name, "^system.network.*") == true and attributes["device"] == "lo"'
-
   attributes/exclude_system_paging:
     include:
       match_type: strict
@@ -2205,18 +2161,14 @@ processors:
     actions:
       - key: type
         action: delete
-
   cumulativetodelta:
-
   transform/host:
     metric_statements:
       - context: metric
         statements:
           - set(metric.description, "")
           - set(metric.unit, "")
-
   batch:
-
   resource_detection:
     detectors: ["system"]
     system:
@@ -2224,17 +2176,14 @@ processors:
       resource_attributes:
         host.id:
           enabled: true
-
   resource_detection/cloud:
     detectors: ["gcp", "ec2", "azure"]
     timeout: 2s
     override: true
-
   resource_detection/env:
     detectors: ["env"]
     timeout: 2s
     override: true
-
 exporters:
   otlphttp:
     endpoint: <YOUR_OTLP_ENDPOINT>
@@ -2243,14 +2192,11 @@ exporters:
     tls:
       insecure: false
     compression: gzip
-
 service:
   telemetry:
     metrics:
       level: none
-
   extensions: [health_check]
-
   pipelines:
     metrics/host:
       receivers: [host_metrics, nrsqlserver]
@@ -2272,7 +2218,6 @@ service:
         - cumulativetodelta
         - batch
       exporters: [otlphttp]
-
     logs/host:
       receivers: [nrsqlserver]
       processors:
@@ -2281,17 +2226,14 @@ service:
         - resource_detection/env
         - batch
       exporters: [otlphttp]
-
     traces:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
     metrics:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]
       exporters: [otlphttp]
-
     logs:
       receivers: [otlp]
       processors: [resource_detection, resource_detection/cloud, resource_detection/env, batch]

--- a/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/windows-rds.mdx
@@ -11,7 +11,6 @@ metaDescription: Set up Microsoft SQL Server monitoring with NRDOT collector on 
 freshnessValidatedDate: never
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
 
 
 <Callout title="Preview">
@@ -144,61 +143,14 @@ This configuration focuses on essential database monitoring with core metrics.
 
 2. **Add the configuration content below to the mssql-config.yaml file** you created in the previous step.
 
-**Enter your values below and see the configuration update in real-time:**
-
-<AgentConfig
-  inputOptions={[
-    {
-      name: 'username',
-      label: 'SQL Server Username',
-      codeLine: 4,
-      defaultValue: 'newrelic',
-      toolTip: 'Enter your SQL Server username',
-    },
-    {
-      name: 'password',
-      label: 'SQL Server Password',
-      codeLine: 5,
-      defaultValue: 'your_password',
-      toolTip: 'Enter your SQL Server password',
-    },
-    {
-      name: 'server',
-      label: 'RDS Endpoint',
-      codeLine: 6,
-      defaultValue: 'mydb-instance.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com',
-      toolTip: 'Enter your RDS SQL Server endpoint',
-    },
-    {
-      name: 'port',
-      label: 'Server Port',
-      codeLine: 7,
-      defaultValue: '1433',
-      toolTip: 'Enter your SQL Server port number (default: 1433)',
-    },
-    {
-      name: 'endpoint',
-      label: 'New Relic OTLP Endpoint',
-      codeLine: 69,
-      defaultValue: 'https://otlp.nr-data.net:4318',
-      toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
-    },
-    {
-      name: 'licenseKey',
-      label: 'New Relic License Key',
-      codeLine: 71,
-      defaultValue: 'YOUR_LICENSE_KEY',
-      toolTip: 'Enter your New Relic license key',
-    },
-  ]}
-  config={`
+```yaml
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    username: <input1>
-    password: <input2>
-    server: <input3>
-    port: <input4>
+    username: <YOUR_USERNAME>
+    password: <YOUR_PASSWORD>
+    server: <YOUR_SERVER>
+    port: <YOUR_PORT>
 
     # Enable comprehensive database metrics
     metrics:
@@ -249,346 +201,19 @@ receivers:
     query_sample_collection:
       max_rows_per_query: 100
 
-    processors:
-      memory_limiter:
-        check_interval: $\{env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-        limit_mib:       $\{env:NR_MEM_LIMITER_LIMIT_MIB:-200}
-        spike_limit_mib: $\{env:NR_MEM_LIMITER_SPIKE_MIB:-50}
-
-      batch:
-
-    exporters:
-      otlphttp:
-        endpoint: <input5>
-        headers:
-          api-key: <input6>
-        tls:
-          insecure: false
-        compression: gzip
-
-    service:
-      telemetry:
-        metrics:
-          level: none
-
-      pipelines:
-        metrics:
-          receivers: [nrsqlserver]
-          processors: [memory_limiter, batch]
-          exporters: [otlphttp]
-
-        logs:
-          receivers: [nrsqlserver]
-          processors: [memory_limiter, batch]
-          exporters: [otlphttp]`}
-  fileName="mssql-config.yaml"
-  tipMdx={{ body: null }}
-  onChange={() => {}}
-/>
-
-</Collapser>
-
-<Collapser
-  id="all"
-  title="Full-feature configuration"
->
-
-This configuration provides comprehensive database monitoring with all available metrics.
-
-<Callout variant="tip">
-  **RDS Endpoint Format:** Your RDS endpoint uses the format: `YOUR_DB_INSTANCE.YOUR_AWS_IDENTIFIER.YOUR_REGION.rds.amazonaws.com` (for example, `mydb-instance.c9akciq32.us-east-1.rds.amazonaws.com`). Locate this in the **AWS RDS console** under **Connectivity & security**.
-</Callout>
-
-1. **Create the configuration file.** The filename must be `mssql-config.yaml`. Run the following command in PowerShell as Administrator:
-
-   ```powershell
-   New-Item -Path "C:\Program Files\nrdot-collector\mssql-config.yaml" -ItemType File
-   ```
-
-2. Add the configuration content below to the `mssql-config.yaml` file you created in the previous step.
-
-**Enter your values below and see the configuration update in real-time:**
-
-<AgentConfig
-  inputOptions={[
-    {
-      name: 'username',
-      label: 'SQL Server Username',
-      codeLine: 4,
-      defaultValue: 'newrelic',
-      toolTip: 'Enter your SQL Server username',
-    },
-    {
-      name: 'password',
-      label: 'SQL Server Password',
-      codeLine: 5,
-      defaultValue: 'your_password',
-      toolTip: 'Enter your SQL Server password',
-    },
-    {
-      name: 'server',
-      label: 'RDS Endpoint',
-      codeLine: 6,
-      defaultValue: 'mydb-instance.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com',
-      toolTip: 'Enter your RDS SQL Server endpoint',
-    },
-    {
-      name: 'port',
-      label: 'Server Port',
-      codeLine: 7,
-      defaultValue: '1433',
-      toolTip: 'Enter your SQL Server port number (default: 1433)',
-    },
-    {
-      name: 'endpoint',
-      label: 'New Relic OTLP Endpoint',
-      codeLine: 233,
-      defaultValue: 'https://otlp.nr-data.net:4318',
-      toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
-    },
-    {
-      name: 'licenseKey',
-      label: 'New Relic License Key',
-      codeLine: 235,
-      defaultValue: 'YOUR_LICENSE_KEY',
-      toolTip: 'Enter your New Relic license key',
-    },
-  ]}
-  config={`receivers:
-nrsqlserver:
-  collection_interval: 15s
-  username: <input1>
-  password: <input2>
-  server: <input3>
-  port: <input4>
-
-  metrics:
-    # Database
-    sqlserver.database.count:
-      enabled: true
-    sqlserver.database.file.size:
-      enabled: true
-    sqlserver.database.io:
-      enabled: true
-    sqlserver.database.latency:
-      enabled: true
-    sqlserver.database.operations:
-      enabled: true
-    sqlserver.database.page_file.size:
-      enabled: true
-    sqlserver.database.transactions.active:
-      enabled: true
-    sqlserver.database.backup_or_restore.rate:
-      enabled: true
-    sqlserver.database.execution.errors:
-      enabled: true
-    sqlserver.database.full_scan.rate:
-      enabled: true
-    sqlserver.database.tempdb.space:
-      enabled: true
-    sqlserver.database.tempdb.version_store.size:
-      enabled: true
-    # Security / Principals
-    sqlserver.database.principals.count:
-      enabled: true
-    sqlserver.database.principals.old:
-      enabled: true
-    sqlserver.database.principals.orphaned_users:
-      enabled: true
-    sqlserver.database.principals.recently_created:
-      enabled: true
-    sqlserver.database.role.members.count:
-      enabled: true
-    sqlserver.database.role.memberships.count:
-      enabled: true
-    sqlserver.database.role.permission.risk_level:
-      enabled: true
-    sqlserver.database.role.roles.count:
-      enabled: true
-    sqlserver.database.security.role_membership.count:
-      enabled: true
-    sqlserver.server.security.principal.count:
-      enabled: true
-    sqlserver.server.security.role_membership.count:
-      enabled: true
-    # Locks
-    sqlserver.lock.by_mode.count:
-      enabled: true
-    sqlserver.lock.by_resource.count:
-      enabled: true
-    sqlserver.lock.timeout.rate:
-      enabled: true
-    sqlserver.lock.wait.count:
-      enabled: true
-    sqlserver.lock.wait.rate:
-      enabled: true
-    sqlserver.deadlock.rate:
-      enabled: true
-    # Transactions
-    sqlserver.transaction.delay:
-      enabled: true
-    sqlserver.transaction.mirror_write.rate:
-      enabled: true
-    sqlserver.transaction.longest_running_time:
-      enabled: true
-    sqlserver.transaction.version_cleanup.rate:
-      enabled: true
-    sqlserver.transaction.version_generation.rate:
-      enabled: true
-    # Memory
-    sqlserver.memory.area:
-      enabled: true
-    sqlserver.memory.cache.object.count:
-      enabled: true
-    sqlserver.memory.grants.pending.count:
-      enabled: true
-    sqlserver.memory.page.count:
-      enabled: true
-    sqlserver.memory.target:
-      enabled: true
-    sqlserver.memory.usage:
-      enabled: true
-    # OS
-    sqlserver.os.disk.size:
-      enabled: true
-    sqlserver.os.memory.usage:
-      enabled: true
-    sqlserver.os.memory.utilization:
-      enabled: true
-    sqlserver.os.scheduler.runnable_tasks.count:
-      enabled: true
-    sqlserver.os.wait.duration:
-      enabled: true
-    sqlserver.os.wait.tasks.count:
-      enabled: true
-    # Pages / Buffer
-    sqlserver.page.buffer_cache.hit_ratio:
-      enabled: true
-    sqlserver.page.buffer_cache.free_list.stalls.rate:
-      enabled: true
-    sqlserver.page.life_expectancy:
-      enabled: true
-    sqlserver.page.lookup.rate:
-      enabled: true
-    # Batch / Compilation
-    sqlserver.batch.request.rate:
-      enabled: true
-    sqlserver.batch.sql_compilation.rate:
-      enabled: true
-    sqlserver.batch.sql_recompilation.rate:
-      enabled: true
-    sqlserver.batch.compilation.utilization:
-      enabled: true
-    sqlserver.batch.page_split.utilization:
-      enabled: true
-    sqlserver.recompilation.ratio:
-      enabled: true
-    sqlserver.parameterization.rate:
-      enabled: true
-    sqlserver.plan.execution.rate:
-      enabled: true
-    sqlserver.attention.rate:
-      enabled: true
-    # Processes / Connections
-    sqlserver.process.count:
-      enabled: true
-    sqlserver.processes.blocked:
-      enabled: true
-    sqlserver.user.connection.count:
-      enabled: true
-    sqlserver.login.rate:
-      enabled: true
-    sqlserver.logout.rate:
-      enabled: true
-    # Thread Pool
-    sqlserver.thread_pool.tasks.count:
-      enabled: true
-    sqlserver.thread_pool.workers.count:
-      enabled: true
-    sqlserver.thread_pool.workers.max:
-      enabled: true
-    sqlserver.thread_pool.workers.utilization:
-      enabled: true
-    # TempDB
-    sqlserver.tempdb.allocation.wait_time.total:
-      enabled: true
-    sqlserver.tempdb.contention.waiters.count:
-      enabled: true
-    sqlserver.tempdb.data_files.count:
-      enabled: true
-    sqlserver.tempdb.file.size:
-      enabled: true
-    sqlserver.tempdb.space.usage:
-      enabled: true
-    # Latch
-    sqlserver.latch.superlatch.count:
-      enabled: true
-    sqlserver.latch.superlatch.transition.rate:
-      enabled: true
-    sqlserver.latch.wait.rate:
-      enabled: true
-    sqlserver.latch.wait_time.avg:
-      enabled: true
-    sqlserver.latch.wait_time.total:
-      enabled: true
-    # Index
-    sqlserver.index.search.rate:
-      enabled: true
-    # Resource Pool
-    sqlserver.resource_pool.disk.operations:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.read.rate:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.write.rate:
-      enabled: true
-    # Replica / Always-On
-    sqlserver.replica.data.rate:
-      enabled: true
-    # Server Properties
-    sqlserver.computer.uptime:
-      enabled: true
-    sqlserver.cpu.count:
-      enabled: true
-    # Tables
-    sqlserver.table.count:
-      enabled: true
-    # Errors
-    sqlserver.kill_connection.error.rate:
-      enabled: true
-
-    events:
-      db.server.query_sample:
-        enabled: true
-      db.server.top_query:
-        enabled: true
-
-    top_query_collection:
-      lookback_time: 60s
-      max_query_sample_count: 1000
-      top_query_count: 250
-      collection_interval: 60s
-
-    collect_full_query_text: true
-    allowed_comment_keys:
-      - nr_service_guid
-
-    query_sample_collection:
-      max_rows_per_query: 100
-
 processors:
   memory_limiter:
-    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
-    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
-    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+    check_interval: $\{env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       $\{env:NR_MEM_LIMITER_LIMIT_MIB:-200}
+    spike_limit_mib: $\{env:NR_MEM_LIMITER_SPIKE_MIB:-50}
 
   batch:
 
-
 exporters:
   otlphttp:
-    endpoint: <input5>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <input6>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -607,11 +232,288 @@ service:
     logs:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp]`}
-  fileName="mssql-config.yaml"
-  tipMdx={{ body: null }}
-  onChange={() => {}}
-/>
+      exporters: [otlphttp]
+
+```
+
+</Collapser>
+
+<Collapser
+  id="all"
+  title="Full-feature configuration">
+
+This configuration provides comprehensive database monitoring with all available metrics.
+
+<Callout variant="tip">
+  **RDS Endpoint Format:** Your RDS endpoint uses the format: `YOUR_DB_INSTANCE.YOUR_AWS_IDENTIFIER.YOUR_REGION.rds.amazonaws.com` (for example, `mydb-instance.c9akciq32.us-east-1.rds.amazonaws.com`). Locate this in the **AWS RDS console** under **Connectivity & security**.
+</Callout>
+
+1. **Create the configuration file.** The filename must be `mssql-config.yaml`. Run the following command in PowerShell as Administrator:
+
+   ```powershell
+   New-Item -Path "C:\Program Files\nrdot-collector\mssql-config.yaml" -ItemType File
+   ```
+
+2. Add the configuration content below to the `mssql-config.yaml` file you created in the previous step.
+
+```yaml
+
+receivers:
+  nrsqlserver:
+    collection_interval: 15s
+    username: <YOUR_USERNAME>
+    password: <YOUR_PASSWORD>
+    server: <YOUR_SERVER>
+    port: <YOUR_PORT>
+
+    metrics:
+      # Database
+      sqlserver.database.count:
+        enabled: true
+      sqlserver.database.file.size:
+        enabled: true
+      sqlserver.database.io:
+        enabled: true
+      sqlserver.database.latency:
+        enabled: true
+      sqlserver.database.operations:
+        enabled: true
+      sqlserver.database.page_file.size:
+        enabled: true
+      sqlserver.database.transactions.active:
+        enabled: true
+      sqlserver.database.backup_or_restore.rate:
+        enabled: true
+      sqlserver.database.execution.errors:
+        enabled: true
+      sqlserver.database.full_scan.rate:
+        enabled: true
+      sqlserver.database.tempdb.space:
+        enabled: true
+      sqlserver.database.tempdb.version_store.size:
+        enabled: true
+      # Security / Principals
+      sqlserver.database.principals.count:
+        enabled: true
+      sqlserver.database.principals.old:
+        enabled: true
+      sqlserver.database.principals.orphaned_users:
+        enabled: true
+      sqlserver.database.principals.recently_created:
+        enabled: true
+      sqlserver.database.role.members.count:
+        enabled: true
+      sqlserver.database.role.memberships.count:
+        enabled: true
+      sqlserver.database.role.permission.risk_level:
+        enabled: true
+      sqlserver.database.role.roles.count:
+        enabled: true
+      sqlserver.database.security.role_membership.count:
+        enabled: true
+      sqlserver.server.security.principal.count:
+        enabled: true
+      sqlserver.server.security.role_membership.count:
+        enabled: true
+      # Locks
+      sqlserver.lock.by_mode.count:
+        enabled: true
+      sqlserver.lock.by_resource.count:
+        enabled: true
+      sqlserver.lock.timeout.rate:
+        enabled: true
+      sqlserver.lock.wait.count:
+        enabled: true
+      sqlserver.lock.wait.rate:
+        enabled: true
+      sqlserver.deadlock.rate:
+        enabled: true
+      # Transactions
+      sqlserver.transaction.delay:
+        enabled: true
+      sqlserver.transaction.mirror_write.rate:
+        enabled: true
+      sqlserver.transaction.longest_running_time:
+        enabled: true
+      sqlserver.transaction.version_cleanup.rate:
+        enabled: true
+      sqlserver.transaction.version_generation.rate:
+        enabled: true
+      # Memory
+      sqlserver.memory.area:
+        enabled: true
+      sqlserver.memory.cache.object.count:
+        enabled: true
+      sqlserver.memory.grants.pending.count:
+        enabled: true
+      sqlserver.memory.page.count:
+        enabled: true
+      sqlserver.memory.target:
+        enabled: true
+      sqlserver.memory.usage:
+        enabled: true
+      # OS
+      sqlserver.os.disk.size:
+        enabled: true
+      sqlserver.os.memory.usage:
+        enabled: true
+      sqlserver.os.memory.utilization:
+        enabled: true
+      sqlserver.os.scheduler.runnable_tasks.count:
+        enabled: true
+      sqlserver.os.wait.duration:
+        enabled: true
+      sqlserver.os.wait.tasks.count:
+        enabled: true
+      # Pages / Buffer
+      sqlserver.page.buffer_cache.hit_ratio:
+        enabled: true
+      sqlserver.page.buffer_cache.free_list.stalls.rate:
+        enabled: true
+      sqlserver.page.life_expectancy:
+        enabled: true
+      sqlserver.page.lookup.rate:
+        enabled: true
+      # Batch / Compilation
+      sqlserver.batch.request.rate:
+        enabled: true
+      sqlserver.batch.sql_compilation.rate:
+        enabled: true
+      sqlserver.batch.sql_recompilation.rate:
+        enabled: true
+      sqlserver.batch.compilation.utilization:
+        enabled: true
+      sqlserver.batch.page_split.utilization:
+        enabled: true
+      sqlserver.recompilation.ratio:
+        enabled: true
+      sqlserver.parameterization.rate:
+        enabled: true
+      sqlserver.plan.execution.rate:
+        enabled: true
+      sqlserver.attention.rate:
+        enabled: true
+      # Processes / Connections
+      sqlserver.process.count:
+        enabled: true
+      sqlserver.processes.blocked:
+        enabled: true
+      sqlserver.user.connection.count:
+        enabled: true
+      sqlserver.login.rate:
+        enabled: true
+      sqlserver.logout.rate:
+        enabled: true
+      # Thread Pool
+      sqlserver.thread_pool.tasks.count:
+        enabled: true
+      sqlserver.thread_pool.workers.count:
+        enabled: true
+      sqlserver.thread_pool.workers.max:
+        enabled: true
+      sqlserver.thread_pool.workers.utilization:
+        enabled: true
+      # TempDB
+      sqlserver.tempdb.allocation.wait_time.total:
+        enabled: true
+      sqlserver.tempdb.contention.waiters.count:
+        enabled: true
+      sqlserver.tempdb.data_files.count:
+        enabled: true
+      sqlserver.tempdb.file.size:
+        enabled: true
+      sqlserver.tempdb.space.usage:
+        enabled: true
+      # Latch
+      sqlserver.latch.superlatch.count:
+        enabled: true
+      sqlserver.latch.superlatch.transition.rate:
+        enabled: true
+      sqlserver.latch.wait.rate:
+        enabled: true
+      sqlserver.latch.wait_time.avg:
+        enabled: true
+      sqlserver.latch.wait_time.total:
+        enabled: true
+      # Index
+      sqlserver.index.search.rate:
+        enabled: true
+      # Resource Pool
+      sqlserver.resource_pool.disk.operations:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.read.rate:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.write.rate:
+        enabled: true
+      # Replica / Always-On
+      sqlserver.replica.data.rate:
+        enabled: true
+      # Server Properties
+      sqlserver.computer.uptime:
+        enabled: true
+      sqlserver.cpu.count:
+        enabled: true
+      # Tables
+      sqlserver.table.count:
+        enabled: true
+      # Errors
+      sqlserver.kill_connection.error.rate:
+        enabled: true
+
+      events:
+        db.server.query_sample:
+          enabled: true
+        db.server.top_query:
+          enabled: true
+
+      top_query_collection:
+        lookback_time: 60s
+        max_query_sample_count: 1000
+        top_query_count: 250
+        collection_interval: 60s
+
+      collect_full_query_text: true
+      allowed_comment_keys:
+        - nr_service_guid
+
+      query_sample_collection:
+        max_rows_per_query: 100
+
+processors:
+  memory_limiter:
+    check_interval: \${env:NR_MEM_LIMITER_CHECK_INTERVAL:-1s}
+    limit_mib:       \${env:NR_MEM_LIMITER_LIMIT_MIB:-500}
+    spike_limit_mib: \${env:NR_MEM_LIMITER_SPIKE_MIB:-50}
+
+  batch:
+
+
+exporters:
+  otlphttp:
+    endpoint: <YOUR_OTLP_ENDPOINT>
+    headers:
+      api-key: <YOUR_LICENSE_KEY>
+    tls:
+      insecure: false
+    compression: gzip
+
+service:
+  telemetry:
+    metrics:
+      level: none
+
+  pipelines:
+    metrics:
+      receivers: [nrsqlserver]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp]
+
+    logs:
+      receivers: [nrsqlserver]
+      processors: [memory_limiter, batch]
+      exporters: [otlphttp]
+
+```
 
 </Collapser>
 
@@ -623,12 +525,13 @@ The following table describes the key configuration parameters for the nrsqlserv
 
 | Parameter | Description |
 |-----------|-------------|
-| `username` | Enter your database username for authentication |
-| `password` | Enter your database password for authentication |
-| `server` | Enter your RDS SQL Server endpoint |
+| `<YOUR_USERNAME>` | Enter your database username for authentication |
+| `<YOUR_PASSWORD>` | Enter your database password for authentication |
+| `<YOUR_SERVER>` | Enter your SQL Server hostname or IP address |
 | `port` | Enter your SQL Server port number. The default value is 1433. |
-| `endpoint` | Enter the New Relic OTLP endpoint . For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
-| `licenseKey` | Enter your New Relic license key. |
+| `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
+| `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
+| `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
 
 <Callout variant="tip">
 **Note:** The `max_concurrent_queries` option controls how many metric queries the receiver executes in parallel against SQL Server during each scrape cycle.
@@ -909,7 +812,7 @@ Use the configuration below with your RDS endpoint:
 receivers:
   nrsqlserver:
     collection_interval: 15s
-    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
+    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
     # Enable comprehensive database metrics
     metrics:
@@ -1029,249 +932,224 @@ This configuration provides comprehensive database monitoring with all available
 
 2. **Add the configuration content below to the mssql-config.yaml file** you created in the previous step.
 
-**Enter your values below and see the configuration update in real-time:**
+```yaml
+receivers:
+  nrsqlserver:
+    collection_interval: 15s
+    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
-<AgentConfig
-  inputOptions={[
-    {
-      name: 'server',
-      label: 'RDS Endpoint',
-      codeLine: 4,
-      defaultValue: 'mydb-instance.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com',
-      toolTip: 'Enter your RDS SQL Server endpoint',
-    },
-    {
-      name: 'endpoint',
-      label: 'New Relic OTLP Endpoint',
-      codeLine: 230,
-      defaultValue: 'https://otlp.nr-data.net:4318',
-      toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
-    },
-    {
-      name: 'licenseKey',
-      label: 'New Relic License Key',
-      codeLine: 232,
-      defaultValue: 'YOUR_LICENSE_KEY',
-      toolTip: 'Enter your New Relic license key',
-    },
-  ]}
-  config={`receivers:
-nrsqlserver:
-  collection_interval: 15s
-  datasource: "server=<input1>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
-
-  metrics:
-    # Database
-    sqlserver.database.count:
-      enabled: true
-    sqlserver.database.file.size:
-      enabled: true
-    sqlserver.database.io:
-      enabled: true
-    sqlserver.database.latency:
-      enabled: true
-    sqlserver.database.operations:
-      enabled: true
-    sqlserver.database.page_file.size:
-      enabled: true
-    sqlserver.database.transactions.active:
-      enabled: true
-    sqlserver.database.backup_or_restore.rate:
-      enabled: true
-    sqlserver.database.execution.errors:
-      enabled: true
-    sqlserver.database.full_scan.rate:
-      enabled: true
-    sqlserver.database.tempdb.space:
-      enabled: true
-    sqlserver.database.tempdb.version_store.size:
-      enabled: true
-    # Security / Principals
-    sqlserver.database.principals.count:
-      enabled: true
-    sqlserver.database.principals.old:
-      enabled: true
-    sqlserver.database.principals.orphaned_users:
-      enabled: true
-    sqlserver.database.principals.recently_created:
-      enabled: true
-    sqlserver.database.role.members.count:
-      enabled: true
-    sqlserver.database.role.memberships.count:
-      enabled: true
-    sqlserver.database.role.permission.risk_level:
-      enabled: true
-    sqlserver.database.role.roles.count:
-      enabled: true
-    sqlserver.database.security.role_membership.count:
-      enabled: true
-    sqlserver.server.security.principal.count:
-      enabled: true
-    sqlserver.server.security.role_membership.count:
-      enabled: true
-    # Locks
-    sqlserver.lock.by_mode.count:
-      enabled: true
-    sqlserver.lock.by_resource.count:
-      enabled: true
-    sqlserver.lock.timeout.rate:
-      enabled: true
-    sqlserver.lock.wait.count:
-      enabled: true
-    sqlserver.lock.wait.rate:
-      enabled: true
-    sqlserver.deadlock.rate:
-      enabled: true
-    # Transactions
-    sqlserver.transaction.delay:
-      enabled: true
-    sqlserver.transaction.mirror_write.rate:
-      enabled: true
-    sqlserver.transaction.longest_running_time:
-      enabled: true
-    sqlserver.transaction.version_cleanup.rate:
-      enabled: true
-    sqlserver.transaction.version_generation.rate:
-      enabled: true
-    # Memory
-    sqlserver.memory.area:
-      enabled: true
-    sqlserver.memory.cache.object.count:
-      enabled: true
-    sqlserver.memory.grants.pending.count:
-      enabled: true
-    sqlserver.memory.page.count:
-      enabled: true
-    sqlserver.memory.target:
-      enabled: true
-    sqlserver.memory.usage:
-      enabled: true
-    # OS
-    sqlserver.os.disk.size:
-      enabled: true
-    sqlserver.os.memory.usage:
-      enabled: true
-    sqlserver.os.memory.utilization:
-      enabled: true
-    sqlserver.os.scheduler.runnable_tasks.count:
-      enabled: true
-    sqlserver.os.wait.duration:
-      enabled: true
-    sqlserver.os.wait.tasks.count:
-      enabled: true
-    # Pages / Buffer
-    sqlserver.page.buffer_cache.hit_ratio:
-      enabled: true
-    sqlserver.page.buffer_cache.free_list.stalls.rate:
-      enabled: true
-    sqlserver.page.life_expectancy:
-      enabled: true
-    sqlserver.page.lookup.rate:
-      enabled: true
-    # Batch / Compilation
-    sqlserver.batch.request.rate:
-      enabled: true
-    sqlserver.batch.sql_compilation.rate:
-      enabled: true
-    sqlserver.batch.sql_recompilation.rate:
-      enabled: true
-    sqlserver.batch.compilation.utilization:
-      enabled: true
-    sqlserver.batch.page_split.utilization:
-      enabled: true
-    sqlserver.recompilation.ratio:
-      enabled: true
-    sqlserver.parameterization.rate:
-      enabled: true
-    sqlserver.plan.execution.rate:
-      enabled: true
-    sqlserver.attention.rate:
-      enabled: true
-    # Processes / Connections
-    sqlserver.process.count:
-      enabled: true
-    sqlserver.processes.blocked:
-      enabled: true
-    sqlserver.user.connection.count:
-      enabled: true
-    sqlserver.login.rate:
-      enabled: true
-    sqlserver.logout.rate:
-      enabled: true
-    # Thread Pool
-    sqlserver.thread_pool.tasks.count:
-      enabled: true
-    sqlserver.thread_pool.workers.count:
-      enabled: true
-    sqlserver.thread_pool.workers.max:
-      enabled: true
-    sqlserver.thread_pool.workers.utilization:
-      enabled: true
-    # TempDB
-    sqlserver.tempdb.allocation.wait_time.total:
-      enabled: true
-    sqlserver.tempdb.contention.waiters.count:
-      enabled: true
-    sqlserver.tempdb.data_files.count:
-      enabled: true
-    sqlserver.tempdb.file.size:
-      enabled: true
-    sqlserver.tempdb.space.usage:
-      enabled: true
-    # Latch
-    sqlserver.latch.superlatch.count:
-      enabled: true
-    sqlserver.latch.superlatch.transition.rate:
-      enabled: true
-    sqlserver.latch.wait.rate:
-      enabled: true
-    sqlserver.latch.wait_time.avg:
-      enabled: true
-    sqlserver.latch.wait_time.total:
-      enabled: true
-    # Index
-    sqlserver.index.search.rate:
-      enabled: true
-    # Resource Pool
-    sqlserver.resource_pool.disk.operations:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.read.rate:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.write.rate:
-      enabled: true
-    # Replica / Always-On
-    sqlserver.replica.data.rate:
-      enabled: true
-    # Server Properties
-    sqlserver.computer.uptime:
-      enabled: true
-    sqlserver.cpu.count:
-      enabled: true
-    # Tables
-    sqlserver.table.count:
-      enabled: true
-    # Errors
-    sqlserver.kill_connection.error.rate:
-      enabled: true
-
-    events:
-      db.server.query_sample:
+    metrics:
+      # Database
+      sqlserver.database.count:
         enabled: true
-      db.server.top_query:
+      sqlserver.database.file.size:
+        enabled: true
+      sqlserver.database.io:
+        enabled: true
+      sqlserver.database.latency:
+        enabled: true
+      sqlserver.database.operations:
+        enabled: true
+      sqlserver.database.page_file.size:
+        enabled: true
+      sqlserver.database.transactions.active:
+        enabled: true
+      sqlserver.database.backup_or_restore.rate:
+        enabled: true
+      sqlserver.database.execution.errors:
+        enabled: true
+      sqlserver.database.full_scan.rate:
+        enabled: true
+      sqlserver.database.tempdb.space:
+        enabled: true
+      sqlserver.database.tempdb.version_store.size:
+        enabled: true
+      # Security / Principals
+      sqlserver.database.principals.count:
+        enabled: true
+      sqlserver.database.principals.old:
+        enabled: true
+      sqlserver.database.principals.orphaned_users:
+        enabled: true
+      sqlserver.database.principals.recently_created:
+        enabled: true
+      sqlserver.database.role.members.count:
+        enabled: true
+      sqlserver.database.role.memberships.count:
+        enabled: true
+      sqlserver.database.role.permission.risk_level:
+        enabled: true
+      sqlserver.database.role.roles.count:
+        enabled: true
+      sqlserver.database.security.role_membership.count:
+        enabled: true
+      sqlserver.server.security.principal.count:
+        enabled: true
+      sqlserver.server.security.role_membership.count:
+        enabled: true
+      # Locks
+      sqlserver.lock.by_mode.count:
+        enabled: true
+      sqlserver.lock.by_resource.count:
+        enabled: true
+      sqlserver.lock.timeout.rate:
+        enabled: true
+      sqlserver.lock.wait.count:
+        enabled: true
+      sqlserver.lock.wait.rate:
+        enabled: true
+      sqlserver.deadlock.rate:
+        enabled: true
+      # Transactions
+      sqlserver.transaction.delay:
+        enabled: true
+      sqlserver.transaction.mirror_write.rate:
+        enabled: true
+      sqlserver.transaction.longest_running_time:
+        enabled: true
+      sqlserver.transaction.version_cleanup.rate:
+        enabled: true
+      sqlserver.transaction.version_generation.rate:
+        enabled: true
+      # Memory
+      sqlserver.memory.area:
+        enabled: true
+      sqlserver.memory.cache.object.count:
+        enabled: true
+      sqlserver.memory.grants.pending.count:
+        enabled: true
+      sqlserver.memory.page.count:
+        enabled: true
+      sqlserver.memory.target:
+        enabled: true
+      sqlserver.memory.usage:
+        enabled: true
+      # OS
+      sqlserver.os.disk.size:
+        enabled: true
+      sqlserver.os.memory.usage:
+        enabled: true
+      sqlserver.os.memory.utilization:
+        enabled: true
+      sqlserver.os.scheduler.runnable_tasks.count:
+        enabled: true
+      sqlserver.os.wait.duration:
+        enabled: true
+      sqlserver.os.wait.tasks.count:
+        enabled: true
+      # Pages / Buffer
+      sqlserver.page.buffer_cache.hit_ratio:
+        enabled: true
+      sqlserver.page.buffer_cache.free_list.stalls.rate:
+        enabled: true
+      sqlserver.page.life_expectancy:
+        enabled: true
+      sqlserver.page.lookup.rate:
+        enabled: true
+      # Batch / Compilation
+      sqlserver.batch.request.rate:
+        enabled: true
+      sqlserver.batch.sql_compilation.rate:
+        enabled: true
+      sqlserver.batch.sql_recompilation.rate:
+        enabled: true
+      sqlserver.batch.compilation.utilization:
+        enabled: true
+      sqlserver.batch.page_split.utilization:
+        enabled: true
+      sqlserver.recompilation.ratio:
+        enabled: true
+      sqlserver.parameterization.rate:
+        enabled: true
+      sqlserver.plan.execution.rate:
+        enabled: true
+      sqlserver.attention.rate:
+        enabled: true
+      # Processes / Connections
+      sqlserver.process.count:
+        enabled: true
+      sqlserver.processes.blocked:
+        enabled: true
+      sqlserver.user.connection.count:
+        enabled: true
+      sqlserver.login.rate:
+        enabled: true
+      sqlserver.logout.rate:
+        enabled: true
+      # Thread Pool
+      sqlserver.thread_pool.tasks.count:
+        enabled: true
+      sqlserver.thread_pool.workers.count:
+        enabled: true
+      sqlserver.thread_pool.workers.max:
+        enabled: true
+      sqlserver.thread_pool.workers.utilization:
+        enabled: true
+      # TempDB
+      sqlserver.tempdb.allocation.wait_time.total:
+        enabled: true
+      sqlserver.tempdb.contention.waiters.count:
+        enabled: true
+      sqlserver.tempdb.data_files.count:
+        enabled: true
+      sqlserver.tempdb.file.size:
+        enabled: true
+      sqlserver.tempdb.space.usage:
+        enabled: true
+      # Latch
+      sqlserver.latch.superlatch.count:
+        enabled: true
+      sqlserver.latch.superlatch.transition.rate:
+        enabled: true
+      sqlserver.latch.wait.rate:
+        enabled: true
+      sqlserver.latch.wait_time.avg:
+        enabled: true
+      sqlserver.latch.wait_time.total:
+        enabled: true
+      # Index
+      sqlserver.index.search.rate:
+        enabled: true
+      # Resource Pool
+      sqlserver.resource_pool.disk.operations:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.read.rate:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.write.rate:
+        enabled: true
+      # Replica / Always-On
+      sqlserver.replica.data.rate:
+        enabled: true
+      # Server Properties
+      sqlserver.computer.uptime:
+        enabled: true
+      sqlserver.cpu.count:
+        enabled: true
+      # Tables
+      sqlserver.table.count:
+        enabled: true
+      # Errors
+      sqlserver.kill_connection.error.rate:
         enabled: true
 
-    top_query_collection:
-      lookback_time: 60s
-      max_query_sample_count: 1000
-      top_query_count: 250
-      collection_interval: 60s
+      events:
+        db.server.query_sample:
+          enabled: true
+        db.server.top_query:
+          enabled: true
 
-    collect_full_query_text: true
-    allowed_comment_keys:
-      - nr_service_guid
+      top_query_collection:
+        lookback_time: 60s
+        max_query_sample_count: 1000
+        top_query_count: 250
+        collection_interval: 60s
 
-    query_sample_collection:
-      max_rows_per_query: 100
+      collect_full_query_text: true
+      allowed_comment_keys:
+        - nr_service_guid
+
+      query_sample_collection:
+        max_rows_per_query: 100
 
 processors:
   memory_limiter:
@@ -1284,9 +1162,9 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: <input2>
+    endpoint: <YOUR_OTLP_ENDPOINT>
     headers:
-      api-key: <input3>
+      api-key: <YOUR_LICENSE_KEY>
     tls:
       insecure: false
     compression: gzip
@@ -1305,11 +1183,9 @@ service:
     logs:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp]`}
-  fileName="mssql-config.yaml"
-  tipMdx={{ body: null }}
-  onChange={() => {}}
-/>
+      exporters: [otlphttp]
+      
+```
 
 </Collapser>
 
@@ -1321,10 +1197,10 @@ The following table describes the key configuration parameters for the nrsqlserv
 
 | Parameter | Description |
 |-----------|-------------|
-| `server` | Enter your RDS SQL Server endpoint |
-| `port` | Enter your SQL Server port number. The default value is 1433. |
-| `endpoint` | Enter the New Relic OTLP endpoint (e.g., https://otlp.nr-data.net). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
-| `licenseKey` | Enter your New Relic license key. |
+| `<HOSTNAME-OR-RDS-ENDPOINT>` | Enter your RDS SQL Server endpoint |
+| `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint (e.g., https://otlp.nr-data.net). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
+| `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
 | `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
 
 </Step>
@@ -1449,11 +1325,11 @@ Ensure your environment meets our [compatibility and prerequisites](/docs/opente
 Connect to your RDS SQL Server instance and run the following SQL commands to create a login for the gMSA account and grant necessary permissions:
 
 ```sql
-USE master;
-CREATE LOGIN [DomainName\gMSA] FROM WINDOWS;
-GRANT VIEW ANY DATABASE TO [DomainName\gMSA];
-GRANT VIEW SERVER STATE TO [DomainName\gMSA];
-GRANT VIEW ANY DEFINITION TO [DomainName\gMSA];
+  USE master;
+  CREATE LOGIN [DomainName\gMSA] FROM WINDOWS;
+  GRANT VIEW ANY DATABASE TO [DomainName\gMSA];
+  GRANT VIEW SERVER STATE TO [DomainName\gMSA];
+  GRANT VIEW ANY DEFINITION TO [DomainName\gMSA];
 ```
 
 <Callout variant="important">
@@ -1515,9 +1391,9 @@ Install the NRDOT Collector on an EC2 Windows instance that is domain-joined and
 
 1. Download and install the NRDOT Collector using PowerShell:
 
-   ```powershell
-   [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; $NRDOT_VERSION = (Invoke-RestMethod -Uri "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest").tag_name; $WebClient = New-Object System.Net.WebClient; $WebClient.Headers.Add("User-Agent", "Mozilla/5.0"); $WebClient.DownloadFile("https://github.com/newrelic/nrdot-collector-releases/releases/download/$NRDOT_VERSION/nrdot-collector_${NRDOT_VERSION}_windows_x64.msi", "$env:TEMP\nrdot-collector.msi"); Start-Process msiexec.exe -ArgumentList "/i `"$env:TEMP\nrdot-collector.msi`" /qn /norestart /L*V `"$env:TEMP\nrdot_install.log`"" -Wait; Get-Service nrdot-collector -ErrorAction SilentlyContinue
-   ```
+  ```powershell
+    [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; $NRDOT_VERSION = (Invoke-RestMethod -Uri "https://api.github.com/repos/newrelic/nrdot-collector-releases/releases/latest").tag_name; $WebClient = New-Object System.Net.WebClient; $WebClient.Headers.Add("User-Agent", "Mozilla/5.0"); $WebClient.DownloadFile("https://github.com/newrelic/nrdot-collector-releases/releases/download/$NRDOT_VERSION/nrdot-collector_${NRDOT_VERSION}_windows_x64.msi", "$env:TEMP\nrdot-collector.msi"); Start-Process msiexec.exe -ArgumentList "/i `"$env:TEMP\nrdot-collector.msi`" /qn /norestart /L*V `"$env:TEMP\nrdot_install.log`"" -Wait; Get-Service nrdot-collector -ErrorAction SilentlyContinue
+  ```
 
 </Step>
 
@@ -1669,6 +1545,7 @@ service:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
       exporters: [otlphttp]
+
 ```
 
 Example with RDS endpoint: `server=mydb-instance.c9akciq32.us-east-1.rds.amazonaws.com`
@@ -1688,255 +1565,230 @@ This configuration provides comprehensive database monitoring with all available
 
 1. **Create the configuration file.** The filename must be `mssql-config.yaml`. Run the following command in PowerShell as Administrator:
 
-   ```powershell
-   New-Item -Path "C:\Program Files\nrdot-collector\mssql-config.yaml" -ItemType File
-   ```
+    ```powershell
+    New-Item -Path "C:\Program Files\nrdot-collector\mssql-config.yaml" -ItemType File
+    ```
 
 2. Add the configuration content below to the `mssql-config.yaml` file you created in the previous step.
 
-**Enter your values below and see the configuration update in real-time:**
+```yaml
+receivers:
+  nrsqlserver:
+    collection_interval: 15s
+    datasource: "server=<HOSTNAME-OR-RDS-ENDPOINT>;port=<YOUR_PORT>;integrated security=true;encrypt=true;TrustServerCertificate=true;"
 
-<AgentConfig
-  inputOptions={[
-    {
-      name: 'server',
-      label: 'RDS Endpoint',
-      codeLine: 4,
-      defaultValue: 'mydb-instance.xxxxxxxxxxxx.us-east-1.rds.amazonaws.com',
-      toolTip: 'Enter your RDS SQL Server endpoint',
-    },
-    {
-      name: 'endpoint',
-      label: 'New Relic OTLP Endpoint',
-      codeLine: 230,
-      defaultValue: 'https://otlp.nr-data.net:4318',
-      toolTip: 'Enter your New Relic OTLP endpoint. For more information, refer to https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/',
-    },
-    {
-      name: 'licenseKey',
-      label: 'New Relic License Key',
-      codeLine: 232,
-      defaultValue: 'YOUR_LICENSE_KEY',
-      toolTip: 'Enter your New Relic license key',
-    },
-  ]}
-  config={`receivers:
-nrsqlserver:
-  collection_interval: 15s
-  datasource: "server=<input1>;port=1433;integrated security=true;encrypt=true;TrustServerCertificate=true;"
-
-  metrics:
-    # Database
-    sqlserver.database.count:
-      enabled: true
-    sqlserver.database.file.size:
-      enabled: true
-    sqlserver.database.io:
-      enabled: true
-    sqlserver.database.latency:
-      enabled: true
-    sqlserver.database.operations:
-      enabled: true
-    sqlserver.database.page_file.size:
-      enabled: true
-    sqlserver.database.transactions.active:
-      enabled: true
-    sqlserver.database.backup_or_restore.rate:
-      enabled: true
-    sqlserver.database.execution.errors:
-      enabled: true
-    sqlserver.database.full_scan.rate:
-      enabled: true
-    sqlserver.database.tempdb.space:
-      enabled: true
-    sqlserver.database.tempdb.version_store.size:
-      enabled: true
-    # Security / Principals
-    sqlserver.database.principals.count:
-      enabled: true
-    sqlserver.database.principals.old:
-      enabled: true
-    sqlserver.database.principals.orphaned_users:
-      enabled: true
-    sqlserver.database.principals.recently_created:
-      enabled: true
-    sqlserver.database.role.members.count:
-      enabled: true
-    sqlserver.database.role.memberships.count:
-      enabled: true
-    sqlserver.database.role.permission.risk_level:
-      enabled: true
-    sqlserver.database.role.roles.count:
-      enabled: true
-    sqlserver.database.security.role_membership.count:
-      enabled: true
-    sqlserver.server.security.principal.count:
-      enabled: true
-    sqlserver.server.security.role_membership.count:
-      enabled: true
-    # Locks
-    sqlserver.lock.by_mode.count:
-      enabled: true
-    sqlserver.lock.by_resource.count:
-      enabled: true
-    sqlserver.lock.timeout.rate:
-      enabled: true
-    sqlserver.lock.wait.count:
-      enabled: true
-    sqlserver.lock.wait.rate:
-      enabled: true
-    sqlserver.deadlock.rate:
-      enabled: true
-    # Transactions
-    sqlserver.transaction.delay:
-      enabled: true
-    sqlserver.transaction.mirror_write.rate:
-      enabled: true
-    sqlserver.transaction.longest_running_time:
-      enabled: true
-    sqlserver.transaction.version_cleanup.rate:
-      enabled: true
-    sqlserver.transaction.version_generation.rate:
-      enabled: true
-    # Memory
-    sqlserver.memory.area:
-      enabled: true
-    sqlserver.memory.cache.object.count:
-      enabled: true
-    sqlserver.memory.grants.pending.count:
-      enabled: true
-    sqlserver.memory.page.count:
-      enabled: true
-    sqlserver.memory.target:
-      enabled: true
-    sqlserver.memory.usage:
-      enabled: true
-    # OS
-    sqlserver.os.disk.size:
-      enabled: true
-    sqlserver.os.memory.usage:
-      enabled: true
-    sqlserver.os.memory.utilization:
-      enabled: true
-    sqlserver.os.scheduler.runnable_tasks.count:
-      enabled: true
-    sqlserver.os.wait.duration:
-      enabled: true
-    sqlserver.os.wait.tasks.count:
-      enabled: true
-    # Pages / Buffer
-    sqlserver.page.buffer_cache.hit_ratio:
-      enabled: true
-    sqlserver.page.buffer_cache.free_list.stalls.rate:
-      enabled: true
-    sqlserver.page.life_expectancy:
-      enabled: true
-    sqlserver.page.lookup.rate:
-      enabled: true
-    # Batch / Compilation
-    sqlserver.batch.request.rate:
-      enabled: true
-    sqlserver.batch.sql_compilation.rate:
-      enabled: true
-    sqlserver.batch.sql_recompilation.rate:
-      enabled: true
-    sqlserver.batch.compilation.utilization:
-      enabled: true
-    sqlserver.batch.page_split.utilization:
-      enabled: true
-    sqlserver.recompilation.ratio:
-      enabled: true
-    sqlserver.parameterization.rate:
-      enabled: true
-    sqlserver.plan.execution.rate:
-      enabled: true
-    sqlserver.attention.rate:
-      enabled: true
-    # Processes / Connections
-    sqlserver.process.count:
-      enabled: true
-    sqlserver.processes.blocked:
-      enabled: true
-    sqlserver.user.connection.count:
-      enabled: true
-    sqlserver.login.rate:
-      enabled: true
-    sqlserver.logout.rate:
-      enabled: true
-    # Thread Pool
-    sqlserver.thread_pool.tasks.count:
-      enabled: true
-    sqlserver.thread_pool.workers.count:
-      enabled: true
-    sqlserver.thread_pool.workers.max:
-      enabled: true
-    sqlserver.thread_pool.workers.utilization:
-      enabled: true
-    # TempDB
-    sqlserver.tempdb.allocation.wait_time.total:
-      enabled: true
-    sqlserver.tempdb.contention.waiters.count:
-      enabled: true
-    sqlserver.tempdb.data_files.count:
-      enabled: true
-    sqlserver.tempdb.file.size:
-      enabled: true
-    sqlserver.tempdb.space.usage:
-      enabled: true
-    # Latch
-    sqlserver.latch.superlatch.count:
-      enabled: true
-    sqlserver.latch.superlatch.transition.rate:
-      enabled: true
-    sqlserver.latch.wait.rate:
-      enabled: true
-    sqlserver.latch.wait_time.avg:
-      enabled: true
-    sqlserver.latch.wait_time.total:
-      enabled: true
-    # Index
-    sqlserver.index.search.rate:
-      enabled: true
-    # Resource Pool
-    sqlserver.resource_pool.disk.operations:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.read.rate:
-      enabled: true
-    sqlserver.resource_pool.disk.throttled.write.rate:
-      enabled: true
-    # Replica / Always-On
-    sqlserver.replica.data.rate:
-      enabled: true
-    # Server Properties
-    sqlserver.computer.uptime:
-      enabled: true
-    sqlserver.cpu.count:
-      enabled: true
-    # Tables
-    sqlserver.table.count:
-      enabled: true
-    # Errors
-    sqlserver.kill_connection.error.rate:
-      enabled: true
-
-    events:
-      db.server.query_sample:
+    metrics:
+      # Database
+      sqlserver.database.count:
         enabled: true
-      db.server.top_query:
+      sqlserver.database.file.size:
+        enabled: true
+      sqlserver.database.io:
+        enabled: true
+      sqlserver.database.latency:
+        enabled: true
+      sqlserver.database.operations:
+        enabled: true
+      sqlserver.database.page_file.size:
+        enabled: true
+      sqlserver.database.transactions.active:
+        enabled: true
+      sqlserver.database.backup_or_restore.rate:
+        enabled: true
+      sqlserver.database.execution.errors:
+        enabled: true
+      sqlserver.database.full_scan.rate:
+        enabled: true
+      sqlserver.database.tempdb.space:
+        enabled: true
+      sqlserver.database.tempdb.version_store.size:
+        enabled: true
+      # Security / Principals
+      sqlserver.database.principals.count:
+        enabled: true
+      sqlserver.database.principals.old:
+        enabled: true
+      sqlserver.database.principals.orphaned_users:
+        enabled: true
+      sqlserver.database.principals.recently_created:
+        enabled: true
+      sqlserver.database.role.members.count:
+        enabled: true
+      sqlserver.database.role.memberships.count:
+        enabled: true
+      sqlserver.database.role.permission.risk_level:
+        enabled: true
+      sqlserver.database.role.roles.count:
+        enabled: true
+      sqlserver.database.security.role_membership.count:
+        enabled: true
+      sqlserver.server.security.principal.count:
+        enabled: true
+      sqlserver.server.security.role_membership.count:
+        enabled: true
+      # Locks
+      sqlserver.lock.by_mode.count:
+        enabled: true
+      sqlserver.lock.by_resource.count:
+        enabled: true
+      sqlserver.lock.timeout.rate:
+        enabled: true
+      sqlserver.lock.wait.count:
+        enabled: true
+      sqlserver.lock.wait.rate:
+        enabled: true
+      sqlserver.deadlock.rate:
+        enabled: true
+      # Transactions
+      sqlserver.transaction.delay:
+        enabled: true
+      sqlserver.transaction.mirror_write.rate:
+        enabled: true
+      sqlserver.transaction.longest_running_time:
+        enabled: true
+      sqlserver.transaction.version_cleanup.rate:
+        enabled: true
+      sqlserver.transaction.version_generation.rate:
+        enabled: true
+      # Memory
+      sqlserver.memory.area:
+        enabled: true
+      sqlserver.memory.cache.object.count:
+        enabled: true
+      sqlserver.memory.grants.pending.count:
+        enabled: true
+      sqlserver.memory.page.count:
+        enabled: true
+      sqlserver.memory.target:
+        enabled: true
+      sqlserver.memory.usage:
+        enabled: true
+      # OS
+      sqlserver.os.disk.size:
+        enabled: true
+      sqlserver.os.memory.usage:
+        enabled: true
+      sqlserver.os.memory.utilization:
+        enabled: true
+      sqlserver.os.scheduler.runnable_tasks.count:
+        enabled: true
+      sqlserver.os.wait.duration:
+        enabled: true
+      sqlserver.os.wait.tasks.count:
+        enabled: true
+      # Pages / Buffer
+      sqlserver.page.buffer_cache.hit_ratio:
+        enabled: true
+      sqlserver.page.buffer_cache.free_list.stalls.rate:
+        enabled: true
+      sqlserver.page.life_expectancy:
+        enabled: true
+      sqlserver.page.lookup.rate:
+        enabled: true
+      # Batch / Compilation
+      sqlserver.batch.request.rate:
+        enabled: true
+      sqlserver.batch.sql_compilation.rate:
+        enabled: true
+      sqlserver.batch.sql_recompilation.rate:
+        enabled: true
+      sqlserver.batch.compilation.utilization:
+        enabled: true
+      sqlserver.batch.page_split.utilization:
+        enabled: true
+      sqlserver.recompilation.ratio:
+        enabled: true
+      sqlserver.parameterization.rate:
+        enabled: true
+      sqlserver.plan.execution.rate:
+        enabled: true
+      sqlserver.attention.rate:
+        enabled: true
+      # Processes / Connections
+      sqlserver.process.count:
+        enabled: true
+      sqlserver.processes.blocked:
+        enabled: true
+      sqlserver.user.connection.count:
+        enabled: true
+      sqlserver.login.rate:
+        enabled: true
+      sqlserver.logout.rate:
+        enabled: true
+      # Thread Pool
+      sqlserver.thread_pool.tasks.count:
+        enabled: true
+      sqlserver.thread_pool.workers.count:
+        enabled: true
+      sqlserver.thread_pool.workers.max:
+        enabled: true
+      sqlserver.thread_pool.workers.utilization:
+        enabled: true
+      # TempDB
+      sqlserver.tempdb.allocation.wait_time.total:
+        enabled: true
+      sqlserver.tempdb.contention.waiters.count:
+        enabled: true
+      sqlserver.tempdb.data_files.count:
+        enabled: true
+      sqlserver.tempdb.file.size:
+        enabled: true
+      sqlserver.tempdb.space.usage:
+        enabled: true
+      # Latch
+      sqlserver.latch.superlatch.count:
+        enabled: true
+      sqlserver.latch.superlatch.transition.rate:
+        enabled: true
+      sqlserver.latch.wait.rate:
+        enabled: true
+      sqlserver.latch.wait_time.avg:
+        enabled: true
+      sqlserver.latch.wait_time.total:
+        enabled: true
+      # Index
+      sqlserver.index.search.rate:
+        enabled: true
+      # Resource Pool
+      sqlserver.resource_pool.disk.operations:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.read.rate:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.write.rate:
+        enabled: true
+      # Replica / Always-On
+      sqlserver.replica.data.rate:
+        enabled: true
+      # Server Properties
+      sqlserver.computer.uptime:
+        enabled: true
+      sqlserver.cpu.count:
+        enabled: true
+      # Tables
+      sqlserver.table.count:
+        enabled: true
+      # Errors
+      sqlserver.kill_connection.error.rate:
         enabled: true
 
-    top_query_collection:
-      lookback_time: 60s
-      max_query_sample_count: 1000
-      top_query_count: 250
-      collection_interval: 60s
+      events:
+        db.server.query_sample:
+          enabled: true
+        db.server.top_query:
+          enabled: true
 
-    collect_full_query_text: true
-    allowed_comment_keys:
-      - nr_service_guid
+      top_query_collection:
+        lookback_time: 60s
+        max_query_sample_count: 1000
+        top_query_count: 250
+        collection_interval: 60s
 
-    query_sample_collection:
-      max_rows_per_query: 100
+      collect_full_query_text: true
+      allowed_comment_keys:
+        - nr_service_guid
+
+      query_sample_collection:
+        max_rows_per_query: 100
 
 processors:
   memory_limiter:
@@ -1970,11 +1822,9 @@ service:
     logs:
       receivers: [nrsqlserver]
       processors: [memory_limiter, batch]
-      exporters: [otlphttp]`}
-  fileName="mssql-config.yaml"
-  tipMdx={{ body: null }}
-  onChange={() => {}}
-/>
+      exporters: [otlphttp]
+
+```
 
 </Collapser>
 
@@ -1986,20 +1836,21 @@ The following table describes the key configuration parameters for the nrsqlserv
 
 | Parameter | Description |
 |-----------|-------------|
-| `server` | Enter your RDS SQL Server endpoint |
-| `port` | Enter your SQL Server port number. The default value is 1433. |
-| `endpoint` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
-| `licenseKey` | Enter your New Relic license key. |
+| `<HOSTNAME-OR-RDS-ENDPOINT>` | Enter your RDS SQL Server endpoint |
+| `<YOUR_PORT>` | Enter your SQL Server port number. The default value is 1433. |
+| `<YOUR_OTLP_ENDPOINT>` | Enter the New Relic OTLP endpoint. For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/). |
+| `<YOUR_LICENSE_KEY>` | Enter your New Relic license key. |
 | `collection_interval` | Interval in seconds to collect database metrics. Default: 15s |
 
 <Callout variant="tip">
-**Note:** The `max_concurrent_queries` option controls how many metric queries the receiver executes in parallel against SQL Server during each scrape cycle.
+The `max_concurrent_queries` option controls how many metric queries the receiver executes in parallel against SQL Server during each scrape cycle.
 
 ```yaml
 receivers:
   nrsqlserver:
     max_concurrent_queries: 4  # default is 4 if omitted or set to 0
 ```
+
 </Callout>
 
 <Callout variant="tip">
@@ -2042,7 +1893,7 @@ sc config "nrdot-collector" binPath= "\"C:\Program Files\nrdot-collector\nrdot-c
 
 Validate the NRDOT Collector configuration to ensure it's correctly formatted and will work properly.
 
-```powershell
+```bash
 & "C:\Program Files\nrdot-collector\nrdot-collector.exe" validate --config="C:\Program Files\nrdot-collector\mssql-config.yaml"
 ```
 
@@ -2054,9 +1905,9 @@ Validate the NRDOT Collector configuration to ensure it's correctly formatted an
 
 After updating your configuration, restart the NRDOT Collector service on your domain-joined EC2 Windows instance:
 
-```powershell
-net stop nrdot-collector
-net start nrdot-collector
+```bash
+  net stop nrdot-collector
+  net start nrdot-collector
 ```
 
 <Callout variant="tip">


### PR DESCRIPTION
 ## Summary
  - Updated OTLP endpoint default value to include port 4318 in MS SQL Server documentation
  - Fixed endpoint configuration in both Windows hosted and RDS deployment guides
  - Changed from `https://otlp.nr-data.net` to `https://otlp.nr-data.net:4318`

  ## Files Changed
  - `src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx`
  - `src/content/docs/opentelemetry/database/mssql/windows-rds.mdx`