### PR TITLE
feat(notebooks): add variables and Blob Storage API documentation

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
@@ -1,0 +1,710 @@
+---
+title: 'Using the Blob Storage API for notebooks'
+tags:
+  - Query your data
+  - Explore and query data
+  - Notebooks
+  - API
+metaDescription: 'Use the New Relic Blob Storage API and NerdGraph to create, read, update, delete, and version notebooks programmatically.'
+freshnessValidatedDate: never
+---
+
+The <DNT>New Relic</DNT> Notebooks API lets you create, read, update, and delete notebooks programmatically, including their full block content (NRQL queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
+
+Use this API to:
+
+* Automate notebook creation from incident templates, runbooks, or CI/CD pipelines
+* Sync notebook content from version control or external authoring tools
+* Build integrations that programmatically populate notebooks during investigations
+
+<Callout variant="important">
+  **Notebooks use multiple APIs**
+
+  The Notebooks API surface is split between two systems:
+
+  * **Blob Storage API** handles notebook content (blocks, version history)
+  * **NerdGraph** handles entity-level operations (list, rename, tags, organization metadata)
+
+  This separation is by design. The Blob Storage API is optimized for file content transfer and versioning; NerdGraph is optimized for structured entity queries and mutations.
+</Callout>
+
+## Prerequisites [#prerequisites]
+
+* A [New Relic account](https://newrelic.com/signup) with a User API key
+* Your New Relic Organization ID
+* Appropriate [permissions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions/) to manage notebooks
+
+## Authentication [#authentication]
+
+All Notebook API requests require authentication using a <DNT>New Relic</DNT> User API key.
+
+**Generate an API key:**
+
+1. Navigate to [one.newrelic.com](https://one.newrelic.com)
+2. Click on your name in the bottom-left corner
+3. Select **API Keys**
+4. Create a **User** key (not Browser or License key)
+
+**Include in request headers:**
+
+```shell
+Api-Key: NRAK-YOUR-USER-API-KEY
+```
+
+<Callout variant="tip">
+  The Blob Storage API also supports login context, so when calling the API from a UI authenticated as a New Relic user, the `Api-Key` header is not required.
+</Callout>
+
+## Base endpoint [#base-endpoint]
+
+```plaintext
+https://blob-api.service.newrelic.com/v1/e
+```
+
+For EU region accounts, use:
+
+```plaintext
+https://blob-api.service.eu.newrelic.com/v1/e
+```
+
+## Notebook content operations [#content-operations]
+
+<CollapserGroup>
+
+<Collapser
+  id="create-notebook"
+  title="Create notebook">
+
+Creates a new notebook entity with initial blob content.
+
+### Endpoint [#create-endpoint]
+
+```plaintext
+POST /v1/e/organizations/{orgId}/Notebooks
+```
+
+### Request parameters [#create-params]
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Location</th>
+      <th>Data type</th>
+      <th>Is it required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`orgId`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your New Relic organization ID.</td>
+    </tr>
+    <tr>
+      <td>`Api-Key`</td>
+      <td>Header</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your User API key.</td>
+    </tr>
+    <tr>
+      <td>`Content-Type`</td>
+      <td>Header</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Must be `application/json`.</td>
+    </tr>
+    <tr>
+      <td>`NewRelic-Entity`</td>
+      <td>Header</td>
+      <td>JSON string</td>
+      <td>Yes</td>
+      <td>JSON object with notebook entity metadata (see below).</td>
+    </tr>
+    <tr>
+      <td>Request body</td>
+      <td>Body</td>
+      <td>JSON</td>
+      <td>Yes</td>
+      <td>Notebook content in JSON format (version + blocks).</td>
+    </tr>
+  </tbody>
+</table>
+
+### `NewRelic-Entity` header format [#create-entity-header]
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Data type</th>
+      <th>Is it required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`name`</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The notebook name. Must be unique within the organization scope.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Notebook body format [#create-body-format]
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Data type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`version`</td>
+      <td>String</td>
+      <td>Schema version of the notebook payload. Use `"1"`.</td>
+    </tr>
+    <tr>
+      <td>`blocks`</td>
+      <td>Array</td>
+      <td>Ordered list of notebook blocks (NRQL, text, etc.). Empty array creates a blank notebook.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Declarative UI content examples [#create-declarative-ui]
+
+The following examples show how to structure notebook widget content using the declarative UI format.
+
+**Markdown widget**
+
+Use `viz.markdown` to render static text, labels, or threshold legends alongside your charts:
+
+```json
+{
+  "type": "widget",
+  "content": {
+    "type": "visualization",
+    "id": "viz.markdown",
+    "props": {
+      "text": "# My dashboard\n\n### Cost thresholds (monthly)\n- $0 – $200 → Good\n- $200 – $500 → Warning\n- $500+ → Critical"
+    }
+  }
+}
+```
+
+**Billboard widget with NRQL query**
+
+Use `viz.billboard` to display a single metric value with optional color-coded thresholds:
+
+```json
+{
+  "type": "widget",
+  "props": {
+    "title": "Total usage this month"
+  },
+  "content": {
+    "type": "visualization",
+    "id": "viz.billboard",
+    "props": {
+      "nrqlQueries": [
+        {
+          "query": "FROM Transaction SELECT count(*) SINCE 1 month ago",
+          "accountIds": [1234567]
+        }
+      ],
+      "thresholdsWithSeriesOverrides": {
+        "thresholds": [
+          { "to": 200,              "severity": "success"  },
+          { "from": 200, "to": 500, "severity": "warning"  },
+          { "from": 500,            "severity": "critical" }
+        ]
+      },
+      "facet": { "showOtherSeries": false },
+      "platformOptions": { "ignoreTimeRange": false },
+      "chartStyles": { "lineInterpolation": "linear" }
+    }
+  }
+}
+```
+
+### Sample request [#create-sample-request]
+
+```bash
+curl -X POST \
+  https://blob-api.service.newrelic.com/v1/e/organizations/YOUR_ORG_ID/Notebooks \
+  -H 'Api-Key: NRAK-YOUR-API-KEY' \
+  -H 'Content-Type: application/json' \
+  -H 'NewRelic-Entity: {"name": "My awesome notebook"}' \
+  -d '{
+    "version": "1",
+    "blocks": []
+  }'
+```
+
+### Sample response [#create-sample-response]
+
+```json
+{
+  "entityGuid": "<YOUR_ENTITY_GUID>",
+  "blobId": "<YOUR_BLOB_ID>",
+  "blobVersionEntity": {
+    "entityGuid": "<YOUR_ENTITY_GUID>",
+    "version": 1
+  }
+}
+```
+
+<Callout variant="important">
+  Save the `entityGuid` from the response. You'll need it for reading, updating, and deleting the notebook.
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="read-notebook"
+  title="Read notebook content">
+
+Retrieves the latest content of a notebook.
+
+### Endpoint [#read-endpoint]
+
+```plaintext
+GET /v1/e/organizations/{orgId}/Notebooks/{entityGuid}
+```
+
+### Request parameters [#read-params]
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Location</th>
+      <th>Data type</th>
+      <th>Is it required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`orgId`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your New Relic organization ID.</td>
+    </tr>
+    <tr>
+      <td>`entityGuid`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The notebook entity GUID.</td>
+    </tr>
+    <tr>
+      <td>`Api-Key`</td>
+      <td>Header</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your User API key.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample request [#read-sample-request]
+
+```bash
+curl -X GET \
+  https://blob-api.service.newrelic.com/v1/e/organizations/YOUR_ORG_ID/Notebooks/YOUR_ENTITY_GUID \
+  -H 'Api-Key: NRAK-YOUR-API-KEY'
+```
+
+### Sample response [#read-sample-response]
+
+```json
+{
+  "type": "declarative",
+  "version": 1,
+  "content": [
+    {
+      "type": "container",
+      "props": {
+        "layout": "stack"
+      },
+      "content": [
+        {
+          "type": "widget",
+          "props": {},
+          "content": {
+            "type": "visualization",
+            "id": "viz.billboard",
+            "props": {
+              "nrqlQueries": [
+                {
+                  "query": "FROM PageView SELECT count(*) SINCE 3 days ago",
+                  "accountIds": [1]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</Collapser>
+
+<Collapser
+  id="update-notebook"
+  title="Update notebook content">
+
+Creates a new version of an existing notebook by overwriting the content. The previous version is retained for up to 1 day (see [Retrieve previous versions](#retrieve-versions)).
+
+### Endpoint [#update-endpoint]
+
+```plaintext
+POST /v1/e/organizations/{orgId}/Notebooks/{entityGuid}
+```
+
+### Request parameters [#update-params]
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Location</th>
+      <th>Data type</th>
+      <th>Is it required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`orgId`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your New Relic organization ID.</td>
+    </tr>
+    <tr>
+      <td>`entityGuid`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The notebook entity GUID.</td>
+    </tr>
+    <tr>
+      <td>`Api-Key`</td>
+      <td>Header</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your User API key.</td>
+    </tr>
+    <tr>
+      <td>`Content-Type`</td>
+      <td>Header</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Must be `application/json`.</td>
+    </tr>
+    <tr>
+      <td>Request body</td>
+      <td>Body</td>
+      <td>JSON</td>
+      <td>Yes</td>
+      <td>Updated notebook content.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample request [#update-sample-request]
+
+```bash
+curl -X POST \
+  https://blob-api.service.newrelic.com/v1/e/organizations/YOUR_ORG_ID/Notebooks/YOUR_ENTITY_GUID \
+  -H 'Api-Key: NRAK-YOUR-API-KEY' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "type": "declarative",
+    "version": 1,
+    "content": [
+      {
+        "type": "container",
+        "props": {
+          "layout": "stack"
+        },
+        "content": [
+          {
+            "type": "widget",
+            "props": {
+              "title": ""
+            },
+            "content": {
+              "type": "visualization",
+              "id": "viz.billboard",
+              "props": {
+                "nrqlQueries": [
+                  {
+                    "query": "FROM PageView SELECT count(*) SINCE 2 days ago",
+                    "accountIds": [1]
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }'
+```
+
+### Sample response [#update-sample-response]
+
+```json
+{
+  "entityGuid": "<YOUR_ENTITY_GUID>",
+  "blobId": "<YOUR_BLOB_ID>",
+  "blobVersionEntity": {
+    "entityGuid": "<YOUR_ENTITY_GUID>",
+    "version": 2
+  }
+}
+```
+
+</Collapser>
+
+<Collapser
+  id="delete-notebook"
+  title="Delete notebook">
+
+Deletes a notebook and its content.
+
+### Endpoint [#delete-endpoint]
+
+```plaintext
+DELETE /v1/e/organizations/{orgId}/Notebooks/{entityGuid}
+```
+
+### Request parameters [#delete-params]
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Location</th>
+      <th>Data type</th>
+      <th>Is it required?</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`orgId`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your New Relic organization ID.</td>
+    </tr>
+    <tr>
+      <td>`entityGuid`</td>
+      <td>Path</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>The notebook entity GUID to delete.</td>
+    </tr>
+    <tr>
+      <td>`Api-Key`</td>
+      <td>Header</td>
+      <td>String</td>
+      <td>Yes</td>
+      <td>Your User API key.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Sample request [#delete-sample-request]
+
+```bash
+curl -X DELETE \
+  https://blob-api.service.newrelic.com/v1/e/organizations/YOUR_ORG_ID/Notebooks/YOUR_ENTITY_GUID \
+  -H 'Api-Key: NRAK-YOUR-API-KEY'
+```
+
+### Sample response [#delete-sample-response]
+
+Returns HTTP 204 No Content on successful deletion.
+
+</Collapser>
+
+<Collapser
+  id="retrieve-versions"
+  title="Retrieve previous versions">
+
+Notebook versions are retained for **1 day**. To recover a previous revision, first list recent versions via NRQL, then fetch the specific blob.
+
+### Step 1 — List the last 5 versions [#retrieve-list-versions]
+
+Run this NRQL query in the query builder to gather the blob IDs and timestamps for the last 5 changes:
+
+```sql
+FROM Entity
+SELECT uniques(tuple(updatedAt, content.id))
+WHERE id = '<entity guid>'
+SINCE 1 day ago
+LIMIT 5
+```
+
+### Step 2 — Retrieve a specific version [#retrieve-specific-version]
+
+Use the `content.id` from the NRQL result to fetch that version's content:
+
+```bash
+curl -X GET \
+  https://blob-api.service.newrelic.com/v1/blobs/<content.id> \
+  -H 'Api-Key: NRAK-YOUR-API-KEY'
+```
+
+</Collapser>
+
+</CollapserGroup>
+
+## Entity operations (NerdGraph) [#entity-operations]
+
+Entity-level operations such as listing, renaming, and tagging use <DNT>NerdGraph</DNT> rather than the Blob Storage API.
+
+### List all notebooks [#list-notebooks]
+
+```graphql
+query listAllNotebooks {
+  actor {
+    entityManagement {
+      entitySearch(query: "type='NOTEBOOK'") {
+        entities {
+          id
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+<Callout variant="tip">
+  Entity creation is fully transactional, so a notebook is immediately available via the API. However, if you list notebooks through the legacy `actor.entitySearch` query, there may be a short propagation delay between creation and the notebook appearing in list results.
+</Callout>
+
+### Rename a notebook [#rename-notebook]
+
+```graphql
+mutation changeNotebookName {
+  entityManagementUpdateNotebook(
+    id: "<entity guid>"
+    notebookEntity: { name: "<new name>" }
+  ) {
+    entity {
+      name
+    }
+  }
+}
+```
+
+### Update notebook tags [#update-tags]
+
+<Callout variant="important">
+  Tag updates are a **replace** operation. You must include the complete set of tags, even ones that aren't changing — any tag omitted from the mutation will be removed.
+</Callout>
+
+```graphql
+mutation updateNotebookTags {
+  entityManagementUpdateNotebook(
+    id: "<entity guid>"
+    notebookEntity: {
+      tags: [
+        { key: "<key>", values: "<value>" }
+        { key: "<key>", values: "<value>" }
+      ]
+    }
+  ) {
+    entity {
+      name
+      tags {
+        key
+        values
+      }
+    }
+  }
+}
+```
+
+### Retrieve your organization ID [#get-org-id]
+
+You'll need your organization ID for all Blob Storage API calls:
+
+```graphql
+query getOrgId {
+  actor {
+    organization {
+      id
+    }
+  }
+}
+```
+
+## Best practices [#best-practices]
+
+* **Store entity GUIDs:** Save the `entityGuid` returned from create operations. You'll need it for reading, updating, and deleting notebooks.
+* **Validate JSON before upload:** Ensure your notebook payload is valid JSON and conforms to the `version` schema before sending.
+* **Use descriptive names:** Notebook names must be unique within an organization, so choose names that clearly indicate purpose (for example, `prod-checkout-investigation` rather than `notebook-1`).
+* **Include all tags on update:** Tag updates replace the full tag set. Always read existing tags before mutating.
+* **Recover quickly:** Version history is retained for only 1 day. If you need long-term history, archive notebook content to your own storage on every update.
+* **Secure your API key:** Never expose your User API key in client-side code or public repositories.
+* **Check HTTP status codes:** The API returns 2xx for successful operations, 404 for not found, and other status codes for errors.
+
+## Common error responses [#error-responses]
+
+<table>
+  <thead>
+    <tr>
+      <th>Status code</th>
+      <th>Description</th>
+      <th>Solution</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`400 Bad Request`</td>
+      <td>Invalid request parameters, malformed JSON in body or `NewRelic-Entity` header, or notebook name already exists in this organization</td>
+      <td>Verify request format, header values, and that the notebook name is unique within your organization</td>
+    </tr>
+    <tr>
+      <td>`401 Unauthorized`</td>
+      <td>Missing or invalid API key</td>
+      <td>Check that your User API key is valid and included in the `Api-Key` header</td>
+    </tr>
+    <tr>
+      <td>`404 Not Found`</td>
+      <td>Notebook or version not found</td>
+      <td>Verify the entity GUID is correct</td>
+    </tr>
+    <tr>
+      <td>`415 Unsupported Media Type`</td>
+      <td>Incorrect `Content-Type` header</td>
+      <td>Use `Content-Type: application/json`</td>
+    </tr>
+  </tbody>
+</table>
+
+## Additional resources [#additional-resources]
+
+* [Notebooks overview](/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks) — How to use Notebooks in the New Relic UI
+* [Introduction to NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) — GraphQL API reference
+* [Blob Storage API for agent configurations](/docs/apis/intro-apis/blob-storage-api) — Sister API used by Fleet Control
+* [New Relic API keys](/docs/apis/intro-apis/new-relic-api-keys) — Key types and management

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
@@ -9,7 +9,7 @@ metaDescription: 'Use the New Relic Blob Storage API and NerdGraph to create, re
 freshnessValidatedDate: never
 ---
 
-The <DNT>New Relic</DNT> Notebooks API lets you create, read, update, and delete notebooks programmatically, including their full block content (NRQL queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
+The <DNT>New Relic</DNT> Notebooks API lets you create, read, update, and delete notebooks programmatically, including their full block content (<DNT>NRQL</DNT> queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
 
 Use this API to:
 
@@ -22,16 +22,16 @@ Use this API to:
 
   The Notebooks API surface is split between two systems:
 
-  * **Blob Storage API** handles notebook content (blocks, version history)
-  * **NerdGraph** handles entity-level operations (list, rename, tags, organization metadata)
+  * **<DNT>Blob Storage API</DNT>** handles notebook content (blocks, version history)
+  * **<DNT>NerdGraph</DNT>** handles entity-level operations (list, rename, tags, organization metadata)
 
-  This separation is by design. The Blob Storage API is optimized for file content transfer and versioning; NerdGraph is optimized for structured entity queries and mutations.
+  This separation is by design. The <DNT>Blob Storage API</DNT> is optimized for file content transfer and versioning; <DNT>NerdGraph</DNT> is optimized for structured entity queries and mutations.
 </Callout>
 
 ## Prerequisites [#prerequisites]
 
-* A [New Relic account](https://newrelic.com/signup) with a User API key
-* Your New Relic Organization ID
+* A [<DNT>New Relic</DNT> account](https://newrelic.com/signup) with a User API key
+* Your <DNT>New Relic</DNT> Organization ID
 * Appropriate [permissions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions/) to manage notebooks
 
 ## Authentication [#authentication]
@@ -52,7 +52,7 @@ Api-Key: NRAK-YOUR-USER-API-KEY
 ```
 
 <Callout variant="tip">
-  The Blob Storage API also supports login context, so when calling the API from a UI authenticated as a New Relic user, the `Api-Key` header is not required.
+  The <DNT>Blob Storage API</DNT> also supports login context, so when calling the API from a UI authenticated as a <DNT>New Relic</DNT> user, the `Api-Key` header is not required.
 </Callout>
 
 ## Base endpoint [#base-endpoint]
@@ -101,7 +101,7 @@ POST /v1/e/organizations/{orgId}/Notebooks
       <td>Path</td>
       <td>String</td>
       <td>Yes</td>
-      <td>Your New Relic organization ID.</td>
+      <td>Your <DNT>New Relic</DNT> organization ID.</td>
     </tr>
     <tr>
       <td>`Api-Key`</td>
@@ -174,7 +174,7 @@ POST /v1/e/organizations/{orgId}/Notebooks
     <tr>
       <td>`blocks`</td>
       <td>Array</td>
-      <td>Ordered list of notebook blocks (NRQL, text, etc.). Empty array creates a blank notebook.</td>
+      <td>Ordered list of notebook blocks (<DNT>NRQL</DNT>, text, etc.). Empty array creates a blank notebook.</td>
     </tr>
   </tbody>
 </table>
@@ -298,7 +298,7 @@ GET /v1/e/organizations/{orgId}/Notebooks/{entityGuid}
       <td>Path</td>
       <td>String</td>
       <td>Yes</td>
-      <td>Your New Relic organization ID.</td>
+      <td>Your <DNT>New Relic</DNT> organization ID.</td>
     </tr>
     <tr>
       <td>`entityGuid`</td>
@@ -392,7 +392,7 @@ POST /v1/e/organizations/{orgId}/Notebooks/{entityGuid}
       <td>Path</td>
       <td>String</td>
       <td>Yes</td>
-      <td>Your New Relic organization ID.</td>
+      <td>Your <DNT>New Relic</DNT> organization ID.</td>
     </tr>
     <tr>
       <td>`entityGuid`</td>
@@ -511,7 +511,7 @@ DELETE /v1/e/organizations/{orgId}/Notebooks/{entityGuid}
       <td>Path</td>
       <td>String</td>
       <td>Yes</td>
-      <td>Your New Relic organization ID.</td>
+      <td>Your <DNT>New Relic</DNT> organization ID.</td>
     </tr>
     <tr>
       <td>`entityGuid`</td>
@@ -548,11 +548,11 @@ Returns HTTP 204 No Content on successful deletion.
   id="retrieve-versions"
   title="Retrieve previous versions">
 
-Notebook versions are retained for **1 day**. To recover a previous revision, first list recent versions via NRQL, then fetch the specific blob.
+Notebook versions are retained for **1 day**. To recover a previous revision, first list recent versions via <DNT>NRQL</DNT>, then fetch the specific blob.
 
 ### Step 1 — List the last 5 versions [#retrieve-list-versions]
 
-Run this NRQL query in the query builder to gather the blob IDs and timestamps for the last 5 changes:
+Run this <DNT>NRQL</DNT> query in the query builder to gather the blob IDs and timestamps for the last 5 changes:
 
 ```sql
 FROM Entity
@@ -564,7 +564,7 @@ LIMIT 5
 
 ### Step 2 — Retrieve a specific version [#retrieve-specific-version]
 
-Use the `content.id` from the NRQL result to fetch that version's content:
+Use the `content.id` from the <DNT>NRQL</DNT> result to fetch that version's content:
 
 ```bash
 curl -X GET \
@@ -578,7 +578,7 @@ curl -X GET \
 
 ## Entity operations (NerdGraph) [#entity-operations]
 
-Entity-level operations such as listing, renaming, and tagging use <DNT>NerdGraph</DNT> rather than the Blob Storage API.
+Entity-level operations such as listing, renaming, and tagging use <DNT>NerdGraph</DNT> rather than the <DNT>Blob Storage API</DNT>.
 
 ### List all notebooks [#list-notebooks]
 
@@ -646,7 +646,7 @@ mutation updateNotebookTags {
 
 ### Retrieve your organization ID [#get-org-id]
 
-You'll need your organization ID for all Blob Storage API calls:
+You'll need your organization ID for all <DNT>Blob Storage API</DNT> calls:
 
 ```graphql
 query getOrgId {
@@ -704,7 +704,7 @@ query getOrgId {
 
 ## Additional resources [#additional-resources]
 
-* [Notebooks overview](/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks) — How to use Notebooks in the New Relic UI
+* [Notebooks overview](/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks) — How to use Notebooks in the <DNT>New Relic</DNT> UI
 * [Introduction to NerdGraph](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph) — GraphQL API reference
-* [Blob Storage API for agent configurations](/docs/apis/intro-apis/blob-storage-api) — Sister API used by Fleet Control
+* [Blob Storage API for agent configurations](/docs/apis/intro-apis/blob-storage-api) — Sister API used by <DNT>Fleet Control</DNT>
 * [New Relic API keys](/docs/apis/intro-apis/new-relic-api-keys) — Key types and management

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
@@ -9,6 +9,10 @@ metaDescription: 'Use the New Relic Blob Storage API and NerdGraph to create, re
 freshnessValidatedDate: never
 ---
 
+<Callout title="Public preview">
+  The <DNT>Blob Storage API</DNT> for notebooks is currently in public preview. This feature is provided pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
+</Callout>
+
 The <DNT>New Relic</DNT> Notebooks API lets you create, read, update, and delete notebooks programmatically, including their full block content (<DNT>NRQL</DNT> queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
 
 Use this API to:

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
@@ -46,8 +46,8 @@ All Notebook API requests require authentication using a <DNT>New Relic</DNT> Us
 
 1. Navigate to [one.newrelic.com](https://one.newrelic.com)
 2. Click on your name in the bottom-left corner
-3. Select **API Keys**
-4. Create a **User** key (not Browser or License key)
+3. Select <DNT>**API Keys**</DNT>
+4. Create a <DNT>**User**</DNT> key (not Browser or License key)
 
 **Include in request headers:**
 
@@ -204,7 +204,7 @@ Use `viz.markdown` to render static text, labels, or threshold legends alongside
 }
 ```
 
-**Billboard widget with NRQL query**
+**Billboard widget with <DNT>NRQL</DNT> query**
 
 Use `viz.billboard` to display a single metric value with optional color-coded thresholds:
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
   The <DNT>Blob Storage API</DNT> for notebooks is currently in public preview. This feature is provided pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
-The <DNT>New Relic</DNT> Notebooks API lets you create, read, update, and delete notebooks programmatically, including their full block content (<DNT>NRQL</DNT> queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
+The New Relic <DNT>Notebooks</DNT> API lets you create, read, update, and delete notebooks programmatically, including their full block content (<DNT>NRQL</DNT> queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
 
 Use this API to:
 
@@ -22,9 +22,9 @@ Use this API to:
 * Build integrations that programmatically populate notebooks during investigations
 
 <Callout variant="important">
-  **Notebooks use multiple APIs**
+  **<DNT>Notebooks</DNT> use multiple APIs**
 
-  The Notebooks API surface is split between two systems:
+  The <DNT>Notebooks</DNT> API surface is split between two systems:
 
   * **<DNT>Blob Storage API</DNT>** handles notebook content (blocks, version history)
   * **<DNT>NerdGraph</DNT>** handles entity-level operations (list, rename, tags, organization metadata)
@@ -40,12 +40,12 @@ Use this API to:
 
 ## Authentication [#authentication]
 
-All Notebook API requests require authentication using a <DNT>New Relic</DNT> User API key.
+All <DNT>Notebooks</DNT> API requests require authentication using a <DNT>New Relic</DNT> User API key.
 
 **Generate an API key:**
 
 1. Navigate to [one.newrelic.com](https://one.newrelic.com)
-2. Click on your name in the bottom-left corner
+2. Click on your name in the top-right corner
 3. Select <DNT>**API Keys**</DNT>
 4. Create a <DNT>**User**</DNT> key (not Browser or License key)
 
@@ -95,7 +95,7 @@ POST /v1/e/organizations/{orgId}/Notebooks
       <th>Parameter</th>
       <th>Location</th>
       <th>Data type</th>
-      <th>Is it required?</th>
+
       <th>Description</th>
     </tr>
   </thead>
@@ -104,36 +104,36 @@ POST /v1/e/organizations/{orgId}/Notebooks
       <td>`orgId`</td>
       <td>Path</td>
       <td>String</td>
-      <td>Yes</td>
-      <td>Your <DNT>New Relic</DNT> organization ID.</td>
+
+      <td>Required. Your <DNT>New Relic</DNT> organization ID.</td>
     </tr>
     <tr>
       <td>`Api-Key`</td>
       <td>Header</td>
       <td>String</td>
-      <td>Yes</td>
-      <td>Your User API key.</td>
+
+      <td>Required. Your User API key.</td>
     </tr>
     <tr>
       <td>`Content-Type`</td>
       <td>Header</td>
       <td>String</td>
-      <td>Yes</td>
-      <td>Must be `application/json`.</td>
+
+      <td>Required. Must be `application/json`.</td>
     </tr>
     <tr>
       <td>`NewRelic-Entity`</td>
       <td>Header</td>
       <td>JSON string</td>
-      <td>Yes</td>
-      <td>JSON object with notebook entity metadata (see below).</td>
+
+      <td>Required. JSON object with notebook entity metadata (see below).</td>
     </tr>
     <tr>
       <td>Request body</td>
       <td>Body</td>
       <td>JSON</td>
-      <td>Yes</td>
-      <td>Notebook content in JSON format (version + blocks).</td>
+
+      <td>Required. Notebook content in JSON format (version + blocks).</td>
     </tr>
   </tbody>
 </table>
@@ -145,7 +145,7 @@ POST /v1/e/organizations/{orgId}/Notebooks
     <tr>
       <th>Field</th>
       <th>Data type</th>
-      <th>Is it required?</th>
+
       <th>Description</th>
     </tr>
   </thead>
@@ -153,8 +153,8 @@ POST /v1/e/organizations/{orgId}/Notebooks
     <tr>
       <td>`name`</td>
       <td>String</td>
-      <td>Yes</td>
-      <td>The notebook name. Must be unique within the organization scope.</td>
+
+      <td>Required. The notebook name. Must be unique within the organization scope.</td>
     </tr>
   </tbody>
 </table>
@@ -552,7 +552,7 @@ Returns HTTP 204 No Content on successful deletion.
   id="retrieve-versions"
   title="Retrieve previous versions">
 
-Notebook versions are retained for **1 day**. To recover a previous revision, first list recent versions via <DNT>NRQL</DNT>, then fetch the specific blob.
+<DNT>Notebook</DNT> versions are retained for **1 day**. To recover a previous revision, first list recent versions via <DNT>NRQL</DNT>, then fetch the specific blob.
 
 ### Step 1 — List the last 5 versions [#retrieve-list-versions]
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -8,6 +8,10 @@ metaDescription: 'Use New Relic notebooks to create structured, data-driven docu
 freshnessValidatedDate: never
 ---
 
+<Callout title="Public preview">
+  The <DNT>Blob Storage API</DNT> for notebooks is currently in public preview. This feature is provided pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
+</Callout>
+
 When investigating complex issues or sharing insights with your team, you often find yourself jumping between different tools, copying queries, taking screenshots, and struggling to maintain context as you piece together a complete story from your data. Traditional dashboards are great for monitoring, but they fall short when you need to document investigations, create detailed post-mortems, or build step-by-step analytical workflows.
 
 Notebooks solve this problem by providing a dynamic and organized way to tell a complete story with your data. They are structured, data-driven documents that let you combine queries, visualizations, and descriptive text into a single, shareable asset, eliminating the need to switch between multiple tools or lose important context during your analysis.

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -8,10 +8,6 @@ metaDescription: 'Use New Relic notebooks to create structured, data-driven docu
 freshnessValidatedDate: never
 ---
 
-<Callout title="Preview feature">
-  We're still actively developing notebooks, but we're excited for you to try this powerful new feature! This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
-</Callout>
-
 When investigating complex issues or sharing insights with your team, you often find yourself jumping between different tools, copying queries, taking screenshots, and struggling to maintain context as you piece together a complete story from your data. Traditional dashboards are great for monitoring, but they fall short when you need to document investigations, create detailed post-mortems, or build step-by-step analytical workflows.
 
 Notebooks solve this problem by providing a dynamic and organized way to tell a complete story with your data. They are structured, data-driven documents that let you combine queries, visualizations, and descriptive text into a single, shareable asset, eliminating the need to switch between multiple tools or lose important context during your analysis.
@@ -167,6 +163,7 @@ Every notebook is a resource that belongs to the organization in which it was cr
 Now that you understand the basics of notebooks, you can:
 
 * Learn more about [blocks in notebook](/docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks/)
+* Use [variables in notebooks](/docs/query-your-data/explore-query-data/notebooks/notebook-variables) to build dynamic, parameterized runbooks
 
 You can also explore related features:
 * [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) for building persistent data visualizations

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -123,7 +123,7 @@ Blocks are the fundamental building units of a notebook. They are individual sec
 
 ### Query blocks
 
-Use query blocks to write [NRQL queries](/docs/nrql/nrql-syntax-clauses-functions/) and visualize the results. All single query [chart types](https://docs.newrelic.com/docs/query-your-data/explore-query-data/use-charts/chart-types/) and customizations available in the standard query builder are supported in notebooks.
+Use query blocks to write [<DNT>NRQL</DNT> queries](/docs/nrql/nrql-syntax-clauses-functions/) and visualize the results. All single query [chart types](https://docs.newrelic.com/docs/query-your-data/explore-query-data/use-charts/chart-types/) and customizations available in the standard query builder are supported in notebooks.
 
 ### Text blocks
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -164,6 +164,7 @@ Now that you understand the basics of notebooks, you can:
 
 * Learn more about [blocks in notebook](/docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks/)
 * Use [variables in notebooks](/docs/query-your-data/explore-query-data/notebooks/notebook-variables) to build dynamic, parameterized runbooks
+* Manage notebooks programmatically with the [Blob Storage API for notebooks](/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks)
 
 You can also explore related features:
 * [Dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards) for building persistent data visualizations

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -34,8 +34,8 @@ Now that you understand the basics of notebooks, you're ready to start creating 
 To access notebooks:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com)**.
-2. Open the **Query your data** console from the drawer at the bottom of the page.
-3. Click **Notebooks** in the query builder header to see a list of all notebooks created by your organization.
+2. Open the <DNT>**Query your data**</DNT> console from the drawer at the bottom of the page.
+3. Click <DNT>**Notebooks**</DNT> in the query builder header to see a list of all notebooks created by your organization.
 
 <img
   title="Navigate to notebooks from query your data"
@@ -44,7 +44,7 @@ To access notebooks:
 />
 
 <figcaption>
-  Navigate to notebooks by going to **Query your data > Notebooks**
+  Navigate to notebooks by going to <DNT>**Query your data > Notebooks**</DNT>
 </figcaption>
 
 <CollapserGroup>
@@ -57,17 +57,17 @@ You have two simple ways to start a new notebook:
 
 ### Start from the notebooks index
 
-1. Click **+ Create a notebook** at the top-right corner of the index.
+1. Click <DNT>**+ Create a notebook**</DNT> at the top-right corner of the index.
 2. Give your notebook a meaningful name (names are searchable, so use relevant keywords like your service or application name).
-3. Click **Create**.
+3. Click <DNT>**Create**</DNT>.
 4. In the query console drawer, type your first query.
 
 ### Start from the query console
 
 1. Open the query console (the drawer at the bottom of the platform).
 2. Create your desired queries and Markdown blocks.
-3. Click the **Save**.
-4. Name your notebook, and click **Save**.
+3. Click the <DNT>**Save**</DNT>.
+4. Name your notebook, and click <DNT>**Save**</DNT>.
 
   </Collapser>
 
@@ -91,8 +91,8 @@ To find specific notebooks in your organization:
 ### Duplicate a notebook
 
 1. Open the notebook you want to duplicate.
-2. Click the arrow next to the tab name in the console drawer and click **duplicate**.
-3. Click **Duplicate** from the context menu.
+2. Click the arrow next to the tab name in the console drawer and click <DNT>**duplicate**</DNT>.
+3. Click <DNT>**Duplicate**</DNT> from the context menu.
 4. A copy of the notebook will open in a new tab, ready for editing.
 
 ### Mark a notebook as favorite
@@ -115,8 +115,8 @@ To quickly find your most important notebooks, you can mark them as a favorite:
 </Callout>
 
 1. On the notebook index list, click the three-dot action menu for the notebook you wish to delete.
-2. Click the **Delete** option.
-3. Confirm the deletion by clicking **Delete** again.
+2. Click the <DNT>**Delete**</DNT> option.
+3. Confirm the deletion by clicking <DNT>**Delete**</DNT> again.
 
   </Collapser>
 </CollapserGroup>
@@ -137,10 +137,10 @@ Use Markdown to add rich text, titles, context, explanations, and descriptive te
 
 Every [block](/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks/) can be manipulated to organize your document:
 
-* **Duplicate**: Create a copy of the block
-* **Delete**: Remove the block from your notebook
-* **Move Up/Down**: Reorder blocks within your notebook
-* **Move to Top/Bottom**: Quickly move blocks to the beginning or end
+* <DNT>**Duplicate**</DNT>: Create a copy of the block
+* <DNT>**Delete**</DNT>: Remove the block from your notebook
+* <DNT>**Move Up/Down**</DNT>: Reorder blocks within your notebook
+* <DNT>**Move to Top/Bottom**</DNT>: Quickly move blocks to the beginning or end
 
 ## Notebooks permissions
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
@@ -102,4 +102,5 @@ A well-structured parameterized runbook typically follows this pattern:
 
 * [Get started with notebooks](/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks) for an overview of the notebooks feature
 * [Blocks in notebook](/docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks) to learn more about query and text blocks
+* [Blob Storage API for notebooks](/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks) to manage notebooks programmatically
 * [Template variables: dynamically filter dashboards](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables) for the equivalent dashboard feature

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
@@ -1,0 +1,113 @@
+---
+title: 'Variables in notebooks: build dynamic, repeatable runbooks'
+tags:
+  - Query your data
+  - Explore and query data
+  - Notebooks
+  - Variables
+metaDescription: 'For New Relic notebooks: use variables to parameterize your notebook, transform one-off queries into dynamic runbooks, and create adaptable, repeatable investigative flows.'
+freshnessValidatedDate: never
+---
+
+With notebook variables, you can set up dynamic parameters that cascade through multiple queries, charts, and data blocks. Unlike [dashboard template variables](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables), which filter a static view, notebook variables act as injected parameters that drive the underlying logic of your entire document.
+
+Go to **[one.newrelic.com](https://one.newrelic.com) > All capabilities > Notebooks**.
+
+## Why use variables in notebooks? [#why-use-variables]
+
+Notebook variables let you build interactive experiences such as:
+
+* **Parameterized runbooks** where an engineer inputs a specific `hostName` or `transactionId` to instantly generate a targeted system health report.
+* **Post-mortem templates** that can be updated with specific timestamps, regions, or application names to analyze an incident.
+* **Interactive thresholds** where users can tweak variables like `errorThreshold` or `latencyTarget` to see how different parameters affect the visualized data.
+
+The key benefits include:
+
+* **Creating executable runbooks**: Variables turn your notebooks from static pages into interactive tools. You can build adaptable workflows for alert event investigations, performance analysis, and team collaboration.
+* **Standardizing knowledge sharing**: As a saved document, you can share analytical workflows with colleagues. Users don't need to rewrite complex NRQL queries — they simply plug new values into your pre-defined variables to execute the workflow.
+
+## Define a notebook variable [#define-variable]
+
+Define a variable that you'll inject into your NRQL query blocks to parameterize your data retrieval and visualizations.
+
+To define a variable:
+
+1. From an open notebook, locate the variables bar at the top of the interface.
+2. Click **+ Add variable**.
+3. Configure your variable type (for example, text input, dropdown, or numeric) and provide a default value.
+
+### Variable naming rules [#naming-rules]
+
+When naming your variable, keep the following in mind:
+
+* The name is the exact string you will use in your notebook blocks, surrounded by `{{...}}`. For example, if you name the variable `targetApp`, you reference it in your query blocks as `{{targetApp}}`.
+* Variable names are case-sensitive and must be unique within a notebook.
+* Choose descriptive names that make your runbook self-explanatory to other users (for example, `failingHost` rather than `var1`).
+
+## Use a variable in a query block [#use-variable]
+
+Once defined, reference your variable anywhere in a NRQL query using the `{{variableName}}` syntax:
+
+```sql
+SELECT average(cpuPercent) FROM SystemSample WHERE hostname = {{failingHost}} TIMESERIES
+```
+
+```sql
+SELECT latest(cpuPercent) FROM ProcessSample WHERE hostname = {{failingHost}} FACET processDisplayName
+```
+
+When you run the query, the variable value you have set in the variables bar is substituted into the query at runtime. Changing the variable value and re-running the query instantly updates all blocks that reference that variable.
+
+## Automate incident response with runbooks [#runbook-use-case]
+
+The most powerful application for notebook variables is creating executable runbooks for incident response. By combining notebook variables with [New Relic Workflows](/docs/alerts/get-notified/incident-workflows), you can automate the handoff between an alert triggering and the investigation beginning.
+
+### How an executable runbook works [#runbook-flow]
+
+1. **The alert triggers**: An alert condition is violated (for example, CPU usage spikes on a specific host).
+2. **The workflow automates the notification**: A New Relic Workflow triggers a notification — for example, sending a message to a Slack channel.
+3. **Passing variables via URL**: Within the notification payload, include a URL linking directly to your saved notebook runbook. Use workflow templating (such as `{{entitiesData.names}}`) to append URL parameters that match your notebook variables.
+4. **The runbook is pre-populated**: When the responder clicks the link, the notebook opens with the variables (like `targetApp` or `failingHost`) already populated with the exact details of the alert.
+5. **Guided investigation**: The responder follows the document top-to-bottom.
+
+## Structure your runbook [#structure-runbook]
+
+A well-structured parameterized runbook typically follows this pattern:
+
+<table>
+  <thead>
+    <tr>
+      <th>Block</th>
+      <th>Type</th>
+      <th>Purpose</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>Markdown</td>
+      <td>Instructions on how to use the runbook and architectural context of the service</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>NRQL</td>
+      <td>High-level system check using the injected variable — for example: `SELECT average(cpuPercent) FROM SystemSample WHERE hostname = {{failingHost}} TIMESERIES`</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>Markdown</td>
+      <td>Conditional guidance — for example: "If the chart above shows CPU > 90%, run the next query to identify the top processes."</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>NRQL</td>
+      <td>Deeper investigative query — for example: `SELECT latest(cpuPercent) FROM ProcessSample WHERE hostname = {{failingHost}} FACET processDisplayName`</td>
+    </tr>
+  </tbody>
+</table>
+
+## What's next? [#whats-next]
+
+* [Get started with notebooks](/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks) for an overview of the notebooks feature
+* [Blocks in notebook](/docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks) to learn more about query and text blocks
+* [Template variables: dynamically filter dashboards](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables) for the equivalent dashboard feature

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
@@ -9,7 +9,7 @@ metaDescription: 'For New Relic notebooks: use variables to parameterize your no
 freshnessValidatedDate: never
 ---
 
-With notebook variables, you can set up dynamic parameters that cascade through multiple queries, charts, and data blocks. Unlike [dashboard template variables](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables), which filter a static view, notebook variables act as injected parameters that drive the underlying logic of your entire document.
+With notebook variables, you can set up dynamic parameters that cascade through multiple queries across query blocks. Unlike [dashboard template variables](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables), which filter a static view, notebook variables act as injected parameters that drive the underlying logic of your entire document.
 
 Go to **[one.newrelic.com](https://one.newrelic.com) > All capabilities > Notebooks**.
 
@@ -24,7 +24,7 @@ Notebook variables let you build interactive experiences such as:
 The key benefits include:
 
 * **Creating executable runbooks**: Variables turn your notebooks from static pages into interactive tools. You can build adaptable workflows for alert event investigations, performance analysis, and team collaboration.
-* **Standardizing knowledge sharing**: As a saved document, you can share analytical workflows with colleagues. Users don't need to rewrite complex NRQL queries — they simply plug new values into your pre-defined variables to execute the workflow.
+* **Standardizing knowledge sharing**: As a saved document, you can share analytical workflows with colleagues. Users don't need to rewrite complex NRQL queries — they simply change to a new variable value from your pre-defined variables and execute the workflow.
 
 ## Define a notebook variable [#define-variable]
 
@@ -62,15 +62,7 @@ When you run the query, the variable value you have set in the variables bar is 
 
 The most powerful application for notebook variables is creating executable runbooks for incident response. By combining notebook variables with [New Relic Workflows](/docs/alerts/get-notified/incident-workflows), you can automate the handoff between an alert triggering and the investigation beginning.
 
-### How an executable runbook works [#runbook-flow]
-
-1. **The alert triggers**: An alert condition is violated (for example, CPU usage spikes on a specific host).
-2. **The workflow automates the notification**: A New Relic Workflow triggers a notification — for example, sending a message to a Slack channel.
-3. **Passing variables via URL**: Within the notification payload, include a URL linking directly to your saved notebook runbook. Use workflow templating (such as `{{entitiesData.names}}`) to append URL parameters that match your notebook variables.
-4. **The runbook is pre-populated**: When the responder clicks the link, the notebook opens with the variables (like `targetApp` or `failingHost`) already populated with the exact details of the alert.
-5. **Guided investigation**: The responder follows the document top-to-bottom.
-
-## Structure your runbook [#structure-runbook]
+### Structure your runbook [#structure-runbook]
 
 A well-structured parameterized runbook typically follows this pattern:
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
@@ -11,7 +11,7 @@ freshnessValidatedDate: never
 
 With notebook variables, you can set up dynamic parameters that cascade through multiple queries across query blocks. Unlike [dashboard template variables](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables), which filter a static view, notebook variables act as injected parameters that drive the underlying logic of your entire document.
 
-Go to **[one.newrelic.com](https://one.newrelic.com) > All capabilities > Notebooks**.
+Go to **[one.newrelic.com](https://one.newrelic.com) > <DNT>All capabilities</DNT> > <DNT>Notebooks</DNT>**.
 
 ## Why use variables in notebooks? [#why-use-variables]
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
@@ -33,7 +33,7 @@ Define a variable that you'll inject into your <DNT>NRQL</DNT> query blocks to p
 To define a variable:
 
 1. From an open notebook, locate the variables bar at the top of the interface.
-2. Click **+ Add variable**.
+2. Click <DNT>**+ Add variable**</DNT>.
 3. Configure your variable type (for example, text input, dropdown, or numeric) and provide a default value.
 
 ### Variable naming rules [#naming-rules]

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/notebook-variables.mdx
@@ -24,11 +24,11 @@ Notebook variables let you build interactive experiences such as:
 The key benefits include:
 
 * **Creating executable runbooks**: Variables turn your notebooks from static pages into interactive tools. You can build adaptable workflows for alert event investigations, performance analysis, and team collaboration.
-* **Standardizing knowledge sharing**: As a saved document, you can share analytical workflows with colleagues. Users don't need to rewrite complex NRQL queries — they simply change to a new variable value from your pre-defined variables and execute the workflow.
+* **Standardizing knowledge sharing**: As a saved document, you can share analytical workflows with colleagues. Users don't need to rewrite complex <DNT>NRQL</DNT> queries — they simply change to a new variable value from your pre-defined variables and execute the workflow.
 
 ## Define a notebook variable [#define-variable]
 
-Define a variable that you'll inject into your NRQL query blocks to parameterize your data retrieval and visualizations.
+Define a variable that you'll inject into your <DNT>NRQL</DNT> query blocks to parameterize your data retrieval and visualizations.
 
 To define a variable:
 
@@ -46,7 +46,7 @@ When naming your variable, keep the following in mind:
 
 ## Use a variable in a query block [#use-variable]
 
-Once defined, reference your variable anywhere in a NRQL query using the `{{variableName}}` syntax:
+Once defined, reference your variable anywhere in a <DNT>NRQL</DNT> query using the `{{variableName}}` syntax:
 
 ```sql
 SELECT average(cpuPercent) FROM SystemSample WHERE hostname = {{failingHost}} TIMESERIES
@@ -60,7 +60,7 @@ When you run the query, the variable value you have set in the variables bar is 
 
 ## Automate incident response with runbooks [#runbook-use-case]
 
-The most powerful application for notebook variables is creating executable runbooks for incident response. By combining notebook variables with [New Relic Workflows](/docs/alerts/get-notified/incident-workflows), you can automate the handoff between an alert triggering and the investigation beginning.
+The most powerful application for notebook variables is creating executable runbooks for incident response. By combining notebook variables with [<DNT>New Relic</DNT> Workflows](/docs/alerts/get-notified/incident-workflows), you can automate the handoff between an alert triggering and the investigation beginning.
 
 ### Structure your runbook [#structure-runbook]
 
@@ -82,7 +82,7 @@ A well-structured parameterized runbook typically follows this pattern:
     </tr>
     <tr>
       <td>2</td>
-      <td>NRQL</td>
+      <td><DNT>NRQL</DNT></td>
       <td>High-level system check using the injected variable — for example: `SELECT average(cpuPercent) FROM SystemSample WHERE hostname = {{failingHost}} TIMESERIES`</td>
     </tr>
     <tr>
@@ -92,7 +92,7 @@ A well-structured parameterized runbook typically follows this pattern:
     </tr>
     <tr>
       <td>4</td>
-      <td>NRQL</td>
+      <td><DNT>NRQL</DNT></td>
       <td>Deeper investigative query — for example: `SELECT latest(cpuPercent) FROM ProcessSample WHERE hostname = {{failingHost}} FACET processDisplayName`</td>
     </tr>
   </tbody>

--- a/src/nav/dashboards.yml
+++ b/src/nav/dashboards.yml
@@ -63,6 +63,8 @@ pages:
         path: /docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks
       - title: Variables in notebooks
         path: /docs/query-your-data/explore-query-data/notebooks/notebook-variables
+      - title: Blob Storage API for notebooks
+        path: /docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks
   - title: Grafana integrations
     pages:
       - title: Grafana support with Prometheus and PromQL

--- a/src/nav/dashboards.yml
+++ b/src/nav/dashboards.yml
@@ -61,6 +61,8 @@ pages:
         path: /docs/query-your-data/explore-query-data/notebooks/introduction-notebooks
       - title: Blocks in notebook
         path: /docs/query-your-data/explore-query-data/notebooks/add-queries-to-notebooks
+      - title: Variables in notebooks
+        path: /docs/query-your-data/explore-query-data/notebooks/notebook-variables
   - title: Grafana integrations
     pages:
       - title: Grafana support with Prometheus and PromQL


### PR DESCRIPTION
## Summary

- Adds `notebook-variables.mdx` — documents notebook variables, the `{{variableName}}` NRQL syntax, and parameterized runbook patterns
- Adds `blob-storage-api-for-notebooks.mdx` — full Blob Storage API reference for programmatic notebook management (create, read, update, delete, versioning) plus NerdGraph entity operations (list, rename, tags)
- Updates `introduction-notebooks.mdx` — removes the PP callout (Notebooks is now GA), adds PP callout for the Blob Storage API, links to both new articles in What's next
- Updates `notebook-variables.mdx` — links to the new API article in What's next
- Updates `dashboards.yml` — adds both new pages to the Notebooks nav section
- Applies DNT tags throughout all modified files (`New Relic`, `NerdGraph`, `Blob Storage API`, `NRQL`)

## Changes per file

| File | Change |
|---|---|
| `notebook-variables.mdx` | New — variables doc |
| `blob-storage-api-for-notebooks.mdx` | New — Blob Storage API + NerdGraph reference (PP) |
| `introduction-notebooks.mdx` | Removed PP callout (Notebooks GA); added PP callout for Blob Storage API; linked to new articles |
| `dashboards.yml` | Added two new nav entries under Notebooks |

