### PR TITLE
Add Japan to DORA data storage regions

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
@@ -64,7 +64,6 @@ New Relic processes data in the following locations*:
             United Kingdom
             </td>
             <td>
-            India
             </td>
         </tr>
         <tr>

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
@@ -139,6 +139,9 @@ New Relic stores data in the following regions**:
             <th>
             EMEA
             </th>
+            <th>
+            APAC
+            </th>
         </tr>
     </thead>   
 <tbody>
@@ -149,11 +152,14 @@ New Relic stores data in the following regions**:
             <td>
             European Union
             </td>
+            <td>
+            Japan
+            </td>
         </tr>
     </tbody>
 </table>
 
-**New Relic’s global data hosting structure consists of two regions. You can select your preferred hosting region when setting up their account. 
+**New Relic’s global data hosting structure consists of three regions. You can select your preferred hosting region when setting up their account. 
 
 For more information please see [Choose Your Data Center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/).
 

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
@@ -64,16 +64,6 @@ New Relic processes data in the following locations*:
             United Kingdom
             </td>
             <td>
-            </td>
-        </tr>
-        <tr>
-            <td>
-            </td>
-            <td>
-            </td>
-            <td>
-            </td>
-            <td>
             Japan
             </td>
         </tr>

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
@@ -118,7 +118,7 @@ New Relic processes data in the following locations*:
 
 ## Data storage [#DORA_storage]
 
-New Relic’s global data hosting structure consists of three regions. You can select your preferred hosting region when setting up your account. For more information, see [Choose your data center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/).
+New Relic’s global data hosting structure consists of three regions. You can select your preferred hosting region when setting up your account. For more information, refer to [Choose your data center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/).
 
 New Relic stores data in the following regions:
 

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
@@ -135,10 +135,10 @@ New Relic stores data in the following regions**:
             <th style={{ width: "200px" }}>
             North America
             </th>
-            <th>
+            <th style={{ width: "200px" }}>
             EMEA
             </th>
-            <th>
+            <th style={{ width: "200px" }}>
             APAC
             </th>
         </tr>

--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx
@@ -118,7 +118,10 @@ New Relic processes data in the following locations*:
 
 ## Data storage [#DORA_storage]
 
-New Relic stores data in the following regions**:
+New Relic’s global data hosting structure consists of three regions. You can select your preferred hosting region when setting up your account. For more information, see [Choose your data center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/).
+
+New Relic stores data in the following regions:
+
 <table>
     <thead>
         <tr>
@@ -148,9 +151,6 @@ New Relic stores data in the following regions**:
     </tbody>
 </table>
 
-**New Relic’s global data hosting structure consists of three regions. You can select your preferred hosting region when setting up their account. 
+**RSS - Atom**
 
-For more information please see [Choose Your Data Center](/docs/accounts/accounts-billing/account-setup/choose-your-data-center/).
-
-## RSS - Atom
 Subscribe to the [RSS feed](https://github.com/newrelic/docs-website/commits/develop/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/dora/dora-data-locations.mdx).


### PR DESCRIPTION
New Relic's data hosting now includes an APAC region (Japan), in addition to North America and EMEA. Update the region count in the following sentence from two to three.