### PR TITLE
refactor(ruby-agent): align Ruby nav with PHP/Java IA pattern and split config

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-ai-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-ai-monitoring-settings.mdx
@@ -1,0 +1,56 @@
+---
+title: Ruby agent AI monitoring settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent AI monitoring configuration: enable AI monitoring and configure LLM event recording.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's AI monitoring settings to enable LLM instrumentation and control whether input and output content is captured in AI events.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## AI Monitoring [#ai-monitoring]
+
+This section includes Ruby agent configurations for setting up AI monitoring.
+
+<Callout variant='important'>You need to enable distributed tracing to capture trace and feedback data. It is turned on by default in Ruby agents 8.0.0 and higher.</Callout>
+
+<CollapserGroup>
+
+  <Collapser id="ai_monitoring-enabled" title="ai_monitoring.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AI_MONITORING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `false`, all LLM instrumentation (OpenAI only for now) will be disabled and no metrics, events, or spans will be sent. AI Monitoring is automatically disabled if `high_security` mode is enabled.
+  </Collapser>
+
+  <Collapser id="ai_monitoring-record_content-enabled" title="ai_monitoring.record_content.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `false`, LLM instrumentation (OpenAI only for now) will not capture input and output content on specific LLM events.
+
+	The excluded attributes include:
+	- `content` from LlmChatCompletionMessage events
+	- `input` from LlmEmbedding events
+
+	This is an optional security setting to prevent recording sensitive data sent to and received from your LLMs.
+
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-attributes-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-attributes-settings.mdx
@@ -1,0 +1,275 @@
+---
+title: Ruby agent attributes settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent attributes configuration: enable/disable attributes and configure include/exclude lists.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's attributes settings to control which key-value pairs are captured and sent to each destination: transaction traces, error collection, span events, transaction events, and browser monitoring.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Attributes [#attributes]
+
+[Attributes](/docs/features/agent-attributes) are key-value pairs containing information that determines the properties of an event or transaction. These key-value pairs can be viewed within transaction traces in APM, traced errors in APM, transaction events in dashboards, and page views in dashboards. You can customize exactly which attributes will be sent to each of these destinations
+
+<CollapserGroup>
+
+  <Collapser id="attributes-enabled" title="attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables capture of attributes for all destinations.
+  </Collapser>
+
+  <Collapser id="attributes-exclude" title="attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from all destinations. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="attributes-include" title="attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in all destinations. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="browser_monitoring-attributes-enabled" title="browser_monitoring.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from browser monitoring.
+  </Collapser>
+
+  <Collapser id="browser_monitoring-attributes-exclude" title="browser_monitoring.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from browser monitoring. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="browser_monitoring-attributes-include" title="browser_monitoring.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in browser monitoring. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="error_collector-attributes-enabled" title="error_collector.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from error collection.
+  </Collapser>
+
+  <Collapser id="error_collector-attributes-exclude" title="error_collector.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from error collection. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="error_collector-attributes-include" title="error_collector.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in error collection. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="span_events-attributes-enabled" title="span_events.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes on span events.
+  </Collapser>
+
+  <Collapser id="span_events-attributes-exclude" title="span_events.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from span events. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="span_events-attributes-include" title="span_events.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include on span events. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_events-attributes-enabled" title="transaction_events.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from transaction events.
+  </Collapser>
+
+  <Collapser id="transaction_events-attributes-exclude" title="transaction_events.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from transaction events. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_events-attributes-include" title="transaction_events.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in transaction events. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_segments-attributes-enabled" title="transaction_segments.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes on transaction segments.
+  </Collapser>
+
+  <Collapser id="transaction_segments-attributes-exclude" title="transaction_segments.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from transaction segments. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_segments-attributes-include" title="transaction_segments.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_SEGMENTS_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include on transaction segments. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-attributes-enabled" title="transaction_tracer.attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures attributes from transaction traces.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-attributes-exclude" title="transaction_tracer.attributes.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to exclude from transaction traces. Allows `*` as wildcard at end.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-attributes-include" title="transaction_tracer.attributes.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  Prefix of attributes to include in transaction traces. Allows `*` as wildcard at end.
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-browser-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-browser-monitoring-settings.mdx
@@ -1,0 +1,47 @@
+---
+title: Ruby agent browser monitoring settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent browser monitoring configuration: enable auto-instrumentation.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's browser monitoring settings to control page load timing injection and Content Security Policy nonce support.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Browser Monitoring [#browser-monitoring]
+
+The <InlinePopover type='browser' /> [page load timing](/docs/browser/new-relic-browser/page-load-timing/page-load-timing-process) feature (sometimes referred to as real user monitoring or RUM) gives you insight into the performance real users are experiencing with your website. This is accomplished by measuring the time it takes for your users' browsers to download and render your web pages by injecting a small amount of JavaScript code into the header and footer of each page.
+
+<CollapserGroup>
+
+  <Collapser id="browser_monitoring-auto_instrument" title="browser_monitoring.auto_instrument">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_AUTO_INSTRUMENT`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables [auto-injection](/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser#select-apm-app) of the JavaScript header for page load timing (sometimes referred to as real user monitoring or RUM).
+  </Collapser>
+
+  <Collapser id="browser_monitoring-content_security_policy_nonce" title="browser_monitoring.content_security_policy_nonce">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BROWSER_MONITORING_CONTENT_SECURITY_POLICY_NONCE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables auto-injection of [Content Security Policy Nonce](https://content-security-policy.com/nonce/) in browser monitoring scripts. For now, auto-injection only works with Rails 5.2+.
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-distributed-tracing-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-distributed-tracing-settings.mdx
@@ -1,0 +1,174 @@
+---
+title: Ruby agent distributed tracing settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent distributed tracing configuration: enable distributed tracing, Infinite Tracing, and span events.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's distributed tracing settings to enable end-to-end request tracking, Infinite Tracing tail-based sampling, and span event collection.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Distributed Tracing [#distributed-tracing]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="distributed_tracing-enabled" title="distributed_tracing.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  Distributed tracing lets you see the path that a request takes through your distributed system. Enabling distributed tracing changes the behavior of some New Relic features, so carefully consult the [transition guide](/docs/transition-guide-distributed-tracing) before you enable this feature.
+  </Collapser>
+
+  <Collapser id="distributed_tracing-sampler-root" title="distributed_tracing.sampler.root">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"adaptive"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_ROOT`</td></tr>
+      </tbody>
+    </table>
+
+  This setting controls the behavior of transaction sampling for transactions without a remote parent, traces that originate within this instance of the New Relic agent. Available values are `adaptive` (the default), `always_on`, `always_off`, and `trace_id_ratio_based`.
+  </Collapser>
+
+  <Collapser id="distributed_tracing-sampler-remote_parent_sampled" title="distributed_tracing.sampler.remote_parent_sampled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"adaptive"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_SAMPLED`</td></tr>
+      </tbody>
+    </table>
+
+  This setting controls the behavior of transaction sampling when a remote parent is sampled. Available values are `adaptive` (the default), `always_on`, `always_off`, and `trace_id_ratio_based`.
+  </Collapser>
+
+  <Collapser id="distributed_tracing-sampler-remote_parent_not_sampled" title="distributed_tracing.sampler.remote_parent_not_sampled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"adaptive"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISTRIBUTED_TRACING_SAMPLER_REMOTE_PARENT_NOT_SAMPLED`</td></tr>
+      </tbody>
+    </table>
+
+  This setting controls the behavior of transaction sampling when a remote parent is not sampled. Available values are `adaptive` (the default), `always_on`, `always_off`, and `trace_id_ratio_based`.
+  </Collapser>
+
+</CollapserGroup>
+
+## Infinite Tracing [#infinite-tracing]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="infinite_tracing-trace_observer-host" title="infinite_tracing.trace_observer.host">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST`</td></tr>
+      </tbody>
+    </table>
+
+  Configures the hostname for the trace observer Host. When configured, enables tail-based sampling by sending all recorded spans to a trace observer for further sampling decisions, irrespective of any usual agent sampling decision.
+  </Collapser>
+
+  <Collapser id="infinite_tracing-trace_observer-port" title="infinite_tracing.trace_observer.port">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`443`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_PORT`</td></tr>
+      </tbody>
+    </table>
+
+  Configures the TCP/IP port for the trace observer Host
+  </Collapser>
+
+  <Collapser id="infinite_tracing-batching" title="infinite_tracing.batching">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_BATCHING`</td></tr>
+      </tbody>
+    </table>
+
+  If `true` (the default), data sent to the trace observer is batched instead of sending each span individually.
+  </Collapser>
+
+  <Collapser id="infinite_tracing-compression_level" title="infinite_tracing.compression_level">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Symbol</td></tr>
+        <tr><th>Default</th><td>`:high`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INFINITE_TRACING_COMPRESSION_LEVEL`</td></tr>
+      </tbody>
+    </table>
+
+  Configure the compression level for data sent to the trace observer. May be one of: `:none`, `:low`, `:medium`, `:high`. Set the level to `:none` to disable compression.
+
+  </Collapser>
+
+</CollapserGroup>
+
+## Span Events [#span-events]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="span_events-enabled" title="span_events.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables span event sampling.
+  </Collapser>
+
+  <Collapser id="span_events-queue_size" title="span_events.queue_size">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`10000`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_QUEUE_SIZE`</td></tr>
+      </tbody>
+    </table>
+
+  Sets the maximum number of span events to buffer when streaming to the trace observer.
+  </Collapser>
+
+  <Collapser id="span_events-max_samples_stored" title="span_events.max_samples_stored">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`2000`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SPAN_EVENTS_MAX_SAMPLES_STORED`</td></tr>
+      </tbody>
+    </table>
+
+  - Defines the maximum number of span events reported from a single harvest. Any Integer between `1` and `10000` is valid.'
+  - When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `10000`.This ensures the agent captures the maximum amount of distributed traces.
+
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-error-collector-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-error-collector-settings.mdx
@@ -1,0 +1,173 @@
+---
+title: Ruby agent error collector settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent error collector configuration: ignore errors, expected errors, and error event sampling.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's error collector to customize how errors are captured, which errors to ignore or treat as expected, and how error events are sampled.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Error Collector [#error-collector]
+
+The agent collects and reports all uncaught exceptions by default. These configuration options allow you to customize the error collection.
+
+For information on ignored and expected errors, [see this page on Error Analytics in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/). To set expected errors via the `NewRelic::Agent.notice_error` Ruby method, [consult the Ruby agent API](/docs/agents/ruby-agent/api-guides/sending-handled-errors-new-relic/).
+
+<CollapserGroup>
+
+  <Collapser id="error_collector-capture_events" title="error_collector.capture_events">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_CAPTURE_EVENTS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent collects [`TransactionError` events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights).
+  </Collapser>
+
+  <Collapser id="error_collector-enabled" title="error_collector.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures traced errors and error count metrics.
+  </Collapser>
+
+  <Collapser id="error_collector-expected_classes" title="error_collector.expected_classes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`None`</td></tr>
+      </tbody>
+    </table>
+
+  A list of error classes that the agent should treat as expected.
+	<Callout variant="caution">
+		This option can't be set via environment variable.
+	</Callout>
+
+  </Collapser>
+
+  <Collapser id="error_collector-expected_messages" title="error_collector.expected_messages">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Hash</td></tr>
+        <tr><th>Default</th><td>`{}`</td></tr>
+        <tr><th>Environ variable</th><td>`None`</td></tr>
+      </tbody>
+    </table>
+
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be treated as expected.
+	<Callout variant="caution">
+		This option can't be set via environment variable.
+	</Callout>
+
+  </Collapser>
+
+  <Collapser id="error_collector-expected_status_codes" title="error_collector.expected_status_codes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_EXPECTED_STATUS_CODES`</td></tr>
+      </tbody>
+    </table>
+
+  A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be treated as expected.
+  </Collapser>
+
+  <Collapser id="error_collector-ignore_classes" title="error_collector.ignore_classes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`["ActionController::RoutingError", "Sinatra::NotFound"]`</td></tr>
+        <tr><th>Environ variable</th><td>`None`</td></tr>
+      </tbody>
+    </table>
+
+  A list of error classes that the agent should ignore.
+	<Callout variant="caution">
+		This option can't be set via environment variable.
+	</Callout>
+
+  </Collapser>
+
+  <Collapser id="error_collector-ignore_messages" title="error_collector.ignore_messages">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Hash</td></tr>
+        <tr><th>Default</th><td>`{ThreadError: ["queue empty"]}`</td></tr>
+        <tr><th>Environ variable</th><td>`None`</td></tr>
+      </tbody>
+    </table>
+
+  A map of error classes to a list of messages. When an error of one of the classes specified here occurs, if its error message contains one of the strings corresponding to it here, that error will be ignored.
+	<Callout variant="caution">
+		This option can't be set via environment variable.
+	</Callout>
+
+  </Collapser>
+
+  <Collapser id="error_collector-ignore_status_codes" title="error_collector.ignore_status_codes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_IGNORE_STATUS_CODES`</td></tr>
+      </tbody>
+    </table>
+
+  A comma separated list of status codes, possibly including ranges. Errors associated with these status codes, where applicable, will be ignored.
+  </Collapser>
+
+  <Collapser id="error_collector-max_backtrace_frames" title="error_collector.max_backtrace_frames">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`50`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_MAX_BACKTRACE_FRAMES`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of frames in an error backtrace. Backtraces over this amount are truncated in the middle, preserving the beginning and the end of the stack trace.
+  </Collapser>
+
+  <Collapser id="error_collector-backtrace_truncate_location" title="error_collector.backtrace_truncate_location">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"middle"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_BACKTRACE_TRUNCATE_LOCATION`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies where in the backtrace to truncate when the number of frames exceeds `error_collector.max_backtrace_frames`. Options are `top` (remove frames from the beginning), `middle` (remove frames from the middle, preserving the beginning and end), or `end` (remove frames from the end).
+  </Collapser>
+
+  <Collapser id="error_collector-max_event_samples_stored" title="error_collector.max_event_samples_stored">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`100`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ERROR_COLLECTOR_MAX_EVENT_SAMPLES_STORED`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of [`TransactionError` events](/docs/insights/new-relic-insights/decorating-events/error-event-default-attributes-insights) reported per harvest cycle.
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-general-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-general-settings.mdx
@@ -1,0 +1,562 @@
+---
+title: Ruby agent general settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent general configuration settings: app name, license key, proxy, agent behavior, and configuration methods.'
+freshnessValidatedDate: never
+---
+
+Configure the core Ruby agent settings including app name, license key, proxy, logging, and general agent behavior.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Configuration methods and precedence [#Options]
+
+The primary (default) method to configure the Ruby agent is via the configuration file (`newrelic.yml`) in the `config` subdirectory. To set configuration values using environment variables:
+
+1. Add the prefix `NEW_RELIC_` to the setting's name.
+2. Replace any periods `.` with underscores `_`.
+
+You can also configure a few values in the UI via [server-side configuration](/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration).
+
+The Ruby agent follows this order of precedence for configuration:
+
+1. Environment variables
+2. Server-side configuration
+3. Configuration file (`newrelic.yml`)
+4. Default configuration settings
+
+In other words, environment variables override all other configuration settings and info, server-side configuration overrides the configuration file and default config settings, and so on.
+
+## View and edit config file options [#Edit]
+
+The Ruby agent's `newrelic.yml` is a standard YAML configuration file. It typically includes a `Defaults` section at the top, plus sections below for each application environment (`Development`, `Test`, `Staging`, and `Production`).
+
+The Ruby agent determines which section of the `newrelic.yml` config file to read from by looking at certain environment variables to derive the application's environment. This can be useful when you want to use `info` for the `log_level` config setting in your production environment, and you want more verbose `log_level` config settings (such as `debug`) in your development environment.
+
+Here is an example `newrelic.yml` config file:
+
+```yaml
+common: &default_settings
+  license_key: 'YOUR_LICENSE_KEY'
+  app_name: 'My Application Name'
+production:
+  <<: *default_settings
+  log_level: info
+development:
+  <<: *default_settings
+  log_level: debug
+```
+
+The Ruby agent looks for the following environment variables, in this order, to find the application environment:
+
+1. `NEW_RELIC_ENV`
+2. `RUBY_ENV`
+3. `RAILS_ENV`
+4. `APP_ENV`
+5. `RACK_ENV`
+
+If the Ruby agent doesn't detect values for any of those environment variables, it will default the application environment to `development` and read from the `development` section of the `newrelic.yml` config file.
+
+When running the Ruby agent in a Rails app, the agent first looks for the `NEW_RELIC_ENV` environment variable to find the application environment and which section of the `newrelic.yml` to use. If `NEW_RELIC_ENV` is not present, the agent uses the Rails environment (`RAILS_ENV`).
+
+When you edit the config file, be sure to:
+
+* Indent only with two spaces.
+* Indent only where relevant, in sections such as **`error_collector`**.
+
+If you do not indent correctly, the agent may throw an `Unable to parse configuration file` error on startup.
+
+To view the most current list of available Ruby agent configuration options, use the `rake newrelic:config:docs` command. This document describes the most common options.
+
+## Update the config file [#Updates]
+
+This documentation applies to the Ruby agent's latest release. For details on earlier versions, refer to the comments in `newrelic.yml` itself.
+
+To update `newrelic.yml` file after a new release, use the template in the base directory of the agent gem. When you update to new gem versions, examine or diff `config/newrelic.yml` and `newrelic.yml` in the [installation directory](/docs/agents/manage-apm-agents/troubleshooting/find-agent-root-directory#ruby-agent) to take advantage of new configuration options.
+
+<Callout variant="important">
+  Updating the gem does not automatically update `config/newrelic.yml`.
+</Callout>
+
+
+## General [#general]
+
+These settings are available for agent configuration. Some settings depend on your New Relic subscription level.
+
+<CollapserGroup>
+
+  <Collapser id="agent_enabled" title="agent_enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AGENT_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, allows the Ruby agent to run.
+  </Collapser>
+
+  <Collapser id="app_name" title="app_name">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APP_NAME`</td></tr>
+      </tbody>
+    </table>
+
+  Specify the [application name](/docs/apm/new-relic-apm/installation-configuration/name-your-application) used to aggregate data in the New Relic UI. To report data to [multiple apps at the same time](/docs/apm/new-relic-apm/installation-configuration/using-multiple-names-app), specify a list of names separated by a semicolon `;`. For example, `MyApp` or `MyStagingApp;Instance1`.
+  </Collapser>
+
+  <Collapser id="license_key" title="license_key">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LICENSE_KEY`</td></tr>
+      </tbody>
+    </table>
+
+  Your New Relic <InlinePopover type="licenseKey" />.
+  </Collapser>
+
+  <Collapser id="log_level" title="log_level">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"info"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_LEVEL`</td></tr>
+      </tbody>
+    </table>
+
+  Sets the level of detail of log messages. Possible log levels, in increasing verbosity, are: `error`, `warn`, `info` or `debug`.
+  </Collapser>
+
+  <Collapser id="active_support_custom_events_names" title="active_support_custom_events_names">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ACTIVE_SUPPORT_CUSTOM_EVENTS_NAMES`</td></tr>
+      </tbody>
+    </table>
+
+  An array of ActiveSupport custom event names to subscribe to and instrument. For example,
+		- one.custom.event
+		- another.event
+		- a.third.event
+
+  </Collapser>
+
+  <Collapser id="active_record_use_table_name" title="active_record_use_table_name">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ACTIVE_RECORD_USE_TABLE_NAME`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will use the Active Record model's table name instead of the class name when naming Active Record metrics, spans, and transaction trace segments. This can reduce cardinality when multiple models share a database table. Defaults to `false`.
+  </Collapser>
+
+  <Collapser id="backport_fast_active_record_connection_lookup" title="backport_fast_active_record_connection_lookup">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_BACKPORT_FAST_ACTIVE_RECORD_CONNECTION_LOOKUP`</td></tr>
+      </tbody>
+    </table>
+
+  Backports the faster ActiveRecord connection lookup introduced in Rails 6, which improves agent performance when instrumenting ActiveRecord. Note that this setting may not be compatible with other gems that patch ActiveRecord.
+  </Collapser>
+
+  <Collapser id="ca_bundle_path" title="ca_bundle_path">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CA_BUNDLE_PATH`</td></tr>
+      </tbody>
+    </table>
+
+  Manual override for the path to your local CA bundle. This CA bundle validates the SSL certificate presented by New Relic's data collection service.
+  </Collapser>
+
+  <Collapser id="capture_memcache_keys" title="capture_memcache_keys">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CAPTURE_MEMCACHE_KEYS`</td></tr>
+      </tbody>
+    </table>
+
+  Enable or disable the capture of memcache keys from transaction traces.
+  </Collapser>
+
+  <Collapser id="capture_params" title="capture_params">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CAPTURE_PARAMS`</td></tr>
+      </tbody>
+    </table>
+
+  When `true`, the agent captures HTTP request parameters and attaches them to transaction traces, traced errors, and [`TransactionError` events](/attribute-dictionary?attribute_name=&events_tids%5B%5D=8241).
+
+<Callout variant="caution">
+	When using the `capture_params` setting, the Ruby agent will not attempt to filter secret information. `Recommendation:` To filter secret information from request parameters, use the [`attributes.include` setting](/docs/agents/ruby-agent/attributes/enable-disable-attributes-ruby) instead. For more information, see the <a href="/docs/agents/ruby-agent/attributes/ruby-attribute-examples#ex_req_params">Ruby attribute examples</a>.
+</Callout>
+
+  </Collapser>
+
+  <Collapser id="clear_transaction_state_after_fork" title="clear_transaction_state_after_fork">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CLEAR_TRANSACTION_STATE_AFTER_FORK`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will clear `Tracer::State` in `Agent.drop_buffered_data`.
+  </Collapser>
+
+  <Collapser id="config_path" title="config_path">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CONFIG_PATH`</td></tr>
+      </tbody>
+    </table>
+
+  Path to `newrelic.yml`. If undefined, the agent checks the following directories (in order):
+	- `config/newrelic.yml`
+	- `newrelic.yml`
+	- `$HOME/.newrelic/newrelic.yml`
+	- `$HOME/newrelic.yml`
+
+  </Collapser>
+
+  <Collapser id="exclude_newrelic_header" title="exclude_newrelic_header">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_EXCLUDE_NEWRELIC_HEADER`</td></tr>
+      </tbody>
+    </table>
+
+  Allows newrelic distributed tracing headers to be suppressed on outbound requests.
+  </Collapser>
+
+  <Collapser id="force_install_exit_handler" title="force_install_exit_handler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_FORCE_INSTALL_EXIT_HANDLER`</td></tr>
+      </tbody>
+    </table>
+
+  The exit handler that sends all cached data to the collector before shutting down is forcibly installed. This is true even when it detects scenarios where it generally should not be. The known use case for this option is when Sinatra runs as an embedded service within another framework. The agent detects the Sinatra app and skips the `at_exit` handler as a result. Sinatra classically runs the entire application in an `at_exit` block and would otherwise misbehave if the agent's `at_exit` handler was also installed in those circumstances. Note: `send_data_on_exit` should also be set to `true` in tandem with this setting.
+
+  </Collapser>
+
+  <Collapser id="high_security" title="high_security">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_HIGH_SECURITY`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables [high security mode](/docs/accounts-partnerships/accounts/security/high-security). Ensure you understand the implications of high security mode before enabling this setting.
+  </Collapser>
+
+  <Collapser id="labels" title="labels">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LABELS`</td></tr>
+      </tbody>
+    </table>
+
+  A dictionary of [label names](/docs/data-analysis/user-interface-functions/labels-categories-organize-your-apps-servers) and values that will be applied to the data sent from this agent. May also be expressed as a semicolon-delimited `;` string of colon-separated `:` pairs. For example, `Server:One;Data Center:Primary`.
+  </Collapser>
+
+  <Collapser id="log_file_name" title="log_file_name">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"newrelic_agent.log"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_FILE_NAME`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a name for the log file.
+  </Collapser>
+
+  <Collapser id="log_file_path" title="log_file_path">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"log/"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_LOG_FILE_PATH`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a path to the agent log file, excluding the filename. If you want to send your agent logs to standard out, set this to STDOUT.
+  </Collapser>
+
+  <Collapser id="marshaller" title="marshaller">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"json"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_MARSHALLER`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies a marshaller for transmitting data to the New Relic [collector](/docs/apm/new-relic-apm/getting-started/glossary#collector). Currently `json` is the only valid value for this setting.
+  </Collapser>
+
+  <Collapser id="monitor_mode" title="monitor_mode">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_MONITOR_MODE`</td></tr>
+      </tbody>
+    </table>
+
+  When `true`, the agent transmits data about your app to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
+  </Collapser>
+
+  <Collapser id="prepend_active_record_instrumentation" title="prepend_active_record_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PREPEND_ACTIVE_RECORD_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, uses `Module#prepend` rather than `alias_method` for ActiveRecord instrumentation.
+  </Collapser>
+
+  <Collapser id="proxy_host" title="proxy_host">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_HOST`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a host for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="proxy_pass" title="proxy_pass">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_PASS`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a password for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="proxy_port" title="proxy_port">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`8080`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_PORT`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a port for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="proxy_user" title="proxy_user">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROXY_USER`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a user for communicating with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) via a proxy server.
+  </Collapser>
+
+  <Collapser id="send_data_on_exit" title="send_data_on_exit">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SEND_DATA_ON_EXIT`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables the exit handler that sends data to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) before shutting down.
+  </Collapser>
+
+  <Collapser id="sync_startup" title="sync_startup">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SYNC_STARTUP`</td></tr>
+      </tbody>
+    </table>
+
+  When set to `true`, forces a synchronous connection to the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector) during application startup. For very short-lived processes, this helps ensure the New Relic agent has time to report.
+  </Collapser>
+
+  <Collapser id="thread_local_tracer_state" title="thread_local_tracer_state">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_THREAD_LOCAL_TRACER_STATE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, tracer state storage is thread-local, otherwise, fiber-local
+  </Collapser>
+
+  <Collapser id="timeout" title="timeout">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`120`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TIMEOUT`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of seconds the agent should spend attempting to connect to the collector.
+  </Collapser>
+
+  <Collapser id="allow_all_headers" title="allow_all_headers">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ALLOW_ALL_HEADERS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables capture of all HTTP request headers for all destinations.
+  </Collapser>
+
+  <Collapser id="automatic_custom_instrumentation_method_list" title="automatic_custom_instrumentation_method_list">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST`</td></tr>
+      </tbody>
+    </table>
+
+  An array of `CLASS#METHOD` (for instance methods) and/or `CLASS.METHOD` (for class methods) strings representing Ruby methods that the agent can automatically add custom instrumentation to. This doesn't require any modifications of the source code that defines the methods.
+
+	Use fully qualified class names (using the `::` delimiter) that include any module or class namespacing.
+
+	Here is some Ruby source code that defines a `render_png` instance method for an `Image` class and a `notify` class method for a `User` class, both within a `MyCompany` module namespace:
+
+	```rb
+		module MyCompany
+			class Image
+				def render_png
+					# code to render a PNG
+				end
+			end
+
+			class User
+				def self.notify
+					# code to notify users
+				end
+			end
+		end
+	```
+
+	Given that source code, the `newrelic.yml` config file might request instrumentation for both of these methods like so:
+
+	```yaml
+		automatic_custom_instrumentation_method_list:
+			- MyCompany::Image#render_png
+			- MyCompany::User.notify
+	```
+
+	That configuration example uses YAML array syntax to specify both methods. Alternatively, you can use a comma-delimited string:
+
+	```yaml
+		automatic_custom_instrumentation_method_list: 'MyCompany::Image#render_png, MyCompany::User.notify'
+	```
+
+	Whitespace around the comma(s) in the list is optional. When configuring the agent with a list of methods via the `NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST` environment variable, use this comma-delimited string format:
+
+	```sh
+		export NEW_RELIC_AUTOMATIC_CUSTOM_INSTRUMENTATION_METHOD_LIST='MyCompany::Image#render_png, MyCompany::User.notify'
+	```
+
+  </Collapser>
+
+  <Collapser id="simplify_action_cable_broadcast_metrics" title="simplify_action_cable_broadcast_metrics">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SIMPLIFY_ACTION_CABLE_BROADCAST_METRICS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, metrics for Action Cable broadcast calls will not include the `broadcasting` value for a given broadcast. Defaults to `false`. The default may change in a future major version release.
+  </Collapser>
+
+  <Collapser id="ignored_middleware_classes" title="ignored_middleware_classes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_IGNORED_MIDDLEWARE_CLASSES`</td></tr>
+      </tbody>
+    </table>
+
+  A list of middleware class or module names the agent should ignore. Example: ["Rack::Cors", "ActionDispatch::Reloader"]
+  </Collapser>
+
+  <Collapser id="defer_rails_initialization" title="defer_rails_initialization">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DEFER_RAILS_INITIALIZATION`</td></tr>
+      </tbody>
+    </table>
+
+              If `true`, when the agent is in an application using Ruby on Rails, it will start after `config/initializers` run.
+
+            <Callout variant="caution">
+            	This option may only be set by environment variable.
+            </Callout>
+
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-logs-in-context-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-logs-in-context-settings.mdx
@@ -1,0 +1,148 @@
+---
+title: Ruby agent logs in context settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent application logging configuration: log forwarding, local log decoration, and log metrics.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's application logging settings to control log forwarding, local decoration, custom attributes on log events, and log metrics collection.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Application Logging [#application-logging]
+
+The Ruby agent supports [APM logs in context](/docs/apm/new-relic-apm/getting-started/get-started-logs-context). For some tips on configuring logs for the Ruby agent, see [Configure Ruby logs in context](/docs/logs/logs-context/configure-logs-context-ruby).
+
+Available logging-related config options include:
+
+<CollapserGroup>
+
+  <Collapser id="application_logging-enabled" title="application_logging.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables log decoration and the collection of log events and metrics.
+  </Collapser>
+
+  <Collapser id="application_logging-forwarding-enabled" title="application_logging.forwarding.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures log records emitted by your application.
+  </Collapser>
+
+  <Collapser id="application_logging-forwarding-log_level" title="application_logging.forwarding.log_level">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"debug"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LOG_LEVEL`</td></tr>
+      </tbody>
+    </table>
+
+  Sets the minimum level a log event must have to be forwarded to New Relic.
+
+	This is based on the integer values of [Ruby's `Logger::Severity` constants](https://github.com/ruby/logger/blob/113b82a06b3076b93a71cd467e1605b23afb3088/lib/logger/severity.rb).
+
+	The intention is to forward logs with the level given to the configuration, as well as any logs with a higher level of severity.
+
+	For example, setting this value to "debug" will forward all log events to New Relic. Setting this value to "error" will only forward log events with the levels "error", "fatal", and "unknown".
+
+	Valid values (ordered lowest to highest):
+	- "debug"
+	- "info"
+	- "warn"
+	- "error"
+	- "fatal"
+	- "unknown"
+
+  </Collapser>
+
+  <Collapser id="application_logging-forwarding-custom_attributes" title="application_logging.forwarding.custom_attributes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Hash</td></tr>
+        <tr><th>Default</th><td>`{}`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_CUSTOM_ATTRIBUTES`</td></tr>
+      </tbody>
+    </table>
+
+  A hash with key/value pairs to add as custom attributes to all log events forwarded to New Relic. If sending using an environment variable, the value must be formatted like: "key1=value1,key2=value2"
+  </Collapser>
+
+  <Collapser id="application_logging-forwarding-labels-enabled" title="application_logging.forwarding.labels.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent attaches [labels](https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#labels) to log records.
+  </Collapser>
+
+  <Collapser id="application_logging-forwarding-labels-exclude" title="application_logging.forwarding.labels.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_LABELS_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  A case-insensitive array or comma-delimited string containing the labels to exclude from log records.
+  </Collapser>
+
+  <Collapser id="application_logging-forwarding-max_samples_stored" title="application_logging.forwarding.max_samples_stored">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`10000`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of log records to buffer in memory at a time.
+  </Collapser>
+
+  <Collapser id="application_logging-local_decorating-enabled" title="application_logging.local_decorating.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent decorates logs with metadata to link to entities, hosts, traces, and spans.
+  </Collapser>
+
+  <Collapser id="application_logging-metrics-enabled" title="application_logging.metrics.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures metrics related to logging for your application.
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-other-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-other-settings.mdx
@@ -1,0 +1,2092 @@
+---
+title: Ruby agent other settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent miscellaneous settings: transaction events, audit log, autostart, cloud, code level metrics, custom events, datastore tracer, disabling, Elasticsearch, Heroku, instrumentation, message tracer, security, serverless, Sidekiq, Stripe, utilization, and more.'
+freshnessValidatedDate: never
+---
+
+Configure miscellaneous Ruby agent settings including transaction events, audit log, autostart behavior, cloud integration, instrumentation controls, security agent, serverless mode, Sidekiq, and utilization detection.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Transaction Events [#transaction-events]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="transaction_events-enabled" title="transaction_events.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables transaction event sampling.
+  </Collapser>
+
+  <Collapser id="transaction_events-max_samples_stored" title="transaction_events.max_samples_stored">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`1200`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_EVENTS_MAX_SAMPLES_STORED`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the maximum number of transaction events reported from a single harvest.
+  </Collapser>
+
+</CollapserGroup>
+
+## Audit Log [#audit-log]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="audit_log-enabled" title="audit_log.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUDIT_LOG_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables an audit log which logs communications with the New Relic [collector](/docs/using-new-relic/welcome-new-relic/get-started/glossary/#collector).
+  </Collapser>
+
+  <Collapser id="audit_log-endpoints" title="audit_log.endpoints">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[".*"]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUDIT_LOG_ENDPOINTS`</td></tr>
+      </tbody>
+    </table>
+
+  List of allowed endpoints to include in audit log.
+  </Collapser>
+
+  <Collapser id="audit_log-path" title="audit_log.path">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`log/newrelic_audit.log`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUDIT_LOG_PATH`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies a path to the audit log file (including the filename).
+  </Collapser>
+
+</CollapserGroup>
+
+## Autostart [#autostart]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="autostart-denylisted_constants" title="autostart.denylisted_constants">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"Rails::Command::ConsoleCommand,Rails::Command::CredentialsCommand,Rails::Command::Db::System::ChangeCommand,Rails::Command::DbConsoleCommand,Rails::Command::DestroyCommand,Rails::Command::DevCommand,Rails::Command::EncryptedCommand,Rails::Command::GenerateCommand,Rails::Command::InitializersCommand,Rails::Command::NotesCommand,Rails::Command::RoutesCommand,Rails::Command::RunnerCommand,Rails::Command::SecretsCommand,Rails::Command::TestCommand,Rails::Console,Rails::DBConsole"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUTOSTART_DENYLISTED_CONSTANTS`</td></tr>
+      </tbody>
+    </table>
+
+  Specify a list of constants that should prevent the agent from starting automatically. Separate individual constants with a comma `,`. For example, `"Rails::Console,UninstrumentedBackgroundJob"`.
+  </Collapser>
+
+  <Collapser id="autostart-denylisted_executables" title="autostart.denylisted_executables">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"irb,rspec"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUTOSTART_DENYLISTED_EXECUTABLES`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a comma-delimited list of executables that the agent should not instrument. For example, `"rake,my_ruby_script.rb"`.
+  </Collapser>
+
+  <Collapser id="autostart-denylisted_rake_tasks" title="autostart.denylisted_rake_tasks">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"about,assets:clean,assets:clobber,assets:environment,assets:precompile,assets:precompile:all,db:create,db:drop,db:fixtures:load,db:migrate,db:migrate:status,db:rollback,db:schema:cache:clear,db:schema:cache:dump,db:schema:dump,db:schema:load,db:seed,db:setup,db:structure:dump,db:version,doc:app,log:clear,middleware,notes,notes:custom,rails:template,rails:update,routes,secret,spec,spec:features,spec:requests,spec:controllers,spec:helpers,spec:models,spec:views,spec:routing,spec:rcov,stats,test,test:all,test:all:db,test:recent,test:single,test:uncommitted,time:zones:all,tmp:clear,tmp:create,webpacker:compile"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_AUTOSTART_DENYLISTED_RAKE_TASKS`</td></tr>
+      </tbody>
+    </table>
+
+  Defines a comma-delimited list of Rake tasks that the agent should not instrument. For example, `"assets:precompile,db:migrate"`.
+  </Collapser>
+
+</CollapserGroup>
+
+## Cloud [#cloud]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="cloud-aws-account_id" title="cloud.aws.account_id">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CLOUD_AWS_ACCOUNT_ID`</td></tr>
+      </tbody>
+    </table>
+
+  The AWS account ID for the AWS account associated with this app
+  </Collapser>
+
+</CollapserGroup>
+
+## Code Level Metrics [#code-level-metrics]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="code_level_metrics-enabled" title="code_level_metrics.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CODE_LEVEL_METRICS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will report source code level metrics for traced methods.
+	See: https://docs.newrelic.com/docs/apm/agents/ruby-agent/features/ruby-codestream-integration/
+  </Collapser>
+
+</CollapserGroup>
+
+## Custom Attributes [#custom-attributes]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="custom_attributes-enabled" title="custom_attributes.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CUSTOM_ATTRIBUTES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `false`, custom attributes will not be sent on events.
+  </Collapser>
+
+</CollapserGroup>
+
+## Custom Events [#custom-events]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="custom_insights_events-enabled" title="custom_insights_events.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures [custom events](/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-new-relic-apm-agents).
+  </Collapser>
+
+  <Collapser id="custom_insights_events-max_samples_stored" title="custom_insights_events.max_samples_stored">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`3000`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_CUSTOM_INSIGHTS_EVENTS_MAX_SAMPLES_STORED`</td></tr>
+      </tbody>
+    </table>
+
+  - Specify a maximum number of custom events to buffer in memory at a time.
+  - When configuring the agent for [AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring), set to max value `100000`. This ensures the agent captures the maximum amount of LLM events.
+
+  </Collapser>
+
+</CollapserGroup>
+
+## Datastore Tracer [#datastore-tracer]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="datastore_tracer-database_name_reporting-enabled" title="datastore_tracer.database_name_reporting.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DATASTORE_TRACER_DATABASE_NAME_REPORTING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `false`, the agent will not add `database_name` parameter to transaction or slow sql traces.
+  </Collapser>
+
+  <Collapser id="datastore_tracer-instance_reporting-enabled" title="datastore_tracer.instance_reporting.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DATASTORE_TRACER_INSTANCE_REPORTING_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `false`, the agent will not report datastore instance metrics, nor add `host` or `port_path_or_id` parameters to transaction or slow SQL traces.
+  </Collapser>
+
+</CollapserGroup>
+
+## Disabling [#disabling]
+
+Use these settings to toggle instrumentation types during agent startup.
+
+<CollapserGroup>
+
+  <Collapser id="disable_action_cable_instrumentation" title="disable_action_cable_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_CABLE_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Cable instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_action_controller" title="disable_action_controller">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_CONTROLLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Controller instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_action_mailbox" title="disable_action_mailbox">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_MAILBOX`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Mailbox instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_action_mailer" title="disable_action_mailer">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTION_MAILER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Action Mailer instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_activejob" title="disable_activejob">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVEJOB`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Active Job instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_active_job_step_names" title="disable_active_job_step_names">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVE_JOB_STEP_NAMES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, step names from Rails Active Job Continuations will not be included in metric names. This reduces metric cardinality but also reduces visibility into individual step performance. Only set this to `true` if you are experiencing metric cardinality issues due to jobs with many steps or dynamically-named steps.
+  </Collapser>
+
+  <Collapser id="disable_active_storage" title="disable_active_storage">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVE_STORAGE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Active Storage instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_active_support" title="disable_active_support">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVE_SUPPORT`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Active Support instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_active_record_instrumentation" title="disable_active_record_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVE_RECORD_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Active Record instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_active_record_notifications" title="disable_active_record_notifications">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_ACTIVE_RECORD_NOTIFICATIONS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables instrumentation for Active Record 4+
+  </Collapser>
+
+  <Collapser id="disable_cpu_sampler" title="disable_cpu_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_CPU_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't sample the CPU usage of the host process.
+  </Collapser>
+
+  <Collapser id="disable_delayed_job_sampler" title="disable_delayed_job_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_DELAYED_JOB_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't measure the depth of Delayed Job queues.
+  </Collapser>
+
+  <Collapser id="disable_gc_profiler" title="disable_gc_profiler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_GC_PROFILER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables the use of `GC::Profiler` to measure time spent in garbage collection
+  </Collapser>
+
+  <Collapser id="disable_memory_sampler" title="disable_memory_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MEMORY_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't sample the memory usage of the host process.
+  </Collapser>
+
+  <Collapser id="disable_middleware_instrumentation" title="disable_middleware_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_MIDDLEWARE_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't wrap third-party middlewares in instrumentation (regardless of whether they are installed via `Rack::Builder` or Rails).
+
+<Callout variant="important">
+When middleware instrumentation is disabled, if an application is using middleware that could alter the response code, the HTTP status code reported on the transaction may not reflect the altered value.
+</Callout>
+
+  </Collapser>
+
+  <Collapser id="disable_samplers" title="disable_samplers">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SAMPLERS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables the collection of sampler metrics. Sampler metrics are metrics that are not event-based (such as CPU time or memory usage).
+  </Collapser>
+
+  <Collapser id="disable_sequel_instrumentation" title="disable_sequel_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SEQUEL_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables [Sequel instrumentation](/docs/agents/ruby-agent/frameworks/sequel-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_sidekiq" title="disable_sidekiq">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SIDEKIQ`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables [Sidekiq instrumentation](/docs/agents/ruby-agent/background-jobs/sidekiq-instrumentation).
+  </Collapser>
+
+  <Collapser id="disable_roda_auto_middleware" title="disable_roda_auto_middleware">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_RODA_AUTO_MIDDLEWARE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables agent middleware for Roda. This middleware is responsible for advanced feature support such as [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser) and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+  </Collapser>
+
+  <Collapser id="disable_sinatra_auto_middleware" title="disable_sinatra_auto_middleware">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_SINATRA_AUTO_MIDDLEWARE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables agent middleware for Sinatra. This middleware is responsible for advanced feature support such as [distributed tracing](/docs/apm/distributed-tracing/getting-started/introduction-distributed-tracing), [page load timing](/docs/browser/new-relic-browser/getting-started/new-relic-browser), and [error collection](/docs/apm/applications-menu/events/view-apm-error-analytics).
+  </Collapser>
+
+  <Collapser id="disable_view_instrumentation" title="disable_view_instrumentation">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_VIEW_INSTRUMENTATION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables view instrumentation.
+  </Collapser>
+
+  <Collapser id="disable_vm_sampler" title="disable_vm_sampler">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_DISABLE_VM_SAMPLER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent won't [sample performance measurements from the Ruby VM](/docs/agents/ruby-agent/features/ruby-vm-measurements).
+  </Collapser>
+
+</CollapserGroup>
+
+## Elasticsearch [#elasticsearch]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="elasticsearch-capture_cluster_name" title="elasticsearch.capture_cluster_name">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ELASTICSEARCH_CAPTURE_CLUSTER_NAME`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures the Elasticsearch cluster name in transaction traces.
+  </Collapser>
+
+  <Collapser id="elasticsearch-capture_queries" title="elasticsearch.capture_queries">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ELASTICSEARCH_CAPTURE_QUERIES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures Elasticsearch queries in transaction traces.
+  </Collapser>
+
+  <Collapser id="elasticsearch-obfuscate_queries" title="elasticsearch.obfuscate_queries">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_ELASTICSEARCH_OBFUSCATE_QUERIES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent obfuscates Elasticsearch queries in transaction traces.
+  </Collapser>
+
+</CollapserGroup>
+
+## Heroku [#heroku]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="heroku-use_dyno_names" title="heroku.use_dyno_names">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_HEROKU_USE_DYNO_NAMES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent uses Heroku dyno names as the hostname.
+  </Collapser>
+
+  <Collapser id="heroku-dyno_name_prefixes_to_shorten" title="heroku.dyno_name_prefixes_to_shorten">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`["scheduler", "run"]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_HEROKU_DYNO_NAME_PREFIXES_TO_SHORTEN`</td></tr>
+      </tbody>
+    </table>
+
+  Ordinarily the agent reports dyno names with a trailing dot and process ID (for example, `worker.3`). You can remove this trailing data by specifying the prefixes you want to report without trailing data (for example, `worker`).
+  </Collapser>
+
+</CollapserGroup>
+
+## Instrumentation [#instrumentation]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="instrumentation-active_support_notifications-active_support_events" title="instrumentation.active_support_notifications.active_support_events">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`["cache_fetch_hit.active_support", "cache_generate.active_support", "cache_read.active_support", "cache_write.active_support", "cache_delete.active_support", "cache_exist?.active_support", "cache_read_multi.active_support", "cache_write_multi.active_support", "cache_delete_multi.active_support", "cache_delete_matched.active_support", "cache_cleanup.active_support", "cache_increment.active_support", "cache_decrement.active_support", "cache_prune.active_support", "message_serializer_fallback.active_support"]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ACTIVE_SUPPORT_NOTIFICATIONS_ACTIVE_SUPPORT_EVENTS`</td></tr>
+      </tbody>
+    </table>
+
+  An allowlist array of Active Support notifications events specific to the Active Support library itself that the agent should subscribe to. The Active Support library specific events focus primarily on caching. Any event name not included in this list will be ignored by the agent. Provide complete event names such as 'cache_fetch_hit.active_support'. Do not provide asterisks or regex patterns, and do not escape any characters with backslashes. For a complete list of all possible Active Support event names, see the [list of caching names](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#active-support-caching) and the [list of messages names](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#active-support-messages) from the official Rails documentation.
+  </Collapser>
+
+  <Collapser id="instrumentation-active_support_broadcast_logger" title="instrumentation.active_support_broadcast_logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ACTIVE_SUPPORT_BROADCAST_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of `ActiveSupport::BroadcastLogger` at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`. Used in Rails versions >= 7.1.
+  </Collapser>
+
+  <Collapser id="instrumentation-active_support_logger" title="instrumentation.active_support_logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ACTIVE_SUPPORT_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of `ActiveSupport::Logger` at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`. Used in Rails versions below 7.1.
+  </Collapser>
+
+  <Collapser id="instrumentation-async_http" title="instrumentation.async_http">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ASYNC_HTTP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Async::HTTP at start up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-bunny" title="instrumentation.bunny">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_BUNNY`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of bunny at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-semantic_logger" title="instrumentation.semantic_logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_SEMANTIC_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the semantic_logger library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-parallel" title="instrumentation.parallel">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PARALLEL`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the parallel library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-aws_sdk_firehose" title="instrumentation.aws_sdk_firehose">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_AWS_SDK_FIREHOSE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the aws-sdk-firehose library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-aws_sdk_lambda" title="instrumentation.aws_sdk_lambda">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_AWS_SDK_LAMBDA`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the aws_sdk_lambda library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-aws_sdk_kinesis" title="instrumentation.aws_sdk_kinesis">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_AWS_SDK_KINESIS`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the aws-sdk-kinesis library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-ruby_kafka" title="instrumentation.ruby_kafka">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RUBY_KAFKA`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the ruby-kafka library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-opensearch" title="instrumentation.opensearch">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_OPENSEARCH`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the opensearch-ruby library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-rdkafka" title="instrumentation.rdkafka">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RDKAFKA`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the rdkafka library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-aws_sqs" title="instrumentation.aws_sqs">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"auto"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_AWS_SQS`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the aws-sdk-sqs library at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-dynamodb" title="instrumentation.dynamodb">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_DYNAMODB`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the aws-sdk-dynamodb library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-fiber" title="instrumentation.fiber">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_FIBER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Fiber class at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-concurrent_ruby" title="instrumentation.concurrent_ruby">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_CONCURRENT_RUBY`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the concurrent-ruby library at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-curb" title="instrumentation.curb">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_CURB`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Curb at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-delayed_job" title="instrumentation.delayed_job">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_DELAYED_JOB`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Delayed Job at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-elasticsearch" title="instrumentation.elasticsearch">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ELASTICSEARCH`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the elasticsearch library at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-ethon" title="instrumentation.ethon">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_ETHON`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of ethon at start up. May be one of `auto`, `prepend`, `chain`, `disabled`
+  </Collapser>
+
+  <Collapser id="instrumentation-excon" title="instrumentation.excon">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`enabled`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_EXCON`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Excon at start-up. May be one of: `enabled`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-grape" title="instrumentation.grape">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRAPE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Grape at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-grpc_client" title="instrumentation.grpc_client">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_CLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of gRPC clients at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-grpc-host_denylist" title="instrumentation.grpc.host_denylist">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_HOST_DENYLIST`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies a list of hostname patterns separated by commas that will match gRPC hostnames that traffic is to be ignored by New Relic for. New Relic's gRPC client instrumentation will ignore traffic streamed to a host matching any of these patterns, and New Relic's gRPC server instrumentation will ignore traffic for a server running on a host whose hostname matches any of these patterns. By default, no traffic is ignored when gRPC instrumentation is itself enabled. For example, `"private.com$,exception.*"`
+  </Collapser>
+
+  <Collapser id="instrumentation-grpc_server" title="instrumentation.grpc_server">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_GRPC_SERVER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of gRPC servers at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-httpclient" title="instrumentation.httpclient">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPCLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of HTTPClient at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-httprb" title="instrumentation.httprb">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPRB`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of http.rb gem at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-httpx" title="instrumentation.httpx">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_HTTPX`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of httpx at start up. May be one of `auto`, `prepend`, `chain`, `disabled`
+  </Collapser>
+
+  <Collapser id="instrumentation-logger" title="instrumentation.logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Ruby standard library Logger at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-logging" title="instrumentation.logging">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_LOGGING`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the logging library at start-up. May be one of `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-logstasher" title="instrumentation.logstasher">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_LOGSTASHER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the LogStasher library at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-rails_event_logger" title="instrumentation.rails_event_logger">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`enabled`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RAILS_EVENT_LOGGER`</td></tr>
+      </tbody>
+    </table>
+
+  Controls instrumentation of Rails.event as structured logs. May be one of: `enabled`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-rails_event_logger-event_names" title="instrumentation.rails_event_logger.event_names">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RAILS_EVENT_LOGGER_EVENT_NAMES`</td></tr>
+      </tbody>
+    </table>
+
+  An array of Rails.event names to capture as structured log events. For example,
+		- user.signup
+		- payment.processed
+		- order.created
+Leave empty to capture all Rails.event notifications. Events are logged with level UNKNOWN (ensuring they're never filtered) unless overridden via :level key in the event payload.
+
+  </Collapser>
+
+  <Collapser id="instrumentation-memcache" title="instrumentation.memcache">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of dalli gem for Memcache at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-memcached" title="instrumentation.memcached">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHED`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of memcached gem for Memcache at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-memcache_client" title="instrumentation.memcache_client">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MEMCACHE_CLIENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of memcache-client gem for Memcache at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-mongo" title="instrumentation.mongo">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`enabled`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_MONGO`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Mongo at start-up. May be one of: `enabled`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-net_http" title="instrumentation.net_http">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_NET_HTTP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of `Net::HTTP` at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-ruby_openai" title="instrumentation.ruby_openai">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RUBY_OPENAI`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the ruby-openai gem at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`. Defaults to `disabled` in high security mode.
+  </Collapser>
+
+  <Collapser id="instrumentation-puma_rack" title="instrumentation.puma_rack">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PUMA_RACK`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of `Puma::Rack`. When enabled, the agent hooks into the `to_app` method in `Puma::Rack::Builder` to find gems to instrument during application startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-puma_rack_urlmap" title="instrumentation.puma_rack_urlmap">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_PUMA_RACK_URLMAP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of `Puma::Rack::URLMap` at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-rack" title="instrumentation.rack">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RACK`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Rack. When enabled, the agent hooks into the `to_app` method in `Rack::Builder` to find gems to instrument during application startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-rack_urlmap" title="instrumentation.rack_urlmap">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RACK_URLMAP`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of `Rack::URLMap` at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-rake" title="instrumentation.rake">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RAKE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of rake at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-redis" title="instrumentation.redis">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_REDIS`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Redis at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-resque" title="instrumentation.resque">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RESQUE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of resque at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-roda" title="instrumentation.roda">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_RODA`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Roda at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-sinatra" title="instrumentation.sinatra">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_SINATRA`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Sinatra at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-stripe" title="instrumentation.stripe">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"enabled"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_STRIPE`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Stripe at startup. May be one of: `enabled`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-view_component" title="instrumentation.view_component">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_VIEW_COMPONENT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of ViewComponent at startup. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-thread" title="instrumentation.thread">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Thread class at start-up to allow the agent to correctly nest spans inside of an asynchronous transaction. This does not enable the agent to automatically trace all threads created (see `instrumentation.thread.tracing`). May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-thread-tracing" title="instrumentation.thread.tracing">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_THREAD_TRACING`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Thread class at start-up to automatically add tracing to all Threads created in the application.
+  </Collapser>
+
+  <Collapser id="instrumentation-tilt" title="instrumentation.tilt">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TILT`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of the Tilt template rendering library at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+  <Collapser id="instrumentation-typhoeus" title="instrumentation.typhoeus">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`auto`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_INSTRUMENTATION_TYPHOEUS`</td></tr>
+      </tbody>
+    </table>
+
+  Controls auto-instrumentation of Typhoeus at start-up. May be one of: `auto`, `prepend`, `chain`, `disabled`.
+  </Collapser>
+
+</CollapserGroup>
+
+## Message Tracer [#message-tracer]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="message_tracer-segment_parameters-enabled" title="message_tracer.segment_parameters.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_MESSAGE_TRACER_SEGMENT_PARAMETERS_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will collect metadata about messages and attach them as segment parameters.
+  </Collapser>
+
+</CollapserGroup>
+
+## Mongo [#mongo]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="mongo-capture_queries" title="mongo.capture_queries">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_MONGO_CAPTURE_QUERIES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures Mongo queries in transaction traces.
+  </Collapser>
+
+  <Collapser id="mongo-obfuscate_queries" title="mongo.obfuscate_queries">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_MONGO_OBFUSCATE_QUERIES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent obfuscates Mongo queries in transaction traces.
+  </Collapser>
+
+</CollapserGroup>
+
+## Opensearch [#opensearch]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="opensearch-capture_queries" title="opensearch.capture_queries">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_OPENSEARCH_CAPTURE_QUERIES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent captures OpenSearch queries in transaction traces.
+  </Collapser>
+
+  <Collapser id="opensearch-obfuscate_queries" title="opensearch.obfuscate_queries">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_OPENSEARCH_OBFUSCATE_QUERIES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent obfuscates OpenSearch queries in transaction traces.
+  </Collapser>
+
+</CollapserGroup>
+
+## OpenTelemetry [#opentelemetry]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="opentelemetry-enabled" title="opentelemetry.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_OPENTELEMETRY_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  A global configuration option for disabling all OpenTelemetry signals sent through New Relic. If false, no OpenTelemetry signals will be sent to New Relic. If true, the signal-specific enabled config option (e.g. opentelemetry.traces.enabled) determines whether telemetry of that signal type will be reported to New Relic.
+  </Collapser>
+
+  <Collapser id="opentelemetry-traces-enabled" title="opentelemetry.traces.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_OPENTELEMETRY_TRACES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  Enables the creation of Transaction Trace segments and timeslice metrics from OpenTelemetry Spans. This will help drive New Relic UI experience for OpenTelemetry spans.
+  </Collapser>
+
+  <Collapser id="opentelemetry-traces-include" title="opentelemetry.traces.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_OPENTELEMETRY_TRACES_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  A comma-delimited list of OpenTelemetry Tracers, represented as a string (e.g. "AppTracer1,OpenTelemetry::Instrumentation::Bunny::Instrumentation"), that **will** have their traces sent to New Relic.
+  </Collapser>
+
+  <Collapser id="opentelemetry-traces-exclude" title="opentelemetry.traces.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`elasticsearch-api,dalli,OpenTelemetry::Instrumentation::ActionMailer::Instrumentation,OpenTelemetry::Instrumentation::ActionPack::Instrumentation,OpenTelemetry::Instrumentation::ActionView::Instrumentation,OpenTelemetry::Instrumentation::ActiveJob::Instrumentation,OpenTelemetry::Instrumentation::ActiveRecord::Instrumentation,OpenTelemetry::Instrumentation::ActiveStorage::Instrumentation,OpenTelemetry::Instrumentation::ActiveSupport::Instrumentation,OpenTelemetry::Instrumentation::AwsLambda::Instrumentation,OpenTelemetry::Instrumentation::AwsSdk::Instrumentation,OpenTelemetry::Instrumentation::Bunny::Instrumentation,OpenTelemetry::Instrumentation::ConcurrentRuby::Instrumentation,OpenTelemetry::Instrumentation::Dalli::Instrumentation,OpenTelemetry::Instrumentation::Ethon::Instrumentation,OpenTelemetry::Instrumentation::Excon::Instrumentation,OpenTelemetry::Instrumentation::Grape::Instrumentation,OpenTelemetry::Instrumentation::GraphQL::Instrumentation,OpenTelemetry::Instrumentation::Grpc::Instrumentation,OpenTelemetry::Instrumentation::HTTP::Instrumentation,OpenTelemetry::Instrumentation::HttpClient::Instrumentation,OpenTelemetry::Instrumentation::HTTPX::Instrumentation,OpenTelemetry::Instrumentation::Logger::Instrumentation,OpenTelemetry::Instrumentation::Mongo::Instrumentation,OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation,OpenTelemetry::Instrumentation::Rack::Instrumentation,OpenTelemetry::Instrumentation::Rails::Instrumentation,OpenTelemetry::Instrumentation::Rake::Instrumentation,OpenTelemetry::Instrumentation::Rdkafka::Instrumentation,OpenTelemetry::Instrumentation::Redis::Instrumentation,OpenTelemetry::Instrumentation::Resque::Instrumentation,OpenTelemetry::Instrumentation::RubyKafka::Instrumentation,OpenTelemetry::Instrumentation::Sidekiq::Instrumentation,OpenTelemetry::Instrumentation::Sinatra::Instrumentation`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_OPENTELEMETRY_TRACES_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  A comma-delimited list of OpenTelemetry Tracers, represented as a string (e.g. "AppTracer1,OpenTelemetry::Instrumentation::Bunny::Instrumentation"), that will **not** have their traces sent to New Relic.
+  </Collapser>
+
+</CollapserGroup>
+
+## Process Host [#process-host]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="process_host-display_name" title="process_host.display_name">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_PROCESS_HOST_DISPLAY_NAME`</td></tr>
+      </tbody>
+    </table>
+
+  Specify a custom host name for [display in the New Relic UI](/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name).
+  </Collapser>
+
+</CollapserGroup>
+
+## Rake [#rake]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="rake-tasks" title="rake.tasks">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_RAKE_TASKS`</td></tr>
+      </tbody>
+    </table>
+
+  Specify an Array of Rake tasks to automatically instrument. This configuration option converts the Array to a RegEx list. If you'd like to allow all tasks by default, use `rake.tasks: [.+]`. No rake tasks will be instrumented unless they're added to this list. For more information, visit the [New Relic Rake Instrumentation docs](/docs/apm/agents/ruby-agent/background-jobs/rake-instrumentation).
+  </Collapser>
+
+  <Collapser id="rake-connect_timeout" title="rake.connect_timeout">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`10`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_RAKE_CONNECT_TIMEOUT`</td></tr>
+      </tbody>
+    </table>
+
+  Timeout for waiting on connect to complete before a rake task
+  </Collapser>
+
+</CollapserGroup>
+
+## Rules [#rules]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="rules-ignore_url_regexes" title="rules.ignore_url_regexes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_RULES_IGNORE_URL_REGEXES`</td></tr>
+      </tbody>
+    </table>
+
+  Define transactions you want the agent to ignore, by specifying a list of patterns matching the URI you want to ignore. For more detail, see [the docs on ignoring specific transactions](/docs/agents/ruby-agent/api-guides/ignoring-specific-transactions/#config-ignoring).
+  </Collapser>
+
+</CollapserGroup>
+
+## Security [#security]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="security-agent-enabled" title="security.agent.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_AGENT_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the security agent is loaded (a Ruby 'require' is performed)
+  </Collapser>
+
+  <Collapser id="security-enabled" title="security.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the security agent is started (the agent runs in its event loop)
+  </Collapser>
+
+  <Collapser id="security-mode" title="security.mode">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"IAST"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_MODE`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the mode for the security agent to operate in. Currently only `IAST` is supported
+  </Collapser>
+
+  <Collapser id="security-validator_service_url" title="security.validator_service_url">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"wss://csec.nr-data.net"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_VALIDATOR_SERVICE_URL`</td></tr>
+      </tbody>
+    </table>
+
+  Defines the endpoint URL for posting security-related data
+  </Collapser>
+
+  <Collapser id="security-application_info-port" title="security.application_info.port">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_APPLICATION_INFO_PORT`</td></tr>
+      </tbody>
+    </table>
+
+  The port the application is listening on. This setting is mandatory for Passenger servers. The agent detects other servers by default.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-api" title="security.exclude_from_iast_scan.api">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_API`</td></tr>
+      </tbody>
+    </table>
+
+  Defines API paths the security agent should ignore in IAST scans. Accepts an array of regex patterns matching the URI to ignore. The regex pattern should find a complete match for the URL without the endpoint. For example, `[".*account.*"], [".*/\api\/v1\/.*?\/login"]`
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-http_request_parameters-header" title="security.exclude_from_iast_scan.http_request_parameters.header">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_HTTP_REQUEST_PARAMETERS_HEADER`</td></tr>
+      </tbody>
+    </table>
+
+  An array of HTTP request headers the security agent should ignore in IAST scans. The array should specify a list of patterns matching the headers to ignore.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-http_request_parameters-query" title="security.exclude_from_iast_scan.http_request_parameters.query">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_HTTP_REQUEST_PARAMETERS_QUERY`</td></tr>
+      </tbody>
+    </table>
+
+  An array of HTTP request query parameters the security agent should ignore in IAST scans. The array should specify a list of patterns matching the HTTP request query parameters to ignore.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-http_request_parameters-body" title="security.exclude_from_iast_scan.http_request_parameters.body">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_HTTP_REQUEST_PARAMETERS_BODY`</td></tr>
+      </tbody>
+    </table>
+
+  An array of HTTP request body keys the security agent should ignore in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-insecure_settings" title="security.exclude_from_iast_scan.iast_detection_category.insecure_settings">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_INSECURE_SETTINGS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables the detection of low-severity insecure settings. For example, hash, crypto, cookie, random generators, trust boundary).
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-invalid_file_access" title="security.exclude_from_iast_scan.iast_detection_category.invalid_file_access">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_INVALID_FILE_ACCESS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables file operation-related IAST detections (File Access & Application integrity violation)
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-sql_injection" title="security.exclude_from_iast_scan.iast_detection_category.sql_injection">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_SQL_INJECTION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables SQL injection detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-nosql_injection" title="security.exclude_from_iast_scan.iast_detection_category.nosql_injection">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_NOSQL_INJECTION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables NOSQL injection detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-ldap_injection" title="security.exclude_from_iast_scan.iast_detection_category.ldap_injection">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_LDAP_INJECTION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables LDAP injection detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-javascript_injection" title="security.exclude_from_iast_scan.iast_detection_category.javascript_injection">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_JAVASCRIPT_INJECTION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Javascript injection detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-command_injection" title="security.exclude_from_iast_scan.iast_detection_category.command_injection">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_COMMAND_INJECTION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables system command injection detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-xpath_injection" title="security.exclude_from_iast_scan.iast_detection_category.xpath_injection">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_XPATH_INJECTION`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables XPATH injection detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-ssrf" title="security.exclude_from_iast_scan.iast_detection_category.ssrf">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_SSRF`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Sever-Side Request Forgery (SSRF) detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-exclude_from_iast_scan-iast_detection_category-rxss" title="security.exclude_from_iast_scan.iast_detection_category.rxss">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_EXCLUDE_FROM_IAST_SCAN_IAST_DETECTION_CATEGORY_RXSS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, disables Reflected Cross-Site Scripting (RXSS) detection in IAST scans.
+  </Collapser>
+
+  <Collapser id="security-scan_schedule-delay" title="security.scan_schedule.delay">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`0`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_SCHEDULE_DELAY`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies the delay time (in minutes) before the IAST scan begins after the application starts.
+  </Collapser>
+
+  <Collapser id="security-scan_schedule-duration" title="security.scan_schedule.duration">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`0`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_SCHEDULE_DURATION`</td></tr>
+      </tbody>
+    </table>
+
+  Indicates the duration (in minutes) for which the IAST scan will be performed.
+  </Collapser>
+
+  <Collapser id="security-scan_schedule-schedule" title="security.scan_schedule.schedule">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`""`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_SCHEDULE_SCHEDULE`</td></tr>
+      </tbody>
+    </table>
+
+  Specifies a cron expression that sets when the IAST scan should run.
+  </Collapser>
+
+  <Collapser id="security-scan_schedule-always_sample_traces" title="security.scan_schedule.always_sample_traces">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_SCHEDULE_ALWAYS_SAMPLE_TRACES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, allows IAST to continuously gather trace data in the background. The security agent uses collected data to perform an IAST scan at the scheduled time.
+  </Collapser>
+
+  <Collapser id="security-scan_controllers-iast_scan_request_rate_limit" title="security.scan_controllers.iast_scan_request_rate_limit">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`3600`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_CONTROLLERS_IAST_SCAN_REQUEST_RATE_LIMIT`</td></tr>
+      </tbody>
+    </table>
+
+  Sets the maximum number of HTTP requests allowed for the IAST scan per minute. Any Integer between 12 and 3600 is valid. The default value is 3600.
+  </Collapser>
+
+  <Collapser id="security-scan_controllers-scan_instance_count" title="security.scan_controllers.scan_instance_count">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`0`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_CONTROLLERS_SCAN_INSTANCE_COUNT`</td></tr>
+      </tbody>
+    </table>
+
+  The number of application instances for a specific entity to perform IAST analysis on.
+  </Collapser>
+
+  <Collapser id="security-scan_controllers-report_http_response_body" title="security.scan_controllers.report_http_response_body">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_SCAN_CONTROLLERS_REPORT_HTTP_RESPONSE_BODY`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables the sending of HTTP responses bodies. Disabling this also disables Reflected Cross-Site Scripting (RXSS) vulnerability detection.
+  </Collapser>
+
+  <Collapser id="security-iast_test_identifier" title="security.iast_test_identifier">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`nil`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SECURITY_IAST_TEST_IDENTIFIER`</td></tr>
+      </tbody>
+    </table>
+
+  A unique test identifier when runnning IAST in a CI/CD environment to differentiate between different test runs. For example, a build number.
+  </Collapser>
+
+</CollapserGroup>
+
+## Serverless Mode [#serverless-mode]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="serverless_mode-enabled" title="serverless_mode.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SERVERLESS_MODE_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will operate in a streamlined mode suitable for use with short-lived serverless functions. NOTE: Only AWS Lambda functions are supported currently and this option isn't intended for use without [New Relic's Ruby Lambda layer](https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/get-started/monitoring-aws-lambda-serverless-monitoring/) offering.
+  </Collapser>
+
+</CollapserGroup>
+
+## Sidekiq [#sidekiq]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="sidekiq-args-include" title="sidekiq.args.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SIDEKIQ_ARGS_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  An array of strings that will collectively serve as an allowlist for filtering which Sidekiq job arguments get reported to New Relic. To capture any Sidekiq arguments, 'job.sidekiq.args.*' must be added to the separate `:'attributes.include'` configuration option. Each string in this array will be turned into a regular expression via `Regexp.new` to permit advanced matching. For job argument hashes, if either a key or value matches the pair will be included. All matching job argument array elements and job argument scalars will be included.
+  </Collapser>
+
+  <Collapser id="sidekiq-args-exclude" title="sidekiq.args.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SIDEKIQ_ARGS_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  An array of strings that will collectively serve as a denylist for filtering which Sidekiq job arguments get reported to New Relic. To capture any Sidekiq arguments, 'job.sidekiq.args.*' must be added to the separate `:'attributes.include'` configuration option. Each string in this array will be turned into a regular expression via `Regexp.new` to permit advanced matching. For job argument hashes, if either a key or value matches the pair will be excluded. All matching job argument array elements and job argument scalars will be excluded.
+  </Collapser>
+
+  <Collapser id="sidekiq-ignore_retry_errors" title="sidekiq.ignore_retry_errors">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SIDEKIQ_IGNORE_RETRY_ERRORS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will ignore exceptions raised during Sidekiq's retry attempts and will only report the error if the job permanently fails.
+  </Collapser>
+
+  <Collapser id="sidekiq-separate_transactions" title="sidekiq.separate_transactions">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SIDEKIQ_SEPARATE_TRANSACTIONS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent starts a new transaction when a Sidekiq job is executed during a web transaction. This prevents Sidekiq job execution time from being included in web transaction metrics.
+  </Collapser>
+
+</CollapserGroup>
+
+## Strip Exception Messages [#strip-exception-messages]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="strip_exception_messages-enabled" title="strip_exception_messages.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_STRIP_EXCEPTION_MESSAGES_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If true, the agent strips messages from all exceptions except those in the [allowed classes list](#strip_exception_messages-allowed_classes). Enabled automatically in [high security mode](/docs/accounts-partnerships/accounts/security/high-security).
+  </Collapser>
+
+  <Collapser id="strip_exception_messages-allowed_classes" title="strip_exception_messages.allowed_classes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_STRIP_EXCEPTION_MESSAGES_ALLOWED_CLASSES`</td></tr>
+      </tbody>
+    </table>
+
+  Specify a list of exceptions you do not want the agent to strip when [strip_exception_messages](#strip_exception_messages-enabled) is `true`. Separate exceptions with a comma. For example, `"ImportantException,PreserveMessageException"`.
+  </Collapser>
+
+</CollapserGroup>
+
+## Stripe [#stripe]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="stripe-user_data-include" title="stripe.user_data.include">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_STRIPE_USER_DATA_INCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  An array of strings to specify which keys inside a Stripe event's `user_data` hash should be reported
+to New Relic. Each string in this array will be turned into a regular expression via `Regexp.new` to
+enable advanced matching. Setting the value to `["."]` will report all `user_data`.
+
+  </Collapser>
+
+  <Collapser id="stripe-user_data-exclude" title="stripe.user_data.exclude">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Array</td></tr>
+        <tr><th>Default</th><td>`[]`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_STRIPE_USER_DATA_EXCLUDE`</td></tr>
+      </tbody>
+    </table>
+
+  An array of strings to specify which keys and/or values inside a Stripe event's `user_data` hash should
+	not be reported to New Relic. Each string in this array will be turned into a regular expression via
+	`Regexp.new` to permit advanced matching. For each hash pair, if either the key or value is matched the pair
+	isn't reported. By default, no `user_data` is reported. Use this option only if the
+	`stripe.user_data.include` option is also used.
+
+  </Collapser>
+
+</CollapserGroup>
+
+## Thread Profiler [#thread-profiler]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="thread_profiler-enabled" title="thread_profiler.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_THREAD_PROFILER_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables use of the [thread profiler](/docs/apm/applications-menu/events/thread-profiler-tool).
+  </Collapser>
+
+</CollapserGroup>
+
+## Utilization [#utilization]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="utilization-detect_aws" title="utilization.detect_aws">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_AWS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in an AWS environment.
+  </Collapser>
+
+  <Collapser id="utilization-detect_azure" title="utilization.detect_azure">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_AZURE`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in an Azure environment.
+  </Collapser>
+
+  <Collapser id="utilization-detect_docker" title="utilization.detect_docker">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_DOCKER`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in Docker.
+  </Collapser>
+
+  <Collapser id="utilization-detect_gcp" title="utilization.detect_gcp">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_GCP`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in an Google Cloud Platform environment.
+  </Collapser>
+
+  <Collapser id="utilization-detect_kubernetes" title="utilization.detect_kubernetes">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_KUBERNETES`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in Kubernetes.
+  </Collapser>
+
+  <Collapser id="utilization-detect_pcf" title="utilization.detect_pcf">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_PCF`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent automatically detects that it is running in a Pivotal Cloud Foundry environment.
+  </Collapser>
+
+  <Collapser id="utilization-detect_in_parallel" title="utilization.detect_in_parallel">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_UTILIZATION_DETECT_IN_PARALLEL`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent will perform environment detection in parallel to speed up agent startup time.
+  </Collapser>
+
+</CollapserGroup>

--- a/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-transaction-tracer-settings.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-transaction-tracer-settings.mdx
@@ -1,0 +1,192 @@
+---
+title: Ruby agent transaction tracer settings
+tags:
+  - Agents
+  - Ruby agent
+  - Configuration
+metaDescription: 'Ruby agent transaction tracer and slow SQL configuration: trace thresholds, SQL recording, and explain plans.'
+freshnessValidatedDate: never
+---
+
+Configure the Ruby agent's transaction tracer and slow SQL settings to control how traces are collected, what SQL is recorded, and when explain plans are gathered.
+
+<Callout variant="tip">
+  Back to the full settings index: [Ruby agent configuration](/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration)
+</Callout>
+
+## Transaction Tracer [#transaction-tracer]
+
+The [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces) feature collects detailed information from a selection of transactions, including a summary of the calling sequence, a breakdown of time spent, and a list of SQL queries and their query plans (on mysql and postgresql). Available features depend on your New Relic subscription level.
+
+<CollapserGroup>
+
+  <Collapser id="transaction_tracer-enabled" title="transaction_tracer.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables collection of [transaction traces](/docs/apm/traces/transaction-traces/transaction-traces).
+  </Collapser>
+
+  <Collapser id="transaction_tracer-explain_enabled" title="transaction_tracer.explain_enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, enables the collection of explain plans in transaction traces. This setting will also apply to explain plans in slow SQL traces if [`slow_sql.explain_enabled`](#slow_sql-explain_enabled) isn't set separately.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-explain_threshold" title="transaction_tracer.explain_threshold">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`0.5`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_EXPLAIN_THRESHOLD`</td></tr>
+      </tbody>
+    </table>
+
+  Threshold (in seconds) above which the agent will collect explain plans. Relevant only when [`explain_enabled`](#transaction_tracer.explain_enabled) is true.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-limit_segments" title="transaction_tracer.limit_segments">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Integer</td></tr>
+        <tr><th>Default</th><td>`4000`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_LIMIT_SEGMENTS`</td></tr>
+      </tbody>
+    </table>
+
+  Maximum number of transaction trace nodes to record in a single transaction trace.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-record_redis_arguments" title="transaction_tracer.record_redis_arguments">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_RECORD_REDIS_ARGUMENTS`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent records Redis command arguments in transaction traces.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-record_sql" title="transaction_tracer.record_sql">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`"obfuscated"`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_RECORD_SQL`</td></tr>
+      </tbody>
+    </table>
+
+  Obfuscation level for SQL queries reported in transaction trace nodes.
+	By default, this is set to `obfuscated`, which strips out the numeric and string literals.
+	- If you do not want the agent to capture query information, set this to `none`.
+	- If you want the agent to capture all query information in its original form, set this to `raw`.
+	- When you enable [high security mode](/docs/agents/manage-apm-agents/configuration/high-security-mode), this is automatically set to `obfuscated`.
+
+  </Collapser>
+
+  <Collapser id="transaction_tracer-stack_trace_threshold" title="transaction_tracer.stack_trace_threshold">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`0.5`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_STACK_TRACE_THRESHOLD`</td></tr>
+      </tbody>
+    </table>
+
+  Specify a threshold in seconds. The agent includes stack traces in transaction trace nodes when the stack trace duration exceeds this threshold.
+  </Collapser>
+
+  <Collapser id="transaction_tracer-transaction_threshold" title="transaction_tracer.transaction_threshold">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`(Dynamic)`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_TRANSACTION_TRACER_TRANSACTION_THRESHOLD`</td></tr>
+      </tbody>
+    </table>
+
+  Specify a threshold in seconds. Transactions with a duration longer than this threshold are eligible for transaction traces. Specify a float value or the string `apdex_f`.
+  </Collapser>
+
+</CollapserGroup>
+
+## Slow SQL [#slow-sql]
+
+
+
+<CollapserGroup>
+
+  <Collapser id="slow_sql-enabled" title="slow_sql.enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SLOW_SQL_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent collects [slow SQL queries](/docs/apm/applications-menu/monitoring/viewing-slow-query-details).
+  </Collapser>
+
+  <Collapser id="slow_sql-explain_threshold" title="slow_sql.explain_threshold">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Float</td></tr>
+        <tr><th>Default</th><td>`0.5`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SLOW_SQL_EXPLAIN_THRESHOLD`</td></tr>
+      </tbody>
+    </table>
+
+  Specify a threshold in seconds. The agent collects [slow SQL queries](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) and explain plans that exceed this threshold.
+  </Collapser>
+
+  <Collapser id="slow_sql-explain_enabled" title="slow_sql.explain_enabled">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`true`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SLOW_SQL_EXPLAIN_ENABLED`</td></tr>
+      </tbody>
+    </table>
+
+  If `true`, the agent collects explain plans in slow SQL queries. If this setting is omitted, the [`transaction_tracer.explain_enabled`](#transaction_tracer-explain_enabled) setting will be applied as the default setting for explain plans in slow SQL as well.
+  </Collapser>
+
+  <Collapser id="slow_sql-record_sql" title="slow_sql.record_sql">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>String</td></tr>
+        <tr><th>Default</th><td>`obfuscated`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SLOW_SQL_RECORD_SQL`</td></tr>
+      </tbody>
+    </table>
+
+  Defines an obfuscation level for slow SQL queries. Valid options are `obfuscated`, `raw`, or `none`.
+  </Collapser>
+
+  <Collapser id="slow_sql-use_longer_sql_id" title="slow_sql.use_longer_sql_id">
+    <table>
+      <tbody>
+        <tr><th>Type</th><td>Boolean</td></tr>
+        <tr><th>Default</th><td>`false`</td></tr>
+        <tr><th>Environ variable</th><td>`NEW_RELIC_SLOW_SQL_USE_LONGER_SQL_ID`</td></tr>
+      </tbody>
+    </table>
+
+  Generate a longer `sql_id` for slow SQL traces. `sql_id` is used for aggregation of similar queries.
+  </Collapser>
+
+</CollapserGroup>

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -1036,21 +1036,11 @@ pages:
       - title: Ruby monitoring
         path: /docs/apm/agents/ruby-agent
         pages:
-          - title: Introduction to Ruby monitoring
-            path: /docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby
-          - title: Install the Ruby agent
-            path: /docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent
-          - title: Ruby configuration
-            path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration
-          - title: Requirements and supported frameworks
-            path: /docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
-          - title: Release and migration guides
+          - title: Compatibility and release
             path: /docs/apm/agents/ruby-agent/getting-started
             pages:
-              - title: Latest release
-                path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
-              - title: Ruby release notes
-                path: /docs/release-notes/agent-release-notes/ruby-release-notes
+              - title: Requirements and supported frameworks
+                path: /docs/apm/agents/ruby-agent/getting-started/ruby-agent-requirements-supported-frameworks
               - title: Ruby agent security
                 path: /docs/apm/agents/ruby-agent/getting-started/apm-agent-security-ruby
               - title: Ruby agent EOL policy
@@ -1065,9 +1055,17 @@ pages:
                 path: /docs/apm/agents/ruby-agent/getting-started/migration-9x-guide
               - title: Ruby agent 10x migration guide
                 path: /docs/apm/agents/ruby-agent/getting-started/migration-10x-guide
-          - title: Configuration
+              - title: Latest release
+                path: /docs/release-notes/agent-release-notes/ruby-release-notes/current
+              - title: Ruby release notes
+                path: /docs/release-notes/agent-release-notes/ruby-release-notes
+          - title: Ruby agent installation
             path: /docs/apm/agents/ruby-agent/installation
             pages:
+              - title: Overview
+                path: /docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent
+              - title: Rails plugin installation
+                path: /docs/apm/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
               - title: GAE flex
                 path: /docs/apm/agents/ruby-agent/installation/install-new-relic-ruby-agent-gae-flexible-environment
               - title: Ruby agent and Heroku
@@ -1076,8 +1074,32 @@ pages:
                 path: /docs/apm/agents/ruby-agent/installation/update-ruby-agent
               - title: Uninstall Ruby agent
                 path: /docs/apm/agents/ruby-agent/installation/uninstall-ruby-agent
-              - title: Rails plugin installation
-                path: /docs/apm/agents/ruby-agent/installation/ruby-agent-installation-rails-plugin
+          - title: Introduction to Ruby monitoring
+            path: /docs/apm/agents/ruby-agent/getting-started/introduction-new-relic-ruby
+          - title: Configuration
+            path: /docs/apm/agents/ruby-agent/configuration
+            pages:
+              - title: Ruby agent configuration
+                path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration
+                pages:
+                  - title: General settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-general-settings
+                  - title: Transaction tracer settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-transaction-tracer-settings
+                  - title: Error collector settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-error-collector-settings
+                  - title: Browser monitoring settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-browser-monitoring-settings
+                  - title: Distributed tracing settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-distributed-tracing-settings
+                  - title: Logs in context settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-logs-in-context-settings
+                  - title: AI monitoring settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-ai-monitoring-settings
+                  - title: Attributes settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-attributes-settings
+                  - title: Other settings
+                    path: /docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration-other-settings
               - title: Custom SSL certificates
                 path: /docs/apm/agents/ruby-agent/configuration/custom-ssl-certificates-ruby
               - title: Connect hosts to account


### PR DESCRIPTION
## Summary

- Restructures the Ruby monitoring nav section to match the established PHP/Java agent IA pattern — Ruby had the most issues of all agents
- Renames "Release and migration guides" → "Compatibility and release" (singular, consistent)
- Moves "Requirements and supported frameworks" into the Compatibility section (was standalone)
- Removes standalone "Introduction to Ruby monitoring", "Install the Ruby agent", and "Ruby configuration" from top level
- Fixes mislabeled "Configuration" section that incorrectly pointed to `/installation` path
- Creates proper "Ruby agent installation" section with Overview, Rails plugin, GAE, Heroku, Update, Uninstall
- Adds "Introduction to Ruby monitoring" as standalone after installation section
- Splits the 3,610-line `ruby-agent-configuration.mdx` into 9 focused sub-pages

**New config sub-pages:**
General settings · Transaction tracer settings · Error collector settings · Browser monitoring settings · Distributed tracing settings · Logs in context settings · AI monitoring settings · Attributes settings · Other settings

## Test plan

- [ ] Verify nav renders correctly in local dev
- [ ] Confirm all 9 new config sub-page paths resolve
- [ ] Confirm existing links to `ruby-agent-configuration` still work
- [ ] Verify the previously mislabeled Configuration section (pointing to /installation) is corrected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)