### PR TITLE
Add Autonomous operation guide (placeholder draft)

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/guides/autonomous-operation.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/autonomous-operation.mdx
@@ -8,7 +8,9 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important" title="Draft placeholder — not yet written">
+
   This guide is a placeholder. It will explain how New Relic is making synthetic monitoring more autonomous, across the three areas below. Content to be added; each section is a stub for now.
+
 </Callout>
 
 New Relic is making synthetic monitoring increasingly autonomous — reducing the manual effort to create, maintain, and scale monitors. This guide will cover three areas.
@@ -16,17 +18,23 @@ New Relic is making synthetic monitoring increasingly autonomous — reducing th
 ## CAT [#cat]
 
 <Callout variant="important" title="Placeholder">
+
   Content coming.
+
 </Callout>
 
 ## Playwright support [#playwright]
 
 <Callout variant="important" title="Placeholder">
+
   Content coming — running Playwright tests as synthetic monitors.
+
 </Callout>
 
 ## AI-driven interface [#ai-driven-interface]
 
 <Callout variant="important" title="Placeholder">
+
   Content coming — AI-assisted, natural-language monitor creation.
+
 </Callout>

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/autonomous-operation.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/autonomous-operation.mdx
@@ -1,0 +1,32 @@
+---
+title: Autonomous operation
+tags:
+  - Synthetics
+  - Synthetic monitoring
+metaDescription: 'How New Relic synthetic monitoring is moving toward autonomous operation: AI-assisted monitor creation, Playwright support, and continuous automated testing.'
+freshnessValidatedDate: never
+---
+
+<Callout variant="important" title="Draft placeholder — not yet written">
+  This guide is a placeholder. It will explain how New Relic is making synthetic monitoring more autonomous, across the three areas below. Content to be added; each section is a stub for now.
+</Callout>
+
+New Relic is making synthetic monitoring increasingly autonomous — reducing the manual effort to create, maintain, and scale monitors. This guide will cover three areas.
+
+## CAT [#cat]
+
+<Callout variant="important" title="Placeholder">
+  Content coming.
+</Callout>
+
+## Playwright support [#playwright]
+
+<Callout variant="important" title="Placeholder">
+  Content coming — running Playwright tests as synthetic monitors.
+</Callout>
+
+## AI-driven interface [#ai-driven-interface]
+
+<Callout variant="important" title="Placeholder">
+  Content coming — AI-assisted, natural-language monitor creation.
+</Callout>


### PR DESCRIPTION
**Placeholder** for the **Autonomous operation** guide (CAT, Playwright support, AI-driven interface). Page stub only. Draft.

**Nav:** the shared **Guides** section (all three entries, ordered: use cases -> private locations -> autonomous) is created in #25052 only, which deploys first. This PR adds its guide page only.