### PR TITLE
Add missing Node agent config sections

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -5903,53 +5903,6 @@ These settings control how the agent detects information about the host and clou
   </Collapser>
 </CollapserGroup>
 
-## OTLP endpoint [#otlp-endpoint]
-
-This section defines the Node.js agent variable that appears in the `otlp_endpoint` top-level key of your app's `newrelic.js` configuration file.
-
-<CollapserGroup>
-  <Collapser
-    id="otlp_endpoint"
-    title="otlp_endpoint"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            String
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            (none)
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OTLP_ENDPOINT`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Endpoint to send OpenTelemetry spans to. This is normally deduced automatically from your account region and other settings, but you can override it here if needed. See [OpenTelemetry](#opentelemetry) for related settings.
-  </Collapser>
-</CollapserGroup>
-
 ## OpenTelemetry [#opentelemetry]
 
 These settings govern the various OpenTelemetry-based features provided by the agent. They appear in the `opentelemetry` section of your app's `newrelic.js` configuration file.

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3855,10 +3855,10 @@ For more information about setting up distributed tracing, see [Enable distribut
 
     When the traceparent header has a sampled flag of `01`, this controls how to handle sampling of spans. The allowable string values are:
 
-      * `adaptive` (default): use New Relic's built-in adaptive sampling algorithm.
-      * `always_on`: the agent will sample spans.
-      * `always_off`: the agent will NOT sample spans.
-      * `trace_id_ratio_based`: sample a fixed ratio of traces, deterministically based on trace ID.
+      * `adaptive` (default): Uses the built-in New Relic adaptive sampling algorithm.
+      * `always_on`: Samples all spans.
+      * `always_off`: Doesn't sample any spans.
+      * `trace_id_ratio_based`: Samples a fixed ratio of traces, determined deterministically by the trace ID.
 
     This setting takes precedence over [`remote_parent_not_sampled`](#dt-sampler-remote-parent-not-sampled) when both could apply.
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -489,6 +489,47 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 
   <Collapser
+    id="otlp_endpoint"
+    title="otlp_endpoint"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OTLP_ENDPOINT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Endpoint to send OpenTelemetry spans to. This is normally deduced automatically from your account region and other settings, but you can override it here if needed. See [OpenTelemetry](#opentelemetry) for related settings.
+  </Collapser>
+
+  <Collapser
     id="labels"
     title="labels"
   >
@@ -1110,6 +1151,504 @@ This section defines the Node.js agent variables to create a relationship betwee
     </table>
 
     The AWS account ID for the AWS account associated with this app.
+  </Collapser>
+</CollapserGroup>
+
+## Utilization [#utilization]
+
+These settings control how the agent detects information about the host and cloud environment it's running in, used to calculate utilization-based pricing. They appear in the `utilization` section of your app's `newrelic.js` configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="utilization-detect-aws"
+    title="detect_aws"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_AWS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to AWS to get info about the VM the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-pcf"
+    title="detect_pcf"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_PCF`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to detect if the process is running on Pivotal Cloud Foundry.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-azure"
+    title="detect_azure"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_AZURE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to Azure to get info about the VM the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-azurefunction"
+    title="detect_azurefunction"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_AZUREFUNCTION`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to read environment variables and invocation context to get info about the Azure Function it's running in.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-docker"
+    title="detect_docker"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_DOCKER`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to read files to get info about the container the process is running in.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-gcp"
+    title="detect_gcp"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_GCP`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to GCP to get info about the VM the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-kubernetes"
+    title="detect_kubernetes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to Kubernetes to get info about the container the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-logical-processors"
+    title="logical_processors"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_LOGICAL_PROCESSORS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Overrides the number of logical processors the agent reports for the host.
+  </Collapser>
+
+  <Collapser
+    id="utilization-billing-hostname"
+    title="billing_hostname"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_BILLING_HOSTNAME`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Overrides the hostname the agent reports for billing/utilization purposes.
+  </Collapser>
+
+  <Collapser
+    id="utilization-total-ram-mib"
+    title="total_ram_mib"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_TOTAL_RAM_MIB`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Overrides the amount of total RAM (in MiB) the agent reports for the host.
+  </Collapser>
+
+  <Collapser
+    id="utilization-gcp-use-instance-as-host"
+    title="gcp_use_instance_as_host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_GCP_USE_INSTANCE_AS_HOST`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent uses the GCP metadata instance ID to set the hostname of the running application.
+  </Collapser>
+
+  <Collapser
+    id="utilization-gcp-cloud-run-include-revision-in-host"
+    title="gcp_cloud_run.include_revision_in_host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_GCP_CLOUD_RUN_INCLUDE_REVISION_IN_HOST`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, and `gcp_use_instance_as_host` is also enabled, the GCP Cloud Run revision (`K_REVISION`) is prepended to the instance ID when setting the hostname of the running application, resulting in a hostname of `${K_REVISION}-${instance_id}`.
   </Collapser>
 </CollapserGroup>
 
