### PR TITLE
Add Synthetic monitoring use cases guide (draft)

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -10,7 +10,9 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important" title="Draft for review — not yet published">
+
   This page is a **working draft** circulated for review. Remove this callout and the [Contribution](#contributing) section before it ships.
+
 </Callout>
 
 New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.
@@ -32,7 +34,9 @@ A scripted monitor can run a **NRQL query** against your New Relic data and asse
 Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
 
 <Callout variant="tip">
+
   Full programmability, unrestricted modules, and native access to your own telemetry make scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
+
 </Callout>
 
 ## Sample use cases [#sample-use-cases]
@@ -89,11 +93,15 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 * **Cloud and SaaS integration** — Capture screenshots during the journey and upload them to cloud storage such as S3.
 
 <Callout variant="tip" title="Where custom code fits">
+
   **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules — the protocol, cloud-SDK, and document checks above are all powered that way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
+
 </Callout>
 
 <Callout variant="tip">
+
   Monitoring **AI and LLM endpoints** — prompt and response contracts, token cost and latency, and guardrails — is covered in a dedicated guide. In the meantime, see [New Relic AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring/) for observing production AI traffic.
+
 </Callout>
 
 ## Related pages [#related]
@@ -109,5 +117,7 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 ## Contribution [#contributing]
 
 <Callout variant="important" title="Remove before publishing">
+
   Draft circulated for review. Delete this section and the draft banner before publishing.
+
 </Callout>

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -1,0 +1,113 @@
+---
+title: Synthetic monitoring use cases
+tags:
+  - Synthetics
+  - Synthetic monitoring
+  - Scripting monitors
+  - Private locations
+metaDescription: 'What you can monitor with New Relic synthetic monitoring, organized by monitor type — from lightweight ping uptime checks to fully scripted API and browser journeys.'
+freshnessValidatedDate: never
+---
+
+<Callout variant="important" title="Draft for review — not yet published">
+  This page is a **working draft** circulated for review. Remove this callout and the [Contribution](#contributing) section before it ships.
+</Callout>
+
+New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.
+
+## An extensible monitoring platform [#programmable-monitoring]
+
+New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the `$http` API, and a scripted browser monitor drives a real browser with the `$browser` API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. Three capabilities turn that into a platform advantage rather than a longer checklist of built-in checks.
+
+### Bring your own code — the full npm ecosystem [#bring-your-own-code]
+
+Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json` and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor**. That is what lets a single platform speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, and decode proprietary formats. Your monitors' reach isn't a fixed feature list — it's the entire package ecosystem plus your own code. When a new need appears, you add a dependency instead of filing a feature request or leaving the platform. Tools that restrict scripts to a fixed set of built-in libraries hit a wall the moment a check needs a protocol, SDK, or format they didn't anticipate.
+
+### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
+
+A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
+
+### Run it privately, inside your network [#run-privately]
+
+Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
+
+<Callout variant="tip">
+  Full programmability, unrestricted modules, and native access to your own telemetry make scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
+</Callout>
+
+## Sample use cases [#sample-use-cases]
+
+What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
+
+### Simple ping [#simple-ping]
+
+Send scheduled HTTP requests to confirm an endpoint is up, responds within budget, and returns the expected content — the cheapest way to cover availability broadly.
+
+* **Endpoint reachable** — Send a request on a schedule and confirm it returns a healthy status code (a 200, or any 2xx or 3xx), with no auth or scripting.
+* **Response-time threshold** — Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
+* **Body string-match** — Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
+
+### Advanced ping [#advanced-ping]
+
+Go beyond a basic ping to validate TLS certificates and trace the network path, so you can localize where availability or latency breaks down.
+
+* **SSL certificate validity** — Verify the TLS certificate is valid and warn before it expires, for example within 30 days.
+* **Traceroute** — Trace the network path to the endpoint and record per-hop latency to localize where delays or drops occur.
+
+### No-code API [#nocode-api]
+
+Point and click to build API checks that assert on status, latency, headers, and JSON — no code required.
+
+* **Reliability and availability** — Call the API on a schedule and assert it returns a healthy status within your latency budget, and read rate-limit headers to catch quota exhaustion.
+* **Security and compliance** — Send an authenticated request and assert it doesn't return 401 (catching key rotation or expiry), then verify TLS certificate validity and CORS headers.
+* **Performance and SLAs** — Fail the check when round-trip latency exceeds your SLA budget, and record usage metrics to NRDB for trend tracking.
+* **Contract and schema** — Assert the response matches its expected schema — required fields, types, and values — so a breaking change fails the monitor.
+
+### Scripted API [#scripted-api]
+
+Write JavaScript with the `$http` API to chain requests, parse responses, and assert on anything — and `require()` your own npm modules to reach protocols and services beyond HTTP.
+
+* **Network and protocol** — Open a non-HTTP connection and assert it succeeds: confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
+* **Certificates and security** — Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
+* **Cloud and SaaS integration** — Authenticate to AWS, Azure, or GCP and assert a resource is present — for example, confirm an S3 export object exists or read an Azure Key Vault secret.
+* **Performance and SEO** — Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
+* **New Relic data (NRDB/NRQL)** — Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
+
+### No-code browser [#nocode-browser]
+
+Record a real user journey with no code; New Relic replays it from global locations to catch broken paths, slow pages, and missing elements.
+
+* **Page availability** — Open the page from global locations and confirm it loads and renders the expected content.
+* **Content and element checks** — Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
+* **Core Web Vitals** — Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
+
+### Scripted browser [#scripted-browser]
+
+Write JavaScript with the `$browser` API to drive complex, conditional, or authenticated journeys the recorder can't capture, extendable with your own npm modules.
+
+* **Browser UX and content** — Drive the page to crawl its links and fail on any broken one, time a file download, or verify the text inside a downloaded PDF.
+* **Cloud and SaaS integration** — Capture screenshots during the journey and upload them to cloud storage such as S3.
+
+<Callout variant="tip" title="Where custom code fits">
+  **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules — the protocol, cloud-SDK, and document checks above are all powered that way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
+</Callout>
+
+<Callout variant="tip">
+  Monitoring **AI and LLM endpoints** — prompt and response contracts, token cost and latency, and guardrails — is covered in a dedicated guide. In the meantime, see [New Relic AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring/) for observing production AI traffic.
+</Callout>
+
+## Related pages [#related]
+
+* [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
+* [Custom node modules](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)
+* [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules/)
+* [Introduction to scripted browsers](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/)
+* [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/)
+
+---
+
+## Contribution [#contributing]
+
+<Callout variant="important" title="Remove before publishing">
+  Draft circulated for review. Delete this section and the draft banner before publishing.
+</Callout>


### PR DESCRIPTION
Adds the **Synthetic monitoring use cases** guide page (programmable-platform pitch + use-case catalog by monitor type). Draft.

**Nav:** the shared **Guides** section (all three entries, ordered: use cases -> private locations -> autonomous) is created in #25052 only, which deploys first. This PR adds its guide page only.