### PR TITLE
docs(notebooks): update permissions model with roles and CRUD capabilities

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -152,14 +152,37 @@ Every notebook is a resource that belongs to the organization in which it was cr
 
 ### Current permissions model
 
+New Relic Notebooks uses custom roles with CRUD capabilities to control access. There are two levels of access: organization-level (set by an admin) and notebook-level (set per notebook by its creator).
+
+#### Organization-level permissions
+
+These are granted via custom roles in the New Relic admin UI.
+
+| Role | Capabilities | What it allows |
+|------|-------------|----------------|
+| **Full access** | `notebooks.create.notebook`<br />`notebooks.read.notebook`<br />`notebooks.update.notebook`<br />`notebooks.delete.notebook` | Create, read, edit, and delete any notebook in the org |
+| **Creator** | `notebooks.create.notebook` | Create new notebooks (own notebooks only) |
+
 <Callout variant="tip">
-  Notebooks currently do not have granular permission settings. Anyone in the organization who has access to the feature can create new notebooks, edit and delete existing ones.
+  For Fine Grain Access control to work, users should be given the Creator role at the org level. Read, update, and delete access is then granted per individual notebook.
 </Callout>
 
-**Current capabilities:**
-* All organization members with notebooks access can view all notebooks
-* All organization members with notebooks access can create, edit, and delete any notebook
-* Notebooks are automatically shared across your entire organization
+#### Notebook-level roles
+
+These are assigned on a specific notebook, typically by the notebook's creator.
+
+| Role | Permission | What it allows |
+|------|-----------|----------------|
+| **Owner** | `notebook_owner` | Read, edit, delete, and manage permissions — automatically assigned to the creator |
+| **Editor** | `notebook_editor` | Edit the notebook |
+| **Reader** | `notebook_reader` | View the notebook (read-only) |
+
+#### How it works together
+
+1. An admin gives a user the **Creator** org-level role — this lets them create notebooks.
+2. When a user creates a notebook, they automatically become its **Owner**.
+3. The owner can then share the notebook with others by granting them **Editor** or **Reader** roles on that specific notebook.
+4. Users who need access to all notebooks org-wide (for example, admins) get the **Full access** role instead.
 
 
 ## What's next?


### PR DESCRIPTION
## Summary
- Replaces the outdated flat permissions callout in the `introduction-notebooks.mdx` article with the full roles and permissions model
- Adds org-level permissions table (Full access / Creator roles with capability strings)
- Adds notebook-level roles table (Owner / Editor / Reader)
- Adds "How it works together" numbered walkthrough

