### PR TITLE
refactor(net-agent): align .NET nav with PHP/Java IA pattern and split config

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-ai-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-ai-monitoring-settings.mdx
@@ -1,0 +1,105 @@
+---
+title: .NET agent AI monitoring settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent AI monitoring settings in newrelic.config: enable AI monitoring, configure content recording, and code level metrics.'
+freshnessValidatedDate: never
+---
+
+AI monitoring settings configure how the .NET agent monitors LLM interactions and records model input/output content.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Code level metrics [#code_level_metrics]
+
+The `codeLevelMetrics` element is a child of the `configuration` element. Use `codeLevelMetrics` to enable code level metrics support in CodeStream via additional instrumented method metadata captured as attributes on span events.
+
+For more details, see our documentation for [New Relic CodeStream integration](/docs/apm/agents/net-agent/other-features/net-codestream-integration).
+
+```xml
+<codeLevelMetrics enabled="true" />
+```
+
+This can also be configured via environment variable:
+
+```ini
+NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
+```
+
+## Cloud provider metadata [#cloud]
+
+The `cloud` element is a child of the `configuration` element. Use `cloud` to configure cloud provider metadata for your application.
+
+The `cloud` element supports the following sub-elements:
+
+<CollapserGroup>
+  <Collapser
+    id="cloud-aws"
+    title="aws"
+  >
+    Use this sub-element to configure AWS account ID for your application.
+
+    <Callout variant="important">
+      Note that this configuration is not normally required, as the agent will automatically detect the AWS account ID at runtime. If automatic detection is not working, the agent will fall back to the value configured here.
+    </Callout>
+
+    ```xml
+    <cloud>
+      <aws accountId="123456789012" />
+    </cloud>
+    ```
+
+    This can also be configured via environment variable:
+
+    ```ini
+    NEW_RELIC_CLOUD_AWS_ACCOUNT_ID=123456789012
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## AI monitoring [#ai_monitoring]
+
+By default, AI monitoring is disabled. To enable AI monitoring, set the `enabled` attribute to `true` in the `aiMonitoring` element. The `aiMonitoring` element is a child of the `configuration` element.
+
+<Callout variant="important">
+  When enabled, AI Monitoring will record a streaming copy of inputs and outputs sent to and from the models you choose to monitor, including any personal information contained therein. When using AI Monitoring, you are responsible for obtaining consent from your model users that their interactions may be recorded by a third party (New Relic) for the purpose of providing the AI Monitoring feature.
+</Callout>
+
+```xml
+<aiMonitoring enabled="true" />
+```
+
+This can also be configured via environment variable:
+
+```ini
+NEW_RELIC_AI_MONITORING_ENABLED=true
+```
+
+The `aiMonitoring` element supports the following sub-elements:
+
+<CollapserGroup>
+  <Collapser
+    id="aiMonitoring_recordContent"
+    title="recordContent"
+  >
+    Use this sub-element to enable all input and output for LLM events to be sent to New Relic. The default value of attribute `enabled` is `true`. Content recording is disabled in High Security Mode.
+
+    Note that if content recording is disabled, LLM token counting must be provided by the customer, by calling the [`SetLlmTokenCountingCallback` API](/docs/agents/net-agent/net-agent-api/setllmtokencountingcallback-net-agent-api). If this callback is not provided, the agent will not be able to provide LLM token counting.
+
+    ```xml
+    <aiMonitoring enabled="true">
+      <recordContent enabled="false" />
+    </aiMonitoring>
+    ```
+
+    This can also be configured via environment variable:
+
+    ```ini
+    NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=false
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-browser-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-browser-monitoring-settings.mdx
@@ -1,0 +1,181 @@
+---
+title: .NET agent browser monitoring settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent browser monitoring settings in newrelic.config: configure auto-instrumentation, request path exclusions, and HTTP request header capture.'
+freshnessValidatedDate: never
+---
+
+Browser monitoring settings configure how the .NET agent injects browser agent JavaScript into your web pages and captures HTTP request headers.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Browser instrumentation [#browser_monitoring]
+
+The `browserMonitoring` element is a child of the `configuration` element. `browserMonitoring` configures <InlinePopover type="browser"/> in your .NET application. Browser gives you insight your end users' performance experience. This is accomplished by measuring the time it takes for your users' browsers to download and render your webpages by injecting a small amount of JavaScript code into the header and footer of each page.
+
+```xml
+// If you use both the Exclude and Attribute elements
+// the Exclude element must be listed first.
+<browserMonitoring autoInstrument="true">
+  <requestPathsExcluded>
+    <path regex="url-regex-1"/>
+    <path regex="url-regex-2"/>
+    ...
+    <path regex="url-regex-n"/>
+  </requestPathsExcluded>
+  <attributes enabled="true">
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
+  </attributes>
+</browserMonitoring>
+```
+
+The `browserMonitoring` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="browsermon-autoInstrument"
+    title="autoInstrument"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    By default the agent automatically injects the browser agent JavaScript. To turn off automatic injection, set this attribute to `false`.
+  </Collapser>
+
+  <Collapser
+    id="browser-attributes"
+    title="attributes"
+  >
+    Use this sub-element to customize your agent attribute settings for [browser monitoring](/docs/browser/new-relic-browser/page-load-timing/instrumentation-page-load-timing). This sub-element uses the same settings as the primary `attributes` element: [`enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-enabled), [`include`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-include), and [`exclude`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-exclude).
+  </Collapser>
+
+  <Collapser
+    id="browser-path-exclusion"
+    title="requestPathsExcluded"
+  >
+    Use this sub-element to prevent the browser agent from being injected in specific pages. The element is used as follows:
+
+    ```xml
+    <requestPathsExcluded>
+      <path regex="url-regex-1"/>
+      <path regex="url-regex-2"/>
+      ...
+      <path regex="url-regex-n"/>
+    </requestPathsExcluded>
+    ```
+
+    The agent will not inject the browser agent into pages whose URL matches one of the specified regular expressions. The regular expression should follow [Microsoft guidelines for the Regex class](https://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regex(v=vs.110).aspx).
+
+    It is a reference to the virtual directory of the path in your application and not the full URL of the path you wish to exclude. For example, to exclude the pages in `https://www.mywebsite.com/mywebpages/` you would simply insert `/mywebpages/` as the path regex value.
+
+    The `requestPathsExcluded` element should be used in cases where it is impossible or undesirable to use the [`DisableBrowserMonitoring()`](/docs/agents/net-agent/net-agent-api/disablebrowsermonitoring-net-agent) call. To minimize a possible performance impact try to use as few regular expressions as possible and keep them as simple as possible.
+  </Collapser>
+</CollapserGroup>
+
+Browser instrumentation can also be enabled or disabled via an environment variable:
+
+```ini
+NEW_RELIC_BROWSER_MONITORING_AUTO_INSTRUMENT= true | 1 | false | 0
+```
+
+## Capture HTTP request headers [#capture_http_request_headers]
+
+The `allowAllHeaders` element is a child of the `configuration` element. Set this to `true` to allow the .NET Agent to capture all HTTP request headers and apply them to `Span` and `Transaction` events as `request.headers.{http-header-name}` attributes. Set this to `false` to only allow the .NET agent to collect the following HTTP request headers:
+
+* `request.headers.referer`
+* `request.headers.accept`
+* `request.headers.content-length`
+* `request.headers.host`
+* `request.headers.user-agent`
+
+<CollapserGroup>
+  <Collapser
+    id="allow-all-headers-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable HTTP request headers capture. Example:
+
+    ```xml
+    <allowAllHeaders enabled="true" />
+    <attributes enabled="true">
+       <include>request.headers.*</include>
+    </attributes>
+    ```
+
+    Alternatively, set the `NEW_RELIC_ALLOW_ALL_HEADERS` environment variable in the application's environment.
+  </Collapser>
+</CollapserGroup>
+
+<Callout variant="important">
+  The `allowAllHeaders` setting is only available in the .NET Agent version 8.40.0+. When using `allowAllHeaders` to capture attributes, the captured request header attributes are still being controlled by the root level and destination level [attributes](/docs/agents/net-agent/configuration/net-agent-configuration/#agent-attributes) settings. Without setting the `request.header.*` in the `include` list under the `attributes` element, the .NET Agent still filters out all header attributes. The default `newrelic.config` is set to include the `request.header.*`.
+
+  ```xml
+  <allowAllHeaders enabled="true" />
+  <attributes enabled="true">
+    <include>request.headers.*</include>
+    ...
+  </attributes>
+  ```
+
+  The default `newrelic.config` is also set to explicitly exclude the following HTTP request headers to prevent the .NET Agent collecting unwanted data.
+
+  ```xml
+  <attributes enabled="true">
+    <exclude>request.headers.cookie</exclude>
+    <exclude>request.headers.authorization</exclude>
+    <exclude>request.headers.proxy-authorization</exclude>
+    <exclude>request.headers.x-*</exclude>
+  </attributes>
+  ```
+</Callout>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-cloud-platform-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-cloud-platform-settings.mdx
@@ -1,0 +1,251 @@
+---
+title: .NET agent cloud platform settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent cloud platform utilization settings in newrelic.config: configure AWS, Azure, GCP, PCF, Docker, and Kubernetes detection.'
+freshnessValidatedDate: never
+---
+
+Cloud platform settings control how the .NET agent collects utilization information from cloud providers and container environments, which is used to determine pricing and infrastructure context.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Cloud platform utilization [#cloud-platform-util]
+
+The `utilization` configuration element controls how the agent collects utilization information and sends it to the New Relic service to determine pricing. The agent can collect information from Amazon Web Services (AWS) EC2 instances, Docker containers, Microsoft Azure, Google Cloud Platform, Pivotal Cloud Foundry, and Kubernetes.
+
+```xml
+<configuration . . . >
+  <utilization detectAws="true" detectAzure="true" detectGcp="true" detectPcf="true" detectDocker="true" detectKubernetes="true" />
+</configuration>
+```
+
+The `utilization` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="detectAws"
+    title="detectAws"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the agent polls AWS metadata API.
+
+    Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_AWS` environment variable:
+
+    ```ini
+    NEW_RELIC_UTILIZATION_DETECT_AWS=false
+    ```
+  </Collapser>
+
+  <Collapser
+    id="detectAzure"
+    title="detectAzure"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the agent polls Microsoft Azure metadata API.
+
+    Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_AZURE` environment variable:
+
+    ```ini
+    NEW_RELIC_UTILIZATION_DETECT_AZURE=false
+    ```
+  </Collapser>
+
+  <Collapser
+    id="detectGcp"
+    title="detectGcp"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the agent polls GCP metadata API.
+
+    Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_GCP` environment variable:
+
+    ```ini
+    NEW_RELIC_UTILIZATION_DETECT_GCP=false
+    ```
+  </Collapser>
+
+  <Collapser
+    id="detectPcf"
+    title="detectPcf"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the agent polls PCF information from environment variables.
+
+    Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_PCF` environment variable:
+
+    ```ini
+    NEW_RELIC_UTILIZATION_DETECT_PCF=false
+    ```
+  </Collapser>
+
+  <Collapser
+    id="detectDocker"
+    title="detectDocker"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the agent reads Docker information from the file system.
+
+    Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_DOCKER` environment variable:
+
+    ```ini
+    NEW_RELIC_UTILIZATION_DETECT_DOCKER=false
+    ```
+  </Collapser>
+
+  <Collapser
+    id="detectKubernetes"
+    title="detectKubernetes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the agent polls Kubernetes information from environment variables.
+
+    Alternatively, this behavior can be controlled via the `NEW_RELIC_UTILIZATION_DETECT_KUBERNETES` environment variable:
+
+    ```ini
+    NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=false
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-distributed-tracing-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-distributed-tracing-settings.mdx
@@ -1,0 +1,473 @@
+---
+title: .NET agent distributed tracing settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent distributed tracing settings in newrelic.config: enable distributed tracing, configure Infinite Tracing, sampler types, and span events.'
+freshnessValidatedDate: never
+---
+
+Distributed tracing settings configure how the .NET agent tracks requests across distributed systems, including sampler configuration, Infinite Tracing, cross-application tracing, and span events.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Distributed tracing [#distributed_tracing]
+
+The `distributedTracing` element is a child of the `configuration` element.
+
+```xml
+<distributedTracing enabled="true"
+   excludeNewrelicHeader="false"/>
+```
+
+Distributed tracing lets you see the path that a request takes as it travels through a distributed system. It requires [.NET agent version 8.6.45.0 or higher](/docs/agents/net-agent/installation/update-net-agent) and is enabled by default in .NET agents 9.0.0.0 and higher.
+
+<Callout variant="important">
+  Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) disables [cross application tracing](#cross_application_tracer), and has other effects on APM features. Before enabling, read the [planning guide](/docs/transition-guide-distributed-tracing).
+</Callout>
+
+For more information about setting up distributed tracing, see [Enable distributed tracing for your .NET applications](/docs/apm/agents/net-agent/configuration/distributed-tracing-net-agent).
+
+The `distributedTracing` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="dt-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Alternatively, enable distributed tracing via the `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
+    ```
+  </Collapser>
+
+  <Collapser
+    id="excludeNewrelicHeader"
+    title="excludeNewrelicHeader"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    By default, supported versions of the agent utilize both the `newrelic` header and [W3C Trace Context](/docs/understand-dependencies/distributed-tracing/get-started/how-new-relic-distributed-tracing-works#headers) headers for distributed tracing. The `newrelic` distributed tracing header allows interoperability with older agents that don't support W3C Trace Context headers. Agent versions that support W3C Trace Context headers will prioritize them over `newrelic` headers for distributed tracing.
+
+    If you do not want to utilize the `newrelic` header, setting this to `true` will result in the agent excluding the `newrelic` header and only using W3C Trace Context headers for distributed tracing.
+  </Collapser>
+</CollapserGroup>
+
+### Sampler configuration
+
+<Callout variant="important">
+  Sampler configuration is available starting with .NET agent version 10.45.0.
+</Callout>
+
+The .NET agent currently supports 4 different sampling algorithms that can be configured for use in distributed tracing:
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        <DNT>
+          **Sampler Type**
+        </DNT>
+      </th>
+
+      <th>
+        <DNT>
+          **Description**
+        </DNT>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        **Adaptive Sampler**
+      </td>
+      <td>
+        The original sampling algorithm used by the .NET agent and is enabled by default. Sampling decisions are made at random, with the goal of retaining a configured number of samples per sampling period.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        **Trace Id Ratio Based Sampler**
+      </td>
+      <td>
+        An implementation of the Open Telemetry Trace Id Ratio Based Sampler which samples a configured percentage of traces based on the (randomly generated) Trace Id.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        **Always On Sampler**
+      </td>
+      <td>
+        As the name implies, this sampler will sample every trace. Note that enabling this sampler can have an impact on application performance and will result in increased data ingest.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        **Always Off Sampler**
+      </td>
+      <td>
+        The opposite of Always On; this sampler does not sample any traces. Useful in very specific cases.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+The supported samplers can be configured at multiple levels:
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        <DNT>
+          **Sampler Level**
+        </DNT>
+      </th>
+
+      <th>
+        <DNT>
+          **Description**
+        </DNT>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        **Root**
+      </td>
+      <td>
+        This is the sampler that is applied at the beginning of a trace. By default, the Adaptive Sampler is configured as the Root sampler.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        **Remote Parent Sampled**
+      </td>
+      <td>
+        This is the sampler that is applied when the trace has a remote parent (i.e., the trace originated in an upstream service) that has been sampled.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        **Remote Parent Not Sampled**
+      </td>
+      <td>
+        This is the sampler that is applied when a trace has a remote parent (i.e., the trace originated in an upstream service) that was NOT sampled.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+The `<sampler>` configuration element is a child of the `<distributedTracing>` element and is structured as follows:
+
+```xml
+<distributedTracing ... >
+  <sampler>
+    <root>
+      <!-- sampler type -->
+    </root>
+    <remoteParentSampled>
+      <!-- sampler type -->
+    </remoteParentSampled>
+    <remoteParentNotSampled>
+      <!-- sampler type -->
+    </remoteParentNotSampled>
+  </sampler>
+</distributedTracing>
+```
+
+For each of the sampler levels, one of the following sampler configurations can be specified:
+
+```xml
+<default /> <!-- default is a synonym for <adaptive /> -->
+<adaptive />
+<traceIdRatioBased ratio="0.12" />
+<alwaysOn />
+<alwaysOff />
+```
+
+The `<traceIdRatioBased>` element has a required `ratio` attribute, which is a value between `0.0` and `1.0` specifying the percentage of traces that should be sampled.
+
+<Callout variant="important">
+  The **Adaptive Sampler** will be used if there is no configuration specified at a particular sampler level or if the configuration element for that level is not specified at all.
+</Callout>
+
+The following environment variables can be used to configure the distributed trace sampler at the various sampler levels:
+
+```ini
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT = default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED =  default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED = default | adaptive | traceIdRatioBased | alwaysOn | alwaysOff
+```
+
+If `traceIdRatioBased` is specified as the value of one these environment variables, a corresponding environment variable to specify the ratio is also required:
+
+```ini
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO = 0.12
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO = 0.12
+NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO = 0.12
+```
+
+### Span event reporting
+
+Distributed tracing reports span events. Span event reporting is enabled by default, but [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing) must be enabled for spans to be reported. To disable span events, choose one of the following options:
+
+<CollapserGroup>
+  <Collapser
+    id="span-events-disable-config"
+    title="Disable span events via config file"
+  >
+    Set the `<spanEvents>` element to `false` to disable via the `newrelic.config` file. This element is a child of the `<configuration>` element.
+
+    ```xml
+    <configuration . . . >
+      <spanEvents enabled="false" />
+    </configuration>
+    ```
+  </Collapser>
+
+  <Collapser
+    id="span-events-disable-env_variable"
+    title="Disable span events via environment variable"
+  >
+    Set the `NEW_RELIC_SPAN_EVENTS_ENABLED` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_SPAN_EVENTS_ENABLED=false
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Infinite Tracing [#infinite_tracing]
+
+[Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing) extends the distributed tracing service by employing a trace observer that is external to the agent. It observes 100% of your application traces across various services and provides actionable data so you can solve issues faster.
+
+To turn on [Infinite Tracing](/docs/distributed-tracing/infinite-tracing/introduction-infinite-tracing), make sure you have [.NET agent version 8.30 or higher](/docs/release-notes/agent-release-notes/net-release-notes), and enable distributed tracing. Then add the following additional settings:
+
+```xml
+<configuration . . . >
+  <distributedTracing enabled="true" />
+  <infiniteTracing>
+    <trace_observer host="YOUR_TRACE_OBSERVER_HOST" />
+  </infiniteTracing>
+</configuration>
+```
+
+<Callout variant="important">
+  Infinite Tracing spans can be limited by the [`transactionTracer.maxSegments`](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#tracer-maxSegments) setting.
+</Callout>
+
+The `infiniteTracing` element supports the following elements:
+
+<CollapserGroup>
+  <Collapser
+    id="trace_observer"
+    title="trace_observer"
+  >
+    The `trace_observer` element identifies an observer host that is independent from the agent. For help getting a valid Infinite Tracing trace observer host entry, see [Find or create a trace observer endpoint](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer).
+
+    The trace observer may be configured using the `NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST` environment variable as well.
+
+    <Callout variant="important">
+      When configuring the trace observer, you should not supply the protocol as part of the host. For example, use `myhost.infinitetracing.com` instead of `https://myhost.infinitetracing.com`.
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+
+## Cross application traces [#cross_application_tracer]
+
+The `crossApplicationTracer` element is a child of the `configuration` element. `crossApplicationTracer` links transaction traces across applications in a service-oriented architecture.
+
+<Callout variant="important">
+  Cross application tracing has been deprecated as of [v9.0.0 of the agent](/docs/release-notes/agent-release-notes/net-release-notes/net-agent-9000/) and disabled by default. It will be removed in a future agent version. To use CAT with v9+ of the agent you must set both `crossApplicationTracer.enabled = true` and `distributedTracing.enabled = false`. Enabling [distributed tracing](/docs/understand-dependencies/distributed-tracing/get-started/introduction-distributed-tracing) will disable [cross application tracing](#cross_application_tracer).
+</Callout>
+
+```xml
+<crossApplicationTracer enabled="true"/>
+```
+
+The `crossApplicationTracer` element supports the following attribute:
+
+<CollapserGroup>
+  <Collapser
+    id="catracer-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable cross application tracing.
+  </Collapser>
+</CollapserGroup>
+
+## Span events
+
+The `spanEvents` element is a child of the `configuration` element. Use `spanEvents` to configure span events.
+
+```xml
+<spanEvents enabled="true">
+  <attributes enabled="true">
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
+  </attributes>
+</spanEvents>
+```
+
+The `spanEvents` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="span-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the event recorder.
+  </Collapser>
+
+  <Collapser
+    id="span-max-samples-stored"
+    title="maximumSamplesStored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Int
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `2000`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The maximum number of sampled span events the agent can store in memory at a time. This will be the maximum number of span events the agent can send per minute.
+
+    * This may be configured using the `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED` environment variable as well.
+    * We do not recommend configuring past 10k. The server will cap data at 10k per-minute.
+    * If you're configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring/), we recommend setting the value to `10000`.
+
+      <Callout variant="important">
+        This configuration option is only available in the .NET Agent v9.0 or higher.
+      </Callout>
+  </Collapser>
+
+  <Collapser
+    id="span-attributes"
+    title="attributes"
+  >
+    Use this sub-element to customize your agent attribute settings for span events. This sub-element uses the same settings as the primary `attributes` element: [`enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-enabled), [`include`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-include), and [`exclude`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-exclude).
+
+    <Callout variant="tip">
+      These attribute settings are specific to span events. Attribute settings may be applied globally to all event types with [the attributes configuration setting](/docs/agents/net-agent/configuration/net-agent-configuration#agent-attributes).
+    </Callout>
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-environment-variables.mdx
@@ -1,0 +1,184 @@
+---
+title: .NET agent environment variables
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: 'Required and optional .NET agent environment variables, including CLR profiler variables, optional config overrides, and errors inbox metadata.'
+freshnessValidatedDate: never
+---
+
+The .NET agent uses environment variables to activate the CLR profiler, and to override configuration file settings.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Required environment variables [#environment-variables]
+
+Our .NET agent relies on environment variables to tell the .NET Common Language Runtime (CLR) to attach New Relic to your processes. Some [.NET agent install procedures](/docs/agents/net-agent/installation/new-relic-net-agent-install-introduction) (like the MSI installer) will automatically set these variables for you; some procedures will require you to manually set them.
+
+<Callout variant="caution">
+  Security recommendation: You should consider what users can set system environment variables. You should also secure the accounts under which your applications execute to prevent user environment variables overriding system environment variables.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="net-framework-env-variables"
+    title=".NET Framework environment variables"
+  >
+    For .NET Framework, the following variables are required:
+
+    ```ini
+    COR_ENABLE_PROFILING=1
+    COR_PROFILER={71DA0A04-7777-4EC6-9643-7D28B46A8A41}
+    NEWRELIC_INSTALL_PATH="INSERT_THE_PATH_TO_THE_AGENT_DIRECTORY"
+    ```
+
+    The Windows .NET agent installer (.msi) will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`.
+
+    When using the Windows .NET agent installer, ensure that `NEWRELIC_INSTALL_PATH` is set to `C:\Program Files\New Relic\.NET Agent\`. This is where the agent DLLs are placed on the system.
+
+    For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
+
+    When installing the agent via the Nuget package, the agent requires [a different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-framework).
+  </Collapser>
+
+  <Collapser
+    id="net-core-env-variables"
+    title=".NET Core environment variables"
+  >
+    For .NET Core, the following variables are required:
+
+    <DNT>
+      **Linux:**
+    </DNT>
+
+    ```ini
+    CORECLR_ENABLE_PROFILING=1
+    CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+    CORECLR_NEWRELIC_HOME=path/to/agent/directory
+    CORECLR_PROFILER_PATH="${CORECLR_NEWRELIC_HOME}/libNewRelicProfiler.so"
+    ```
+
+    <DNT>
+      **Windows (MSI Installer):**
+    </DNT>
+
+    ```ini
+    CORECLR_ENABLE_PROFILING=1
+    CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
+    NEWRELIC_INSTALL_PATH=C:\Program Files\New Relic\.NET Agent\
+    CORECLR_NEWRELIC_HOME=C:\ProgramData\New Relic\.NET Agent\
+    ```
+
+    The Windows .NET agent installer will add these to IIS by default, or as system-wide environment variables when enabling `Instrument All`. Exception: `CORECLR_ENABLE_PROFILING` needs to be set manually in order to instrument non-IIS hosted .NET Core applications.
+
+    For more details on these variables, as well as correct values for other installation scenarios, please see [understanding .NET agent environment variables](/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables/).
+
+    When installing the agent via the Nuget package in Windows, the agent requires a [different set of environment variables](/docs/apm/agents/net-agent/install-guides/install-net-agent-using-nuget/#nuget-windows).
+  </Collapser>
+</CollapserGroup>
+
+If your system has previously used monitoring services (non-New Relic), you may have a "profiler conflict" when trying to install and use the New Relic agent. More details:
+
+<CollapserGroup>
+  <Collapser
+    id="profiler-conflicts"
+    title="Profiler conflict explanation"
+  >
+    New Relic's .NET agents rely on environment variables to tell the .NET Common Language Runtime (CLR) to load New Relic into your processes. The install-related environment variables are Microsoft variables, not New Relic variables. They can be used by other .NET profilers, and only one profiler can be attached to a process at a time. For this reason, if you have used previous application monitoring products, you may have [profiler conflicts](/docs/agents/net-agent/troubleshooting/profiler-conflicts).
+  </Collapser>
+</CollapserGroup>
+
+For specific install instructions, see the [.NET agent install documentation](/docs/agents/net-agent/installation/new-relic-net-agent-install-introduction).
+
+## Optional environment variables [#optional-environment-variables]
+
+Some configuration options in New Relic's .NET agent can be set via environment variables as an alternative to setting them in a config file. Below is a list of environment variables recognized by the .NET agent with example values.
+
+```ini
+NEW_RELIC_LICENSE_KEY=YOUR_LICENSE_KEY
+NEW_RELIC_APP_NAME=Descriptive Name
+MAX_TRANSACTION_SAMPLES_STORED=500
+MAX_EVENT_SAMPLES_STORED=500
+NEW_RELIC_DISTRIBUTED_TRACING_ENABLED=true
+NEW_RELIC_SPAN_EVENTS_ENABLED=false
+NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED=2000
+NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST=myhost.infinitetracing.com
+NEW_RELIC_LABELS="foo:bar;zip:zap"
+NEW_RELIC_PROCESS_HOST_DISPLAY_NAME=Custom Name
+NEW_RELIC_HOST=gov-collector.newrelic.com
+NEW_RELIC_PROXY_HOST=hostname
+NEW_RELIC_PROXY_URI_PATH=path/to/something.aspx
+NEW_RELIC_PROXY_PORT=5000
+NEW_RELIC_PROXY_USER=YOUR_USER_NAME
+NEW_RELIC_PROXY_PASS=YOUR_PROXY_PASSWORD
+NEW_RELIC_PROXY_DOMAIN=mydomain.com
+NEW_RELIC_PROXY_PASS_OBFUSCATED=YOUR_OBFUSCATED_PROXY_PASSWORD
+NEW_RELIC_CONFIG_OBSCURING_KEY=YOUR_OBSCURING_KEY
+NEW_RELIC_SEND_DATA_ON_EXIT=true
+NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=2000
+NEW_RELIC_HIGH_SECURITY=true
+NEW_RELIC_DISABLE_SAMPLERS=true
+NEW_RELIC_LOG=MyApp.log
+NEW_RELIC_LOG_ENABLED=true
+NEWRELIC_LOG_LEVEL=info
+NEW_RELIC_LOG_CONSOLE=true
+NEWRELIC_PROFILER_LOG_DIRECTORY=path\to\a\directory # not configurable via config file
+NEWRELIC_LOG_DIRECTORY=path\to\a\directory # Insert a directory where you want to put the agent and profiler logs. You can't set this directory for both agent and profiler logs in the configuration file.
+NEW_RELIC_LOG_ROLLING_STRATEGY=day
+NEW_RELIC_LOG_MAX_FILE_SIZE_MB=100
+NEW_RELIC_LOG_MAX_FILES=2
+NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=401, 403.18
+NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES=401, 501-503
+NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE="myCustomAttribute1, myOtherCustomAttribute*"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE="myCustomAttribute2, myOtherCustomAttributeMoreSpecificName"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST="debug, warn"
+NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=true
+NEW_RELIC_ALLOW_ALL_HEADERS=true
+NEW_RELIC_ATTRIBUTES_ENABLED=true
+NEW_RELIC_ATTRIBUTES_INCLUDE=request.headers.*,foo.bar
+NEW_RELIC_ATTRIBUTES_EXCLUDE=request.headers.cookie,request.headers.authorization
+NEW_RELIC_UTILIZATION_DETECT_AWS=true
+NEW_RELIC_UTILIZATION_DETECT_AZURE=true
+NEW_RELIC_UTILIZATION_DETECT_GCP=true
+NEW_RELIC_UTILIZATION_DETECT_PCF=true
+NEW_RELIC_UTILIZATION_DETECT_DOCKER=true
+NEW_RELIC_UTILIZATION_DETECT_KUBERNETES=true
+NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=true
+NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
+NEW_RELIC_AI_MONITORING_ENABLED=true
+NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=true
+NEW_RELIC_CLOUD_AWS_ACCOUNT_ID=123456789012
+```
+
+<CollapserGroup>
+  <Collapser
+    id="net-framework-32on64-env-variables"
+    title="Supporting 32-bit applications on 64-bit systems"
+  >
+    The 64-bit MSI installer for New Relic's .NET agent automatically installs the 32-bit profiler assembly along with the 64-bit assembly and as of v10.16.0, enables 32-bit support for IIS automatically. For non-IIS hosted applications, you can set the required environment variable manually.
+
+    ```ini
+    COR_PROFILER_PATH_32="C:\Program Files (x86)\New Relic\.NET Agent\NewRelic.Profiler.dll"
+    ```
+  </Collapser>
+</CollapserGroup>
+
+If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/observability/repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/observability/error-investigation/#buildsha).
+
+## Errors inbox configuration [#errors-inbox-configuration]
+
+Setting one of the following tags will help you identify which versions of your software are producing the errors.
+
+* `NEW_RELIC_METADATA_SERVICE_VERSION` will create tags.service.version on event data containing the version of your code that is deployed, in many cases a semantic version such as 1.2.3, but not always.
+* `NEW_RELIC_METADATA_RELEASE_TAG` will create tags.releaseTag on event data containing the release tag (such as v0.1.209 or release-209).
+* `NEW_RELIC_METADATA_COMMIT` will create tags.commit on event data containing the commit sha. The entire sha can be used or just the first seven characters (e.g., 734713b).
+
+An upcoming release of errors inbox will automatically track which versions of your software are producing errors. Any version data will also be displayed in [CodeStream](/docs/codestream/how-use-codestream/performance-monitoring/#buildsha).

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-error-collector-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-error-collector-settings.mdx
@@ -1,0 +1,278 @@
+---
+title: .NET agent error collector settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent error collector settings in newrelic.config: configure which exceptions to ignore, expect, and how error events are captured.'
+freshnessValidatedDate: never
+---
+
+Error collector settings configure how the .NET agent captures and reports uncaught exceptions, including which exceptions to ignore or mark as expected, and how error events are sampled.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Error collection [#error_collector]
+
+The `errorCollector` element is a child of the `configuration` element. `errorCollector` configures error collection, which captures information about uncaught exceptions and sends them to New Relic.
+
+```xml
+<errorCollector enabled="true" captureEvents="true" maxEventSamplesStored="100">
+  <ignoreClasses>
+    <errorClass>System.IO.FileNotFoundException</errorClass>
+    <errorClass>System.Threading.ThreadAbortException</errorClass>
+  </ignoreClasses>
+  <ignoreMessages>
+    <errorClass name="System.Exception">
+       <message>Ignore message</message>
+       <message>Ignore too</message>
+    </errorClass>
+  </ignoreMessages>
+  <ignoreStatusCodes>
+    <code>401</code>
+    <code>404</code>
+  </ignoreStatusCodes>
+  <expectedClasses>
+    <errorClass>System.ArgumentNullException</errorClass>
+    <errorClass>System.ArgumentOutOfRangeException</errorClass>
+  </expectedClasses>
+  <expectedMessages>
+    <errorClass name="System.Exception">
+       <message>Expected message</message>
+       <message>Expected too</message>
+    </errorClass>
+  </expectedMessages>
+  <expectedStatusCodes>403,500-505</expectedStatusCodes>
+  <attributes enabled="true">
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
+  </attributes>
+</errorCollector>
+```
+
+<Callout variant="tip">
+  For an overview of error configuration in APM, see [Manage errors in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected).
+</Callout>
+
+<Callout variant="important">
+  `expectedClasses`, `expectedMessages`, and `expectedStatusCodes` configuration settings require [.NET agent version 8.31.0.0 or higher](/docs/agents/net-agent/installation/update-net-agent).
+</Callout>
+
+The `errorCollector` element supports the following elements and attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="error-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the error collector.
+  </Collapser>
+
+  <Collapser
+    id="error-captureEvents"
+    title="captureEvents"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the capturing of error events.
+  </Collapser>
+
+  <Collapser
+    id="error-maxEventSamplesStored"
+    title="maxEventSamplesStored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `100`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Reservoir limit for error events.
+  </Collapser>
+
+  <Collapser
+    id="error-ignoreClasses"
+    title="ignoreClasses"
+  >
+    A list of fully qualified class names to be ignored. The maximum number of error class and message combinations that <DNT>**SHOULD**</DNT> be reported is 50. If more than 50 are listed, then only the first 50 <DNT>**SHOULD**</DNT> be used.
+  </Collapser>
+
+  <Collapser
+    id="error-ignoreMessages"
+    title="ignoreMessages"
+  >
+    An optional map of fully qualified class names to list of strings matching a substring of the message of an error. The maximum number of error class and message combinations that <DNT>**SHOULD**</DNT> be reported is 50. If more than 50 are listed, then only the first 50 <DNT>**SHOULD**</DNT> be used.
+  </Collapser>
+
+  <Collapser
+    id="error-ignoreErrors"
+    title="ignoreErrors (obsolete)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Lists specific exceptions to not report to New Relic. The full name of the exception should be used, such as `System.IO.FileNotFoundException`.
+  </Collapser>
+
+  <Collapser
+    id="error-ignoreStatusCodes"
+    title="ignoreStatusCodes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Lists specific HTTP error codes to not report to New Relic. You can use standard integral HTTP error codes, such as just `401`, or you may use Microsoft full status codes with decimal points, such as `401.4` or `403.18`. The status codes should be equal to or greater than `400`.
+
+    This can also be configured via environment variable, specifying multiple codes with a comma-separated list:
+
+    ```ini
+    NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES=401, 403.18
+    ```
+
+    <Callout variant="tip">
+      Custom errors reported with the agent's [`NoticeError()` API](/docs/agents/net-agent/net-agent-api/noticeerror-net-agent) are still reported to New Relic even if the associated transaction has an HTTP status code configured here.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="error-expectedClasses"
+    title="expectedClasses"
+  >
+    A list of fully qualified class names to be marked as expected. The maximum number of error class and message combinations that <DNT>**SHOULD**</DNT> be reported is 50. If more than 50 are listed, then only the first 50 <DNT>**SHOULD**</DNT> be used.
+  </Collapser>
+
+  <Collapser
+    id="error-expectedMessages"
+    title="expectedMessages"
+  >
+    An optional map of fully qualified class names to list of strings matching a substring of the message of an error. The maximum number of error class and message combinations that <DNT>**SHOULD**</DNT> be reported is 50. If more than 50 are listed, then only the first 50 <DNT>**SHOULD**</DNT> be used.
+  </Collapser>
+
+  <Collapser
+    id="error-expectedStatusCodes"
+    title="expectedStatusCodes"
+  >
+    A comma-separated list of status codes. The list may include integer ranges using a single dash (`-`), and will be inclusive of both the starting and ending integer in the range.
+
+    This can also be configured via environment variable:
+
+    ```ini
+    NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES=401, 501-503
+    ```
+  </Collapser>
+
+  <Collapser
+    id="error-attributes"
+    title="attributes"
+  >
+    Use this sub-element to customize your agent attribute settings for error traces. This sub-element uses the same settings as the primary `attributes` element: [`enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-enabled), [`include`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-include), and [`exclude`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-exclude).
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-general-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-general-settings.mdx
@@ -1,0 +1,1293 @@
+---
+title: .NET agent general settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent general settings in newrelic.config: service, proxy, log, application, and data transmission configuration options.'
+freshnessValidatedDate: never
+---
+
+General settings configure the core behavior of the .NET agent via the `newrelic.config` file, including the connection to New Relic, proxy settings, logging, application naming, and data transmission.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Setup options, newrelic.config [#setup]
+
+Use these options to setup and configure your agent via the `newrelic.config` file. The .NET agent supports the following categories of setup options:
+
+* [Configuration element](#configuration)
+* [Service element](#service)
+* [Obscuring key element](#obscuring-key)
+* [Proxy element](#proxy)
+* [Log element](#log)
+* [Application element (configuration)](#application-configuration)
+* [Data transmission element](#data-transmission)
+* [Host name](#host-name)
+
+### Configuration element [#configuration]
+
+The root element of the configuration document is a `configuration` element.
+
+```xml
+<configuration xmlns="urn:newrelic-config"
+  agentEnabled="true"
+  maxStackTraceLines="50">
+```
+
+The `configuration` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="config-agentEnabled"
+    title="agentEnabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the New Relic agent.
+  </Collapser>
+
+  <Collapser
+    id="config-maxStackTraceLines"
+    title="maxStackTraceLines"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `80`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The maximum number of stack frames to trace in any stack dump.
+  </Collapser>
+</CollapserGroup>
+
+### Service element [#service]
+
+The first child of the `configuration` element is a `service` element. The service element configures the agent's connection to the New Relic service.
+
+```xml
+<service licenseKey="YOUR_LICENSE_KEY"
+  sendEnvironmentInfo="true"
+  syncStartup="false"
+  sendDataOnExit="false"
+  sendDataOnExitThreshold="60000"
+  autoStart="true"/>
+```
+
+The `service` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="service-licenseKey"
+    title={<>licenseKey <strong>(required)</strong></>}
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Your New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key). New Relic uses the license key to match your app's data to the correct account in the UI. Set the license key via environment variable.
+
+    Alternatively, set the `NEW_RELIC_LICENSE_KEY` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_LICENSE_KEY=YOUR_LICENSE_KEY
+    ```
+  </Collapser>
+
+  <Collapser
+    id="service-sendEnvironmentInfo"
+    title="sendEnvironmentInfo"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Instructs the agent to record execution environment information. Environment information includes operating system, agent version, and which assemblies are available.
+  </Collapser>
+
+  <Collapser
+    id="service-syncStartup"
+    title="syncStartup"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Block application startup until the agent connects to New Relic. If set to `true`, the first transaction may take substantially longer to complete, because it is blocked until the connection to New Relic is finished.
+  </Collapser>
+
+  <Collapser
+    id="service-sendDataOnExit"
+    title="sendDataOnExit"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Block application shutdown while the agent initiates a final harvest cycle and sends all data to New Relic.
+
+    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_SEND_DATA_ON_EXIT=true
+    ```
+  </Collapser>
+
+  <Collapser
+    id="service-sendDataOnExitThreshold"
+    title="sendDataOnExitThreshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `60000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Unit
+          </th>
+
+          <td>
+            Milliseconds
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The minimum amount of time the process must run before the agent blocks it from shutting down. This setting only applies when [`sendDataOnExit`](#service-sendDataOnExit) is `true`.
+
+    Alternatively, set the `NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_SEND_DATA_ON_EXIT_THRESHOLD_MS=2000
+    ```
+  </Collapser>
+
+  <Collapser
+    id="service-completeTransactionsOnThread"
+    title="completeTransactionsOnThread"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `false`, the agent uses a pool thread to complete the transaction processing.
+
+    If true, the agent will complete transaction processing on the request thread.
+  </Collapser>
+
+  <Collapser
+    id="service-forceNewTransactionOnNewThread"
+    title="forceNewTransactionOnNewThread"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `false`, the agent attempts to re-use existing transactions when custom instrumented methods are encountered in async/threaded scenarios.
+
+    If `true`, the agent attempts to create new transactions when custom instrumented methods are encountered in async/threaded scenarios.
+
+    Alternatively, the `NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD` environment variable may be used to control this behavior.
+
+    ```ini
+    NEW_RELIC_FORCE_NEW_TRANSACTION_ON_NEW_THREAD=true
+    ```
+  </Collapser>
+
+  <Collapser
+    id="service-requestTimeout"
+    title="requestTimeout"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `2000` (with [`sendDataOnExit`](#service-sendDataOnExit) enabled)
+
+            `120000` (with [`sendDataOnExit`](#service-sendDataOnExit) disabled)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Unit
+          </th>
+
+          <td>
+            Milliseconds
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The agent's request timeout when communicating with New Relic.
+  </Collapser>
+
+  <Collapser
+    id="service-autoStart"
+    title="autoStart"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Automatically start the .NET agent when the first instrumented method is hit.
+  </Collapser>
+
+  <Collapser
+    id="service-host"
+    title="host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Provides the ability to configure a [FedRAMP compliant endpoint](/docs/security/security-privacy/compliance/fedramp-compliant-endpoints/) for the agent to use, with the value `gov-collector.newrelic.com`.
+
+    ```xml
+    <service licenseKey="YOUR_LICENSE_KEY"
+      host="gov-collector.newrelic.com" />
+    ```
+
+    You can also use the environment variable `NEW_RELIC_HOST`.
+
+    ```ini
+    NEW_RELIC_HOST=gov-collector.newrelic.com
+    ```
+  </Collapser>
+</CollapserGroup>
+
+### Obscuring key element [#obscuring-key]
+
+The `obscuringKey` element is an optional child of the `service` element. The .NET Agent uses this value to deobfuscate supported configuration values. For example, when an [obfuscated proxy password](#proxy-password) is supplied, it will be deobfuscated using this key.
+
+```xml
+<service licenseKey="YOUR_LICENSE_KEY">
+  <obscuringKey>OBSCURING_KEY</obscuringKey>
+</service>
+```
+
+The obscuring key may also be configured by setting the `NEW_RELIC_CONFIG_OBSCURING_KEY` environment variable.
+
+<Callout variant="caution">
+  Security recommendation: The placement of the obscuring Key in the same configuration file as an obfuscated value may pose a security risk. Consider placing the obscuring key and [obfuscated proxy password](#proxy-password) in environment variables and limiting access to environment variables within your environment.
+</Callout>
+
+### Proxy element [#proxy]
+
+The `proxy` element is an optional child of the `service` element. The `proxy` element is used when the agent communicates to the New Relic backend service via a proxy.
+
+```xml
+<service licenseKey="YOUR_LICENSE_KEY">
+  <proxy
+    host="hostname"
+    port="PROXY_PORT"
+    uriPath="path/to/something.aspx"
+    domain="mydomain.com"
+    user="PROXY_USERNAME"
+    password="PROXY_PASSWORD"
+    passwordObfuscated="OBFUSCATED_PROXY_PASSWORD"/>
+</service>
+```
+
+The `proxy` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="proxy-host"
+    title="host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the proxy host.
+
+    Alternatively, set the `NEW_RELIC_PROXY_HOST` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="proxy-port"
+    title="port"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `8080`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the proxy port.
+
+    Alternatively, set the `NEW_RELIC_PROXY_PORT` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="proxy-uripath"
+    title="uriPath"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Optionally define a proxy URI path.
+
+    Alternatively, set the `NEW_RELIC_PROXY_URI_PATH` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="proxy-domain"
+    title="domain"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Optionally define a domain to use when authenticating with the proxy server.
+
+    Alternatively, set the `NEW_RELIC_PROXY_DOMAIN` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="proxy-user"
+    title="user"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Optionally define a user name for authentication.
+
+    Alternatively, set the `NEW_RELIC_PROXY_USER` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="proxy-password"
+    title="password"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Optionally define a password for authentication.
+
+    Alternatively, set the `NEW_RELIC_PROXY_PASS` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="proxy-passwordObfuscated"
+    title="passwordObfuscated"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    For additional security, the .NET Agent supports the use of an obfuscated proxy password with the `passwordObfuscated` attribute. The obfuscated proxy password is generated using the following [New Relic CLI](https://github.com/newrelic/newrelic-cli) command:
+
+    ```bash
+    newrelic agent config obfuscate --key OBSCURING_KEY --value "PLAIN_TEXT_PROXY_PASSWORD"
+    ```
+
+    Alternatively, set the `NEW_RELIC_PROXY_PASS_OBFUSCATED` environment variable in the application's environment.
+
+    <Callout variant="important">
+      When using an obfuscated proxy password, the [obscuring key](#obscuring-key) must also be configured.
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+
+### Log element [#log]
+
+The `log` element is a child of the `configuration` element. The `log` element configures New Relic's logging. The agent generates its own log file to keep its logging information separate from your application's logs.
+
+```xml
+<log enabled="true"
+  level="info"
+  auditLog="false"
+  console="false"
+  directory="PATH\TO\LOG\DIRECTORY"
+  fileName="FILENAME.log" />
+```
+
+The `log` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="log-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `false`, all logging is disabled. Alternatively, set the `NEW_RELIC_LOG_ENABLED` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="log-level"
+    title="level"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `info`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the level of detail recorded in the log file. Possible values, in increasing order of detail, are:
+
+    * `off`
+    * `error`
+    * `warn`
+    * `info`
+    * `debug`
+    * `finest`
+    * `all`
+
+      Alternatively, set the `NEWRELIC_LOG_LEVEL` environment variable in the application's environment.
+
+      <Callout variant="important">
+        Increasing the log level will increase New Relic's performance impact.
+      </Callout>
+  </Collapser>
+
+  <Collapser
+    id="log-auditLog"
+    title="auditLog"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Records all data sent to and received from New Relic in both an auditlog log file and the standard log file. Ignored if `enabled` is set to `false` or `console` is set to `true`.
+  </Collapser>
+
+  <Collapser
+    id="log-console"
+    title="console"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Send log messages to the console instead of the log file (in agent versions prior to 10.35.0, logs are sent to both the console and the log file). Ignored if `enabled` is set to `false`. Alternatively, set the `NEW_RELIC_LOG_CONSOLE` environment variable in the application's environment.
+
+    Console logging in the profiler is limited to `info` level and higher due to performance considerations.
+  </Collapser>
+
+  <Collapser
+    id="log-directory"
+    title="directory"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `C:\ProgramData\New Relic\.NET Agent\Logs`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The directory to hold log files generated by the agent. If this is omitted, then a directory named `Logs` in the New Relic agent install area will be used by default.
+
+    Alternatively, set the `NEWRELIC_LOG_DIRECTORY` environment variable in the application's environment. You can also send your profiler logs to a custom directory, but you can only do that with the `NEWRELIC_PROFILER_LOG_DIRECTORY` environment variable:
+
+    ```ini
+    NEWRELIC_LOG_DIRECTORY=path\to\a\directory
+    NEWRELIC_PROFILER_LOG_DIRECTORY=path\to\a\directory # not configurable via config file
+    ```
+  </Collapser>
+
+  <Collapser
+    id="log-fileName"
+    title="fileName"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines a name for the log file. If you do not define a `fileName`, the name is derived from the name of the monitored process.
+
+    Alternatively, set the `NEW_RELIC_LOG` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_LOG=MyApp.log
+    ```
+  </Collapser>
+
+  <Collapser
+    id="log-logRollingStrategy"
+    title="logRollingStrategy"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `size`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the agent log file rolling strategy. Possible values are:
+
+    * `size` (default): The log file rolls over when it reaches the size specified in `maxLogFileSizeMB`.
+    * `day`: The log file rolls over at midnight.
+
+      Alternatively, set the `NEW_RELIC_LOG_ROLLING_STRATEGY` environment variable in the application's environment:
+
+      ```ini
+      NEW_RELIC_LOG_ROLLING_STRATEGY=day
+      ```
+
+      Supported in .NET agent v10.21.0 and higher.
+  </Collapser>
+
+  <Collapser
+    id="log-logMaxFiles"
+    title="logMaxFiles"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `4`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the number of agent log files to retain per instance of the agent. Multiple apps running on the same host will each create this many files. When the maximum number of log files is reached, the oldest log file is deleted. A value of `0` specifies that there is no maximum number of log files.
+
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILES` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_LOG_MAX_FILES=2
+    ```
+
+    Supported in .NET agent v10.21.0 and higher.
+  </Collapser>
+
+  <Collapser
+    id="log-maxLogFileSizeMB"
+    title="maxLogFileSizeMB"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            50
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the maximum size of the agent log file in megabytes before it rolls over. Valid only when `logRollingStrategy` is set to `size`. A value of `0` specifies that there is no maximum log file size.
+
+    Alternatively, set the `NEW_RELIC_LOG_MAX_FILE_SIZE_MB` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_LOG_MAX_FILE_SIZE_MB=100
+    ```
+
+    Supported in .NET agent v10.21.0 and higher.
+  </Collapser>
+</CollapserGroup>
+
+### Application element (required) [#application-configuration]
+
+The `application` element is a child of the `configuration` element. This required element defines your application name, and disables or enables sampling.
+
+<CollapserGroup>
+  <Collapser
+    id="app-name"
+    title="name"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `My Application`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The [name of your .NET application](/docs/agents/net-agent/installation-and-configuration/naming-your-net-application) is a child of the `application` element. New Relic will aggregate your data according to this name.
+
+    You can also assign [up to three names](/docs/agents/manage-apm-agents/app-naming/use-multiple-names-app) to your app. The first name is the primary name. For example:
+
+    ```xml
+    <application>
+      <name>MY APPLICATION PRIMARY</name>
+      <name>SECOND APP NAME</name>
+      <name>THIRD APP NAME</name>
+    </application>
+    ```
+
+    Alternatively, set the `NEW_RELIC_APP_NAME` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_APP_NAME=Descriptive Name
+    ```
+
+    For multiple names:
+
+    ```ini
+    NEW_RELIC_APP_NAME="App Name, App Name 2, App Name 3"
+    ```
+  </Collapser>
+
+  <Collapser
+    id="app-disableSamplers"
+    title="disableSamplers"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Samplers collect information about memory and CPU consumption. Set this to `true` to disable sampling.
+
+    Alternatively, set the `NEW_RELIC_DISABLE_SAMPLERS` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_DISABLE_SAMPLERS=true
+    ```
+  </Collapser>
+</CollapserGroup>
+
+### Data transmission element [#data-transmission]
+
+The `dataTransmission` element is a child of the `configuration` element. This element affects how data is sent to New Relic and can be used if you have specific data transmission requirements.
+
+```xml
+<dataTransmission
+  putForDataSend="false"
+  compressedContentEncoding="deflate"/>
+```
+
+The `dataTransmission` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="data-transmission-putfordatasend"
+    title="putForDataSend"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the HTTP method used when sending data to New Relic. Set this to `true` to enable using the `PUT` method when sending data. The `POST` method is used by default.
+  </Collapser>
+</CollapserGroup>
+
+### Host name
+
+If the default host name label in the APM UI is not useful, you can decorate that name in the New Relic UI with a display name. After the application process is restarted and the .NET agent is reporting again, the display name will appear in the <DNT>**Servers**</DNT> drop-down list.
+
+To set a display name, choose one of the following options. The environment variable takes precedence over the config file value. Then restart your application to see your changes in the New Relic UI.
+
+<CollapserGroup>
+  <Collapser
+    id="host-name-config"
+    title="Set using config file"
+  >
+    Set the `displayName` attribute in the `processHost` element in `newrelic.config`. The `processHost` element is a child of the `configuration` element.
+
+    ```xml
+    <configuration . . . >
+      <processHost displayName="CUSTOM_NAME" />
+    </configuration>
+    ```
+  </Collapser>
+
+  <Collapser
+    id="host-name-env_variable"
+    title="Set using environment variable"
+  >
+    Set the `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME` environment variable:
+
+    ```ini
+    NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="CUSTOM_NAME"
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings.mdx
@@ -1,0 +1,224 @@
+---
+title: .NET agent instrumentation settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent instrumentation settings in newrelic.config: control which assemblies and processes are instrumented, and configure attribute collection.'
+freshnessValidatedDate: never
+---
+
+Instrumentation settings control which elements of your application and environment the .NET agent instruments, including assembly-level ignore rules, non-IIS application targeting, and attribute collection.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Instrumentation options [#instrumentation]
+
+The .NET agent supports the following categories of instrumentation options:
+
+* [Instrumentation element](#instrumentation-element)
+* [Rules element](#instrumentation-rules)
+* [Applications element](#application-instrumentation)
+* [Attributes element](#agent-attributes)
+
+### Instrumentation element
+
+The `instrumentation` element is a child of the `configuration` element. By default, the .NET agent instruments IIS asp worker processes and Microsoft Azure web and worker roles. To instrument other processes, see [Instrumenting custom applications](/docs/agents/net-agent/features/instrumenting-custom-applications).
+
+### Rules element (instrumentation) [#instrumentation-rules]
+
+<Callout variant="important">
+  This feature is available in .NET Agent 10.21.0 and above.
+</Callout>
+
+The `rules` element is a child of the `instrumentation` element. The `rules` element supports any number of `ignore` child elements, which instructs the Profiler to NOT instrument any methods defined in the specified assembly. Methods defined in other assemblies will still be instrumented.
+
+```xml
+<instrumentation>
+  <rules>
+    <ignore assemblyName="NameOfAssemblyToIgnore" />
+  </rules>
+</instrumentation>
+```
+
+The `ignore` rule allows you to optionally define a class name. In the following example, only methods defined in `MyNamespace.MyClass` in the assembly `MyAssembly` will be ignored. Other methods in other classes both inside that assembly and within other assemblies will not be ignored by the profiler.
+
+```xml
+<instrumentation>
+  <rules>
+    <ignore assemblyName="MyAssembly" className="MyNamespace.MyClass" />
+  </rules>
+</instrumentation>
+```
+
+More than one ignore rule can be specified. The following example disables both the Confluent Kafka and StackExchange Redis instrumentations.
+
+```xml
+<instrumentation>
+  <rules>
+    <ignore assemblyName="Confluent.Kafka" />
+    <ignore assemblyName="StackExchange.Redis" />
+  </rules>
+</instrumentation>
+```
+
+Please note that custom instrumentation cannot be ignored via the `rules` element.
+
+### Applications element (instrumentation) [#application-instrumentation]
+
+The `applications` element is a child of the `instrumentation` element. The `applications` element supports `application` child elements which specify which non-web apps to instrument. The `application` element contains a `name` attribute. Additionally, starting in agent version 10.48.0, there is an optional `include` attribute with a default value of "true". Set this attribute to "false" to prevent the agent from instrumenting that process.
+
+<Callout variant="important">
+  This is not the same as the [`application` (configuration)](#application-configuration) element, which is a child of the `configuration` element.
+</Callout>
+
+```xml
+<instrumentation>
+  <applications>
+    <application name="MyService1.exe" />
+    <application name="MyService2.exe" />
+    <application name="MyService3.exe" include="false" />
+  </applications>
+</instrumentation>
+```
+
+Alternatively, starting in agent version 10.48.0, set the `NEW_RELIC_INCLUDED_APPLICATION_NAMES` and/or the `NEW_RELIC_EXCLUDED_APPLICATION_NAMES` environment variable(s) in the application's environment:
+
+```ini
+NEW_RELIC_INCLUDED_APPLICATION_NAMES="MyService1.exe,MyService2.exe"
+NEW_RELIC_EXCLUDED_APPLICATION_NAMES="MyService3.exe"
+```
+
+Note that exclude takes priority over include.
+
+### Attributes element [#agent-attributes]
+
+An attribute is a key/value pair that determines the properties of an event or transaction. Each attribute is sent to APM transaction traces, APM error traces, `Transaction` events, `TransactionError` events, `Span` events, or `PageView` events. The primary `attributes` element enables or disables attribute collection for the .NET agent, and defines specific attributes to collect or exclude. You can also configure attribute settings by the specific destination:
+
+* [Error collection](#error-attributes)
+* [Transaction events](#transaction-attributes)
+* [Transaction traces](#tracer-attributes)
+* [Span events](#span-attributes)
+* [Browser agent events](#browser-attributes)
+
+In this example, the agent excludes all attributes whose key begins with `myApiKey` (`myApiKey.bar`, `myApiKey.value`) but collects the custom attribute `myApiKey.foo`.
+
+```xml
+<attributes enabled="true">
+  <exclude>myApiKey.*</exclude>
+  <include>myApiKey.foo</include>
+</attributes>
+```
+
+You can view the .NET APM attributes on the [.NET agent attributes](/docs/agents/net-agent/attributes/net-agent-attributes) page. You can also define custom attributes with the agent API call [`AddCustomAttribute`](/docs/agents/net-agent/net-agent-api/itransaction/#addcustomattribute).
+
+<CollapserGroup>
+  <Collapser
+    id="agent-attributes-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable attribute collection. When set to `false` in the primary attribute element, this setting overrides all attribute settings for individual destinations.
+
+    Alternatively, set the `NEW_RELIC_ATTRIBUTES_ENABLED` environment variable in the application's environment.
+  </Collapser>
+
+  <Collapser
+    id="agent-attributes-include"
+    title="include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled, the agent will collect all attribute keys specified in this list. To specify multiple attribute keys, specify each individually. You can also use a `*` wildcard character at the end of a key to match multiple attributes (for example, `myApiKey.*`). For more information, see [Attribute rules](/docs/agents/net-agent/attributes/enabling-disabling-attributes#attruls).
+
+    Alternatively, set the `NEW_RELIC_ATTRIBUTES_INCLUDE` environment variable in the application's environment. This environment variable accepts a comma delimited list of attribute names.
+
+    <Callout variant="caution">
+      When using the `NEW_RELIC_ATTRIBUTES_INCLUDE` environment variable the default set of includes in the `newrelic.config` is overwritten.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="agent-attributes-exclude"
+    title="exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled, the agent will not collect attribute keys specified in this list. To specify multiple attribute keys, specify each individually. You can also use a `*` wildcard character at the end of a key to match multiple attributes (for example, `myApiKey.*`). For more information, see [Attribute rules](/docs/agents/net-agent/attributes/enabling-disabling-attributes#attruls).
+
+    Alternatively, set the `NEW_RELIC_ATTRIBUTES_EXCLUDE` environment variable in the application's environment. This environment variable accepts a comma delimited list of attribute names.
+
+    <Callout variant="caution">
+      When using the `NEW_RELIC_ATTRIBUTES_EXCLUDE` environment variable the default set of excludes in the `newrelic.config` is overwritten.
+    </Callout>
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-logs-in-context-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-logs-in-context-settings.mdx
@@ -1,0 +1,157 @@
+---
+title: .NET agent logs in context settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent application logging settings in newrelic.config: configure log forwarding, local log decoration, log metrics, and context data.'
+freshnessValidatedDate: never
+---
+
+Logs in context settings configure how the .NET agent instruments your application's logging activity, including log forwarding to New Relic, local log decoration, and log metrics collection.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Application logging [#application_logging]
+
+<Callout variant="important">
+  These configuration options are available only with .NET agent versions 9.7.1 and higher. The options related to context data (custom attributes) are only available in .NET agent versions 10.4.0 and higher.
+</Callout>
+
+The `applicationLogging` element is a child of the `configuration` element. Use `applicationLogging` to configure instrumentation of your application's logging activity.
+
+There are three main sub-features:
+
+1. **Metrics**: Collect metrics on the total number of log lines written per harvest cycle (`Logging/lines`), as well as the number of log lines written at particular logging levels (for example, `Logging/lines/ERROR`).
+2. **Log forwarding**: When enabled, the agent will capture log data and send it to New Relic.
+   * **Context data** (via [`AddCustomAttribute`](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)): When enabled, the agent will capture and forward any custom log attributes. The `include` and `exclude` elements are comma-separated lists of attribute names to include or exclude, following the [same rules](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls) as other agent attribute configuration. They're both empty by default, which results in all log context data being captured and forwarded.
+   * **Log-level filtering**: When configured with one or more log levels in a comma-separated list, the agent will prevent messages at those levels from being captured and forwarded.
+   * **Labels**: When enabled, the agent adds custom labels to agent-forwarded logs. You can use the `exclude` attribute, which is a case-insensitive, comma-separated list of label names. By default, the agent adds custom labels when the `exclude` attribute is empty.
+3. **Local log decoration**: When enabled, your existing logs will be decorated with metadata which links logs with other New Relic data, such as errors.
+
+For more details, see [our docs on using .NET agent logs in context](/docs/logs/logs-context/net-configure-logs-context-all).
+
+```xml
+<applicationLogging enabled="true">
+  <metrics enabled="true" />
+  <forwarding enabled="true" maxSamplesStored="10000" logLevelDenyList="">
+    <contextData enabled="false" include="" exclude="" />
+    <labels enabled="false" exclude="" />
+  </forwarding>
+  <localDecorating enabled="false" />
+</applicationLogging>
+```
+
+These features can also be configured via environment variables:
+
+```ini
+NEW_RELIC_APPLICATION_LOGGING_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE="myCustomAttribute1, myOtherCustomAttribute*"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE="myCustomAttribute2, myOtherCustomAttributeMoreSpecificName"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED=10000
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST="debug, warn"
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED=true
+NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE="label1, label2"
+NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED=true
+```
+
+The `applicationLogging` element supports the following attributes and sub-elements:
+
+<CollapserGroup>
+  <Collapser
+    id="applog-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable all logging instrumentation features. If `true`, the individual sub-feature configurations take effect. If `false`, no logging instrumentation features are enabled.
+
+    Or use the `NEW_RELIC_APPLICATION_LOGGING_ENABLED` environment variable.
+  </Collapser>
+
+  <Collapser
+    id="applog-metrics"
+    title="metrics"
+  >
+    Use this sub-element to enable collection of logging metrics (such as `Logging/lines`) for common .NET logging frameworks. The default value of attribute `enabled` is `true`.
+
+    Or use the `NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED` environment variable.
+  </Collapser>
+
+  <Collapser
+    id="applog-forwarding"
+    title="forwarding"
+  >
+    Use this sub-element to enable forwarding of your application's logs to New Relic. The default value of attribute `enabled` is `true`, you can also use the `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED` environment variable.
+
+    The default value of attribute `maxSamplesStored` is `10000`, you can also use the `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED` env variable for this setting. Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
+
+    Each log receives the same priority as its associated transaction. Logs that occur outside of a transaction will receive a random priority. Some logs may not be included because they are limited by `maxSamplesStored`.
+
+    Use the `logLevelDenyList` attribute (or the `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL_DENYLIST` environment variable) to filter out log messages of the specified log levels. The value for this attribute is a comma-separated case-insensitive list of levels. Outside of the case, the log level string must exactly match the log level being filtered, wildcards and regex are not supported. For example, if the value was set to `logLevelDenyList="debug,warn"`, any log messages with the log level of `Debug` or `Warn` will not be captured or forwarded, but a log with a level of `Warning` would still be sent to New Relic.
+
+    <Callout variant="caution">
+      If you are already sending your application's logs to New Relic using an existing log forwarding solution, be sure to disable that before enabling log forwarding in the agent, in order to prevent being billed for duplicate log data.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="contextData"
+    title="contextData (custom attributes)"
+  >
+    Use this sub-element, which is a child of the `forwarding` element, to configure the capture and forwarding of logging context data ([custom attributes](/docs/apm/agents/net-agent/net-agent-api/itransaction/#addcustomattribute)), in agent versions 10.4.0 and higher.
+
+    Set the `enabled` attribute to `true` to enable capture and forwarding of logging context data to New Relic, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED`. The default value is `false`.
+
+    The `include` attribute is a comma-separated list of names of attributes to include when context data capture is enabled, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE`. The default value is an empty string, which means "include everything."
+
+    The `exclude` attribute is a comma-separated list of names of attributes to exclude when context data capture is enabled, you can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE`. The default value is an empty string, which means "exclude nothing."
+
+    The include and exclude lists follow the [same precedence rules as other agent attributes configuration](/docs/apm/agents/net-agent/attributes/enable-disable-attributes-net/#attruls).
+  </Collapser>
+
+  <Collapser
+    id="labels"
+    title="labels (tags)"
+  >
+    Use this sub-element, which is a child of the `forwarding` element, to configure adding your [labels (tags)](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#labels-tags) to agent-forwarded logs, in agent versions 10.34.0 and higher.
+
+    Set the `enabled` attribute to `true` to enable adding your labels to agent-forwarded logs. You can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED`. The default value is `false`.
+
+    The `exclude` attribute is a case-insensitive, comma-separated list of label names to exclude when you enable labels. You can also use the environment variable `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE`. The default value is an empty string, which means "exclude nothing". This attribute does not support wildcards or regex.
+  </Collapser>
+
+  <Collapser
+    id="localDecorating"
+    title="Local log decoration"
+  >
+    Use this sub-element to enable decoration of your application's logs with New Relic linking metadata. The default value of attribute `enabled` is `false`. Some additional configuration changes are required for local log decoration, please see [.NET: Configure logs in context](/docs/logs/logs-context/net-configure-logs-context-all#2-decorate) for more information.
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-other-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-other-settings.mdx
@@ -1,0 +1,561 @@
+---
+title: .NET agent other settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent miscellaneous settings in newrelic.config: app pools, high-security mode, transaction events, custom events, labels, and app.config/appsettings.json.'
+freshnessValidatedDate: never
+---
+
+These settings cover additional .NET agent configuration options including IIS app pool filtering, security modes, event sampling, custom parameters, labels, and per-app configuration via `app.config` or `appsettings.json`.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## App pools [#include_exclude_apps]
+
+<Callout variant="important">
+  This is only applicable to a system's [global config file](/docs/apm/agents/net-agent/configuration/net-agent-configuration/#config-options-precedence).
+</Callout>
+
+<Callout variant="important">
+  This setting only applies when the IIS hosting model is set to in-process.
+</Callout>
+
+The `applicationPools` element is a child of the `configuration` element. The `applicationPools` element specifies for the profiler exactly which application pools to instrument and uses the same name as the IIS application pool name. This configuration element is useful when you may need to instrument only a small subset of your app pools.
+
+Here is an example of disabling instrumentation for specific application pools:
+
+```xml
+<applicationPools>
+  <applicationPool name="Foo" instrument="false"/>
+  <applicationPool name="Bar" instrument="false"/>
+</applicationPools>
+```
+
+Here is an example of disabling instrumentation for all application pools currently executing on the server and enabling instrumentation for specific application pools:
+
+```xml
+<applicationPools>
+  <defaultBehavior instrument="false"/>
+  <applicationPool name="Foo" instrument="true"/>
+  <applicationPool name="Bar" instrument="true"/>
+</applicationPools>
+```
+
+The `applicationPools` element supports the following elements:
+
+<CollapserGroup>
+  <Collapser
+    id="appPool-defaultBehavior"
+    title="defaultBehavior"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines how the .NET agent will behave on a "global" level for application pools served via IIS. The .NET agent instruments all application pools by default. When `true`, application pools listed under `applicationPool` with an `instrument` attribute set to false will not be instrumented.
+
+    Essentially, when set to `false`, the application pool list acts as an allow list. When set to `true`, the application pool list acts as a deny list.
+  </Collapser>
+
+  <Collapser
+    id="appPool-applicationPool"
+    title="applicationPool"
+  >
+    Defines instrumentation behavior for a specific application pool. The `name` attribute is the name of an application pool. Enable or disable profiling in the `instrument` attribute.
+  </Collapser>
+</CollapserGroup>
+
+## High-security mode [#high_security_mode]
+
+The `highSecurity` element is a child of the `configuration` element. To enable [high-security mode](/docs/subscriptions/high-security), set this property to `true` and enable the high security property in the New Relic user interface. Enabling high security turns SSL on; request parameters, custom parameters and HTTP request headers are not collected; strip exception messages is enabled; and queries can't be sent to New Relic in their raw form.
+
+<CollapserGroup>
+  <Collapser
+    id="highsecurity-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable high-security mode. Example:
+
+    ```xml
+    <highSecurity enabled="true"/>
+    ```
+
+    Alternatively, set the `NEW_RELIC_HIGH_SECURITY` environment variable in the application's environment:
+
+    ```ini
+    NEW_RELIC_HIGH_SECURITY=true
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Strip exception messages [#strip_exception_messages]
+
+The `stripExceptionMessages` element is a child of the `configuration` element. To enable strip exception messages, set this property to `true`. By default, this is set to false, which means that the agent sends messages from all exceptions to the New Relic collector. If you enable high-security mode, this is automatically changed to true, and the agent strips the messages from exceptions.
+
+<CollapserGroup>
+  <Collapser
+    id="stripExceptionMessages-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable strip exception messages. Example:
+
+    ```xml
+    <stripExceptionMessages enabled="true"/>
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Transaction events [#transaction_events]
+
+The `transactionEvents` element is a child of the `configuration` element. Use `transactionEvents` to configure transaction events.
+
+```xml
+<transactionEvents enabled="true" maximumSamplesStored="10000">
+  <attributes enabled="true">
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
+  </attributes>
+</transactionEvents>
+```
+
+The `transactionEvents` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="transaction-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the event recorder.
+  </Collapser>
+
+  <Collapser
+    id="transaction-maximumSamplesStored"
+    title="maximumSamplesStored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The maximum number of sampled transaction events the agent can store in memory at once. This will be the maximum number of transaction events the agent can send per minute.
+
+    Alternatively, set the `MAX_TRANSACTION_SAMPLES_STORED` environment variable in the application's environment:
+
+    ```ini
+    MAX_TRANSACTION_SAMPLES_STORED=500
+    ```
+  </Collapser>
+
+  <Collapser
+    id="transaction-attributes"
+    title="attributes"
+  >
+    Use this sub-element to customize your agent attribute settings for transaction events. This sub-element uses the same settings as the primary `attributes` element: [`enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-enabled), [`include`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-include), and [`exclude`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-exclude).
+
+    <Callout variant="caution">
+      When distributed tracing and/or Infinite Tracing are enabled, information from transaction events is applied to the root Span Event of the transaction. Consider applying any attribute settings for transaction events to span events and/or apply them as [Global Attribute settings](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes).
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+
+## Custom events [#custom_events]
+
+The `customEvents` element is a child of the `configuration` element. Use `customEvents` to configure [custom events](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents#net-att).
+
+```xml
+<customEvents enabled="true" maximumSamplesStored="10000"/>
+```
+
+The `customEvents` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="customevents-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the event recorder.
+  </Collapser>
+
+  <Collapser
+    id="customevents-maximumSamplesStored"
+    title="maximumSamplesStored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The maximum number of sampled custom events the agent can store in memory at once. This will be the maximum number of custom events the agent can send per minute.
+
+    Alternatively, set the `MAX_EVENT_SAMPLES_STORED` environment variable in the application's environment:
+
+    ```ini
+    MAX_EVENT_SAMPLES_STORED=500
+    ```
+
+    * If you're configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring/), we recommend setting the value to `100000`.
+  </Collapser>
+</CollapserGroup>
+
+## Custom parameters [#custom_parameters]
+
+The `customParameters` element is a child of the `configuration` element. Use `customParameters` to configure [custom parameters](/docs/insights/insights-data-sources/custom-data/add-custom-attributes-apm-data).
+
+```xml
+<customParameters enabled="true" />
+```
+
+The `customParameters` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="customparameters-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable the capture of custom parameters.
+  </Collapser>
+</CollapserGroup>
+
+## Labels (tags) [#labels-tags]
+
+The `labels` element is a child of the `configuration` element.
+
+This sets [tag](/docs/new-relic-one/use-new-relic-one/core-concepts/tagging-use-tags-organize-group-what-you-monitor) names and values. The list is a semicolon delimited list of colon-separated name and value pairs. You can also use with the `NEW_RELIC_LABELS` environment variable. Example:
+
+```xml
+<labels>foo:bar;zip:zap</labels>
+```
+
+```ini
+NEW_RELIC_LABELS="foo:bar;zip:zap"
+```
+
+## Settings in app.config or web.config [#app-config-settings]
+
+For ASP.NET and .NET Framework console apps you can also configure the following settings in your app's `app.config` or `web.config`, within the outermost element, `<configuration>`:
+
+<CollapserGroup>
+  <Collapser
+    id="app-cfg-agent-enabled"
+    title="Enable and disable the agent"
+  >
+    ```xml
+    <appSettings>
+       <add key="NewRelic.AgentEnabled" value="false" />
+    </appSettings>
+    ```
+
+    <Callout variant="important">
+      If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will **not** enable the agent.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="app-cfg-application-name"
+    title="Application name"
+  >
+    For more information, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application).
+
+    ```xml
+    <appSettings>
+      <add key="NewRelic.AppName" value="Descriptive Name" />
+    </appSettings>
+    ```
+  </Collapser>
+
+  <Collapser
+    id="app-cfg-license-key"
+    title="License key"
+  >
+    ```xml
+    <appSettings>
+      <add key="NewRelic.LicenseKey" value="YOUR_LICENSE_KEY" />
+    </appSettings>
+    ```
+  </Collapser>
+
+  <Collapser
+    id="app-cfg-labels"
+    title="Labels"
+  >
+    ```xml
+    <appSettings>
+      <add key="NewRelic.Labels" value="key1:value1;key2:value2" />
+    </appSettings>
+    ```
+  </Collapser>
+
+  <Collapser
+    id="app-cfg-location"
+    title="Change newrelic.config location"
+  >
+    Designates an alternative location for the config file outside of the local root of the app or global config location. The location entered must be an absolute path.
+
+    ```xml
+    <appSettings>
+      <add key="NewRelic.ConfigFile" value="C:\Path-to-alternate-config-dir\newrelic.config" />
+    </appSettings>
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Settings in appsettings.json [#appsettings-json]
+
+For .NET Core apps, you can configure the following settings in `appsettings.json` if the following is true:
+
+* The `appsettings.json` file must be located in the current working directory of the application.
+* The application must have the following dependencies:
+  * [`Microsoft.Extensions.Configuration`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration)
+  * [`Microsoft.Extensions.Configuration.Json`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json)
+  * [`Microsoft.Extensions.Configuration.EnvironmentVariables`](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.EnvironmentVariables)
+
+<CollapserGroup>
+  <Collapser
+    id="appsettings-json-agent-enabled"
+    title="Enable and disable the agent"
+  >
+    ```json
+    {
+       "NewRelic.AgentEnabled":"false"
+    }
+    ```
+
+    <Callout variant="important">
+      If the agent is disabled in the local or global `newrelic.config`, the `NewRelic.AgentEnabled` settings in these files will enable the agent.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="appsettings-json-application-name"
+    title="Application name"
+  >
+    For more information, see [Name your .NET application](/docs/agents/net-agent/installation-configuration/name-your-net-application).
+
+    ```json
+    {
+      "NewRelic.AppName": "Descriptive Name"
+    }
+    ```
+  </Collapser>
+
+  <Collapser
+    id="appsettings-json-application-license-key"
+    title="License key"
+  >
+    ```json
+    {
+      "NewRelic.LicenseKey": "YOUR_LICENSE_KEY"
+    }
+    ```
+  </Collapser>
+
+  <Collapser
+    id="appsettings-json-labels"
+    title="Labels"
+  >
+    ```json
+    {
+      "NewRelic.Labels": "key1:value1;key2:value2"
+    }
+    ```
+  </Collapser>
+
+  <Collapser
+    id="appsettings-json-location"
+    title="Change newrelic.config location"
+  >
+    Designates an alternative location for the config file outside of the local root of the app or global config location. The location entered must be an absolute path.
+
+    ```json
+    {
+      "NewRelic.ConfigFile": "C:\Path-to-alternate-config-dir\newrelic.config"
+    }
+    ```
+  </Collapser>
+</CollapserGroup>
+
+<Callout variant="important">
+  For [ASP.NET Core apps](https://asp.net/), the .NET Agent will read from `appsettings.{environment}.json` if you set the `ASPNETCORE_ENVIRONMENT` variable.
+</Callout>

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-transaction-tracer-settings.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration-transaction-tracer-settings.mdx
@@ -1,0 +1,396 @@
+---
+title: .NET agent transaction tracer settings
+tags:
+  - Agents
+  - NET agent
+  - Configuration
+metaDescription: '.NET agent transaction tracer settings in newrelic.config: configure slow query capture, transaction trace thresholds, explain plans, and datastore tracing.'
+freshnessValidatedDate: never
+---
+
+Transaction tracer settings configure how the .NET agent captures detailed traces of slow transactions, SQL queries, and datastore calls.
+
+<Callout variant="tip">
+  Back to the full settings index: [.NET agent configuration](/docs/apm/agents/net-agent/configuration/net-agent-configuration)
+</Callout>
+
+## Slow queries [#slow_sql]
+
+The `slowSql` element is a child of the `configuration` element. `slowSql` configures capturing information about slow query executions, and captures and obfuscates explain plans for these queries.
+
+```xml
+<slowSql enabled="true"/>
+```
+
+The `slowSql` element supports the following attribute:
+
+<CollapserGroup>
+  <Collapser
+    id="slowsql-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable slow query tracing.
+  </Collapser>
+</CollapserGroup>
+
+## Transaction traces [#transaction_tracer]
+
+The `transactionTracer` element is a child of the `configuration` element. `transactionTracer` configures [transaction traces](/docs/traces/transaction-traces). Included in the trace is the exact call sequence of the transactions, including any query statements issued.
+
+```xml
+<transactionTracer enabled="true"
+    transactionThreshold="apdex_f"
+    recordSql="obfuscated"
+    explainEnabled="true"
+    explainThreshold="500"
+    maxSegments="3000"
+    maxExplainPlans="20">
+  <attributes enabled="true">
+    <exclude>myApiKey.*</exclude>
+    <include>myApiKey.foo</include>
+  </attributes>
+ </transactionTracer>
+```
+
+The `transactionTracer` element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="tracer-enabled"
+    title="enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces).
+  </Collapser>
+
+  <Collapser
+    id="tracer-transactionThreshold"
+    title="transactionThreshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `apdex_f`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the threshold for transaction traces. If a transaction takes longer than the threshold, it is eligible for being traced. See [transaction trace basics](/docs/apm/transactions/transaction-traces/transaction-traces#basics) for more about the rules governing traces.
+
+    The default value is `apdex_f`, which sets the threshold to four times the application's `apdex_t` value. For more information about `apdex_t`, see [Apdex](/docs/site/apdex-measuring-user-satisfaction).
+
+    You can also set the threshold to be a specific time value in milliseconds.
+  </Collapser>
+
+  <Collapser
+    id="tracer-recordSql"
+    title="recordSql"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `obfuscated`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Select a query tracing policy. Options are `off`, which records nothing; `obfuscated`, which records an obfuscated version of the query; or `raw`, which records the query exactly as it is issued to the database.
+
+    <Callout variant="caution">
+      Recording raw queries may capture sensitive information.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="tracer-explainEnabled"
+    title="explainEnabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent captures `EXPLAIN` statements for slow queries with durations exceeding `explainThreshold`. Note that enabling this feature can have performance implications because plans are captured for every transaction up to the `maxExplainPlans` value.
+  </Collapser>
+
+  <Collapser
+    id="tracer-explainThreshold"
+    title="explainThreshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `500`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Unit
+          </th>
+
+          <td>
+            Milliseconds
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The agent collects [slow query data](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) for queries that exceed this threshold, along with any available explain plans, as part of transaction traces.
+  </Collapser>
+
+  <Collapser
+    id="tracer-maxSegments"
+    title="maxSegments"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `3000`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The maximum number of segments to collect in a transaction trace.
+  </Collapser>
+
+  <Collapser
+    id="tracer-maxExplainPlans"
+    title="maxExplainPlans"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `20`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The maximum number of explain plans to collect per transaction.
+  </Collapser>
+
+  <Collapser
+    id="tracer-maxStackTrace"
+    title="maxStackTrace"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `0`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    By default `maxStackTrace` is set to `0`, which disables stack traces as part of a transaction trace. If this value is set greater than `0`, then stack traces will be captured for transaction traces.
+  </Collapser>
+
+  <Collapser
+    id="tracer-attributes"
+    title="attributes"
+  >
+    Use this sub-element to customize your agent attribute settings for transaction traces. This sub-element uses the same settings as the primary `attributes` element: [`enabled`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-enabled), [`include`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-include), and [`exclude`](/docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings/#agent-attributes-exclude).
+  </Collapser>
+</CollapserGroup>
+
+## Datastore tracer [#datastore_tracer]
+
+The `datastoreTracer` element is a child of the `configuration` element.
+
+```xml
+<datastoreTracer>
+  <instanceReporting enabled="true"  />
+  <databaseNameReporting enabled="true" />
+  <queryParameters enabled="false" />
+</datastoreTracer>
+```
+
+The `datastoreTracer` element supports the following sub-elements:
+
+<CollapserGroup>
+  <Collapser
+    id="instance-reporting"
+    title="instanceReporting"
+  >
+    Use this sub-element to enable collection of datastore instance metrics (such as the host and port) for [some database drivers](/docs/agents/net-agent/features/net-agent-instance-level-database-information). These are reported on slow query traces and transaction traces. The default value of attribute `enabled` is `true`.
+  </Collapser>
+
+  <Collapser
+    id="database-name-reporting"
+    title="databaseNameReporting"
+  >
+    Use this sub-element to enable collection of the database name on slow query traces and transaction traces for [some database drivers](/docs/agents/net-agent/features/net-agent-instance-level-database-information). The default value of attribute `enabled` is `true`.
+  </Collapser>
+
+  <Collapser
+    id="datastore-tracer-query-parameters"
+    title="queryParameters"
+  >
+    Use this sub-element to enable collection of the SQL query parameters on slow query traces. The default value of attribute `enabled` is `false`.
+
+    <Callout variant="caution">
+      * Recording query parameters may capture sensitive information.
+      * The `transactionTracer.recordSql` configuration option must be set to `raw` or this option is ignored.
+    </Callout>
+  </Collapser>
+</CollapserGroup>

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -296,12 +296,31 @@ pages:
       - title: .NET monitoring
         path: /docs/apm/agents/net-agent
         pages:
-          - title: Introduction to .NET monitoring
-            path: /docs/apm/agents/net-agent/getting-started/introduction-new-relic-net
-          - title: Installation
+          - title: Compatibility and release
+            path: /docs/apm/agents/net-agent/getting-started
+            pages:
+              - title: Compatibility and requirements
+                path: /docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements
+              - title: .NET agent security
+                path: /docs/apm/agents/net-agent/getting-started/apm-agent-security-net
+              - title: .NET agent EOL policy
+                path: /docs/apm/agents/net-agent/getting-started/net-agent-eol-policy
+              - title: .NET OpenTracing to AWS Lambda migration guide
+                path: /docs/apm/agents/net-agent/getting-started/opentracing-to-layers-migration-guide
+              - title: .NET serverless AWS Lambda
+                path: /docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda
+              - title: .NET agent 9.x to 10.x migration guide
+                path: /docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide
+              - title: .NET agent 8.x to 9.x migration guide
+                path: /docs/apm/agents/net-agent/getting-started/8x-to-9x-agent-migration-guide
+              - title: Latest release
+                path: /docs/release-notes/agent-release-notes/net-release-notes/current
+              - title: .NET release notes
+                path: /docs/release-notes/agent-release-notes/net-release-notes
+          - title: .NET agent installation
             path: /docs/apm/agents/net-agent/other-installation
             pages:
-              - title: Install the .NET agent
+              - title: Overview
                 path: /install/dotnet
               - title: Advanced installation
                 path: /docs/apm/agents/net-agent/other-installation/net-agent-install-resources
@@ -309,32 +328,40 @@ pages:
                 path: /docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables
               - title: How to verify the checksum of .NET agent downloads
                 path: /docs/apm/agents/net-agent/other-installation/how-verify-checksum-net-agent-downloads
-              - title: Uninstall the agent
+              - title: Update the .NET agent
+                path: /docs/apm/agents/net-agent/installation/update-net-agent
+              - title: Uninstall the .NET agent
                 path: /docs/apm/agents/net-agent/installation/uninstall-net-agent
-          - title: Update the agent
-            path: /docs/apm/agents/net-agent/installation/update-net-agent
-          - title: Compatibility and releases
-            path: /docs/apm/agents/net-agent/getting-started
-            pages:
-              - title: Compatibility and requirements
-                path: /docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements
-              - title: 'APM agent security: .NET'
-                path: /docs/apm/agents/net-agent/getting-started/apm-agent-security-net
-              - title: '.NET agent EOL policy'
-                path: /docs/apm/agents/net-agent/getting-started/net-agent-eol-policy
-              - title: .NET OpenTracing to AWS Lambda layers migration guide
-                path: /docs/apm/agents/net-agent/getting-started/opentracing-to-layers-migration-guide
-              - title: '.NET serverless AWS Lambda performance monitoring'
-                path:  /docs/apm/agents/net-agent/getting-started/net-agent-approaches-lambda
-              - title: .NET agent 9.x to 10.x migration guide
-                path: /docs/apm/agents/net-agent/getting-started/9x-to-10x-agent-migration-guide
-              - title: .NET agent 8.x to 9.x migration guide
-                path: /docs/apm/agents/net-agent/getting-started/8x-to-9x-agent-migration-guide
+          - title: Introduction to .NET monitoring
+            path: /docs/apm/agents/net-agent/getting-started/introduction-new-relic-net
           - title: Configuration
             path: /docs/apm/agents/net-agent/configuration
             pages:
               - title: .NET agent configuration
                 path: /docs/apm/agents/net-agent/configuration/net-agent-configuration
+                pages:
+                  - title: General settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-general-settings
+                  - title: Environment variables
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-environment-variables
+                  - title: Cloud platform settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-cloud-platform-settings
+                  - title: Instrumentation settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-instrumentation-settings
+                  - title: Error collector settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-error-collector-settings
+                  - title: Transaction tracer settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-transaction-tracer-settings
+                  - title: Distributed tracing settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-distributed-tracing-settings
+                  - title: Browser monitoring settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-browser-monitoring-settings
+                  - title: Logs in context settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-logs-in-context-settings
+                  - title: AI monitoring settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-ai-monitoring-settings
+                  - title: Other settings
+                    path: /docs/apm/agents/net-agent/configuration/net-agent-configuration-other-settings
               - title: Name your .NET application
                 path: /docs/apm/agents/net-agent/configuration/name-your-net-application
               - title: Distributed tracing


### PR DESCRIPTION
## Summary

- Restructures the .NET monitoring nav section to match the established PHP/Java agent IA pattern
- Renames "Compatibility and releases" → "Compatibility and release" (singular, consistent)
- Moves Compatibility and release to top; adds Latest release + .NET release notes
- Renames "Installation" → ".NET agent installation" and merges standalone "Update the agent" into it
- Moves "Introduction to .NET monitoring" after the installation section
- Splits the 4,107-line `net-agent-configuration.mdx` into 11 focused sub-pages nested under the main config page in the nav

**New config sub-pages:**
General settings · Environment variables · Cloud platform settings · Instrumentation settings · Error collector settings · Transaction tracer settings · Distributed tracing settings · Browser monitoring settings · Logs in context settings · AI monitoring settings · Other settings

## Test plan

- [ ] Verify nav renders correctly in local dev
- [ ] Confirm all 11 new config sub-page paths resolve
- [ ] Confirm existing links to `net-agent-configuration` still work (redirects not needed — page still exists as index)
- [ ] Check "Compatibility and release" section items all resolve

🤖 Generated with [Claude Code](https://claude.ai/claude-code)