### PR TITLE
chore(deps): bump gatsby-theme-newrelic to 9.17.1 (search locale fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.17.0",
+    "@newrelic/gatsby-theme-newrelic": "9.17.1",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,10 +3383,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.17.0":
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.17.0.tgz#9539b298e1966cc8f3f5ef61291a2c822c44a9ff"
-  integrity sha512-xFZEchex+j1GlfsL1EdBl6doizUZhHlBCaRTJAmpTZygAR+/H/2YpD6rlNpbQdyMWCx/h1smzLY424nuNBjTKw==
+"@newrelic/gatsby-theme-newrelic@9.17.1":
+  version "9.17.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.17.1.tgz#44541fea9c5848305e41644310c899db76071946"
+  integrity sha512-pWinx9u6XsfBJEGgkZ6Tm5BSIb+4kiO1AiXJmmWSnn8gI6pbHaAbTyZAli5BzYPDYxwrFmM66HpGoOSjkw3YQw==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Summary

Bumps `@newrelic/gatsby-theme-newrelic` **9.17.0 → 9.17.1** to pull in the search locale fix ([theme #1176](https://github.com/newrelic/gatsby-theme-newrelic/pull/1176)).

### Why

On localized sites (e.g. `/fr/`), the header search typeahead called the SearchGPT `suggest` API with the correct `language=fr`, but pressing **Enter** navigated to an unlocalized `/search-results/` path — dropping the `/fr/` prefix, landing on the English results page, and scoping the actual `search` query to `language=en`. 9.17.1 routes those navigations (header Enter/submit, recent-query links, 404-page search) through `localizePath`, so the locale prefix is preserved and this page resolves the correct language.

No code changes needed in docs-website — the fix is entirely in the theme. `search-results.js` already reads the locale via `useLocale()` + `localeToSearchLanguage()`; it now receives `fr` instead of `en` when reached from a localized site.

### Diff

- `package.json`: `9.17.0` → `9.17.1`
- `yarn.lock`: resolved to `9.17.1`

### Testing

- Confirmed the published 9.17.1 artifact contains the `localizePath` fix in `GlobalSearch.js`, `SearchDropdown/SearchDropdown.js`, and `pages/404.js`.
- `eslint src/pages/search-results.js` passes.
- `yarn install` resolves cleanly to 9.17.1 (lockfile updated, no lingering 9.17.0 refs).
- Local `gatsby develop` smoke test was inconclusive on this machine (port conflicts), but no dependency/resolution errors surfaced — deploy preview will exercise the full build.
- Runtime search is CORS-scoped to `docs.newrelic.com`, so end-to-end locale behavior (Enter on `/fr/` → `/fr/search-results/` → `language=fr`) is verified on the deploy preview / production, not localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
