### PR TITLE
Add Autopilot Slack integration docs

### DIFF
--- a/src/content/docs/agentic-ai/autopilot/connect-to-slack.mdx
+++ b/src/content/docs/agentic-ai/autopilot/connect-to-slack.mdx
@@ -1,0 +1,256 @@
+---
+title: Autopilot Slack integration
+metaDescription: "Connect your Slack workspace to New Relic Autopilot to investigate alerts, check entity health, and analyze deployments directly in Slack threads."
+tags:
+  - Agentic AI
+  - Autopilot
+  - Slack
+  - Slack integration
+  - Incident management
+freshnessValidatedDate: never
+---
+
+
+When an alert triggers, you often jump between <DNT>Slack</DNT>, where your team is already talking, and the New Relic UI to investigate. That context switching slows your response.
+
+Connect <DNT>Autopilot</DNT> to <DNT>Slack</DNT> so your team can investigate right in the thread and receive the same outputs from Autopilot in your <DNT>Slack</DNT> workflows. Mention the New Relic app (for example, `@New Relic`) with a question, and it replies using your New Relic permissions.
+
+## What you can do [#what-you-can-do]
+
+In any channel where you've invited the app, mention it (for example, `@New Relic`). <DNT>Autopilot</DNT> can:
+
+* **Triage alerts**: Find out why an alert triggered, what's affected, and what correlates.
+* **Check entity health**: Get the current status of any monitored service.
+* **Analyze changes**: Find out whether a recent deployment caused a regression.
+* **Run multi-turn investigations**: Ask follow-up questions in the same thread to dig deeper.
+* **Retrieve investigation status, summary, and key details**: Retrieve status and summary information in addition to details, such as severity, root cause, resolution, detection, and the assigned incident commander.
+
+
+<DNT>Autopilot</DNT> replies in the same thread and accesses only the data your New Relic permissions allow.
+
+## Prerequisites [#prerequisites]
+
+Before you begin, make sure you have:
+
+* **A configured <DNT>Autopilot</DNT>**: An active agent with accounts and permissions set up. Refer to [Set up Autopilot](/docs/agentic-ai/autopilot/setup).
+* **<DNT>Slack</DNT> admin access**: Admin permissions in your <DNT>Slack</DNT> workspace to approve the New Relic app.
+* **Preview opt-ins**: Active <DNT>Autopilot</DNT> and <DNT>MCP Server</DNT> preview trials on your account.
+
+## Set up the Slack connection [#setup]
+
+<Steps>
+  <Step>
+    ### Connect your Slack workspace (admin) [#connect-slack]
+
+    An [Organization manager](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#role-scopes) connects the workspace during <DNT>Autopilot</DNT> configuration:
+
+    1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com)**</DNT>.
+    2. In the upper right, select <DNT>**Ask AI**</DNT>, then select the <DNT>**Configure**</DNT> tab (gear icon).
+    3. Under <DNT>**Agents**</DNT>, select your <DNT>Autopilot</DNT>.
+    4. In the <DNT>**Slack (optional)**</DNT> section, click <DNT>**Connect**</DNT>.
+    5. On the <DNT>Slack</DNT> authorization screen:
+       1. Select the workspace you want to connect.
+       2. Review the requested default permissions and click <DNT>**Allow**</DNT>.
+    6. Verify that a green <DNT>**Connected**</DNT> badge appears.
+    7. Click <DNT>**Update agent**</DNT>.
+
+    <Callout variant="important">
+      The workspace connection allows users to link their <DNT>Slack</DNT> identity so that the <DNT>Autopilot</DNT> can respond in the workspace. The <DNT>Autopilot</DNT> will only respond in the [Slack workspace](https://slack.com/help/categories/200122103-Workspace-administration) it is connected to.
+    </Callout>
+
+    <Callout variant="tip">
+      To stop <DNT>Autopilot</DNT> from responding in the workspace, from this page you can disconnect the workspace at any time.
+    </Callout>
+  </Step>
+
+  <Step>
+    ### Invite the New Relic app to a channel [#invite-to-channel]
+
+    Any workspace member can invite the New Relic app to a channel. In the channel, mention the New Relic app (for example, `@New Relic`). If the app isn't already there, <DNT>Slack</DNT> prompts you to add it. You can also add it from the <DNT>integration</DNT> tab of the <DNT>Slack</DNT> channel.
+  </Step>
+
+  <Step>
+    ### Link your identity (first time only) [#link-identity]
+
+    If you are mentioning the New Relic app in a thread for the first time before your identity is linked, you get a private message prompting you to connect your New Relic account. Click <DNT>**Connect**</DNT> and log in with your New Relic credentials to link your identity. The <DNT>**Connect**</DNT> and <DNT>**Authenticate**</DNT> links expire after 10 minutes. If a link expires, mention the New Relic app again.
+
+    <Callout variant="important">
+      This is a one-time step per workspace. After you link your identity, you can mention the New Relic app in any channel of that workspace without needing to connect again.
+    </Callout>
+  </Step>
+</Steps>
+
+## Use Autopilot in Slack [#use-in-slack]
+
+After setup, use <DNT>Autopilot</DNT> from any channel where you've invited the app, or from the app's Home tab.
+
+
+### Check your connection from the Home tab [#home-tab]
+
+To open its Home tab and check your connection status, in your <DNT>Slack</DNT> sidebar, click the New Relic app:
+
+* **Not connected**: A welcome screen with a <DNT>**Connect to New Relic**</DNT> button to link your account.
+* **Connection expired**: A prompt with an <DNT>**Authenticate**</DNT> button to re-authenticate.
+* **Error**: A "Something went wrong" message with recovery steps.
+
+When you're connected, the Home tab also shows your currently linked New Relic organization, a <DNT>**Switch orgs**</DNT> option, and a <DNT>**Disconnect**</DNT> option.
+
+### Ask a question [#ask-a-question]
+
+Mention the New Relic app (for example, `@New Relic`) with your question in any thread:
+
+```
+@New Relic why is checkout-service alerting?
+@New Relic what deployed on payment-gateway in the last hour?
+@New Relic investigate this alert
+```
+
+### Investigate alerts in context [#investigate-in-context]
+
+When New Relic posts an alert notification to a channel, reply in that thread. <DNT>Autopilot</DNT> reads the notification to identify the entity and issue, so you don't need to name them.
+
+### Ask follow-up questions [#follow-up-questions]
+
+Continue in the same thread. <DNT>Autopilot</DNT> reads earlier messages to keep context:
+
+```
+@New Relic what's causing this?
+[Autopilot replies with a root cause analysis]
+@New Relic what was the deployment before that?
+[Autopilot replies with more context]
+```
+
+### Switch New Relic organizations [#switch-orgs]
+
+If you have access to multiple New Relic organizations, switch to the one your <DNT>Slack</DNT> identity uses without disconnecting:
+
+1. Open the New Relic app's Home tab in <DNT>Slack</DNT>.
+2. Click <DNT>**Switch orgs**</DNT>.
+3. On the New Relic login page, sign in with the account for the organization you want.
+
+After you authenticate, the Home tab shows the newly linked organization, and future mentions in this workspace query it.
+
+<Callout variant="important">
+  Your <DNT>Slack</DNT> identity links to only one New Relic organization at a time per workspace. Switching replaces the previous New Relic organization mapping.
+</Callout>
+
+### Pause your access to Autopilot [#pause-access]
+
+If you want to stop your own direct, interactive access to <DNT>Autopilot</DNT> without disconnecting the whole workspace:
+
+1. In your <DNT>Slack</DNT> sidebar, click the New Relic app to open its Home tab.
+2. Click <DNT>**Disconnect**</DNT>.
+
+Your interactive access to <DNT>Autopilot</DNT> stops immediately. You still receive notifications in the workspace, including automated updates from <DNT>Autopilot</DNT>. If you want to remove the integration for the entire organization instead, refer to [Remove the Slack integration](#remove-integration).
+
+<CollapserGroup>
+<Collapser id="how-data-is-used" title="How Autopilot uses Slack data">
+
+When you mention the New Relic app, it reads the thread that it is mentioned in for up to 48 hours of history in order to understand the thread's context.
+
+<Callout variant="caution">
+  <DNT>Autopilot</DNT> reads every message in the thread where it's invoked. Don't share passwords, API keys, tokens, credentials, or other sensitive information in those threads. If credentials were shared, mention the New Relic app in a new thread instead so that information is not used.
+</Callout>
+
+<DNT>Autopilot</DNT> does the following:
+
+* Reads messages in the thread where it's mentioned.
+* Extracts alert and entity details from New Relic notification URLs in the thread.
+* Responds using New Relic insights based on your New Relic permissions.
+* Posts responses visible to all channel members.
+
+
+<Callout variant="important">
+  Responses are visible to everyone in the channel, including people without New Relic access. <DNT>Autopilot</DNT> queries data with your permissions, but its replies are public to the channel.
+</Callout>
+
+### Data isolation [#data-isolation]
+
+Each request from <DNT>Slack</DNT> is isolated to the following:
+
+* **Credentials per request**: Each invocation of <DNT>Autopilot</DNT> uses the invoking user's token.
+* **No credential storage**: Credentials pass through request headers only. They aren't stored or persisted.
+* **Thread specific**: Requests are scoped to the thread where the Autopilot is invoked.
+* **No persistent <DNT>Slack</DNT> data**: <DNT>Autopilot</DNT> holds thread messages temporarily in memory for a single request only.
+
+</Collapser>
+
+<Collapser id="nr-connect" title="NR Connect: Identity linking and authentication">
+
+<DNT>NR Connect</DNT> is the authentication bridge that maps your <DNT>Slack</DNT> user ID to your New Relic account. Before <DNT>Autopilot</DNT> responds, <DNT>NR Connect</DNT> verifies that your <DNT>Slack</DNT> user ID is linked to a New Relic account (user mapping) and that your authentication session is active (valid token).
+
+### How validation works [#how-validation-works]
+
+Each time you mention the New Relic app, the system checks:
+
+1. **Workspace authorization**: Whether an admin has connected this workspace to a New Relic organization.
+2. **User mapping**: Whether your <DNT>Slack</DNT> user ID is linked to a New Relic account.
+3. **Token validation**: Whether your authentication session is active and unexpired.
+
+If all checks pass, <DNT>Autopilot</DNT> processes your request and replies in the thread. If mapping or token fails, you get a private message with a <DNT>**Connect**</DNT> button. Sign in, then mention the New Relic app again. For specific errors, refer to [Troubleshoot Autopilot Slack connection issues](/docs/agentic-ai/sre-agent/troubleshoot).
+
+### Authentication checks by request origin [#slack-vs-ui]
+
+Requests from <DNT>Slack</DNT> originate outside the New Relic UI, so the system verifies both your identity mapping and your token. From within the New Relic UI, the system trusts your active web session and checks only the mapping.
+
+<table>
+  <thead>
+    <tr>
+      <th>Origin</th>
+      <th>Checks performed</th>
+      <th>On failure</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>From <DNT>Slack</DNT> (<DNT>**@New Relic**</DNT> mention)</td>
+      <td>User mapping and token validity</td>
+      <td>Ephemeral error with a <DNT>**Connect**</DNT> button that redirects to the New Relic login</td>
+    </tr>
+    <tr>
+      <td>From the New Relic UI (<DNT>**Ask AI**</DNT> panel)</td>
+      <td>User mapping only</td>
+      <td>UI error: "Account not connected"</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser id="limitations" title="Current limitations">
+
+* **Text responses only**: Charts, images, and interactive buttons aren't available or supported.
+* **Thread-scoped context**: <DNT>Autopilot</DNT> reads only the thread where it's mentioned, not the full <DNT>Slack</DNT> channel.
+* **No action execution**: <DNT>Autopilot</DNT> investigates and recommends but doesn't run remediation actions, such as rollbacks or restarts.
+* **No external incident data**: <DNT>Autopilot</DNT> doesn't access <DNT>ServiceNow</DNT>, <DNT>PagerDuty</DNT>, or other external incident data.
+* **<DNT>Slack</DNT> only**: <DNT>Microsoft Teams</DNT> isn't supported yet.
+
+</Collapser>
+</CollapserGroup>
+
+## Remove the Slack integration [#remove-integration]
+
+<Callout variant="important">
+  Uninstalling the New Relic app from your <DNT>Slack</DNT> workspace removes it entirely. It stops <DNT>Autopilot</DNT> notifications along with all other <DNT>Slack</DNT>-based alert notifications for your organization. If you only want to pause your own access instead, refer to [Pause your access to Autopilot](#pause-access).
+</Callout>
+
+A <DNT>Slack</DNT> workspace administrator can fully remove the New Relic integration using <DNT>Slack</DNT>'s standard app removal flow. Refer to [Slack's documentation on removing apps](https://slack.com/help/articles/360003125231).
+
+After uninstall, New Relic automatically marks the corresponding <DNT>Slack</DNT> destination as <DNT>**UNINSTALLED**</DNT> and sets it to inactive. You don't need to manually delete it.
+
+## Next steps [#next-steps]
+
+<DocTiles>
+  <DocTile title="Set up Autopilot" path="/docs/agentic-ai/autopilot/setup">
+    Configure prerequisites, permissions, and alert integration before connecting <DNT>Slack</DNT>.
+  </DocTile>
+  <DocTile title="Use Autopilot" path="/docs/agentic-ai/autopilot/use-autopilot">
+    Learn usage tips and best practices for incident analysis and investigation.
+  </DocTile>
+  <DocTile title="Autopilot overview" path="/docs/agentic-ai/autopilot/overview">
+    Learn more about <DNT>Autopilot</DNT>'s capabilities and billing.
+  </DocTile>
+  <DocTile title="Troubleshoot Autopilot Slack connection issues" path="/docs/agentic-ai/sre-agent/troubleshoot">
+    Find fixes for common <DNT>Slack</DNT> connection and authentication errors.
+  </DocTile>
+</DocTiles>

--- a/src/content/docs/agentic-ai/autopilot/overview.mdx
+++ b/src/content/docs/agentic-ai/autopilot/overview.mdx
@@ -48,7 +48,9 @@ Here are some examples of how <DNT>Autopilot</DNT> can help best support your op
 
 * **Deep incident analysis**: When system degradation occurs, the agent is designed to assist with automated root-cause discovery. It can traverse distributed traces, analyze log patterns, and inspect resource metrics to help identify potential technical failures or downstream dependencies that may be contributing to an outage.
 
-* **Automated remediation**: Beyond diagnosis, <DNT>Autopilot</DNT> aims to assist with recovery efforts. Once a potential root cause is identified, the agent may suggest potential technical interventions—such as rolling back a deployment or adjusting resource allocations—which an engineer should review before implementation.
+* **Automated remediation**: Beyond diagnosis, <DNT>Autopilot</DNT> aims to assist with recovery efforts. After a potential root cause is identified, the agent may suggest potential technical interventions—such as rolling back a deployment or adjusting resource allocations—which an engineer should review before implementation.
+
+* **<DNT>Slack</DNT> collaboration**: Use <DNT>Autopilot</DNT> directly in <DNT>Slack</DNT>. Mention the New Relic app in a channel to triage alerts and investigate incidents without leaving the thread. Refer to [Autopilot Slack integration](/docs/agentic-ai/autopilot/connect-to-slack).
 
 ## Operational workflow
 The following workflow illustrates how <DNT>Autopilot</DNT> transforms telemetry into actionable operational intelligence. Each stage builds on the previous one, allowing engineers to move from detection to diagnosis and recommended remediation more quickly.
@@ -61,7 +63,7 @@ The agent’s analysis process follows three primary pillars:
 
 * **Comprehensive context gathering**: The agent is designed to gather relevant details, such as mapping available architecture. It can help identify relevant entities, explore their relationships and dependencies, and highlight recent change events or deployments that may have triggered a shift in performance.
 
-* **Deep telemetry investigation**: Once the context is established, the agent dives into the problem. It can help evaluate:
+* **Deep telemetry investigation**: After the context is established, the agent dives into the problem. It can help evaluate:
   * **Metrics and trends**: Analyzing throughput, latency, and error rates attempting to forecast potential future system behavior.
   * **Logs and errors**: Sifting through distributed traces, error groups, and log patterns to help isolate potential sources and causes of an anomaly.
   * **Health and alerts**: Reviewing active incidents, alert policies, and security vulnerabilities to understand the potential blast radius.

--- a/src/content/docs/agentic-ai/autopilot/setup.mdx
+++ b/src/content/docs/agentic-ai/autopilot/setup.mdx
@@ -30,7 +30,7 @@ Before setting up <DNT>Autopilot</DNT>, ensure you meet the following requiremen
 To give users permission to use <DNT>Autopilot</DNT>, a user must be an **Organization Manager** and **Authentication Domain Manager**.
 
 <Callout variant="tip">
-  If you don't have these permissions, you'll see the message: "This looks like a job for an admin." Contact your organization manager to enable the agent for you.
+  If you don't have these permissions, you'll get the message: "This looks like a job for an admin." Contact your organization manager to enable the agent for you.
 </Callout>
 
 ### User permissions (for access)
@@ -82,15 +82,16 @@ To onboard <DNT>Autopilot</DNT>:
      Admin users will have the ability to modify the accounts and grants provided to the agent. A reduction in grants from the standard read-only role will limit the telemetry data <DNT>Autopilot</DNT> can access, which can result in incomplete analysis, missed anomalies, or degraded root-cause identification capabilities.
    </Callout>
 
-6. Click <DNT>**Add Agent**</DNT>. The system takes a few moments to complete the setup.
+6. (Optional) To let your team invoke <DNT>Autopilot</DNT> in <DNT>Slack</DNT> threads, go to the <DNT>**Slack (optional)**</DNT> section, click <DNT>**Connect**</DNT>, select your <DNT>Slack</DNT> workspace, and allow the requested <DNT>Slack</DNT> permissions. Refer to [Autopilot Slack integration](/docs/agentic-ai/autopilot/connect-to-slack).
+7. Click <DNT>**Add Agent**</DNT>. The system takes a few moments to complete the setup.
 
 <Callout variant="tip">
-  Creating the alert destination does not automatically assign any alert conditions or policies to <DNT>Autopilot</DNT>. See [Integrate with alerts](#alerts) to configure that.
+  Creating the alert destination does not automatically assign any alert conditions or policies to <DNT>Autopilot</DNT>. Refer to [Integrate with alerts](#alerts) to configure that.
 </Callout>
 
 ## Integrate with alerts [#alerts]
 
-Connect <DNT>Autopilot</DNT> to your alert workflows so that <DNT>Autopilot</DNT> insights are automatically attached to every fired alert or issue.
+Connect <DNT>Autopilot</DNT> to your alert workflows so that <DNT>Autopilot</DNT> insights are automatically attached to every triggered alert or issue.
 
 ### Configure alert workflows
 
@@ -104,7 +105,7 @@ To set up <DNT>Autopilot</DNT> with alerts:
 2. In your workflow configuration, under the <DNT>**Notify**</DNT> section, select <DNT>**AI agent**</DNT>.
 3. Choose the <DNT>Autopilot</DNT> destination created during onboarding and click <DNT>**Save message**</DNT>.
 
-Once configured, when you open a recently fired alert or issue, you'll automatically see the <DNT>Autopilot</DNT> summary for that item.
+After it's configured, the <DNT>Autopilot</DNT> summary appears automatically when you open a recently triggered alert or issue.
 
 ## Next steps [#next-steps]
 
@@ -114,5 +115,8 @@ Once configured, when you open a recently fired alert or issue, you'll automatic
   </DocTile>
   <DocTile title="Autopilot overview" path="/docs/agentic-ai/autopilot/overview">
     Learn more about capabilities and billing.
+  </DocTile>
+  <DocTile title="Autopilot Slack integration" path="/docs/agentic-ai/autopilot/connect-to-slack">
+    Connect your <DNT>Slack</DNT> workspace so your team can investigate directly in threads.
   </DocTile>
 </DocTiles>

--- a/src/content/docs/agentic-ai/autopilot/troubleshoot.mdx
+++ b/src/content/docs/agentic-ai/autopilot/troubleshoot.mdx
@@ -1,0 +1,51 @@
+---
+title: Troubleshoot Autopilot Slack connection issues
+metaDescription: "Common issues and solutions for connecting New Relic Autopilot to Slack, including authentication and workspace connection errors."
+freshnessValidatedDate: never
+---
+
+<Callout title="preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
+</Callout>
+
+## "Connect your New Relic account" message
+
+Your <DNT>Slack</DNT> identity isn't linked to New Relic. Click <DNT>**Connect**</DNT> and complete the New Relic login.
+
+## "Session expired" message
+
+Your authentication token expired. Click <DNT>**Connect**</DNT> to re-authenticate.
+
+## No response from Autopilot
+
+The app isn't invited to this channel. Invite <DNT>**@New Relic**</DNT> to the channel.
+
+## "This New Relic login is already in use"
+
+Another <DNT>Slack</DNT> user in this workspace is already linked to that account. Sign in with a different account, or ask the other user to disconnect first.
+
+## Connect button does nothing, or "We couldn't authenticate you"
+
+The link expired (more than 10 minutes old), or a transient error occurred. Mention the New Relic app again for a fresh link, then retry.
+
+## No response and no error
+
+Your account doesn't have <DNT>Autopilot</DNT> entitlement. Ask your New Relic admin to enable <DNT>Autopilot</DNT> access.
+
+## "Workspace not connected"
+
+An admin hasn't set up the <DNT>Slack</DNT> connection. Ask your org admin to connect your [Slack workspace with Autopilot](/docs/agentic-ai/autopilot/connect-to-slack#connect-slack).
+
+## Connected to the wrong workspace
+
+The connection links to a different workspace than intended. An admin must disconnect and reconnect the correct workspace.
+
+## Next steps [#next-steps]
+
+<DocTiles>
+  <DocTile title="Autopilot Slack integration" path="/docs/agentic-ai/autopilot/connect-to-slack">
+    Connect your <DNT>Slack</DNT> workspace so your team can investigate directly in threads.
+  </DocTile>
+</DocTiles>

--- a/src/content/docs/agentic-ai/autopilot/use-autopilot.mdx
+++ b/src/content/docs/agentic-ai/autopilot/use-autopilot.mdx
@@ -19,7 +19,7 @@ redirects:
   This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
-Once you've [set up Autopilot](/docs/agentic-ai/autopilot/setup), you can start using it to analyze your environment and investigate incidents. This guide provides practical tips and best practices for getting the most out of <DNT>Autopilot</DNT>.
+After you've [set up Autopilot](/docs/agentic-ai/autopilot/setup), you can start using it to analyze your environment and investigate incidents. This guide provides practical tips and best practices for getting the most out of <DNT>Autopilot</DNT>.
 
 ## Usage tips [#usage-tips]
 
@@ -39,7 +39,7 @@ Agents may not always act as you intend. For example, an agent may make a sugges
 
 ## New Relic AI Knowledge with Autopilot [#knowledge]
 
-Connect [<DNT>New Relic AI Knowledge</DNT>](/docs/agentic-ai/knowledge-integration/overview/) to <DNT>Autopilot</DNT> so its answers draw on your team's own documents, not just general knowledge. Once connected, the agent searches your connected content during every investigation.
+Connect [<DNT>New Relic AI Knowledge</DNT>](/docs/agentic-ai/knowledge-integration/overview/) to <DNT>Autopilot</DNT> so its answers draw on your team's own documents, not just general knowledge. After connecting, the agent searches your connected content during every investigation.
 
 With <DNT>New Relic AI Knowledge</DNT> enabled, you can:
 
@@ -48,7 +48,17 @@ With <DNT>New Relic AI Knowledge</DNT> enabled, you can:
 - Ask questions in plain language, such as "What are the standard triage steps for this alert?" or "Show me the runbook for a `database connection limit exceeded` error," and get an answer drawn directly from your own documentation.
 - Schedule regular content updates so the agent always has access to your most current documents.
 
-For setup instructions and supported connectors, see [<DNT>New Relic AI Knowledge</DNT>](/docs/agentic-ai/knowledge-integration/overview/).
+For setup instructions and supported connectors, refer to [<DNT>New Relic AI Knowledge</DNT>](/docs/agentic-ai/knowledge-integration/overview/).
+
+## Use Autopilot in Slack [#slack]
+
+If an admin has connected your workspace to <DNT>Slack</DNT>, you can investigate without leaving the conversation. Mention the New Relic app (for example, `@New Relic`) in any channel where it's invited, and <DNT>Autopilot</DNT> replies in the same thread. You can:
+
+* Ask why an alert triggered, check the health of a service, or analyze a recent deployment.
+* Reply in an alert notification's thread to investigate it in context, without naming the entity.
+* Ask follow-up questions in the same thread to dig deeper.
+
+For workspace setup, identity linking, and the full usage guide, refer to [Autopilot Slack integration](/docs/agentic-ai/autopilot/connect-to-slack).
 
 ## Next steps
 
@@ -58,5 +68,8 @@ For setup instructions and supported connectors, see [<DNT>New Relic AI Knowledg
   </DocTile>
   <DocTile title="Set up Autopilot" path="/docs/agentic-ai/autopilot/setup">
     Review setup and configuration options.
+  </DocTile>
+  <DocTile title="Autopilot Slack integration" path="/docs/agentic-ai/autopilot/connect-to-slack">
+    Ask the agent questions and get investigation responses directly in <DNT>Slack</DNT> threads.
   </DocTile>
 </DocTiles>

--- a/src/nav/agentic-ai.yml
+++ b/src/nav/agentic-ai.yml
@@ -15,6 +15,10 @@ pages:
         path: /docs/agentic-ai/autopilot/setup
       - title: Use Autopilot
         path: /docs/agentic-ai/autopilot/use-autopilot
+      - title: Slack integration
+        path: /docs/agentic-ai/autopilot/connect-to-slack
+      - title: Troubleshoot Slack connection
+        path: /docs/agentic-ai/autopilot/troubleshoot
   - title: New Relic AI Agent to Agent Integration
     pages:
       - title: Get started with agentic integration


### PR DESCRIPTION
Adds documentation for connecting Autopilot to Slack, including setup steps, usage guidance, troubleshooting, and nav updates. Migrated from [docs-website-private#187](https://github.com/newrelic/docs-website-private/pull/187).