### PR TITLE
fix: Group arguments by requirement

### DIFF
--- a/src/content/docs/change-tracking/config/nerdgraph.mdx
+++ b/src/content/docs/change-tracking/config/nerdgraph.mdx
@@ -43,6 +43,7 @@ For general information on using NerdGraph, see [Introduction to NerdGraph](/doc
 
   <TabsPages>
 
+  {/* start work area */}
   <TabsPageItem id="event">
 
 
@@ -61,8 +62,8 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
 <CollapserGroup>
   <Collapser
     className="freq-link"
-    id="argument"
-    title="Argument"
+    id="required-arguments"
+    title="Required arguments"
   >
 
       <table>
@@ -92,17 +93,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
             * To use Custom categories or types:
                 * Within the `dataHandlingRules` argument, set the `validationFlags` field to `ALLOW_CUSTOM_CATEGORY_OR_TYPE`.
         </td>
-        </tr>
-        <tr>
-          <td>`dataHandlingRules`</td>
-          <td>Array of String</td>
-          <td> No </td>
-          <td>
-            The `dataHandlingRules` field, , which includes the `validationFlags` subfield, defines how the API handles validation failures. The `validationFlags` field accepts an array of the following values: 
-            * `ALLOW_CUSTOM_CATEGORY_OR_TYPE`: Required for custom or non-standard `category` and `type` combinations. Without this flag, New Relic returns an error if values don't exactly match predefined standards. For example, pairing the standard category `Deployment` with a custom type like `Rainbow` requires this flag.
-            * `FAIL_ON_FIELD_LENGTH`: Validates that string fields don't exceed 4096 characters. If a field exceeds this limit, New Relic returns an error and doesn't save the data; otherwise, the data is trimmed and appended with ellipses `(...)`.
-            * `FAIL_ON_REST_API_FAILURES`: For APM entities, the agent calls the legacy New Relic v2 REST API. If the call fails, New Relic returns an error and doesn't save the data. If this flag is omitted, New Relic returns the failure message but doesn't block the save.
-          </td>
         </tr>
         <tr>
           <td>`entitySearch.query`</td>
@@ -154,12 +144,7 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
                     * To find an OpenTelemetry service in a specific account: `"name = '<service name>' AND domain = 'EXT' AND type = 'SERVICE' AND accountId = '<account id>'"`
             </td>
         </tr>
-        <tr>
-          <td>`featureFlagId`</td>
-          <td>String</td>
-          <td> No </td>
-          <td>If you select `Feature Flag` as your category, under the `categoryFields` argument, you must also select `featureFlag` and include a `featureFlagId`. This `featureFlagId` can be any string you would like to identify your feature flag by.</td>
-        </tr>
+
         <tr>
           <td>`type`</td>
           <td> String </td>
@@ -173,6 +158,44 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
                 * Set the `validationFlags` field to `ALLOW_CUSTOM_CATEGORY_OR_TYPE`.
           </td>
         </tr>
+    </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="optional-arguments"
+    title="Optional arguments"
+  >
+      <table>
+      <thead>
+        <tr>
+          <th style={{ width: "220px" }}>Argument</th>
+          <th>Datatype</th>
+          <th>Required?</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>`dataHandlingRules`</td>
+          <td>Array of String</td>
+          <td> No </td>
+          <td>
+            The `dataHandlingRules` field, , which includes the `validationFlags` subfield, defines how the API handles validation failures. The `validationFlags` field accepts an array of the following values:
+            * `ALLOW_CUSTOM_CATEGORY_OR_TYPE`: Required for custom or non-standard `category` and `type` combinations. Without this flag, New Relic returns an error if values don't exactly match predefined standards. For example, pairing the standard category `Deployment` with a custom type like `Rainbow` requires this flag.
+            * `FAIL_ON_FIELD_LENGTH`: Validates that string fields don't exceed 4096 characters. If a field exceeds this limit, New Relic returns an error and doesn't save the data; otherwise, the data is trimmed and appended with ellipses `(...)`.
+            * `FAIL_ON_REST_API_FAILURES`: For APM entities, the agent calls the legacy New Relic v2 REST API. If the call fails, New Relic returns an error and doesn't save the data. If this flag is omitted, New Relic returns the failure message but doesn't block the save.
+          </td>
+        </tr>
+
+        <tr>
+          <td>`featureFlagId`</td>
+          <td>String</td>
+          <td> No </td>
+          <td>If you select `Feature Flag` as your category, under the `categoryFields` argument, you must also select `featureFlag` and include a `featureFlagId`. This `featureFlagId` can be any string you would like to identify your feature flag by.</td>
+        </tr>
+
         <tr>
           <td>`version`</td>
           <td> String </td>
@@ -207,7 +230,7 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
           <td>`groupId`</td>
           <td>String</td>
           <td>No</td>
-          <td> 
+          <td>
           A `groupId` attribute lets you organize the related changes across one or more entities. By using the same `groupId` for each related change, you can easily view these changes together in New Relic interfaces or refine query results. You can also use the same `groupId` to add changes to an existing group.
 
             <Callout variant="tip" title="TIP">
@@ -239,7 +262,7 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
           <td>No</td>
           <td>User identification or a valid email address. For example, user: `datanerd@example.com`.</td>
         </tr>
-    </tbody>
+      </tbody>
     </table>
   </Collapser>
 
@@ -520,7 +543,7 @@ The following examples show NerdGraph mutations, with their required and optiona
     ```
 
   </Collapser>
-  
+
 </CollapserGroup>
 
 
@@ -684,7 +707,7 @@ For change tracking events, these are the valid predefined category and type pai
     <tr>
       <td>`Deployment`</td>
       <td>
-        * `Basic` 
+        * `Basic`
         * `Blue Green`
         * `Canary`
         * `Rolling`
@@ -736,6 +759,7 @@ For change tracking events, these are the valid predefined category and type pai
 </Collapser>
 
   </TabsPageItem>
+  {/* end work area */}
 
   <TabsPageItem id="deployment">
 

--- a/src/content/docs/change-tracking/config/nerdgraph.mdx
+++ b/src/content/docs/change-tracking/config/nerdgraph.mdx
@@ -57,7 +57,7 @@ This method offers several benefits:
 * Broad visibility: You get a unified view of changes across all your accounts.
 * Easy to use: You don't need to know an `entity.guid`. This feature is powered by New Relic's flexible entity search.
 
-To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The events are stored in NRDB as `changeTrackingEvent` event type.
+To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The events are stored in NRDB as [changeTrackingEvent](https://docs.newrelic.com/attribute-dictionary/?event=ChangeTrackingEvent) event type.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/change-tracking/config/nerdgraph.mdx
+++ b/src/content/docs/change-tracking/config/nerdgraph.mdx
@@ -71,7 +71,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <th style={{ width: "220px" }}>Argument</th>
           <th>Datatype</th>
-          <th>Required?</th>
           <th>Description</th>
         </tr>
       </thead>
@@ -79,7 +78,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`category`</td>
           <td>String</td>
-          <td>Yes</td>
           <td>
             Categorize changes using various category and type combinations. You can either use our predefined [standard categories and types](#standard-categories-types) or define your own custom ones.
 
@@ -97,7 +95,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`entitySearch.query`</td>
           <td>String</td>
-          <td> Yes </td>
           <td>
 
             Find a specific entity within New Relic. You can search by using its specific entity guid using the `id` field or by providing other identifying information if the entity guid is unknown. An entity guid is a unique identifier that New Relic assigns to your system components such as applications or microservices during their instrumentation or setup. For more information about entities, refer to [New Relic Entities](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/#what-is-entity).
@@ -148,7 +145,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`type`</td>
           <td> String </td>
-          <td>Yes</td>
           <td>
             The `type` argument provides a further distinction for a change event and is used in conjunction with the `category`. For example, if an event's `category` is `Deployment`, its type might be `Rolling`.
 
@@ -172,7 +168,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <th style={{ width: "220px" }}>Argument</th>
           <th>Datatype</th>
-          <th>Required?</th>
           <th>Description</th>
         </tr>
       </thead>
@@ -180,7 +175,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`dataHandlingRules`</td>
           <td>Array of String</td>
-          <td> No </td>
           <td>
             The `dataHandlingRules` field, , which includes the `validationFlags` subfield, defines how the API handles validation failures. The `validationFlags` field accepts an array of the following values:
             * `ALLOW_CUSTOM_CATEGORY_OR_TYPE`: Required for custom or non-standard `category` and `type` combinations. Without this flag, New Relic returns an error if values don't exactly match predefined standards. For example, pairing the standard category `Deployment` with a custom type like `Rainbow` requires this flag.
@@ -192,44 +186,37 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`featureFlagId`</td>
           <td>String</td>
-          <td> No </td>
           <td>If you select `Feature Flag` as your category, under the `categoryFields` argument, you must also select `featureFlag` and include a `featureFlagId`. This `featureFlagId` can be any string you would like to identify your feature flag by.</td>
         </tr>
 
         <tr>
           <td>`version`</td>
           <td> String </td>
-          <td> No </td>
           <td> If the `category` argument is set to `Deployment`, then within the `categoryFields`, you must define `deployment` and ensure this `deployment` argument includes a `version`.</td>
         </tr>
         <tr>
           <td>`changelog`</td>
           <td>String</td>
-          <td>No</td>
           <td>If the `category` is set to `Deployment`, then you can optionally include `changelog` information.</td>
         </tr>
         <tr>
           <td>`commit`</td>
           <td>String</td>
-          <td>No</td>
           <td>If the `category` is set to `Deployment`, then you can optionally include `commit` information such as a commit SHA.</td>
         </tr>
         <tr>
           <td>`deepLink`</td>
           <td>String</td>
-          <td>No</td>
           <td>If the `category` is set to `Deployment`, then you can optionally include `deepLink` such as a URL. </td>
         </tr>
         <tr>
           <td>`description`</td>
           <td>String</td>
-          <td>No</td>
           <td>A description for the change tracking event. For example: `A change event to track the marketing campaign impact.`</td>
         </tr>
         <tr>
           <td>`groupId`</td>
           <td>String</td>
-          <td>No</td>
           <td>
           A `groupId` attribute lets you organize the related changes across one or more entities. By using the same `groupId` for each related change, you can easily view these changes together in New Relic interfaces or refine query results. You can also use the same `groupId` to add changes to an existing group.
 
@@ -241,7 +228,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`shortDescription`</td>
           <td>String</td>
-          <td>No</td>
           <td>
           A short description for each change lets you identify the change events sent to New Relic quickly. If left blank, an autogenerated description is created that includes the entity, user, and version. The short description appears in the following areas:
 
@@ -259,7 +245,6 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
         <tr>
           <td>`user`</td>
           <td>String</td>
-          <td>No</td>
           <td>User identification or a valid email address. For example, user: `datanerd@example.com`.</td>
         </tr>
       </tbody>


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?

This PR splits the section on attributes into 2 sections: Required attributes and Optional attributes. This makes for quicker reference to the required attributes, to more quickly enable users to start sending data. 

I updated the text reference to change tracking events to a link to the event dictionary entry. 

* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.

I have an internal ticket. 

* If your issue relates to an existing GitHub issue, please link to it.

NA 