### PR TITLE
[LENS]: Added callout for data center specific data fetching

### DIFF
--- a/src/content/docs/new-relic-lens/overview.mdx
+++ b/src/content/docs/new-relic-lens/overview.mdx
@@ -60,6 +60,10 @@ Using <DNT>Lens</DNT> involves the following steps:
     * **Spreadsheets**: <DNT>Google Sheets</DNT>
     * **Data lakes**: <DNT>Iceberg</DNT>
     * **Metrics and monitoring**: <DNT>Prometheus</DNT>, <DNT>AWS CloudWatch</DNT>
+
+    <Callout variant="tip">
+      When you query <DNT>NRDB</DNT> data through the built-in <DNT>system connector</DNT>, <DNT>Lens</DNT> automatically routes the query to your account's primary data center: US or EU. <DNT>Lens</DNT> doesn't support querying across US and EU <DNT>NRDB</DNT> in the same query.
+    </Callout>
   </Step>
 
   <Step>

--- a/src/content/docs/new-relic-lens/overview.mdx
+++ b/src/content/docs/new-relic-lens/overview.mdx
@@ -62,7 +62,7 @@ Using <DNT>Lens</DNT> involves the following steps:
     * **Metrics and monitoring**: <DNT>Prometheus</DNT>, <DNT>AWS CloudWatch</DNT>
 
     <Callout variant="tip">
-      When you query <DNT>NRDB</DNT> data through the built-in <DNT>system connector</DNT>, <DNT>Lens</DNT> automatically routes the query to your account's primary data center: US or EU. <DNT>Lens</DNT> doesn't support querying across US and EU <DNT>NRDB</DNT> in the same query.
+      The built-in <DNT>system connector</DNT> only queries <DNT>NRDB</DNT> data from your account's primary data center: US or EU. <DNT>Lens</DNT> doesn't support querying <DNT>NRDB</DNT> data from a different data center.
     </Callout>
   </Step>
 


### PR DESCRIPTION
Adds a tip callout to the New Relic Lens overview page, under the "Set up connectors" step, clarifying that querying NRDB data through the built-in system connector automatically routes to the account's primary data center (US or EU).
Notes that Lens doesn't support querying across US and EU NRDB in the same query.



https://newrelic.slack.com/archives/C08FPSBN5V5/p1783710800867989