### PR TITLE
fix(php): update outdated link

### DIFF
--- a/src/content/docs/apm/agents/php-agent/troubleshooting/fargate-nitro-clock-performance-impact.mdx
+++ b/src/content/docs/apm/agents/php-agent/troubleshooting/fargate-nitro-clock-performance-impact.mdx
@@ -15,7 +15,7 @@ Using the New Relic PHP agent in AWS Fargate results in poor performance.
 
 ## Explanation
 
-The PHP agent relies heavily on the clock source of a system for timing activities. Because of the constant clock checking, to be effective, the PHP agent needs a vDSO based clocksource so that the repetitive calls to check the time don't dominate the overall performance. You can find more details about how to check/change the clocksource [here](https://discuss.newrelic.com/t/relic-solution-php-agent-cpu-overhead-tips/70182).
+The PHP agent relies heavily on the clock source of a system for timing activities. Because of the constant clock checking, to be effective, the PHP agent needs a vDSO based clocksource so that the repetitive calls to check the time don't dominate the overall performance. You can find more details about how to check/change the clocksource [here](https://support.newrelic.com/s/hubtopic/aAX8W0000008a7r/relic-solution-php-agent-cpu-overhead-tips).
 
 Unfortunately, AWS Fargate mandates the xen clocksource which does NOT support vDSO. Despite the availability of other clocksources, AWS Fargate prohibits you from changing the clocksource by making the `sys` directory read-only.
 This is an [open issue](https://github.com/aws/containers-roadmap/issues/974) with Fargate regarding this limitation.


### PR DESCRIPTION
This PR updates an outdated link for this troubleshooting page: https://docs.newrelic.com/docs/apm/agents/php-agent/troubleshooting/fargate-nitro-clock-performance-impact/