### PR TITLE
docs(security): update PCI DSS AOC to 2025 cycle

### DIFF
--- a/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/pci-dss.mdx
+++ b/src/content/docs/security/security-privacy/compliance/certificates-standards-regulations/pci-dss.mdx
@@ -5,12 +5,12 @@ tags:
   - Security and Privacy
   - Compliance
 metaDescription: Criteria and compliance with PCI DSS audits by New Relic services.
-freshnessValidatedDate: 2024-07-25
+freshnessValidatedDate: 2025-10-03
 ---
 
 Payment Card Industry Data Security Standard (PCI DSS), maintained by Security Standards Council, is a set of security requirements to protect cardholder data environments (CDEs) where payment card data is stored, processed, or transmitted. PCI DSS provides a baseline of rigorous technical and operational requirements designed to protect CDEs.
 
-Assessed against the PCI DSS version 4.0, New Relic maintains a Report on Compliance (ROC) and Attestation of Compliance (AOC) as a [Level 1 Service Provider](https://www.pcisecuritystandards.org/glossary/service-provider/).
+Assessed against the PCI DSS version 4.0.1, New Relic maintains a Report on Compliance (ROC) and Attestation of Compliance (AOC) as a [Level 1 Service Provider](https://www.pcisecuritystandards.org/glossary/service-provider/).
 
 New Relic removes some of your sensitive data in logs with automatic [log obfuscation](https://docs.newrelic.com/docs/logs/get-started/new-relics-log-management-security-privacy/#auto-obfuscation). Enabled by default for all customers.
 
@@ -34,8 +34,8 @@ The following applies to the New Relic Observability Platform:
   <tbody>
     <tr>
       <td>Attestation of Compliance</td>
-      <td>2024-NOV-13</td>
-      <td>AWS, First Party</td>
+      <td>2025-OCT-03</td>
+      <td>AWS, Azure</td>
       <td>New Relic Observability Platform</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Updates the PCI DSS compliance page to reflect the new Attestation of Compliance signed October 27, 2025:
- PCI DSS version: 4.0 → 4.0.1
- AOC date: 2024-NOV-13 → 2025-OCT-03
- Infrastructure: AWS, First Party → AWS, Azure
- freshnessValidatedDate: 2024-07-25 → 2025-10-03

