### PR TITLE
[chore]fix: restore Firehose config and restructure manual AWS integration doc

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
@@ -13,35 +13,95 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-For seamless integration of your AWS account with New Relic, [Integration via CloudFormation and CloudWatch metric stream](/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation) is the most recommended approach. If you cannot use CloudFormation templates and do not prefer to use Terraform, refer to the following procedure to integrate manually from the AWS console.
+For a seamless integration of your AWS account with New Relic, [integration via CloudFormation and CloudWatch metric stream](/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation) is the recommended approach. If you can't use CloudFormation templates and don't want to use Terraform, follow this procedure to integrate manually from the AWS console.
 
+<Callout variant="tip">
+* If you manage multiple AWS accounts, [connect each account to a single New Relic account](/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account).
+* If you manage multiple regions within those accounts, create a separate [Kinesis Data Firehose](#create-firehose) for each region.
+</Callout>
+
+<Steps>
+<Step>
 ## Prerequisites [#prerequisites]
 
 Before you begin integrating your AWS account with New Relic, ensure that you meet the following prerequisites:
 * **A New Relic [Ingest - license key and a User key](https://one.newrelic.com/api-keys)**: You'll need these keys to connect your AWS services to your New Relic account.
-* **[Permissions](https://docs.aws.amazon.com/ARG/latest/userguide/gettingstarted-prereqs-permissions.html)** to deploy new AWS resources and **[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)**: You’ll need this permission for your AWS account.
-* **[Permissions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions/#infrastructure)** for cloud integrations: You’ll need these permissions for your New Relic account.
+* **[Permissions](https://docs.aws.amazon.com/ARG/latest/userguide/gettingstarted-prereqs-permissions.html)** to deploy new AWS resources and **[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)**: You'll need this permission for your AWS account.
+* **[Permissions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions/#infrastructure)** for cloud integrations: You'll need these permissions for your New Relic account.
 
-## Integration steps [#integration-steps]
+</Step>
+<Step>
+## Create a Kinesis Data Firehose delivery stream [#create-firehose]
 
-To integrate your AWS account with New Relic, follow these steps:
+In the AWS console, set the following destination parameters for the delivery stream:
 
-1. Navigate to [<DNT>**Infrastructure > AWS**</DNT>](https://one.newrelic.com/infra/infrastructure/cloud-aws).
+* Source: Direct PUT or other sources
+* Destination: New Relic
+* Data transformation: Disabled
+* Record format conversion: Disabled
+* Ensure the following settings are defined:
+  * New Relic configuration (Destination Settings):
+    * HTTP endpoint URL:
+      * US Datacenter: `https://aws-api.newrelic.com/cloudwatch-metrics/v1`
+      * EU Datacenter: `https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1`
+      * JP Datacenter: `https://aws-api.jp.nr-data.net/cloudwatch-metrics/v1`
+    * API key: Enter your <InlinePopover type="licenseKey"/>
+    * Content encoding: `GZIP`
+    * Retry duration: `60`
+    * New Relic buffer conditions:
+      * Buffer size: `1 MB`
+      * Buffer interval: `60 (seconds)`
+  * S3 backup mode: Failed data only
+  * S3 backup bucket: Select a bucket or create a new one to store metrics that failed to be sent.
+  * Advanced settings:
+    * Service access: Provide permissions for IAM role:
+      * Create or update IAM role
+
+</Step>
+<Step>
+## Create a CloudWatch metric stream [#create-metric-stream]
+
+1. In the AWS console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
+2. To control which AWS services send metrics to New Relic, configure inclusion and exclusion filters.
+3. From the Firehose delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
+4. In the output format field, select `Open Telemetry 0.7`. JSON isn't supported.
+
+</Step>
+<Step>
+## Connect your AWS account to New Relic [#connect-aws-account]
+
+1. In New Relic, go to [<DNT>**Infrastructure > AWS**</DNT>](https://one.newrelic.com/infra/infrastructure/cloud-aws).
 2. Select the correct account.
 3. Click <DNT>**Set up integration**</DNT>.
-4. Follow the instructions on each screen, and fill in the fields that apply to you. For this integration, choose the following options in the given screens:
+4. On each screen, fill in the fields that apply to you. For this integration, choose the following options:
 
-    1. <DNT>**Choose Data type(s)**</DNT>: <DNT>Metrics</DNT>
-    2. <DNT>**Choose a setup method**</DNT>: <DNT>Manually integrate your AWS account</DNT>
+   * <DNT>**Choose Data type(s)**</DNT>: <DNT>Metrics</DNT>
+   * <DNT>**Choose a setup method**</DNT>: <DNT>Manually integrate your AWS account</DNT>
 
-5. On the <DNT>**Select services**</DNT> screen, if needed, use the <DNT>**Show resources not supported by CloudWatch Metric Streams**</DNT> toggle, select the services you want to monitor, and then continue.
+5. On the <DNT>**Select services**</DNT> screen, toggle <DNT>**Show resources not supported by CloudWatch Metric Streams**</DNT> if needed, select the services you want to monitor, and continue.
+6. On the <DNT>**Choose data integration type**</DNT> screen, choose from the following options:
+   * **Real-time AWS monitoring (Recommended)**: This option is for services that support CloudWatch Metric Streams.
+   * **API Polling**: This option is for services not supported by CloudWatch Metric Streams.
+7. From the <DNT>**Create role**</DNT> page to the <DNT>**Configure budgets policy**</DNT> page, follow the on-screen instructions and complete the steps in the AWS console.
 
-7. On the <DNT>**Choose data integration type**</DNT> screen, choose from the following integration options:
-   * **Real-time AWS monitoring (Recommended)**: This option is for the services that support CloudWatch Metric Streams.
-   * **API Polling**: This option is suitable for services not supported by CloudWatch Metric Streams.
+</Step>
+<Step>
+## Validate your data[#validate]
 
-8. From the <DNT>**Create role**</DNT> page to <DNT>**Configure budgets policy**</DNT> page, follow the on-screen instructions and perform the steps in AWS console.
-9. After creating the policy in AWS console, switch to the New Relic platform and continue with the guided integration till you see your AWS data in New Relic.
+To confirm you're receiving data from Metric Streams:
+
+1. In New Relic, go to <DNT>**[one.newrelic.com > All capabilities > Infrastructure > AWS](https://one.newrelic.com/infra/infrastructure/cloud-aws)**</DNT>, search for your connected AWS account, and look for **Stream** accounts.
+2. In the account status dashboard, confirm that New Relic is receiving metric data, including errors and the number of namespaces and metrics ingested.
+3. To explore specific metrics, write queries for the sets of metrics you want to analyze.
+
+It may take a few minutes for New Relic to detect new resources and synthesize them as entities.
+
+<Callout variant="tip">
+AWS CloudWatch metrics for global services, such as AWS Billing, are only available in the <DNT>**us-east-1**</DNT> region. Make sure there's an active CloudWatch metric stream configured in that region.
+</Callout>
+
+</Step>
+</Steps>
 
 ## Related topics [#related-topics]
 
@@ -52,7 +112,3 @@ To integrate your AWS account with New Relic, follow these steps:
   <DocTile title="AWS integrations via CloudFormation and API Polling" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-and-api-polling" >Integrate AWS services with New Relic using CloudFormation and API Polling.</DocTile>
   <DocTile title="AWS integrations via Terraform" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform" >Integrate AWS services with New Relic using Terraform.</DocTile>
 </DocTiles>
-
-
-
-

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
@@ -1,5 +1,5 @@
 ---
-title: Integrate manually from AWS console
+title: Manual integration from AWS console
 tags:
     - Integrate manually
     - Manual integration
@@ -13,29 +13,29 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-For a seamless integration of your AWS account with New Relic, [integration via CloudFormation and CloudWatch metric stream](/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation) is the recommended approach. If you can't use CloudFormation templates and don't want to use Terraform, follow this procedure to integrate manually from the AWS console.
+For a seamless integration of your <DNT>AWS</DNT> account with New Relic, [integration via <DNT>CloudFormation</DNT> and CloudWatch metric stream](/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation) is the recommended approach. If you can't use <DNT>CloudFormation</DNT> templates and don't want to use <DNT>Terraform</DNT>, follow this procedure to integrate manually from the <DNT>AWS</DNT> console.
 
 <Callout variant="tip">
-* If you manage multiple AWS accounts, [connect each account to a single New Relic account](/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account).
-* If you manage multiple regions within those accounts, create a separate [Kinesis Data Firehose](#create-firehose) for each region.
+* If you manage multiple <DNT>AWS</DNT> accounts, [connect each account to a single New Relic account](/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account).
+* If you manage multiple regions within those accounts, create a separate [Kinesis Data <DNT>Firehose</DNT>](#create-firehose) for each region.
 </Callout>
 
 <Steps>
 <Step>
 ## Prerequisites [#prerequisites]
 
-Before you begin integrating your AWS account with New Relic, ensure that you meet the following prerequisites:
-* **A New Relic [Ingest - license key and a User key](https://one.newrelic.com/api-keys)**: You'll need these keys to connect your AWS services to your New Relic account.
-* **[Permissions](https://docs.aws.amazon.com/ARG/latest/userguide/gettingstarted-prereqs-permissions.html)** to deploy new AWS resources and **[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)**: You'll need this permission for your AWS account.
+Before you begin integrating your <DNT>AWS</DNT> account with New Relic, ensure that you meet the following prerequisites:
+* **A New Relic [Ingest - license key and a User key](https://one.newrelic.com/api-keys)**: You'll need these keys to connect your <DNT>AWS</DNT> services to your New Relic account.
+* **[Permissions](https://docs.aws.amazon.com/ARG/latest/userguide/gettingstarted-prereqs-permissions.html)** to deploy new <DNT>AWS</DNT> resources and **[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)**: You'll need this permission for your <DNT>AWS</DNT> account.
 * **[Permissions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions/#infrastructure)** for cloud integrations: You'll need these permissions for your New Relic account.
 
 </Step>
 <Step>
-## Create a Kinesis Data Firehose delivery stream [#create-firehose]
+## Create a Kinesis Data <DNT>Firehose</DNT> delivery stream [#create-firehose]
 
-In the AWS console, set the following destination parameters for the delivery stream:
+In the <DNT>AWS</DNT> console, set the following destination parameters for the delivery stream:
 
-* Source: Direct PUT or other sources
+* Source: <DNT>Direct PUT</DNT> or other sources
 * Destination: New Relic
 * Data transformation: Disabled
 * Record format conversion: Disabled
@@ -61,14 +61,14 @@ In the AWS console, set the following destination parameters for the delivery st
 <Step>
 ## Create a CloudWatch metric stream [#create-metric-stream]
 
-1. In the AWS console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
-2. To control which AWS services send metrics to New Relic, configure inclusion and exclusion filters.
-3. From the Firehose delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
+1. In the <DNT>AWS</DNT> console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
+2. To control which <DNT>AWS</DNT> services send metrics to New Relic, configure inclusion and exclusion filters.
+3. From the <DNT>Firehose</DNT> delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
 4. In the output format field, select `Open Telemetry 0.7` or `Open Telemetry 1.0`. JSON isn't supported.
 
 </Step>
 <Step>
-## Connect your AWS account to New Relic [#connect-aws-account]
+## Connect your <DNT>AWS</DNT> account to New Relic [#connect-aws-account]
 
 1. In New Relic, go to [<DNT>**Infrastructure > AWS**</DNT>](https://one.newrelic.com/infra/infrastructure/cloud-aws).
 2. Select the correct account.
@@ -80,9 +80,9 @@ In the AWS console, set the following destination parameters for the delivery st
 
 5. On the <DNT>**Select services**</DNT> screen, toggle <DNT>**Show resources not supported by CloudWatch Metric Streams**</DNT> if needed, select the services you want to monitor, and continue.
 6. On the <DNT>**Choose data integration type**</DNT> screen, choose from the following options:
-   * **Real-time AWS monitoring (Recommended)**: This option is for services that support CloudWatch Metric Streams.
+   * **Real-time <DNT>AWS</DNT> monitoring (Recommended)**: This option is for services that support CloudWatch Metric Streams.
    * **API Polling**: This option is for services not supported by CloudWatch Metric Streams.
-7. From the <DNT>**Create role**</DNT> page to the <DNT>**Configure budgets policy**</DNT> page, follow the on-screen instructions and complete the steps in the AWS console.
+7. From the <DNT>**Create role**</DNT> page to the <DNT>**Configure budgets policy**</DNT> page, follow the on-screen instructions and complete the steps in the <DNT>AWS</DNT> console.
 
 </Step>
 <Step>
@@ -90,14 +90,14 @@ In the AWS console, set the following destination parameters for the delivery st
 
 To confirm you're receiving data from Metric Streams:
 
-1. In New Relic, go to <DNT>**[one.newrelic.com > All capabilities > Infrastructure > AWS](https://one.newrelic.com/infra/infrastructure/cloud-aws)**</DNT>, search for your connected AWS account, and look for **Stream** accounts.
+1. In New Relic, go to <DNT>**[one.newrelic.com > All capabilities > Infrastructure > AWS](https://one.newrelic.com/infra/infrastructure/cloud-aws)**</DNT>, search for your connected <DNT>AWS</DNT> account, and look for **Stream** accounts.
 2. In the account status dashboard, confirm that New Relic is receiving metric data, including errors and the number of namespaces and metrics ingested.
 3. To explore specific metrics, write queries for the sets of metrics you want to analyze.
 
 It may take a few minutes for New Relic to detect new resources and synthesize them as entities.
 
 <Callout variant="tip">
-AWS CloudWatch metrics for global services, such as AWS Billing, are only available in the <DNT>**us-east-1**</DNT> region. Make sure there's an active CloudWatch metric stream configured in that region.
+<DNT>AWS</DNT> CloudWatch metrics for global services, such as <DNT>AWS</DNT> Billing, are only available in the <DNT>**us-east-1**</DNT> region. Make sure there's an active CloudWatch metric stream configured in that region.
 </Callout>
 
 </Step>
@@ -106,9 +106,9 @@ AWS CloudWatch metrics for global services, such as AWS Billing, are only availa
 ## Related topics [#related-topics]
 
 <DocTiles>
-  <DocTile title="Collect data from multiple AWS accounts" path="/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account/" >Learn how to collect data from multiple AWS accounts.</DocTile>
+  <DocTile title="Collect data from multiple AWS accounts" path="/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account/" >Learn how to collect data from multiple <DNT>AWS</DNT> accounts.</DocTile>
   <DocTile title="AWS integrations metrics" path="/docs/infrastructure/amazon-integrations/manage-aws-data/aws-integrations-metrics/" >Explore and use metrics from CloudWatch Metric Stream.</DocTile>
-  <DocTile title="AWS integrations via CloudFormation and CWMS" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-cwms" >Integrate AWS services with New Relic using CloudFormation and CloudWatch Metric Streams.</DocTile>
-  <DocTile title="AWS integrations via CloudFormation and API Polling" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-and-api-polling" >Integrate AWS services with New Relic using CloudFormation and API Polling.</DocTile>
-  <DocTile title="AWS integrations via Terraform" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform" >Integrate AWS services with New Relic using Terraform.</DocTile>
+  <DocTile title="AWS integrations via CloudFormation and CWMS" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-cwms" >Integrate <DNT>AWS</DNT> services with New Relic using <DNT>CloudFormation</DNT> and CloudWatch Metric Streams.</DocTile>
+  <DocTile title="AWS integrations via CloudFormation and API Polling" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-and-api-polling" >Integrate <DNT>AWS</DNT> services with New Relic using <DNT>CloudFormation</DNT> and API Polling.</DocTile>
+  <DocTile title="AWS integrations via Terraform" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform" >Integrate <DNT>AWS</DNT> services with New Relic using <DNT>Terraform</DNT>.</DocTile>
 </DocTiles>

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
@@ -64,7 +64,7 @@ In the AWS console, set the following destination parameters for the delivery st
 1. In the AWS console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
 2. To control which AWS services send metrics to New Relic, configure inclusion and exclusion filters.
 3. From the Firehose delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
-4. In the output format field, select `Open Telemetry 0.7`. JSON isn't supported.
+4. In the output format field, select `Open Telemetry 1.0.0`. JSON isn't supported.
 
 </Step>
 <Step>

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
@@ -64,7 +64,7 @@ In the AWS console, set the following destination parameters for the delivery st
 1. In the AWS console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
 2. To control which AWS services send metrics to New Relic, configure inclusion and exclusion filters.
 3. From the Firehose delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
-4. In the output format field, select `Open Telemetry 1.0.0`. JSON isn't supported.
+4. In the output format field, select `Open Telemetry 0.7` or `Open Telemetry 1.0`. JSON isn't supported.
 
 </Step>
 <Step>


### PR DESCRIPTION
## Summary

Restores the Kinesis Data Firehose delivery stream configuration that was inadvertently dropped in PR #24651 when the legacy `/install/aws-cloudwatch/` flow was retired. Customers were hitting `413 Payload too large` errors because the critical buffer size (`1 MB`) and buffer interval (`60 seconds`) guidance was no longer documented.

Reported in [#docs-community Slack thread](https://newrelic.slack.com/archives/C0DSGL3FZ/p1784050036664109) by Alaia Nakama (GTS Support).

**Changes:**
- Restores Kinesis Data Firehose destination parameters (source, destination, HTTP endpoint URLs for US/EU/JP datacenters, content encoding, retry duration, buffer conditions, S3 backup, IAM role)
- Restructures the page using the `<Steps>` component with five clear steps: prerequisites, Firehose setup, CloudWatch metric stream creation, NR account connection, and data validation
- Restores CloudWatch metric stream creation steps and data validation steps (also dropped in #24651)
- Adds a tip callout for multi-account and multi-region setups
- Applies purpose-place-action sentence format throughout procedural steps
- Fixes step numbering gap that existed in the previous version

🤖 Generated with [Claude Code](https://claude.com/claude-code)