### PR TITLE
Add Intelligent Exemplar doc (public preview)

### DIFF
--- a/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
@@ -1,0 +1,143 @@
+---
+title: Intelligent Exemplar
+tags:
+  - Distributed tracing
+  - Intelligent Tracing
+  - UI and data
+metaDescription: "Use Intelligent Exemplar to go from a latency or error spike directly to the anomalous span — without manually rebuilding filters or sifting through trace lists."
+redirects:
+  - /docs/intelligent-tracing
+freshnessValidatedDate: 2026-07-17
+---
+
+<Callout variant="important">
+  This feature is currently in public preview. It is subject to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+When an alert fires for a latency spike or surge in errors, the first challenge is finding *where* the problem lives. The standard workflow drops you into an unfiltered list of thousands of traces with your investigative context stripped away — forcing you to manually rebuild filters and scrub through data to find the one trace that actually shows the problem.
+
+Intelligent Exemplar eliminates that search. It preserves the exact context from your click, algorithmically surfaces the traces that best represent the anomaly, and navigates you directly to the failing span — so you go from spike to root span in clicks instead of hours.
+
+Once you've identified the failing span, use [Attribute Correlation Analysis](/docs/distributed-tracing/ui-data/attribute-correlation-analysis/) to answer *why* it's failing — by statistically comparing your anomalous traces against a healthy baseline and surfacing the specific attributes driving the issue.
+
+## How Intelligent Exemplar works [#how-it-works]
+
+Intelligent Exemplar combines three behaviors to close the gap between a high-level metric and the exact code-level trace you need:
+
+**Context preservation**
+When you click a time window on a supported error or latency chart, Intelligent Exemplar captures everything in scope at that moment: the entity, the exact time range, any active filters such as `transaction.name` or `error.class`, and selected facets. These are passed natively to the backend. You are never dropped into a generic, unfiltered trace list.
+
+**Algorithmic trace prioritization**
+Rather than showing a random or chronologically ordered sample, Intelligent Exemplar evaluates the full trace dataset and surfaces a curated list of up to 500 traces that best represent the anomaly. Fragmented traces are filtered out automatically. Traces are weighted toward occurrences that fall within the spike window. If a single variable — such as one transaction name, host, or deployment version — accounts for more than 60% of the anomalous traces, it is surfaced automatically as the suggested starting point.
+
+**Anomalous span navigation**
+When you select a trace from the list, the UI navigates directly to the anomalous span — not the root span, not the slowest span overall, but the span that deviates most from the baseline behavior for that operation. In a 200-span waterfall that crosses multiple downstream services, this eliminates the manual traversal required to locate where things went wrong.
+
+## Requirements [#requirements]
+
+Before using Intelligent Exemplar:
+
+- [Distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/) must be enabled for your services.
+- The more services in your trace path that are instrumented, the more complete the downstream dependency map. Uninstrumented services create gaps in the causal path.
+
+## Start an investigation [#start-investigation]
+
+Intelligent Exemplar is available on error and latency charts in three locations:
+
+- <DNT>**APM & Services > Summary**</DNT>: the Web transactions time chart and the error rate chart
+- <DNT>**Errors Inbox**</DNT>: error and latency charts on the Errors Inbox home page
+- <DNT>**Transactions**</DNT>: error and latency charts on the Transactions home page
+
+The steps are the same in all three locations:
+
+1. Click the time window on the error or latency chart that corresponds to the spike you want to investigate.
+2. In the tooltip that appears, select <DNT>**Intelligent Traces**</DNT>.
+
+## Review the landing page [#landing-page]
+
+After selecting the spike window, the Intelligent Exemplar landing page opens with a full picture of the anomalous behavior for that service and time range. No query building or manual filter setup is required — your context from the click has already been applied.
+
+The landing page has four components:
+
+### Summary bar [#summary-bar]
+
+Displays the time range, the type of anomaly (latency or errors), and the number of outlier traces identified for that window.
+
+### Patterns we detected [#patterns]
+
+Categorized signals that identify where the anomaly is occurring and what may be driving it. You can select one or more patterns to focus the outlier trace list on a specific signal.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>Pattern</th>
+      <th>What it means</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Downstream latency</td>
+      <td>A dependency's p95 or p99 latency correlates with the focal entity's spike. The root cause likely lives in a service downstream of the one you started from.</td>
+    </tr>
+    <tr>
+      <td>Downstream errors</td>
+      <td>Error rate in a downstream service increased during the spike window. The anomaly is propagating from a dependency.</td>
+    </tr>
+    <tr>
+      <td>Focal entity latency</td>
+      <td>The service you started from is itself the latency source — the issue is not being caused by a downstream dependency.</td>
+    </tr>
+    <tr>
+      <td>Throughput surge</td>
+      <td>A sharp increase in request volume in the focal entity or a downstream entity correlates with the latency or error spike. The anomaly may be load-induced rather than a code or infrastructure failure.</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+  If a single pattern accounts for more than 60% of the anomalous traces, Intelligent Exemplar selects it automatically as the suggested starting point. You can deselect it and choose a different pattern to explore alternative hypotheses.
+</Callout>
+
+### Outlier traces [#outlier-traces]
+
+The ranked list of traces that exhibit anomalous behavior within the selected window. Traces are sorted by their contribution to the spike. Select any trace to open it and navigate directly to the anomalous span.
+
+### Scatter plot [#scatter-plot]
+
+A visual comparison of outlier traces against all other traces in the time window.
+
+- **X-axis**: time within the selected window
+- **Y-axis**: trace duration (for latency investigations) or error count
+- **Outlier traces** are plotted distinctly from the **All Traces** baseline series
+
+Use the scatter plot to confirm that the outlier traces cluster around the spike window rather than being distributed randomly across the full time range. A tight cluster confirms the anomaly is time-bounded and that the selected traces are genuinely representative of the spike.
+
+## Inspect the anomalous span [#anomalous-span]
+
+Selecting a trace from the outlier list opens the trace detail panel. Intelligent Exemplar does not land you at the root span — it navigates directly to the span that deviates most from the expected baseline behavior for that operation.
+
+This matters most in deep, multi-service traces. In a 200-span waterfall that crosses five downstream services, the anomalous span may be buried several layers deep in a dependency you did not initially suspect. Intelligent Exemplar navigates you there automatically.
+
+From the anomalous span, you can:
+
+- Review the span attributes to see the values that deviate from baseline
+- Navigate to the entity that owns the span to see its APM summary
+- View the surrounding spans in the waterfall for additional context
+- Run [Attribute Correlation Analysis](/docs/distributed-tracing/ui-data/attribute-correlation-analysis/) to identify the specific attribute-value pairs driving the anomaly — such as a deployment version, host, or error class
+
+For a full guide to working with trace details and span attributes, see [Understand the trace details UI page](/docs/distributed-tracing/ui-data/trace-details/).
+
+## Understand downstream correlation [#downstream-correlation]
+
+When the anomaly originates in a downstream dependency, Intelligent Exemplar maps the causal propagation path across your service dependency graph.
+
+The system automatically analyzes correlating latency and error patterns across downstream entities and calculates the contribution of each pathway to the aggregate failure. 
+<Callout variant="tip">
+  More complete instrumentation across your trace path produces more accurate downstream attribution. If a downstream service is not instrumented, its contribution will not appear in the correlation map.
+</Callout>
+
+## What's next [#whats-next]
+
+- **Identify the root cause**: Run [Attribute Correlation Analysis](/docs/distributed-tracing/ui-data/attribute-correlation-analysis/) to identify the specific attribute-value pairs — such as a deployment version, host, region, or error class — responsible for the anomaly.
+- **Manage trace volume**: See [Control distributed tracing data ingestion](/docs/cost-optimization-strategies-distributed-tracing/) to manage trace ingestion costs during and after an incident.
+- **Tune sampling**: See [Configure sampling](/docs/intelligent-tracing-sampling/) to adjust sampling rates for the affected service.

