### PR TITLE
docs: Document NRIA_IS_SECURE_FORWARD_ONLY as alternative forward mod…

### DIFF
--- a/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
+++ b/src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx
@@ -70,83 +70,131 @@ To install using CloudFormation:
        id="fargate-cloudformation"
        title="AWS Fargate launch type"
      >
-       1. Download the task definition example with the sidecar container to be deployed:
-          ```sh
-          curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-fargate-example-latest.json
-          ```
-          <Callout variant="tip">
-            For Graviton, replace `"cpuArchitecture": "X86_64"` with `"cpuArchitecture": "ARM64"`.
-          </Callout>
+        1. Download the task definition example with the sidecar container to be deployed:
+           ```sh
+           curl -O https://download.newrelic.com/infrastructure_agent/integrations/ecs/newrelic-infra-ecs-fargate-example-latest.json
+           ```
+           <Callout variant="tip">
+             For Graviton, replace `"cpuArchitecture": "X86_64"` with `"cpuArchitecture": "ARM64"`.
+           </Callout>
 
-       2. Add the `newrelic-infra` container in this task definition as a sidecar to the task definitions you want to monitor. In this example task, your application's containers replace the placeholder `busybox` container.
+        2. Add the `newrelic-infra` container in this task definition as a sidecar to the task definitions you want to monitor. In this example task, your application's containers replace the placeholder `busybox` container.
 
-       ### Configure NRIA_IS_FORWARD_ONLY for Fargate [#fargate-isforwardonly]
+        ### Configure infrastructure agent forward modes for Fargate [#fargate-forward-modes]
 
-       When deploying the New Relic infrastructure agent as a sidecar in Fargate environments, you must set the `NRIA_IS_FORWARD_ONLY` environment variable to `true`. This is a critical configuration for proper operation in serverless Fargate deployments.
+        When deploying the New Relic infrastructure agent as a sidecar in Fargate environments, you must configure the agent's forward mode. Fargate is a serverless compute service where AWS manages the underlying infrastructure, so the agent should not report host-level metrics or attempt to create host entities.
 
-       *Why this setting is required:*
-       * **Prevents incorrect host entity creation:** Fargate is serverless and AWS manages the underlying compute resources. Without this setting, the infrastructure agent may attempt to create host entities for non-existent infrastructure.
-       * **Avoids billing discrepancies:** Entity-based metering charges customers based on the number of monitored entities. Incorrect host entity creation causes billing issues.
-       * **Enables proper APM-to-Container linking:** This setting ensures that APM applications are correctly linked to Container entities rather than synthetic Host entities.
+        #### Recommended: NRIA_IS_FORWARD_ONLY
 
-       This example task definition includes the required Fargate configuration:
-       ```json
-       {
-         "family": "newrelic-infra-fargate",
-         "networkMode": "awsvpc",
-         "requiresCompatibilities": ["FARGATE"],
-         "cpu": "256",
-         "memory": "512",
-         "containerDefinitions": [
-           {
-             "name": "newrelic-infra",
-             "image": "newrelic/nri-ecs:latest",
-             "essential": false,
-             "environment": [
-               {
-                 "name": "NRIA_IS_FORWARD_ONLY",
-                 "value": "true"
-               },
-               {
-                 "name": "NRIA_LICENSE_KEY",
-                 "value": "your-license-key"
-               },
-               {
-                 "name": "NRIA_PASSTHROUGH_ENVIRONMENT",
-                 "value": "ECS_CONTAINER_METADATA_URI,ECS_CONTAINER_METADATA_URI_V4,FARGATE"
-               },
-               {
-                 "name": "FARGATE",
-                 "value": "true"
-               }
-             ]
-           },
-           {
-             "name": "your-application",
-             "image": "your-app-image:latest",
-             "essential": true
-           }
-         ]
-       }
-       ```
+        For most Fargate deployments, set `NRIA_IS_FORWARD_ONLY` to `true`:
 
