### PR TITLE
docs(mongodb): document Windows limitation for Percona mongodb_exporter

### DIFF
--- a/src/install/mongodb/default-requirements.mdx
+++ b/src/install/mongodb/default-requirements.mdx
@@ -7,5 +7,5 @@ componentType: default
 * To monitor MongoDB Atlas, you'll need a hosted environment to install the infrastructure agent and integration and remotely connect to the Atlas instance.
 
 <Callout variant="important">
-  Windows support for the MongoDB integration is currently frozen at its existing bundled exporter version. The upstream [Percona `mongodb_exporter`](https://github.com/percona/mongodb_exporter) project stopped publishing Windows binaries starting with its `v0.47.1` release, so the integration won't receive exporter updates, including security fixes, on Windows until Windows builds are available again upstream.
+  Windows support for the MongoDB integration is currently frozen at its existing bundled exporter version. The upstream [Percona `mongodb_exporter`](https://github.com/percona/mongodb_exporter) project stopped publishing Windows binaries starting with the `v0.47.1` release. As a result, the integration won't receive exporter updates, including security fixes, until upstream builds resume.
 </Callout>

--- a/src/install/mongodb/default-requirements.mdx
+++ b/src/install/mongodb/default-requirements.mdx
@@ -5,3 +5,7 @@ componentType: default
 
 * Our integration is compatible with MongoDB 4.0 or higher, Percona Server, and MongoDB Atlas M10 or higher.
 * To monitor MongoDB Atlas, you'll need a hosted environment to install the infrastructure agent and integration and remotely connect to the Atlas instance.
+
+<Callout variant="important">
+  Windows support for the MongoDB integration is currently frozen at its existing bundled exporter version. The upstream [Percona `mongodb_exporter`](https://github.com/percona/mongodb_exporter) project stopped publishing Windows binaries starting with its `v0.47.1` release, so the integration won't receive exporter updates, including security fixes, on Windows until Windows builds are available again upstream.
+</Callout>

--- a/src/install/mongodb/windows/install-msi.mdx
+++ b/src/install/mongodb/windows/install-msi.mdx
@@ -3,6 +3,10 @@ componentType: default
 headingText: Download using MSI
 ---
 
+<Callout variant="important">
+  Windows builds of this integration are frozen at their current bundled version of the Percona `mongodb_exporter`. Upstream Percona stopped producing Windows binaries from `v0.47.1` onward, so updates to the exporter, including security fixes, aren't available for Windows until Windows builds resume upstream.
+</Callout>
+
 1. Download the latest .MSI installer image for the desired integration [from our repository](https://download.newrelic.com/infrastructure_agent/windows/integrations/).
 2. In an admin account, run the install script using an absolute path.
    ```shell

--- a/src/install/mongodb/windows/install-msi.mdx
+++ b/src/install/mongodb/windows/install-msi.mdx
@@ -4,7 +4,7 @@ headingText: Download using MSI
 ---
 
 <Callout variant="important">
-  Windows builds of this integration are frozen at their current bundled version of the Percona `mongodb_exporter`. Upstream Percona stopped producing Windows binaries from `v0.47.1` onward, so updates to the exporter, including security fixes, aren't available for Windows until Windows builds resume upstream.
+  Windows builds of this integration are frozen at their current bundled version of the Percona `mongodb_exporter`. Upstream Percona stopped producing Windows binaries starting with `v0.47.1`. Consequently, updates to the exporter, including security fixes, are unavailable until upstream builds resume.
 </Callout>
 
 1. Download the latest .MSI installer image for the desired integration [from our repository](https://download.newrelic.com/infrastructure_agent/windows/integrations/).

--- a/src/install/mongodb/windows/install-windows.mdx
+++ b/src/install/mongodb/windows/install-windows.mdx
@@ -3,6 +3,10 @@ componentType: default
 headingText: Configure the MongoDB integration
 ---
 
+<Callout variant="important">
+  Windows builds of this integration are frozen at their current bundled version of the Percona `mongodb_exporter`. Upstream Percona stopped producing Windows binaries from `v0.47.1` onward, so updates to the exporter, including security fixes, aren't available for Windows until Windows builds resume upstream.
+</Callout>
+
 1. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
    ```shell

--- a/src/install/mongodb/windows/install-windows.mdx
+++ b/src/install/mongodb/windows/install-windows.mdx
@@ -3,10 +3,6 @@ componentType: default
 headingText: Configure the MongoDB integration
 ---
 
-<Callout variant="important">
-  Windows builds of this integration are frozen at their current bundled version of the Percona `mongodb_exporter`. Upstream Percona stopped producing Windows binaries from `v0.47.1` onward, so updates to the exporter, including security fixes, aren't available for Windows until Windows builds resume upstream.
-</Callout>
-
 1. In the Integrations directory, `C:\Program Files\New Relic\newrelic-infra\integrations.d\`, create a copy of the sample configuration file by running:
 
    ```shell


### PR DESCRIPTION
## Summary
- Adds a callout to the MongoDB monitoring integration install guide noting that Windows builds are frozen at their current bundled Percona `mongodb_exporter` version.
- Upstream `percona/mongodb_exporter` stopped publishing Windows binaries from GoReleaser starting with `v0.47.1`, until Windows builds resume upstream.

## Related
- newrelic/newrelic-prometheus-exporters-packages [PR](https://github.com/newrelic/newrelic-prometheus-exporters-packages/pull/297)