--- a/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
@@ -10,43 +10,47 @@ redirects:
 freshnessValidatedDate: 2026-07-17
 ---
 
-<Callout variant="important">
+<Callout title="preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
+</Callout>
   This feature is currently in public preview. It is subject to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
 </Callout>
 
-When an alert fires for a latency spike or surge in errors, the first challenge is finding *where* the problem lives. The standard workflow drops you into an unfiltered list of thousands of traces with your investigative context stripped away — forcing you to manually rebuild filters and scrub through data to find the one trace that actually shows the problem.
+When an alert fires for a latency spike or error surge, your first challenge is finding *where* the problem lives. Instead of keeping your investigative context, the standard workflow drops you into an unfiltered list of thousands of traces—forcing you to manually rebuild filters and scrub through data to find the one trace that shows the problem.
 
-Intelligent Exemplar eliminates that search. It preserves the exact context from your click, algorithmically surfaces the traces that best represent the anomaly, and navigates you directly to the failing span — so you go from spike to root span in clicks instead of hours.
+<DNT>Intelligent Exemplar (IE)</DNT> eliminates that search. It preserves the exact context from your click, algorithmically surfaces the traces that best represent the anomaly, and navigates you directly to the failing span — so you go from spike to root span in clicks instead of hours.
 
 Once you've identified the failing span, use [Attribute Correlation Analysis](/docs/distributed-tracing/ui-data/attribute-correlation-analysis/) to answer *why* it's failing — by statistically comparing your anomalous traces against a healthy baseline and surfacing the specific attributes driving the issue.
 
 ## How Intelligent Exemplar works [#how-it-works]
 