-       <Callout variant="important">
-         The `NRIA_IS_FORWARD_ONLY=true` environment variable is **required** for all Fargate deployments. Omitting this setting can result in:
-         * Incorrect host entity creation
-         * APM-to-Container relationship failures  
-         * Billing discrepancies due to unexpected entity counts
+        ```json
+        {
+          "name": "NRIA_IS_FORWARD_ONLY",
+          "value": "true"
+        }
+        ```
 
-         If you download the example task definition, verify that this environment variable is present and set to true.
-       </Callout>
+        **Why this is recommended for Fargate:**
+        * **Prevents unnecessary host entity creation:** The infrastructure agent will not create a host entity in New Relic, since Fargate is serverless and AWS manages the underlying compute resources.
+        * **Avoids billing discrepancies:** Entity-based metering charges are based on the number of monitored entities. Incorrect host entity creation causes unexpected billing.
+        * **Enables proper APM-to-Container linking:** APM applications are correctly linked to Container entities rather than synthetic Host entities.
+        * **Focuses on integration data:** The agent collects and forwards integration data (databases, web servers, message queues, etc.) without reporting host metrics.
 
-       3. Register the task definition:
-          ```sh
-          aws ecs register-task-definition --cli-input-json file://newrelic-infra-ecs-fargate-example-latest.json
-          ```
+        #### Alternative: NRIA_IS_SECURE_FORWARD_ONLY
 
-       4. Create a service or run a task using this task definition.
-     </Collapser>
-   </CollapserGroup>
+        An alternative forward mode is `NRIA_IS_SECURE_FORWARD_ONLY`. Set this to `true` if you need host entity visibility in the New Relic UI:
+
+        ```json
+        {
+          "name": "NRIA_IS_SECURE_FORWARD_ONLY",
+          "value": "true"
+        }
+        ```
+
+        **Differences between forward modes:**
+
+        | Capability | NRIA_IS_FORWARD_ONLY | NRIA_IS_SECURE_FORWARD_ONLY |
+        | :--- | :--- | :--- |
+        | Host entity visible in NR1 | No | Yes |
+        | Host inventory visible in Infrastructure UI | No | Yes |
+        | Integration inventory | No | Yes |
+        | Integration events forwarded | Yes | Yes |
+        | Integration entities (e.g., Redis server) | No | Yes |
+        | Host metrics (CPU, Memory, Disk) | No | No |
+        | Container metadata decorated | No | Yes |
+        | Entity metadata on integration events | No | Partial |
+
+        **When to use each mode:**
+
+        * **Use `NRIA_IS_FORWARD_ONLY=true` (recommended) if:**
+          - You want to minimize entity count and billing impact
+          - You only need container and integration monitoring
+          - You don't need to see host inventory in the New Relic UI
+
+        * **Use `NRIA_IS_SECURE_FORWARD_ONLY=true` if:**
+          - You need to see host metadata and inventory information in the New Relic UI
+          - You want integration entities to appear in the Infrastructure UI
+          - Entity count is not a concern
+
+        *Example task definition with required Fargate configuration:*
+        ```json
+        {
+          "family": "newrelic-infra-fargate",
+          "networkMode": "awsvpc",
+          "requiresCompatibilities": ["FARGATE"],
+          "cpu": "256",
+          "memory": "512",
+          "containerDefinitions": [
+            {
+              "name": "newrelic-infra",
+              "image": "newrelic/nri-ecs:latest",
+              "essential": false,
+              "environment": [
+                {
+                  "name": "NRIA_IS_FORWARD_ONLY",
+                  "value": "true"
+                },
+                {
+                  "name": "NRIA_LICENSE_KEY",
+                  "value": "your-license-key"
+                },
+                {
+                  "name": "NRIA_PASSTHROUGH_ENVIRONMENT",
+                  "value": "ECS_CONTAINER_METADATA_URI,ECS_CONTAINER_METADATA_URI_V4,FARGATE"
+                },
+                {
+                  "name": "FARGATE",
+                  "value": "true"
+                }
+              ]
+            },
+            {
+              "name": "your-application",
+              "image": "your-app-image:latest",
+              "essential": true
+            }
+          ]
+        }
+        ```
+
+        <Callout variant="important">
+          The `NRIA_IS_FORWARD_ONLY=true` environment variable is **required** for all Fargate deployments. Omitting this setting can result in:
+          * Incorrect host entity creation
+          * APM-to-Container relationship failures  
+          * Billing discrepancies due to unexpected entity counts
+
+          If you download the example task definition, verify that this environment variable is present and set to true.
+        </Callout>
+
+        3. Register the task definition:
+           ```sh
+           aws ecs register-task-definition --cli-input-json file://newrelic-infra-ecs-fargate-example-latest.json
+           ```
+
+        4. Create a service or run a task using this task definition.
+      </Collapser>
+    </CollapserGroup>
 
 When you're done, see [Next steps](#next-steps).
 


