### PR TITLE
fix: break release-notes sort ties by version, not file order

### DIFF
--- a/src/templates/releaseNoteLandingPage.js
+++ b/src/templates/releaseNoteLandingPage.js
@@ -47,10 +47,13 @@ const ReleaseNoteLandingPage = ({ data, pageContext, location }) => {
   }, []);
 
   const sortedPosts = uniquePosts.slice().sort((a, b) => {
-    // Sort by releaseDate descending
-    return (
-      new Date(b.frontmatter.releaseDate) - new Date(a.frontmatter.releaseDate)
-    );
+    // Sort by releaseDate descending, then by version descending to break ties
+    const dateDiff =
+      new Date(b.frontmatter.releaseDate) - new Date(a.frontmatter.releaseDate);
+
+    return dateDiff !== 0
+      ? dateDiff
+      : Number(b.frontmatter.version) - Number(a.frontmatter.version);
   });
 
   const title = `${subject} release notes`;
@@ -238,7 +241,10 @@ export const pageQuery = graphql`
       filter: {
         frontmatter: { subject: { eq: $subject }, releaseDate: { ne: null } }
       }
-      sort: { fields: [frontmatter___releaseDate], order: [DESC] }
+      sort: {
+        fields: [frontmatter___releaseDate, frontmatter___version]
+        order: [DESC, DESC]
+      }
       limit: $limit
       skip: $skip
     ) {


### PR DESCRIPTION
## Summary
- Release note entries with the same `releaseDate` (e.g. Job Manager v589 and v593, both `2026-07-16`) were ordered by GraphQL/array insertion order instead of anything meaningful, so v589 rendered before v593.
- Adds `version` as a numeric-descending tiebreaker in both the GraphQL `sort` and the client-side re-sort in `releaseNoteLandingPage.js`, so higher version numbers appear first when dates tie.

## Test plan
- [ ] Run `gatsby develop`, visit the Job Manager release notes landing page, and confirm v593 renders above v589 under the `July 16` date.
- [ ] Spot-check another release-notes subject with multiple same-day entries to confirm ordering still looks correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)