### PR TITLE
docs(release-notes): add release-notes for aws-unified-lambda

### DIFF
--- a/src/content/docs/release-notes/logs-release-notes/logs-26-07-28.mdx
+++ b/src/content/docs/release-notes/logs-release-notes/logs-26-07-28.mdx
@@ -1,0 +1,17 @@
+---
+subject: Logs
+releaseDate: '2026-07-28'
+version: '260728'
+---
+
+### AWS Unified Lambda version 1.1.3
+
+This release bumps the [AWS Unified Lambda](https://github.com/newrelic/aws-unified-lambda) to version 1.1.3.
+
+### Changed
+
+* The Go version is upgraded to 1.26.5 for CVE fixes
+
+### Notes
+
+To stay up to date with the most recent fixes and enhancements, subscribe to our [Logs RSS feed](/docs/release-notes/logs-release-notes/).


### PR DESCRIPTION
### Description

This PR aims to add logs release-notes for `aws-unified-lambda`.