### PR TITLE
docs(mobile): document generateDistributedTracingHeaders + DT startup…

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt.mdx
@@ -20,6 +20,12 @@ Watch this short video (approx. 2:15 minutes) to learn how to:
 
 To use distributed tracing, you need iOS agent version 7.3.0 or higher. We recommend you use the most recent agent.
 
+## Limitations [#limitations]
+
+<Callout variant="important">
+  When your app launches, the iOS agent needs to finish initializing before it can generate distributed tracing data. Network requests made — or [distributed tracing headers generated](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/generate-distributed-tracing-headers) — during this brief startup window won't be included in a distributed trace.
+</Callout>
+
 ## How to set up distributed tracing [#setup]
 
 For mobile agents that support this feature, it’s enabled by default.

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/generate-distributed-tracing-headers.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/generate-distributed-tracing-headers.mdx
@@ -37,28 +37,45 @@ Returns a dictionary (`NSDictionary` in Objective-C, `[String : String]` in Swif
 
 ## Examples [#examples]
 
+When you instrument a request manually, use the generated headers in two places:
+
+1. Add them to your outgoing request so downstream services join the trace.
+2. Pass the same dictionary to the `traceHeaders` parameter of [`noticeNetworkRequest`](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/network-request-success/) so the transaction the agent records is linked to that same distributed trace.
+
 ### Objective-C [#objc-example]
 
 ```objectivec
-NSDictionary<NSString*,NSString*> *headers = [NewRelic generateDistributedTracingHeaders];
+// 1. Generate the distributed tracing headers.
+NSDictionary<NSString*,NSString*> *traceHeaders = [NewRelic generateDistributedTracingHeaders];
 
+// 2. Add them to the request you send, so downstream services join the trace.
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.example.com"]];
-for (NSString *key in headers) {
-    [request setValue:headers[key] forHTTPHeaderField:key];
+for (NSString *key in traceHeaders) {
+    [request setValue:traceHeaders[key] forHTTPHeaderField:key];
 }
 
-[[[NSURLSession sharedSession] dataTaskWithRequest:request] resume];
+// 3. If you record the request manually, pass the same headers so the
+//    transaction is linked to the same distributed trace.
+[NewRelic noticeNetworkRequestForURL:request.URL httpMethod:@"GET" withTimer:[[NRTimer alloc] init]
+                     responseHeaders:@{} statusCode:200 bytesSent:1024 bytesReceived:52
+                        responseData:[NSData data] traceHeaders:traceHeaders andParams:nil];
 ```
 
 ### Swift [#swift-example]
 
 ```swift
-let headers = NewRelic.generateDistributedTracingHeaders()
+// 1. Generate the distributed tracing headers.
+let traceHeaders = NewRelic.generateDistributedTracingHeaders()
 
-var request = URLRequest(url: URL(string: "https://www.example.com")!)
-for (key, value) in headers {
+// 2. Add them to the request you send, so downstream services join the trace.
+let url = URL(string: "https://www.example.com")!
+var request = URLRequest(url: url)
+for (key, value) in traceHeaders {
     request.setValue(value, forHTTPHeaderField: key)
 }
 
-URLSession.shared.dataTask(with: request).resume()
+// 3. If you record the request manually, pass the same headers so the
+//    transaction is linked to the same distributed trace.
+NewRelic.noticeNetworkRequest(for: url, httpMethod: "GET", with: NRTimer(), responseHeaders: [:],
+                              statusCode: 200, bytesSent: 1024, bytesReceived: 52, responseData: Data(), traceHeaders: traceHeaders, andParams: nil)
 ```

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/generate-distributed-tracing-headers.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/generate-distributed-tracing-headers.mdx
@@ -1,0 +1,64 @@
+---
+title: Generate distributed tracing headers
+tags:
+  - Mobile monitoring
+  - API guides
+metaDescription: 'iOS: use the generateDistributedTracingHeaders() method to create distributed tracing headers for network requests you instrument manually.'
+freshnessValidatedDate: never
+---
+
+Use the `generateDistributedTracingHeaders()` method to generate [distributed tracing](/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-and-dt) headers that you can attach to network requests the iOS agent doesn't automatically instrument. Adding these headers to a request links that call to a distributed trace, connecting your mobile app to the backend services it calls.
+
+## Syntax [#syntax]
+
+### Objective-C [#objc]
+
+```objectivec
++ (NSDictionary<NSString*,NSString*>*)generateDistributedTracingHeaders;
+```
+
+### Swift [#swift]
+
+```swift
+class func generateDistributedTracingHeaders() -> [String : String]
+```
+
+## Description [#description]
+
+The iOS agent automatically instruments network requests made with `NSURLSession` and attaches distributed tracing headers for you. If you send requests through a mechanism the agent doesn't automatically instrument, use this method to generate the headers yourself and add them to your request. Each key in the returned dictionary is an HTTP header field name, and each value is the corresponding header value.
+
+<Callout variant="important">
+  When your app launches, the iOS agent needs to finish initializing before it can generate distributed tracing data. Distributed tracing headers generated — or network requests made — during this brief startup window won't be included in a distributed trace.
+</Callout>
+
+## Return values [#return-values]
+
+Returns a dictionary (`NSDictionary` in Objective-C, `[String : String]` in Swift) of distributed tracing header field names and values. Add each entry to your outbound request as an HTTP header.
+
+## Examples [#examples]
+
+### Objective-C [#objc-example]
+
+```objectivec
+NSDictionary<NSString*,NSString*> *headers = [NewRelic generateDistributedTracingHeaders];
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.example.com"]];
+for (NSString *key in headers) {
+    [request setValue:headers[key] forHTTPHeaderField:key];
+}
+
+[[[NSURLSession sharedSession] dataTaskWithRequest:request] resume];
+```
+
+### Swift [#swift-example]
+
+```swift
+let headers = NewRelic.generateDistributedTracingHeaders()
+
+var request = URLRequest(url: URL(string: "https://www.example.com")!)
+for (key, value) in headers {
+    request.setValue(value, forHTTPHeaderField: key)
+}
+
+URLSession.shared.dataTask(with: request).resume()
+```

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/mobile-sdk-api-guide.mdx
@@ -142,6 +142,16 @@ The table below lists supported SDK methods to customize your mobile agent instr
     </tr>
 
     <tr>
+      <td id="distributed-tracing">
+        (iOS) Generate distributed tracing headers to add to network requests you instrument manually.
+      </td>
+
+      <td>
+        [Generate distributed tracing headers](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/generate-distributed-tracing-headers)
+      </td>
+    </tr>
+
+    <tr>
       <td>
         Record a handled exception as an event, including the context of what happened.
       </td>


### PR DESCRIPTION
… limitation

NR-523360

- Add new Mobile SDK API reference page for generateDistributedTracingHeaders() (iOS)
- Add a row for it to the Mobile SDK API guide "Available customizations" table
- Note the distributed tracing startup-window limitation on the iOS DT page and the new API page

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.