### PR TITLE
refactor(go-agent): align Go nav with PHP/Java IA pattern and split config

### DIFF
--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-ai-monitoring-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-ai-monitoring-settings.mdx
@@ -1,0 +1,187 @@
+---
+title: Go agent AI monitoring settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent AI monitoring and version tag configuration settings.'
+freshnessValidatedDate: never
+---
+
+Configure AI monitoring and service version tagging for the Go agent.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Set version tag [#version-tag]
+
+Setting NEW_RELIC_METADATA_SERVICE_VERSION will create a tag, `tag.service.version` on event data. In this context, the service version is the version of your code that is deployed, in many cases a semantic version such as 1.2.3 but not always. Sending this information allows you to facet your telemetry by the version of the software deployed so you can quickly identify which versions of your software are producing the errors.
+
+## AI monitoring [#ai-monitoring]
+
+This section includes Go agent configurations for setting up AI monitoring.
+
+<Callout variant="important">
+  If distributed tracing is disabled or high security mode is enabled, AI monitoring will not collect AI data.
+</Callout>
+
+<Callout variant="important">
+  When enabled, AI monitoring  records a streaming copy of inputs and outputs sent to and from the models you choose to monitor, including any personal information contained therein. 
+  You're responsible for obtaining consent from your model users that their interactions may be recorded by a third party (New Relic) for the purpose of providing the AI monitoring feature.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="ai-monitoring-enabled"
+    title="AIMonitoring.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_AI_MONITORING_ENABLED`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Configuration function
+          </th>
+
+          <td>
+            `newrelic.ConfigAIMonitoringEnabled`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, enables AI monitoring.
+  </Collapser>
+
+  <Collapser
+    id="ai-monitoring-streaming"
+    title="AIMonitoring.Streaming.Enabled "
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_AI_MONITORING_STREAMING_ENABLED`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Configuration function
+          </th>
+
+          <td>
+            `newrelic.ConfigAIMonitoringStreamingEnabled`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, enables the agent to capture streamed responses. If set to `false`, agent won't capture event data about streamed responses, but the agent can still capture metrics and spans. The span duration will end when the LLM function call exits. When set to `true`, the span duration ends when the final result is read from the stream.
+  </Collapser>
+
+  <Collapser
+    id="ai-monitoring-record-content"
+    title="AIMonitoring.RecordContent.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Configuration function
+          </th>
+
+          <td>
+            `newrelic.ConfigAIMonitoringRecordContentEnabled()`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If set to `false`, agent will omit input and output content (like text strings from prompts and responses) captured in LLM events. This is an optional security setting if you don't want to record sensitive data sent to and received from your LLMs.
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-distributed-tracing-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-distributed-tracing-settings.mdx
@@ -1,0 +1,337 @@
+---
+title: Go agent distributed tracing settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent distributed tracing configuration: enable DT, span events, Infinite Tracing, and cross-application tracing (deprecated).'
+freshnessValidatedDate: never
+---
+
+Configure distributed tracing, span events, Infinite Tracing, and the deprecated cross-application tracing feature for the Go agent.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Cross application tracing configuration [#cross-application-tracing]
+
+Here are settings for changing the [cross application tracing](/docs/agents/go-agent/features/cross-application-tracing-go) feature.
+
+<Callout variant="important">
+  Cross application tracing has been deprecated in favor of [Distributed tracing](/docs/agents/go-agent/features/distributed-tracing-go) and will be removed in a future agent version.
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="cross-tracer-enabled"
+    title="CrossApplicationTracer.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Cross-application tracing on/off`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent will add cross application tracing headers in outbound requests, and scan incoming requests for cross application tracing headers.
+
+    Distributed tracing and cross application tracing cannot be used simultaneously. The default configuration for the Go agent disables distributed tracing and enables cross application tracing.
+  </Collapser>
+</CollapserGroup>
+
+## Distributed tracing configuration [#distributed-tracing]
+
+<Callout variant="important">
+  Enabling distributed tracing requires Go agent version 2.1.0 or higher, and it disables [cross application tracing](#cross-application-tracing). It also has effects on other features. Before enabling, read the [transition guide](/docs/transition-guide-distributed-tracing).
+</Callout>
+
+[Distributed tracing](/docs/agents/go-agent/features/distributed-tracing-go) lets you see the path that a request takes as it travels through a distributed system.
+
+When distributed tracing is enabled, you can collect [span events](/docs/apm/distributed-tracing/ui-data/span-event).
+
+<CollapserGroup>
+  <Collapser
+    id="distributed-enabled"
+    title="DistributedTracer.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Standard tracing is on by default in Go agent versions 3.16.0 and higher. This means the agent will automatically add distributed tracing headers in outbound requests, and scan incoming requests for distributed tracing headers. To disable distributed tracing, set the value to `false`.
+
+    For more information about setting up distributed tracing, see [Enable distributed tracing for your Go applications](/docs/apm/agents/go-agent/instrumentation/distributed-tracing-go-agent).
+
+    <Callout variant="important">
+      Enabling distributed tracing disables [cross application tracing](#cross-application-tracing).
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="dt-exclude-newrelic-header"
+    title="DistributedTracer.ExcludeNewRelicHeader"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Set this to `true` to exclude the New Relic header that is attached to outbound requests, and instead only rely on W3C Trace Context Headers for distributed tracing. If this is `false` then both types of headers are used.
+  </Collapser>
+</CollapserGroup>
+
+## Span events configuration [#span-events]
+
+[Span events](/docs/apm/distributed-tracing/ui-data/span-event) are reported for [distributed tracing](/docs/agents/java-agent/configuration/java-agent-configuration-config-file#distributed-tracing). Distributed tracing must be enabled to report span events. These settings control the collection of span events:
+
+<CollapserGroup>
+  <Collapser
+    id="span-events-enabled"
+    title="SpanEvents.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent will collect span events.
+  </Collapser>
+
+  <Collapser
+    id="span-event-attributes"
+    title="SpanEvents.Attributes"
+  >
+    <Callout variant="important">
+      Available for Go agent version 2.6.0 or higher.
+    </Callout>
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Struct
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            Enabled, no exclusions
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    `SpanEvents.Attributes` is a struct with three fields:
+
+    ```go
+    Enabled bool
+    Include []string
+    Exclude []string
+    ```
+
+    Use `SpanEvents.Attributes.Enabled` to enable or disable attribute collection for span events. Use `Include` and `Exclude` to include or exclude specific attributes.
+
+    An example of excluding an attribute slice named `allSpanAttributeNames` from traces:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+            config.TransactionTracer.Segments.Attributes.Exclude = allSpanAttributeNames
+        },
+    )
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Infinite Tracing configuration [#infinite-tracing]
+
+To enable Infinite Tracing, enable distributed tracing (set `config.DistributedTracer.Enabled = true` on the `newrelic.Config` struct) and add the additional settings below. For an example, see [Language agents: Configure distributed tracing](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#go-config).
+
+<CollapserGroup>
+  <Collapser
+    id="trace-observer-host"
+    title="InfiniteTracing.TraceObserver.Host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            string
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    For help getting a valid Infinite Tracing trace observer host entry, see [Find or create a trace observer endpoint](/docs/understand-dependencies/distributed-tracing/enable-configure/language-agents-enable-distributed-tracing#provision-trace-observer).
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-error-collector-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-error-collector-settings.mdx
@@ -1,0 +1,384 @@
+---
+title: Go agent error collector settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent error collector configuration: ignore errors, expected errors, and error event sampling.'
+freshnessValidatedDate: never
+---
+
+Configure the Go agent's error collector to control which errors are collected, ignored, or marked as expected.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Error collector configuration [#error-collector]
+
+The following settings are used to configure the error collector:
+
+<Callout variant="tip">
+  For an overview of error configuration in New Relic, see [Manage errors in APM](/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected).
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="error-collector-enabled"
+    title="ErrorCollector.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Error Collection on/off`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `false`, the agent collects no errors or error traces.
+  </Collapser>
+
+  <Collapser
+    id="error-capture-events"
+    title="ErrorCollector.CaptureEvents"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent collects error analytic events.
+  </Collapser>
+
+  <Collapser
+    id="error-group-callback"
+    title="ErrorCollector.ErrorGroupCallback"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            ErrorGroupCallback
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            nil
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+
+          <td>
+            `newrelic.ConfigSetErrorGroupCallbackFunction` config option
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When not nil, the agent will apply the user defined callback function to all noticed errors at harvest time, applying an error group to them.
+  </Collapser>
+
+  <Collapser
+    id="error-ignore-status"
+    title="ErrorCollector.IgnoreStatusCodes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            Error codes 399 and below, and 404, are ignored.
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Error Collection: Ignore from error collection`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This controls which HTTP response codes are ignored as errors.
+
+    Response codes that are greater than or equal to 100 and strictly less than 400 are ignored by default and never have to be specified when calling this function. Response codes 0, 5, and 404 are included on the list by default, but must be specified when adding to the ignore list.
+
+    This function's default form is:
+
+    ```go
+    config.ErrorCollector.IgnoreStatusCodes = []int{
+        0,                   // gRPC OK
+        5,                   // gRPC NOT_FOUND
+        http.StatusNotFound, // 404
+    }
+    ```
+
+    You can also add response codes as HTTPs, as `http.StatusNotFound` above.
+
+    <Callout variant="important">
+      If used, [server-side configuration](#server-side-configuration) will override any values set on the `newrelic.Config` struct. Therefore to ignore 404 when server-side configuration is enabled, you must include 404 in the configuration set in the UI.
+    </Callout>
+
+    <CollapserGroup>
+      <Collapser
+        id="ignore-error-example"
+        title="Example of ignoring error code"
+      >
+        To add HTTP response code 418 to the default ignore list, which includes 0, 5, and 404:
+
+        ```go
+        app, err := newrelic.NewApplication(
+            newrelic.ConfigAppName("Your Application Name"),
+            newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+            func(config *newrelic.Config) {
+                config.ErrorCollector.IgnoreStatusCodes = []int{0, 5, 404, 418}
+            },
+        )
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    id="error-expected-status"
+    title="ErrorCollector.ExpectStatusCodes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            No error codes are set as expected by default.
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This controls which HTTP response codes are expected as errors.
+
+    Response codes that are expected will not affect your application's apdex or error alerts, but they will still be recorded.
+
+    This function's default form is:
+
+    ```go
+    config.ErrorCollector.ExpectStatusCodes = []int{
+        100,
+        http.StatusAccepted,
+    }
+    ```
+
+    You can also add response codes as HTTPs such as `http.StatusAccepted` described above.
+
+    <CollapserGroup>
+      <Collapser
+        id="expected-error-example"
+        title="Example of marking error codes as expected"
+      >
+        To add HTTP response codes 418 and 502 to the expected list:
+
+        ```go
+        app, err := newrelic.NewApplication(
+            newrelic.ConfigAppName("Your Application Name"),
+            newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+            func(config *newrelic.Config) {
+                config.ErrorCollector.ExpectStatusCodes = []int{418, 502}
+            },
+        )
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    id="error-attributes"
+    title="ErrorCollector.Attributes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Struct
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            Enabled, no exclusions
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    `ErrorCollector.Attributes` is a struct with three fields:
+
+    ```go
+    Enabled bool
+    Include []string
+    Exclude []string
+    ```
+
+    Use `ErrorCollector.Attributes.Enabled` to turn attribute collection on or off for errors. Use `Include` and `Exclude` to include or exclude specific attributes.
+
+    An example of excluding an attribute slice named `allAgentAttributeNames` from errors:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+            config.ErrorCollector.Attributes.Exclude = allAgentAttributeNames
+        },
+    )
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-general-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-general-settings.mdx
@@ -1,0 +1,1750 @@
+---
+title: Go agent general settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent general configuration settings: app name, license key, proxy, agent behavior, configuration methods, and environment variable configuration.'
+freshnessValidatedDate: never
+---
+
+Configure the Go agent's core behavior including app name, license key, proxy, and high-security mode using the `newrelic.Config` struct or environment variables.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Configuration methods and precedence [#options]
+
+The primary way to configure the Go agent is by modifying the `newrelic.Config` struct as part of calling `newrelic.NewApplication()`, which is part of the standard [installation process](/docs/agents/go-agent/installation/install-new-relic-go). With [Go agent versions 2.7.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes), you can also set a limited number of configuration options using [server-side configuration in the UI](#server-side-configuration).
+
+The Go agent follows this order of precedence for configuration. If enabled, server-side configuration overrides <DNT>**all**</DNT> corresponding values in the `newrelic.Config` struct, even if the server-side values are left blank.
+
+<img
+  title="New Relic Go agent: config order of precedence"
+  alt="New Relic Go agent: config order of precedence"
+  src="/images/apm_diagram_Go-agent-config-precedence.webp"
+/>
+
+<figcaption>
+  If server-side configuration is enabled with the Go agent, it overrides <DNT>**all**</DNT> corresponding values in the `newrelic.Config` struct, even if the server-side values are left blank.
+</figcaption>
+
+Here are detailed descriptions of each configuration method:
+
+<CollapserGroup>
+  <Collapser
+    id="server-side-configuration"
+    title="Server-side configuration (2.7.0 or higher)"
+  >
+    [Server-side configuration](/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration) is available with [Go agent versions 2.7.0 or higher](/docs/release-notes/agent-release-notes/go-release-notes). This allows you to configure certain settings in the UI. This applies your changes automatically to all agents even if they run across multiple hosts. Where available, this document includes the UI labels for server-side config under individual config options as the <DNT>**Server-side label**</DNT>.
+
+    You must still call `newrelic.NewApplication()` in your application process following the steps described in the [in-process configuration](#in-process-config). Configuration options set server-side will overwrite those set locally. Since not all configuration options are available server side, you may want to still update your `newrelic.Config` struct.
+
+    <Callout variant="caution">
+      If server-side config is enabled, the agent ignores any value in the `newrelic.Config` struct that <DNT>**could**</DNT> be set in the UI. Even if the UI value is empty, the agent treats this as an empty value and doesn't use the `newrelic.Config` value.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="in-process-config"
+    title={<>In process <InlineCode>newrelic.Config</InlineCode> struct</>}
+  >
+    You configure your Go agent from the local in process `newrelic.Config` struct. This struct can be accessed when calling `newrelic.NewApplication()`.
+
+    1. Add the following in the `main` function or in an `init` block:
+
+       ```go
+       app, err := newrelic.NewApplication(
+           newrelic.ConfigAppName("Your Application Name"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+       )
+       ```
+
+       Note the use of `os.Getenv` to read your license key from the environment rather than hard-coding it as a string literal value passed to `newrelic.ConfigLicense`. We recommend that you don't place license keys or other sensitive information in your source code, as that may result in them being stored in your SCM repository and possibly revealed to unauthorized parties.
+    2. Update values on the `newrelic.Config` struct to configure your application using `newrelic.ConfigOption`s. These are functions that accept a pointer to the `newrelic.Config` struct. Add additional `newrelic.ConfigOption`s to further configure your application. For example, you can use one of the predefined options to do common configurations:
+
+       ```go
+       app, err := newrelic.NewApplication(
+           newrelic.ConfigAppName("Your Application Name"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+           // add debug level logging to stdout
+           newrelic.ConfigDebugLogger(os.Stdout),
+       )
+       ```
+    3. Or, you can create your own `newrelic.ConfigOption` to do more complex configurations:
+
+       ```go
+       app, err := newrelic.NewApplication(
+           newrelic.ConfigAppName("Your Application Name"),
+           newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+           newrelic.ConfigDebugLogger(os.Stdout),
+           func(config *newrelic.Config) {
+           // add more specific configuration of the agent within a custom ConfigOption
+           config.HighSecurity = true
+               config.CrossApplicationTracer.Enabled = false
+           },
+       )
+       ```
+  </Collapser>
+</CollapserGroup>
+
+## Change configuration settings [#make-config-changes]
+
+To make Go agent configuration changes, set the values in the `newrelic.Config` struct from within a custom `newrelic.ConfigOption`. For example, to turn New Relic monitoring off temporarily for testing purposes, change the `Enabled` value to `false`:
+
+```go
+app, err := newrelic.NewApplication(
+    newrelic.ConfigAppName("Your Application Name"),
+    newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+    func(config *newrelic.Config) {
+    	config.Enabled = false
+    },
+)
+```
+
+In this and the following examples, `config` represents your New Relic config struct, although you may have given it a different variable name when you [installed the Go agent](/docs/agents/go-agent/get-started/get-new-relic-go) and initiated the configuration in your app.
+
+## General configuration settings [#general-settings]
+
+<CollapserGroup>
+  <Collapser
+    id="license"
+    title="License (REQUIRED)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Specifies your New Relic [license key](/docs/subscriptions/license-key), used to associate your app's metrics with a New Relic account. The license and the app name are both set as part of the [New Relic installation process](/docs/apm/agents/go-agent/installation/install-new-relic-go/#get-new-relic).
+  </Collapser>
+
+  <Collapser
+    id="app-name"
+    title="AppName (REQUIRED)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `(none)`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This is the [application name](/docs/apm/agents/manage-apm-agents/app-naming/name-your-application/) used to aggregate data in the New Relic UI. You set both the license and the app name as part of the [New Relic installation process](/docs/apm/agents/go-agent/installation/install-new-relic-go/#get-new-relic).
+
+    To report data to [multiple apps at the same time](/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app/), specify a list of names separated with a semicolon. Do not put a space before the semicolon itself. For example:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("YOUR_APP_NAME;APP_GROUP_1;ALL_APPS"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+    )
+    ```
+  </Collapser>
+
+  <Collapser
+    id="enabled"
+    title="Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent sends data from your app to the [New Relic collector](/docs/new-relic-solutions/get-started/glossary/#collector).
+
+    To turn off New Relic monitoring, set this to `false`.
+
+    For example:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+        	config.Enabled = false
+        },
+    )
+    ```
+
+    You may make use of the `ConfigEnabled` option to make this easier:
+
+    ```go
+    app, err: = newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        newrelic.ConfigEnabled(false),
+    )
+    ```
+
+    This can be useful for installing New Relic in a development environment or for troubleshooting purposes. When `Enabled` is set to `false`:
+
+    * The New Relic Go agent won't communicate with the New Relic collector.
+    * The agent won't spawn goroutines.
+    * The license key isn't required during installation.
+  </Collapser>
+
+  <Collapser
+    id="labels"
+    title="Labels"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            map\[string]string
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Add [tags](/docs/new-relic-solutions/new-relic-one/core-concepts/use-tags-help-organize-find-your-data/).
+
+    <CollapserGroup>
+      <Collapser
+        id="example-labels"
+        title="Creating four tag pairs"
+      >
+        Here's an example of setting four tags:
+
+        ```go
+        app, err := newrelic.NewApplication(
+            newrelic.ConfigAppName("Your Application Name"),
+            newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+            func(config *newrelic.Config) {
+                config.Labels = map[string]string{
+                    "Env":    "Dev",
+                    "Label2": "label2",
+                    "Label3": "label3",
+                    "Label4": "label4",
+                }
+            },
+        )
+        ```
+      </Collapser>
+    </CollapserGroup>
+  </Collapser>
+
+  <Collapser
+    id="logger"
+    title="Logger"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Interface
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](/docs/apm/agents/go-agent/configuration/go-agent-configuration/#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    You can use the `Logger` interface to [write Go log files](/docs/apm/agents/go-agent/configuration/go-agent-logging/) to a specific location or logging system.
+  </Collapser>
+
+  <Collapser
+    id="high_security"
+    title="HighSecurity"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="important">
+      This feature requires [Enterprise tier](https://www.newrelic.com/pricing).
+    </Callout>
+
+    [High-security mode](/docs/accounts-partnerships/accounts/security/high-security) enforces certain security settings and prevents them from being overridden, so that the agent sends no sensitive data. High-security mode does the following:
+
+    * Turns SSL on
+    * Turns off reporting of error message strings
+    * Turns off reporting of custom events
+
+      This setting must match the corresponding account setting in the UI. For example:
+
+      ```go
+      app, err := newrelic.NewApplication(
+          newrelic.ConfigAppName("Your Application Name"),
+          newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+          func(config *newrelic.Config) {
+              config.HighSecurity = true
+          },
+      )
+      ```
+
+      The agent communicates with New Relic via HTTPS by default, and New Relic [requires HTTPS](/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls) for all traffic to APM and our REST API.
+  </Collapser>
+
+  <Collapser
+    id="use-tls"
+    title="UseTLS (DEPRECATED)"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Callout variant="important">
+      This option was removed in [agent version 2.0](/docs/release-notes/agent-release-notes/go-release-notes/go-agent-20).
+    </Callout>
+
+    Controls whether HTTPS or HTTP is used to send data to New Relic. The agent communicates with New Relic via HTTPS by default (which uses TLS protocol), and New Relic [requires HTTPS](/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls) for all traffic to APM and the New Relic REST API.
+  </Collapser>
+
+  <Collapser
+    id="host-display-name"
+    title="HostDisplayName"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This sets the [hostname displayed in the APM UI](/docs/apm/agents/manage-apm-agents/configuration/add-rename-remove-hosts/#display_name). This is an optional configuration.
+  </Collapser>
+
+  <Collapser
+    id="transport"
+    title="Transport"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            [http.RoundTripper](https://golang.org/pkg/net/http/#RoundTripper)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This customizes [http.Client](https://golang.org/pkg/net/http/#Client) communication with New Relic collectors. You can use this to configure a proxy.
+  </Collapser>
+
+  <Collapser
+    id="runtime-sampler"
+    title="RuntimeSampler.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent captures runtime statistics.
+  </Collapser>
+</CollapserGroup>
+
+If you're using New Relic CodeStream to monitor performance from your IDE you may also want to [associate repositories with your services](/docs/codestream/observability/repo-association) and [associate build SHAs or release tags with errors](/docs/codestream/observability/error-investigation/#buildsha).
+
+## Configuring from the environment [#configuring-from-the-environment]
+
+For greater flexibility, you can set many configuration options by setting environment variables instead of hardcoding them into your application's
+source code. In order to use them, add a call to `ConfigFromEnvironment()` among your other configuration options:
+
+```go
+app, err := newrelic.NewApplication(
+   newrelic.ConfigAppName("Your Application Name"),
+   newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+   newrelic.ConfigFromEnvironment(),
+)
+```
+
+Note that the environment variables will be read, and their corresponding entries in the `newrelic.Config` struct will be updated, at the
+point in the list of options where `newrelic.ConfigFromEnvironment()` appears. If there are additional configuration options listed after
+`ConfigFromEnvironment`, they may override the values set by `ConfigFromEnvironment`.
+
+For example, if the following environment variables are set:
+
+```ini
+NEW_RELIC_LICENSE_KEY="your_license_key_here"
+NEW_RELIC_APP_NAME="Your Application Name"
+NEW_RELIC_CODE_LEVEL_METRICS_ENABLED="true"
+NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIX="myproject/src"
+NEW_RELIC_LABELS="Env:Dev;Label2:label2;Label3:label3;Label4:label4"
+```
+
+then the following code:
+
+```go
+app, err := newrelic.NewApplication(
+    newrelic.ConfigFromEnvironment(),
+)
+```
+
+will accomplish the same result as the hard-coded equivalent:
+
+```go
+app, err := newrelic.NewApplication(
+    newrelic.ConfigAppName("Your Application Name"),
+    newrelic.ConfigLicense("your_license_key_here"),
+    newrelic.ConfigCodeLevelMetricsEnabled(true),
+    newrelic.ConfigCodeLevelMetricsPathPrefix("myproject/src"),
+    func(config *newrelic.Config) {
+        config.Labels = map[string]string{
+            "Env":    "Dev",
+            "Label2": "label2",
+            "Label3": "label3",
+            "Label4": "label4",
+        }
+    },
+)
+```
+
+Not all possible configuration options may be set via environment variables. The [table of environment variables and functions](#env-var-table) in the collapser below lists all of the available configuration functions and their corresponding environment variables. Although any named configuration option may be set by directly assigning a value to the corresponding field in the `Config` structure, we recommend using configuration functions and/or environment variables whenever possible.
+
+<CollapserGroup>
+  <Collapser
+    className="freq-link"
+    id="env-var-table"
+    title="Table of environment variables and functions"
+  >
+    Here are some tips for how to use the table:
+
+    * If an environment variable is listed in the table, then you may set the corresponding option by setting the named environment variable. You must also include the `ConfigFromEnvironment()` function, which will cause the agent to accept all `NEW_RELIC_*` environment variables.
+    * If a configuration function is listed, you can use that function to set the corresponding option instead of using `ConfigFromEnvironment()`. Keep in mind that the configuration functions listed in the program, including `ConfigFromEnvironment()`, are resolved in the order they appear in the code. This means that if you create an environment variable and call the function `ConfigFromEnvironment()`, it will overwrite corresponding configurations you may have set previously using a specific function. Subsequent configuration options after `ConfigFromEnvironment()` will override previous configuration functions and environment variables.
+    * See the documentation here and at [the Go documentation site](https://pkg.go.dev/github.com/newrelic/go-agent/v3@v3.20.0/newrelic#ConfigOption) for more information about how to use each function.
+
+      <table>
+        <thead>
+          <tr>
+            <th>
+              Configuration field
+            </th>
+
+            <th>
+              Configuration functions
+            </th>
+
+            <th>
+              Environment variables
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+              `AppName`
+            </td>
+
+            <td>
+              `ConfigAppName`
+            </td>
+
+            <td>
+              `NEW_RELIC_APP_NAME`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ApplicationLogging.Enabled`
+            </td>
+
+            <td>
+              `ConfigAppLogForwardingEnabled`
+
+              `ConfigAppLogEnabled`
+
+              (See [note 1](#table-note-one) below)
+            </td>
+
+            <td>
+              `NEW_RELIC_APPLICATION_LOGGING_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ApplicationLogging.Forwarding.Enabled`
+            </td>
+
+            <td>
+              `ConfigAppLogForwardingEnabled`
+
+              `ConfigAppLogDecoratingEnabled`
+
+              `ConfigAppLogMetricsEnabled`
+
+              (See [note 1](#table-note-one) below)
+            </td>
+
+            <td>
+              `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ApplicationLogging.Forwarding.MaxSamplesStored`
+            </td>
+
+            <td>
+              `ConfigAppLogForwardingEnabled`
+
+              `ConfigAppLogForwardingMaxSamplesStored`
+
+              (See [note 1](#table-note-one) below)
+            </td>
+
+            <td>
+              `NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ApplicationLogging.LocalDecorating.Enabled`
+            </td>
+
+            <td>
+              `ConfigAppLogDecoratingEnabled`
+            </td>
+
+            <td>
+              `NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ApplicationLogging.Metrics.Enabled`
+            </td>
+
+            <td>
+              `ConfigAppLogMetricsEnabled`
+            </td>
+
+            <td>
+              `NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_ATTRIBUTES_EXCLUDE`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_ATTRIBUTES_INCLUDE`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `BrowserMonitoring.Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `BrowserMonitoring.Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `BrowserMonitoring.Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `BrowserMonitoring.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `CodeLevelMetrics.Enabled`
+            </td>
+
+            <td>
+              `ConfigCodeLevelMetricsEnabled`
+            </td>
+
+            <td>
+              `NEW_RELIC_CODE_LEVEL_METRICS_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `CodeLevelMetrics.IgnoredPrefixes`
+            </td>
+
+            <td>
+              `ConfigCodeLevelMetricsIngoredPrefixes`
+            </td>
+
+            <td>
+              `NEW_RELIC_CODE_LEVEL_METRICS_IGNORED_PREFIXES`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `CodeLevelMetrics.PathPrefixes`
+            </td>
+
+            <td>
+              `ConfigCodeLevelMetricsPathPrefixes`
+            </td>
+
+            <td>
+              `NEW_RELIC_CODE_LEVEL_METRICS_PATH_PREFIXES`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `CodeLevelMetrics.RedactIgnoredPrefixes`
+            </td>
+
+            <td>
+              `ConfigCodeLevelMetricsRedactIgnoredPrefixes`
+            </td>
+
+            <td>
+              `NEW_RELIC_CODE_LEVEL_METRICS_REDACT_IGNORED_PREFIXES`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `CodeLevelMetrics.RedactPathPrefixes`
+            </td>
+
+            <td>
+              `ConfigCodeLevelMetricsRedactPathPrefixes`
+            </td>
+
+            <td>
+              `NEW_RELIC_CODE_LEVEL_METRICS_REDACT_PATH_PREFIXES`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `CodeLevelMetrics.Scope`
+            </td>
+
+            <td>
+              `ConfigCodeLevelMetricsScope`
+            </td>
+
+            <td>
+              `NEW_RELIC_CODE_LEVEL_METRICS_SCOPE`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `CrossApplicationTracer.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `CustomInsightsEvents.Enabled`
+            </td>
+
+            <td>
+              `ConfigCustomInsightsEventsEnabled`
+            </td>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `CustomInsightsEvents.MaxSamplesStored`
+            </td>
+
+            <td>
+              `ConfigCustomInsightsEventsMaxSamplesStored`
+            </td>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DatastoreTracer.DatabaseNameReporting.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DatastoreTracer.InstanceReporting.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DatastoreTracer.QueryParameters.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DatastoreTracer.SlowQuery.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DatastoreTracer.SlowQuery.Threshold`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DistributedTracer.Enabled`
+            </td>
+
+            <td>
+              `ConfigDistributedTracerEnabled`
+            </td>
+
+            <td>
+              `NEW_RELIC_DISTRIBUTED_TRACING_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `DistributedTracer.ExcludeNewRelicHeader`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `DistributedTracer.ReservoirLimit`
+            </td>
+
+            <td>
+              `ConfigDistributedTracerReservoirLimit`
+            </td>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Enabled`
+            </td>
+
+            <td>
+              `ConfigEnabled`
+            </td>
+
+            <td>
+              `NEW_RELIC_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.CaptureEvents`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.IgnoreStatusCodes`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ErrorCollector.RecordPanics`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Error`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Heroku.DynoNamePrefixesToShorten`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Heroku.UseDynoNames`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `HighSecurity`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_HIGH_SECURITY`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `HostDisplayName`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_PROCESS_HOST_DISPLAY_NAME`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Host`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_HOST`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `InfiniteTracing.SpanEvents.QueueSize`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_INFINITE_TRACING_SPAN_EVENTS_QUEUE_SIZE`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `InfiniteTracing.TraceObserver.Host`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_HOST`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `InfiniteTracing.TraceObserver.Port`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_INFINITE_TRACING_TRACE_OBSERVER_PORT`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Labels`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_LABELS`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `License`
+            </td>
+
+            <td>
+              `ConfigLicense`
+            </td>
+
+            <td>
+              `NEW_RELIC_LICENSE_KEY`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Logger`
+            </td>
+
+            <td>
+              `ConfigLogger`
+
+              `ConfigInfoLogger`
+
+              `ConfigDebugLogger`
+
+              (See [note 2](#table-note-two) below)
+            </td>
+
+            <td>
+              `NEW_RELIC_LOG`
+
+              `NEW_RELIC_LOG_LEVEL`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ModuleDependencyMetrics.Enabled`
+            </td>
+
+            <td>
+              `ConfigModuleDependencyMetricsEnabled`
+            </td>
+
+            <td>
+              `NEW_RELIC_MODULE_DEPENDENCY_METRICS_ENABLED`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ModuleDependencyMetrics.IgnoredPrefixes`
+            </td>
+
+            <td>
+              `ConfigModuleDependencyMetricsIgnoredPrefixes`
+            </td>
+
+            <td>
+              `NEW_RELIC_MODULE_DEPENDENCY_METRICS_IGNORED_PREFIXES`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `ModuleDependencyMetrics.RedaceIgnoredPrefixes`
+            </td>
+
+            <td>
+              `ConfigModuleDependencyMetricsRedactIgnoredPrefixes`
+            </td>
+
+            <td>
+              `NEW_RELIC_MODULE_DEPENDENCY_METRICS_REDACT_IGNORED_PREFIXES`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `RuntimeSampler.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `SecurityPoliciesToken`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_SECURITY_POLICIES_TOKEN`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Segments.Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Segments.Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Segments.Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Segments.StackTraceThreshold`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Segments.Threshold`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ServerlessMode.AccountID`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ServerlessMode.ApdexThreshold`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ServerlessMode.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ServerlessMode.PrimaryAppID`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `ServerlessMode.TrustedAccountKey`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `SpanEvents.Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `SpanEvents.Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `SpanEvents.Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `SpanEvents.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionEvents.Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionEvents.Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionEvents.Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionEvents.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionEvents.MaxSamplesStored`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionTracer.Attributes.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionTracer.Attributes.Exclude`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionTracer.Attributes.Include`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionTracer.Enabled`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionTracer.Threshold.Duration`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `TransactionTracer.Threshold.IsApdexFailing`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Transport`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.BillingHostname`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_UTILIZATION_BILLING_HOSTNAME`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.DetectAWS`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.DetectAzure`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.DetectDocker`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.DetectGCP`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.DetectKubernetes`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.DetectPCF`
+            </td>
+
+            <td/>
+
+            <td/>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.LocalRAMMIB`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_UTILIZATION_TOTAL_RAM_MIB`
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              `Utilization.LogicalProcessors`
+            </td>
+
+            <td/>
+
+            <td>
+              `NEW_RELIC_UTILIZATION_LOGICAL_PROCESSORS`
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      ### Table note 1: [#table-note-one]
+
+      Calling one of the listed functions to enable a subordinate feature also enables the main feature and/or sets other configuration values:
+
+      * `ConfigAppLogForwardingEnabled(true)` sets `ApplicationLogging.Forwarding.Enabled=true` but also sets `ApplicationLogging.Enabled=true`.
+      * `ConfigAppLogForwardingEnabled(false)` sets `ApplicationLogging.Forwarding.Enabled=false` but also sets `ApplicationLogging.Forwarding.MaxSamplesStored=0`.
+      * `ConfigAppLogDecoratingEnabled(true)` sets `ApplicationLogging.LocalDecorating.Enabled=true` but also sets `ApplicationLogging.Enabled=true`.
+      * `ConfigAppLogDecoratingEnabled(false)` sets `ApplicationLogging.LocalDecorating.Enabled=false` but does not affect `ApplicationLogging.Enabled`.
+      * `ConfigAppLogMetricsEnabled(true)` sets `ApplicationLogging.Metrics.Enabled=true` but also sets `ApplicationLogging.Enabled=true`.
+      * `ConfigAppLogMetricsEnabled(false)` sets `ApplicationLogging.Metrics.Enabled=false` but does not affect `ApplicationLogging.Enabled`.
+
+      ### Table note 2: [#table-note-two]
+
+      When setting `Logger` via the `NEW_RELIC_LOG` environment variable, the type of logger used depends on the value of `NEW_RELIC_LOG_LEVEL`. If the latter variable is defined and has the value `debug`, `Debug`, `DEBUG`, `d`, or `D`, then a debug-level logger is used instead of a standard one. `NEW_RELIC_LOG` may have the values `stdout`, `Stdout`, `STDOUT`, `stderr`, `Stderr`, or `STDERR`.
+
+    <Callout variant="tip">
+      Environment variables must have a non-empty value in order to be read by `newrelic.ConfigFromEnvironment`.
+    </Callout>
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-logs-in-context-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-logs-in-context-settings.mdx
@@ -1,0 +1,227 @@
+---
+title: Go agent logs in context settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent application logging configuration: log forwarding, local log decoration, and log metrics.'
+freshnessValidatedDate: never
+---
+
+Configure application logging features for the Go agent, including log forwarding to New Relic, local log decoration, and log metrics collection.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Application logging settings [#application-logging]
+
+The following settings are available for configuration of application logging in the agent. For tips on using Go agent logs in context, see [Go logs in context](/docs/logs/logs-context/configure-logs-context-go).
+
+<Callout variant="important">
+  Requires Go agent version 3.17.0 or higher
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="application-logging-enabled"
+    title="ApplicationLogging.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, enables the collection of log events and logging metrics if these sub-feature configurations are also enabled.  If `false`, no logging instrumentation features are enabled.
+
+    Configure ApplicationLogging by calling `ConfigAppLogEnabled()`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppLogEnabled(true),
+    )
+    ```
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-enabled"
+    title="ApplicationLogging.Forwarding.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent captures log records emitted by your application and forwards them to New Relic. `ApplicationLogging.Enabled` must also be `true` for this setting to take effect.
+
+    Enable log forwarding by calling `ConfigAppLogForwardingEnabled()`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppLogForwardingEnabled(true),
+    )
+    ```
+  </Collapser>
+
+  <Collapser
+    id="application-logging-forwarding-maximum-samples-stored"
+    title="ApplicationLogging.Forwarding.MaxSamplesStored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Number of log records to send per minute to New Relic. This setting controls overall memory consumption when using the log forwarding feature.
+
+    Configure `ApplicationLogging.Forwarding.MaxSamplesStored` by calling `ConfigAppLogForwardingMaxSamplesStored()`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppLogForwardingMaxSamplesStored(1000),
+    )
+    ```
+
+    Set this to a lower value to reduce the amount of log lines sent (may cause log sampling). Set this to a higher value to send more log lines.
+
+    Each log receives the same priority as its associated transaction. Logs that occur outside of a transaction will receive a random priority. Some logs may not be included because they are limited by `MaxSamplesStored`. For example, if logging `MaxSamplesStored` is set to 10,000 and transaction 1 has 10,000 log entries, only log entries for transaction 1 will be recorded. If transaction 1 has less than 10,000 logs, you receive all logs for transaction 1. If there is still space, you receive all the logs for transaction 2, and so on.
+
+    If after all the logs for sampled transactions are recorded, and they haven't reached the limit in `MaxSamplesStored`, then log messages for transactions that were not in our sampling are sent. If there are any left, log messages outside of transactions are recorded.
+  </Collapser>
+
+  <Collapser
+    id="application-logging-metrics-enabled"
+    title="ApplicationLogging.Metrics.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, the agent captures metrics related to the log lines being sent up by your application. `ApplicationLogging.Enabled` must also be `true` for this setting to take effect.
+
+    Configure ApplicationLogging.Metrics.Enabled by calling `ConfigAppLogMetricsEnabled()`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppLogMetricsEnabled(true),
+    )
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-other-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-other-settings.mdx
@@ -1,0 +1,1020 @@
+---
+title: Go agent other settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent miscellaneous settings: custom events, transaction events, datastore tracer, module dependency metrics, and New Relic IAST.'
+freshnessValidatedDate: never
+---
+
+Configure miscellaneous Go agent features including custom events, transaction events, the datastore tracer, module dependency metrics, and New Relic IAST security testing.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Custom events configuration [#custom-insights-events-settings]
+
+You can create custom events and make them available for querying and analysis.
+
+<CollapserGroup>
+  <Collapser
+    id="custom-insights-events-enabled"
+    title="CustomInsightsEvents.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent [sends custom events](/docs/data-apis/custom-data/custom-events/apm-report-custom-events-attributes/#go) to [New Relic](/docs/insights/new-relic-insights/understanding-insights/new-relic-insights). This setting is overridden by [`HighSecurity`](#high_security), which disables custom events.
+
+    To disable custom events, place the following in your Go app after the [New Relic config](/docs/agents/go-agent/get-started/get-new-relic-go#get-new-relic) is initiated:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+            config.CustomInsightsEvents.Enabled = false
+        },
+    )
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## Transaction events configuration [#transaction-events-settings]
+
+Transaction events are used in collecting events corresponding to web requests and background tasks. Event data allows the New Relic UI to show additional information such as [histograms](/docs/applications-menu/histograms-viewing-data-distribution) and [percentiles](/docs/applications-menu/percentiles-comparing-ranked-data).
+
+<CollapserGroup>
+  <Collapser
+    id="transaction-events"
+    title="TransactionEvents.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent collects transaction events.
+  </Collapser>
+
+  <Collapser
+    id="txn-events-attributes"
+    title="TransactionEvents.Attributes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Struct
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            Enabled, no exclusions
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    `TransactionEvents.Attributes` is a struct with three fields:
+
+    ```go
+    Enabled bool
+    Include []string
+    Exclude []string
+    ```
+
+    Use `TransactionEvents.Attributes.Enabled` to turn attribute collection on or off for transaction events. Use `Include` and `Exclude` to include or exclude specific attributes.
+
+    An example of excluding an attribute slice named `allAgentAttributeNames` from transaction events:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+            config.TransactionEvents.Attributes.Exclude = allAgentAttributeNames
+        },
+    )
+    ```
+  </Collapser>
+
+  <Collapser
+    id="transaction-events-maxsamplesstored"
+    title="TransactionEvents.MaxSamplesStored"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10000`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Defines the maximum number of transaction events per minute to be sent to New Relic, up to the default maximum of 10,000 transaction events.
+  </Collapser>
+</CollapserGroup>
+
+## Datastore tracer configuration [#datastore-tracer]
+
+Here are datastore settings, including [slow query](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) enabling and settings.
+
+<CollapserGroup>
+  <Collapser
+    id="instance-reporting"
+    title="DatastoreTracer.InstanceReporting.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This enables collection of datastore instance metrics (such as the host and port) for some database drivers. These are reported on transaction traces and as part of [slow query data](/docs/apm/applications-menu/monitoring/viewing-slow-query-details).
+  </Collapser>
+
+  <Collapser
+    id="name-reporting"
+    title="DatastoreTracer.NameReporting.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Use this to enable collection of the database name on slow query traces and transaction traces. The default value of attribute enabled is `true`.
+  </Collapser>
+
+  <Collapser
+    id="data-query-enabled"
+    title="DatastoreTracer.QueryParameters.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent collects datastore call query parameters.
+  </Collapser>
+
+  <Collapser
+    id="slow-query"
+    title="DatastoreTracer.SlowQuery.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Controls whether [slow queries](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) are captured.
+  </Collapser>
+
+  <Collapser
+    id="slow-query-threshold"
+    title="DatastoreTracer.SlowQuery.Threshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            time.Millisecond
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `10`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    The agent captures [slow query data](/docs/apm/applications-menu/monitoring/viewing-slow-query-details) for queries slower than this.
+  </Collapser>
+</CollapserGroup>
+
+## Module dependency metrics settings [#mdm]
+
+Module dependency metrics can be configured in a variety of ways in the Go agent. Module dependency metrics reports the list of imported modules used by your Go application to help facilitate code dependency management. It also includes the version information of the modules of your app.
+
+<Callout variant="important">
+  Requires Go agent version 3.20.0 or higher
+</Callout>
+
+<CollapserGroup>
+  <Collapser
+    id="mdm-enabled"
+    title="ModuleDependencyMetrics.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `true`, enables the collection of module dependency data.  If `false`, no module dependency information is collected.
+
+    Configure ModuleDependencyMetrics by calling `ConfigModuleDependencyMetricsEnabled`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigModuleDependencyMetricsEnabled(true),
+    )
+    ```
+
+    You can enable the setting of your Go agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`. If you've done this you can enable or disable module dependency metrics collection by setting the environment variable.
+
+    ```ini
+    NEW_RELIC_MODULE_DEPENDENCY_METRICS_ENABLED=true
+    ```
+  </Collapser>
+
+  <Collapser
+    id="mdm-ignored-prefixes"
+    title="ModuleDependencyMetrics.IgnoredPrefixes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String(s)
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `nil`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This list of module path prefixes specifies that you want to exclude some modules from the dependency information reported by the agent.
+    Any module whose `import` path begins with any of the listed prefix strings will be excluded. The default is an empty list, which means
+    to report all modules found.
+
+    Specify a list of path prefix strings to be excluded by calling `ConfigModuleDependencyMetricsIgnoredPrefixes`.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigModuleDependencyMetricsIgnoredPrefixes("example.com/packageAlpha", "example.com/packageBeta"),
+    )
+    ```
+
+    If you enabled the setting of your Go agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you can list the path prefixes by setting the environment variable.
+
+    ```ini
+    NEW_RELIC_MODULE_DEPENDENCY_METRICS_IGNORED_PREFIXES="example.com/packageAlpha,example.com/packageBeta"
+    ```
+  </Collapser>
+
+  <Collapser
+    id="mdm-redact-ignored-prefixes"
+    title="ModuleDependencyMetrics.RedactIgnoredPrefixes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Normally all of the options you set as part of your agent configuration are reported and visible in the New Relic UI. If you choose to exclude some modules from being reported via the `ConfigModuleDependencyIgnoredPrefixes` option, you can also redact them from the configuration data as well. For example, if the modules were excluded for reasons of confidentiality.
+
+    Enable or disable the redaction of excluded paths by calling `ConfigModuleDependencyMetricsRedactIgnoredPrefixes`.
+    If `true`, the list of excluded module prefixes won't be reported. If `false`, they are reported.
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigModuleDependencyMetricsRedactIgnoredPrefixes(false),
+    )
+    ```
+
+    If you enabled the setting of your Go agent options via environment variables by inserting `ConfigFromEnvironment()` into your call to `NewApplication`, you can list the path prefixes by setting the environment variable.
+
+    ```ini
+    NEW_RELIC_MODULE_DEPENDENCY_METRICS_REDACT_IGNORED_PREFIXES=false
+    ```
+  </Collapser>
+</CollapserGroup>
+
+## New Relic IAST [#go-IAST]
+
+[New Relic Interactive Applications Security Testing](/docs/iast/introduction/) (IAST) tests your applications for any exploitable vulnerability by replaying the generated HTTP request with vulnerable payloads. You can enable New Relic IAST by updating your Go app code with configurations that are passed to the INIT function. You can also make these configurations through a YAML file or with environment variables.
+
+Options set using INIT functions take precedence over environment or YAML configurations. That said, we recommend enabling IAST using a YAML file because those configurations will pass to other agents in your environment.
+
+### Setup Instructions
+
+Import the integration by adding the following direct dependency to you `go.mod` file.
+
+```go
+import "github.com/newrelic/go-agent/v3/integrations/nrsecurityagent"
+```
+
+Next initialize and enable the security agent.
+
+### Enable IAST
+
+<CollapserGroup>
+  <Collapser
+    id="iast-option"
+    title="Enable with option functions"
+  >
+    ```go
+    err: = nrsecurityagent.InitSecurityAgent(
+        app,
+        nrsecurityagent.ConfigSecurityMode("IAST"),
+        nrsecurityagent.ConfigSecurityValidatorServiceEndPointUrl("wss://csec.nr-data.net"),
+        nrsecurityagent.ConfigSecurityEnable(true),
+    )
+    ```
+
+  </Collapser>
+
+  <Collapser
+    id="iast-enviro"
+    title="Enable with environment variables"
+  >
+    ConfigSecurityFromEnvironment directs the nrsecurityagent integration to obtain all of its configuration information from environment variables.
+
+    ```go
+     err: = nrsecurityagent.InitSecurityAgent(
+         app,
+         ConfigSecurityFromEnvironment(),
+     )
+    ```
+  </Collapser>
+
+  <Collapser
+    id="iast-yaml"
+    title="Enable from YAML file"
+  >
+    ConfigSecurityFromYaml directs the nrsecurityagent integration to read an external YAML-formatted file to obtain its configuration values. The path to this file must be provided by setting the environment variable NEW_RELIC_SECURITY_CONFIG_PATH.
+
+    ```go
+    err: = nrsecurityagent.InitSecurityAgent(
+        app,
+        ConfigSecurityFromYaml(),
+    )
+    ```
+
+    The default YAML file looks like this.
+
+    ```yaml
+    enabled: true
+
+    # NR security provides two modes IAST and RASP
+    # Default is IAST
+    mode: IAST
+
+    # New Relic's SaaS connection URLs
+    validator_service_url: wss://csec.nr-data.net
+
+    # Following category of security events
+    # can be disabled from generating.
+    detection:
+      rxss:
+        enabled: true
+    request:
+      body_limit: 300
+    ```
+  </Collapser>
+</CollapserGroup>
+
+### Configure IAST
+
+The security agent can be configured with the following options.
+
+<CollapserGroup>
+  <Collapser
+    id="cfg-security-agent-enabled"
+    title="cfg.Security.Agent.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Config Function
+          </th>
+
+          <td>
+            ```go
+            func(cfg *SecurityConfig) {
+                cfg.Security.Agent.Enabled = true
+            }
+            ```
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environment Variable
+          </th>
+
+          <td>
+            `NEW_RELIC_SECURITY_AGENT_ENABLED`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    To completely disable all security functionality, set this flag to false. By importing and initializing the security agent in go, its assumed that you intend to use it, so this value defaults to `true`. Note that this is the oposite behavior from automatically instrumenting agents. This property is read only once at application start.
+  </Collapser>
+
+  <Collapser
+    id="cfg-security-enabled"
+    title="cfg.Security.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Config Function
+          </th>
+
+          <td>
+            `nrsecurityagent.ConfigSecurityEnable(false)`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environment Variable
+          </th>
+
+          <td>
+            `NEW_RELIC_SECURITY_ENABLED`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Determines whether the security data is sent to New Relic or not. When this is disabled and agent.enabled is true, the security module will run but data will not be sent. Default is false.
+  </Collapser>
+
+  <Collapser
+    id="cfg-security-mode"
+    title="cfg.Security.Mode"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Config Function
+          </th>
+
+          <td>
+            `nrsecurityagent.ConfigSecurityMode("IAST")`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environment Variable
+          </th>
+
+          <td>
+            `NEW_RELIC_SECURITY_MODE`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `IAST`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    New Relic Security provide mode: IAST. Default is IAST. Due to the invasive nature of IAST scanning, DO NOT enable this mode in either a production environment or an environment where production data is processed.
+  </Collapser>
+
+  <Collapser
+    id="cfg-security-validator-service-url"
+    title="cfg.Security.Validator_service_url"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            String
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Config Function
+          </th>
+
+          <td>
+            `nrsecurityagent.ConfigSecurityValidatorServiceEndPointUrl("wss://csec.nr-data.net")`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environment Variable
+          </th>
+
+          <td>
+            `NEW_RELIC_SECURITY_VALIDATOR_SERVICE_URL`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `wss://csec.nr-data.net`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    New Relic Security's SaaS connection URL. This is the endpoint that the security agent sends data to, it should match that environment that you have set for the APM Java agent.
+
+    US Production: wss://csec.nr-data.net
+  </Collapser>
+
+  <Collapser
+    id="cfg-security-detection-rxss-enabled"
+    title="cfg.Security.Detection.Rxss.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Config Function
+          </th>
+
+          <td>
+            `nrsecurityagent.ConfigSecurityDetectionDisableRxss(true)`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environment Variable
+          </th>
+
+          <td>
+            `NEW_RELIC_SECURITY_DETECTION_RXSS_ENABLED`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable RXSS security event detection. Default is true.
+  </Collapser>
+
+  <Collapser
+    id="cfg-security-request-body-limit"
+    title="cfg.Security.Request.BodyLimit"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Int
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Config Function
+          </th>
+
+          <td>
+            `nrsecurityagent.ConfigSecurityRequestBodyLimit(300)`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Environment Variable
+          </th>
+
+          <td>
+            `NEW_RELIC_SECURITY_REQUEST_BODY_LIMIT`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            300
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Security Request Body Limit sets a limit on read the amount of memory that can be consumed when reading from a request body in kb. By default, this is "300".
+  </Collapser>
+
+  ### Instrument security sensitive parts of your application
+
+  The `nrgin`, `nrgrpc`, `nrmicro`, `fasthttp`, or `nrmongo` integrations now contain code to support security analysis of the data they handle.
+
+  Additionally, the Go agent will perform vulnerability scanning on instrumented code containing datastore segments, SQL operations, transactions, and wrapped HTTP calls and endpoints.
+</CollapserGroup>

--- a/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-transaction-tracer-settings.mdx
+++ b/src/content/docs/apm/agents/go-agent/configuration/go-agent-configuration-transaction-tracer-settings.mdx
@@ -1,0 +1,399 @@
+---
+title: Go agent transaction tracer settings
+tags:
+  - Agents
+  - Go agent
+  - Configuration
+metaDescription: 'Go agent transaction tracer configuration: trace thresholds, SQL recording, and segment limits.'
+freshnessValidatedDate: never
+---
+
+Configure the Go agent's transaction tracer to control slow transaction capture, segment thresholds, and attribute collection.
+
+<Callout variant="tip">
+  Back to the full settings index: [Go agent configuration](/docs/apm/agents/go-agent/configuration/go-agent-configuration)
+</Callout>
+
+## Transaction tracer configuration [#transaction-tracer]
+
+Here are settings for changing transaction tracer configuration. For more information about transaction traces, see [Transaction traces](/docs/traces/transaction-traces).
+
+<CollapserGroup>
+  <Collapser
+    id="txn-tracer-enabled"
+    title="TransactionTracer.Enabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Transaction Tracing on/off`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When `true`, the agent collects [transaction traces](/docs/apm/transactions/transaction-traces/transaction-traces) (detailed information about slow transactions).
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-threshold-apdex-falling"
+    title="TransactionTracer.Threshold.IsApdexFailing"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Transaction Tracing: Threshold`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Controls whether the transaction trace threshold is based on Apdex.
+
+    * If `true`, then the trace threshold is four times the [Apdex threshold](/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction).
+    * If `false`, the agent uses [`Threshold.Duration`](/docs/go-agent-configuration#txn-tracer-threshold-duration) as the transaction trace threshold.
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-threshold-duration"
+    title="TransactionTracer.Threshold.Duration"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            time.Millisecond
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `500`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Transaction Tracing: Threshold`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    If `Threshold.IsApdexFailing` is set to `false`, the agent uses this duration as the transaction trace threshold.
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-segment-threshold"
+    title="TransactionTracer.Segments.Threshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            time.Millisecond
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `2`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This is the threshold at which segments will be added to the trace.
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-segments-attributes"
+    title="TransactionTracer.Segments.Attributes"
+  >
+    <Callout variant="important">
+      Available for Go agent version 2.6.0 or higher.
+    </Callout>
+
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Struct
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            Enabled, no exclusions
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    `TransactionTracer.Segments.Attributes` is a struct with three fields:
+
+    ```go
+    Enabled bool
+    Include []string
+    Exclude []string
+    ```
+
+    Use `TransactionTracer.Segments.Attributes.Enabled` to turn attribute collection on or off for transaction trace segments. Use `Include` and `Exclude` to include or exclude specific attributes.
+
+    An example of excluding an attribute slice named `allSegmentAttributeNames` from traces:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+            config.TransactionTracer.Segments.Attributes.Exclude = allSegmentAttributeNames
+        },
+    )
+    ```
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-stack-threshold"
+    title="TransactionTracer.Segments.StackTraceThreshold"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            time.Millisecond
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `500`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct, Server-side config
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Server-side label](#server-side-configuration)
+          </th>
+
+          <td>
+            `Transaction Tracing: Stack trace threshold`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This is the threshold at which segments will be given a stack trace in the transaction trace.
+
+    <Callout variant="caution">
+      Lowering this setting may drastically increase agent overhead.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    id="txn-tracer-attributes"
+    title="TransactionTracer.Attributes"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Struct
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            Enabled, no exclusions
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Set in](/docs/agents/go-agent/instrumentation/go-agent-configuration#options)
+          </th>
+
+          <td>
+            `newrelic.Config` struct
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    `TransactionTracer.Attributes` is a struct with three fields:
+
+    ```go
+    Enabled bool
+    Include []string
+    Exclude []string
+    ```
+
+    Use `TransactionTracer.Attributes.Enabled` to turn attribute collection on or off for transaction traces. Use `Include` and `Exclude` to include or exclude specific attributes.
+
+    An example of excluding an attribute slice named `allAgentAttributeNames` from traces:
+
+    ```go
+    app, err := newrelic.NewApplication(
+        newrelic.ConfigAppName("Your Application Name"),
+        newrelic.ConfigLicense(os.Getenv("NEW_RELIC_LICENSE_KEY")),
+        func(config *newrelic.Config) {
+            config.TransactionTracer.Attributes.Exclude = allAgentAttributeNames
+        },
+    )
+    ```
+  </Collapser>
+</CollapserGroup>

--- a/src/nav/apm.yml
+++ b/src/nav/apm.yml
@@ -5,12 +5,14 @@ pages:
     path: /docs/apm/new-relic-apm/getting-started/introduction-apm
   - title: APM agent installation and configuration
     pages:
-      - title: Go agent installation and configuration
+      - title: Go monitoring
         path: /docs/apm/agents/go-agent
         pages:
-          - title: Compatibility and requirements
-            path: /docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements
+          - title: Compatibility and release
+            path: /docs/apm/agents/go-agent/get-started
             pages:
+              - title: Compatibility and requirements
+                path: /docs/apm/agents/go-agent/get-started/go-agent-compatibility-requirements
               - title: Go agent security
                 path: /docs/apm/agents/go-agent/get-started/apm-agent-security-go
               - title: Go agent EOL policy
@@ -19,7 +21,7 @@ pages:
                 path: /docs/release-notes/agent-release-notes/go-release-notes/current
               - title: Go agent release notes
                 path: /docs/release-notes/agent-release-notes/go-release-notes
-          - title: Go agent Installation
+          - title: Go agent installation
             path: /docs/apm/agents/go-agent/installation
             pages:
               - title: Install New Relic for Go (Automated)
@@ -30,50 +32,65 @@ pages:
                 path: /docs/apm/agents/go-agent/installation/update-go-agent
               - title: Uninstall the Go agent
                 path: /docs/apm/agents/go-agent/installation/uninstall-go-agent
-          - title: Go agent configuration
+          - title: Introduction to Go monitoring
+            path: /docs/apm/agents/go-agent/get-started/introduction-new-relic-go
+          - title: Configuration
             path: /docs/apm/agents/go-agent/configuration
             pages:
-              - title: Go configuration
+              - title: Go agent configuration
                 path: /docs/apm/agents/go-agent/configuration/go-agent-configuration
+                pages:
+                  - title: General settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-general-settings
+                  - title: AI monitoring settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-ai-monitoring-settings
+                  - title: Error collector settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-error-collector-settings
+                  - title: Transaction tracer settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-transaction-tracer-settings
+                  - title: Distributed tracing settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-distributed-tracing-settings
+                  - title: Logs in context settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-logs-in-context-settings
+                  - title: Other settings
+                    path: /docs/apm/agents/go-agent/configuration/go-agent-configuration-other-settings
               - title: Distributed tracing
                 path: /docs/apm/agents/go-agent/configuration/distributed-tracing-go-agent
               - title: Go agent logging
                 path: /docs/apm/agents/go-agent/configuration/go-agent-logging
               - title: Code-level metrics configuration
                 path: /docs/apm/agents/go-agent/configuration/go-agent-code-level-metrics-config
-          - title: Additional configuration
+          - title: Instrumentation
+            path: /docs/apm/agents/go-agent/instrumentation
             pages:
-              - title: Instrumentation
-                path: /docs/apm/agents/go-agent/instrumentation
-                pages:
-                  - title: Instrument Go transactions
-                    path: /docs/apm/agents/go-agent/instrumentation/instrument-go-transactions
-                  - title: Instrument Go segments
-                    path: /docs/apm/agents/go-agent/instrumentation/instrument-go-segments
-                  - title: Go agent attributes
-                    path: /docs/apm/agents/go-agent/instrumentation/go-agent-attributes
-                  - title: Create custom metrics in Go
-                    path: /docs/apm/agents/go-agent/instrumentation/create-custom-metrics-go
-                  - title: Code-level metrics instrumentation
-                    path: /docs/apm/agents/go-agent/instrumentation/go-agent-code-level-metrics-instrument
-              - title: API guides
-                path: /docs/apm/agents/go-agent/api-guides
-                pages:
-                  - title: Go agent API guide
-                    path: /docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api
-              - title: Features
-                path: /docs/apm/agents/go-agent/features
-                pages:
-                  - title: Go runtime UI page
-                    path: /docs/apm/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
-                  - title: Custom events
-                    path: /docs/apm/agents/go-agent/features/create-custom-events-go
-                  - title: Add browser monitoring
-                    path: /docs/apm/agents/go-agent/features/add-browser-monitoring-your-go-apps
-                  - title: Cross application tracing
-                    path: /docs/apm/agents/go-agent/features/cross-application-tracing-go
-                  - title: Trace asynchronous applications
-                    path: /docs/apm/agents/go-agent/features/trace-asynchronous-applications
+              - title: Instrument Go transactions
+                path: /docs/apm/agents/go-agent/instrumentation/instrument-go-transactions
+              - title: Instrument Go segments
+                path: /docs/apm/agents/go-agent/instrumentation/instrument-go-segments
+              - title: Go agent attributes
+                path: /docs/apm/agents/go-agent/instrumentation/go-agent-attributes
+              - title: Create custom metrics in Go
+                path: /docs/apm/agents/go-agent/instrumentation/create-custom-metrics-go
+              - title: Code-level metrics instrumentation
+                path: /docs/apm/agents/go-agent/instrumentation/go-agent-code-level-metrics-instrument
+          - title: API guides
+            path: /docs/apm/agents/go-agent/api-guides
+            pages:
+              - title: Go agent API guide
+                path: /docs/apm/agents/go-agent/api-guides/guide-using-go-agent-api
+          - title: Features
+            path: /docs/apm/agents/go-agent/features
+            pages:
+              - title: Go runtime UI page
+                path: /docs/apm/agents/go-agent/features/go-runtime-page-troubleshoot-performance-problems
+              - title: Custom events
+                path: /docs/apm/agents/go-agent/features/create-custom-events-go
+              - title: Add browser monitoring
+                path: /docs/apm/agents/go-agent/features/add-browser-monitoring-your-go-apps
+              - title: Cross application tracing
+                path: /docs/apm/agents/go-agent/features/cross-application-tracing-go
+              - title: Trace asynchronous applications
+                path: /docs/apm/agents/go-agent/features/trace-asynchronous-applications
           - title: Troubleshooting
             path: /docs/apm/agents/go-agent/troubleshooting
             pages:


### PR DESCRIPTION
## Summary

- Restructures the Go agent nav section to match the established PHP/Java agent IA pattern
- Renames top-level "Go agent installation and configuration" → "Go monitoring"
- Fixes "Compatibility and requirements" which was incorrectly structured as a parent page with children → renamed to "Compatibility and release" as a proper section with siblings
- Renames "Go agent Installation" → "Go agent installation" (lowercase, consistent)
- Adds "Introduction to Go monitoring" as standalone after installation section (page existed but was not in nav)
- Flattens "Additional configuration" section into top-level Instrumentation, API guides, and Features
- Splits the 4,218-line `go-agent-configuration.mdx` into 7 focused sub-pages

**New config sub-pages:**
General settings · AI monitoring settings · Error collector settings · Transaction tracer settings · Distributed tracing settings · Logs in context settings · Other settings

## Test plan

- [ ] Verify nav renders correctly in local dev
- [ ] Confirm all 7 new config sub-page paths resolve
- [ ] Confirm existing links to `go-agent-configuration` still work
- [ ] Verify Introduction to Go monitoring now appears in nav

🤖 Generated with [Claude Code](https://claude.ai/claude-code)