### PR DESCRIPTION
…e for Fargate comparison and use case guidance.

Add comprehensive documentation of infrastructure agent forward modes for Fargate  deployments, including NRIA_IS_SECURE_FORWARD_ONLY as an alternative to  NRIA_IS_FORWARD_ONLY with detailed capability comparison and use case guidance.

## Summary

This PR enhances the ECS Fargate integration documentation by documenting both  forward modes (NRIA_IS_FORWARD_ONLY and NRIA_IS_SECURE_FORWARD_ONLY) available  for infrastructure agent deployments in serverless Fargate environments.

## Problem Statement

The existing documentation only mentioned NRIA_IS_FORWARD_ONLY without explaining:
- Why this setting is critical for Fargate deployments
- What alternative forward modes are available
- When to use NRIA_IS_SECURE_FORWARD_ONLY instead
- The capability differences between forward modes

This gap in documentation caused confusion among customers who discovered  NRIA_IS_SECURE_FORWARD_ONLY in the agent source code but found no guidance  on when and why to use it.

## Changes

**File:** src/content/docs/infrastructure/elastic-container-service-integration/install-ecs-integration.mdx

**Section Updated:** AWS Fargate launch type (<Collapser id="fargate-cloudformation">)

### Key Additions:

1. **Renamed Section:**    - Old: "Configure NRIA_IS_FORWARD_ONLY for Fargate"    - New: "Configure infrastructure agent forward modes for Fargate"    - Rationale: Reflects the availability of multiple forward mode options

2. **Enhanced NRIA_IS_FORWARD_ONLY Documentation:**    - Clarified why this is the recommended setting for Fargate    - Explained serverless architecture implications    - Added context about entity creation and billing impact

3. **Documented NRIA_IS_SECURE_FORWARD_ONLY:**    - Introduced as an alternative mode with specific use cases    - Explained when host entity visibility in NR1 UI is needed

4. **Added Capability Comparison Table:**    - 8-row comparison table showing differences between modes:      - Host entity visibility
     - Infrastructure UI visibility
     - Integration inventory
     - Entity metadata on events
     - Host metrics collection
   - Both modes confirmed to NOT collect host metrics (appropriate for serverless)

5. **Added Use Case Guidance:**    - Clear decision tree: when to use each mode
   - Emphasis on NRIA_IS_FORWARD_ONLY=true as recommended default    - Alternative guidance for teams needing host inventory visibility

6. **Updated Example Task Definition:**    - Verified environment variable configuration
   - Added context about validation requirements

## Internal References

Sources that informed this documentation:

- https://newrelic.atlassian.net/wiki/spaces/INST/pages/2824023359/Infra+Agent+Forward+Modes    (Internal Platform Documentation: Forward Modes Capability Comparison, Last Updated 2025-03-11)

- https://newrelic.slack.com/archives/C10EE1D9P/p1747077441569019?thread_ts=1747077441.569019&cid=C10EE1D9P   (Slack: Nelson Rothermel discussion on forward mode behavior for Fargate)

## Customer Impact

:white_check_mark: **Positive Impact:**
- Customers will understand both forward mode options available for Fargate
- Clear guidance on selecting the right mode for their use case
- Reduced support tickets about NRIA_IS_SECURE_FORWARD_ONLY confusion
- Better alignment with internal forward modes documentation

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.