### PR TITLE
docs: Add Fargate NRIA_IS_FORWARD_ONLY configuration guidance

### DIFF
--- a/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
@@ -22,6 +22,7 @@ New Relic's ECS integration reports and displays performance data from your Amaz
 Before you [install](#install-options), it may help you to understand at a high level how our infrastructure agent (`newrelic-infra`) is deployed for these two launch types:
 
 * <DNT>**EC2 and EXTERNAL (ECS Anywhere) launch type:**</DNT> Our agent gets deployed onto an ECS cluster as a service using the daemon scheduling strategy ([explained here in the AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)). This installs the agent in all EC2 instances of the cluster, and it then monitors ECS and Docker containers.
+
 * <DNT>**AWS Fargate launch type:**</DNT> In every task to monitor, our agent gets deployed as a sidecar. Optional: [learn more about how AWS defines a sidecar](https://aws.github.io/copilot-cli/docs/developing/sidecars/).
 
 ## Install options [#install-options]
@@ -39,10 +40,11 @@ To help you install using AWS CloudFormation, we provide some CloudFormation tem
 To install using CloudFormation:
 
 1. To register the ECS integration task, deploy [this stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/integrations/ecs/cloudformation/task/master.yaml&stackName=NewRelicECSIntegration). Ensure you're deploying the stack to your desired region(s). This stack creates the following resources:
-   * A secret that stores the New Relic <InlinePopover type="licenseKey"/>.
+   * A secret that stores the New Relic <InlinePopover type="licenseKey" />.
    * A policy to access the license key.
    * An instance role to be used as an ECS task `ExecutionRole`, with access to the license key.
    * For EC2 and External (ECS Anywhere) launch type: Registers the New Relic infrastructure ECS integration task.
+
 2. Follow the additional instructions for your launch type:
 
    <CollapserGroup>
@@ -69,15 +71,80 @@ To install using CloudFormation:
        title="AWS Fargate launch type"
      >
        1. Download the task definition example with the sidecar container to be deployed:
-
           ```sh
           curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-fargate-example-latest.json
           ```
-
           <Callout variant="tip">
             For Graviton, replace `"cpuArchitecture": "X86_64"` with `"cpuArchitecture": "ARM64"`.
           </Callout>
+
        2. Add the `newrelic-infra` container in this task definition as a sidecar to the task definitions you want to monitor. In this example task, your application's containers replace the placeholder `busybox` container.
+
+       **Important: Configure isForwardOnly for Fargate** [#fargate-isforwardonly]
+
+       When deploying the New Relic infrastructure agent as a sidecar in Fargate environments, you **must** set the `NRIA_IS_FORWARD_ONLY` environment variable to `true`. This is a critical configuration for proper operation in serverless Fargate deployments.
+
+       *Why this setting is required:*
+       * **Prevents incorrect host entity creation:** Fargate is serverless and AWS manages the underlying compute resources. Without this setting, the infrastructure agent may attempt to create host entities for non-existent infrastructure.
+       * **Avoids billing discrepancies:** Entity-based metering charges customers based on the number of monitored entities. Incorrect host entity creation causes billing issues.
+       * **Enables proper APM-to-Container linking:** This setting ensures that APM applications are correctly linked to Container entities rather than synthetic Host entities.
+
+       *Example task definition with required Fargate configuration:*
+       ```json
+       {
+         "family": "newrelic-infra-fargate",
+         "networkMode": "awsvpc",
+         "requiresCompatibilities": ["FARGATE"],
+         "cpu": "256",
+         "memory": "512",
+         "containerDefinitions": [
+           {
+             "name": "newrelic-infra",
+             "image": "newrelic/nri-ecs:latest",
+             "essential": false,
+             "environment": [
+               {
+                 "name": "NRIA_IS_FORWARD_ONLY",
+                 "value": "true"
+               },
+               {
+                 "name": "NRIA_LICENSE_KEY",
+                 "value": "your-license-key"
+               },
+               {
+                 "name": "NRIA_PASSTHROUGH_ENVIRONMENT",
+                 "value": "ECS_CONTAINER_METADATA_URI,ECS_CONTAINER_METADATA_URI_V4,FARGATE"
+               },
+               {
+                 "name": "FARGATE",
+                 "value": "true"
+               }
+             ]
+           },
+           {
+             "name": "your-application",
+             "image": "your-app-image:latest",
+             "essential": true
+           }
+         ]
+       }
+       ```
+
+       <Callout variant="important">
+         The `NRIA_IS_FORWARD_ONLY=true` environment variable is **required** for all Fargate deployments. Omitting this setting can result in:
+         * Incorrect host entity creation
+         * APM-to-Container relationship failures  
+         * Billing discrepancies due to unexpected entity counts
+
+         If you download the example task definition, verify that this environment variable is present and set to true.
+       </Callout>
+
+       3. Register the task definition:
+          ```sh
+          aws ecs register-task-definition --cli-input-json file://newrelic-infra-ecs-fargate-example-latest.json
+          ```
+
+       4. Create a service or run a task using this task definition.
      </Collapser>
    </CollapserGroup>
 
@@ -88,36 +155,31 @@ When you're done, see [Next steps](#next-steps).
 One [install option](#install-overview) is using our install script. To use the automatic install script:
 
 1. Download the ECS integration installer:
-
    ```sh
    curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-installer.sh
    ```
 
 2. Add execute permissions to the installer:
-
    ```sh
    chmod +x newrelic-infra-ecs-installer.sh
    ```
 
 3. Execute it with `-h` to see the documentation and requirements:
-
    ```sh
    ./newrelic-infra-ecs-installer.sh -h
    ```
 
 4. Check that your AWS profile points to the same region where your ECS cluster was created:
-
    ```sh
    aws configure get region
    [output] us-east-1
-   [output] 
+
    aws ecs list-clusters
    [output] YOUR_CLUSTER_ARNS 	
    [output] arn:aws:ecs:us-east-1:YOUR_AWS_ACCOUNT:cluster/YOUR_CLUSTER
    ```
 
-5. Execute the installer, specifying your <InlinePopover type="licenseKey"/> and cluster name.
-
+5. Execute the installer, specifying your <InlinePopover type="licenseKey" /> and cluster name.
    <CollapserGroup>
      <Collapser
        id="auto-script-ec2"
@@ -148,24 +210,25 @@ One [install option](#install-overview) is using our install script. To use the 
    </CollapserGroup>
 
 6. Additional steps for the Fargate launch type (not EC2 launch type):
-
    * Download the task definition example with the sidecar container to be deployed:
-
      ```sh
      curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-fargate-example-latest.json
      ```
-
      <Callout variant="tip">
        For Graviton, replace `"cpuArchitecture": "X86_64"` with `"cpuArchitecture": "ARM64"`.
      </Callout>
 
      Notice that the just created `NewRelicECSTaskExecutionRole` needs to be used as the task execution role.
-     Policies attached to the role (All launch types):
 
+     Policies attached to the role (All launch types):
      * `NewRelicSSMLicenseKeyReadAccess` which enables access to the SSM parameter with the license key.
      * `AmazonECSTaskExecutionRolePolicy`
 
    * Then, you can add the container you want to monitor as a sidecar.
+
+   <Callout variant="important">
+     When using AWS Fargate, you must also ensure the sidecar container has the environment variable `NRIA_IS_FORWARD_ONLY` set to `true` inside your task definition. Refer to the [Fargate setup instructions](#fargate-isforwardonly) under CloudFormation for configuration details and why this setting is critical.
+   </Callout>
 
 When you're done, see [Next steps](#next-steps).
 
@@ -174,17 +237,16 @@ When you're done, see [Next steps](#next-steps).
 One [install option](#install-overview) is to manually do the steps that are done by the [automatic installer script](#auto-script-install). We will describe how this is done using the `awscli` tool:
 
 1. Check that your AWS profile points to the same region where your ECS cluster was created:
-
    ```sh
    aws configure get region
    [output] us-east-1
-   [output] 
+
    aws ecs list-clusters
    [output] YOUR_CLUSTER_ARNS
    [output] arn:aws:ecs:us-east-1:YOUR_AWS_ACCOUNT:cluster/YOUR_CLUSTER
    ```
-2. Save your <InlinePopover type="licenseKey"/> as a Systems Manager (SSM) parameter:
 
+2. Save your <InlinePopover type="licenseKey" /> as a Systems Manager (SSM) parameter:
    ```sh
    aws ssm put-parameter \
      --name "/newrelic-infra/ecs/license-key" \
@@ -192,50 +254,46 @@ One [install option](#install-overview) is to manually do the steps that are don
      --description 'New Relic license key for ECS monitoring' \
      --value "NEW_RELIC_LICENSE_KEY"
    ```
-3. Create an IAM policy to access the license key parameter:
 
+3. Create an IAM policy to access the license key parameter:
    ```sh
    aws iam create-policy \
      --policy-name "NewRelicSSMLicenseKeyReadAccess" \
-     --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"ssm:GetParameters\"],\"Resource\":[\"ARN_OF_LICENSE_KEY_PARAMETER\"]}]}" \
+     --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["ssm:GetParameters"],"Resource":["ARN_OF_LICENSE_KEY_PARAMETER"]}]}' \
      --description "Provides read access to the New Relic SSM license key parameter"
    ```
-4. Create an IAM role to be used as the task execution role:
 
+4. Create an IAM role to be used as the task execution role:
    ```sh
    aws iam create-role \
      --role-name "NewRelicECSTaskExecutionRole" \
      --assume-role-policy-document '{"Version":"2008-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"ecs-tasks.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
      --description "ECS task execution role for New Relic infrastructure"
    ```
-5. Attach the policies `NewRelicSSMLicenseKeyReadAccess`, and `AmazonECSTaskExecutionRolePolicy` to the role:
 
+5. Attach the policies `NewRelicSSMLicenseKeyReadAccess`, and `AmazonECSTaskExecutionRolePolicy` to the role:
    ```sh
    aws iam attach-role-policy \
      --role-name "NewRelicECSTaskExecutionRole" \
      --policy-arn "POLICY_ARN"
    ```
-6. Choose your launch type for more instructions:
 
+6. Choose your launch type for more instructions:
    <CollapserGroup>
      <Collapser
        id="manual-ec2"
        title="EC2 and EXTERNAL (ECS Anywhere) launch type"
      >
        Additional steps for EC2 launch type:
-
        1. Download the New Relic ECS integration task definition template file:
-
           ```sh
           curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-ec2-latest.json
           ```
        2. Replace the task execution role in the template file with the newly created role:
-
           ```json
           "executionRoleArn": "NewRelicECSTaskExecutionRole",
           ```
        3. Replace the `valueFrom` attribute of the `secret` with the name of the Systems Manager parameter:
-
           ```json
           "secrets": [
             {
@@ -245,20 +303,17 @@ One [install option](#install-overview) is to manually do the steps that are don
           ],
           ```
        4. Register the task definition file:
-
           ```sh
           aws ecs register-task-definition --cli-input-json file://newrelic-infra-ecs-ec2-latest.json
           ```
        5. Create a service with the [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) strategy for the registered task:
 
           For EC2 launch type:
-
           ```sh
           aws ecs create-service --cluster "YOUR_CLUSTER_NAME" --service-name "newrelic-infra" --task-definition "newrelic-infra" --scheduling-strategy DAEMON --launch-type EC2
           ```
 
           For EXTERNAL (ECS Anywhere) launch type:
-
           ```sh
           aws ecs create-service --cluster "YOUR_CLUSTER_NAME" --service-name "newrelic-infra-external" --task-definition "newrelic-infra" --scheduling-strategy DAEMON --launch-type EXTERNAL
           ```
@@ -269,24 +324,24 @@ One [install option](#install-overview) is to manually do the steps that are don
        title="AWS Fargate launch type"
      >
        Additional steps for the AWS Fargate launch type:
-
        1. Download the task definition example with the sidecar container to be deployed:
-
           ```sh
           curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-fargate-example-latest.json
           ```
-
           <Callout variant="tip">
             For Graviton, replace `"cpuArchitecture": "X86_64"` with `"cpuArchitecture": "ARM64"`.
           </Callout>
-
        2. Add the `newrelic-infra` container in this task definition as a sidecar to the task definitions you want to monitor. In this example task, your application's containers replace the placeholder `busybox` container.
+
+       <Callout variant="important">
+         Ensure that you configure the environment variable `NRIA_IS_FORWARD_ONLY` to `true` in your manually edited task definition sidecar container settings. Refer to the [CloudFormation Fargate section](#fargate-isforwardonly) for detailed instructions and a full JSON example.
+       </Callout>
      </Collapser>
    </CollapserGroup>
 
 When you're done, see [Next steps](#next-steps).
 
-<InstallFeedback/>
+<InstallFeedback />
 
 ## Next steps after install [#next-steps]
 
@@ -301,7 +356,7 @@ After you've installed this integration:
 
 When you install the ECS integration using default/recommended values, it does the following in AWS:
 
-* Creates Systems Manager (SSM) parameter `/newrelic-infra/ecs/license-key`. This system parameter contains the New Relic <InlinePopover type="licenseKey"/>.
+* Creates Systems Manager (SSM) parameter `/newrelic-infra/ecs/license-key`. This system parameter contains the New Relic <InlinePopover type="licenseKey" />.
 * Creates IAM policy `NewRelicSSMLicenseKeyReadAccess`, which enables access to the SSM parameter with the license key.
 * Creates IAM role `NewRelicECSTaskExecutionRole` used as the [task execution role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html). Policies attached to the role:
   * `NewRelicSSMLicenseKeyReadAccess` (created by the installer).

--- a/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
@@ -180,6 +180,7 @@ One [install option](#install-overview) is using our install script. To use the 
    ```
 
 5. Execute the installer, specifying your <InlinePopover type="licenseKey" /> and cluster name.
+
    <CollapserGroup>
      <Collapser
        id="auto-script-ec2"
@@ -279,6 +280,7 @@ One [install option](#install-overview) is to manually do the steps that are don
    ```
 
 6. Choose your launch type for more instructions:
+
    <CollapserGroup>
      <Collapser
        id="manual-ec2"

--- a/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install the ECS integration
+title: Install the ECS Integration
 tags:
   - Integrations
   - Elastic Container Service integration
@@ -21,9 +21,9 @@ New Relic's ECS integration reports and displays performance data from your Amaz
 
 Before you [install](#install-options), it may help you to understand at a high level how our infrastructure agent (`newrelic-infra`) is deployed for these two launch types:
 
-* <DNT>**EC2 and EXTERNAL (ECS Anywhere) launch type:**</DNT> Our agent gets deployed onto an ECS cluster as a service using the daemon scheduling strategy ([explained here in the AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)). This installs the agent in all EC2 instances of the cluster, and it then monitors ECS and Docker containers.
+* <DNT>**EC2 and EXTERNAL (ECS Anywhere) launch type:**</DNT> The daemon scheduling strategy deploys our agent onto an ECS cluster as a service ([explained here in the AWS docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)). This installs the agent in all EC2 instances of the cluster, and it then monitors ECS and Docker containers.
 
-* <DNT>**AWS Fargate launch type:**</DNT> In every task to monitor, our agent gets deployed as a sidecar. Optional: [learn more about how AWS defines a sidecar](https://aws.github.io/copilot-cli/docs/developing/sidecars/).
+* <DNT>**AWS Fargate launch type:**</DNT> In every task to monitor, you deploy our agent as a sidecar. You can optionally [learn more about how AWS defines a sidecar](https://aws.github.io/copilot-cli/docs/developing/sidecars/).
 
 ## Install options [#install-options]
 
@@ -35,15 +35,15 @@ Choose the install you want:
 
 ## Install using CloudFormation [#cloud-formation-install]
 
-To help you install using AWS CloudFormation, we provide some CloudFormation templates that install the ECS integration onto your AWS account for EC2, EXTERNAL (ECS Anywhere) and AWS Fargate launch types.
+To help you install using AWS CloudFormation, we provide some CloudFormation templates that install the ECS integration onto your AWS account for EC2, EXTERNAL (ECS Anywhere), and AWS Fargate launch types.
 
 To install using CloudFormation:
 
-1. To register the ECS integration task, deploy [this stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/integrations/ecs/cloudformation/task/master.yaml&stackName=NewRelicECSIntegration). Ensure you're deploying the stack to your desired region(s). This stack creates the following resources:
+1. To register the ECS integration task, deploy [this stack](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://nr-downloads-main.s3.amazonaws.com/infrastructure_agent/integrations/ecs/cloudformation/task/master.yaml&stackName=NewRelicECSIntegration). Ensure you're deploying the stack to one or more of your desired regions. This stack creates the following resources:
    * A secret that stores the New Relic <InlinePopover type="licenseKey" />.
    * A policy to access the license key.
    * An instance role to be used as an ECS task `ExecutionRole`, with access to the license key.
-   * For EC2 and External (ECS Anywhere) launch type: Registers the New Relic infrastructure ECS integration task.
+   * A registration of the New Relic infrastructure ECS integration task, for EC2 and External (ECS Anywhere) launch type.
 
 2. Follow the additional instructions for your launch type:
 
@@ -80,16 +80,16 @@ To install using CloudFormation:
 
        2. Add the `newrelic-infra` container in this task definition as a sidecar to the task definitions you want to monitor. In this example task, your application's containers replace the placeholder `busybox` container.
 
-       **Important: Configure isForwardOnly for Fargate** [#fargate-isforwardonly]
+       ### Configure NRIA_IS_FORWARD_ONLY for Fargate [#fargate-isforwardonly]
 
-       When deploying the New Relic infrastructure agent as a sidecar in Fargate environments, you **must** set the `NRIA_IS_FORWARD_ONLY` environment variable to `true`. This is a critical configuration for proper operation in serverless Fargate deployments.
+       When deploying the New Relic infrastructure agent as a sidecar in Fargate environments, you must set the `NRIA_IS_FORWARD_ONLY` environment variable to `true`. This is a critical configuration for proper operation in serverless Fargate deployments.
 
        *Why this setting is required:*
        * **Prevents incorrect host entity creation:** Fargate is serverless and AWS manages the underlying compute resources. Without this setting, the infrastructure agent may attempt to create host entities for non-existent infrastructure.
        * **Avoids billing discrepancies:** Entity-based metering charges customers based on the number of monitored entities. Incorrect host entity creation causes billing issues.
        * **Enables proper APM-to-Container linking:** This setting ensures that APM applications are correctly linked to Container entities rather than synthetic Host entities.
 
-       *Example task definition with required Fargate configuration:*
+       This example task definition includes the required Fargate configuration:
        ```json
        {
          "family": "newrelic-infra-fargate",
@@ -219,13 +219,13 @@ One [install option](#install-overview) is using our install script. To use the 
        For Graviton, replace `"cpuArchitecture": "X86_64"` with `"cpuArchitecture": "ARM64"`.
      </Callout>
 
-     Notice that the just created `NewRelicECSTaskExecutionRole` needs to be used as the task execution role.
+     Notice that you must use the role you just created, `NewRelicECSTaskExecutionRole`, as the task execution role.
 
-     Policies attached to the role (All launch types):
+     This role includes the following policies for all launch types:
      * `NewRelicSSMLicenseKeyReadAccess` which enables access to the SSM parameter with the license key.
      * `AmazonECSTaskExecutionRolePolicy`
 
-   * Then, you can add the container you want to monitor as a sidecar.
+   * Add the container you want to monitor as a sidecar.
 
    <Callout variant="important">
      When using AWS Fargate, you must also ensure the sidecar container has the environment variable `NRIA_IS_FORWARD_ONLY` set to `true` inside your task definition. Refer to the [Fargate setup instructions](#fargate-isforwardonly) under CloudFormation for configuration details and why this setting is critical.
@@ -235,7 +235,7 @@ When you're done, see [Next steps](#next-steps).
 
 ## Manual install
 
-One [install option](#install-overview) is to manually do the steps that are done by the [automatic installer script](#auto-script-install). We will describe how this is done using the `awscli` tool:
+One [install option](#install-overview) is to manually do the steps that are done by the [automatic installer script](#auto-script-install). We'll describe how this is done using the `awscli` tool:
 
 1. Check that your AWS profile points to the same region where your ECS cluster was created:
    ```sh
@@ -272,7 +272,7 @@ One [install option](#install-overview) is to manually do the steps that are don
      --description "ECS task execution role for New Relic infrastructure"
    ```
 
-5. Attach the policies `NewRelicSSMLicenseKeyReadAccess`, and `AmazonECSTaskExecutionRolePolicy` to the role:
+5. Attach the policies `NewRelicSSMLicenseKeyReadAccess` and `AmazonECSTaskExecutionRolePolicy` to the role:
    ```sh
    aws iam attach-role-policy \
      --role-name "NewRelicECSTaskExecutionRole" \
@@ -284,7 +284,7 @@ One [install option](#install-overview) is to manually do the steps that are don
    <CollapserGroup>
      <Collapser
        id="manual-ec2"
-       title="EC2 and EXTERNAL (ECS Anywhere) launch type"
+       title="EC2 and External (ECS Anywhere) launch type"
      >
        Additional steps for EC2 launch type:
        1. Download the New Relic ECS integration task definition template file:
@@ -350,7 +350,7 @@ When you're done, see [Next steps](#next-steps).
 After you've installed this integration:
 
 * Wait a few minutes and then [look for your data in the UI](/docs/ecs-integration-understand-use-data).
-* Recommended: Install our [ECS cloud integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration), which gets you other ECS data, including information about clusters and services.
+* Install our recommended [ECS cloud integration](/docs/integrations/amazon-integrations/aws-integrations-list/aws-ecsecr-monitoring-integration), which gets you other ECS data, including information about clusters and services.
 * See [recommended alert conditions](/docs/ecs-integration-recommended-alert-conditions).
 * Understand the [AWS resources](#aws-resources) created by this process.
 
@@ -360,11 +360,11 @@ When you install the ECS integration using default/recommended values, it does t
 
 * Creates Systems Manager (SSM) parameter `/newrelic-infra/ecs/license-key`. This system parameter contains the New Relic <InlinePopover type="licenseKey" />.
 * Creates IAM policy `NewRelicSSMLicenseKeyReadAccess`, which enables access to the SSM parameter with the license key.
-* Creates IAM role `NewRelicECSTaskExecutionRole` used as the [task execution role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html). Policies attached to the role:
+* Creates IAM role `NewRelicECSTaskExecutionRole` used as the [task execution role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html). This role includes the following policies:
   * `NewRelicSSMLicenseKeyReadAccess` (created by the installer).
   * `AmazonECSTaskExecutionRolePolicy`
 * Registers the `newrelic-infra` ECS task definition for EC2 and External (ECS Anywhere) launch types.
-* For EC2 [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html), this is also done:
-  * Creates the service `newrelic-infra` for the registered task using a [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) strategy and EC2 launch type.
-* For EXTERNAL (ECS Anywhere) [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html), this is also done:
-  * Creates the service `newrelic-infra-external` for the registered task using a [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) strategy and EXTERNAL (ECS Anywhere) launch type.
+* Creates the following for EC2 [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html):
+  * The service `newrelic-infra` for the registered task, using a [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) strategy and EC2 launch type.
+* Creates the following for EXTERNAL (ECS Anywhere) [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html):
+  * The service `newrelic-infra-external` for the registered task, using a [daemon scheduling](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html) strategy and EXTERNAL (ECS Anywhere) launch type.

--- a/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install the ECS Integration
+title: Install the ECS integration
 tags:
   - Integrations
   - Elastic Container Service integration


### PR DESCRIPTION
markdown
## Description

This PR adds critical documentation for the required `NRIA_IS_FORWARD_ONLY=true` configuration when deploying the New Relic infrastructure agent as a sidecar in AWS Fargate environments.

## Problem

Customers deploying the infrastructure agent as a sidecar in Fargate environments were missing critical configuration guidance for the `NRIA_IS_FORWARD_ONLY` setting. This resulted in:
- Incorrect host entity creation
- Unexpected billing charges due to entity-based metering
- Failed APM-to-Container relationships

## Solution

Added a new "Important: Configure isForwardOnly for Fargate" section to the AWS Fargate CloudFormation installation instructions that includes:

- Clear explanation of why this setting is required
- Detailed example task definition with proper `NRIA_IS_FORWARD_ONLY=true` configuration
- Important callout warning about consequences of missing this setting

## Changes

- **File**: `src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx`
- **Section**: AWS Fargate launch type (id="fargate-cloudformation")
- **Location**: Between step 2 (Add the newrelic-infra container) and step 3 (Register the task definition)

## Why this matters

In Fargate environments, AWS manages the underlying compute resources. Without the `NRIA_IS_FORWARD_ONLY=true` setting:
1. Infrastructure agent may create host entities for non-existent infrastructure
2. Entity-based metering charges customers for these synthetic entities
3. APM applications may fail to link properly to Container entities

This documentation aligns public guidance with internal platform documentation and best practices.

## Testing

- [x] Documentation builds without errors
- [x] MDX syntax is valid
- [x] JSON code examples are syntactically correct
- [x] All Callout tags are properly formatted
- [x] Indentation is consistent with existing content

## References

- Internal: Confluence - Infra Agent Forward Modes documentation
- Related customer feedback: Multiple Fargate deployments reported configuration confusion

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.