### PR TITLE
docs(azure-vnet-flow-logs): multi-plan support, FedRAMP endpoint, private-mode outbound routing

### DIFF
--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/azure-vnet-flow-log-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/azure-vnet-flow-log-monitoring.mdx
@@ -164,8 +164,7 @@ You can deploy the VNet Flow Logs Forwarder using ARM/Bicep templates (recommend
       * Isolates the Function App, its storage account, and the Event Hub within a private virtual network, with public network access to them disabled
       * Adds VNet integration with private endpoints for storage services (blob, file, queue, and table)
       * Creates private DNS zones for name resolution
-      * Routes all outbound traffic — including calls to the New Relic Logs API — through the VNet integration subnet. If your VNet has network security groups (NSGs) or an Azure Firewall that restrict outbound to `0.0.0.0/0`, allow outbound to the New Relic Logs API endpoint (all plans) and to GitHub Releases (Elastic Premium and Basic plans only, for the function package fetch at boot)
-      * Doesn't modify the source storage account (containing the VNet Flow Logs), which should keep public network access enabled
+      * Routes all outbound traffic — including calls to the New Relic Logs API — through the VNet integration subnet.
     </TabsPageItem>
 
     <TabsPageItem id="manual-deploy">
@@ -229,7 +228,7 @@ Configure the following application settings on your Azure Function App:
   <tbody>
     <tr>
       <td>`NR_ENDPOINT`</td>
-      <td>New Relic Logs API endpoint. Use `https://log-api.eu.newrelic.com/log/v1` for EU, `https://log-api.jp.newrelic.com/log/v1` for JP, or `https://gov-log-api.newrelic.com/log/v1` for FedRAMP (US Gov Cloud).</td>
+      <td>New Relic Logs API endpoint. Defaults to the US endpoint. Override for other regions: `https://log-api.eu.newrelic.com/log/v1` (EU), `https://log-api.jp.newrelic.com/log/v1` (JP), or `https://gov-log-api.newrelic.com/log/v1` (FedRAMP / US Gov Cloud).</td>
       <td>`https://log-api.newrelic.com/log/v1`</td>
     </tr>
     <tr>

--- a/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/azure-vnet-flow-log-monitoring.mdx
+++ b/src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/azure-vnet-flow-log-monitoring.mdx
@@ -76,7 +76,7 @@ You can deploy the VNet Flow Logs Forwarder using ARM/Bicep templates (recommend
 
       The template will automatically:
       * Create an Event Hub namespace, Event Hub, and consumer group
-      * Deploy the Function App (Flex Consumption plan, Node.js 22) with the VNet Flow Logs functions
+      * Deploy the Function App on your selected hosting plan with the Node.js 22 runtime and the VNet Flow Logs functions
       * Create a Storage Account for the Function App runtime and cursor tracking
       * Create an Event Grid system topic and subscription that routes PT1H.json blob-creation events directly to the Event Hub
       * Assign a managed identity with the required role assignments
@@ -92,10 +92,11 @@ You can deploy the VNet Flow Logs Forwarder using ARM/Bicep templates (recommend
       5. Click <DNT>**Deploy to Azure**</DNT>. A new tab opens in Azure with the ARM template loaded.
       6. Select the <DNT>**Resource group**</DNT> and a <DNT>**Region**</DNT> for the deployment. We recommend a new resource group, to avoid accidentally deleting the components it creates.
       7. In the <DNT>**New Relic license key**</DNT> field, paste the license key you copied earlier.
-      8. Ensure the [New Relic endpoint](/docs/logs/log-api/introduction-log-api/#endpoint) is set to the one corresponding to your account (US, EU, or JP).
+      8. Ensure the [New Relic endpoint](/docs/logs/log-api/introduction-log-api/#endpoint) is set to the one corresponding to your account (US, EU, JP, or FedRAMP for US Gov Cloud).
       9. (Optional) Enter the <DNT>**Source Storage Account Name**</DNT> where your VNet Flow Logs are stored. It must be in the same resource group as this deployment. Leave it blank to create a new source storage account automatically.
       10. (Optional) Select <DNT>**Disable Public Access To Storage Account**</DNT> to enable private networking mode with VNet integration and private endpoints.
-      11. (Optional) Configure advanced settings:
+      11. (Optional) Select the <DNT>**Function App Plan**</DNT> dropdown. Four values: `FlexConsumption` (default), `ElasticPremium`, `Basic`, or `Consumption`. See [Choose a hosting plan](#hosting-plans) below for guidance on when to pick each.
+      12. (Optional) Configure advanced settings:
           * <DNT>**New Relic Tags**</DNT>: Semicolon-separated tags (format: `key1:value1;key2:value2`)
           * <DNT>**Max Retries**</DNT>: Maximum delivery retry attempts (default: 3)
           * <DNT>**Retry Interval**</DNT>: Milliseconds between retries (default: 2000)
@@ -104,9 +105,49 @@ You can deploy the VNet Flow Logs Forwarder using ARM/Bicep templates (recommend
           * <DNT>**Min Event Batch Size**</DNT>: Minimum number of Event Hub events per batch (default: 5)
           * <DNT>**Max Wait Time**</DNT>: Maximum time the trigger waits to fill a batch before processing, as `hh:mm:ss` (default: `00:00:30`)
           * <DNT>**Event Hub Scaling Mode**</DNT>: `Basic` (1 throughput unit, 4 partitions, no auto-inflate — low-to-medium traffic) or `Enterprise` (auto-inflate up to 40 throughput units, 32 partitions — high-throughput volumes) (default: `Basic`)
-      12. Click <DNT>**Review + create**</DNT>, review the configuration, and click <DNT>**Create**</DNT>.
-      13. Back in New Relic, on the <DNT>**Create log partition**</DNT> step, click <DNT>**Create partition**</DNT>. This creates a `Log_VNET_Flows_Azure` data partition (rule: `instrumentation.name = 'vnet-app'`, STANDARD retention) so your VNet Flow Logs are stored and queried separately from your other logs. If a `Log_VNET_Flows_Azure` partition already exists on the account, click <DNT>**Continue**</DNT> to skip this step.
-      14. On the <DNT>**Test your logs**</DNT> step, confirm data is arriving by running `SELECT * FROM Log_VNET_Flows_Azure`, then click <DNT>**See your data**</DNT>.
+      13. Click <DNT>**Review + create**</DNT>, review the configuration, and click <DNT>**Create**</DNT>.
+      14. Back in New Relic, on the <DNT>**Create log partition**</DNT> step, click <DNT>**Create partition**</DNT>. This creates a `Log_VNET_Flows_Azure` data partition (rule: `instrumentation.name = 'vnet-app'`, STANDARD retention) so your VNet Flow Logs are stored and queried separately from your other logs. If a `Log_VNET_Flows_Azure` partition already exists on the account, click <DNT>**Continue**</DNT> to skip this step.
+      15. On the <DNT>**Test your logs**</DNT> step, confirm data is arriving by running `SELECT * FROM Log_VNET_Flows_Azure`, then click <DNT>**See your data**</DNT>.
+
+      ### Choose a hosting plan [#hosting-plans]
+
+      The template deploys the Function App on one of four Azure hosting plans, selected with the <DNT>**Function App Plan**</DNT> dropdown. The default is `FlexConsumption`.
+
+      <table>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>When to pick</th>
+            <th>Gov Cloud</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>`FlexConsumption` (default)</td>
+            <td>Any region where Flex Consumption is Generally Available. Modern serverless model with native VNet integration that scales elastically without pre-warmed capacity.</td>
+            <td>—</td>
+          </tr>
+          <tr>
+            <td>`ElasticPremium`</td>
+            <td>Production or bursty workloads in regions where Flex Consumption is not yet available, or workloads with a strict no-cold-start SLA.</td>
+            <td>Supported</td>
+          </tr>
+          <tr>
+            <td>`Basic`</td>
+            <td>Small tenants or development deployments that need private networking. Cheapest VNet-capable option. Not suitable for high-throughput workloads.</td>
+            <td>Supported</td>
+          </tr>
+          <tr>
+            <td>`Consumption`</td>
+            <td>Public-network development or evaluation deployments where private networking isn't required. Cheapest overall.</td>
+            <td>Supported</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <Callout variant="important">
+        `Consumption` doesn't support Azure VNet integration. If you enable <DNT>**Disable Public Access To Storage Account**</DNT>, pick one of `FlexConsumption`, `ElasticPremium`, or `Basic` — the deployment fails-fast within the first minute if you combine `Consumption` with private networking.
+      </Callout>
 
       ### Deployment architectures [#deployment-architectures]
 
@@ -123,6 +164,7 @@ You can deploy the VNet Flow Logs Forwarder using ARM/Bicep templates (recommend
       * Isolates the Function App, its storage account, and the Event Hub within a private virtual network, with public network access to them disabled
       * Adds VNet integration with private endpoints for storage services (blob, file, queue, and table)
       * Creates private DNS zones for name resolution
+      * Routes all outbound traffic — including calls to the New Relic Logs API — through the VNet integration subnet. If your VNet has network security groups (NSGs) or an Azure Firewall that restrict outbound to `0.0.0.0/0`, allow outbound to the New Relic Logs API endpoint (all plans) and to GitHub Releases (Elastic Premium and Basic plans only, for the function package fetch at boot)
       * Doesn't modify the source storage account (containing the VNet Flow Logs), which should keep public network access enabled
     </TabsPageItem>
 
@@ -187,7 +229,7 @@ Configure the following application settings on your Azure Function App:
   <tbody>
     <tr>
       <td>`NR_ENDPOINT`</td>
-      <td>New Relic Logs API endpoint. Use `https://log-api.eu.newrelic.com/log/v1` for EU accounts.</td>
+      <td>New Relic Logs API endpoint. Use `https://log-api.eu.newrelic.com/log/v1` for EU, `https://log-api.jp.newrelic.com/log/v1` for JP, or `https://gov-log-api.newrelic.com/log/v1` for FedRAMP (US Gov Cloud).</td>
       <td>`https://log-api.newrelic.com/log/v1`</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary

Updates the Azure VNet Flow Logs monitoring setup page to reflect three recently landed changes in the forwarder template:

| Upstream PR | What shipped |
|---|---|
| [newrelic/azure-vnet-flow-logs#26](https://github.com/newrelic/azure-vnet-flow-logs/pull/26) | `functionAppPlan` deploy-time parameter with four hosting plans (`FlexConsumption` default, `ElasticPremium`, `Basic`, `Consumption`) |
| [newrelic/azure-vnet-flow-logs#27](https://github.com/newrelic/azure-vnet-flow-logs/pull/27) | FedRAMP / US Gov Cloud endpoint support (`gov-log-api.newrelic.com`) |
| [newrelic/azure-vnet-flow-logs#29](https://github.com/newrelic/azure-vnet-flow-logs/pull/29) | Private-mode deployments now route all outbound traffic through the VNet integration subnet (`outboundVnetRouting.allTraffic`) |

## Doc changes

Single file: `src/content/docs/network-performance-monitoring/setup-performance-monitoring/cloud-flow-logs/azure-vnet-flow-log-monitoring.mdx`

* Replaced the hard-coded ""Flex Consumption plan"" claim in the template-summary bullet list with plan-agnostic wording.
* Added FedRAMP to the endpoint-selection step and to the `NR_ENDPOINT` optional-setting row.
* Added a new step 11 for the **Function App Plan** dropdown (renumbering later steps).
* Added a **Choose a hosting plan** subsection with a 4-plan When-to-pick table + Gov Cloud column, plus a callout that `Consumption` + private networking is not supported (deployment fails-fast).
* Added a bullet under **Private networking deployment** describing outbound-VNet routing and what customers need to allow if they attach restrictive NSGs (New Relic Logs API endpoint for all plans; GitHub Releases for Elastic Premium and Basic).

## Test plan

- [ ] Docs preview build succeeds
- [ ] Anchor `#hosting-plans` resolves from the in-page cross-link
- [ ] `<DNT>`, `<Callout>`, and table components render as expected
- [ ] Steps 11-15 renumbering is consistent throughout

## Not addressed here

- Manual-deployment section (bottom) is not updated — the plan/endpoint/routing choices there are set as env vars, which are already described in the config table.
- Attribute reference table is untouched.