### PR TITLE
fix: Denotes entityGuid as not required

### DIFF
--- a/src/content/docs/data-apis/ingest-apis/security-data-api.mdx
+++ b/src/content/docs/data-apis/ingest-apis/security-data-api.mdx
@@ -203,22 +203,6 @@ The following fields are required in the request:
         ```
       </td>
     </tr>
-
-    <tr>
-      <td>
-        `entityGuid`
-      </td>
-
-      <td>
-        A unique identifier for a specific entity within the New Relic platform, essential for tracking and managing applications, services, or infrastructure components.
-
-        An example of `entityGuid` would be:
-
-        ```
-        "entityGuid": "MTI1NjM5fEFQfEFQUExJQ0FUSU9OfDEyMzQ1Njc4OQ"
-        ```
-      </td>
-    </tr>
   </tbody>
 </table>
 
@@ -240,6 +224,21 @@ Your request may contain any of the following optional fields:
   </thead>
 
   <tbody>
+    <tr>
+      <td>
+        `entityGuid`
+      </td>
+
+      <td>
+        A unique identifier for a specific entity within the New Relic platform, essential for tracking and managing applications, services, or infrastructure components.
+
+        An example of `entityGuid` would be:
+
+        ```
+        "entityGuid": "MTI1NjM5fEFQfEFQUExJQ0FUSU9OfDEyMzQ1Njc4OQ"
+        ```
+      </td>
+    </tr>
     <tr>
       <td>
         `cvssScore`


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

`entityGuid` is not required in this context. This edit corrects the documentation to reflect current backend expectations. 

For many security ingests, it doesn't make sense to require it and this API is meant to ingest all Security data to help customers triage in one place.