### PR TITLE
What's New: Autopilot K8s Agent - Limited Preview

### DIFF
--- a/src/content/whats-new/2026/07/whats-new-07-21-autopilot-k8s-agent.md
+++ b/src/content/whats-new/2026/07/whats-new-07-21-autopilot-k8s-agent.md
@@ -1,0 +1,22 @@
+---
+title: 'Autopilot K8s Agent is now in Limited Preview'
+summary: 'Autopilot K8s Agent autonomously investigates Kubernetes issues — from CrashLoopBackOff to OOMKilled — and hands you ready-to-run remediation. No deep Kubernetes experience needed.'
+releaseDate: '2026-07-21'
+---
+
+Diagnosing Kubernetes failures has always required deep expertise and manual work across kubectl, dashboards, and logs. Autopilot K8s Agent changes that.
+
+Now in Limited Preview, Autopilot K8s Agent is an AI-powered diagnostic co-pilot embedded inside New Relic Autopilot. It autonomously correlates events, metrics, logs, and traces to pinpoint root cause and deliver actionable remediation steps — in a fraction of the time it would take manually.
+
+## What it does
+
+- **Root cause analysis** for the most common K8s failures: CrashLoopBackOff, OOMKilled, Pending pods, ImagePullBackOff, Replica Mismatches, and High Restart Counts
+- **Deep context**: analyzes manifests, events, resource metrics, and deployment history together
+- **Ready-to-run remediation**: specific fix steps, not just detection
+- **No additional instrumentation required**: works with your existing New Relic Kubernetes integration data
+
+## How to access
+
+Autopilot K8s Agent is accessible through New Relic Autopilot (now GA). Ask your New Relic account team to activate the Autopilot K8s Agent entitlement for your accounts.
+
+For more details, see the [Autopilot K8s Agent documentation](https://docs-preview.newrelic.com/docs/k8s-autopilot).

--- a/src/content/whats-new/2026/07/whats-new-07-21-autopilot-k8s-agent.md
+++ b/src/content/whats-new/2026/07/whats-new-07-21-autopilot-k8s-agent.md
@@ -1,12 +1,18 @@
 ---
 title: 'Autopilot K8s Agent is now in Limited Preview'
-summary: 'Autopilot K8s Agent autonomously investigates Kubernetes issues — from CrashLoopBackOff to OOMKilled — and hands you ready-to-run remediation. No deep Kubernetes experience needed.'
+summary: 'Autopilot K8s Agent autonomously investigates Kubernetes issues, from CrashLoopBackOff to OOMKilled, and hands you ready-to-run remediation. No deep Kubernetes experience needed.'
 releaseDate: '2026-07-21'
 ---
 
 Diagnosing Kubernetes failures has always required deep expertise and manual work across kubectl, dashboards, and logs. Autopilot K8s Agent changes that.
 
-Now in Limited Preview, Autopilot K8s Agent is an AI-powered diagnostic co-pilot embedded inside New Relic Autopilot. It autonomously correlates events, metrics, logs, and traces to pinpoint root cause and deliver actionable remediation steps — in a fraction of the time it would take manually.
+Now in Limited Preview, Autopilot K8s Agent is an AI-powered diagnostic co-pilot embedded inside New Relic Autopilot. It autonomously correlates events, metrics, logs, and traces to pinpoint root cause and deliver actionable remediation steps, in a fraction of the time it would take manually.
+
+<img
+  title="Autopilot K8s Agent analyzing a deployment and providing root cause analysis with remediation steps"
+  alt="Autopilot K8s Agent analyzing a deployment and providing root cause analysis with remediation steps"
+  src={k8sAutopilotDemo}
+/>
 
 ## What it does
 


### PR DESCRIPTION
## Summary
- Adds What's New post for the Autopilot K8s Agent Limited Preview launch
- File: `src/content/whats-new/2026/07/whats-new-07-21-autopilot-k8s-agent.md`

## Notes
- Doc link currently points to `docs-preview.newrelic.com/docs/k8s-autopilot` — will update to `docs.newrelic.com` once the beta-docs-site PR #702 is published
- Release date set to 2026-07-21, adjust if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)