### PR TITLE
fix(dnt): fix DNT tagging in AWS manual integration doc

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/manual.mdx
@@ -13,32 +13,32 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-For a seamless integration of your <DNT>AWS</DNT> account with New Relic, [integration via <DNT>CloudFormation</DNT> and CloudWatch metric stream](/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation) is the recommended approach. If you can't use <DNT>CloudFormation</DNT> templates and don't want to use <DNT>Terraform</DNT>, follow this procedure to integrate manually from the <DNT>AWS</DNT> console.
+For a seamless integration of your AWS account with New Relic, [integration via CloudFormation and CloudWatch metric stream](/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation) is the recommended approach. If you can't use CloudFormation templates and don't want to use Terraform, follow this procedure to integrate manually from the AWS console.
 
 <Callout variant="tip">
-* If you manage multiple <DNT>AWS</DNT> accounts, [connect each account to a single New Relic account](/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account).
-* If you manage multiple regions within those accounts, create a separate [Kinesis Data <DNT>Firehose</DNT>](#create-firehose) for each region.
+* If you manage multiple AWS accounts, [connect each account to a single New Relic account](/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account).
+* If you manage multiple regions within those accounts, create a separate [Kinesis Data Firehose](#create-firehose) for each region.
 </Callout>
 
 <Steps>
 <Step>
 ## Prerequisites [#prerequisites]
 
-Before you begin integrating your <DNT>AWS</DNT> account with New Relic, ensure that you meet the following prerequisites:
-* **A New Relic [Ingest - license key and a User key](https://one.newrelic.com/api-keys)**: You'll need these keys to connect your <DNT>AWS</DNT> services to your New Relic account.
-* **[Permissions](https://docs.aws.amazon.com/ARG/latest/userguide/gettingstarted-prereqs-permissions.html)** to deploy new <DNT>AWS</DNT> resources and **[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)**: You'll need this permission for your <DNT>AWS</DNT> account.
+Before you begin integrating your AWS account with New Relic, ensure that you meet the following prerequisites:
+* **A New Relic [Ingest - license key and a User key](https://one.newrelic.com/api-keys)**: You'll need these keys to connect your AWS services to your New Relic account.
+* **[Permissions](https://docs.aws.amazon.com/ARG/latest/userguide/gettingstarted-prereqs-permissions.html)** to deploy new AWS resources and **[IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html)**: You'll need this permission for your AWS account.
 * **[Permissions](/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions/#infrastructure)** for cloud integrations: You'll need these permissions for your New Relic account.
 
 </Step>
 <Step>
-## Create a Kinesis Data <DNT>Firehose</DNT> delivery stream [#create-firehose]
+## Create a Kinesis Data Firehose delivery stream [#create-firehose]
 
-In the <DNT>AWS</DNT> console, set the following destination parameters for the delivery stream:
+In the AWS console, set the following destination parameters for the delivery stream:
 
 * Source: <DNT>Direct PUT</DNT> or other sources
 * Destination: New Relic
-* Data transformation: Disabled
-* Record format conversion: Disabled
+* Data transformation: <DNT>Disabled</DNT>
+* Record format conversion: <DNT>Disabled</DNT>
 * Ensure the following settings are defined:
   * New Relic configuration (Destination Settings):
     * HTTP endpoint URL:
@@ -51,24 +51,24 @@ In the <DNT>AWS</DNT> console, set the following destination parameters for the 
     * New Relic buffer conditions:
       * Buffer size: `1 MB`
       * Buffer interval: `60 (seconds)`
-  * S3 backup mode: Failed data only
+  * S3 backup mode: <DNT>Failed data only</DNT>
   * S3 backup bucket: Select a bucket or create a new one to store metrics that failed to be sent.
   * Advanced settings:
     * Service access: Provide permissions for IAM role:
-      * Create or update IAM role
+      * <DNT>Create or update IAM role</DNT>
 
 </Step>
 <Step>
 ## Create a CloudWatch metric stream [#create-metric-stream]
 
-1. In the <DNT>AWS</DNT> console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
-2. To control which <DNT>AWS</DNT> services send metrics to New Relic, configure inclusion and exclusion filters.
-3. From the <DNT>Firehose</DNT> delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
+1. In the AWS console, go to <DNT>**CloudWatch service**</DNT>, select <DNT>**Streams**</DNT> under the <DNT>**Metrics**</DNT> menu, and click <DNT>**Create metric stream**</DNT>.
+2. To control which AWS services send metrics to New Relic, configure inclusion and exclusion filters.
+3. From the Firehose delivery stream list, select the stream you created, then enter a meaningful name for the metric stream, for example, `newrelic-metric-stream`.
 4. In the output format field, select `Open Telemetry 0.7` or `Open Telemetry 1.0`. JSON isn't supported.
 
 </Step>
 <Step>
-## Connect your <DNT>AWS</DNT> account to New Relic [#connect-aws-account]
+## Connect your AWS account to New Relic [#connect-aws-account]
 
 1. In New Relic, go to [<DNT>**Infrastructure > AWS**</DNT>](https://one.newrelic.com/infra/infrastructure/cloud-aws).
 2. Select the correct account.
@@ -80,9 +80,9 @@ In the <DNT>AWS</DNT> console, set the following destination parameters for the 
 
 5. On the <DNT>**Select services**</DNT> screen, toggle <DNT>**Show resources not supported by CloudWatch Metric Streams**</DNT> if needed, select the services you want to monitor, and continue.
 6. On the <DNT>**Choose data integration type**</DNT> screen, choose from the following options:
-   * **Real-time <DNT>AWS</DNT> monitoring (Recommended)**: This option is for services that support CloudWatch Metric Streams.
+   * **Real-time AWS monitoring (Recommended)**: This option is for services that support CloudWatch Metric Streams.
    * **API Polling**: This option is for services not supported by CloudWatch Metric Streams.
-7. From the <DNT>**Create role**</DNT> page to the <DNT>**Configure budgets policy**</DNT> page, follow the on-screen instructions and complete the steps in the <DNT>AWS</DNT> console.
+7. From the <DNT>**Create role**</DNT> page to the <DNT>**Configure budgets policy**</DNT> page, follow the on-screen instructions and complete the steps in the AWS console.
 
 </Step>
 <Step>
@@ -90,14 +90,14 @@ In the <DNT>AWS</DNT> console, set the following destination parameters for the 
 
 To confirm you're receiving data from Metric Streams:
 
-1. In New Relic, go to <DNT>**[one.newrelic.com > All capabilities > Infrastructure > AWS](https://one.newrelic.com/infra/infrastructure/cloud-aws)**</DNT>, search for your connected <DNT>AWS</DNT> account, and look for **Stream** accounts.
+1. In New Relic, go to <DNT>**[one.newrelic.com > All capabilities > Infrastructure > AWS](https://one.newrelic.com/infra/infrastructure/cloud-aws)**</DNT>, search for your connected AWS account, and look for **Stream** accounts.
 2. In the account status dashboard, confirm that New Relic is receiving metric data, including errors and the number of namespaces and metrics ingested.
 3. To explore specific metrics, write queries for the sets of metrics you want to analyze.
 
 It may take a few minutes for New Relic to detect new resources and synthesize them as entities.
 
 <Callout variant="tip">
-<DNT>AWS</DNT> CloudWatch metrics for global services, such as <DNT>AWS</DNT> Billing, are only available in the <DNT>**us-east-1**</DNT> region. Make sure there's an active CloudWatch metric stream configured in that region.
+AWS CloudWatch metrics for global services, such as AWS Billing, are only available in the <DNT>**us-east-1**</DNT> region. Make sure there's an active CloudWatch metric stream configured in that region.
 </Callout>
 
 </Step>
@@ -106,9 +106,9 @@ It may take a few minutes for New Relic to detect new resources and synthesize t
 ## Related topics [#related-topics]
 
 <DocTiles>
-  <DocTile title="Collect data from multiple AWS accounts" path="/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account/" >Learn how to collect data from multiple <DNT>AWS</DNT> accounts.</DocTile>
+  <DocTile title="Collect data from multiple AWS accounts" path="/docs/infrastructure/amazon-integrations/manage-aws-data/aws-multi-account/" >Learn how to collect data from multiple AWS accounts.</DocTile>
   <DocTile title="AWS integrations metrics" path="/docs/infrastructure/amazon-integrations/manage-aws-data/aws-integrations-metrics/" >Explore and use metrics from CloudWatch Metric Stream.</DocTile>
-  <DocTile title="AWS integrations via CloudFormation and CWMS" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-cwms" >Integrate <DNT>AWS</DNT> services with New Relic using <DNT>CloudFormation</DNT> and CloudWatch Metric Streams.</DocTile>
-  <DocTile title="AWS integrations via CloudFormation and API Polling" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-and-api-polling" >Integrate <DNT>AWS</DNT> services with New Relic using <DNT>CloudFormation</DNT> and API Polling.</DocTile>
-  <DocTile title="AWS integrations via Terraform" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform" >Integrate <DNT>AWS</DNT> services with New Relic using <DNT>Terraform</DNT>.</DocTile>
+  <DocTile title="AWS integrations via CloudFormation and CWMS" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-cwms" >Integrate AWS services with New Relic using CloudFormation and CloudWatch Metric Streams.</DocTile>
+  <DocTile title="AWS integrations via CloudFormation and API Polling" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/via-cloudformation-and-api-polling" >Integrate AWS services with New Relic using CloudFormation and API Polling.</DocTile>
+  <DocTile title="AWS integrations via Terraform" path="/docs/infrastructure/amazon-integrations/aws-integration-for-metrics/terraform" >Integrate AWS services with New Relic using Terraform.</DocTile>
 </DocTiles>


### PR DESCRIPTION
## Summary


### Removed `<DNT>` from proper nouns (brand/product names globally recognized, should not carry a DNT tag):
- `AWS` (all standalone occurrences)
- `CloudFormation` (all standalone occurrences)
- `Terraform`
- `Firehose` (standalone in "Kinesis Data Firehose")

### Added `<DNT>` to AWS parameter values (exact UI strings that must not be translated):
- `Disabled` — value for **Data transformation** and **Record format conversion** fields
- `Failed data only` — value for **S3 backup mode** field
- `Create or update IAM role` — option under **Service access**
