### PR TITLE
Added the document to the left nav

### DIFF
--- a/src/nav/ebpf.yml
+++ b/src/nav/ebpf.yml
@@ -13,6 +13,8 @@ pages:
         path: /docs/ebpf/k8s-installation
       - title: Proxy configuration
         path: /docs/ebpf/proxy-configuration
+      - title: Multi-account routing
+        path: /docs/ebpf/multi-account-routing
   - title: Capabilities
     pages:
       - title: eBPF APM


### PR DESCRIPTION
As per the request that we had received on the #help-documentation channel from Gilbert, missed out to add the file to the left nav, hence creating the PR to add the file "https://docs.newrelic.com/docs/ebpf/multi-account-routing/" to the left nav