### PR TITLE
docs(lambda): add CloudWatch fallback to nav and fix mislinked 'configure CloudWatch' references

### DIFF
--- a/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/sdk-based-instrumentation.mdx
+++ b/src/content/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/sdk-based-instrumentation.mdx
@@ -86,7 +86,7 @@ Select your runtime below and follow the setup instructions.
     7. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
        Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs.
-       Next, you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
+       Next, you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback).
   </Collapser>
 
   <Collapser
@@ -144,7 +144,7 @@ Select your runtime below and follow the setup instructions.
     7. Configure the [environment variables](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda).
     8. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
-       Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next, you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
+       Our wrapper gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next, you'll [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback).
 
        Please see the [AWS Lambda distributed tracing example](https://github.com/newrelic/newrelic-lambda-tracer-java/tree/main/examples/distributed-tracing-example) for a complete project that illustrates common use cases such as:
 
@@ -286,7 +286,7 @@ Select your runtime below and follow the setup instructions.
 
     8. Invoke the Lambda at least once. This creates a CloudWatch log group, which must be present for the next step to work.
 
-        The New Relic decorator gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next, [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs).
+        The New Relic decorator gathers data about the Lambda execution, generates a JSON message, and logs it to CloudWatch Logs. Next, [configure CloudWatch to send those logs to New Relic](/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback).
   </Collapser>
 
   <Collapser

--- a/src/nav/serverless-function-monitoring.yml
+++ b/src/nav/serverless-function-monitoring.yml
@@ -23,8 +23,8 @@ pages:
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/sdk-based-instrumentation
           - title: Containerized instrumentation
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/containerized-images
-          # - title: CloudWatch fallback
-          #   path: /docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback
+          - title: CloudWatch fallback
+            path: /docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback
           - title: Update Lambda monitoring
             path: /docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/update-lambda-monitoring
       # - title: UI and data


### PR DESCRIPTION
## Summary

Addresses two issues from the #help-documentation request:

### 1. Add CloudWatch fallback to the left nav

The `cloud-watch-fallback.mdx` page already exists but was commented out in the nav. CloudWatch fallback is a layerless instrumentation approach that instruments Lambda/serverless applications using logs. It has been added under **AWS Lambda monitoring > Installation and configuration**, between Containerized instrumentation and Update Lambda monitoring.

### 2. Fix 3 broken 'configure CloudWatch' links in `sdk-based-instrumentation.mdx`

Three occurrences of the link text "configure CloudWatch to send those logs to New Relic" were pointing to:
- `/docs/serverless-function-monitoring/aws-lambda-monitoring/enable-lambda-monitoring/instrument-your-own/#manual-stream-logs` ❌ (layered instrumentation page)

Corrected to:
- `/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/cloud-watch-fallback` ✅

These links appear in the Go, Java, and Python SDK instrumentation sections of the page. CloudWatch log shipping is an alternative instrumentation approach, not part of the layered instrumentation page.

