### PR TITLE
Clarify that custom org-scoped roles don't auto-receive new capabilities

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -133,11 +133,16 @@ You can create roles at three different scopes, each serving different purposes:
 
 * **Entity-scoped roles**: You apply these roles for fine-grained access to specific resources like individual fleets or alert policies. This enables precise permission control at the individual resource level. You can create custom entity-scoped roles based on your needs.
 
+<Callout variant="important">
+  Custom organization-scoped roles don't receive new capabilities automatically. When New Relic releases a new organization-scoped feature, its capability is added to the standard <DNT>**Organization product admin**</DNT> and <DNT>**Organization read only**</DNT> roles, so users who hold those standard roles get the new feature automatically. A custom organization-scoped role only contains the capabilities you add to it, so when a new capability ships, an administrator must add it to each custom role that should have it. Otherwise, users assigned only to that custom role can't use the new feature. To have users receive new organization-scoped features automatically, assign the standard <DNT>**Organization product admin**</DNT> role for full access, or the <DNT>**Organization read only**</DNT> role for read access.
+</Callout>
+
 ### Important points about roles:
 
 * Roles are additive: users with multiple roles assigned have the total of all permissions granted by those roles. For example, if you're in a group that gives you the `All product admin` role in an account, and in another group that gives you a `Read only` role for the same account, you have both roles, and are not restricted by the `Read only` role.
 * Your access depends on both your user type and your permissions ([learn more](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type#user-type-and-roles)).
 * Creating a role doesn't grant access until you create an access grant linking a group to that role.
+* Standard roles keep pace with new features, but custom roles don't. New capabilities are added to the standard roles automatically, while a custom role only contains what you've added to it. If you rely on custom organization-scoped roles, an administrator needs to add each new organization-scoped capability to those roles as features are released.
 
 To view roles and their permissions, go to the [<DNT>**Access management**</DNT> UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) and click <DNT>**Roles**</DNT>.
 

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -123,7 +123,7 @@ You can create roles at three different scopes, each serving different purposes:
   * <DNT>**Organization manager**</DNT>: Permissions related to organization settings, including adding accounts, and changing the name of the organization and accounts. This also includes sensitive observability tasks, such as deleting certain entities.
   * <DNT>**Authentication domain manager**</DNT>: Permissions related to adding and managing users, including configuring authentication domains and customizing groups and roles.
   * <DNT>**Billing**</DNT>: Lets a user view and manage billing and usage, and data retention. For organizations with multiple accounts, billing is aggregated in the <DNT>**reporting account**</DNT> (usually the first account created in an organization).
-  * <DNT>**Organization product admin**</DNT>: Permissions related to organization-scoped observability features like scorecard and team management. This is the organization-scoped equivalent to <strong>All product admin</strong>
+  * <DNT>**Organization product admin**</DNT>: Permissions related to organization-scoped observability features like scorecard and team management. This is the organization-scoped equivalent to <strong>All product admin. This does not have administrative features the IAM, billing, and org settings.</strong>
 * <DNT>**Organization read only**</DNT>: Provides read-only access to the New Relic platform organization-scoped features.
 
 * **Account-scoped roles**: You apply these roles for access to platform features within specific accounts, such as configuring APM settings, managing alerts, or running queries. These are the traditional roles most users work with. Standard roles include:
@@ -134,7 +134,9 @@ You can create roles at three different scopes, each serving different purposes:
 * **Entity-scoped roles**: You apply these roles for fine-grained access to specific resources like individual fleets or alert policies. This enables precise permission control at the individual resource level. You can create custom entity-scoped roles based on your needs.
 
 <Callout variant="important">
-  Custom organization-scoped roles don't receive new capabilities automatically. When New Relic releases a new organization-scoped feature, its capability is added to the standard <DNT>**Organization product admin**</DNT> and <DNT>**Organization read only**</DNT> roles, so users who hold those standard roles get the new feature automatically. A custom organization-scoped role only contains the capabilities you add to it, so when a new capability ships, an administrator must add it to each custom role that should have it. Otherwise, users assigned only to that custom role can't use the new feature. To have users receive new organization-scoped features automatically, assign the standard <DNT>**Organization product admin**</DNT> role for full access, or the <DNT>**Organization read only**</DNT> role for read access.
+  Custom organization-scoped roles don't receive new permissions automatically. When New Relic releases a new organization-scoped feature, its permissions are added to standard roles, so users who hold those standard roles get the new feature automatically. A custom organization-scoped role only contains the permissions you add to it, so an administrator must add new ones to each custom role that should have it.
+
+To have users receive new organization-scoped features automatically, assign the standard <DNT>**Organization product admin**</DNT> role for full product access, or the <DNT>**Organization read only**</DNT> role for read access. 
 </Callout>
 
 ### Important points about roles:

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts.mdx
@@ -123,7 +123,7 @@ You can create roles at three different scopes, each serving different purposes:
   * <DNT>**Organization manager**</DNT>: Permissions related to organization settings, including adding accounts, and changing the name of the organization and accounts. This also includes sensitive observability tasks, such as deleting certain entities.
   * <DNT>**Authentication domain manager**</DNT>: Permissions related to adding and managing users, including configuring authentication domains and customizing groups and roles.
   * <DNT>**Billing**</DNT>: Lets a user view and manage billing and usage, and data retention. For organizations with multiple accounts, billing is aggregated in the <DNT>**reporting account**</DNT> (usually the first account created in an organization).
-  * <DNT>**Organization product admin**</DNT>: Permissions related to organization-scoped observability features like scorecard and team management. This is the organization-scoped equivalent to <strong>All product admin. This does not have administrative features the IAM, billing, and org settings.</strong>
+  * <DNT>**Organization product admin**</DNT>: Permissions related to organization-scoped observability features like scorecard and team management. This is the organization-scoped equivalent to <DNT>**All product admin**</DNT>. It doesn't contain administrative features like IAM, billing, or organization settings.
 * <DNT>**Organization read only**</DNT>: Provides read-only access to the New Relic platform organization-scoped features.
 
 * **Account-scoped roles**: You apply these roles for access to platform features within specific accounts, such as configuring APM settings, managing alerts, or running queries. These are the traditional roles most users work with. Standard roles include:
@@ -136,7 +136,7 @@ You can create roles at three different scopes, each serving different purposes:
 <Callout variant="important">
   Custom organization-scoped roles don't receive new permissions automatically. When New Relic releases a new organization-scoped feature, its permissions are added to standard roles, so users who hold those standard roles get the new feature automatically. A custom organization-scoped role only contains the permissions you add to it, so an administrator must add new ones to each custom role that should have it.
 
-To have users receive new organization-scoped features automatically, assign the standard <DNT>**Organization product admin**</DNT> role for full product access, or the <DNT>**Organization read only**</DNT> role for read access. 
+  To have users receive new organization-scoped features automatically, assign the standard <DNT>**Organization product admin**</DNT> role for full product access, or the <DNT>**Organization read only**</DNT> role for read access.
 </Callout>
 
 ### Important points about roles:
@@ -144,7 +144,6 @@ To have users receive new organization-scoped features automatically, assign the
 * Roles are additive: users with multiple roles assigned have the total of all permissions granted by those roles. For example, if you're in a group that gives you the `All product admin` role in an account, and in another group that gives you a `Read only` role for the same account, you have both roles, and are not restricted by the `Read only` role.
 * Your access depends on both your user type and your permissions ([learn more](/docs/accounts/accounts-billing/new-relic-one-user-management/user-type#user-type-and-roles)).
 * Creating a role doesn't grant access until you create an access grant linking a group to that role.
-* Standard roles keep pace with new features, but custom roles don't. New capabilities are added to the standard roles automatically, while a custom role only contains what you've added to it. If you rely on custom organization-scoped roles, an administrator needs to add each new organization-scoped capability to those roles as features are released.
 
 To view roles and their permissions, go to the [<DNT>**Access management**</DNT> UI](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks#where) and click <DNT>**Roles**</DNT>.
 

--- a/src/content/whats-new/2025/02/whats-new-02-18-new-access-management.md
+++ b/src/content/whats-new/2025/02/whats-new-02-18-new-access-management.md
@@ -32,6 +32,9 @@ Admins should audit and make any necessary changes to your groups and access gra
 2. Create custom roles, which can only be done via our API. Learn more in this [doc](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-manage-groups/#create-role).
 
 
+If you already use custom organization-scoped roles, note that these roles don't receive new capabilities automatically. As New Relic releases new organization-scoped features, an administrator must add each new capability to the custom roles that should have it, or users assigned only to a custom role that lacks the capability won't see the new feature. To have new features arrive automatically instead, assign users the standard **Organization Product Admin** or **Organization read only** role. See [role scopes](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#role-scopes) for details.
+
+
 No action is required if default access is acceptable for your organization.
 
 

--- a/src/content/whats-new/2025/02/whats-new-02-18-new-access-management.md
+++ b/src/content/whats-new/2025/02/whats-new-02-18-new-access-management.md
@@ -32,9 +32,6 @@ Admins should audit and make any necessary changes to your groups and access gra
 2. Create custom roles, which can only be done via our API. Learn more in this [doc](https://docs.newrelic.com/docs/apis/nerdgraph/examples/nerdgraph-manage-groups/#create-role).
 
 
-If you already use custom organization-scoped roles, note that these roles don't receive new capabilities automatically. As New Relic releases new organization-scoped features, an administrator must add each new capability to the custom roles that should have it, or users assigned only to a custom role that lacks the capability won't see the new feature. To have new features arrive automatically instead, assign users the standard **Organization Product Admin** or **Organization read only** role. See [role scopes](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#role-scopes) for details.
-
-
 No action is required if default access is acceptable for your organization.
 
 


### PR DESCRIPTION
## What & why

Customers who use custom organization-scoped roles don't automatically receive new org-scoped capabilities when New Relic ships them. A new feature's capability is added to the standard **Organization product admin** and **Organization read only** roles, but a custom org-scoped role only contains what an admin explicitly adds. Today the docs never state this, so orgs on custom roles lose access to new features at GA and can't tell why.

## Changes

- **user-management-concepts.mdx**
  - New `important` callout after the "Role scopes" list: custom org-scoped roles don't auto-receive new capabilities; the standard Organization product admin / Organization read only roles do.
  - New bullet under "Important points about roles" making the same point in the additive-roles context.
- **whats-new/2025/02/whats-new-02-18-new-access-management.md**
  - Adds an "if you already use custom roles" note under "What action is required?", linking to role scopes.

## Notes

- Docs only, no behavior or config changes.
- The main fix is on user-management-concepts; the whats-new addition is a small pointer for anyone landing on the original announcement.