### PR TITLE
restore: elasticsearch MT translations from PR #24814 resync

### DIFF
--- a/src/i18n/content/es/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
+++ b/src/i18n/content/es/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
@@ -452,335 +452,335 @@ Seleccione la distribución del recopilador que se ajuste a sus necesidades:
 
               1. Cree el espacio de nombres:
 
-                 ```bash
-                 kubectl create namespace newrelic
-                 ```
+              ```bash
+              kubectl create namespace newrelic
+              ```
 
               2. Cree el secreto:
 
-                 ```bash
-                 kubectl create secret generic newrelic-licenses \
+              ```bash
+              kubectl create secret generic newrelic-licenses \
                    --from-literal=NEWRELIC_LICENSE_KEY=YOUR_LICENSE_KEY_HERE \
                    --from-literal=NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318 \
                    --from-literal=NEW_RELIC_MEMORY_LIMIT_MIB=100 \
                    -n newrelic
-                 ```
+              ```
 
-                 Actualice los valores:
+              Actualice los valores:
 
-                 * Reemplace `YOUR_LICENSE_KEY_HERE` con su clave de licencia de New Relic real
-                 * Reemplace `https://otlp.nr-data.net:4318` con el endpoint de su región (consulte la [documentación del endpoint OTLP](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol))
-                 * Reemplace `100` con el límite de memoria deseado en MiB para el recolector
+              * Reemplace `YOUR_LICENSE_KEY_HERE` con su clave de licencia de New Relic real
+              * Reemplace `https://otlp.nr-data.net:4318` con el endpoint de su región (consulte la [documentación del endpoint OTLP](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol))
+              * Reemplace `100` con el límite de memoria deseado en MiB para el recolector
 
               #### Configurar el monitoreo de Elasticsearch [#nrdot-helm-configure-es]
 
               Cree un archivo `values.yaml` para el monitoreo de Elasticsearch del NRDOT Collector:
 
-```yaml
-mode: deployment
+              ```yaml
+              mode: deployment
 
-image:
-  repository: newrelic/nrdot-collector
-  tag: latest
-  pullPolicy: IfNotPresent
+              image:
+                repository: newrelic/nrdot-collector
+                tag: latest
+                pullPolicy: IfNotPresent
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 200m
-    memory: 256Mi
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
 
-ports: {}
+              ports: {}
 
-extraEnvs:
-  - name: NEWRELIC_LICENSE_KEY
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_LICENSE_KEY
-  - name: NEWRELIC_OTLP_ENDPOINT
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_OTLP_ENDPOINT
-  - name: NEW_RELIC_MEMORY_LIMIT_MIB
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEW_RELIC_MEMORY_LIMIT_MIB
-  - name: K8S_CLUSTER_NAME
-    value: "elasticsearch-cluster"
+              extraEnvs:
+                - name: NEWRELIC_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_LICENSE_KEY
+                - name: NEWRELIC_OTLP_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_OTLP_ENDPOINT
+                - name: NEW_RELIC_MEMORY_LIMIT_MIB
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEW_RELIC_MEMORY_LIMIT_MIB
+                - name: K8S_CLUSTER_NAME
+                  value: "elasticsearch-cluster"
 