-Intelligent Exemplar combines three behaviors to close the gap between a high-level metric and the exact code-level trace you need:
+IE combines three behaviors to close the gap between a high-level metric and the exact code-level trace you need:
 
 **Context preservation**
-When you click a time window on a supported error or latency chart, Intelligent Exemplar captures everything in scope at that moment: the entity, the exact time range, any active filters such as `transaction.name` or `error.class`, and selected facets. These are passed natively to the backend. You are never dropped into a generic, unfiltered trace list.
+When you click a time window on a supported error or latency chart, <DNT>Intelligent Exemplar</DNT> captures everything in scope at that moment: the entity, the exact time range, any active filters such as `transaction.name` or `error.class`, and selected facets. These are passed natively to the backend. You are never dropped into a generic, unfiltered trace list.
 
 **Algorithmic trace prioritization**
-Rather than showing a random or chronologically ordered sample, Intelligent Exemplar evaluates the full trace dataset and surfaces a curated list of up to 500 traces that best represent the anomaly. Fragmented traces are filtered out automatically. Traces are weighted toward occurrences that fall within the spike window. If a single variable — such as one transaction name, host, or deployment version — accounts for more than 60% of the anomalous traces, it is surfaced automatically as the suggested starting point.
+Rather than showing a random or chronologically ordered sample, <DNT>Intelligent Exemplar</DNT> evaluates the full trace dataset and surfaces a curated list of up to 500 traces that best represent the anomaly. Fragmented traces are filtered out automatically. Traces are weighted toward occurrences that fall within the spike window. If a single variable — such as single transaction name, host, or deployment version — accounts for more than 60% of the anomalous traces, it is surfaced automatically as the suggested starting point.
 
 **Anomalous span navigation**
 When you select a trace from the list, the UI navigates directly to the anomalous span — not the root span, not the slowest span overall, but the span that deviates most from the baseline behavior for that operation. In a 200-span waterfall that crosses multiple downstream services, this eliminates the manual traversal required to locate where things went wrong.
 
 ## Requirements [#requirements]
 
-Before using Intelligent Exemplar:
+Before using <DNT>Intelligent Exemplar</DNT>:
 
 - [Distributed tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing/) must be enabled for your services.
 - The more services in your trace path that are instrumented, the more complete the downstream dependency map. Uninstrumented services create gaps in the causal path.
 
 ## Start an investigation [#start-investigation]
 
-Intelligent Exemplar is available on error and latency charts in three locations:
+<DNT>Intelligent Exemplar<DNT> is available on error and latency charts in three locations:
 
-- <DNT>**APM & Services > Summary**</DNT>: the Web transactions time chart and the error rate chart
-- <DNT>**Errors Inbox**</DNT>: error and latency charts on the Errors Inbox home page
-- <DNT>**Transactions**</DNT>: error and latency charts on the Transactions home page
+- <DNT>**APM & Services > Summary**</DNT>: web transactions time chart and the error rate chart
+- <DNT>**Errors Inbox**</DNT>: error and latency charts on the <DNT>**Errors Inbox**</DNT> home page
+- <DNT>**Transactions**</DNT>: error and latency charts on the <DNT>**Transactions**</DNT> home page
 
 The steps are the same in all three locations:
 
@@ -55,7 +59,7 @@ The steps are the same in all three locations:
 
 ## Review the landing page [#landing-page]
 
-After selecting the spike window, the Intelligent Exemplar landing page opens with a full picture of the anomalous behavior for that service and time range. No query building or manual filter setup is required — your context from the click has already been applied.
+After selecting the spike window, the <DNT>Intelligent Exemplar</DNT> landing page opens with a full picture of the anomalous behavior for that service and time range. No query building or manual filter setup is required — your context from the click has already been applied.
 
 The landing page has four components:
 
@@ -81,7 +85,7 @@ Categorized signals that identify where the anomaly is occurring and what may be
     </tr>
     <tr>
       <td>Downstream errors</td>
-      <td>Error rate in a downstream service increased during the spike window. The anomaly is propagating from a dependency.</td>
+      <td>An error rate in a downstream service increased during the spike window. The anomaly is propagating from a dependency.</td>
     </tr>
     <tr>
       <td>Focal entity latency</td>
@@ -95,7 +99,7 @@ Categorized signals that identify where the anomaly is occurring and what may be
 </table>
 
 <Callout variant="tip">
-  If a single pattern accounts for more than 60% of the anomalous traces, Intelligent Exemplar selects it automatically as the suggested starting point. You can deselect it and choose a different pattern to explore alternative hypotheses.
+  If a single pattern accounts for more than 60% of the anomalous traces, <DNT>Intelligent Exemplar</DNT> selects it automatically as the suggested starting point. You can deselect it and choose a different pattern to explore alternative hypotheses.
 </Callout>
 
 ### Outlier traces [#outlier-traces]
