### PR TITLE
Add Synthetic monitoring for generative AI applications guide (placeholder draft)

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-generative-ai.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-generative-ai.mdx
@@ -9,7 +9,9 @@ freshnessValidatedDate: never
 ---
 
 <Callout variant="important" title="Draft placeholder — for review">
+
   This guide is an early draft for go-to-market enablement. The use cases below are summarized and will be refined. Remove this callout and the [Contribution](#contributing) section before publishing.
+
 </Callout>
 
 As generative AI moves into critical enterprise pipelines, reactive monitoring falls short for the application owners accountable for business outcomes in production. Evaluation tools that sample production traffic for post-hoc analysis can only tell you something broke *after* users were exposed. **Continuous synthetic monitoring is the proactive, controlled safety net:** by simulating user behavior on a schedule, synthetics establish a consistent performance baseline and catch quiet AI failures — PII leaks, third-party model regressions, and RAG data staleness — before they reach real users. Unlike sampling-based tracing, synthetics guarantee **100% evaluation coverage** for the prompts and paths most critical to business outcomes.
@@ -54,5 +56,7 @@ Monitor the search precision of your vector database (such as Pinecone or Milvus
 ## Contribution [#contributing]
 
 <Callout variant="important" title="Remove before publishing">
+
   Early GTM-enablement draft. Validate the positioning and claims with product and GTM, then delete this section and the draft banner before publishing.
+
 </Callout>

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-generative-ai.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-generative-ai.mdx
@@ -1,0 +1,58 @@
+---
+title: Synthetic monitoring for generative AI applications
+tags:
+  - Synthetics
+  - Synthetic monitoring
+  - AI monitoring
+metaDescription: 'How continuous synthetic monitoring gives generative AI applications a proactive safety net — catching model regressions, guardrail failures, and RAG staleness before they reach users.'
+freshnessValidatedDate: never
+---
+
+<Callout variant="important" title="Draft placeholder — for review">
+  This guide is an early draft for go-to-market enablement. The use cases below are summarized and will be refined. Remove this callout and the [Contribution](#contributing) section before publishing.
+</Callout>
+
+As generative AI moves into critical enterprise pipelines, reactive monitoring falls short for the application owners accountable for business outcomes in production. Evaluation tools that sample production traffic for post-hoc analysis can only tell you something broke *after* users were exposed. **Continuous synthetic monitoring is the proactive, controlled safety net:** by simulating user behavior on a schedule, synthetics establish a consistent performance baseline and catch quiet AI failures — PII leaks, third-party model regressions, and RAG data staleness — before they reach real users. Unlike sampling-based tracing, synthetics guarantee **100% evaluation coverage** for the prompts and paths most critical to business outcomes.
+
+## Why synthetics for AI [#why]
+
+* **Proactive, not post-hoc** — catch regressions and guardrail failures on live endpoints before a real user hits them, instead of after exposure.
+* **Controlled and repeatable** — a fixed golden dataset gives an apples-to-apples baseline, so you can isolate a vendor-side regression from a chaotic "bad user prompt."
+* **Cost-aware** — use tiered test suites and cheaper, fine-tuned Small Language Models (SLMs) as the evaluation judge to keep continuous testing inexpensive.
+* **Enterprise-grade alerting** — convert non-deterministic evaluation scores into statistical thresholds in your existing APM pipelines, turning abstract AI-quality metrics into actionable uptime alerts.
+
+## Use cases [#use-cases]
+
+### Guard against third-party model regressions [#model-regressions]
+
+Run a consistent benchmark suite against live production endpoints to detect silent foundation-model updates that shift formatting, verbosity, or accuracy. A tiered strategy — a small daily smoke test that escalates to the full benchmark only on failure — keeps volume and cost low, while deterministic JSON-schema validation plus rolling-average statistical alerting catches real regressions without paging on minor, non-deterministic phrasing changes.
+
+### Gate model changes in CI/CD (model-as-code) [#cicd-gating]
+
+Shift the same golden dataset and eval harness left, bound to a deployment event instead of a clock. Webhook-triggered synthetics run the golden dataset against a candidate model *before* it serves traffic; Terraform-managed checks combine schema validation with LLM-as-a-judge evaluations and write results back to your model registry (such as MLflow or Hugging Face) to block failing promotions. The gate covers regressions *you* introduce at promotion; the continuous production monitor covers the silent vendor-side updates a gate structurally cannot see.
+
+### Continuously test guardrails and content safety [#guardrails]
+
+Deploy synthetic red-team prompts — jailbreak, toxicity, and PII-extraction attempts — against the live LLM or RAG endpoint to catch guardrail failures before a real user encounters them. When an adversarial prompt bypasses safety filters, trigger high-priority alerts into your existing security pipelines (such as a SIEM) to dynamically audit compliance and close exposures before a malicious actor can.
+
+### Verify RAG data freshness against vendor SLAs [#rag-freshness]
+
+Run daily synthetic queries to confirm downstream LLMs can retrieve and reference newly updated or migrated records. Data-engineering tools confirm that a migration succeeded, but not whether a prompt template is clipping context or embeddings are misaligned. Lightweight regex validation for deterministic identifiers — an updated SKU or policy number — confirms end-to-end freshness within your SLA.
+
+### Detect live RAG degradation from vector-database deterioration [#rag-degradation]
+
+Monitor the search precision of your vector database (such as Pinecone or Milvus) under heavy concurrent load and frequent re-indexing, both of which can silently erode retrieval quality. Split signals into live production index checks (performance and score-drift) and isolated namespace queries that measure Precision and Recall against a stable golden corpus — so you catch degraded retrieval before it ruins the final generation.
+
+## Related pages [#related]
+
+* [Synthetic monitoring use cases](/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases/)
+* [New Relic AI monitoring](/docs/ai-monitoring/intro-to-ai-monitoring/)
+* [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/)
+
+---
+
+## Contribution [#contributing]
+
+<Callout variant="important" title="Remove before publishing">
+  Early GTM-enablement draft. Validate the positioning and claims with product and GTM, then delete this section and the draft banner before publishing.
+</Callout>


### PR DESCRIPTION
**Placeholder / GTM-enablement draft** for a **Synthetic monitoring for generative AI applications** guide, to help go-to-market communicate the value prop of synthetics for AI use cases: guard against third-party model regressions, gate model changes in CI/CD (model-as-code), continuously test guardrails / content safety, verify RAG data freshness against vendor SLAs, and detect live RAG degradation from vector-DB deterioration.

Page only; its **Guides** nav entry is added in #25052 (the nav-owning PR, deploys first). Draft.