### PR TITLE
Remove Terraform integration step not present in UI

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform.mdx
@@ -32,8 +32,6 @@ To integrate your AWS account with New Relic, follow these steps:
     1. <DNT>**Choose Data type(s)**</DNT>: <DNT>Metrics</DNT>
     2. <DNT>**Choose a setup method**</DNT>: <DNT>Automate with Terraform</DNT>
 
-5. On the <DNT>**Select services**</DNT> screen, if needed, use the <DNT>**Show resources not supported by CloudWatch Metric Streams**</DNT> toggle, select the services you want to monitor, and then continue.
-
 7. From the <DNT>**Terraform**</DNT> screen, open the documentation that guides how to connect your New Relic account with the Terraform provider account.
 
 8. After a successful integration, you can see your AWS data in New Relic.


### PR DESCRIPTION
## Summary
- Removes step 5 ("On the Select services screen, if needed, use the Show resources not supported by CloudWatch Metric Streams toggle...") from the Terraform AWS integration doc, since this step doesn't exist in the current UI flow.

## Test plan
- [ ] Verify the remaining steps still render correctly and renumber sequentially