### PR TITLE
[NR-538543]: Restore permission definitions and fix outdated Applied …

### DIFF
--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-permissions.mdx
@@ -61,7 +61,6 @@ The UI provides detailed information about permissions for all roles, including:
 The Access Management UI shows the most current permission details for each role.
 
 <DNT>
-{/* Commented out detailed permission definitions as they are maintained in the UI and may become outdated
 
 <CollapserGroup>
   <Collapser
@@ -316,6 +315,4 @@ The Access Management UI shows the most current permission details for each role
     * <DNT>**Vulnerabilities**</DNT>: refers to the ability to view and manage vulnerabilities detected in entities.
   </Collapser>
 </CollapserGroup>
-
-*/}
 </DNT>

--- a/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
+++ b/src/content/docs/accounts/accounts-billing/new-relic-one-user-management/user-type.mdx
@@ -1017,9 +1017,9 @@ Here are additional details about permissions for some features:
 <CollapserGroup>
   <Collapser
     id="ai-capabilities"
-    title="Alerts and applied intelligence access"
+    title="Alerts access"
   >
-    Here are more details about how user type impacts access to alerting and applied intelligence features:
+    Here are more details about how user type impacts access to alerting features:
 
     <table>
       <thead>
@@ -1105,7 +1105,7 @@ Here are additional details about permissions for some features:
 
         <tr>
           <td>
-            Access to higher-level [applied intelligence](/docs/alerts-applied-intelligence/new-relic-alerts/get-started/introduction-applied-intelligence) features, including:
+            Access to higher-level [<DNT>Alerts</DNT>](/docs/alerts/overview) features, including:
 
             * Root cause analysis
             * Alert event/anomaly analysis


### PR DESCRIPTION


Uncommented the detailed permission definitions in user-permissions.mdx so the Lifecycle overrides > muting rules mapping is visible again, and updated user-type.mdx's Alerts access section to drop the retired "applied intelligence" naming in favor of Alerts.
