### PR TITLE
fix(prometheus): Document prometheus_server requirement for Prometheus HA deduplication

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
@@ -16,23 +16,27 @@ If you are using our Prometheus remote write integration in a high-availability 
   For information on standard Prometheus remote write integration without using a high-availability configuration, see [Set up your Prometheus remote write integration](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration).
 </Callout>
 
-## External labels [#prometheus-labels]
+## Quick reference [#prometheus-labels]
 
-New Relic requires two external labels to deduplicate data from replicas in a high-availability configuration:
+New Relic deduplicates HA replicas using three values. Set all three on every replica in a high-availability cluster:
 
 <table>
   <thead>
     <tr>
       <th>
-        Label name
+        Setting
       </th>
 
       <th>
-        Description
+        Where you set it
       </th>
 
       <th>
-        Example value
+        Value across replicas in the same HA cluster
+      </th>
+
+      <th>
+        Example
       </th>
     </tr>
   </thead>
@@ -44,7 +48,11 @@ New Relic requires two external labels to deduplicate data from replicas in a hi
       </td>
 
       <td>
-        A label whose value identifies the name of a high-availability cluster or group of Prometheus servers.
+        Prometheus external label
+      </td>
+
+      <td>
+        **Same** for all replicas
       </td>
 
       <td>
@@ -58,50 +66,99 @@ New Relic requires two external labels to deduplicate data from replicas in a hi
       </td>
 
       <td>
-        A label whose value identifies the unique replica sending this data.
+        Prometheus external label
       </td>
 
       <td>
-        `replica-1`
+        **Unique** per replica
+      </td>
+
+      <td>
+        `replica-1`, `replica-2`
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        `prometheus_server`
+      </td>
+
+      <td>
+        `remote_write` URL query parameter
+      </td>
+
+      <td>
+        **Same** for all replicas
+      </td>
+
+      <td>
+        `prod-monitoring`
       </td>
     </tr>
   </tbody>
 </table>
 
-<Callout variant="caution">
-  An account can have up to 1,500 unique Prometheus HA clusters. If this limit is exceeded, data from additional HA clusters will be dropped. In such cases, New Relic generates `PrometheusHAClusterLimit` [`NrIntegrationError`](/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events/) events.
-</Callout>
+**How it works:** New Relic groups replicas into one HA cluster by your account, the `prometheus` label, and the `prometheus_server` parameter. Within each group it elects a single leader (identified by `prometheus_replica`) and keeps only that replica's data.
 
-## Prometheus Operator [#kubernetes-operator]
+## Set up deduplication [#set-up]
 
