### PR TITLE
Add 10.x min Ruby version to table

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/getting-started/ruby-agent-eol-policy.mdx
@@ -50,6 +50,16 @@ The latest version of the New Relic Ruby agent may support a Ruby version outsid
   <tbody>
     <tr>
       <td>
+        10.x
+      </td>
+
+      <td>
+        2.6.0
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         9.x
       </td>
 


### PR DESCRIPTION
Now, the agent only supports Ruby versions 2.6 and above. We missed this in our documentation updates released as part of 10.0.0.