@@ -3716,6 +4255,106 @@ For more information about setting up distributed tracing, see [Enable distribut
     ```
   </Collapser>
   <Collapser
+    id="dt-sampler-root"
+    title="sampler.root"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String or object
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `adaptive`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Controls how sampling decisions are made for root spans — transactions that do not have a remote parent (that is, no incoming `traceparent`/`newrelic` distributed tracing header). The allowable string values are:
+
+      * `adaptive` (default): use New Relic's built-in adaptive sampling algorithm.
+      * `always_on`: the agent will sample spans.
+      * `always_off`: the agent will NOT sample spans.
+      * `trace_id_ratio_based`: sample a fixed ratio of traces, deterministically based on trace ID.
+
+    For example, to set this in the config file, you would use:
+
+    ```js
+    distributed_tracing: {
+      enabled: true,
+      sampler: {
+        root: 'always_on'
+      }
+    }
+    ```
+
+    When set to `trace_id_ratio_based`, you must also provide a `ratio` (a number between `0` and `1`):
+
+    ```js
+    distributed_tracing: {
+      enabled: true,
+      sampler: {
+        root: {
+          trace_id_ratio_based: {
+            ratio: 0.5
+          }
+        }
+      }
+    }
+    ```
+
+    Or via environment variables:
+
+    ```ini
+    NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT=trace_id_ratio_based
+    NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO=0.5
+    ```
+
+    When set to `adaptive`, you may optionally override the sampling target (in transactions per minute, `[1, 120]`) for this sampler specifically:
+
+    ```js
+    distributed_tracing: {
+      enabled: true,
+      sampler: {
+        root: {
+          adaptive: {
+            sampling_target: 50
+          }
+        }
+      }
+    }
+    ```
+
+    Or via environment variables:
+
+    ```ini
+    NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT=adaptive
+    NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_ADAPTIVE_SAMPLING_TARGET=50
+    ```
+  </Collapser>
+  <Collapser
     id="dt-sampler-remote-parent-sampled"
     title="sampler.remote_parent_sampled"
   >
@@ -3727,7 +4366,7 @@ For more information about setting up distributed tracing, see [Enable distribut
           </th>
 
           <td>
-            String
+            String or object
           </td>
         </tr>
 
@@ -3737,7 +4376,7 @@ For more information about setting up distributed tracing, see [Enable distribut
           </th>
 
           <td>
-            `default`
+            `adaptive`
           </td>
         </tr>
 
@@ -3753,11 +4392,14 @@ For more information about setting up distributed tracing, see [Enable distribut
       </tbody>
     </table>
 
-    When the traceparent header has a sampled flag of `01`, this controls how to handle sampling of spans. The allowable values are:
+    When the traceparent header has a sampled flag of `01`, this controls how to handle sampling of spans. The allowable string values are:
 
-      * `always_on`: the agent will sample spans
-      * `always_off`: the agent will NOT sample spans
-      * `default`: the agent will use the existing NR sampling (default)
+      * `adaptive` (default): use New Relic's built-in adaptive sampling algorithm.
+      * `always_on`: the agent will sample spans.
+      * `always_off`: the agent will NOT sample spans.
+      * `trace_id_ratio_based`: sample a fixed ratio of traces, deterministically based on trace ID.
+
+    This setting takes precedence over [`remote_parent_not_sampled`](#dt-sampler-remote-parent-not-sampled) when both could apply.
 
     For example, to enable this in the config file, you would use:
 
@@ -3769,6 +4411,8 @@ For more information about setting up distributed tracing, see [Enable distribut
       }
     }
     ```
+
+    When set to `trace_id_ratio_based`, you must also provide a `ratio` (a number between `0` and `1`), and when set to `adaptive` you may optionally override the sampling target for this sampler specifically — see the object-form and environment variable examples under [`sampler.root`](#dt-sampler-root) for the equivalent syntax (substitute `remote_parent_sampled` for `root`).
   </Collapser>
   <Collapser
     id="dt-sampler-remote-parent-not-sampled"
@@ -3782,7 +4426,7 @@ For more information about setting up distributed tracing, see [Enable distribut
           </th>
 
           <td>
-            String
+            String or object
           </td>
         </tr>
 
@@ -3792,7 +4436,7 @@ For more information about setting up distributed tracing, see [Enable distribut
           </th>
 
           <td>
-            `default`
+            `adaptive`
           </td>
         </tr>
 
@@ -3808,11 +4452,14 @@ For more information about setting up distributed tracing, see [Enable distribut
       </tbody>
     </table>
 
-    When the traceparent header is has a sampled flag of `00`, this controls how to handle sampling of spans. The allowable values are:
+    When the traceparent header has a sampled flag of `00`, this controls how to handle sampling of spans. The allowable string values are:
 
-      * `always_on`: the agent will sample spans
-      * `always_off`: the agent will NOT sample spans
-      * `default`: the agent will use the existing NR sampling (default)
+      * `adaptive` (default): use New Relic's built-in adaptive sampling algorithm.
+      * `always_on`: the agent will sample spans.
+      * `always_off`: the agent will NOT sample spans.
+      * `trace_id_ratio_based`: sample a fixed ratio of traces, deterministically based on trace ID.
+
+    This setting only takes effect when [`remote_parent_sampled`](#dt-sampler-remote-parent-sampled) does not apply (that is, the traceparent sampled flag is `00`).
 
     For example, to enable this in the config file, you would use:
 
@@ -3821,6 +4468,59 @@ For more information about setting up distributed tracing, see [Enable distribut
       enabled: true,
       sampler: {
         remote_parent_not_sampled: 'always_on'
+      }
+    }
+    ```
+
+    When set to `trace_id_ratio_based`, you must also provide a `ratio` (a number between `0` and `1`), and when set to `adaptive` you may optionally override the sampling target for this sampler specifically — see the object-form and environment variable examples under [`sampler.root`](#dt-sampler-root) for the equivalent syntax (substitute `remote_parent_not_sampled` for `root`).
+  </Collapser>
+  <Collapser
+    id="dt-sampler-adaptive-sampling-target"
+    title="sampler.adaptive_sampling_target"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ADAPTIVE_SAMPLING_TARGET`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The sampling target for adaptive sampling, in transactions per minute, used when configuring the default/adaptive sampler. Must be within the range `[1, 120]` (inclusive). Upon connecting to New Relic, this value is sent to the collector, and the `sampling_target` value returned in the connect response is used as the effective sampling target for adaptive sampling in the agent.
+
+    For example, to set this in the config file, you would use:
+
+    ```js
+    distributed_tracing: {
+      enabled: true,
+      sampler: {
+        adaptive_sampling_target: 20
       }
     }
     ```
@@ -4620,6 +5320,266 @@ For tips on configuring logs for the Node.js agent, see [Configure Node.js logs 
   </Collapser>
 </CollapserGroup>
 
+## OpenTelemetry [#opentelemetry]
+
+These settings govern the various OpenTelemetry-based features provided by the agent. They appear in the `opentelemetry` section of your app's `newrelic.js` configuration file.
+
+<Callout variant="important">
+  This configuration is subject to change while the OpenTelemetry feature set is in development.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="opentelemetry-enabled"
+    title="opentelemetry.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Global switch for the whole OpenTelemetry feature. If set to `false`, no other OpenTelemetry sub-feature (such as `traces`, `logs`, or `metrics`) will be enabled, regardless of that sub-feature's own setting.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-traces-enabled"
+    title="opentelemetry.traces.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables bridging OpenTelemetry instrumentations (for example, `@fastify/otel`) into the New Relic agent.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-logs-enabled"
+    title="opentelemetry.logs.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_LOGS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent automatically configures the OpenTelemetry logs API to send logs emitted through the OTel-specific API to New Relic.
+
+    <Callout variant="important">
+      This feature depends on [application logs forwarding](#application-logging-forwarding-enabled) — `application_logging.forwarding.enabled` must also be `true`.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-metrics-enabled"
+    title="opentelemetry.metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent automatically configures the OpenTelemetry metrics API to send metrics to New Relic, attached to the application entity instrumented by the agent.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-metrics-export-interval"
+    title="opentelemetry.metrics.export_interval"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `60000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_INTERVAL`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The number of milliseconds between each attempt to ship OpenTelemetry metrics to New Relic. Must be greater than or equal to `opentelemetry.metrics.export_timeout`.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-metrics-export-timeout"
+    title="opentelemetry.metrics.export_timeout"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_TIMEOUT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The number of milliseconds an OpenTelemetry metrics export operation is allowed before it must successfully complete. If the timeout is exceeded, it's reported via the OpenTelemetry diagnostics API.
+  </Collapser>
+</CollapserGroup>
+
 ## Code level metrics [#code-level-metrics]
 
 The code-level metrics configuration settings require [Node.JS agent version 9.7.5 or higher](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/).
@@ -5241,6 +6201,221 @@ In agent versions prior to 11.0.0, the agent ran in both main and worker threads
     </table>
 
     If true, the agent will load when in a worker thread if specified.
+  </Collapser>
+</CollapserGroup>
+
+## Apollo Server instrumentation [#apollo-server-instrumentation]
+
+These settings customize the behavior of the agent's Apollo Server (GraphQL) instrumentation. They appear in the `apollo_server` section of your app's `newrelic.js` configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="apollo-server-scalars"
+    title="apollo_server.scalars"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_APOLLO_SERVER_SCALARS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables capture of timing for fields resolved with the `GraphQLScalarType` return type. This may be desired when performing time-intensive calculations to return a scalar value. Not recommended for queries that return a large number of pre-calculated scalar fields.
+
+    <Callout variant="tip">
+      Query/mutation resolvers are always captured, even when they return a scalar type.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="apollo-server-introspection-queries"
+    title="apollo_server.introspection_queries"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_APOLLO_SERVER_INTROSPECTION_QUERIES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables capture of timings for an [IntrospectionQuery](https://www.graphql-js.org/api-v16/utilities/#introspectionquery).
+  </Collapser>
+
+  <Collapser
+    id="apollo-server-service-definition-queries"
+    title="apollo_server.service_definition_queries"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_APOLLO_SERVER_SERVICE_DEFINITION_QUERIES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables capture of timings for a [service definition query](https://www.apollographql.com/docs/federation/federation-spec/#fetch-service-capabilities) received from an Apollo Federated Gateway Server.
+  </Collapser>
+
+  <Collapser
+    id="apollo-server-health-check-queries"
+    title="apollo_server.health_check_queries"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_APOLLO_SERVER_HEALTH_CHECK_QUERIES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables capture of timings for a [health check query](https://www.apollographql.com/docs/federation/api/apollo-gateway/#servicehealthcheck) received from an Apollo Federated Gateway Server.
+  </Collapser>
+
+  <Collapser
+    id="apollo-server-field-metrics"
+    title="apollo_server.field_metrics"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_APOLLO_SERVER_FIELD_METRICS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables capture of metrics for every field and resolver argument seen for an Apollo query. Intended for identifying unused fields in your GraphQL schema.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -489,47 +489,6 @@ This section defines the Node.js agent variables in the order they typically app
   </Collapser>
 
   <Collapser
-    id="otlp_endpoint"
-    title="otlp_endpoint"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            String
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            (none)
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OTLP_ENDPOINT`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Endpoint to send OpenTelemetry spans to. This is normally deduced automatically from your account region and other settings, but you can override it here if needed. See [OpenTelemetry](#opentelemetry) for related settings.
-  </Collapser>
-
-  <Collapser
     id="labels"
     title="labels"
   >
@@ -1151,504 +1110,6 @@ This section defines the Node.js agent variables to create a relationship betwee
     </table>
 
     The AWS account ID for the AWS account associated with this app.
-  </Collapser>
-</CollapserGroup>
-
-## Utilization [#utilization]
-
-These settings control how the agent detects information about the host and cloud environment it's running in, used to calculate utilization-based pricing. They appear in the `utilization` section of your app's `newrelic.js` configuration file.
-
-<CollapserGroup>
-  <Collapser
-    id="utilization-detect-aws"
-    title="detect_aws"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_AWS`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to reach out to AWS to get info about the VM the process is running on.
-  </Collapser>
-
-  <Collapser
-    id="utilization-detect-pcf"
-    title="detect_pcf"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_PCF`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to detect if the process is running on Pivotal Cloud Foundry.
-  </Collapser>
-
-  <Collapser
-    id="utilization-detect-azure"
-    title="detect_azure"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_AZURE`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to reach out to Azure to get info about the VM the process is running on.
-  </Collapser>
-
-  <Collapser
-    id="utilization-detect-azurefunction"
-    title="detect_azurefunction"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_AZUREFUNCTION`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to read environment variables and invocation context to get info about the Azure Function it's running in.
-  </Collapser>
-
-  <Collapser
-    id="utilization-detect-docker"
-    title="detect_docker"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_DOCKER`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to read files to get info about the container the process is running in.
-  </Collapser>
-
-  <Collapser
-    id="utilization-detect-gcp"
-    title="detect_gcp"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_GCP`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to reach out to GCP to get info about the VM the process is running on.
-  </Collapser>
-
-  <Collapser
-    id="utilization-detect-kubernetes"
-    title="detect_kubernetes"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Whether the agent attempts to reach out to Kubernetes to get info about the container the process is running on.
-  </Collapser>
-
-  <Collapser
-    id="utilization-logical-processors"
-    title="logical_processors"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Float
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `null`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_LOGICAL_PROCESSORS`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Overrides the number of logical processors the agent reports for the host.
-  </Collapser>
-
-  <Collapser
-    id="utilization-billing-hostname"
-    title="billing_hostname"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            String
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `null`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_BILLING_HOSTNAME`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Overrides the hostname the agent reports for billing/utilization purposes.
-  </Collapser>
-
-  <Collapser
-    id="utilization-total-ram-mib"
-    title="total_ram_mib"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Integer
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `null`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_TOTAL_RAM_MIB`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Overrides the amount of total RAM (in MiB) the agent reports for the host.
-  </Collapser>
-
-  <Collapser
-    id="utilization-gcp-use-instance-as-host"
-    title="gcp_use_instance_as_host"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_GCP_USE_INSTANCE_AS_HOST`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    When enabled, the agent uses the GCP metadata instance ID to set the hostname of the running application.
-  </Collapser>
-
-  <Collapser
-    id="utilization-gcp-cloud-run-include-revision-in-host"
-    title="gcp_cloud_run.include_revision_in_host"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `false`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_UTILIZATION_GCP_CLOUD_RUN_INCLUDE_REVISION_IN_HOST`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    When enabled, and `gcp_use_instance_as_host` is also enabled, the GCP Cloud Run revision (`K_REVISION`) is prepended to the instance ID when setting the hostname of the running application, resulting in a hostname of `${K_REVISION}-${instance_id}`.
   </Collapser>
 </CollapserGroup>
 
@@ -5320,266 +4781,6 @@ For tips on configuring logs for the Node.js agent, see [Configure Node.js logs 
   </Collapser>
 </CollapserGroup>
 
-## OpenTelemetry [#opentelemetry]
-
-These settings govern the various OpenTelemetry-based features provided by the agent. They appear in the `opentelemetry` section of your app's `newrelic.js` configuration file.
-
-<Callout variant="important">
-  This configuration is subject to change while the OpenTelemetry feature set is in development.
-</Callout>
-
-<CollapserGroup>
-  <Collapser
-    id="opentelemetry-enabled"
-    title="opentelemetry.enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `false`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OPENTELEMETRY_ENABLED`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Global switch for the whole OpenTelemetry feature. If set to `false`, no other OpenTelemetry sub-feature (such as `traces`, `logs`, or `metrics`) will be enabled, regardless of that sub-feature's own setting.
-  </Collapser>
-
-  <Collapser
-    id="opentelemetry-traces-enabled"
-    title="opentelemetry.traces.enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    Enables bridging OpenTelemetry instrumentations (for example, `@fastify/otel`) into the New Relic agent.
-  </Collapser>
-
-  <Collapser
-    id="opentelemetry-logs-enabled"
-    title="opentelemetry.logs.enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OPENTELEMETRY_LOGS_ENABLED`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    When `true`, the agent automatically configures the OpenTelemetry logs API to send logs emitted through the OTel-specific API to New Relic.
-
-    <Callout variant="important">
-      This feature depends on [application logs forwarding](#application-logging-forwarding-enabled) — `application_logging.forwarding.enabled` must also be `true`.
-    </Callout>
-  </Collapser>
-
-  <Collapser
-    id="opentelemetry-metrics-enabled"
-    title="opentelemetry.metrics.enabled"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Boolean
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `true`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    When `true`, the agent automatically configures the OpenTelemetry metrics API to send metrics to New Relic, attached to the application entity instrumented by the agent.
-  </Collapser>
-
-  <Collapser
-    id="opentelemetry-metrics-export-interval"
-    title="opentelemetry.metrics.export_interval"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Integer
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `60000`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_INTERVAL`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    The number of milliseconds between each attempt to ship OpenTelemetry metrics to New Relic. Must be greater than or equal to `opentelemetry.metrics.export_timeout`.
-  </Collapser>
-
-  <Collapser
-    id="opentelemetry-metrics-export-timeout"
-    title="opentelemetry.metrics.export_timeout"
-  >
-    <table>
-      <tbody>
-        <tr>
-          <th>
-            Type
-          </th>
-
-          <td>
-            Integer
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            Default
-          </th>
-
-          <td>
-            `10000`
-          </td>
-        </tr>
-
-        <tr>
-          <th>
-            [Environ variable](#environment)
-          </th>
-
-          <td>
-            `NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_TIMEOUT`
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    The number of milliseconds an OpenTelemetry metrics export operation is allowed before it must successfully complete. If the timeout is exceeded, it's reported via the OpenTelemetry diagnostics API.
-  </Collapser>
-</CollapserGroup>
-
 ## Code level metrics [#code-level-metrics]
 
 The code-level metrics configuration settings require [Node.JS agent version 9.7.5 or higher](/docs/apm/agents/nodejs-agent/installation-configuration/update-nodejs-agent/).
@@ -6201,6 +5402,811 @@ In agent versions prior to 11.0.0, the agent ran in both main and worker threads
     </table>
 
     If true, the agent will load when in a worker thread if specified.
+  </Collapser>
+</CollapserGroup>
+
+## Utilization [#utilization]
+
+These settings control how the agent detects information about the host and cloud environment it's running in, used to calculate utilization-based pricing. They appear in the `utilization` section of your app's `newrelic.js` configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="utilization-detect-aws"
+    title="detect_aws"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_AWS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to AWS to get info about the VM the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-pcf"
+    title="detect_pcf"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_PCF`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to detect if the process is running on Pivotal Cloud Foundry.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-azure"
+    title="detect_azure"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_AZURE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to Azure to get info about the VM the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-azurefunction"
+    title="detect_azurefunction"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_AZUREFUNCTION`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to read environment variables and invocation context to get info about the Azure Function it's running in.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-docker"
+    title="detect_docker"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_DOCKER`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to read files to get info about the container the process is running in.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-gcp"
+    title="detect_gcp"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_GCP`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to GCP to get info about the VM the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect-kubernetes"
+    title="detect_kubernetes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Whether the agent attempts to reach out to Kubernetes to get info about the container the process is running on.
+  </Collapser>
+
+  <Collapser
+    id="utilization-logical-processors"
+    title="logical_processors"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_LOGICAL_PROCESSORS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Overrides the number of logical processors the agent reports for the host.
+  </Collapser>
+
+  <Collapser
+    id="utilization-billing-hostname"
+    title="billing_hostname"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_BILLING_HOSTNAME`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Overrides the hostname the agent reports for billing/utilization purposes.
+  </Collapser>
+
+  <Collapser
+    id="utilization-total-ram-mib"
+    title="total_ram_mib"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `null`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_TOTAL_RAM_MIB`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Overrides the amount of total RAM (in MiB) the agent reports for the host.
+  </Collapser>
+
+  <Collapser
+    id="utilization-gcp-use-instance-as-host"
+    title="gcp_use_instance_as_host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_GCP_USE_INSTANCE_AS_HOST`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent uses the GCP metadata instance ID to set the hostname of the running application.
+  </Collapser>
+
+  <Collapser
+    id="utilization-gcp-cloud-run-include-revision-in-host"
+    title="gcp_cloud_run.include_revision_in_host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_GCP_CLOUD_RUN_INCLUDE_REVISION_IN_HOST`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, and `gcp_use_instance_as_host` is also enabled, the GCP Cloud Run revision (`K_REVISION`) is prepended to the instance ID when setting the hostname of the running application, resulting in a hostname of `${K_REVISION}-${instance_id}`.
+  </Collapser>
+</CollapserGroup>
+
+## OTLP endpoint [#otlp-endpoint]
+
+This section defines the Node.js agent variable that appears in the `otlp_endpoint` top-level key of your app's `newrelic.js` configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="otlp_endpoint"
+    title="otlp_endpoint"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OTLP_ENDPOINT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Endpoint to send OpenTelemetry spans to. This is normally deduced automatically from your account region and other settings, but you can override it here if needed. See [OpenTelemetry](#opentelemetry) for related settings.
+  </Collapser>
+</CollapserGroup>
+
+## OpenTelemetry [#opentelemetry]
+
+These settings govern the various OpenTelemetry-based features provided by the agent. They appear in the `opentelemetry` section of your app's `newrelic.js` configuration file.
+
+<Callout variant="important">
+  This configuration is subject to change while the OpenTelemetry feature set is in development.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="opentelemetry-enabled"
+    title="opentelemetry.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Global switch for the whole OpenTelemetry feature. If set to `false`, no other OpenTelemetry sub-feature (such as `traces`, `logs`, or `metrics`) will be enabled, regardless of that sub-feature's own setting.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-traces-enabled"
+    title="opentelemetry.traces.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables bridging OpenTelemetry instrumentations (for example, `@fastify/otel`) into the New Relic agent.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-logs-enabled"
+    title="opentelemetry.logs.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_LOGS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent automatically configures the OpenTelemetry logs API to send logs emitted through the OTel-specific API to New Relic.
+
+    <Callout variant="important">
+      This feature depends on [application logs forwarding](#application-logging-forwarding-enabled) — `application_logging.forwarding.enabled` must also be `true`.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-metrics-enabled"
+    title="opentelemetry.metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent automatically configures the OpenTelemetry metrics API to send metrics to New Relic, attached to the application entity instrumented by the agent.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-metrics-export-interval"
+    title="opentelemetry.metrics.export_interval"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `60000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_INTERVAL`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The number of milliseconds between each attempt to ship OpenTelemetry metrics to New Relic. Must be greater than or equal to `opentelemetry.metrics.export_timeout`.
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry-metrics-export-timeout"
+    title="opentelemetry.metrics.export_timeout"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_METRICS_EXPORT_TIMEOUT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The number of milliseconds an OpenTelemetry metrics export operation is allowed before it must successfully complete. If the timeout is exceeded, it's reported via the OpenTelemetry diagnostics API.
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -3753,12 +3753,12 @@ For more information about setting up distributed tracing, see [Enable distribut
       </tbody>
     </table>
 
-    Controls how sampling decisions are made for root spans — transactions that do not have a remote parent (that is, no incoming `traceparent`/`newrelic` distributed tracing header). The allowable string values are:
+    Controls how sampling decisions are made for root spans-transactions that don't have a remote parent (meaning they lack an incoming `traceparent` or `newrelic` distributed tracing header). Valid values are:
 
-      * `adaptive` (default): use New Relic's built-in adaptive sampling algorithm.
-      * `always_on`: the agent will sample spans.
-      * `always_off`: the agent will NOT sample spans.
-      * `trace_id_ratio_based`: sample a fixed ratio of traces, deterministically based on trace ID.
+      * `adaptive` (default): Uses the built-in New Relic adaptive sampling algorithm.
+      * `always_on`: Samples all spans.
+      * `always_off`: Doesn't sample any spans.
+      * `trace_id_ratio_based`: Samples a fixed ratio of traces, determined deterministically by the trace ID.
 
     For example, to set this in the config file, you would use:
 
@@ -3793,7 +3793,7 @@ For more information about setting up distributed tracing, see [Enable distribut
     NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO=0.5
     ```
 
-    When set to `adaptive`, you may optionally override the sampling target (in transactions per minute, `[1, 120]`) for this sampler specifically:
+    When you set this to `adaptive`, you can optionally override the sampling target (to 1–120 transactions/minute) specifically for this sampler:
 
     ```js
     distributed_tracing: {
@@ -3873,7 +3873,7 @@ For more information about setting up distributed tracing, see [Enable distribut
     }
     ```
 
-    When set to `trace_id_ratio_based`, you must also provide a `ratio` (a number between `0` and `1`), and when set to `adaptive` you may optionally override the sampling target for this sampler specifically — see the object-form and environment variable examples under [`sampler.root`](#dt-sampler-root) for the equivalent syntax (substitute `remote_parent_sampled` for `root`).
+    When you set this to `trace_id_ratio_based`, you must provide a `ratio` value of `0`–`1`. When you set this to `adaptive`, you can optionally override the sampling target specifically for this sampler. For the equivalent syntax, see the object-form and environment variable examples under [`sampler.root`](#dt-sampler-root) and substitute `remote_parent_sampled` for `root`.
   </Collapser>
   <Collapser
     id="dt-sampler-remote-parent-not-sampled"
@@ -3915,10 +3915,10 @@ For more information about setting up distributed tracing, see [Enable distribut
 
     When the traceparent header has a sampled flag of `00`, this controls how to handle sampling of spans. The allowable string values are:
 
-      * `adaptive` (default): use New Relic's built-in adaptive sampling algorithm.
-      * `always_on`: the agent will sample spans.
-      * `always_off`: the agent will NOT sample spans.
-      * `trace_id_ratio_based`: sample a fixed ratio of traces, deterministically based on trace ID.
+      * `adaptive` (default): Uses the built-in New Relic adaptive sampling algorithm.
+      * `always_on`: Samples all spans.
+      * `always_off`: Doesn't sample any spans.
+      * `trace_id_ratio_based`: Samples a fixed ratio of traces, determined deterministically by the trace ID.
 
     This setting only takes effect when [`remote_parent_sampled`](#dt-sampler-remote-parent-sampled) does not apply (that is, the traceparent sampled flag is `00`).
 
@@ -3933,7 +3933,7 @@ For more information about setting up distributed tracing, see [Enable distribut
     }
     ```
 
-    When set to `trace_id_ratio_based`, you must also provide a `ratio` (a number between `0` and `1`), and when set to `adaptive` you may optionally override the sampling target for this sampler specifically — see the object-form and environment variable examples under [`sampler.root`](#dt-sampler-root) for the equivalent syntax (substitute `remote_parent_not_sampled` for `root`).
+    When you set this to `trace_id_ratio_based`, you must provide a `ratio` value of `0`–`1`. When you set this to `adaptive`, you can optionally override the sampling target specifically for this sampler.  For the equivalent syntax, see the object-form and environment variable examples under [`sampler.root`](#dt-sampler-root) and substitute `remote_parent_not_sampled` for `root`.
   </Collapser>
   <Collapser
     id="dt-sampler-adaptive-sampling-target"
@@ -5407,7 +5407,7 @@ In agent versions prior to 11.0.0, the agent ran in both main and worker threads
 
 ## Utilization [#utilization]
 
-These settings control how the agent detects information about the host and cloud environment it's running in, used to calculate utilization-based pricing. They appear in the `utilization` section of your app's `newrelic.js` configuration file.
+Configure how the agent detects host and cloud environment information to accurately calculate your utilization-based pricing. These settings appear in the `utilization` section of your app's `newrelic.js` configuration file.
 
 <CollapserGroup>
   <Collapser


### PR DESCRIPTION
 The Node.js agent configuration page is missing several key sections: `apollo_server`, `distributed_tracing.sampler`, `opentelemetry`, and `utilization`. This PR adds them in.