### PR TITLE
refactor(python-agent): align Python nav with PHP/Java IA pattern and split config

### DIFF
--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-ai-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-ai-monitoring-settings.mdx
@@ -1,0 +1,188 @@
+---
+title: Python agent AI monitoring settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent AI monitoring configuration: enable AI monitoring, record content, and LLM token counting.'
+freshnessValidatedDate: never
+---
+
+Configure AI monitoring settings for the Python agent to enable monitoring of LLM interactions, control content recording, and manage streaming behavior.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## AI monitoring [#ai-monitoring]
+
+This section includes Python agent configurations for setting up AI monitoring.
+
+<Callout variant="important">
+  You must enable [distributed tracing](/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration/#dt-main) to capture AI data. It's turned on by default in Python agent versions 7.0.0.166 and higher.
+</Callout>
+
+<Callout variant="important">
+  When enabled, AI monitoring  records a streaming copy of inputs and outputs sent to and from the models you choose to monitor, including any personal information contained therein. 
+  You're responsible for obtaining consent from your model users that their interactions may be recorded by a third party (New Relic) for the purpose of providing the AI monitoring feature.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="ai-monitoring-enabled"
+    title="ai_monitoring.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_AI_MONITORING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, enables AI monitoring.
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="ai-monitoring-streaming"
+    title="ai_monitoring.streaming.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_AI_MONITORING_STREAMING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `false`, disables instrumentation that records summary and message events for streamed Large Language Model data.
+  </Collapser>
+
+  <Collapser
+    id="ai-monitoring-record-content"
+    title="ai_monitoring.record_content.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If set to `false`, the agent will omit input and output content (like text strings from prompts and responses) captured in LLM events. This is an optional security setting if you don’t want to record sensitive data sent to and received from your LLMs.
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-attributes-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-attributes-settings.mdx
@@ -1,0 +1,189 @@
+---
+title: Python agent attributes settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent attributes configuration: enable/disable attributes, include/exclude lists for transactions, errors, traces, and span events.'
+freshnessValidatedDate: never
+---
+
+Configure Python agent attributes to control which key-value pairs are sent to transaction traces, traced errors, browser monitoring, and transaction events.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Attributes
+
+Attributes are key-value pairs that provide information for transaction traces, traced errors, <InlinePopover type="browser"/>, and transaction events. In addition to configuring attributes for all four destinations with the general attribute settings below, they can also be configured on a per-destination basis.
+
+For more information, see [Python agent attributes](/docs/agents/python-agent/attributes/python-agent-attributes), [Enabling and disabling attributes](/docs/agents/python-agent/attributes/enabling-disabling-attributes-python), and [Attribute examples](/docs/agents/python-agent/attributes/python-attribute-examples).
+
+<CollapserGroup>
+  <Collapser
+    id="cfg-attributes-enabled"
+    title="attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off all attributes.
+  </Collapser>
+
+  <Collapser
+    id="cfg-attributes-include"
+    title="attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled, attribute keys found in this list will be sent to us. Keys in the list should be space-separated as shown below:
+
+    ```
+    key1 key2 key3
+    ```
+
+    Rules for attributes can be found [on the agent attributes page](/docs/subscriptions/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-attributes-exclude"
+    title="attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent to us. Keys in the list should be space-separated as shown below:
+
+    ```
+    key1 key2 key3
+    ```
+
+    Rules for attributes can be found [on the agent attributes page](/docs/subscriptions/agent-attributes).
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-browser-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-browser-monitoring-settings.mdx
@@ -1,0 +1,319 @@
+---
+title: Python agent browser monitoring settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent browser monitoring configuration: enable auto-instrumentation and configure browser monitoring attributes.'
+freshnessValidatedDate: never
+---
+
+Configure browser monitoring settings for the Python agent to enable auto-instrumentation and control which attributes are sent to page view events.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Browser monitoring settings [#browser-settings]
+
+Here are browser monitoring settings available via the agent configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="browser-enabled"
+    title="browser_monitoring.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables browser monitoring. For more information, see [Page load timing in Python](/docs/python/page-load-timing-in-python).
+
+    <Callout variant="important">
+      Before enabling browser monitoring in the config file, [enable it in the application settings in the browser monitoring UI](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser#select-apm-app).
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="browser-auto"
+    title="browser_monitoring.auto_instrument"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    For [supported Python web frameworks](/docs/agents/python-agent/supported-features/page-load-timing-python#restrictions_on_instrumentation), this setting enables auto-insertion of the browser monitoring JavaScript fragments.
+  </Collapser>
+
+  <Collapser
+    id="browser-content-type"
+    title="browser_monitoring.content_type"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `text/html`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Specify the HTML `Content-Type`(s) that our browser monitoring agent should auto-instrument. Add additional entries in a space-separated list.
+
+    <CollapserGroup>
+      <Collapser
+        id="example-instrument-xhtml-xml"
+        title="Instrument xhtml+xml page responses"
+      >
+        If you are generating HTML page responses and using the `Content-Type` of `application/xhtml+xml`, you can override the allowed content types to list both this content type and the default `text/html` by using:
+
+        ```ini
+        browser_monitoring.content_type = text/html application/xhtml+xml
+        ```
+
+        <Callout variant="important">
+          The browser monitoring JavaScript snippet prevents the page from validating as `application/xhtml+xml`, although the page should load and render in end-user browsers.
+        </Callout>
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    id="cfg-browser-attributes-enabled"
+    title="browser_monitoring.attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off all attributes for browser monitoring. This is the data which gets sent to page view events. If `attributes.enabled` is false at the root level, no attributes will be sent up in browser monitoring regardless on how the configuration setting (`browser_monitoring.attributes.enabled`) is set.
+  </Collapser>
+
+  <Collapser
+    id="cfg-bm-attributes-include"
+    title="browser_monitoring.attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for `browser_monitoring`, all attribute keys found in this list will be sent in page views. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-bm-attributes-exclude"
+    title="browser_monitoring.attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent in page views. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-distributed-tracing-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-distributed-tracing-settings.mdx
@@ -1,0 +1,631 @@
+---
+title: Python agent distributed tracing settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent distributed tracing configuration: enable distributed tracing, span events, and Infinite Tracing.'
+freshnessValidatedDate: never
+---
+
+Configure distributed tracing and span event settings for the Python agent, including sampler options, span event limits, and attribute controls.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Distributed tracing settings [#dt-main]
+
+Distributed tracing lets you see the path that a request takes as it travels through a distributed system. Starting in [Python agent version 7.0.0.166 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent), distributed tracing is enabled by default.
+
+<Callout variant="important">
+  Enabling distributed tracing disables [cross application tracing](#cross-application-tracer) and has other effects on APM features. If migrating from cross application tracing, read the [transition guide](/docs/transition-guide-distributed-tracing).
+</Callout>
+
+For more information, see [Distributed tracing for your Python services](/docs/apm/agents/python-agent/configuration/distributed-tracing-python-agent).
+
+Settings include:
+
+<CollapserGroup>
+  <Collapser
+    id="distributed-tracing-enabled"
+    title="distributed_tracing.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables [Distributed Tracing](/docs/distributed-tracing/concepts/introduction-distributed-tracing)
+  
+  </Collapser>
+  <Collapser
+    id="distributed-tracing-sampler-remote_parent_sampled"
+    title="distributed_tracing.sampler.remote_parent_sampled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Adaptive
+          </th>
+
+          <td>
+            `adaptive`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    This is the sampler that is applied when the trace has a remote parent (that is, the trace originated in an upstream service) that has been sampled. Sampler options are:
+    - `adaptive` is the default behavior and delegates the sampling decision to the adaptive sampling algorithm to determine whether a trace will be sampled.
+    - `trace_id_ratio_based` delegates the sampling decision to the Trace ID Ratio Based sampling algorithm to determine whether a trace will be sampled. If you use this option, the ratio is required, so use [distributed_tracing.sampler.remote_parent_sampled.trace_id_ratio_based.ratio](#distributed-tracing-sampler-remote-parent-sampled-trace-id-ratio-based-ratio) instead.
+    - `always_on`: Always samples traces that have a sampled remote parent.
+    - `always_off`: Never samples traces that have a sampled remote parent.
+  
+  </Collapser>
+  <Collapser
+    id="distributed-tracing-sampler-remote-parent-sampled-trace-id-ratio-based-ratio"
+    title="distributed_tracing.sampler.remote_parent_sampled.trace_id_ratio_based.ratio"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Unset
+          </th>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    - A number between 0 (exclusive) and 1 inclusive.
+  </Collapser>
+  <Collapser
+    id="distributed-tracing-sampler-remote_parent_not_sampled"
+    title="distributed_tracing.sampler.remote_parent_not_sampled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Adaptive
+          </th>
+
+          <td>
+            `adaptive`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    This is the sampler that is applied when a trace has a remote parent (that is, the trace originated in an upstream service) that was not sampled. Sampler options are:
+    - `adaptive` is the default behavior and delegates the sampling decision to the adaptive sampling algorithm to determine whether a trace will be sampled.
+    - `trace_id_ratio_based` delegates the sampling decision to the Trace ID Ratio Based sampling algorithm to determine whether a trace will be sampled. If you use this option, the ratio is required, so use [distributed_tracing.sampler.remote_parent_not_sampled.trace_id_ratio_based.ratio](#distributed-tracing-sampler-remote-parent-not-sampled-trace-id-ratio-based-ratio) instead.
+    - `always_on`: Always samples traces that have an unsampled remote parent.
+    - `always_off`: Never samples traces that have an unsampled remote parent.
+  
+  </Collapser>
+  <Collapser
+    id="distributed-tracing-sampler-remote-parent-not-sampled-trace-id-ratio-based-ratio"
+    title="distributed_tracing.sampler.remote-parent-not-sampled.trace_id_ratio_based.ratio"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Unset
+          </th>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED_TRACE_ID_RATIO_BASED_RATIO`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    - A number between 0 (exclusive) and 1 inclusive.
+  </Collapser>
+  <Collapser
+    id="distributed-tracing-sampler-root"
+    title="distributed_tracing.sampler.root"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Adaptive
+          </th>
+
+          <td>
+            `adaptive`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    This is the sampler that is applied at the beginning of a trace. By default, the Adaptive Sampler is configured as the Root sampler. Sampler options are:
+    - `adaptive` is the default behavior and delegates the sampling decision to the adaptive sampling algorithm to determine whether a trace will be sampled.
+    - `trace_id_ratio_based` delegates the sampling decision to the Trace ID Ratio Based sampling algorithm to determine whether a trace will be sampled. If you use this option, the ratio is required, so use [distributed_tracing.sampler.root.trace_id_ratio_based.ratio](#distributed-tracing-sampler-root-trace-id-ratio-based-ratio) instead.
+    - `always_on`: Always samples transactions that originate from the current service and do not have a distributed tracing header present for the entry call.
+    - `always_off`: Never samples transactions that originate from the current service and do not have a distributed tracing header present for the entry call.
+  
+  </Collapser>
+  <Collapser
+    id="distributed-tracing-sampler-root-trace-id-ratio-based-ratio"
+    title="distributed_tracing.sampler.root.trace_id_ratio_based.ratio"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Unset
+          </th>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT_TRACE_ID_RATIO_BASED_RATIO`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    - A number between 0 (exclusive) and 1 inclusive.
+  </Collapser>
+</CollapserGroup>
+
+## Span event configuration [#txn-span-events-settings]
+
+[Span events](/docs/apm/distributed-tracing/getting-started/how-new-relic-distributed-tracing-works#data-structure) are collected for [distributed tracing](#distributed-tracing-settings). Distributed tracing must be enabled to report span events. Configuration options include:
+
+<CollapserGroup>
+  <Collapser
+    id="cfg-tt-enabled"
+    title="span_events.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off whether the Python agent sends spans.
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-max-samples-stored"
+    title="span_events.max_samples_stored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `2000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    * Limit for span events per minute sent by an instance of the Python agent to New Relic.
+    * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000` to ensure that the agent captures the maximum amount of distributed traces.
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-enabled"
+    title="span_events.attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off for all [attributes](/docs/using-new-relic/welcome-new-relic/getting-started/glossary#attribute) for span events. If `attributes.enabled` at the root level is `false`, no attributes will be sent to span events regardless on how this configuration setting (`span_events.attributes.enabled`) is set. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-include"
+    title="span_events.attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for span events, all attribute keys found in this list will be sent in span events. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-exclude"
+    title="span_events.attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent in span events. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-error-collector-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-error-collector-settings.mdx
@@ -1,0 +1,546 @@
+---
+title: Python agent error collector settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent error collector configuration: ignore errors, expected errors, error classes, and error event sampling.'
+freshnessValidatedDate: never
+---
+
+Configure error collector settings for the Python agent to control which errors are captured, ignored, or marked as expected, and to manage error event sampling.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Error collector configuration [#error-collector-settings]
+
+Here are error collector settings available via the agent configuration file.
+
+<Callout variant="tip">
+  For an overview of error configuration in APM, see [Manage errors in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected).
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="error-enabled"
+    title="error_collector.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Enable error collection?`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If enabled, the error collector captures information about uncaught exceptions.
+  </Collapser>
+
+  <Collapser
+    id="error-ignore"
+    title="error_collector.ignore_classes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Ignore these errors`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    To stop collecting specific errors, set this to a space-separated list of the Python exception type names to ignore. Use the form `module:class` for the exception name.
+
+    <Callout variant="caution">
+      `error_collector.ignore_errors` was removed in version 11.0.0. Before version 6.4.0 of the agent, this setting was named `error_collector.ignore_errors`. If your configuration file still uses `ignore_errors`, update your agent to use `ignore_classes`.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="error-ignore-status-codes"
+    title="error_collector.ignore_status_codes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `100-102 200-208 226 300-308 404`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Ignore these status codes`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Lists HTTP status codes which the agent should ignore rather than record as errors. List additional status codes as integers separated by spaces, and specify ranges with a hyphen `-` separator between the start and end values. To add one of the default codes to your allow list, preface the code with an exclamation point `!`.
+
+    This setting is only compatible with some web frameworks, as some frameworks do not use exceptions to return HTTP responses.
+
+    <Callout variant="tip">
+      This configuration option can only be set in server-side configuration in Python agent versions 6.4.0 and newer.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="error-expected"
+    title="error_collector.expected_classes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Expect these error class names`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Prevents specified exception classes from affecting error rate or Apdex score while still reporting the errors to APM. Set this to a space-separated list of the Python exception type names to be expected. Use the form `module:class` for the exception name.
+
+    <Callout variant="tip">
+      This configuration option is only available in Python agent versions 6.4.0 and newer.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="error-expected-status-codes"
+    title="error_collector.expected_status_codes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Expect these status codes`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Prevents specified HTTP status codes from affecting error rate or Apdex score while still reporting the errors to APM. List status codes as integers separated by spaces and specify ranges with a hyphen `-` separator between the start and end values. To negate one of the codes in your list, preface the code with an exclamation point `!`.
+
+    This setting is only compatible with some web frameworks, as some frameworks do not use exceptions to return HTTP responses.
+
+    <Callout variant="tip">
+      This configuration option is only available in Python agent versions 6.4.0 and newer.
+    </Callout>
+  </Collapser>
+
+<Collapser
+    id="error-max-event-samples-stored"
+    title="error_collector.max_event_samples_stored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            100
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ERROR_COLLECTOR_MAX_EVENT_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Limit for error events per minute sent by an instance of the Python agent to New Relic.
+  </Collapser>
+
+  <Collapser
+    id="cfg-error-attributes-enabled"
+    title="error_collector.attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off all attributes for traced errors. If `attributes.enabled` is `false` at the root level, then no attributes will be sent to traced errors regardless on how this configuration setting (`error_collector.attributes.enabled`) is set.
+  </Collapser>
+
+  <Collapser
+    id="cfg-ec-attributes-include"
+    title="error_collector.attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for traced errors, all attribute keys found in this list will be sent to in traced errors. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-ec-attributes-exclude"
+    title="error_collector.attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Attribute keys found in this list will not be sent to in traced errors. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-ec-capture-events"
+    title="error_collector.capture_events"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If enabled, the error collector captures event data for advanced analytics. For more information, see [APM Errors](/docs/apm/applications-menu/events/view-apm-errors-error-traces).
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-general-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-general-settings.mdx
@@ -1,0 +1,1385 @@
+---
+title: Python agent general settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent general configuration settings: app name, license key, proxy, agent behavior, configuration methods, and multiple environment support.'
+freshnessValidatedDate: never
+---
+
+Configure core Python agent settings including app name, license key, proxy, high security mode, configuration methods, environment variables, and multiple environment support.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Configuration methods and precedence [#options]
+
+The primary way to configure the Python agent is via the [configuration file](#agent-configuration-file), which is generated as part of the standard [install process](/docs/agents/python-agent/installation-configuration/python-agent-installation). It is also possible to set a limited number of configuration options using [server-side configuration in the UI](#server-side-configuration) or by using [environment variables](#environment-variables). You can also specify some settings on a per-request basis by passing settings with the [WSGI request environ dictionary](#per-request-configuration).
+
+The Python agent follows this order of precedence for configuration:
+
+<img
+  title="diagram-python-config-precedence.png"
+  alt="diagram-python-config-precedence.png"
+  src="/images/apm_diagram_config-settings.webp"
+/>
+
+<figcaption>
+  With the Python agent, per-request options override server-side config. If enabled, server-side config overrides <DNT>**all**</DNT> corresponding values in the agent config file, even if the server-side values are left blank. The agent config file overrides environment variables. Environment variables override the agent defaults.
+</figcaption>
+
+Here are detailed descriptions of each configuration method:
+
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="agent-configuration-file"
+    title="Agent configuration file"
+  >
+    Typically you configure your Python agent from a local configuration file on the agent's host system. Supply the path to the config file at startup using one of these methods:
+
+    * When you call [`newrelic.agent.initialize()`](/docs/agents/python-agent/customization-extension/python-management-api#mgmt), provide the path to the config file as the first argument.
+
+      OR
+    * Set the `NEW_RELIC_CONFIG_FILE` environment variable. If you use the `newrelic-admin` wrapper script, you must use the environment variable because the wrapper script calls the agent automatically.
+
+      The agent supports two types of configuration files, agents v10.2.0 and older must use the `.ini` syntax while agent versions v10.3.0 and above running on Python versions 3.11 and above support `.toml` files as well.
+
+      <Collapser
+        className="freq-link"
+        id="agent-configuration-file-ini"
+        title="`.ini` configuration file format"
+      >
+        The configuration file uses a structure similar to Microsoft Windows `.ini` files. For more information, see the Python ConfigParser module's [file format documentation](https://docs.python.org/3/library/configparser.html).
+
+        The basic structure should look like the following:
+
+        ```ini
+        [newrelic]
+        license_key = <license key>
+        app_name = Python Application
+        ```
+      </Collapser>
+
+      <Collapser
+        className="freq-link"
+        id="agent-configuration-file-toml"
+        title="`.toml` configuration file format"
+      >
+        <Callout variant="tip">
+          Starting with Python 3.11 the newer `.toml` syntax for configuration was added to the [standard library](https://docs.python.org/3/library/tomllib.html). Agent version `10.3.0` added support for using this newer format.
+        </Callout>
+        The configuration file uses Tom's Obvious Minimal Language `.toml` files. For more information, see the [official file format documentation](https://toml.io/en/).
+
+        To use the `.toml` syntax, the configuration file's name must end with `.toml` to indicate the syntax type. The standard `pyproject.toml` may be used alongside configuration for other libraries, or you may use a more specific file like `newrelic.toml`.
+
+        The basic structure should look like the following:
+
+        ```ini
+        [tool.newrelic]
+        license_key = <license key>
+        app_name = Python Application
+        ```
+      </Collapser>
+
+      <Callout variant="tip">
+        A sample configuration file is included with the Python agent as `newrelic/newrelic.ini`. You can also generate one from the `newrelic-admin` script using the `generate-config` command, or download a copy from [our download repo](https://download.newrelic.com/python_agent/release/).
+      </Callout>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="server-side-configuration"
+    title="Server-side configuration"
+  >
+    [Server-side configuration](/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration) allows you to configure certain settings in the New Relic UI. This applies your changes automatically to all agents even if they run across multiple hosts. Where available, this document includes the UI labels for server-side config under individual config options as the <DNT>**Server-side label**</DNT>.
+
+    <Callout variant="important">
+      If server-side config is enabled, the agent ignores any value in the config file that <DNT>**could**</DNT> be set in the UI. Even if the UI value is empty, the agent treats this as an empty string and does not use the agent config file.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="environment-variables"
+    title="Environment variables"
+  >
+    Environment variables allow you to override the defaults for certain core settings. If the equivalent setting is explicitly listed in the agent config file, the config file settings take precedence over the environment variable. Where available, environment variables are documented below under individual config options as the <DNT>**Environ variable**</DNT>.
+
+    For simple configurations, you can use the environment variables in conjunction with [server-side configuration](#server-side-configuration) and avoid the agent config file altogether. This is the default setup with [Heroku](/docs/agents/python-agent/hosting-services/python-agent-heroku), where installing the New Relic add-on automatically populates the necessary environment variables.
+
+    If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/observability/repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/observability/error-investigation/#buildsha).
+
+    <table>
+      <thead>
+        <tr>
+          <th width="400px">
+            <DNT>
+              **Environment variable**
+            </DNT>
+          </th>
+
+          <th>
+            <DNT>
+              **Configuration setting**
+            </DNT>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+            `NEW_RELIC_ENABLED`
+          </td>
+
+          <td>
+            `enabled`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_LICENSE_KEY`
+          </td>
+
+          <td>
+            `license_key`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_APP_NAME`
+          </td>
+
+          <td>
+            `app_name`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_MONITOR_MODE`
+          </td>
+
+          <td>
+            `monitor_mode`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_DEVELOPER_MODE`
+          </td>
+
+          <td>
+            `developer_mode`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_LOG`
+          </td>
+
+          <td>
+            `log_file`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_LOG_LEVEL`
+          </td>
+
+          <td>
+            `log_level`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_HIGH_SECURITY`
+          </td>
+
+          <td>
+            `high_security`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_HOST`
+          </td>
+
+          <td>
+            `host`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_OTLP_HOST`
+          </td>
+
+          <td>
+            `otlp_host`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PORT`
+          </td>
+
+          <td>
+            `port`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_OTLP_PORT`
+          </td>
+
+          <td>
+            `otlp_port`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PROXY_SCHEME`
+          </td>
+
+          <td>
+            `proxy_scheme`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PROXY_HOST`
+          </td>
+
+          <td>
+            `proxy_host`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PROXY_PORT`
+          </td>
+
+          <td>
+            `proxy_port`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PROXY_USER`
+          </td>
+
+          <td>
+            `proxy_user`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PROXY_PASS`
+          </td>
+
+          <td>
+            `proxy_pass`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_AUDIT_LOG`
+          </td>
+
+          <td>
+            `audit_log_file`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_STARTUP_TIMEOUT`
+          </td>
+
+          <td>
+            `startup_timeout`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_SHUTDOWN_TIMEOUT`
+          </td>
+
+          <td>
+            `shutdown_timeout`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_LABELS`
+          </td>
+
+          <td>
+            `labels`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME`
+          </td>
+
+          <td>
+            `process_host.display_name`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_API_KEY`
+          </td>
+
+          <td>
+            `api_key`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_CA_BUNDLE_PATH`
+          </td>
+
+          <td>
+            `ca_bundle_path`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`
+          </td>
+
+          <td>
+            `distributed_tracing.enabled`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_APDEX_T`
+          </td>
+
+          <td>
+            `apdex_t`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_GC_RUNTIME_METRICS_ENABLED`
+          </td>
+
+          <td>
+            `gc_runtime_metrics.enabled`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_MEMORY_RUNTIME_PID_METRICS_ENABLED`
+          </td>
+
+          <td>
+            `memory_runtime_pid_metrics.enabled`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_ANALYTICS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+
+          <td>
+            `transaction_events.max_samples_stored`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+
+          <td>
+            `custom_insights_events.max_samples_stored`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_ATTRIBUTE_VALUE`
+          </td>
+
+          <td>
+            `custom_insights_events.max_attribute_value`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_ML_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+
+          <td>
+            `event_harvest_config.harvest_limits.ml_event_data`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+
+          <td>
+            `span_events.max_samples_stored`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_ERROR_COLLECTOR_MAX_EVENT_SAMPLES_STORED`
+          </td>
+
+          <td>
+            `error_collector.max_event_samples_stored`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            `NEW_RELIC_FEATURE_FLAG`
+          </td>
+
+          <td>
+            `feature_flag`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
+    id="per-request-configuration"
+    title="Per-request configuration"
+  >
+    For certain WSGI servers, you can override the [app name](#app_name) and [capture attributes](#attributes) settings on a per-request basis. This is possible with WSGI servers where you can define additional key/value pairs that are passed into the per-request WSGI environ dictionary.
+
+    Set these values with the strings `on`, `off`, `true`, `false`, `1` and `0`. If set from a configuration mechanism implemented using Python code, Python objects evaluating to True or False will also be accepted.
+
+    <CollapserGroup>
+      <Collapser
+        id="example-apache-mod-wsgi"
+        title="Example: Apache/mod_wsgi app name"
+      >
+        In the Apache/mod_wsgi server, you can use the `SetEnv` directive to override config settings (optionally inside a `Location` or `Directory` block). For example, you could override the [app name](#app_name) for a complete virtual host, or for a subset of URLs handled by the WSGI application for that virtual host.
+      </Collapser>
+    </CollapserGroup>
+
+    In addition to being able to override certain agent configuration settings, you can set other per-request configuration settings with their WSGI environment key:
+
+    <CollapserGroup>
+      <Collapser
+        id="set_background_task"
+        title="newrelic.set_background_task"
+      >
+        If set to `true`, this web transaction will instead be reported as a [non-web transaction](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions).
+      </Collapser>
+
+      <Collapser
+        id="ignore_transaction"
+        title="newrelic.ignore_transaction"
+      >
+        If set to `true`, this web transaction will not be reported.
+      </Collapser>
+
+      <Collapser
+        id="suppress_apdex_metric"
+        title="newrelic.suppress_apdex_metric"
+      >
+        If set to `true`, no Apdex metric will be generated for this web transaction.
+      </Collapser>
+
+      <Collapser
+        id="suppress_transaction_trace"
+        title="newrelic.suppress_transaction_trace"
+      >
+        If set to `true`, this web transaction cannot be recorded in a [transaction trace](/docs/apm/transactions/transaction-traces/transaction-traces).
+      </Collapser>
+
+      <Collapser
+        id="disable_browser_autorum"
+        title="newrelic.disable_browser_autorum"
+      >
+        If set to `true`, this disables automatic insertion of the JavaScript header/footer for page load timing (sometimes referred to as real user monitoring or RUM). Only applicable if auto-insertion is [available for your web framework](/docs/agents/python-agent/supported-features/page-load-timing-python#restrictions_on_instrumentation).
+      </Collapser>
+    </CollapserGroup>
+
+    <Callout variant="important">
+      Using a WSGI middleware to set these values will not work where the Python agent's own WSGI application wrapper was applied at an outer scope. In these cases you must make calls to the agent API to achieve the same outcome.
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+
+## Multiple environment configuration [#config-file-deployment-environments]
+
+The agent reads its primary configuration from an agent config section called `[newrelic]` for `ini` files, or `[tool.newrelic]` for `.toml` files. You can provide overrides for specific deployment environments (for example, Development, Staging, Production) in additional sections. Preface these sections with `[newrelic:environment]` for `.ini` files, or `[tool.newrelic.env.environment]` for `.toml` files (where `environment` is replaced with the name of your environment).
+
+To specify that the agent should use an environment-based configuration, use one of these methods:
+
+* When you call [`newrelic.agent.initialize()`](/docs/agents/python-agent/customization-extension/python-management-api#mgmt), provide the environment name as the second argument.
+
+  OR
+* Set the `NEW_RELIC_ENVIRONMENT` environment variable to the environment name.
+
+If no environment is specified, the agent will use the default settings as specified in the `newrelic` agent config section.
+
+The basic structure of the configuration file is:
+
+
+<Collapser
+  className="freq-link"
+  id="config-file-format-example-ini"
+  title="`.ini` configuration file format"
+>
+```ini
+[newrelic]
+... default settings
+
+[newrelic:development]
+... override settings
+
+[newrelic:staging]
+... override settings
+
+[newrelic:production]
+... override settings
+```
+</Collapser>
+
+<Collapser
+  className="freq-link"
+  id="config-file-format-example-toml"
+  title="`.toml` configuration file format"
+>
+```ini
+[tool.newrelic]
+... default settings
+
+[tool.newrelic.env.development]
+... override settings
+
+[tool.newrelic.env.staging]
+... override settings
+
+[tool.newrelic.env.production]
+... override settings
+```
+</Collapser>
+
+## General configuration settings [#general-settings]
+
+These settings are available in the agent configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="license_key"
+    title="license_key (REQUIRED)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_LICENSE_KEY`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Specifies the <InlinePopover type="licenseKey"/> of your New Relic account. This key associates your app's metrics with your New Relic account.
+  </Collapser>
+
+  <Collapser
+    id="app_name"
+    title="app_name (HIGHLY RECOMMENDED)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `Python Application`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Per-request option, config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Per-request option](#per-request-configuration)
+          </th>
+
+          <td>
+            `newrelic.app_name`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APP_NAME`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated with a semicolon `;`. Do not put a space before the semicolon, which causes the Python config parser to interpret the name as an embedded comment.
+  </Collapser>
+
+  <Collapser
+    id="monitor_mode"
+    title="monitor_mode"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_MONITOR_MODE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent collects performance data about your app and reports this data to our [data collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector).
+  </Collapser>
+
+  <Collapser
+    id="developer_mode"
+    title="developer_mode"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_DEVELOPER_MODE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent will instrument your web app, but will not send any actual data. In this offline mode, you will not be billed for an active agent.
+
+    Use developer mode to test [new versions of the agent](/docs/release-notes/agent-release-notes/python-release-notes), or test the agent against third-party packages in a developer environment. Offline mode is not a way of running the APM locally, because the metrics the agent collects are not reported anywhere.
+  </Collapser>
+
+  <Collapser
+    id="log_file"
+    title="log_file"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_LOG`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Sets the name of a log file, which is useful for debugging issues with the agent. This is not set by default, since the agent does not know your web app process's parent user or what directories that process has permission to write to. For detailed information, see [Python agent logging](/docs/agents/python-agent/installation-configuration/python-agent-logging).
+
+    Whatever you set this to, ensure the permissions for the containing directory and the file itself are correct, and that the user that your web application runs as can write to the file.
+
+    <Callout variant="tip">
+      Use an absolute path unless you are sure what the working directory of your application will be at startup. If you can't write out a log file, you can also use `stderr` and output to standard error output. This would normally result in output appearing in your web server log.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="log_level"
+    title="log_level"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `info`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_LOG_LEVEL`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Sets the level of detail of log messages, if you've set the [log file location](#log_file). This `log_level` will not affect the Python logging module log level. Possible values, in increasing order of detail, are `critical`, `error`, `warning`, `info`, and `debug`.
+
+    To report agent issues, the most useful setting is `debug`. However, `debug` generates a lot of information very quickly, so do not keep the agent at this level for longer than it takes to reproduce your problem.
+  </Collapser>
+
+  <Collapser
+    id="high_security"
+    title="high_security"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_HIGH_SECURITY`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    High-security mode enforces certain security settings and prevents them from being overridden, so that no sensitive data is sent to us. Enabling high-security mode means that request parameters are not collected, and you cannot send raw SQL.
+
+    To activate high-security mode, set it to `true` in the local <DNT>**.ini**</DNT> configuration file <DNT>**and**</DNT> activate it from the <DNT>**Account settings**</DNT> page. For more information, see [High security](/docs/accounts-partnerships/accounts/security/high-security).
+  </Collapser>
+
+  <Collapser
+    id="proxy"
+    title="proxy_scheme, proxy_host, proxy_port, proxy_user, proxy_pass"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environ variables
+          </th>
+
+          <td>
+            `NEW_RELIC_PROXY_SCHEME`
+
+            `NEW_RELIC_PROXY_HOST`
+
+            `NEW_RELIC_PROXY_PORT`
+
+            `NEW_RELIC_PROXY_USER`
+
+            `NEW_RELIC_PROXY_PASS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    By default, the Python agent attempts to directly connect to our servers. If there is a firewall between your host and the our [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector) that requires you to use an HTTP proxy, set `proxy_host` and `proxy_port` to the required values for your HTTP proxy. If proxy authentication is implemented by the HTTP proxy, also set `proxy_user` and `proxy_pass`.
+
+    The `proxy_scheme` setting dictates what protocol scheme is used to talk to the HTTP proxy. When set to `http`, the agent uses a SSL tunnel through the HTTP proxy for end-to-end encryption.
+
+    Instead of setting the `proxy_scheme`, `proxy_host` and `proxy_port` settings, you can also set the `proxy_host` setting to a valid URI for the proxy. Include the scheme, host, and port; for example, `http://proxy-host:8000`. This also works if you set the details of the HTTP proxy with the `NEW_RELIC_PROXY_HOST` environment variable.
+  </Collapser>
+
+  <Collapser
+    id="audit-log-file"
+    title="audit_log_file"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_AUDIT_LOG`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Sets the name of the audit log file. If set, the agent logs details of messages passed back and forth between the monitored process and the [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector). This allows you to evaluate the security of the Python agent.
+
+    Use an absolute path unless you are sure what your app's working directory will be at startup. Whatever you set this to, ensure the permissions for the containing directory and the file itself are correct. Also ensure your web app's parent user can write to the file.
+
+    <Callout variant="caution">
+      Do not use audit logging on an ongoing basis, especially in a production environment. Because the agent does not truncate or rotate the log file, the log file can grow very quickly.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="labels"
+    title="labels (tags)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_LABELS`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Adds [tags](/docs/apm/new-relic-apm/maintenance/labels-categories-organize-your-apps-servers). Specify _name:value_ separated by a colon `:`, and separate additional tags with semicolons `;`.
+
+    <CollapserGroup>
+      <Collapser
+        id="example-2-labels"
+        title="Two tags"
+      >
+        ```ini
+        labels = Server:One;Data Center:Primary
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    id="process_host-display_name"
+    title="process_host.display_name"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Sets the hostname to be [displayed in the APM UI](/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name). If set, this overrides the default hostname that the agent captures automatically.
+  </Collapser>
+
+  <Collapser
+    id="api-key"
+    title="api_key"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_API_KEY`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Sets the [api_key](/docs/apis/rest-api-v2/requirements/api-keys) to be used with [newrelic-admin record-deploy](/docs/agents/python-agent/installation-configuration/python-agent-admin-script#record-deploy).
+  </Collapser>
+
+  <Collapser
+    id="ca-bundle-path"
+    title="ca_bundle_path"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_CA_BUNDLE_PATH`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Manual override for the path to your local CA bundle. This CA bundle will be used to validate the SSL certificate presented by our data collection service.
+
+    <Callout variant="tip">
+      This configuration option is only available in Python agent versions 4.2.0 and newer.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="apdex-t"
+    title="apdex_t"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `0.5`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APDEX_T`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    We'll record transaction traces when they exceed this threshold. The format is a number of seconds (decimal points allowed).
+
+    See our glossary entry for [apdex_t](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#apdex_t)
+
+    <Callout variant="important">
+      This is only set in the config file or the environment variable if `serverless_mode` is set, which is enabled for AWS Lambda.  Otherwise, the local `apdex_t` value is overridden by the value in UI application settings which is then used to set the `apdex_f` value.
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-logs-in-context-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-logs-in-context-settings.mdx
@@ -1,0 +1,677 @@
+---
+title: Python agent logs in context settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent application logging configuration: log forwarding, local log decoration, log metrics, and context data.'
+freshnessValidatedDate: never
+---
+
+Configure application logging settings for the Python agent to enable log forwarding, local log decoration, log metrics collection, and context data enrichment.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Application logging settings [#application-logging]
+
+The following settings are available for configuration of application logging in the agent.
+
+For some tips on configuring logs for the Python agent, see [Configure Python logs in context](/docs/logs/logs-context/configure-logs-context-python).
+
+<Callout variant="important">
+  Requires [Python agent version 7.12.0.176 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="application-logging-enabled"
+    title="application_logging.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, enables log decoration and the collection of log events and logging metrics if these sub-feature configurations are also enabled.  If `false`, no logging instrumentation features are enabled.
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-enabled"
+    title="application_logging.forwarding.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `application_logging.enabled` must also be `true` for this setting to take effect.
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+
+    <Callout variant="caution">
+      If you are already sending your application's logs to New Relic using an existing log forwarding solution, be sure to disable that before enabling log forwarding in the agent, in order to prevent being billed for duplicate log data.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-custom-attributes"
+    title="application_logging.forwarding.custom_attributes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CUSTOM_ATTRIBUTES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    A hash with key/value pairs to add as custom attributes to all log events forwarded to New Relic. The value must be formatted like: "key1:value1;key2:value2"
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-labels-enabled"
+    title="application_logging.forwarding.labels.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Toggles whether the agent will add labels to log records for sending to New Relic.
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-labels-exclude"
+    title="application_logging.forwarding.labels.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    A case-insensitive list of label names to exclude when you enable including labels in logs. This attribute does not support wildcards or regex.
+    <Callout variant="important">When adding labels as attributes, the agent prefixes the keys with `tags.`. This prefix is <b>NOT</b> included when matching against the exclude filtering rules.</Callout>
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-context-data-enabled"
+    title="application_logging.forwarding.context_data.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent will capture available context data (extras, dictionary message attributes, attributes provided by logging frameworks) and add its contents as attributes on the logs forwarded to New Relic. You can control this behavior through the settings under the `application_logging.forwarding.context_data` section.
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-context-data-include"
+    title="application_logging.forwarding.context_data.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for `context_data`, all attribute keys found in this list will be sent to us in transaction traces. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+
+    <Callout variant="important">
+      When adding context attributes, the agent prefixes the keys with `context.` for attributes from the logging framework context, and `message.` for attributes from a dictionary message context.
+
+      These prefixes are <b>NOT</b> included when matching against include/exclude filtering rules.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-context-data-exclude"
+    title="application_logging.forwarding.context_data.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CONTEXT_DATA_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent in context_data. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+
+    <Callout variant="important">
+      When adding context attributes, the agent prefixes the keys with `context.` for attributes from the logging framework context, and `message.` for attributes from a dictionary message context.
+
+      These prefixes are <b>NOT</b> included when matching against include/exclude filtering rules.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-max-samples-stored"
+    title="application_logging.forwarding.max_samples_stored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            10000
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Number of log records to send per minute to New Relic. This setting controls overall memory consumption when using the log forwarding feature.
+
+    Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
+
+    Each log receives the same priority as its associated transaction.  Logs that occur outside of a transaction will receive a random priority. Some logs may not be included because they are limited by `max_samples_stored`. For example, if logging `max_samples_stored` is set to 10,000 and transaction 1 has 10,000 log entries, only log entries for transaction 1 will be recorded. If transaction 1 has less than 10,000 logs you receive all logs for transaction 1. If there is still space, you receive all the logs for transaction 2, and so on.
+
+    If after all the logs for sampled transactions are recorded, and they haven't reached the limit in `max_samples_stored`, then log messages for transactions that were not in our sampling are sent. If there are any left, log messages outside of transactions are recorded.
+  </Collapser>
+
+  <Collapser
+    id="event-harvest-config-harvest-limits-log-event-data"
+    title="event_harvest_config.harvest_limits.log_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            10000
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="warning">
+      This setting has been deprecated starting in version 11.0.0.  Please use [`application_logging.forwarding.max_samples_stored`](#application-logging-forwarding-max-samples-stored) instead.
+    </Callout>
+
+    Number of log records to send per minute to New Relic. This setting controls overall memory consumption when using the log forwarding feature.
+
+    Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
+
+    Each log receives the same priority as its associated transaction.  Logs that occur outside of a transaction will receive a random priority. Some logs may not be included because they are limited by `max_samples_stored`. For example, if logging `max_samples_stored` is set to 10,000 and transaction 1 has 10,000 log entries, only log entries for transaction 1 will be recorded. If transaction 1 has less than 10,000 logs you receive all logs for transaction 1. If there is still space, you receive all the logs for transaction 2, and so on.
+
+    If after all the logs for sampled transactions are recorded, and they haven't reached the limit in `max_samples_stored`, then log messages for transactions that were not in our sampling are sent. If there are any left, log messages outside of transactions are recorded.
+  </Collapser>
+
+  <Collapser
+    id="application-logging-metrics-enabled"
+    title="application_logging.metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent captures metrics related to the log lines being sent up by your application. `application_logging.enabled` must also be `true` for this setting to take effect.
+  </Collapser>
+
+  <Collapser
+    id="application-logging-local-decorating-enabled"
+    title="application_logging.local_decorating.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans. `application_logging.enabled` must also be `true` for this setting to take effect.
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-ml-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-ml-settings.mdx
@@ -1,0 +1,555 @@
+---
+title: Python agent machine learning settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent machine learning and hybrid agent (OpenTelemetry) configuration settings.'
+freshnessValidatedDate: never
+---
+
+Configure machine learning and hybrid agent (OpenTelemetry) settings for the Python agent, including ML event collection, inference value recording, and OpenTelemetry trace inclusion and exclusion rules.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Machine Learning settings [#ml-settings]
+
+<Callout variant="important">
+  Requires [Python agent version 9.1.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+The following settings are available for configuration of machine learning data in the agent.
+
+<CollapserGroup>
+  <Collapser
+    id="machine-learning-enabled"
+    title="machine_learning.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_MACHINE_LEARNING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set to `true` to enable agent attribute collection for machine learning metrics.
+  </Collapser>
+
+  <Collapser
+    id="inference-events-value-enabled"
+    title="machine_learning.inference_events_value.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_MACHINE_LEARNING_INFERENCE_EVENT_VALUE_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set to `true` to enable capturing of the raw inference value.
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="ml-insights-events-enabled"
+    title="ml_insights_events.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Allow recording of machine learning events to the Event API via [`record_ml_event()`](/docs/agents/python-agent/python-agent-api/recordmlevent-python-agent-api/).
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="harvest-limits-ml-event-data"
+    title="event_harvest_config.harvest_limits.ml_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            100000
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ML_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Limit for how many ML events per minute that an instance of the Python agent can send to New Relic.
+  </Collapser>
+</CollapserGroup>
+
+## Hybrid agent settings [#otel-settings]
+
+<Callout variant="important">
+  Requires [Python agent version 11.5.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+For more information on hybrid agent functionalities, refer to [this page](/docs/apm/agents/manage-apm-agents/opentelemetry-api-support). 
+
+The following settings are available for configuration of the hybrid agent:
+
+<CollapserGroup>
+  <Collapser
+    id="opentelemetry.enabled"
+    title="opentelemetry.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            False
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    From v11.5.0 to v13.0.0: If enabled, any OpenTelemetry API and most [OpenTelemetry instrumented frameworks](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation#readme) that are installed will be used.
+    From v13.0.0+: If enabled, any OpenTelemetry API and frameworks that are [supported by OpenTelemetry](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation#readme) but not New Relic will be used.
+
+    <Callout variant="important">
+      While most libraries in [OpenTelemetry's instrumented frameworks](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation#readme) are supported, AWS and gRPC instrumentation libraries will continue to use New Relic's instrumentation. ML/AI libraries with native instrumentation are explicitly disabled for now and will be supported in a future release.
+    </Callout>
+
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry.traces.enabled"
+    title="opentelemetry.traces.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            True
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    From v11.5.0 to v13.0.0: If enabled, any OpenTelemetry span and trace APIs will be used, regardless of whether an existing New Relic instrumentation library exists.
+    From v13.0.0+: If enabled, any manual call using the OpenTelemetry span API and spans from frameworks that are [supported by OpenTelemetry](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation#readme) but not New Relic will be used.
+
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry.traces.exclude"
+    title="opentelemetry.traces.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, comma-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables users to exclude tracer(s) from being reported to New Relic.  See the [section below](#include-exclude-rules) for more details.
+    
+    <Callout variant="important">
+      Requires [Python agent version 13.0.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="opentelemetry.traces.include"
+    title="opentelemetry.traces.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, comma-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_OPENTELEMETRY_TRACES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables users to include tracer(s) to be reported to New Relic.  See the [section below](#include-exclude-rules) for more details.
+
+    <Callout variant="important">
+      Requires [Python agent version 13.0.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+    </Callout>
+  </Collapser>
+
+</CollapserGroup>
+
+Include and Exclude rules [#include-exclude-rules]
+
+New Relic follows these rules when determining which tracers to include or exclude for monitoring.
+
+<CollapserGroup>
+  <Collapser
+    id="rule-precedence"
+    title="Enabled takes precedence over include and exclude."
+  >
+    `opentelemetry.traces.enabled` flag takes precedence over include and exclude settings.
+
+    Example configuration:
+
+    ```ini
+    opentelemetry.traces.enabled = false
+    opentelemetry.traces.include = one,two
+    ```
+
+    Example output:
+
+    ```
+    Tracers used: one, two, three, four
+    Tracers included:
+    Tracers excluded: one, two, three, four
+    ```
+  </Collapser>
+
+  <Collapser
+    id="rule-trace-included"
+    title="Trace is included if tracing is enabled."
+  >
+    If tracing is enabled, any custom OpenTelemetry tracers and tracers from OpenTelemetry libraries not supported by New Relic are monitored by default.
+
+    Example configuration:
+
+    ```ini
+    opentelemetry.traces.enabled = true
+    opentelemetry.traces.exclude = myTrace
+    ```
+
+    Example output:
+
+    ```
+    Tracers used: foo, bar, myTrace
+    Tracers included: foo, bar
+    Tracers excluded: myTrace
+    ```
+  </Collapser>
+
+  <Collapser
+    id="rule-exclude-wins"
+    title="Exclude always supersedes include."
+  >
+    If the same tracer is listed in the include and exclude lists, then the tracer will be excluded.
+
+    Example configuration:
+
+    ```ini
+    opentelemetry.traces.enabled = true
+    opentelemetry.traces.include = foo,myTrace
+    opentelemetry.traces.exclude = bar,myTrace
+    ```
+
+    Example output:
+
+    ```
+    Tracers used: foo, myTrace, bar
+    Tracers included: foo
+    Tracers excluded: bar, myTrace
+    ```
+  </Collapser>
+
+  <Collapser
+    id="rule-tracers-case-sensitive"
+    title="Tracers are case sensitive."
+  >
+    Tracers are case sensitive.
+
+    Example configuration:
+
+    ```ini
+    opentelemetry.traces.enabled = true
+    opentelemetry.traces.exclude = myTrace,mYtRaCe
+    ```
+
+    Example output:
+
+    ```
+    Tracers used: mytrace, Mytrace, MYTRACE, mYtRaCe, MyTRACE
+    Tracers included: mytrace, Mytrace, MYTRACE, MyTRACE
+    Tracers excluded: mYtRaCe
+    ```
+  </Collapser>
+</CollapserGroup>
+

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-other-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-other-settings.mdx
@@ -1,0 +1,2395 @@
+---
+title: Python agent other settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent miscellaneous settings: transaction events, custom events, datastore tracer, event harvest, event loop, runtime metrics, garbage collection, code-level metrics, errors inbox, instrumentation, middleware filters, other config settings, and Heroku.'
+freshnessValidatedDate: never
+---
+
+Configure miscellaneous Python agent settings including transaction events, custom events, datastore tracing, event harvest limits, event loop visibility, runtime metrics, garbage collection, code-level metrics, instrumentation filters, and Heroku support.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Transaction events settings
+
+Here are Transaction events settings available via the agent configuration file.
+
+<Callout variant="tip">
+  These configuration settings used to be called `analytic_events`. If your configuration file still uses `analytic_events`, update your agent to use `transaction_events`.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="transaction-events-enabled"
+    title="transaction_events.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Transaction event data allows the use of additional information such as [histograms](/docs/applications-menu/histograms-viewing-data-distribution) and [percentiles](/docs/applications-menu/percentiles-comparing-ranked-data).
+  </Collapser>
+
+  <Collapser
+    id="transaction-events-max-samples-stored"
+    title="transaction_events.max_samples_stored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `1200`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ANALYTICS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Limit for analytic events per minute sent by an instance of the Python agent to New Relic.
+  </Collapser>
+
+  <Collapser
+    id="cfg-events-attributes-enabled"
+    title="transaction_events.attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off all attributes for transaction events. If `attributes.enabled` is `false` at the root level, then no attributes will be sent to transaction events regardless on how this configuration setting (`transaction_events.attributes.enabled`) is set.
+  </Collapser>
+
+  <Collapser
+    id="cfg-events-attributes-include"
+    title="transaction_events.attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for transaction events, all attribute keys found in this list will be sent in transaction events. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-events-attributes-exclude"
+    title="transaction_events.attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent to in transaction events. Note that excluding attributes from transaction events does not exclude from span events. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+</CollapserGroup>
+
+## Custom events settings
+
+Here are custom events settings available via the agent configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="custom-insights-events-enabled"
+    title="custom_insights_events.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Allow recording of events to the Event API via [`record_custom_event()`](/docs/agents/python-agent/python-agent-api/recordcustomevent-python-agent-api/).
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="custom-insights-events-max-samples-stored"
+    title="custom_insights_events.max_samples_stored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `3600`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    * Limits how many custom events per minute that an instance of the Python agent can send to New Relic.
+    * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `100000` to ensure the agent captures the maximum amount of LLM events.
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+
+  </Collapser>
+</CollapserGroup>
+
+## Datastore tracer settings
+
+These datastore tracer settings are available via the agent configuration file:
+
+<CollapserGroup>
+  <Collapser
+    id="datastore-tracer-instance-reporting-enabled"
+    title="datastore_tracer.instance_reporting.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent collects datastore instance metrics (such as host and port) for some database drivers. These are also reported on slow query traces and transaction traces.
+  </Collapser>
+
+  <Collapser
+    id="datastore-tracer-database-name-reporting-enabled"
+    title="datastore_tracer.database_name_reporting.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent collects database name for some database drivers. The database name is reported on slow query traces and transaction traces.
+  </Collapser>
+</CollapserGroup>
+
+
+## Event harvest configuration [#event-harvest-config]
+
+Event harvest settings limit the amount of event type data sent to New Relic. When you use these settings, consider these important points:
+
+* Event harvest settings affect the limits for a single instance of the agent, and not across the entire application. See the usage example below for how to set limits across an entire application.
+* [Real time streaming](/docs/agents/manage-apm-agents/agent-data/real-time-streaming) sends data every five seconds (12 times per minute), but the event harvest settings still affect the rate in events per <DNT>**minute**</DNT>. Enabling or disabling real time streaming does not require changing these settings.
+* With real time streaming (enabled by default), New Relic will display the event harvest limits for entities in five second intervals. This means, for example, when you set a limit value of 1200 in the config file, you'll see it as 100 in New Relic.
+
+### Usage example
+
+Let's say an application is deployed across 10 hosts, each running four processes per host. To limit the number of span events to 10,000 events per minute for the entire application, divide that number by 10 hosts. Then divide again by four processes per host.
+
+10000 / (10 \* 4) = 250
+
+Based on that calculation, the final setting is:
+
+span_events.max_samples_stored = 250
+
+<Callout variant="tip">
+  Because of the way New Relic harvests data (12 times per minute), if the event data count is less than 12, it will show up as 0 in New Relic.
+</Callout>
+
+Event harvest configuration settings include:
+
+<CollapserGroup>
+  <Collapser
+    id="harvest-limits-analytic-event-data"
+    title="event_harvest_config.harvest_limits.analytic_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `1200`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ANALYTICS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="warning">
+      This setting has been deprecated starting in version 11.0.0.  Please use [`transaction_events.max_samples_stored`](#transaction-events-max-samples-stored) instead.
+    </Callout>
+
+    Limit for analytic events per minute sent by an instance of the Python agent to New Relic.
+  </Collapser>
+
+  <Collapser
+    id="harvest-limits-custom-event-data"
+    title="event_harvest_config.harvest_limits.custom_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `3600`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="warning">
+      This setting has been deprecated starting in version 11.0.0.  Please use [`custom_insights_events.max_samples_stored`](#custom-insights-events-max-samples-stored) instead.
+    </Callout>
+
+    Limit for how many custom events per minute that an instance of the Python agent can send to New Relic.
+  </Collapser>
+
+  <Collapser
+    id="harvest-limits-span-event-data"
+    title="event_harvest_config.harvest_limits.span_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `2000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="warning">
+      This setting has been deprecated starting in version 11.0.0.  Please use [`span_events.max_samples_stored`](#cfg-tt-max-samples-stored) instead.
+    </Callout>
+
+    * Limit for span events per minute sent by an instance of the Python agent to New Relic.
+    * When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000` to ensure that the agent captures the maximum amount of distributed traces.
+  </Collapser>
+
+  <Collapser
+    id="harvest-limits-error-event-data"
+    title="event_harvest_config.harvest_limits.error_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            100
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ERROR_COLLECTOR_MAX_EVENT_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="warning">
+      This setting has been deprecated starting in version 11.0.0.  Please use [`error_collector.max_event_samples_stored`](#error-max-event-samples-stored) instead.
+    </Callout>
+
+    Limit for error events per minute sent by an instance of the Python agent to New Relic.
+  </Collapser>
+
+  <Collapser
+    id="event-harvest-limits-ml-event-data"
+    title="event_harvest_config.harvest_limits.ml_event_data"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            100000
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_ML_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Limit for how many ML events per minute that an instance of the Python agent can send to New Relic.
+  </Collapser>
+</CollapserGroup>
+
+## Event loop visibility settings [#event-loop]
+
+<Callout variant="important">
+  Requires [Python agent version 5.0.0.124 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+Event loop visibility surfaces information about transactions that block the event loop. The agent will generate information about transactions that have waited a significant amount of time to acquire control of the event loop. Settings include:
+
+<CollapserGroup>
+  <Collapser
+    id="event-loop-visibility-enabled"
+    title="event_loop_visibility.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set this to `false` to disable event loop information.
+  </Collapser>
+
+  <Collapser
+    id="event-loop-visbility-blocking-threshold"
+    title="event_loop_visibility.blocking_threshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `0.1`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Threshold in seconds for how long a transaction must block the event loop before generating event loop information.
+  </Collapser>
+</CollapserGroup>
+
+## Runtime metrics for physical memory [#runtime-metrics]
+
+<Callout variant="important">
+  Requires [Python agent version 9.9.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+These runtime metrics settings are available via the agent configuration file:
+
+<CollapserGroup>
+  <Collapser
+    id="runtime-metrics-reporting-enabled"
+    title="memory_runtime_pid_metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            true
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_MEMORY_RUNTIME_PID_METRICS_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will generate and send runtime metrics per process ID.
+  </Collapser>
+</CollapserGroup>
+
+## Garbage collection runtime metrics settings [#garbage-collection-runtime-metrics]
+
+<Callout variant="important">
+  Requires [Python agent version 6.2.0.156 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+These garbage collection runtime metrics settings are available via the agent configuration file:
+
+<CollapserGroup>
+  <Collapser
+    id="datastore-tracer-instance-reporting-enabled"
+    title="gc_runtime_metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            false
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will generate and send garbage collection metrics.
+  </Collapser>
+
+  <Collapser
+    id="datastore-tracer-database-name-reporting-enabled"
+    title="gc_runtime_metrics.top_object_count_limit"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            5
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The agent reports object count metrics for the most common object types being collected by the garbage collector. For each object type, this setting allows you to set the maximum number of individual metrics that will be sampled.
+  </Collapser>
+</CollapserGroup>
+
+## Code-level metrics settings [#codestream-integration]
+
+The following settings are available for configuration of code-level metrics in the agent.
+
+<CollapserGroup>
+  <Collapser
+    id="code-level-metrics-enabled"
+    title="code_level_metrics.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set this to `false` to disable agent attribute collection for code-level metrics.
+  </Collapser>
+
+  <Collapser
+    id="NEW_RELIC_METADATA_COMMIT"
+    title="NEW_RELIC_METADATA_COMMIT"
+  >
+    <Callout variant="important">
+      This can only be set through an environment variable.
+    </Callout>
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `None`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Environment variable
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The commit sha. The entire sha can be used or just the first seven characters (for example 734713b).
+  </Collapser>
+
+  <Collapser
+    id="NEW_RELIC_METADATA_RELEASE_TAG"
+    title="NEW_RELIC_METADATA_RELEASE_TAG"
+  >
+    <Callout variant="important">
+      This can only be set through an environment variable.
+    </Callout>
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `None`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Environment variable
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    A release tag (such as v0.1.209 or release-209).
+  </Collapser>
+</CollapserGroup>
+
+## Errors inbox configuration [#errors-inbox-configuration]
+
+Setting one of the following tags will help you identify which versions of your software are producing the errors.
+
+* `NEW_RELIC_METADATA_SERVICE_VERSION` will create tags.service.version on event data containing the version of your code that is deployed, in many cases a semantic version such as 1.2.3, but not always.
+* `NEW_RELIC_METADATA_RELEASE_TAG ` will create tags.releaseTag on event data containing the release tag (such as v0.1.209 or release-209).
+* `NEW_RELIC_METADATA_COMMIT` will create tags.commit on event data containing the commit sha. The entire sha can be used or just the first seven characters (e.g., 734713b).
+
+An upcoming release of errors inbox will automatically track which versions of your software are producing errors. Any version data will also be displayed in [CodeStream](/docs/codestream/how-use-codestream/performance-monitoring/#buildsha).
+
+
+## Instrumentation settings [#instrumentation-settings]
+
+<Callout variant="important">
+  Requires [Python agent version 8.7.1 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+These instrumentation package specific settings are available via the agent configuration file:
+
+<CollapserGroup>
+  <Collapser
+    id="instrumentation-graphql-capture-introspection-queries"
+    title="instrumentation.graphql.capture_introspection_queries"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_INSTRUMENTATION_GRAPHQL_CAPTURE_INTROSPECTION_QUERIES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will capture transactions for introspection queries in GraphQL.
+  </Collapser>
+
+  <Collapser
+    id="instrumentation-kombu-consumer-enabled"
+    title="instrumentation.kombu.consumer.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_INSTRUMENTATION_KOMBU_CONSUMER_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will consumer MessageTransactions in Kombu.
+  </Collapser>
+
+  <Collapser
+    id="instrumentation-kombu-ignored-exchanges"
+    title="instrumentation.kombu.ignored_exchanges"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `celeryev`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_INSTRUMENTATION_KOMBU_IGNORED_EXCHANGES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    A space separated list of exchanges to ignore when capturing MessageTransactions in Kombu.
+  </Collapser>
+</CollapserGroup>
+
+
+## Middleware Instrumentation Filters [#middleware-filters]
+
+<Callout variant="important">
+  Requires [Python agent version 10.17.0 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+</Callout>
+
+These instrumentation package specific settings are available for toggling middleware instrumentation:
+
+<CollapserGroup>
+  <Collapser
+    id="instrumentation-middleware-django-enabled"
+    title="instrumentation.middleware.django.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environment variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_INSTRUMENTATION_DJANGO_MIDDLEWARE_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, the agent will monitor middleware in Django.
+  </Collapser>
+
+  <Collapser
+    id="instrumentation-middleware-django-include"
+    title="instrumentation.middleware.django.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+
+    If middleware instrumentation is enabled, middleware names found in this list will be sent. Names in the list should be space-separated as shown below:
+
+    ```
+    middleware1 middleware2 middleware3
+    ```
+
+    Rules for middleware instrumentation filtering can be found [on the middleware filtering page](/docs/apm/agents/python-agent/supported-features/django-middleware-filtering/#django-middleware-rules).
+  </Collapser>
+
+  <Collapser
+    id="instrumentation-middleware-django-exclude"
+    title="instrumentation.middleware.django.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+
+    Middleware names found in this list will NOT be sent. Names in the list should be space-separated as shown below:
+
+    ```
+    middleware1 middleware2 middleware3
+    ```
+
+    Rules for middleware instrumentation filtering can be found [on the middleware filtering page](/docs/apm/agents/python-agent/supported-features/django-middleware-filtering/#django-middleware-rules).
+  </Collapser>
+</CollapserGroup>
+
+
+
+## Other configuration settings [#other-settings]
+
+Here are assorted other settings available via the agent configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="utilization-detect_aws"
+    title="utilization.detect_aws"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent automatically detects that it is running in an AWS environment.
+  </Collapser>
+
+  <Collapser
+    id="cloud-aws-account-id"
+    title="cloud.aws.account_id"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `None`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If set, the agent uses this AWS `account_id` to link AWS entities when an account ID cannot be automatically determined by the instrumentation. Refer [AWS Manage Account Identifiers documentation](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#awsaccountid) for an example of a valid AWS account ID and how to find it.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect_azure"
+    title="utilization.detect_azure"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent automatically detects that it is running in an Azure environment.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect_gcp"
+    title="utilization.detect_gcp"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent automatically detects that it is running in a Google Cloud Platform environment.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect_pcf"
+    title="utilization.detect_pcf"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent automatically detects that it is running in a Pivotal Cloud Foundry environment.
+  </Collapser>
+
+  <Collapser
+    id="utilization-detect_docker"
+    title="utilization.detect_docker"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent automatically detects that it is running in Docker.
+  </Collapser>
+
+  <Collapser
+    id="slow-sql"
+    title="slow_sql.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Enable Slow SQL?`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If enabled, the agent captures details from long-running SQL database queries.
+  </Collapser>
+
+  <Collapser
+    id="thread-profiler"
+    title="thread_profiler.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Enable thread profiler?`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables you to schedule [thread profiling sessions](/docs/apm/applications-menu/events/thread-profiler-dashboard). The thread profiler will periodically capture a snapshot of the call stack for each active thread in the application to construct a statistically representative call tree.
+  </Collapser>
+
+  <Collapser
+    id="cross-application-tracer"
+    title="cross_application_tracer.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enables [cross application tracing](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces), which connect your apps and services within your service-oriented architecture.
+
+    <Callout variant="caution">
+      [Cross application tracing (CAT)](/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces) has been completely removed in version 12.0.0.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="strip_exception_messages_enabled"
+    title="strip_exception_messages.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If enabled, exception messages will be stripped from error traces before they are sent to the [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector), in order to prevent the inadvertent capture of sensitive information. This option is automatically enabled in high-security mode.
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="strip_exception_messages_allowlist"
+    title="strip_exception_messages.allowlist"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Exceptions listed in your allow list will not have their messages stripped, even if `strip_exception_messages.enabled` is `true`. The allow list is a space-separated string of exception types, each in the form of `module:exception_name`. List built-in exceptions as `exception_name`; you do not need to prepend `module:` to them.
+
+    <DNT>
+      **Example: Built-in exception and user-defined exception**
+    </DNT>
+
+    ```py
+    KeyError my_module:MyException
+    ```
+  </Collapser>
+
+  <Collapser
+    id="startup-timeout"
+    title="startup_timeout"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `0.0`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_STARTUP_TIMEOUT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    By default, the agent starts when it receives the first transaction (either web or [non-web](/docs/apm/transactions/intro-transactions/monitor-background-processes-other-non-web-transactions)). The agent then starts in parallel, ensuring that this initial request isn't delayed. However, the agent doesn't record the details of this initial request because the agent cannot collect data until registration is complete. This is the recommended configuration for the majority of web applications in order to not delay the first couple transactions while New Relic starts up.
+
+    To override this, you can set a startup timeout in seconds. The agent will then pause the initial transaction and wait for registration to complete. This might be useful when instrumenting a single program run or task, where the process runs once and immediately terminates.
+
+    <Callout variant="important">
+      Since `startup_timeout` delays your app start, we recommend only setting a startup timeout for background task queuing systems, not web applications.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="shutdown-timeout"
+    title="shutdown_timeout"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `2.5`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_SHUTDOWN_TIMEOUT`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    On process shutdown, the agent attempts one final upload to the [collector](/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector). To prevent the agent running indefinitely in case of an issue, the process shuts down normally if the `shutdown_timeout` threshold is reached. This shutdown can result in data loss, but the agent prioritizes key metric data during the upload process.
+
+    For background task queuing systems, especially those which run a small number of tasks per process, you may want to increase the shutdown timeout to ensure the agent can upload all data on process shutdown.
+
+    <Callout variant="tip">
+      The agent defaults to a 2.5 second timeout because Apache and many other web servers have a 3.0 second process termination timeout. The agent exits at 2.5 seconds to allow `atexit` cleanup code registered for the process to run.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="compressed-content-encoding"
+    title="compressed_content_encoding"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `gzip`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If the data compression threshold is reached in the payload, the agent compresses data, using gzip compression by default. The config option `compression_content_encoding` can be set to `deflate` to use deflate compression.
+  </Collapser>
+
+  <Collapser
+    id="package-reporting-enabled"
+    title="package_reporting.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            true
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_PACKAGE_REPORTING_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If this setting is enabled, it will capture package and version information on startup of the agent that is displayed in the APM environment tab.
+
+    <Callout variant="tip">
+      In applications that have a large number of packages, having this setting enabled may cause a CPU spike as it captures all the package and version information. It is recommended in those cases to disable this setting.
+    </Callout>
+
+    <Callout variant="caution">
+      Disabling this setting will disable the ability to detect vulnerabilities in outdated packages.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="NEW_RELIC_STARTUP_DEBUG"
+    title="NEW_RELIC_STARTUP_DEBUG"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            false
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_STARTUP_DEBUG`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If this setting is enabled, the agent will send detailed troubleshooting messages from its startup scripts directly to your console (STDOUT). This can be helpful for debugging crashes in the `newrelic-admin` startup script, the alternative `bootstrap/sitecustomize.py` startup script, or the startup sequence of the Kubernetes APM auto-attach.
+
+    <Callout variant="caution">
+      This environment variable setting has no corresponding config file setting, as the code related to it runs before the config file is read. For comprehensive debug logging after the agent has started, set [log level](#log_level) to `debug`.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="NEW_RELIC_K8S_OPERATOR_ENABLED"
+    title="NEW_RELIC_K8S_OPERATOR_ENABLED"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            false
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_K8S_OPERATOR_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This is an informational setting used to report when the agent is injected into a Kubernetes cluster.
+    <Callout variant="caution">
+      This setting does **not** enable or disable this function of the agent.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="NEW_RELIC_AZURE_OPERATOR_ENABLED"
+    title="NEW_RELIC_AZURE_OPERATOR_ENABLED"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            false
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment-variables)
+          </th>
+
+          <td>
+            `NEW_RELIC_AZURE_OPERATOR_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This is an informational setting used to report when the agent is injected into a Microsoft Azure Container App.
+    <Callout variant="caution">
+      This setting does **not** enable or disable this function of the agent.
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+
+## Heroku
+
+<CollapserGroup>
+  <Collapser
+    id="heroku-use_dyno_names"
+    title="heroku.use_dyno_names"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environ variable
+          </th>
+
+          <td>
+            `NEW_RELIC_HEROKU_USE_DYNO_NAMES`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent uses Heroku dyno names as the hostname.
+  </Collapser>
+
+  <Collapser
+    id="heroku-dyno_name_prefixes_to_shorten"
+    title="heroku.dyno_name_prefixes_to_shorten"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Array
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `["scheduler", "run"]`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environ variable
+          </th>
+
+          <td>
+            `NEW_RELIC_HEROKU_DYNO_NAME_PREFIXES_TO_SHORTEN`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Ordinarily the agent reports dyno names with a trailing dot and process ID (for example, <DNT>**worker.3**</DNT>). You can remove this trailing data by specifying the prefixes you want to report without trailing data (for example, <DNT>**worker**</DNT>).
+  </Collapser>
+</CollapserGroup>
+
+## Built-in instrumentation [#builtin-instrumentation]
+
+The Python agent instruments a range of Python packages/modules. This instrumentation only occurs when the target Python package/module is imported by an application.
+
+To disable default instrumentation, provide a special `import-hook` section corresponding to the name of the module that triggered instrumentation. Then set the `enabled` setting to `false` to disable instrumentation of that module.
+
+<CollapserGroup>
+  <Collapser
+    id="example-disable-mysqldb"
+    title="Example: Disabling MySQLdb database query instrumentation"
+  >
+
+    Add the following to the `.ini` configuration file:
+
+    ```ini
+    [import-hook:MySQLdb]
+    enabled = false
+    ```
+
+    Or for `.toml` configuration files add the following:
+
+    ```ini
+    [tool.newrelic.import-hook.MySQLdb]
+    enabled = false
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-transaction-tracer-settings.mdx
+++ b/src/content/docs/apm/agents/python-agent/configuration/python-agent-configuration-transaction-tracer-settings.mdx
@@ -1,0 +1,724 @@
+---
+title: Python agent transaction tracer settings
+tags:
+  - Agents
+  - Python agent
+  - Configuration
+metaDescription: 'Python agent transaction tracer and segment configuration: trace thresholds, SQL recording, explain plans, and segment limits.'
+freshnessValidatedDate: never
+---
+
+Configure transaction tracer and segment settings for the Python agent to control trace thresholds, SQL recording modes, explain plans, and function tracing.
+
+<Callout variant="tip">
+  Back to the full settings index: [Python agent configuration](/docs/apm/agents/python-agent/configuration/python-agent-configuration)
+</Callout>
+
+## Transaction tracer configuration [#txn-tracer-settings]
+
+<Callout variant="important">
+  Do not use brackets `[suffix]` at the end of your transaction name. The agent automatically strips brackets from the name. Instead, use parentheses `(suffix)` or other symbols if needed.
+</Callout>
+
+For more information about transaction traces, see [Transaction traces](/docs/traces/transaction-traces).
+
+<CollapserGroup>
+  <Collapser
+    id="txn-tracer-enabled"
+    title="transaction_tracer.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Enable transaction tracing?`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If enabled, the transaction tracer [captures deep information about slow transactions](/docs/apm/transactions/transaction-traces/transaction-traces).
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-threshold"
+    title="transaction_tracer.transaction_threshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Positive float or string (`apdex_f`)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `apdex_f`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Threshold`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Threshold in seconds for when to collect a transaction trace. When the response time of a controller action exceeds this threshold, the agent records a transaction trace. Valid values are any positive float, or `apdex_f` (four times [apdex_t](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#apdex_t)).
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-sql"
+    title="transaction_tracer.record_sql"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `obfuscated`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Record SQL?`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When the transaction tracer is [enabled](#txn-tracer-enabled), the agent can record SQL statements. The recorder has three modes: `off` (sends no SQL), `raw` (sends the SQL statement in its original form), and `obfuscated` (strips out numeric and string literals).
+
+    Most web frameworks (including Django) parameterize SQL queries so they do not actually contain the values used to fill out the query. If you use `raw` mode with one of these frameworks, the Python agent will only see the SQL prior to insertion of values. The parametrized SQL will look much like `obfuscated` mode.
+
+    <Callout variant="important">
+      This setting is disabled when [high security mode](/docs/apm/agents/python-agent/getting-started/apm-agent-security-python/#restricted) is enabled.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-stack"
+    title="transaction_tracer.stack_trace_threshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `0.5`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Stack trace threshold`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Threshold in seconds for when to collect stack traces from SQL calls. When SQL statements exceed this threshold, the agent captures the current stack trace. This is helpful for pinpointing where long SQL calls originate in an application.
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-explain"
+    title="transaction_tracer.explain_enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Enable SQL query plans?`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the Python agent will capture query plans for slow SQL queries. Only supported in MySQL and PostgreSQL.
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-explain-threshold"
+    title="transaction_tracer.explain_threshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Float
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `0.5`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Server-side config, config file
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Query plan threshold`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Queries in transaction traces that exceed this threshold will report [slow query data](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) and any available explain plans. Explain plan collection will not happen if [`transaction_tracer.explain_enabled`](#txn-tracer-explain-threshold) is `false`.
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-enabled"
+    title="transaction_tracer.attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off all attributes for transaction traces. If `attributes.enabled` at the root level is `false`, no attributes will be sent to transaction traces regardless on how this configuration setting (`transaction_tracer.attributes.enabled`) is set.
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-include"
+    title="transaction_tracer.attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for transaction traces, all attribute keys found in this list will be sent to us in transaction traces. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-exclude"
+    title="transaction_tracer.attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent in transaction traces. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-function"
+    title="transaction_tracer.function_trace"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    For the specified functions or methods, the agent will capture additional function timing instrumentation. Specify these names in the form `module:function` or `module:class.function`.
+
+    Wildcarding (globbing) for function and class names is possible using patterns supported by the [fnmatch](https://docs.python.org/3/library/fnmatch.html) module. Module paths are not supported by wildcards. Specify the patterns in the form `module:function*` or `module:class.*`.
+
+    For example, if you want to add function tracing to all validation functions in the below file:
+
+    <b>
+      my-app/common/utils.py
+    </b>
+
+    ```py
+    def validate_credentials():
+    …
+    def validate_status():
+    …
+    def format_message():
+    …
+    ```
+
+    Add the following line to the agent config file to include function tracing to all validation functions in `my-app/common/utils.py` by using wildcarding.
+
+    <b>
+      my-app/newrelic.ini
+    </b>
+
+    ```ini
+    [newrelic]
+    ...
+    transaction_tracer.function_trace = common.utils:validate*
+    ```
+
+    <Callout variant="important">
+      Wilcarding requires [Python agent version 6.4.4.161 or higher](/docs/agents/python-agent/installation-configuration/upgrade-python-agent).
+    </Callout>
+  </Collapser>
+</CollapserGroup>
+
+## Transaction segment configuration [#txn-segment-settings]
+
+Here are Transaction segment settings available via the agent configuration file.
+
+<CollapserGroup>
+  <Collapser
+    id="cfg-tt-attributes-enabled"
+    title="transaction_segments.attributes.enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_ENABLED`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This setting can be used to turn on or off all attributes for segments of transaction traces. If `attributes.enabled` at the root level is `false`, no attributes will be sent to segments of transaction traces regardless on how this configuration setting (`transaction_segments.attributes.enabled`) is set.
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-include"
+    title="transaction_segments.attributes.include"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_INCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If attributes are enabled for segments of transaction traces, all attribute keys found in this list will be sent in segments of transaction traces. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+
+  <Collapser
+    id="cfg-tt-attributes-exclude"
+    title="transaction_segments.attributes.exclude"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            List of Strings, space-separated
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            Config file, environment variable
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_EXCLUDE`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    All attribute keys found in this list will not be sent in segments of transaction traces. For more information, see the [agent attribute rules](/docs/apm/other-features/attributes/agent-attributes).
+  </Collapser>
+</CollapserGroup>
+

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -781,11 +781,7 @@ pages:
       - title: Python monitoring
         path: /docs/apm/agents/python-agent
         pages:
-          - title: Introduction to Python monitoring
-            path: /docs/apm/agents/python-agent/getting-started/introduction-new-relic-python
-          - title: Monitor your Python app
-            path: /install/python
-          - title: Compatibility and releases
+          - title: Compatibility and release
             path: /docs/apm/agents/python-agent/getting-started
             pages:
               - title: Compatibility and requirements
@@ -800,20 +796,45 @@ pages:
                 path: /docs/release-notes/agent-release-notes/python-release-notes/current
               - title: Python release notes
                 path: /docs/release-notes/agent-release-notes/python-release-notes/
-          - title: Other installation options
+          - title: Python agent installation
             path: /docs/apm/agents/python-agent/installation
             pages:
+              - title: Overview
+                path: /install/python
               - title: 'Admin script: Advanced use'
                 path: /docs/apm/agents/python-agent/installation/python-agent-admin-script-advanced-usage
               - title: Update the Python agent
                 path: /docs/apm/agents/python-agent/installation/update-python-agent
               - title: Uninstall the Python agent
                 path: /docs/apm/agents/python-agent/installation/uninstall-python-agent
+          - title: Introduction to Python monitoring
+            path: /docs/apm/agents/python-agent/getting-started/introduction-new-relic-python
           - title: Configuration
             path: /docs/apm/agents/python-agent/configuration
             pages:
               - title: Python agent configuration
                 path: /docs/apm/agents/python-agent/configuration/python-agent-configuration
+                pages:
+                  - title: General settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-general-settings
+                  - title: Attributes settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-attributes-settings
+                  - title: AI monitoring settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-ai-monitoring-settings
+                  - title: Transaction tracer settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-transaction-tracer-settings
+                  - title: Error collector settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-error-collector-settings
+                  - title: Browser monitoring settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-browser-monitoring-settings
+                  - title: Distributed tracing settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-distributed-tracing-settings
+                  - title: Logs in context settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-logs-in-context-settings
+                  - title: Machine learning settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-ml-settings
+                  - title: Other settings
+                    path: /docs/apm/agents/python-agent/configuration/python-agent-configuration-other-settings
               - title: Distributed tracing
                 path: /docs/apm/agents/python-agent/configuration/distributed-tracing-python-agent
           - title: Supported features


### PR DESCRIPTION
## Summary

- Restructures the Python monitoring nav section to match the established PHP/Java agent IA pattern
- Renames "Compatibility and releases" → "Compatibility and release" (singular, consistent)
- Removes standalone "Introduction to Python monitoring" and "Monitor your Python app" from top level
- Renames "Other installation options" → "Python agent installation" and adds Overview (install/python)
- Adds "Introduction to Python monitoring" as standalone after installation section
- Splits the 7,468-line `python-agent-configuration.mdx` into 10 focused sub-pages

**New config sub-pages:**
General settings · Attributes settings · AI monitoring settings · Transaction tracer settings · Error collector settings · Browser monitoring settings · Distributed tracing settings · Logs in context settings · Machine learning settings · Other settings

## Test plan

- [ ] Verify nav renders correctly in local dev
- [ ] Confirm all 10 new config sub-page paths resolve
- [ ] Confirm existing links to `python-agent-configuration` still work
- [ ] Verify ML/OTel settings page is correctly scoped

🤖 Generated with [Claude Code](https://claude.ai/claude-code)