### PR TITLE
docs(mobile): update stale 600s harvest cycle references to 60s

### DIFF
--- a/src/content/docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes.mdx
+++ b/src/content/docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes.mdx
@@ -249,7 +249,7 @@ Naming syntax and rules: See [Rules for custom data](/docs/insights/insights-dat
 
 By default, New Relic transmits event data in any of these situations:
 
-* A session has been ongoing for 600 seconds.
+* A session has been ongoing for 60 seconds.
 * The app session ends by backgrounding.
 * The app crashes.
 

--- a/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-pool-size.mdx
@@ -77,10 +77,10 @@ NewRelic.setMaxEventPoolSize(maxSize: Int)
 
       Sets the maximum size of the event pool.
 
-      By default, <InlinePopover type="mobile"/> collects a maximum of 1,000 events per event harvest cycle, which is 600 seconds long by default.
+      By default, <InlinePopover type="mobile"/> collects a maximum of 1,000 events per event harvest cycle, which is 60 seconds long by default.
       This method controls the maximum size of the event pool stored in the memory until the next harvest cycle. When the pool size limit is reached, the New Relic Android agent will begin  [sampling events](/docs/agents/manage-apm-agents/agent-data/new-relic-events-limits-sampling), discarding some old and some new events, until the pool of events are transmitted with the next harvest cycle. This method lets you override the maximum size of that event pool.
 
-      The default value for the event harvest cycle is 600 seconds. See [Set max event buffer time](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time) to change the length of the event harvest cycle.
+      The default value for the event harvest cycle is 60 seconds. See [Set max event buffer time](/docs/mobile-monitoring/new-relic-mobile/mobile-sdk/set-max-event-buffer-time) to change the length of the event harvest cycle.
 
       <Callout variant="important">
         Be aware that reporting a large number of events, or reporting events too frequently, may impact app performance.


### PR DESCRIPTION

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
Mobile agents' default event harvest cycle changed from 600s to 60s; these two pages still described the old default.
