### PR TITLE
Remove outdated references/links to Insights

### DIFF
--- a/src/content/docs/errors-inbox/mobile-tab.mdx
+++ b/src/content/docs/errors-inbox/mobile-tab.mdx
@@ -89,10 +89,10 @@ These steps outline our recommended approach to crash investigation, enabling yo
     id="insights"
     title="Queries and image links: Query crash data and share charts with others"
   >
-    Mobile monitoring's <DNT>**Crash analysis**</DNT> charts use [default attributes for mobile events](/docs/insights/new-relic-insights/decorating-events/mobile-default-attributes-insights#mobile-list), along with any custom attributes you have added to this event type. To view or share the data, click the ellipsis icon.
+    Mobile monitoring's <DNT>**Crash analysis**</DNT> charts use [default attributes for mobile events](/docs/data-apis/understand-data/event-data/events-reported-mobile-monitoring), along with any custom attributes you have added to this event type. To view or share the data, click the ellipsis icon.
 
-    * <DNT>**Add to dashboard**</DNT> link: [View the chart](/docs/insights/new-relic-insights/using-insights-interface/query-page-creating-editing-nrql-queries), and copy it to a new or existing dashboard.
-    * <DNT>**View query**</DNT> link: View the [NRQL query](/docs/insights/new-relic-insights/using-new-relic-query-language/using-nrql) used to calculate the chart data.
+    * <DNT>**Add to dashboard**</DNT> link: [View the chart](/docs/nrql/get-started/introduction-nrql-new-relics-query-language), and copy it to a new or existing dashboard.
+    * <DNT>**View query**</DNT> link: View the [NRQL query](/docs/nrql/get-started/introduction-nrql-new-relics-query-language) used to calculate the chart data.
     * <DNT>**Get as image**</DNT> link: Select this option to get a public URL of the chart, then share it using any media.
   </Collapser>
 

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -377,7 +377,7 @@ Whether you're considering New Relic or you're already using our capabilities, t
   >
     An [event](#event), in New Relic terms, is a data object with attached [attributes](#attribute). New Relic reports default event types, like `Transaction` and `TransactionError`. You can also create your own events. Events can be [queried](/docs/using-new-relic/data/understand-data/query-new-relic-data), and are used in some other features.
 
-    You can generate custom events with [APM agents](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents), the [browser monitoring agent](/docs/insights/insights-data-sources/custom-data/insert-via-new-relic-browser), the [mobile monitoring agents](/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data), and via the [Event API](/docs/insights/insights-data-sources/custom-data/insert-custom-events-insights-api). Alternatively, you can add [custom attributes](#custom-attribute) to some existing default New Relic events.
+    You can generate custom events with [APM agents](/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes), the [browser monitoring agent](/docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes), the [mobile monitoring agents](/docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes), and via the [Event API](/docs/data-apis/ingest-apis/event-api/introduction-event-api). Alternatively, you can add [custom attributes](#custom-attribute) to some existing default New Relic events.
   </Collapser>
 
   <Collapser
@@ -608,7 +608,7 @@ Whether you're considering New Relic or you're already using our capabilities, t
     id="nr-insights"
     title="Insights"
   >
-    Insights was the name for the New Relic product that previously governed the reporting of custom events, and the ability to query and chart your New Relic data. These features are now a fundamental part of our platform and are no longer governed by the Insights product or name. To learn more about these features:
+    Insights was the name of a legacy New Relic product, now decommissioned, that governed the reporting of custom events and the ability to query and chart your New Relic data. These features are now a fundamental part of our platform and are no longer governed by the Insights product or name. To learn more about these features:
 
     * [Event API](/docs/telemetry-data-platform/ingest-apis/introduction-event-api) for reporting custom events
 

--- a/src/content/docs/new-relic-solutions/get-started/glossary.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/glossary.mdx
@@ -608,7 +608,9 @@ Whether you're considering New Relic or you're already using our capabilities, t
     id="nr-insights"
     title="Insights"
   >
-    Insights was the name of a legacy New Relic product, now decommissioned, that governed the reporting of custom events and the ability to query and chart your New Relic data. These features are now a fundamental part of our platform and are no longer governed by the Insights product or name. To learn more about these features:
+    Insights was a legacy New Relic product (now decommissioned) that managed custom event reporting, querying, and charting. These capabilities are now core, integrated platform features rather than a separate product.
+
+To learn more about querying and custom events:
 
     * [Event API](/docs/telemetry-data-platform/ingest-apis/introduction-event-api) for reporting custom events
 

--- a/src/nav/licenses.yml
+++ b/src/nav/licenses.yml
@@ -41,10 +41,6 @@ pages:
             path: /docs/licenses/product-or-service-licenses/new-relic-browser/new-relic-browser-licenses
           - title: Browser agent licenses
             path: /docs/licenses/product-or-service-licenses/new-relic-browser/browser-agent-licenses
-      - title: New Relic Insights
-        pages:
-          - title: Insights licenses
-            path: /docs/licenses/product-or-service-licenses/new-relic-insights/new-relic-insights-licenses
       - title: New Relic Mobile
         pages:
           - title: Android SDK licenses


### PR DESCRIPTION
The legacy Insights monolith was fully decommissioned 1 July 2026 and no longer serves any pages, in particular the New Relic Insights licenses page (which already returns a 404 today).

Other references to "Insights" docs have been replaced with direct links to the pages that they currently redirect to:

* `/docs/insights/new-relic-insights/decorating-events/mobile-default-attributes-insights#mobile-list -> /docs/data-apis/understand-data/event-data/events-reported-mobile-monitoring`
* `/docs/insights/new-relic-insights/using-insights-interface/query-page-creating-editing-nrql-queries -> /docs/nrql/get-started/introduction-nrql-new-relics-query-language/`
* `/docs/insights/new-relic-insights/using-new-relic-query-language/using-nrql -> /docs/nrql/get-started/introduction-nrql-new-relics-query-language`
* `/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents -> /docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes`
* `/docs/insights/insights-data-sources/custom-data/insert-via-new-relic-browser -> /docs/data-apis/custom-data/custom-events/report-browser-monitoring-custom-events-attributes`
* `/docs/insights/insights-data-sources/custom-events/insert-custom-events-attributes-mobile-data -> /docs/data-apis/custom-data/custom-events/report-mobile-monitoring-custom-events-attributes`
* `/docs/insights/insights-data-sources/custom-data/insert-custom-events-insights-api -> /docs/data-apis/ingest-apis/event-api/introduction-event-api/`