-clusterRole:
-  create: true
-  rules:
-    - apiGroups: [""]
-      resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["apps"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
+              clusterRole:
+                create: true
+                rules:
+                  - apiGroups: [""]
+                    resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
+                    verbs: ["get", "list", "watch"]
+                  - apiGroups: ["apps"]
+                    resources: ["replicasets"]
+                    verbs: ["get", "list", "watch"]
 
-config:
-  extensions:
-    health_check:
-      endpoint: 0.0.0.0:13133
-    k8s_observer:
-      auth_type: serviceAccount
-      observe_pods: true
-      observe_nodes: true
+              config:
+                extensions:
+                  health_check:
+                    endpoint: 0.0.0.0:13133
+                  k8s_observer:
+                    auth_type: serviceAccount
+                    observe_pods: true
+                    observe_nodes: true
 
-  receivers:
-    jaeger: null
-    zipkin: null
-    prometheus: null
-    otlp: null
-    receiver_creator/elasticsearch:
-      watch_observers: [k8s_observer]
-      receivers:
-        elasticsearch:
-          rule: type == "pod" && labels["app"] == "elasticsearch"
-          config:
-            endpoint: 'http://`endpoint`:9200'
-            collection_interval: 15s
-            metrics:
-              elasticsearch.os.cpu.usage:
-                enabled: true
-              elasticsearch.cluster.data_nodes:
-                enabled: true
-              elasticsearch.cluster.health:
-                enabled: true
-              elasticsearch.cluster.in_flight_fetch:
-                enabled: true
-              elasticsearch.cluster.nodes:
-                enabled: true
-              elasticsearch.cluster.pending_tasks:
-                enabled: true
-              elasticsearch.cluster.shards:
-                enabled: true
-              elasticsearch.cluster.state_update.time:
-                enabled: true
-              elasticsearch.index.documents:
-                enabled: true
-              elasticsearch.index.operations.merge.current:
-                enabled: true
-              elasticsearch.index.operations.time:
-                enabled: true
-              elasticsearch.node.cache.count:
-                enabled: true
-              elasticsearch.node.cache.evictions:
-                enabled: true
-              elasticsearch.node.cache.memory.usage:
-                enabled: true
-              elasticsearch.node.shards.size:
-                enabled: true
-              elasticsearch.node.cluster.io:
-                enabled: true
-              elasticsearch.node.documents:
-                enabled: true
-              elasticsearch.node.disk.io.read:
-                enabled: true
-              elasticsearch.node.disk.io.write:
-                enabled: true
-              elasticsearch.node.fs.disk.available:
-                enabled: true
-              elasticsearch.node.fs.disk.total:
-                enabled: true
-              elasticsearch.node.http.connections:
-                enabled: true
-              elasticsearch.node.ingest.documents.current:
-                enabled: true
-              elasticsearch.node.ingest.operations.failed:
-                enabled: true
-              elasticsearch.node.open_files:
-                enabled: true
-              elasticsearch.node.operations.completed:
-                enabled: true
-              elasticsearch.node.operations.current:
-                enabled: true
-              elasticsearch.node.operations.get.completed:
-                enabled: true
-              elasticsearch.node.operations.time:
-                enabled: true
-              elasticsearch.node.shards.reserved.size:
-                enabled: true
-              elasticsearch.index.shards.size:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.1m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.5m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.15m:
-                enabled: true
-              elasticsearch.os.memory:
-                enabled: true
-              jvm.gc.collections.count:
-                enabled: true
-              jvm.gc.collections.elapsed:
-                enabled: true
-              jvm.memory.heap.max:
-                enabled: true
-              jvm.memory.heap.used:
-                enabled: true
-              jvm.memory.heap.utilization:
-                enabled: true
-              jvm.threads.count:
-                enabled: true
-              elasticsearch.index.segments.count:
-                enabled: true
-              elasticsearch.index.operations.completed:
-                enabled: true
-              elasticsearch.node.script.cache_evictions:
-                enabled: false
-              elasticsearch.node.cluster.connections:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.preprocessed:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.queued:
-                enabled: false
-              elasticsearch.cluster.published_states.full:
-                enabled: false
-              jvm.memory.pool.max:
-                enabled: false
-              elasticsearch.node.script.compilation_limit_triggered:
-                enabled: false
-              elasticsearch.node.shards.data_set.size:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.current:
-                enabled: false
-              elasticsearch.cluster.state_update.count:
-                enabled: false
-              elasticsearch.node.fs.disk.free:
-                enabled: false
-              jvm.memory.nonheap.used:
-                enabled: false
-              jvm.memory.pool.used:
-                enabled: false
-              elasticsearch.node.translog.size:
-                enabled: false
-              elasticsearch.node.thread_pool.threads:
-                enabled: false
-              elasticsearch.cluster.state_queue:
-                enabled: false
-              elasticsearch.node.translog.operations:
-                enabled: false
-              elasticsearch.memory.indexing_pressure:
-                enabled: false
-              elasticsearch.node.ingest.documents:
-                enabled: false
-              jvm.classes.loaded:
-                enabled: false
-              jvm.memory.heap.committed:
-                enabled: false
-              elasticsearch.breaker.memory.limit:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.replica_rejections:
-                enabled: false
-              elasticsearch.breaker.memory.estimated:
-                enabled: false
-              elasticsearch.cluster.published_states.differences:
-                enabled: false
-              jvm.memory.nonheap.committed:
-                enabled: false
-              elasticsearch.node.translog.uncommitted.size:
-                enabled: false
-              elasticsearch.node.script.compilations:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.operations.failed:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.limit:
-                enabled: false
-              elasticsearch.breaker.tripped:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.primary_rejections:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.finished:
-                enabled: false
+                receivers:
+                  jaeger: null
+                  zipkin: null
+                  prometheus: null
+                  otlp: null
+                  receiver_creator/elasticsearch:
+                    watch_observers: [k8s_observer]
+                    receivers:
+                      elasticsearch:
+                        rule: type == "pod" && labels["app"] == "elasticsearch"
+                        config:
+                          endpoint: 'http://`endpoint`:9200'
+                          collection_interval: 15s
+                          metrics:
+                            elasticsearch.os.cpu.usage:
+                              enabled: true
+                            elasticsearch.cluster.data_nodes:
+                              enabled: true
+                            elasticsearch.cluster.health:
+                              enabled: true
+                            elasticsearch.cluster.in_flight_fetch:
+                              enabled: true
+                            elasticsearch.cluster.nodes:
+                              enabled: true
+                            elasticsearch.cluster.pending_tasks:
+                              enabled: true
+                            elasticsearch.cluster.shards:
+                              enabled: true
+                            elasticsearch.cluster.state_update.time:
+                              enabled: true
+                            elasticsearch.index.documents:
+                              enabled: true
+                            elasticsearch.index.operations.merge.current:
+                              enabled: true
+                            elasticsearch.index.operations.time:
+                              enabled: true
+                            elasticsearch.node.cache.count:
+                              enabled: true
+                            elasticsearch.node.cache.evictions:
+                              enabled: true
+                            elasticsearch.node.cache.memory.usage:
+                              enabled: true
+                            elasticsearch.node.shards.size:
+                              enabled: true
+                            elasticsearch.node.cluster.io:
+                              enabled: true
+                            elasticsearch.node.documents:
+                              enabled: true
+                            elasticsearch.node.disk.io.read:
+                              enabled: true
+                            elasticsearch.node.disk.io.write:
+                              enabled: true
+                            elasticsearch.node.fs.disk.available:
+                              enabled: true
+                            elasticsearch.node.fs.disk.total:
+                              enabled: true
+                            elasticsearch.node.http.connections:
+                              enabled: true
+                            elasticsearch.node.ingest.documents.current:
+                              enabled: true
+                            elasticsearch.node.ingest.operations.failed:
+                              enabled: true
+                            elasticsearch.node.open_files:
+                              enabled: true
+                            elasticsearch.node.operations.completed:
+                              enabled: true
+                            elasticsearch.node.operations.current:
+                              enabled: true
+                            elasticsearch.node.operations.get.completed:
+                              enabled: true
+                            elasticsearch.node.operations.time:
+                              enabled: true
+                            elasticsearch.node.shards.reserved.size:
+                              enabled: true
+                            elasticsearch.index.shards.size:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.1m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.5m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.15m:
+                              enabled: true
+                            elasticsearch.os.memory:
+                              enabled: true
+                            jvm.gc.collections.count:
+                              enabled: true
+                            jvm.gc.collections.elapsed:
+                              enabled: true
+                            jvm.memory.heap.max:
+                              enabled: true
+                            jvm.memory.heap.used:
+                              enabled: true
+                            jvm.memory.heap.utilization:
+                              enabled: true
+                            jvm.threads.count:
+                              enabled: true
+                            elasticsearch.index.segments.count:
+                              enabled: true
+                            elasticsearch.index.operations.completed:
+                              enabled: true
+                            elasticsearch.node.script.cache_evictions:
+                              enabled: false
+                            elasticsearch.node.cluster.connections:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.preprocessed:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.queued:
+                              enabled: false
+                            elasticsearch.cluster.published_states.full:
+                              enabled: false
+                            jvm.memory.pool.max:
+                              enabled: false
+                            elasticsearch.node.script.compilation_limit_triggered:
+                              enabled: false
+                            elasticsearch.node.shards.data_set.size:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.current:
+                              enabled: false
+                            elasticsearch.cluster.state_update.count:
+                              enabled: false
+                            elasticsearch.node.fs.disk.free:
+                              enabled: false
+                            jvm.memory.nonheap.used:
+                              enabled: false
+                            jvm.memory.pool.used:
+                              enabled: false
+                            elasticsearch.node.translog.size:
+                              enabled: false
+                            elasticsearch.node.thread_pool.threads:
+                              enabled: false
+                            elasticsearch.cluster.state_queue:
+                              enabled: false
+                            elasticsearch.node.translog.operations:
+                              enabled: false
+                            elasticsearch.memory.indexing_pressure:
+                              enabled: false
+                            elasticsearch.node.ingest.documents:
+                              enabled: false
+                            jvm.classes.loaded:
+                              enabled: false
+                            jvm.memory.heap.committed:
+                              enabled: false
+                            elasticsearch.breaker.memory.limit:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.replica_rejections:
+                              enabled: false
+                            elasticsearch.breaker.memory.estimated:
+                              enabled: false
+                            elasticsearch.cluster.published_states.differences:
+                              enabled: false
+                            jvm.memory.nonheap.committed:
+                              enabled: false
+                            elasticsearch.node.translog.uncommitted.size:
+                              enabled: false
+                            elasticsearch.node.script.compilations:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.operations.failed:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.limit:
+                              enabled: false
+                            elasticsearch.breaker.tripped:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.primary_rejections:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.finished:
+                              enabled: false
 
-  processors:
-    memory_limiter:
-      check_interval: 60s
-      limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
-    cumulativetodelta: {}
-    attributes/cluster_state_aggregate:
-      include:
-        match_type: strict
-        metric_names:
-          - elasticsearch.cluster.state_update.time
-      actions:
-        - key: type
-          action: delete
-        - key: state
-          action: delete
-    filter/critical_operations:
-      metrics:
-        datapoint:
-          - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
-    resource/cluster:
-      attributes:
-        - key: k8s.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: insert
-    resource/cluster_name_override:
-      attributes:
-        - key: elasticsearch.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: upsert
-    resourcedetection:
-      detectors: [env, system]
-      system:
-        resource_attributes:
-          host.name:
-            enabled: true
-          host.id:
-            enabled: true
-          os.type:
-            enabled: true
-    batch:
-      timeout: 30s
-      send_batch_size: 2048
-      send_batch_max_size: 4096
-    attributes/cardinality_reduction:
-      actions:
-        - key: process.pid
-          action: delete
-        - key: process.parent_pid
-          action: delete
-        - key: k8s.pod.uid
-          action: delete
-    transform/metadata_nullify:
-      metric_statements:
-        - context: metric
-          statements:
-            - set(description, "")
-            - set(unit, "")
+                processors:
+                  memory_limiter:
+                    check_interval: 60s
+                    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
+                  cumulativetodelta: {}
+                  attributes/cluster_state_aggregate:
+                    include:
+                      match_type: strict
+                      metric_names:
+                        - elasticsearch.cluster.state_update.time
+                    actions:
+                      - key: type
+                        action: delete
+                      - key: state
+                        action: delete
+                  filter/critical_operations:
+                    metrics:
+                      datapoint:
+                        - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+                  resource/cluster:
+                    attributes:
+                      - key: k8s.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: insert
+                  resource/cluster_name_override:
+                    attributes:
+                      - key: elasticsearch.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: upsert
+                  resourcedetection:
+                    detectors: [env, system]
+                    system:
+                      resource_attributes:
+                        host.name:
+                          enabled: true
+                        host.id:
+                          enabled: true
+                        os.type:
+                          enabled: true
+                  batch:
+                    timeout: 30s
+                    send_batch_size: 2048
+                    send_batch_max_size: 4096
+                  attributes/cardinality_reduction:
+                    actions:
+                      - key: process.pid
+                        action: delete
+                      - key: process.parent_pid
+                        action: delete
+                      - key: k8s.pod.uid
+                        action: delete
+                  transform/metadata_nullify:
+                    metric_statements:
+                      - context: metric
+                        statements:
+                          - set(description, "")
+                          - set(unit, "")
 
-  exporters:
-    otlp_http:
-      endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
-      headers:
-        api-key: "${env:NEWRELIC_LICENSE_KEY}"
-      compression: gzip
-      timeout: 30s
-      retry_on_failure:
-        enabled: true
-        initial_interval: 5s
-        max_interval: 30s
-        max_elapsed_time: 300s
+                exporters:
+                  otlp_http:
+                    endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
+                    headers:
+                      api-key: "${env:NEWRELIC_LICENSE_KEY}"
+                    compression: gzip
+                    timeout: 30s
+                    retry_on_failure:
+                      enabled: true
+                      initial_interval: 5s
+                      max_interval: 30s
+                      max_elapsed_time: 300s
 
-  service:
-    extensions: [health_check, k8s_observer]
-    pipelines:
-      traces: null
-      logs: null
-      metrics: null
-      metrics/elasticsearch:
-        receivers: [receiver_creator/elasticsearch]
-        processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
-        exporters: [otlp_http]
-```
+                service:
+                  extensions: [health_check, k8s_observer]
+                  pipelines:
+                    traces: null
+                    logs: null
+                    metrics: null
+                    metrics/elasticsearch:
+                      receivers: [receiver_creator/elasticsearch]
+                      processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+                      exporters: [otlp_http]
+              ```
 
               <Callout variant="tip">
                 **Personalice para su entorno:**

--- a/src/i18n/content/fr/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
+++ b/src/i18n/content/fr/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
@@ -452,335 +452,335 @@ Choisissez la distribution du collecteur qui correspond à vos besoins :
 
               1. Créer l&apos;espace de noms :
 
-                 ```bash
-                 kubectl create namespace newrelic
-                 ```
+              ```bash
+              kubectl create namespace newrelic
+              ```
 
               2. Créez le secret :
 
-                 ```bash
-                 kubectl create secret generic newrelic-licenses \
+              ```bash
+              kubectl create secret generic newrelic-licenses \
                    --from-literal=NEWRELIC_LICENSE_KEY=YOUR_LICENSE_KEY_HERE \
                    --from-literal=NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318 \
                    --from-literal=NEW_RELIC_MEMORY_LIMIT_MIB=100 \
                    -n newrelic
-                 ```
+              ```
 
-                 Mettre à jour les valeurs :
+              Mettre à jour les valeurs :
 
-                 * Remplacez `YOUR_LICENSE_KEY_HERE` par votre clé de licence New Relic
-                 * Remplacez `https://otlp.nr-data.net:4318` par l&apos;endpoint de votre région (consultez la [documentation sur les endpoints OTLP](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol))
-                 * Remplacez `100` par la limite de mémoire souhaitée en MiB pour le collecteur
+              * Remplacez `YOUR_LICENSE_KEY_HERE` par votre clé de licence New Relic
+              * Remplacez `https://otlp.nr-data.net:4318` par l&apos;endpoint de votre région (consultez la [documentation sur les endpoints OTLP](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol))
+              * Remplacez `100` par la limite de mémoire souhaitée en MiB pour le collecteur
 
               #### Configurer le monitoring d&apos;Elasticsearch [#nrdot-helm-configure-es]
 
               Créez un fichier `values.yaml` pour le monitoring d&apos;Elasticsearch du Collector NRDOT :
 
-```yaml
-mode: deployment
+              ```yaml
+              mode: deployment
 
-image:
-  repository: newrelic/nrdot-collector
-  tag: latest
-  pullPolicy: IfNotPresent
+              image:
+                repository: newrelic/nrdot-collector
+                tag: latest
+                pullPolicy: IfNotPresent
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 200m
-    memory: 256Mi
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
 
-ports: {}
+              ports: {}
 
-extraEnvs:
-  - name: NEWRELIC_LICENSE_KEY
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_LICENSE_KEY
-  - name: NEWRELIC_OTLP_ENDPOINT
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_OTLP_ENDPOINT
-  - name: NEW_RELIC_MEMORY_LIMIT_MIB
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEW_RELIC_MEMORY_LIMIT_MIB
-  - name: K8S_CLUSTER_NAME
-    value: "elasticsearch-cluster"
+              extraEnvs:
+                - name: NEWRELIC_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_LICENSE_KEY
+                - name: NEWRELIC_OTLP_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_OTLP_ENDPOINT
+                - name: NEW_RELIC_MEMORY_LIMIT_MIB
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEW_RELIC_MEMORY_LIMIT_MIB
+                - name: K8S_CLUSTER_NAME
+                  value: "elasticsearch-cluster"
 
-clusterRole:
-  create: true
-  rules:
-    - apiGroups: [""]
-      resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["apps"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
+              clusterRole:
+                create: true
+                rules:
+                  - apiGroups: [""]
+                    resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
+                    verbs: ["get", "list", "watch"]
+                  - apiGroups: ["apps"]
+                    resources: ["replicasets"]
+                    verbs: ["get", "list", "watch"]
 
-config:
-  extensions:
-    health_check:
-      endpoint: 0.0.0.0:13133
-    k8s_observer:
-      auth_type: serviceAccount
-      observe_pods: true
-      observe_nodes: true
+              config:
+                extensions:
+                  health_check:
+                    endpoint: 0.0.0.0:13133
+                  k8s_observer:
+                    auth_type: serviceAccount
+                    observe_pods: true
+                    observe_nodes: true
 
-  receivers:
-    jaeger: null
-    zipkin: null
-    prometheus: null
-    otlp: null
-    receiver_creator/elasticsearch:
-      watch_observers: [k8s_observer]
-      receivers:
-        elasticsearch:
-          rule: type == "pod" && labels["app"] == "elasticsearch"
-          config:
-            endpoint: 'http://`endpoint`:9200'
-            collection_interval: 15s
-            metrics:
-              elasticsearch.os.cpu.usage:
-                enabled: true
-              elasticsearch.cluster.data_nodes:
-                enabled: true
-              elasticsearch.cluster.health:
-                enabled: true
-              elasticsearch.cluster.in_flight_fetch:
-                enabled: true
-              elasticsearch.cluster.nodes:
-                enabled: true
-              elasticsearch.cluster.pending_tasks:
-                enabled: true
-              elasticsearch.cluster.shards:
-                enabled: true
-              elasticsearch.cluster.state_update.time:
-                enabled: true
-              elasticsearch.index.documents:
-                enabled: true
-              elasticsearch.index.operations.merge.current:
-                enabled: true
-              elasticsearch.index.operations.time:
-                enabled: true
-              elasticsearch.node.cache.count:
-                enabled: true
-              elasticsearch.node.cache.evictions:
-                enabled: true
-              elasticsearch.node.cache.memory.usage:
-                enabled: true
-              elasticsearch.node.shards.size:
-                enabled: true
-              elasticsearch.node.cluster.io:
-                enabled: true
-              elasticsearch.node.documents:
-                enabled: true
-              elasticsearch.node.disk.io.read:
-                enabled: true
-              elasticsearch.node.disk.io.write:
-                enabled: true
-              elasticsearch.node.fs.disk.available:
-                enabled: true
-              elasticsearch.node.fs.disk.total:
-                enabled: true
-              elasticsearch.node.http.connections:
-                enabled: true
-              elasticsearch.node.ingest.documents.current:
-                enabled: true
-              elasticsearch.node.ingest.operations.failed:
-                enabled: true
-              elasticsearch.node.open_files:
-                enabled: true
-              elasticsearch.node.operations.completed:
-                enabled: true
-              elasticsearch.node.operations.current:
-                enabled: true
-              elasticsearch.node.operations.get.completed:
-                enabled: true
-              elasticsearch.node.operations.time:
-                enabled: true
-              elasticsearch.node.shards.reserved.size:
-                enabled: true
-              elasticsearch.index.shards.size:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.1m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.5m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.15m:
-                enabled: true
-              elasticsearch.os.memory:
-                enabled: true
-              jvm.gc.collections.count:
-                enabled: true
-              jvm.gc.collections.elapsed:
-                enabled: true
-              jvm.memory.heap.max:
-                enabled: true
-              jvm.memory.heap.used:
-                enabled: true
-              jvm.memory.heap.utilization:
-                enabled: true
-              jvm.threads.count:
-                enabled: true
-              elasticsearch.index.segments.count:
-                enabled: true
-              elasticsearch.index.operations.completed:
-                enabled: true
-              elasticsearch.node.script.cache_evictions:
-                enabled: false
-              elasticsearch.node.cluster.connections:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.preprocessed:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.queued:
-                enabled: false
-              elasticsearch.cluster.published_states.full:
-                enabled: false
-              jvm.memory.pool.max:
-                enabled: false
-              elasticsearch.node.script.compilation_limit_triggered:
-                enabled: false
-              elasticsearch.node.shards.data_set.size:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.current:
-                enabled: false
-              elasticsearch.cluster.state_update.count:
-                enabled: false
-              elasticsearch.node.fs.disk.free:
-                enabled: false
-              jvm.memory.nonheap.used:
-                enabled: false
-              jvm.memory.pool.used:
-                enabled: false
-              elasticsearch.node.translog.size:
-                enabled: false
-              elasticsearch.node.thread_pool.threads:
-                enabled: false
-              elasticsearch.cluster.state_queue:
-                enabled: false
-              elasticsearch.node.translog.operations:
-                enabled: false
-              elasticsearch.memory.indexing_pressure:
-                enabled: false
-              elasticsearch.node.ingest.documents:
-                enabled: false
-              jvm.classes.loaded:
-                enabled: false
-              jvm.memory.heap.committed:
-                enabled: false
-              elasticsearch.breaker.memory.limit:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.replica_rejections:
-                enabled: false
-              elasticsearch.breaker.memory.estimated:
-                enabled: false
-              elasticsearch.cluster.published_states.differences:
-                enabled: false
-              jvm.memory.nonheap.committed:
-                enabled: false
-              elasticsearch.node.translog.uncommitted.size:
-                enabled: false
-              elasticsearch.node.script.compilations:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.operations.failed:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.limit:
-                enabled: false
-              elasticsearch.breaker.tripped:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.primary_rejections:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.finished:
-                enabled: false
+                receivers:
+                  jaeger: null
+                  zipkin: null
+                  prometheus: null
+                  otlp: null
+                  receiver_creator/elasticsearch:
+                    watch_observers: [k8s_observer]
+                    receivers:
+                      elasticsearch:
+                        rule: type == "pod" && labels["app"] == "elasticsearch"
+                        config:
+                          endpoint: 'http://`endpoint`:9200'
+                          collection_interval: 15s
+                          metrics:
+                            elasticsearch.os.cpu.usage:
+                              enabled: true
+                            elasticsearch.cluster.data_nodes:
+                              enabled: true
+                            elasticsearch.cluster.health:
+                              enabled: true
+                            elasticsearch.cluster.in_flight_fetch:
+                              enabled: true
+                            elasticsearch.cluster.nodes:
+                              enabled: true
+                            elasticsearch.cluster.pending_tasks:
+                              enabled: true
+                            elasticsearch.cluster.shards:
+                              enabled: true
+                            elasticsearch.cluster.state_update.time:
+                              enabled: true
+                            elasticsearch.index.documents:
+                              enabled: true
+                            elasticsearch.index.operations.merge.current:
+                              enabled: true
+                            elasticsearch.index.operations.time:
+                              enabled: true
+                            elasticsearch.node.cache.count:
+                              enabled: true
+                            elasticsearch.node.cache.evictions:
+                              enabled: true
+                            elasticsearch.node.cache.memory.usage:
+                              enabled: true
+                            elasticsearch.node.shards.size:
+                              enabled: true
+                            elasticsearch.node.cluster.io:
+                              enabled: true
+                            elasticsearch.node.documents:
+                              enabled: true
+                            elasticsearch.node.disk.io.read:
+                              enabled: true
+                            elasticsearch.node.disk.io.write:
+                              enabled: true
+                            elasticsearch.node.fs.disk.available:
+                              enabled: true
+                            elasticsearch.node.fs.disk.total:
+                              enabled: true
+                            elasticsearch.node.http.connections:
+                              enabled: true
+                            elasticsearch.node.ingest.documents.current:
+                              enabled: true
+                            elasticsearch.node.ingest.operations.failed:
+                              enabled: true
+                            elasticsearch.node.open_files:
+                              enabled: true
+                            elasticsearch.node.operations.completed:
+                              enabled: true
+                            elasticsearch.node.operations.current:
+                              enabled: true
+                            elasticsearch.node.operations.get.completed:
+                              enabled: true
+                            elasticsearch.node.operations.time:
+                              enabled: true
+                            elasticsearch.node.shards.reserved.size:
+                              enabled: true
+                            elasticsearch.index.shards.size:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.1m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.5m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.15m:
+                              enabled: true
+                            elasticsearch.os.memory:
+                              enabled: true
+                            jvm.gc.collections.count:
+                              enabled: true
+                            jvm.gc.collections.elapsed:
+                              enabled: true
+                            jvm.memory.heap.max:
+                              enabled: true
+                            jvm.memory.heap.used:
+                              enabled: true
+                            jvm.memory.heap.utilization:
+                              enabled: true
+                            jvm.threads.count:
+                              enabled: true
+                            elasticsearch.index.segments.count:
+                              enabled: true
+                            elasticsearch.index.operations.completed:
+                              enabled: true
+                            elasticsearch.node.script.cache_evictions:
+                              enabled: false
+                            elasticsearch.node.cluster.connections:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.preprocessed:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.queued:
+                              enabled: false
+                            elasticsearch.cluster.published_states.full:
+                              enabled: false
+                            jvm.memory.pool.max:
+                              enabled: false
+                            elasticsearch.node.script.compilation_limit_triggered:
+                              enabled: false
+                            elasticsearch.node.shards.data_set.size:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.current:
+                              enabled: false
+                            elasticsearch.cluster.state_update.count:
+                              enabled: false
+                            elasticsearch.node.fs.disk.free:
+                              enabled: false
+                            jvm.memory.nonheap.used:
+                              enabled: false
+                            jvm.memory.pool.used:
+                              enabled: false
+                            elasticsearch.node.translog.size:
+                              enabled: false
+                            elasticsearch.node.thread_pool.threads:
+                              enabled: false
+                            elasticsearch.cluster.state_queue:
+                              enabled: false
+                            elasticsearch.node.translog.operations:
+                              enabled: false
+                            elasticsearch.memory.indexing_pressure:
+                              enabled: false
+                            elasticsearch.node.ingest.documents:
+                              enabled: false
+                            jvm.classes.loaded:
+                              enabled: false
+                            jvm.memory.heap.committed:
+                              enabled: false
+                            elasticsearch.breaker.memory.limit:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.replica_rejections:
+                              enabled: false
+                            elasticsearch.breaker.memory.estimated:
+                              enabled: false
+                            elasticsearch.cluster.published_states.differences:
+                              enabled: false
+                            jvm.memory.nonheap.committed:
+                              enabled: false
+                            elasticsearch.node.translog.uncommitted.size:
+                              enabled: false
+                            elasticsearch.node.script.compilations:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.operations.failed:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.limit:
+                              enabled: false
+                            elasticsearch.breaker.tripped:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.primary_rejections:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.finished:
+                              enabled: false
 
-  processors:
-    memory_limiter:
-      check_interval: 60s
-      limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
-    cumulativetodelta: {}
-    attributes/cluster_state_aggregate:
-      include:
-        match_type: strict
-        metric_names:
-          - elasticsearch.cluster.state_update.time
-      actions:
-        - key: type
-          action: delete
-        - key: state
-          action: delete
-    filter/critical_operations:
-      metrics:
-        datapoint:
-          - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
-    resource/cluster:
-      attributes:
-        - key: k8s.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: insert
-    resource/cluster_name_override:
-      attributes:
-        - key: elasticsearch.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: upsert
-    resourcedetection:
-      detectors: [env, system]
-      system:
-        resource_attributes:
-          host.name:
-            enabled: true
-          host.id:
-            enabled: true
-          os.type:
-            enabled: true
-    batch:
-      timeout: 30s
-      send_batch_size: 2048
-      send_batch_max_size: 4096
-    attributes/cardinality_reduction:
-      actions:
-        - key: process.pid
-          action: delete
-        - key: process.parent_pid
-          action: delete
-        - key: k8s.pod.uid
-          action: delete
-    transform/metadata_nullify:
-      metric_statements:
-        - context: metric
-          statements:
-            - set(description, "")
-            - set(unit, "")
+                processors:
+                  memory_limiter:
+                    check_interval: 60s
+                    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
+                  cumulativetodelta: {}
+                  attributes/cluster_state_aggregate:
+                    include:
+                      match_type: strict
+                      metric_names:
+                        - elasticsearch.cluster.state_update.time
+                    actions:
+                      - key: type
+                        action: delete
+                      - key: state
+                        action: delete
+                  filter/critical_operations:
+                    metrics:
+                      datapoint:
+                        - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+                  resource/cluster:
+                    attributes:
+                      - key: k8s.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: insert
+                  resource/cluster_name_override:
+                    attributes:
+                      - key: elasticsearch.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: upsert
+                  resourcedetection:
+                    detectors: [env, system]
+                    system:
+                      resource_attributes:
+                        host.name:
+                          enabled: true
+                        host.id:
+                          enabled: true
+                        os.type:
+                          enabled: true
+                  batch:
+                    timeout: 30s
+                    send_batch_size: 2048
+                    send_batch_max_size: 4096
+                  attributes/cardinality_reduction:
+                    actions:
+                      - key: process.pid
+                        action: delete
+                      - key: process.parent_pid
+                        action: delete
+                      - key: k8s.pod.uid
+                        action: delete
+                  transform/metadata_nullify:
+                    metric_statements:
+                      - context: metric
+                        statements:
+                          - set(description, "")
+                          - set(unit, "")
 
-  exporters:
-    otlp_http:
-      endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
-      headers:
-        api-key: "${env:NEWRELIC_LICENSE_KEY}"
-      compression: gzip
-      timeout: 30s
-      retry_on_failure:
-        enabled: true
-        initial_interval: 5s
-        max_interval: 30s
-        max_elapsed_time: 300s
+                exporters:
+                  otlp_http:
+                    endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
+                    headers:
+                      api-key: "${env:NEWRELIC_LICENSE_KEY}"
+                    compression: gzip
+                    timeout: 30s
+                    retry_on_failure:
+                      enabled: true
+                      initial_interval: 5s
+                      max_interval: 30s
+                      max_elapsed_time: 300s
 
-  service:
-    extensions: [health_check, k8s_observer]
-    pipelines:
-      traces: null
-      logs: null
-      metrics: null
-      metrics/elasticsearch:
-        receivers: [receiver_creator/elasticsearch]
-        processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
-        exporters: [otlp_http]
-```
+                service:
+                  extensions: [health_check, k8s_observer]
+                  pipelines:
+                    traces: null
+                    logs: null
+                    metrics: null
+                    metrics/elasticsearch:
+                      receivers: [receiver_creator/elasticsearch]
+                      processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+                      exporters: [otlp_http]
+              ```
 
               <Callout variant="tip">
                 **Personnalisez pour votre environnement :**

--- a/src/i18n/content/jp/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
+++ b/src/i18n/content/jp/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
@@ -452,335 +452,335 @@ translationType: machine
 
               1. ネームスペースを作成します。
 
-                 ```bash
-                 kubectl create namespace newrelic
-                 ```
+              ```bash
+              kubectl create namespace newrelic
+              ```
 
               2. 秘密を作り出す：
 
-                 ```bash
-                 kubectl create secret generic newrelic-licenses \
+              ```bash
+              kubectl create secret generic newrelic-licenses \
                    --from-literal=NEWRELIC_LICENSE_KEY=YOUR_LICENSE_KEY_HERE \
                    --from-literal=NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318 \
                    --from-literal=NEW_RELIC_MEMORY_LIMIT_MIB=100 \
                    -n newrelic
-                 ```
+              ```
 
-                 値を更新します:
+              値を更新します:
 
-                 * `YOUR_LICENSE_KEY_HERE`実際の New Relic ライセンスキーに置き換えてください。
-                 * `https://otlp.nr-data.net:4318`地域のエンドポイントに置き換えます ([OTLP エンドポイントのドキュメント](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol)を参照してください)。
-                 * `100`をコレクターの任意のメモリ制限（MiB単位）に置き換えます。
+              * `YOUR_LICENSE_KEY_HERE`実際の New Relic ライセンスキーに置き換えてください。
+              * `https://otlp.nr-data.net:4318`地域のエンドポイントに置き換えます ([OTLP エンドポイントのドキュメント](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol)を参照してください)。
+              * `100`をコレクターの任意のメモリ制限（MiB単位）に置き換えます。
 
               #### Elasticsearchの監視を設定する [#nrdot-helm-configure-es]
 
               NRDOT Collector Elasticsearch監視用の`values.yaml`ファイルを作成します：
 
-```yaml
-mode: deployment
+              ```yaml
+              mode: deployment
 
-image:
-  repository: newrelic/nrdot-collector
-  tag: latest
-  pullPolicy: IfNotPresent
+              image:
+                repository: newrelic/nrdot-collector
+                tag: latest
+                pullPolicy: IfNotPresent
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 200m
-    memory: 256Mi
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
 
-ports: {}
+              ports: {}
 
-extraEnvs:
-  - name: NEWRELIC_LICENSE_KEY
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_LICENSE_KEY
-  - name: NEWRELIC_OTLP_ENDPOINT
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_OTLP_ENDPOINT
-  - name: NEW_RELIC_MEMORY_LIMIT_MIB
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEW_RELIC_MEMORY_LIMIT_MIB
-  - name: K8S_CLUSTER_NAME
-    value: "elasticsearch-cluster"
+              extraEnvs:
+                - name: NEWRELIC_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_LICENSE_KEY
+                - name: NEWRELIC_OTLP_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_OTLP_ENDPOINT
+                - name: NEW_RELIC_MEMORY_LIMIT_MIB
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEW_RELIC_MEMORY_LIMIT_MIB
+                - name: K8S_CLUSTER_NAME
+                  value: "elasticsearch-cluster"
 
-clusterRole:
-  create: true
-  rules:
-    - apiGroups: [""]
-      resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["apps"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
+              clusterRole:
+                create: true
+                rules:
+                  - apiGroups: [""]
+                    resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
+                    verbs: ["get", "list", "watch"]
+                  - apiGroups: ["apps"]
+                    resources: ["replicasets"]
+                    verbs: ["get", "list", "watch"]
 
-config:
-  extensions:
-    health_check:
-      endpoint: 0.0.0.0:13133
-    k8s_observer:
-      auth_type: serviceAccount
-      observe_pods: true
-      observe_nodes: true
+              config:
+                extensions:
+                  health_check:
+                    endpoint: 0.0.0.0:13133
+                  k8s_observer:
+                    auth_type: serviceAccount
+                    observe_pods: true
+                    observe_nodes: true
 
-  receivers:
-    jaeger: null
-    zipkin: null
-    prometheus: null
-    otlp: null
-    receiver_creator/elasticsearch:
-      watch_observers: [k8s_observer]
-      receivers:
-        elasticsearch:
-          rule: type == "pod" && labels["app"] == "elasticsearch"
-          config:
-            endpoint: 'http://`endpoint`:9200'
-            collection_interval: 15s
-            metrics:
-              elasticsearch.os.cpu.usage:
-                enabled: true
-              elasticsearch.cluster.data_nodes:
-                enabled: true
-              elasticsearch.cluster.health:
-                enabled: true
-              elasticsearch.cluster.in_flight_fetch:
-                enabled: true
-              elasticsearch.cluster.nodes:
-                enabled: true
-              elasticsearch.cluster.pending_tasks:
-                enabled: true
-              elasticsearch.cluster.shards:
-                enabled: true
-              elasticsearch.cluster.state_update.time:
-                enabled: true
-              elasticsearch.index.documents:
-                enabled: true
-              elasticsearch.index.operations.merge.current:
-                enabled: true
-              elasticsearch.index.operations.time:
-                enabled: true
-              elasticsearch.node.cache.count:
-                enabled: true
-              elasticsearch.node.cache.evictions:
-                enabled: true
-              elasticsearch.node.cache.memory.usage:
-                enabled: true
-              elasticsearch.node.shards.size:
-                enabled: true
-              elasticsearch.node.cluster.io:
-                enabled: true
-              elasticsearch.node.documents:
-                enabled: true
-              elasticsearch.node.disk.io.read:
-                enabled: true
-              elasticsearch.node.disk.io.write:
-                enabled: true
-              elasticsearch.node.fs.disk.available:
-                enabled: true
-              elasticsearch.node.fs.disk.total:
-                enabled: true
-              elasticsearch.node.http.connections:
-                enabled: true
-              elasticsearch.node.ingest.documents.current:
-                enabled: true
-              elasticsearch.node.ingest.operations.failed:
-                enabled: true
-              elasticsearch.node.open_files:
-                enabled: true
-              elasticsearch.node.operations.completed:
-                enabled: true
-              elasticsearch.node.operations.current:
-                enabled: true
-              elasticsearch.node.operations.get.completed:
-                enabled: true
-              elasticsearch.node.operations.time:
-                enabled: true
-              elasticsearch.node.shards.reserved.size:
-                enabled: true
-              elasticsearch.index.shards.size:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.1m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.5m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.15m:
-                enabled: true
-              elasticsearch.os.memory:
-                enabled: true
-              jvm.gc.collections.count:
-                enabled: true
-              jvm.gc.collections.elapsed:
-                enabled: true
-              jvm.memory.heap.max:
-                enabled: true
-              jvm.memory.heap.used:
-                enabled: true
-              jvm.memory.heap.utilization:
-                enabled: true
-              jvm.threads.count:
-                enabled: true
-              elasticsearch.index.segments.count:
-                enabled: true
-              elasticsearch.index.operations.completed:
-                enabled: true
-              elasticsearch.node.script.cache_evictions:
-                enabled: false
-              elasticsearch.node.cluster.connections:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.preprocessed:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.queued:
-                enabled: false
-              elasticsearch.cluster.published_states.full:
-                enabled: false
-              jvm.memory.pool.max:
-                enabled: false
-              elasticsearch.node.script.compilation_limit_triggered:
-                enabled: false
-              elasticsearch.node.shards.data_set.size:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.current:
-                enabled: false
-              elasticsearch.cluster.state_update.count:
-                enabled: false
-              elasticsearch.node.fs.disk.free:
-                enabled: false
-              jvm.memory.nonheap.used:
-                enabled: false
-              jvm.memory.pool.used:
-                enabled: false
-              elasticsearch.node.translog.size:
-                enabled: false
-              elasticsearch.node.thread_pool.threads:
-                enabled: false
-              elasticsearch.cluster.state_queue:
-                enabled: false
-              elasticsearch.node.translog.operations:
-                enabled: false
-              elasticsearch.memory.indexing_pressure:
-                enabled: false
-              elasticsearch.node.ingest.documents:
-                enabled: false
-              jvm.classes.loaded:
-                enabled: false
-              jvm.memory.heap.committed:
-                enabled: false
-              elasticsearch.breaker.memory.limit:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.replica_rejections:
-                enabled: false
-              elasticsearch.breaker.memory.estimated:
-                enabled: false
-              elasticsearch.cluster.published_states.differences:
-                enabled: false
-              jvm.memory.nonheap.committed:
-                enabled: false
-              elasticsearch.node.translog.uncommitted.size:
-                enabled: false
-              elasticsearch.node.script.compilations:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.operations.failed:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.limit:
-                enabled: false
-              elasticsearch.breaker.tripped:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.primary_rejections:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.finished:
-                enabled: false
+                receivers:
+                  jaeger: null
+                  zipkin: null
+                  prometheus: null
+                  otlp: null
+                  receiver_creator/elasticsearch:
+                    watch_observers: [k8s_observer]
+                    receivers:
+                      elasticsearch:
+                        rule: type == "pod" && labels["app"] == "elasticsearch"
+                        config:
+                          endpoint: 'http://`endpoint`:9200'
+                          collection_interval: 15s
+                          metrics:
+                            elasticsearch.os.cpu.usage:
+                              enabled: true
+                            elasticsearch.cluster.data_nodes:
+                              enabled: true
+                            elasticsearch.cluster.health:
+                              enabled: true
+                            elasticsearch.cluster.in_flight_fetch:
+                              enabled: true
+                            elasticsearch.cluster.nodes:
+                              enabled: true
+                            elasticsearch.cluster.pending_tasks:
+                              enabled: true
+                            elasticsearch.cluster.shards:
+                              enabled: true
+                            elasticsearch.cluster.state_update.time:
+                              enabled: true
+                            elasticsearch.index.documents:
+                              enabled: true
+                            elasticsearch.index.operations.merge.current:
+                              enabled: true
+                            elasticsearch.index.operations.time:
+                              enabled: true
+                            elasticsearch.node.cache.count:
+                              enabled: true
+                            elasticsearch.node.cache.evictions:
+                              enabled: true
+                            elasticsearch.node.cache.memory.usage:
+                              enabled: true
+                            elasticsearch.node.shards.size:
+                              enabled: true
+                            elasticsearch.node.cluster.io:
+                              enabled: true
+                            elasticsearch.node.documents:
+                              enabled: true
+                            elasticsearch.node.disk.io.read:
+                              enabled: true
+                            elasticsearch.node.disk.io.write:
+                              enabled: true
+                            elasticsearch.node.fs.disk.available:
+                              enabled: true
+                            elasticsearch.node.fs.disk.total:
+                              enabled: true
+                            elasticsearch.node.http.connections:
+                              enabled: true
+                            elasticsearch.node.ingest.documents.current:
+                              enabled: true
+                            elasticsearch.node.ingest.operations.failed:
+                              enabled: true
+                            elasticsearch.node.open_files:
+                              enabled: true
+                            elasticsearch.node.operations.completed:
+                              enabled: true
+                            elasticsearch.node.operations.current:
+                              enabled: true
+                            elasticsearch.node.operations.get.completed:
+                              enabled: true
+                            elasticsearch.node.operations.time:
+                              enabled: true
+                            elasticsearch.node.shards.reserved.size:
+                              enabled: true
+                            elasticsearch.index.shards.size:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.1m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.5m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.15m:
+                              enabled: true
+                            elasticsearch.os.memory:
+                              enabled: true
+                            jvm.gc.collections.count:
+                              enabled: true
+                            jvm.gc.collections.elapsed:
+                              enabled: true
+                            jvm.memory.heap.max:
+                              enabled: true
+                            jvm.memory.heap.used:
+                              enabled: true
+                            jvm.memory.heap.utilization:
+                              enabled: true
+                            jvm.threads.count:
+                              enabled: true
+                            elasticsearch.index.segments.count:
+                              enabled: true
+                            elasticsearch.index.operations.completed:
+                              enabled: true
+                            elasticsearch.node.script.cache_evictions:
+                              enabled: false
+                            elasticsearch.node.cluster.connections:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.preprocessed:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.queued:
+                              enabled: false
+                            elasticsearch.cluster.published_states.full:
+                              enabled: false
+                            jvm.memory.pool.max:
+                              enabled: false
+                            elasticsearch.node.script.compilation_limit_triggered:
+                              enabled: false
+                            elasticsearch.node.shards.data_set.size:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.current:
+                              enabled: false
+                            elasticsearch.cluster.state_update.count:
+                              enabled: false
+                            elasticsearch.node.fs.disk.free:
+                              enabled: false
+                            jvm.memory.nonheap.used:
+                              enabled: false
+                            jvm.memory.pool.used:
+                              enabled: false
+                            elasticsearch.node.translog.size:
+                              enabled: false
+                            elasticsearch.node.thread_pool.threads:
+                              enabled: false
+                            elasticsearch.cluster.state_queue:
+                              enabled: false
+                            elasticsearch.node.translog.operations:
+                              enabled: false
+                            elasticsearch.memory.indexing_pressure:
+                              enabled: false
+                            elasticsearch.node.ingest.documents:
+                              enabled: false
+                            jvm.classes.loaded:
+                              enabled: false
+                            jvm.memory.heap.committed:
+                              enabled: false
+                            elasticsearch.breaker.memory.limit:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.replica_rejections:
+                              enabled: false
+                            elasticsearch.breaker.memory.estimated:
+                              enabled: false
+                            elasticsearch.cluster.published_states.differences:
+                              enabled: false
+                            jvm.memory.nonheap.committed:
+                              enabled: false
+                            elasticsearch.node.translog.uncommitted.size:
+                              enabled: false
+                            elasticsearch.node.script.compilations:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.operations.failed:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.limit:
+                              enabled: false
+                            elasticsearch.breaker.tripped:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.primary_rejections:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.finished:
+                              enabled: false
 
-  processors:
-    memory_limiter:
-      check_interval: 60s
-      limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
-    cumulativetodelta: {}
-    attributes/cluster_state_aggregate:
-      include:
-        match_type: strict
-        metric_names:
-          - elasticsearch.cluster.state_update.time
-      actions:
-        - key: type
-          action: delete
-        - key: state
-          action: delete
-    filter/critical_operations:
-      metrics:
-        datapoint:
-          - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
-    resource/cluster:
-      attributes:
-        - key: k8s.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: insert
-    resource/cluster_name_override:
-      attributes:
-        - key: elasticsearch.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: upsert
-    resourcedetection:
-      detectors: [env, system]
-      system:
-        resource_attributes:
-          host.name:
-            enabled: true
-          host.id:
-            enabled: true
-          os.type:
-            enabled: true
-    batch:
-      timeout: 30s
-      send_batch_size: 2048
-      send_batch_max_size: 4096
-    attributes/cardinality_reduction:
-      actions:
-        - key: process.pid
-          action: delete
-        - key: process.parent_pid
-          action: delete
-        - key: k8s.pod.uid
-          action: delete
-    transform/metadata_nullify:
-      metric_statements:
-        - context: metric
-          statements:
-            - set(description, "")
-            - set(unit, "")
+                processors:
+                  memory_limiter:
+                    check_interval: 60s
+                    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
+                  cumulativetodelta: {}
+                  attributes/cluster_state_aggregate:
+                    include:
+                      match_type: strict
+                      metric_names:
+                        - elasticsearch.cluster.state_update.time
+                    actions:
+                      - key: type
+                        action: delete
+                      - key: state
+                        action: delete
+                  filter/critical_operations:
+                    metrics:
+                      datapoint:
+                        - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+                  resource/cluster:
+                    attributes:
+                      - key: k8s.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: insert
+                  resource/cluster_name_override:
+                    attributes:
+                      - key: elasticsearch.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: upsert
+                  resourcedetection:
+                    detectors: [env, system]
+                    system:
+                      resource_attributes:
+                        host.name:
+                          enabled: true
+                        host.id:
+                          enabled: true
+                        os.type:
+                          enabled: true
+                  batch:
+                    timeout: 30s
+                    send_batch_size: 2048
+                    send_batch_max_size: 4096
+                  attributes/cardinality_reduction:
+                    actions:
+                      - key: process.pid
+                        action: delete
+                      - key: process.parent_pid
+                        action: delete
+                      - key: k8s.pod.uid
+                        action: delete
+                  transform/metadata_nullify:
+                    metric_statements:
+                      - context: metric
+                        statements:
+                          - set(description, "")
+                          - set(unit, "")
 
-  exporters:
-    otlp_http:
-      endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
-      headers:
-        api-key: "${env:NEWRELIC_LICENSE_KEY}"
-      compression: gzip
-      timeout: 30s
-      retry_on_failure:
-        enabled: true
-        initial_interval: 5s
-        max_interval: 30s
-        max_elapsed_time: 300s
+                exporters:
+                  otlp_http:
+                    endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
+                    headers:
+                      api-key: "${env:NEWRELIC_LICENSE_KEY}"
+                    compression: gzip
+                    timeout: 30s
+                    retry_on_failure:
+                      enabled: true
+                      initial_interval: 5s
+                      max_interval: 30s
+                      max_elapsed_time: 300s
 
-  service:
-    extensions: [health_check, k8s_observer]
-    pipelines:
-      traces: null
-      logs: null
-      metrics: null
-      metrics/elasticsearch:
-        receivers: [receiver_creator/elasticsearch]
-        processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
-        exporters: [otlp_http]
-```
+                service:
+                  extensions: [health_check, k8s_observer]
+                  pipelines:
+                    traces: null
+                    logs: null
+                    metrics: null
+                    metrics/elasticsearch:
+                      receivers: [receiver_creator/elasticsearch]
+                      processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+                      exporters: [otlp_http]
+              ```
 
               <Callout variant="tip">
                 **環境に合わせてカスタマイズ：**

--- a/src/i18n/content/kr/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
+++ b/src/i18n/content/kr/docs/opentelemetry/integrations/elasticsearch/elasticsearch-otel-integration-k8-install.mdx
@@ -452,335 +452,335 @@ translationType: machine
 
               1. 네임스페이스를 생성합니다.
 
-                 ```bash
-                 kubectl create namespace newrelic
-                 ```
+              ```bash
+              kubectl create namespace newrelic
+              ```
 
               2. 비밀을 만들어 보세요:
 
-                 ```bash
-                 kubectl create secret generic newrelic-licenses \
+              ```bash
+              kubectl create secret generic newrelic-licenses \
                    --from-literal=NEWRELIC_LICENSE_KEY=YOUR_LICENSE_KEY_HERE \
                    --from-literal=NEWRELIC_OTLP_ENDPOINT=https://otlp.nr-data.net:4318 \
                    --from-literal=NEW_RELIC_MEMORY_LIMIT_MIB=100 \
                    -n newrelic
-                 ```
+              ```
 
-                 값을 업데이트하세요:
+              값을 업데이트하세요:
 
-                 * `YOUR_LICENSE_KEY_HERE` 실제 뉴웰 클러스터 키로 바꾸세요.
-                 * `https://otlp.nr-data.net:4318` 해당 지역의 엔드포인트로 바꾸세요([OTLP 엔드포인트 문서를](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol) 참조하세요).
-                 * `100` 을(를) 수집기의 원하는 메모리 제한(MiB)으로 변경하십시오.
+              * `YOUR_LICENSE_KEY_HERE` 실제 뉴웰 클러스터 키로 바꾸세요.
+              * `https://otlp.nr-data.net:4318` 해당 지역의 엔드포인트로 바꾸세요([OTLP 엔드포인트 문서를](/docs/opentelemetry/best-practices/opentelemetry-otlp/#configure-endpoint-port-protocol) 참조하세요).
+              * `100` 을(를) 수집기의 원하는 메모리 제한(MiB)으로 변경하십시오.
 
               #### Elasticsearch 모니터링을 구성합니다. [#nrdot-helm-configure-es]
 
               NRDOT Collector Elasticsearch 모니터링을 위한 `values.yaml` 파일을 생성합니다:
 
-```yaml
-mode: deployment
+              ```yaml
+              mode: deployment
 
-image:
-  repository: newrelic/nrdot-collector
-  tag: latest
-  pullPolicy: IfNotPresent
+              image:
+                repository: newrelic/nrdot-collector
+                tag: latest
+                pullPolicy: IfNotPresent
 
-resources:
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 200m
-    memory: 256Mi
+              resources:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 200m
+                  memory: 256Mi
 
-ports: {}
+              ports: {}
 
-extraEnvs:
-  - name: NEWRELIC_LICENSE_KEY
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_LICENSE_KEY
-  - name: NEWRELIC_OTLP_ENDPOINT
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEWRELIC_OTLP_ENDPOINT
-  - name: NEW_RELIC_MEMORY_LIMIT_MIB
-    valueFrom:
-      secretKeyRef:
-        name: newrelic-licenses
-        key: NEW_RELIC_MEMORY_LIMIT_MIB
-  - name: K8S_CLUSTER_NAME
-    value: "elasticsearch-cluster"
+              extraEnvs:
+                - name: NEWRELIC_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_LICENSE_KEY
+                - name: NEWRELIC_OTLP_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEWRELIC_OTLP_ENDPOINT
+                - name: NEW_RELIC_MEMORY_LIMIT_MIB
+                  valueFrom:
+                    secretKeyRef:
+                      name: newrelic-licenses
+                      key: NEW_RELIC_MEMORY_LIMIT_MIB
+                - name: K8S_CLUSTER_NAME
+                  value: "elasticsearch-cluster"
 
-clusterRole:
-  create: true
-  rules:
-    - apiGroups: [""]
-      resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["apps"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
+              clusterRole:
+                create: true
+                rules:
+                  - apiGroups: [""]
+                    resources: ["pods", "nodes", "nodes/stats", "nodes/proxy"]
+                    verbs: ["get", "list", "watch"]
+                  - apiGroups: ["apps"]
+                    resources: ["replicasets"]
+                    verbs: ["get", "list", "watch"]
 
-config:
-  extensions:
-    health_check:
-      endpoint: 0.0.0.0:13133
-    k8s_observer:
-      auth_type: serviceAccount
-      observe_pods: true
-      observe_nodes: true
+              config:
+                extensions:
+                  health_check:
+                    endpoint: 0.0.0.0:13133
+                  k8s_observer:
+                    auth_type: serviceAccount
+                    observe_pods: true
+                    observe_nodes: true
 
-  receivers:
-    jaeger: null
-    zipkin: null
-    prometheus: null
-    otlp: null
-    receiver_creator/elasticsearch:
-      watch_observers: [k8s_observer]
-      receivers:
-        elasticsearch:
-          rule: type == "pod" && labels["app"] == "elasticsearch"
-          config:
-            endpoint: 'http://`endpoint`:9200'
-            collection_interval: 15s
-            metrics:
-              elasticsearch.os.cpu.usage:
-                enabled: true
-              elasticsearch.cluster.data_nodes:
-                enabled: true
-              elasticsearch.cluster.health:
-                enabled: true
-              elasticsearch.cluster.in_flight_fetch:
-                enabled: true
-              elasticsearch.cluster.nodes:
-                enabled: true
-              elasticsearch.cluster.pending_tasks:
-                enabled: true
-              elasticsearch.cluster.shards:
-                enabled: true
-              elasticsearch.cluster.state_update.time:
-                enabled: true
-              elasticsearch.index.documents:
-                enabled: true
-              elasticsearch.index.operations.merge.current:
-                enabled: true
-              elasticsearch.index.operations.time:
-                enabled: true
-              elasticsearch.node.cache.count:
-                enabled: true
-              elasticsearch.node.cache.evictions:
-                enabled: true
-              elasticsearch.node.cache.memory.usage:
-                enabled: true
-              elasticsearch.node.shards.size:
-                enabled: true
-              elasticsearch.node.cluster.io:
-                enabled: true
-              elasticsearch.node.documents:
-                enabled: true
-              elasticsearch.node.disk.io.read:
-                enabled: true
-              elasticsearch.node.disk.io.write:
-                enabled: true
-              elasticsearch.node.fs.disk.available:
-                enabled: true
-              elasticsearch.node.fs.disk.total:
-                enabled: true
-              elasticsearch.node.http.connections:
-                enabled: true
-              elasticsearch.node.ingest.documents.current:
-                enabled: true
-              elasticsearch.node.ingest.operations.failed:
-                enabled: true
-              elasticsearch.node.open_files:
-                enabled: true
-              elasticsearch.node.operations.completed:
-                enabled: true
-              elasticsearch.node.operations.current:
-                enabled: true
-              elasticsearch.node.operations.get.completed:
-                enabled: true
-              elasticsearch.node.operations.time:
-                enabled: true
-              elasticsearch.node.shards.reserved.size:
-                enabled: true
-              elasticsearch.index.shards.size:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.1m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.5m:
-                enabled: true
-              elasticsearch.os.cpu.load_avg.15m:
-                enabled: true
-              elasticsearch.os.memory:
-                enabled: true
-              jvm.gc.collections.count:
-                enabled: true
-              jvm.gc.collections.elapsed:
-                enabled: true
-              jvm.memory.heap.max:
-                enabled: true
-              jvm.memory.heap.used:
-                enabled: true
-              jvm.memory.heap.utilization:
-                enabled: true
-              jvm.threads.count:
-                enabled: true
-              elasticsearch.index.segments.count:
-                enabled: true
-              elasticsearch.index.operations.completed:
-                enabled: true
-              elasticsearch.node.script.cache_evictions:
-                enabled: false
-              elasticsearch.node.cluster.connections:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.preprocessed:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.queued:
-                enabled: false
-              elasticsearch.cluster.published_states.full:
-                enabled: false
-              jvm.memory.pool.max:
-                enabled: false
-              elasticsearch.node.script.compilation_limit_triggered:
-                enabled: false
-              elasticsearch.node.shards.data_set.size:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.documents.current:
-                enabled: false
-              elasticsearch.cluster.state_update.count:
-                enabled: false
-              elasticsearch.node.fs.disk.free:
-                enabled: false
-              jvm.memory.nonheap.used:
-                enabled: false
-              jvm.memory.pool.used:
-                enabled: false
-              elasticsearch.node.translog.size:
-                enabled: false
-              elasticsearch.node.thread_pool.threads:
-                enabled: false
-              elasticsearch.cluster.state_queue:
-                enabled: false
-              elasticsearch.node.translog.operations:
-                enabled: false
-              elasticsearch.memory.indexing_pressure:
-                enabled: false
-              elasticsearch.node.ingest.documents:
-                enabled: false
-              jvm.classes.loaded:
-                enabled: false
-              jvm.memory.heap.committed:
-                enabled: false
-              elasticsearch.breaker.memory.limit:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.replica_rejections:
-                enabled: false
-              elasticsearch.breaker.memory.estimated:
-                enabled: false
-              elasticsearch.cluster.published_states.differences:
-                enabled: false
-              jvm.memory.nonheap.committed:
-                enabled: false
-              elasticsearch.node.translog.uncommitted.size:
-                enabled: false
-              elasticsearch.node.script.compilations:
-                enabled: false
-              elasticsearch.node.pipeline.ingest.operations.failed:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.limit:
-                enabled: false
-              elasticsearch.breaker.tripped:
-                enabled: false
-              elasticsearch.indexing_pressure.memory.total.primary_rejections:
-                enabled: false
-              elasticsearch.node.thread_pool.tasks.finished:
-                enabled: false
+                receivers:
+                  jaeger: null
+                  zipkin: null
+                  prometheus: null
+                  otlp: null
+                  receiver_creator/elasticsearch:
+                    watch_observers: [k8s_observer]
+                    receivers:
+                      elasticsearch:
+                        rule: type == "pod" && labels["app"] == "elasticsearch"
+                        config:
+                          endpoint: 'http://`endpoint`:9200'
+                          collection_interval: 15s
+                          metrics:
+                            elasticsearch.os.cpu.usage:
+                              enabled: true
+                            elasticsearch.cluster.data_nodes:
+                              enabled: true
+                            elasticsearch.cluster.health:
+                              enabled: true
+                            elasticsearch.cluster.in_flight_fetch:
+                              enabled: true
+                            elasticsearch.cluster.nodes:
+                              enabled: true
+                            elasticsearch.cluster.pending_tasks:
+                              enabled: true
+                            elasticsearch.cluster.shards:
+                              enabled: true
+                            elasticsearch.cluster.state_update.time:
+                              enabled: true
+                            elasticsearch.index.documents:
+                              enabled: true
+                            elasticsearch.index.operations.merge.current:
+                              enabled: true
+                            elasticsearch.index.operations.time:
+                              enabled: true
+                            elasticsearch.node.cache.count:
+                              enabled: true
+                            elasticsearch.node.cache.evictions:
+                              enabled: true
+                            elasticsearch.node.cache.memory.usage:
+                              enabled: true
+                            elasticsearch.node.shards.size:
+                              enabled: true
+                            elasticsearch.node.cluster.io:
+                              enabled: true
+                            elasticsearch.node.documents:
+                              enabled: true
+                            elasticsearch.node.disk.io.read:
+                              enabled: true
+                            elasticsearch.node.disk.io.write:
+                              enabled: true
+                            elasticsearch.node.fs.disk.available:
+                              enabled: true
+                            elasticsearch.node.fs.disk.total:
+                              enabled: true
+                            elasticsearch.node.http.connections:
+                              enabled: true
+                            elasticsearch.node.ingest.documents.current:
+                              enabled: true
+                            elasticsearch.node.ingest.operations.failed:
+                              enabled: true
+                            elasticsearch.node.open_files:
+                              enabled: true
+                            elasticsearch.node.operations.completed:
+                              enabled: true
+                            elasticsearch.node.operations.current:
+                              enabled: true
+                            elasticsearch.node.operations.get.completed:
+                              enabled: true
+                            elasticsearch.node.operations.time:
+                              enabled: true
+                            elasticsearch.node.shards.reserved.size:
+                              enabled: true
+                            elasticsearch.index.shards.size:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.1m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.5m:
+                              enabled: true
+                            elasticsearch.os.cpu.load_avg.15m:
+                              enabled: true
+                            elasticsearch.os.memory:
+                              enabled: true
+                            jvm.gc.collections.count:
+                              enabled: true
+                            jvm.gc.collections.elapsed:
+                              enabled: true
+                            jvm.memory.heap.max:
+                              enabled: true
+                            jvm.memory.heap.used:
+                              enabled: true
+                            jvm.memory.heap.utilization:
+                              enabled: true
+                            jvm.threads.count:
+                              enabled: true
+                            elasticsearch.index.segments.count:
+                              enabled: true
+                            elasticsearch.index.operations.completed:
+                              enabled: true
+                            elasticsearch.node.script.cache_evictions:
+                              enabled: false
+                            elasticsearch.node.cluster.connections:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.preprocessed:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.queued:
+                              enabled: false
+                            elasticsearch.cluster.published_states.full:
+                              enabled: false
+                            jvm.memory.pool.max:
+                              enabled: false
+                            elasticsearch.node.script.compilation_limit_triggered:
+                              enabled: false
+                            elasticsearch.node.shards.data_set.size:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.documents.current:
+                              enabled: false
+                            elasticsearch.cluster.state_update.count:
+                              enabled: false
+                            elasticsearch.node.fs.disk.free:
+                              enabled: false
+                            jvm.memory.nonheap.used:
+                              enabled: false
+                            jvm.memory.pool.used:
+                              enabled: false
+                            elasticsearch.node.translog.size:
+                              enabled: false
+                            elasticsearch.node.thread_pool.threads:
+                              enabled: false
+                            elasticsearch.cluster.state_queue:
+                              enabled: false
+                            elasticsearch.node.translog.operations:
+                              enabled: false
+                            elasticsearch.memory.indexing_pressure:
+                              enabled: false
+                            elasticsearch.node.ingest.documents:
+                              enabled: false
+                            jvm.classes.loaded:
+                              enabled: false
+                            jvm.memory.heap.committed:
+                              enabled: false
+                            elasticsearch.breaker.memory.limit:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.replica_rejections:
+                              enabled: false
+                            elasticsearch.breaker.memory.estimated:
+                              enabled: false
+                            elasticsearch.cluster.published_states.differences:
+                              enabled: false
+                            jvm.memory.nonheap.committed:
+                              enabled: false
+                            elasticsearch.node.translog.uncommitted.size:
+                              enabled: false
+                            elasticsearch.node.script.compilations:
+                              enabled: false
+                            elasticsearch.node.pipeline.ingest.operations.failed:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.limit:
+                              enabled: false
+                            elasticsearch.breaker.tripped:
+                              enabled: false
+                            elasticsearch.indexing_pressure.memory.total.primary_rejections:
+                              enabled: false
+                            elasticsearch.node.thread_pool.tasks.finished:
+                              enabled: false
 
-  processors:
-    memory_limiter:
-      check_interval: 60s
-      limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
-    cumulativetodelta: {}
-    attributes/cluster_state_aggregate:
-      include:
-        match_type: strict
-        metric_names:
-          - elasticsearch.cluster.state_update.time
-      actions:
-        - key: type
-          action: delete
-        - key: state
-          action: delete
-    filter/critical_operations:
-      metrics:
-        datapoint:
-          - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
-    resource/cluster:
-      attributes:
-        - key: k8s.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: insert
-    resource/cluster_name_override:
-      attributes:
-        - key: elasticsearch.cluster.name
-          value: "${env:K8S_CLUSTER_NAME}"
-          action: upsert
-    resourcedetection:
-      detectors: [env, system]
-      system:
-        resource_attributes:
-          host.name:
-            enabled: true
-          host.id:
-            enabled: true
-          os.type:
-            enabled: true
-    batch:
-      timeout: 30s
-      send_batch_size: 2048
-      send_batch_max_size: 4096
-    attributes/cardinality_reduction:
-      actions:
-        - key: process.pid
-          action: delete
-        - key: process.parent_pid
-          action: delete
-        - key: k8s.pod.uid
-          action: delete
-    transform/metadata_nullify:
-      metric_statements:
-        - context: metric
-          statements:
-            - set(description, "")
-            - set(unit, "")
+                processors:
+                  memory_limiter:
+                    check_interval: 60s
+                    limit_mib: ${env:NEW_RELIC_MEMORY_LIMIT_MIB}
+                  cumulativetodelta: {}
+                  attributes/cluster_state_aggregate:
+                    include:
+                      match_type: strict
+                      metric_names:
+                        - elasticsearch.cluster.state_update.time
+                    actions:
+                      - key: type
+                        action: delete
+                      - key: state
+                        action: delete
+                  filter/critical_operations:
+                    metrics:
+                      datapoint:
+                        - 'attributes["operation"] == "query" or attributes["operation"] == "index" or attributes["operation"] == "get" or attributes["operation"] == "merge" or attributes["operation"] == nil'
+                  resource/cluster:
+                    attributes:
+                      - key: k8s.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: insert
+                  resource/cluster_name_override:
+                    attributes:
+                      - key: elasticsearch.cluster.name
+                        value: "${env:K8S_CLUSTER_NAME}"
+                        action: upsert
+                  resourcedetection:
+                    detectors: [env, system]
+                    system:
+                      resource_attributes:
+                        host.name:
+                          enabled: true
+                        host.id:
+                          enabled: true
+                        os.type:
+                          enabled: true
+                  batch:
+                    timeout: 30s
+                    send_batch_size: 2048
+                    send_batch_max_size: 4096
+                  attributes/cardinality_reduction:
+                    actions:
+                      - key: process.pid
+                        action: delete
+                      - key: process.parent_pid
+                        action: delete
+                      - key: k8s.pod.uid
+                        action: delete
+                  transform/metadata_nullify:
+                    metric_statements:
+                      - context: metric
+                        statements:
+                          - set(description, "")
+                          - set(unit, "")
 
-  exporters:
-    otlp_http:
-      endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
-      headers:
-        api-key: "${env:NEWRELIC_LICENSE_KEY}"
-      compression: gzip
-      timeout: 30s
-      retry_on_failure:
-        enabled: true
-        initial_interval: 5s
-        max_interval: 30s
-        max_elapsed_time: 300s
+                exporters:
+                  otlp_http:
+                    endpoint: "${env:NEWRELIC_OTLP_ENDPOINT}"
+                    headers:
+                      api-key: "${env:NEWRELIC_LICENSE_KEY}"
+                    compression: gzip
+                    timeout: 30s
+                    retry_on_failure:
+                      enabled: true
+                      initial_interval: 5s
+                      max_interval: 30s
+                      max_elapsed_time: 300s
 
-  service:
-    extensions: [health_check, k8s_observer]
-    pipelines:
-      traces: null
-      logs: null
-      metrics: null
-      metrics/elasticsearch:
-        receivers: [receiver_creator/elasticsearch]
-        processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
-        exporters: [otlp_http]
-```
+                service:
+                  extensions: [health_check, k8s_observer]
+                  pipelines:
+                    traces: null
+                    logs: null
+                    metrics: null
+                    metrics/elasticsearch:
+                      receivers: [receiver_creator/elasticsearch]
+                      processors: [memory_limiter, resourcedetection, resource/cluster, resource/cluster_name_override, attributes/cardinality_reduction, filter/critical_operations, attributes/cluster_state_aggregate, cumulativetodelta, transform/metadata_nullify, batch]
+                      exporters: [otlp_http]
+              ```
 
               <Callout variant="tip">
                 **환경에 맞게 맞춤 설정:**


### PR DESCRIPTION
## Why this PR

During the merge-cascade resync of PR #24814, the elasticsearch files for `es/fr/jp/kr` locales were resolved with `--theirs` (develop's version) to preserve the Pattern G structural fix. That call sacrificed #24814's fresh MT translations for those 4 files.

This PR restores the Pattern-G-applied versions from #24814's original fix commit (6e936babda) — same structural correctness, but with the newer MT content preserved.

## Scope

4 files changed, all elasticsearch-otel-integration-k8-install.mdx (es/fr/jp/kr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)