-These external labels are added by default if you use [Prometheus Operator](https://github.com/coreos/prometheus-operator) version 0.19.0 (or higher). This applies whether you use Prometheus Operator directly or via the [helm chart](https://hub.helm.sh/charts/stable/prometheus-operator).
+### Prometheus Operator [#kubernetes-operator]
 
-The operator sets the value of the `prometheus` label (the one identifying a cluster) as `<prometheus deployment namespace>/<prometheus deployment name>`. For example, if your namespace for the Prometheus deployment is `monitoring` and the name of the deployment is `prometheus-cluster1`, the value is `monitoring/prometheus-cluster1`.
+[Prometheus Operator](https://github.com/coreos/prometheus-operator) version 0.19.0 or higher adds the `prometheus` and `prometheus_replica` external labels for you, whether you use the operator directly or via the [helm chart](https://hub.helm.sh/charts/stable/prometheus-operator):
 
-The operator sets the value of the `prometheus_replica` label as the name of the pod for each replica. This follows the format `replica-<replica number>`, where the number is the ordinal of that replica (for example, the first replica is named replica-1).
+* `prometheus` is set to `<prometheus deployment namespace>/<prometheus deployment name>`. For example, a deployment named `prometheus-cluster1` in the `monitoring` namespace produces `monitoring/prometheus-cluster1`.
+* `prometheus_replica` is set to each replica's pod name, in the format `replica-<replica number>` (for example, `replica-1`).
 
-<Callout variant="tip">
-  If you still see duplicate copies of replica data, make sure you do not have [`replicaExternalLabelName` or `prometheusExternalLabelName`](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec) in your Prometheus spec or chart configuration because these overrides change the label name.
-</Callout>
+Set `prometheus_server` yourself in the `remoteWrite` configuration on the `Prometheus` resource, using the same value for every replica.
 
-## Standalone Prometheus
+### Standalone Prometheus [#standalone-prometheus]
 
-When deploying a Prometheus server directly, you need to add the external labels to the [configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/). Here are two different example configurations for replicas within the same high-availability cluster:
+Add the external labels to each replica's [configuration file](https://prometheus.io/docs/prometheus/latest/configuration/configuration/), and use an identical `remote_write` URL — including the `prometheus_server` parameter — across all replicas.
 
 <DNT>**Replica 1**</DNT> (`prometheus.yml`)
 
 ```yml
 global:
-	external_labels:
-		prometheus: monitoring-cluster
-		prometheus_replica: replica-1
+  external_labels:
+    prometheus: monitoring-cluster
+    prometheus_replica: replica-1
+
+remote_write:
+  - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=prod-monitoring
+    authorization:
+      credentials: YOUR_LICENSE_KEY
 ```
 
-<DNT>**Replica 2**</DNT> (`prometheus.yml)`
+<DNT>**Replica 2**</DNT> (`prometheus.yml`)
 
 ```yml
 global:
-	external_labels:
-		prometheus: monitoring-cluster
-		prometheus_replica: replica-2
+  external_labels:
+    prometheus: monitoring-cluster
+    prometheus_replica: replica-2
+
+remote_write:
+  - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=prod-monitoring
+    authorization:
+      credentials: YOUR_LICENSE_KEY
 ```
+
+Only `prometheus_replica` differs between the two replicas; `prometheus` and `prometheus_server` are identical.
+
+## Notes, limits, and troubleshooting [#notes]
+
+<Callout variant="important">
+  Keep `prometheus_server` identical across replicas. Because `prometheus_server` is part of how New Relic groups replicas, giving replicas *different* values — for example, setting it per host or per pod — places each replica in its own separate HA group. Each replica is then the sole member of its group and is always elected leader, so none of its data is dropped. The result is duplicate data in New Relic with no error or warning surfaced, because each replica looks like a healthy, standalone leader. To distinguish individual replicas in your data, use the `prometheus_replica` label instead.
+</Callout>
+
+<Callout variant="caution">
+  An account can have up to 1,500 unique Prometheus HA clusters, counted per unique combination of account, `prometheus` label, and `prometheus_server` parameter. If this limit is exceeded, data from additional HA clusters will be dropped. In such cases, New Relic generates `PrometheusHAClusterLimit` [`NrIntegrationError`](/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events/) events. Keeping `prometheus_server` consistent across replicas also prevents a single HA group from unintentionally consuming multiple slots against this limit.
+</Callout>
+
+<Callout variant="tip">
+  Prometheus Operator does not set `prometheus_server` — that value comes entirely from your `remoteWrite` configuration on the `Prometheus` resource. This is consistent by default when all replicas share a single `remoteWrite` block (the normal case). If you inject per-replica `remoteWrite` overrides, make sure `prometheus_server` is not varied between them.
+</Callout>
+
+<Callout variant="tip">
+  If you still see duplicate copies of replica data, make sure you do not have [`replicaExternalLabelName` or `prometheusExternalLabelName`](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec) in your Prometheus spec or chart configuration because these overrides change the label name.
+</Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 If you are using our Prometheus remote write integration in a high-availability (HA) configuration, you need to make sure your Prometheus servers aren't sending multiple copies of the same metrics to New Relic. This document describes how you can configure your remote write integration so that New Relic does not keep duplicated metrics.
 
 <Callout variant="tip">
-  For information on standard Prometheus remote write integration without using a high-availability configuration, see [Set up your Prometheus remote write integration](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration).
+  This page applies only if you run your own Prometheus servers in a high-availability configuration and forward metrics with [remote write](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration). If you don't already run Prometheus, the [Prometheus agent for Kubernetes](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent/) is a fully New Relic-managed alternative that doesn't require HA deduplication; see [Send Prometheus metric data to New Relic](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) to compare your options.
 </Callout>
 
 ## Quick reference [#prometheus-labels]
@@ -109,7 +109,25 @@ New Relic deduplicates HA replicas using three values. Set all three on every re
 * `prometheus` is set to `<prometheus deployment namespace>/<prometheus deployment name>`. For example, a deployment named `prometheus-cluster1` in the `monitoring` namespace produces `monitoring/prometheus-cluster1`.
 * `prometheus_replica` is set to each replica's pod name, in the format `replica-<replica number>` (for example, `replica-1`).
 
-Set `prometheus_server` yourself in the `remoteWrite` configuration on the `Prometheus` resource, using the same value for every replica.
+Set `prometheus_server` yourself in the `remoteWrite` configuration on the `Prometheus` resource, using the same value for every replica. For example, this resource runs a two-replica HA pair with a single `remoteWrite` block, so `prometheus_server` stays consistent across both replicas:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: monitoring-cluster
+  namespace: monitoring
+spec:
+  replicas: 2
+  remoteWrite:
+    - url: https://metric-api.newrelic.com/prometheus/v1/write?prometheus_server=prod-monitoring
+      authorization:
+        credentials:
+          name: nr-license-key
+          key: licenseKey
+```
+
+The operator then sets `prometheus` to `monitoring/monitoring-cluster` and `prometheus_replica` to each replica's pod name automatically — you only supply `prometheus_server`. If you use the `kube-prometheus-stack` helm chart, set the same `remoteWrite` block under `prometheus.prometheusSpec`.
 
 ### Standalone Prometheus [#standalone-prometheus]
 

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
@@ -180,3 +180,7 @@ Only `prometheus_replica` differs between the two replicas; `prometheus` and `pr
 <Callout variant="tip">
   If you still see duplicate copies of replica data, make sure you do not have [`replicaExternalLabelName` or `prometheusExternalLabelName`](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec) in your Prometheus spec or chart configuration because these overrides change the label name.
 </Callout>
+
+<Callout variant="tip">
+  For the most consistent deduplication, keep your Prometheus `scrape_interval` at 60 seconds or less. New Relic identifies the active replica in each HA cluster from its most recently received data, and Prometheus remote write forwards new samples about once per scrape. If a cluster sends data less frequently than that, New Relic may not consistently recognize the same leader and can retain duplicated or interleaved data from more than one replica, with no error surfaced.
+</Callout>

--- a/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/install-configure/prometheus-high-availability-ha.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 If you are using our Prometheus remote write integration in a high-availability (HA) configuration, you need to make sure your Prometheus servers aren't sending multiple copies of the same metrics to New Relic. This document describes how you can configure your remote write integration so that New Relic does not keep duplicated metrics.
 
 <Callout variant="tip">
-  This page applies only if you run your own Prometheus servers in a high-availability configuration and forward metrics with [remote write](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration). If you don't already run Prometheus, the [Prometheus agent for Kubernetes](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent/) is a fully New Relic-managed alternative that doesn't require HA deduplication; see [Send Prometheus metric data to New Relic](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) to compare your options.
+  This page applies only if you run your own <DNT>Prometheus</DNT> servers in a high-availability configuration and forward metrics with [remote write](/docs/integrations/prometheus-integrations/install-configure/set-your-prometheus-remote-write-integration). If you don't already run <DNT>Prometheus</DNT>, the [Prometheus agent for Kubernetes](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent/) is a fully New Relic-managed alternative that doesn't require HA deduplication; see [Send Prometheus metric data to New Relic](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) to compare your options.
 </Callout>
 
 ## Quick reference [#prometheus-labels]
@@ -24,7 +24,7 @@ New Relic deduplicates HA replicas using three values. Set all three on every re
   <thead>
     <tr>
       <th>
-        Setting
+        Values
       </th>
 
       <th>
@@ -48,7 +48,7 @@ New Relic deduplicates HA replicas using three values. Set all three on every re
       </td>
 
       <td>
-        Prometheus external label
+        <DNT>Prometheus</DNT> external label
       </td>
 
       <td>
@@ -66,7 +66,7 @@ New Relic deduplicates HA replicas using three values. Set all three on every re
       </td>
 
       <td>
-        Prometheus external label
+        <DNT>Prometheus</DNT> external label
       </td>
 
       <td>
@@ -98,13 +98,13 @@ New Relic deduplicates HA replicas using three values. Set all three on every re
   </tbody>
 </table>
 
-**How it works:** New Relic groups replicas into one HA cluster by your account, the `prometheus` label, and the `prometheus_server` parameter. Within each group it elects a single leader (identified by `prometheus_replica`) and keeps only that replica's data.
+**How it works:** New Relic organizes replicas into HA clusters based on your account, the `prometheus` label, and the `prometheus_server` parameter. In each cluster, New Relic designates one replica as the leader and stores only the data from that leader. The leader is identified by the `prometheus_replica` label.
 
 ## Set up deduplication [#set-up]
 
 ### Prometheus Operator [#kubernetes-operator]
 
-[Prometheus Operator](https://github.com/coreos/prometheus-operator) version 0.19.0 or higher adds the `prometheus` and `prometheus_replica` external labels for you, whether you use the operator directly or via the [helm chart](https://hub.helm.sh/charts/stable/prometheus-operator):
+[<DNT>Prometheus Operator</DNT>](https://github.com/coreos/prometheus-operator) version 0.19.0 or higher adds the `prometheus` and `prometheus_replica` external labels for you, whether you use the operator directly or via the [helm chart](https://hub.helm.sh/charts/stable/prometheus-operator):
 
 * `prometheus` is set to `<prometheus deployment namespace>/<prometheus deployment name>`. For example, a deployment named `prometheus-cluster1` in the `monitoring` namespace produces `monitoring/prometheus-cluster1`.
 * `prometheus_replica` is set to each replica's pod name, in the format `replica-<replica number>` (for example, `replica-1`).
@@ -163,24 +163,16 @@ remote_write:
 
 Only `prometheus_replica` differs between the two replicas; `prometheus` and `prometheus_server` are identical.
 
-## Notes, limits, and troubleshooting [#notes]
+## Limitations [#limitations]
 
-<Callout variant="important">
-  Keep `prometheus_server` identical across replicas. Because `prometheus_server` is part of how New Relic groups replicas, giving replicas *different* values — for example, setting it per host or per pod — places each replica in its own separate HA group. Each replica is then the sole member of its group and is always elected leader, so none of its data is dropped. The result is duplicate data in New Relic with no error or warning surfaced, because each replica looks like a healthy, standalone leader. To distinguish individual replicas in your data, use the `prometheus_replica` label instead.
-</Callout>
+Keep `prometheus_server` identical across replicas. Because New Relic uses `prometheus_server` to group replicas, giving replicas *different* values — for example, per host or per pod — places each in its own HA group. Each replica becomes the sole member of its group, is always elected leader, and retains all its data. The result is duplicate data in New Relic with no error or warning, since each replica appears as a healthy, standalone leader. To distinguish individual replicas, use the `prometheus_replica` label instead.
 
-<Callout variant="caution">
-  An account can have up to 1,500 unique Prometheus HA clusters, counted per unique combination of account, `prometheus` label, and `prometheus_server` parameter. If this limit is exceeded, data from additional HA clusters will be dropped. In such cases, New Relic generates `PrometheusHAClusterLimit` [`NrIntegrationError`](/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events/) events. Keeping `prometheus_server` consistent across replicas also prevents a single HA group from unintentionally consuming multiple slots against this limit.
-</Callout>
+An account can have up to 1,500 unique <DNT>Prometheus HA</DNT> clusters, counted per unique combination of account, `prometheus` label, and `prometheus_server` parameter. Exceeding this limit causes data from additional HA clusters to be dropped, and New Relic generates `PrometheusHAClusterLimit` [`NrIntegrationError`](/docs/data-apis/ingest-apis/metric-api/troubleshoot-nrintegrationerror-events/) events. Keeping `prometheus_server` consistent across replicas also prevents a single HA group from consuming multiple slots against this limit.
 
-<Callout variant="tip">
-  Prometheus Operator does not set `prometheus_server` — that value comes entirely from your `remoteWrite` configuration on the `Prometheus` resource. This is consistent by default when all replicas share a single `remoteWrite` block (the normal case). If you inject per-replica `remoteWrite` overrides, make sure `prometheus_server` is not varied between them.
-</Callout>
+## Troubleshooting [#troubleshooting]
 
-<Callout variant="tip">
-  If you still see duplicate copies of replica data, make sure you do not have [`replicaExternalLabelName` or `prometheusExternalLabelName`](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec) in your Prometheus spec or chart configuration because these overrides change the label name.
-</Callout>
+<DNT>Prometheus Operator</DNT> does not set `prometheus_server` — that value comes entirely from your `remoteWrite` configuration on the `Prometheus` resource. When all replicas share a single `remoteWrite` block (the normal case), this is consistent by default. If you inject per-replica `remoteWrite` overrides, ensure `prometheus_server` is the same across all of them.
 
-<Callout variant="tip">
-  For the most consistent deduplication, keep your Prometheus `scrape_interval` at 60 seconds or less. New Relic identifies the active replica in each HA cluster from its most recently received data, and Prometheus remote write forwards new samples about once per scrape. If a cluster sends data less frequently than that, New Relic may not consistently recognize the same leader and can retain duplicated or interleaved data from more than one replica, with no error surfaced.
-</Callout>
+If you still see duplicate copies of replica data, ensure you do not have [`replicaExternalLabelName` or `prometheusExternalLabelName`](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec) in your <DNT>Prometheus</DNT> spec or chart configuration because these overrides change the label name.
+
+For the most consistent deduplication, keep your <DNT>Prometheus</DNT> `scrape_interval` at 60 seconds or less. New Relic identifies the active replica in each HA cluster from its most recently received data, and <DNT>Prometheus</DNT> remote write forwards new samples about once per scrape. If a cluster sends data less frequently than that, New Relic may not consistently recognize the same leader and can retain duplicated or interleaved data from more than one replica, with no error surfaced.


### PR DESCRIPTION
## Summary

The Prometheus HA page documented only the `prometheus` and `prometheus_replica` external labels as inputs to deduplication. In practice, HA deduplication also depends on the `prometheus_server` parameter on the `remote_write` URL.

New Relic groups replicas into an HA cluster by account + `prometheus` label + `prometheus_server`. If replicas use *different* `prometheus_server` values, each replica lands in its own single-member HA group, is always elected leader, and its data is never deduplicated — producing duplicate data with no error surfaced. Because `prometheus_server` is otherwise documented as a free-form data-source tag, it's reasonable for operators to vary it per replica and unknowingly break deduplication.

## What changed

- Restructured the page reference-first: a quick-reference table up front lists all three required settings (`prometheus`, `prometheus_replica`, `prometheus_server`), where each is set, and whether it must be the same or unique across replicas.
- Documented the `prometheus_server` requirement and added a dedicated **Notes, limits, and troubleshooting** section for the warnings, the cluster limit, and troubleshooting tips.
- Clarified that the 1,500 HA cluster limit is counted per unique combination of account + `prometheus` label + `prometheus_server`.
- Added a **Prometheus Operator** `remoteWrite` CRD example (a two-replica HA pair) and `remote_write` examples for **Standalone Prometheus**, all including `prometheus_server`.
- Added a top-of-page pointer for readers who don't run their own Prometheus, directing them to the New Relic-managed [Prometheus agent for Kubernetes](/docs/infrastructure/prometheus-integrations/install-configure-prometheus-agent/install-prometheus-agent/) and the [integration comparison](/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) (those paths don't involve HA deduplication).
- Added a troubleshooting note recommending a `scrape_interval` of 60 seconds or less for consistent HA deduplication (New Relic tracks the active replica from recently received data, so infrequent sends can cause replicas to be treated inconsistently).
- Preserved existing in-page anchors (`#prometheus-labels`, `#kubernetes-operator`, `#standalone-prometheus`) and fixed a backtick typo in the Replica 2 heading.

## Validation

Both configuration examples were validated locally:

- Standalone `prometheus.yml` (both replicas): `promtool check config` → valid Prometheus config.
- Operator `Prometheus` CRD: `kubeconform --strict` against the `monitoring.coreos.com` schema → valid.

The page was also built and rendered with `gatsby develop`: MDX compiles, callouts/table/code blocks render, and the new internal links resolve.

## Notes

Section headings were reorganized as part of the reference-first restructure, so the "On this page" list changes. Existing anchor IDs are preserved for deep links.
