### PR TITLE
chore: Add a note that Node agent only supports Hybrid Agent for NextJS >=16

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/extend-your-instrumentation/nextjs-instrumentation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Next.js instrumentation with the hybrid agent
+title: Next.js instrumentation with the Hybrid Agent
 tags:
   - Agents
   - Nodejs agent
@@ -8,17 +8,19 @@ metaDescription: The New Relic Node.js agent can intercept native Next.js OpenTe
 freshnessValidatedDate: never
 ---
 
-The recommended way to monitor a <DNT>Next.js</DNT> application is to rely on the native <DNT>OpenTelemetry</DNT> spans emitted by <DNT>Next.js</DNT> together with the <DNT>Node.js</DNT> agent's hybrid agent feature, rather than the agent's built-in <DNT>Next.js</DNT> instrumentation. This page explains how to enable the hybrid agent, points to example applications, and covers common questions about injecting the browser agent and deploying to cloud providers.
+The recommended way to monitor a <DNT>Next.js</DNT> application is to rely on the native <DNT>OpenTelemetry</DNT> spans emitted by <DNT>Next.js</DNT> together with the <DNT>Node.js</DNT> agent's Hybrid Agent feature, rather than the agent's built-in <DNT>Next.js</DNT> instrumentation. This page explains how to enable the Hybrid Agent, points to example applications, and covers common questions about injecting the browser agent and deploying to cloud providers.
 
 <Callout variant="important">
-  Native <DNT>Next.js OpenTelemetry</DNT> support requires <DNT>Node.js</DNT> agent version [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0) or later. The hybrid agent only instruments the <DNT>Node.js</DNT> runtime; the <DNT>Next.js</DNT> edge runtime is not supported, which is why the `register()` example below exits early unless `NEXT_RUNTIME` is `nodejs`.
+  Native <DNT>Next.js OpenTelemetry</DNT> support requires <DNT>Node.js</DNT> agent version [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0) or later. The Hybrid Agent only instruments the <DNT>Node.js</DNT> runtime; the <DNT>Next.js</DNT> edge runtime is not supported, which is why the `register()` example below exits early unless `NEXT_RUNTIME` is `nodejs`.
+
+  In addition, we currently only support the Hybrid Agent approach for Next.js versions 16 and above.
 </Callout>
 
-The <DNT>Node.js</DNT> agent has had <DNT>Next.js</DNT> instrumentation since 2022 through [@newrelic/next](https://github.com/newrelic/newrelic-node-nextjs/releases/tag/v0.1.0), and that instrumentation was bundled into the agent in [12.0.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.0.0). However, it was limited and didn't work when deploying to cloud providers like <DNT>[Vercel](https://vercel.com/frameworks/nextjs)</DNT>, <DNT>[AWS Amplify](https://aws.amazon.com/amplify/)</DNT>, <DNT>[Netlify](https://www.netlify.com/with/nextjs/)</DNT>, or <DNT>[Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static)</DNT>. With the introduction of the [hybrid agent](/docs/apm/agents/manage-apm-agents/opentelemetry-api-support), the <DNT>Node.js</DNT> agent can intercept <DNT>OpenTelemetry</DNT> spans and synthesize the telemetry that drives the New Relic experience. Native <DNT>Next.js OpenTelemetry</DNT> instrumentation was added in [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0).
+The <DNT>Node.js</DNT> agent has had <DNT>Next.js</DNT> instrumentation since 2022 through [@newrelic/next](https://github.com/newrelic/newrelic-node-nextjs/releases/tag/v0.1.0), and that instrumentation was bundled into the agent in [12.0.0](https://github.com/newrelic/node-newrelic/releases/tag/v12.0.0). However, it was limited and didn't work when deploying to cloud providers like <DNT>[Vercel](https://vercel.com/frameworks/nextjs)</DNT>, <DNT>[AWS Amplify](https://aws.amazon.com/amplify/)</DNT>, <DNT>[Netlify](https://www.netlify.com/with/nextjs/)</DNT>, or <DNT>[Azure Static Web Apps](https://azure.microsoft.com/en-us/products/app-service/static)</DNT>. With the introduction of the [Hybrid Agent](/docs/apm/agents/manage-apm-agents/opentelemetry-api-support), the <DNT>Node.js</DNT> agent can intercept <DNT>OpenTelemetry</DNT> spans and synthesize the telemetry that drives the New Relic experience. Native <DNT>Next.js OpenTelemetry</DNT> instrumentation was added in [14.1.0](https://github.com/newrelic/node-newrelic/releases/tag/v14.1.0).
 
-## Enable the hybrid agent [#enable]
+## Enable the Hybrid Agent [#enable]
 
-To enable the hybrid agent and disable the agent instrumentations that conflict with <DNT>Next.js</DNT>, set the following configuration in `newrelic.js`:
+To enable the Hybrid Agent and disable the agent instrumentations that conflict with <DNT>Next.js</DNT>, set the following configuration in `newrelic.js`:
 
 ```js
 'use strict'


### PR DESCRIPTION
- Updates casing for the Hybrid Agent
- Adds a note that this approach is only for Next.js versions 16 and above.