@@ -106,17 +110,17 @@ The ranked list of traces that exhibit anomalous behavior within the selected wi
 
 A visual comparison of outlier traces against all other traces in the time window.
 
-- **X-axis**: time within the selected window
-- **Y-axis**: trace duration (for latency investigations) or error count
-- **Outlier traces** are plotted distinctly from the **All Traces** baseline series
+- <DNT>**X-axis**</DNT>: time within the selected window
+- <DNT>**Y-axis**</DNT>: trace duration (for latency investigations) or error count
+- <DNT>**Outlier traces**</DNT> are plotted distinctly from the <DNT>**All Traces**</DNT> baseline series
 
 Use the scatter plot to confirm that the outlier traces cluster around the spike window rather than being distributed randomly across the full time range. A tight cluster confirms the anomaly is time-bounded and that the selected traces are genuinely representative of the spike.
 
 ## Inspect the anomalous span [#anomalous-span]
 
-Selecting a trace from the outlier list opens the trace detail panel. Intelligent Exemplar does not land you at the root span — it navigates directly to the span that deviates most from the expected baseline behavior for that operation.
+Selecting a trace from the outlier list opens the trace detail panel. <DNT>Intelligent Exemplar</DNT> does not land you at the root span — it navigates directly to the span that deviates most from the expected baseline behavior for that operation.
 
-This matters most in deep, multi-service traces. In a 200-span waterfall that crosses five downstream services, the anomalous span may be buried several layers deep in a dependency you did not initially suspect. Intelligent Exemplar navigates you there automatically.
+This matters most in deep, multi-service traces. In a 200-span waterfall that crosses five downstream services, the anomalous span may be buried several layers deep in a dependency you did not initially suspect. <DNT>Intelligent Exemplar</DNT> navigates you there automatically.
 
 From the anomalous span, you can:
 
@@ -129,7 +133,7 @@ For a full guide to working with trace details and span attributes, see [Underst
 
 ## Understand downstream correlation [#downstream-correlation]
 
-When the anomaly originates in a downstream dependency, Intelligent Exemplar maps the causal propagation path across your service dependency graph.
+When the anomaly originates in a downstream dependency, <DNT>Intelligent Exemplar</DNT> maps the causal propagation path across your service dependency graph.
 
 The system automatically analyzes correlating latency and error patterns across downstream entities and calculates the contribution of each pathway to the aggregate failure. 
 <Callout variant="tip">

--- a/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
@@ -15,8 +15,6 @@ freshnessValidatedDate: 2026-07-17
 
   This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
-  This feature is currently in public preview. It is subject to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
-</Callout>
 
 When an alert fires for a latency spike or error surge, your first challenge is finding *where* the problem lives. Instead of keeping your investigative context, the standard workflow drops you into an unfiltered list of thousands of traces—forcing you to manually rebuild filters and scrub through data to find the one trace that shows the problem.
 

--- a/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
+++ b/src/content/docs/distributed-tracing/ui-data/intelligent-exemplar.mdx
@@ -44,7 +44,7 @@ Before using <DNT>Intelligent Exemplar</DNT>:
 
 ## Start an investigation [#start-investigation]
 
-<DNT>Intelligent Exemplar<DNT> is available on error and latency charts in three locations:
+<DNT>Intelligent Exemplar</DNT> is available on error and latency charts in three locations:
 
 - <DNT>**APM & Services > Summary**</DNT>: web transactions time chart and the error rate chart
 - <DNT>**Errors Inbox**</DNT>: error and latency charts on the <DNT>**Errors Inbox**</DNT> home page

--- a/src/nav/distributed-tracing.yml
+++ b/src/nav/distributed-tracing.yml
@@ -21,6 +21,8 @@ pages:
         path: /docs/distributed-tracing/ui-data/query-distributed-trace-data
       - title: Related trace entity signals
         path: /docs/distributed-tracing/ui-data/related-trace-entity-signals
+      - title: Intelligent Exemplar
+        path: /docs/distributed-tracing/ui-data/intelligent-exemplar
   - title: Infinite Tracing
     pages:
       - title: Introduction to Infinite Tracing


### PR DESCRIPTION
## Summary

Adds the Intelligent Exemplar public preview doc as a standalone page under `distributed-tracing/ui-data/`.

**What's covered:**
- How it works: context preservation, algorithmic trace prioritization, anomalous span navigation
- Entry points: APM & Services > Summary, Errors Inbox home page, Transactions home page (error and latency charts only)
- Landing page: summary bar, detected patterns table, outlier traces list, scatter plot


