### PR TITLE
doc: PHP 12.9.0.38 agent release

### DIFF
--- a/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements.mdx
@@ -511,7 +511,7 @@ The following frameworks are supported:
       <td>
         Wordpress
       </td>
-      <td>5.9+</td>
+      <td>6.0+</td>
       <td>[Wordpress specific functionality](/docs/apm/agents/php-agent/frameworks-libraries/wordpress-specific-functionality/)</td>
     </tr>
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-9-0-38.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-9-0-38.mdx
@@ -4,7 +4,7 @@ releaseDate: '2026-07-27'
 version: 12.9.0.38
 downloadLink: 'https://download.newrelic.com/php_agent/archive/12.9.0.38'
 features: ['Wordress 7 verified and supported']
-security: ['Upgrade golang to 1.26.5']
+security: ['Upgrade golang to 1.26.5', 'go.mod dependency updates', 'bump google.golang.org/grpc from 1.82.0 to 1.82.1']
 ---
 
 ## New Relic PHP agent v12.9.0.38
@@ -16,6 +16,8 @@ security: ['Upgrade golang to 1.26.5']
 ### Security updates
 
 * Upgraded golang to 1.26.5 ([#1258](https://github.com/newrelic/newrelic-php-agent/pull/1258))
+* go.mod dependency updates ([#1247](https://github.com/newrelic/newrelic-php-agent/pull/1247))
+* bump google.golang.org/grpc from 1.82.0 to 1.82.1 ([#1259](https://github.com/newrelic/newrelic-php-agent/pull/1259))
 
 ### Support Statement
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-9-0-38.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-9-0-38.mdx
@@ -3,10 +3,15 @@ subject: PHP agent
 releaseDate: '2026-07-27'
 version: 12.9.0.38
 downloadLink: 'https://download.newrelic.com/php_agent/archive/12.9.0.38'
+features: ['Wordress 7 verified and supported']
 security: ['Upgrade golang to 1.26.5']
 ---
 
 ## New Relic PHP agent v12.9.0.38
+
+### New Features
+
+* Wordress 7 verified and supported
 
 ### Security updates
 

--- a/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-9-0-38.mdx
+++ b/src/content/docs/release-notes/agent-release-notes/php-release-notes/php-agent-12-9-0-38.mdx
@@ -1,0 +1,35 @@
+---
+subject: PHP agent
+releaseDate: '2026-07-27'
+version: 12.9.0.38
+downloadLink: 'https://download.newrelic.com/php_agent/archive/12.9.0.38'
+security: ['Upgrade golang to 1.26.5']
+---
+
+## New Relic PHP agent v12.9.0.38
+
+### Security updates
+
+* Upgraded golang to 1.26.5 ([#1258](https://github.com/newrelic/newrelic-php-agent/pull/1258))
+
+### Support Statement
+
+* PHP Agent support for the following library & framework versions will be discontinued and New Relic recommends you upgrade to the latest version supported by the vendor:
+    * Slim 2 support will be discontinued in all PHP Agent Versions after July 31, 2026
+    * Drupal 7: Support ends October 15, 2026 (updated from September 30)
+    * Drupal 9: Support ends October 15, 2026 (updated from September 30)
+    * Laravel 11 support will be discontinued in all PHP Agent Versions after September 30, 2026
+    * Joomla: All Joomla support ends September 30, 2026
+
+* New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. For more information on supported agent versions and EOL timelines, check out our [New Relic PHP Agent EOL policy](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-eol-policy/).
+* The [PHP agent compatibility and requirements](https://docs.newrelic.com/docs/apm/agents/php-agent/getting-started/php-agent-compatibility-requirements/) page should be consulted for the latest information on supported PHP versions and platforms.
+
+<Callout variant="important">
+  **For installations using an unsupported PHP version or platform, it's highly recommended that you disable the auto-update mechanisms for the PHP agent packages.** This can be done by adding the PHP agent packages to an exclusion list for package upgrades. Or you could version pin the PHP agent package to an agent version that supports the old, unsupported feature(s). Failure to prevent upgrades may result in a newer agent release being installed and the removal of support for the required, unsupported features. This would disrupt APM data collection.
+
+  The PHP agent packages that are affected are:
+
+* newrelic-php5
+* newrelic-php5-common
+* newrelic-daemon
+</Callout>


### PR DESCRIPTION
This is the release notes for the 12.9.0.38 PHP agent release.

Please review and merge.