### PR TITLE
docs(mssql): add DatabaseName field to metrics table

### DIFF
--- a/src/install/microsoft-sql/whatsNext.mdx
+++ b/src/install/microsoft-sql/whatsNext.mdx
@@ -1358,6 +1358,10 @@ The Microsoft SQL Server integration collects both metrics and inventory informa
                 <td>The unique identifier for the query plan.</td>
             </tr>
             <tr>
+                <td> `DatabaseName`</td>
+                <td>The name of the database.</td>
+            </tr>
+            <tr>
                 <td>`NodeId`</td>
                 <td>The ID of the node in the execution plan.</td>
             </tr>


### PR DESCRIPTION
## Description
Added missing `DatabaseName` field documentation to the Microsoft SQL Server integration metrics reference table.

## Changes
- Added `DatabaseName` field entry in the metrics table
- Included field description: "The name of the database."