### PR TITLE
Add Synthetic monitoring use cases guide

### DIFF
--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -9,7 +9,7 @@ metaDescription: 'What you can monitor with New Relic synthetic monitoring, orga
 freshnessValidatedDate: never
 ---
 
-## Establish a baseline across your stack [#overview]
+## Establish a baseline across your monitoring stack [#overview]
 
 Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you find failures, slowdowns, and broken flows proactively rather than waiting for a customer to report them or for enough production traffic to expose the problem.
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -104,7 +104,7 @@ Drives a real browser with the `$browser` API (Selenium WebDriver) through multi
 </Callout>
 
 
-## An extensible monitoring platform [#programmable-monitoring]
+## Key New Relic Differentiator - The extensible synthetic monitoring platform [#programmable-monitoring]
 
 New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check on the same schedule and alerting path as your uptime monitors. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -9,17 +9,11 @@ metaDescription: 'What you can monitor with New Relic synthetic monitoring, orga
 freshnessValidatedDate: never
 ---
 
-<Callout variant="important" title="Draft for review — not yet published">
-
-  This page is a **working draft** circulated for review. Remove this callout and the [Contribution](#contributing) section before it ships.
-
-</Callout>
-
-New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.
+New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
 
 # An extensible monitoring platform [#programmable-monitoring]
 
-New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the `$http` API, and a scripted browser monitor drives a real browser with the `$browser` API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. Three capabilities turn that into a platform advantage rather than a longer checklist of built-in checks.
+New Relic synthetic monitoring offers full programmability, unrestricted modules, and native access to your own telemetry make scripted monitoring an extensible platform rather than a catalog of pre-built checks. The scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the `$http` API, and a scripted browser monitor drives a real browser with the `$browser` API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. Three capabilities turn that into a platform advantage rather than a longer checklist of built-in checks. If you can express it in code, you can monitor it.
 
 ### Bring your own code — the full npm ecosystem [#bring-your-own-code]
 
@@ -33,11 +27,6 @@ A scripted monitor can run a **NRQL query** against your New Relic data and asse
 
 Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
 
-<Callout variant="tip">
-
-  Full programmability, unrestricted modules, and native access to your own telemetry make scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
-
-</Callout>
 
 # Sample use cases [#sample-use-cases]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -124,6 +124,3 @@ A scripted API monitor can query your own New Relic data and alert on the result
 
 * **Query your data:** [Call the NerdGraph API with `$http`](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/#get-nerdgraph-example), using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), to run a NRQL query.
 * **Alert on deviations:** Use an `assertion` or similar logic to fail the check when the result crosses a threshold or deviates from a prior period.
-
-
----

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -38,6 +38,8 @@ The cheapest check you can run: a scheduled HTTP request confirming an endpoint 
   </Collapser>
 </CollapserGroup>
 
+To get started, see [Add and edit monitors](/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors/) for creating one, and [View ping monitor results](/docs/synthetics/synthetic-monitoring/using-monitors/view-ping-monitor-results/) for reading what it reports.
+
 
 ### Scripted API [#scripted-api]
 
@@ -60,6 +62,8 @@ Node.js with the `$http` API: chain requests, carry auth and state across steps,
   </Collapser>
 </CollapserGroup>
 
+To get started, see [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/) for building your first script, and [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules/) for extending it with libraries.
+
 ### Simple browser [#simple-browser]
 
 Loads your page in a real Chrome or Firefox instance, so the check runs your JavaScript, assets, CDN, and cache — not just the status code. Catches render-blocking script errors, missing bundles, and silently failing third-party tags that a ping never sees. No code required, so it's the fastest way to get real-render coverage across many pages.
@@ -79,6 +83,8 @@ Loads your page in a real Chrome or Firefox instance, so the check runs your Jav
   </Collapser>
 </CollapserGroup>
 
+To get started, see [Add and edit monitors](/docs/synthetics/synthetic-monitoring/using-monitors/add-edit-monitors/) for creating one, and [Device emulation](/docs/synthetics/synthetic-monitoring/using-monitors/device-emulation/) for testing mobile and tablet viewports.
+
 ### Scripted browser [#scripted-browser]
 
 Drives a real browser with the `$browser` API (Selenium WebDriver) through multi-step, conditional, authenticated journeys. One check validates the whole path from browser to data layer — sign-in, search, checkout, or a critical internal flow. It's the slowest and most resource-intensive monitor, so reserve it for the journeys that carry revenue and trust.
@@ -96,6 +102,8 @@ Drives a real browser with the `$browser` API (Selenium WebDriver) through multi
 
   </Collapser>
 </CollapserGroup>
+
+To get started, see [Introduction to scripted browser monitors](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/) for the basics, and the [scripted browser reference](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100/) for the full `$browser` API.
 
 <Callout variant="tip" title="Where custom code fits">
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -9,19 +9,17 @@ metaDescription: 'What you can monitor with New Relic synthetic monitoring, orga
 freshnessValidatedDate: never
 ---
 
-## Establishing a baseline for your Observability [#overview]
+Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you catch failures, slowdowns, and broken flows as early as possible.
 
-Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you find failures, slowdowns, and broken flows proactively rather than waiting for a customer to report them or for enough production traffic to expose the problem.
-
-Because those checks are consistent and always running, they give you a performance and availability baseline for every application you care about — both API endpoints and browser journeys. That baseline is what makes the rest of your observability data actionable: APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical paths work right now — overnight, in regions with little traffic, or before a release reaches users.
+Because those checks are always running, they give you a performance and availability baseline for every application you care about (both API endpoints and browser journeys). That baseline is what makes the rest of your observability data actionable. APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical paths work right now — overnight, in regions with little traffic, or before a release reaches users.
 
 ## Sample use cases [#sample-use-cases]
 
-New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors running from private locations you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.  Here you can find what you can monitor, organized by monitor type - each use case names what the monitor does and what it checks.
+New Relic synthetic monitoring spans a spectrum from lightweight uptime pings that cover availability broadly to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors running from private locations you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.
 
 ### Ping [#ping]
 
-The cheapest check you can run: a scheduled HTTP request confirming an endpoint is online and fast enough — no JavaScript, no page render. Cheap enough to run frequently across hundreds of endpoints, which makes it your foundation for broad availability and uptime reporting. It detects outages, not broken functionality, so treat it as your first signal rather than proof the app works.
+The most economical check you can run is a scheduled HTTP request confirming an endpoint is online and fast enough. Economical enough to run frequently across hundreds of endpoints, which makes it your foundation for broad availability and uptime reporting. It detects outages, not broken functionality, so treat it as your first signal rather than proof the app works.
 
 <CollapserGroup>
   <Collapser
@@ -31,9 +29,9 @@ The cheapest check you can run: a scheduled HTTP request confirming an endpoint 
 
     Common checks:
 
-    * **Endpoint reachable** — Send a request on a schedule and confirm it returns a healthy status code (a 200, or any 2xx or 3xx), with no auth or scripting.
-    * **Response-time threshold** — Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
-    * **Body string-match** — Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
+    * **Endpoint reachable:** Send a request on a schedule and confirm it returns a healthy status code (a 200, or any 2xx or 3xx), with no auth or scripting.
+    * **Response-time threshold:** Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
+    * **Body string-match:** Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
 
   </Collapser>
 </CollapserGroup>
@@ -43,7 +41,7 @@ To get started, see [Add and edit monitors](/docs/synthetics/synthetic-monitorin
 
 ### Scripted API [#scripted-api]
 
-Node.js with the `$http` API: chain requests, carry auth and state across steps, and assert on status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, `require()` your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
+Uses Node.js with the `$http` API to chain requests, carry auth and state across steps, and assert on status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, `require()` your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
 
 <CollapserGroup>
   <Collapser
@@ -53,11 +51,11 @@ Node.js with the `$http` API: chain requests, carry auth and state across steps,
 
     Common checks:
 
-    * **Network and protocol** — Open a non-HTTP connection and assert it succeeds: confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
-    * **Certificates and security** — Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
-    * **Cloud and SaaS integration** — Authenticate to AWS, Azure, or GCP and assert a resource is present — for example, confirm an S3 export object exists or read an Azure Key Vault secret.
-    * **Performance and SEO** — Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
-    * **New Relic data (NRDB/NRQL)** — Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
+    * **Network and protocol:** Open a non-HTTP connection and assert it succeeds. Confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
+    * **Certificates and security:** Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
+    * **Cloud and SaaS integration:** Authenticate to AWS, Azure, or GCP and assert a resource is present, for example, confirm an S3 export object exists or read an Azure Key Vault secret.
+    * **Performance and SEO:** Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
+    * **New Relic data (NRDB/NRQL):** Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
 
   </Collapser>
 </CollapserGroup>
@@ -66,7 +64,7 @@ To get started, see [Write synthetic API tests](/docs/synthetics/synthetic-monit
 
 ### Simple browser [#simple-browser]
 
-Loads your page in a real Chrome or Firefox instance, so the check runs your JavaScript, assets, CDN, and cache — not just the status code. Catches render-blocking script errors, missing bundles, and silently failing third-party tags that a ping never sees. No code required, so it's the fastest way to get real-render coverage across many pages.
+Loads your page in a real Chrome or Firefox instance, so the check runs your JavaScript, assets, CDN, and cache, rather than just the status code. Catches render-blocking script errors, missing bundles, and silently failing third-party tags that a ping never sees. No code required, so it's the fastest way to get real-render coverage across many pages.
 
 <CollapserGroup>
   <Collapser
@@ -76,9 +74,9 @@ Loads your page in a real Chrome or Firefox instance, so the check runs your Jav
 
     Common checks:
 
-    * **Page availability** — Open the page from global locations and confirm it loads and renders the expected content.
-    * **Content and element checks** — Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
-    * **Core Web Vitals** — Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
+    * **Page availability:** Open the page from global locations and confirm it loads and renders the expected content.
+    * **Content and element checks:** Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
+    * **Core Web Vitals:** Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
 
   </Collapser>
 </CollapserGroup>
@@ -87,7 +85,7 @@ To get started, see [Add and edit monitors](/docs/synthetics/synthetic-monitorin
 
 ### Scripted browser [#scripted-browser]
 
-Drives a real browser with the `$browser` API (Selenium WebDriver) through multi-step, conditional, authenticated journeys. One check validates the whole path from browser to data layer — sign-in, search, checkout, or a critical internal flow. It's the slowest and most resource-intensive monitor, so reserve it for the journeys that carry revenue and trust.
+Drives a real browser with the `$browser` API (Selenium WebDriver) through multi-step, conditional, authenticated journeys. One check validates the whole path from browser to data layer, such as sign-in, search, checkout, or a critical internal flow. It's the slowest and most resource-intensive monitor, so reserve it for the journeys that carry revenue and trust.
 
 <CollapserGroup>
   <Collapser
@@ -97,8 +95,8 @@ Drives a real browser with the `$browser` API (Selenium WebDriver) through multi
 
     Common checks:
 
-    * **Browser UX and content** — Drive the page to crawl its links and fail on any broken one, time a file download, or verify the text inside a downloaded PDF.
-    * **Cloud and SaaS integration** — Capture screenshots during the journey and upload them to cloud storage such as S3.
+    * **Browser UX and content:** Drive the page to crawl its links and fail on any broken one, time a file download, or verify the text inside a downloaded PDF.
+    * **Cloud and SaaS integration:** Capture screenshots during the journey and upload them to cloud storage such as S3.
 
   </Collapser>
 </CollapserGroup>
@@ -107,27 +105,27 @@ To get started, see [Introduction to scripted browser monitors](/docs/synthetics
 
 <Callout variant="tip" title="Where custom code fits">
 
-  **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules — the protocol, cloud-SDK, and document checks above are all powered that way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
+  **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules. You power the protocol, cloud-SDK, and document checks above the same way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
 
 </Callout>
 
 
-## What's different about New Relic Synthetic Monitoring? - The extensibility of the platform [#programmable-monitoring]
+## Custom code and extensibility [#programmable-monitoring]
 
 New Relic scripted monitors aren't fixed-function checkers — they're programs. If you can express it in code, you can monitor it.
 
-A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. 
+That means you can chain custom logic, query your own New Relic data, and extend monitors with your own code and modules.
 
-### Bring your own code — the full npm ecosystem [#bring-your-own-code]
+### Bring your own code [#bring-your-own-code]
 
-Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json` and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor**. That is what lets a single platform speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, and decode proprietary formats. Your monitors' reach isn't a fixed feature list — it's the entire package ecosystem plus your own code. When a new need appears, you add a dependency instead of filing a feature request or leaving the platform. Tools that restrict scripts to a fixed set of built-in libraries hit a wall the moment a check needs a protocol, SDK, or format they didn't anticipate.
+Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json`, and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor** — enough to speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, or decode proprietary formats. Your monitors' reach is the entire package ecosystem plus your own code, not a fixed feature list — so a new need means adding a dependency, not filing a feature request.
 
 ### Run it privately, inside your network [#run-privately]
 
-Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
+Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. That means exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
 
-### Get alerted on anomalies and deviations in your telemetry data [#monitor-telemetry]
+### Get alerted on telemetry anomalies [#monitor-telemetry]
 
-A scripted monitor can query your own New Relic data and assert or alert on the result: call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), and run a NRQL query — then fail the check when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
+A scripted monitor can query your own New Relic data and assert or alert on the result. Call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), and run a NRQL query. Fail the check when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data. One monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 ---

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -120,13 +120,4 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 
 A scripted monitor can query your own New Relic data and assert or alert on the result: call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), and run a NRQL query — then fail the check when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
-
-## Related pages [#related]
-
-* [Custom node modules](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)
-* [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules/)
-* [Introduction to scripted browsers](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/)
-* [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/)
-* [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
-
 ---

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -13,19 +13,19 @@ New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings t
 
 # An extensible monitoring platform [#programmable-monitoring]
 
-New Relic synthetic monitoring offers full programmability, unrestricted modules, and native access to your own telemetry make scripted monitoring an extensible platform rather than a catalog of pre-built checks. The scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the `$http` API, and a scripted browser monitor drives a real browser with the `$browser` API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. Three capabilities turn that into a platform advantage rather than a longer checklist of built-in checks. If you can express it in code, you can monitor it.
+New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check on the same schedule and alerting path as your uptime monitors. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
 
 ### Bring your own code — the full npm ecosystem [#bring-your-own-code]
 
 Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json` and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor**. That is what lets a single platform speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, and decode proprietary formats. Your monitors' reach isn't a fixed feature list — it's the entire package ecosystem plus your own code. When a new need appears, you add a dependency instead of filing a feature request or leaving the platform. Tools that restrict scripts to a fixed set of built-in libraries hit a wall the moment a check needs a protocol, SDK, or format they didn't anticipate.
 
-### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
-
-A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
-
 ### Run it privately, inside your network [#run-privately]
 
 Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
+
+### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
+
+A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 
 # Sample use cases [#sample-use-cases]
@@ -51,7 +51,7 @@ Write JavaScript with the `$http` API to chain requests, parse responses, and as
 * **Performance and SEO** — Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
 * **New Relic data (NRDB/NRQL)** — Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
 
-### No-code browser [#nocode-browser]
+### Simple browser [#nocode-browser]
 
 Record a real user journey with no code; New Relic replays it from global locations to catch broken paths, slow pages, and missing elements.
 
@@ -73,7 +73,7 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 </Callout>
 
 
-## Related pages [#related]
+# Related pages [#related]
 
 * [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
 * [Custom node modules](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -116,17 +116,17 @@ Scripted monitors let you `require()` your own modules. On [private locations](/
 
 Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
 
-### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
+### Get alerted on anomalies and deviations in your telemetry data [#monitor-telemetry]
 
 A scripted monitor can query your own New Relic data and assert or alert on the result: call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), and run a NRQL query — then fail the check when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 
 ## Related pages [#related]
 
-* [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
 * [Custom node modules](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)
 * [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules/)
 * [Introduction to scripted browsers](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/)
 * [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/)
+* [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
 
 ---

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -21,7 +21,7 @@ New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings t
 
 ### Ping [#ping]
 
-Send scheduled HTTP requests to confirm an endpoint is up, responds within budget, and returns the expected content — the cheapest way to cover availability broadly.
+Ping monitors are the lightest-weight check: they make a scheduled HTTP request to confirm an endpoint is online and answers within your latency budget, without executing JavaScript or rendering a page. That makes them cheap enough to run frequently across hundreds of endpoints, which is what makes them the right foundation for broad availability coverage and uptime reporting. Because they never load your front end, treat them as your outage-detection layer rather than proof that the application actually works for a customer.
 
 <CollapserGroup>
   <Collapser
@@ -41,7 +41,7 @@ Send scheduled HTTP requests to confirm an endpoint is up, responds within budge
 
 ### Scripted API [#scripted-api]
 
-Write JavaScript with the `$http` API to chain requests, parse responses, and assert on anything — and on private locations, `require()` your own npm modules to reach protocols and services beyond HTTP.
+Scripted API monitors run Node.js with the `$http` API, so one check can chain requests, carry authentication and state across steps, parse any response, and assert on status, payload, and timing. This is where you encode a business transaction at the service layer — a sign-in followed by a data fetch, a third-party dependency you depend on but don't control, or a JSON contract that must not drift between releases. On private locations you can also `require()` your own npm modules, which is what lets a single check reach non-HTTP protocols or call model, vector-store, and cloud APIs with the same SDKs your applications already use.
 
 <CollapserGroup>
   <Collapser
@@ -62,7 +62,7 @@ Write JavaScript with the `$http` API to chain requests, parse responses, and as
 
 ### Simple browser [#simple-browser]
 
-Record a real user journey with no code; New Relic replays it from global locations to catch broken paths, slow pages, and missing elements.
+Simple browser monitors are pre-built scripted browsers: they request your page in a real Chrome or Firefox instance, so the check runs your JavaScript, fetches your assets, and exercises your CDN and caching the way a customer's browser would. That surfaces an entire class of failures a status code can't reveal — render-blocking script errors, missing bundles, and third-party tags that fail silently. They require no code, which makes them the fastest way to get real-render coverage across many pages at once.
 
 <CollapserGroup>
   <Collapser
@@ -81,7 +81,7 @@ Record a real user journey with no code; New Relic replays it from global locati
 
 ### Scripted browser [#scripted-browser]
 
-Write JavaScript with the `$browser` API to drive complex, conditional, or authenticated journeys the recorder can't capture, extendable with your own npm modules on private locations.
+Scripted browser monitors drive a real browser through the `$browser` API (Selenium WebDriver), so you can navigate multi-step journeys, branch on what the page returns, authenticate, and assert that specific elements and resources are present. Use them for the flows where revenue and trust actually live — sign-in, search, checkout, or a critical internal admin path — because a single check validates the whole stack from the browser down to your data layer. They're also the slowest and most resource-intensive monitor to run, so choose critical paths deliberately instead of scripting everything.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -19,39 +19,83 @@ Because those checks are consistent and always running, they give you a performa
 
 What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
 
-### Simple ping [#simple-ping]
+### Ping [#ping]
 
 Send scheduled HTTP requests to confirm an endpoint is up, responds within budget, and returns the expected content — the cheapest way to cover availability broadly.
 
-* **Endpoint reachable** — Send a request on a schedule and confirm it returns a healthy status code (a 200, or any 2xx or 3xx), with no auth or scripting.
-* **Response-time threshold** — Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
-* **Body string-match** — Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
+<CollapserGroup>
+  <Collapser
+    id="ping-use-cases"
+    title="See example use cases"
+  >
+
+    Common checks:
+
+    * **Endpoint reachable** — Send a request on a schedule and confirm it returns a healthy status code (a 200, or any 2xx or 3xx), with no auth or scripting.
+    * **Response-time threshold** — Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
+    * **Body string-match** — Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
+
+  </Collapser>
+</CollapserGroup>
 
 
 ### Scripted API [#scripted-api]
 
-Write JavaScript with the `$http` API to chain requests, parse responses, and assert on anything — and `require()` your own npm modules to reach protocols and services beyond HTTP.
+Write JavaScript with the `$http` API to chain requests, parse responses, and assert on anything — and on private locations, `require()` your own npm modules to reach protocols and services beyond HTTP.
 
-* **Network and protocol** — Open a non-HTTP connection and assert it succeeds: confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
-* **Certificates and security** — Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
-* **Cloud and SaaS integration** — Authenticate to AWS, Azure, or GCP and assert a resource is present — for example, confirm an S3 export object exists or read an Azure Key Vault secret.
-* **Performance and SEO** — Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
-* **New Relic data (NRDB/NRQL)** — Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
+<CollapserGroup>
+  <Collapser
+    id="scripted-api-use-cases"
+    title="See example use cases"
+  >
 
-### Simple browser [#nocode-browser]
+    Common checks:
+
+    * **Network and protocol** — Open a non-HTTP connection and assert it succeeds: confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
+    * **Certificates and security** — Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
+    * **Cloud and SaaS integration** — Authenticate to AWS, Azure, or GCP and assert a resource is present — for example, confirm an S3 export object exists or read an Azure Key Vault secret.
+    * **Performance and SEO** — Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
+    * **New Relic data (NRDB/NRQL)** — Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
+
+  </Collapser>
+</CollapserGroup>
+
+### Simple browser [#simple-browser]
 
 Record a real user journey with no code; New Relic replays it from global locations to catch broken paths, slow pages, and missing elements.
 
-* **Page availability** — Open the page from global locations and confirm it loads and renders the expected content.
-* **Content and element checks** — Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
-* **Core Web Vitals** — Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
+<CollapserGroup>
+  <Collapser
+    id="simple-browser-use-cases"
+    title="See example use cases"
+  >
+
+    Common checks:
+
+    * **Page availability** — Open the page from global locations and confirm it loads and renders the expected content.
+    * **Content and element checks** — Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
+    * **Core Web Vitals** — Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
+
+  </Collapser>
+</CollapserGroup>
 
 ### Scripted browser [#scripted-browser]
 
-Write JavaScript with the `$browser` API to drive complex, conditional, or authenticated journeys the recorder can't capture, extendable with your own npm modules.
+Write JavaScript with the `$browser` API to drive complex, conditional, or authenticated journeys the recorder can't capture, extendable with your own npm modules on private locations.
 
-* **Browser UX and content** — Drive the page to crawl its links and fail on any broken one, time a file download, or verify the text inside a downloaded PDF.
-* **Cloud and SaaS integration** — Capture screenshots during the journey and upload them to cloud storage such as S3.
+<CollapserGroup>
+  <Collapser
+    id="scripted-browser-use-cases"
+    title="See example use cases"
+  >
+
+    Common checks:
+
+    * **Browser UX and content** — Drive the page to crawl its links and fail on any broken one, time a file download, or verify the text inside a downloaded PDF.
+    * **Cloud and SaaS integration** — Capture screenshots during the journey and upload them to cloud storage such as S3.
+
+  </Collapser>
+</CollapserGroup>
 
 <Callout variant="tip" title="Where custom code fits">
 
@@ -60,7 +104,7 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 </Callout>
 
 
-New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
+New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors running from private locations you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
 
 ## An extensible monitoring platform [#programmable-monitoring]
 
@@ -76,7 +120,7 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 
 ### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
 
-A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
+A scripted monitor can query your own New Relic data and assert or alert on the result: call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), and run a NRQL query — then fail the check when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 
 ## Related pages [#related]

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -108,9 +108,7 @@ Scripted API and scripted browser monitors run your JavaScript, so you can use `
 
 ## Custom code and extensibility [#programmable-monitoring]
 
-New Relic scripted monitors aren't fixed-function checkers — they're programs. If you can express it in code, you can monitor it.
-
-That means you can chain custom logic, query your own New Relic data, and extend monitors with your own code and modules.
+New Relic scripted monitors aren't fixed-function checkers — they're programs. If you can express it in code, you can monitor it. That means you can chain custom logic, query your own New Relic data, and extend monitors with your own code and modules.
 
 ### Bring your own code [#bring-your-own-code]
 
@@ -122,7 +120,7 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 
 ### Get alerted on telemetry anomalies [#monitor-telemetry]
 
-A scripted monitor can query your own New Relic data and alert on the result:
+A scripted API monitor can query your own New Relic data and alert on the result based on the logic you define in the custom scripts:
 
 * **Query your data:** Call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), to run a NRQL query.
 * **Alert on deviations:** Fail the check when the result crosses a threshold or deviates from a prior period.

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -9,25 +9,6 @@ metaDescription: 'What you can monitor with New Relic synthetic monitoring, orga
 freshnessValidatedDate: never
 ---
 
-New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
-
-# An extensible monitoring platform [#programmable-monitoring]
-
-New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check on the same schedule and alerting path as your uptime monitors. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
-
-### Bring your own code — the full npm ecosystem [#bring-your-own-code]
-
-Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json` and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor**. That is what lets a single platform speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, and decode proprietary formats. Your monitors' reach isn't a fixed feature list — it's the entire package ecosystem plus your own code. When a new need appears, you add a dependency instead of filing a feature request or leaving the platform. Tools that restrict scripts to a fixed set of built-in libraries hit a wall the moment a check needs a protocol, SDK, or format they didn't anticipate.
-
-### Run it privately, inside your network [#run-privately]
-
-Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
-
-### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
-
-A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
-
-
 # Sample use cases [#sample-use-cases]
 
 What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
@@ -71,6 +52,25 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
   **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules — the protocol, cloud-SDK, and document checks above are all powered that way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
 
 </Callout>
+
+
+New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
+
+# An extensible monitoring platform [#programmable-monitoring]
+
+New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check on the same schedule and alerting path as your uptime monitors. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
+
+### Bring your own code — the full npm ecosystem [#bring-your-own-code]
+
+Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json` and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor**. That is what lets a single platform speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, and decode proprietary formats. Your monitors' reach isn't a fixed feature list — it's the entire package ecosystem plus your own code. When a new need appears, you add a dependency instead of filing a feature request or leaving the platform. Tools that restrict scripts to a fixed set of built-in libraries hit a wall the moment a check needs a protocol, SDK, or format they didn't anticipate.
+
+### Run it privately, inside your network [#run-privately]
+
+Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
+
+### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
+
+A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 
 # Related pages [#related]

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -41,7 +41,7 @@ To get started, see [Add and edit monitors](/docs/synthetics/synthetic-monitorin
 
 ### Scripted API [#scripted-api]
 
-Uses Node.js with the `$http` API to chain requests, carry auth and state across steps, and check status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, use `require()` for your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
+Uses Node.js with the `$http` API to chain requests, carry auth and state across steps, and use an `assertion` on status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, use `require()` for your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
 
 <CollapserGroup>
   <Collapser
@@ -51,9 +51,9 @@ Uses Node.js with the `$http` API to chain requests, carry auth and state across
 
     Common checks:
 
-    * **Network and protocol:** Open a non-HTTP connection and check that it succeeds. Confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
-    * **Certificates and security:** Call an API with a client certificate (mutual TLS) and confirm it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
-    * **Cloud and SaaS integration:** Authenticate to AWS, Azure, or GCP and confirm a resource is present, for example, confirm an S3 export object exists or read an Azure Key Vault secret.
+    * **Network and protocol:** Open a non-HTTP connection and use `assert` to ensure that it succeeds. Confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
+    * **Certificates and security:** Call an API with a client certificate (mutual TLS) and use `assert` to ensure that it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
+    * **Cloud and SaaS integration:** Authenticate to AWS, Azure, or GCP and use `assert` to ensure that a resource is present, for example, confirm an S3 export object exists or read an Azure Key Vault secret.
     * **Performance and SEO:** Run a <DNT>Lighthouse</DNT> audit through the <DNT>PageSpeed</DNT> API and record the scores, or pull <DNT>Search Console</DNT> metrics on a schedule.
     * **New Relic data (NRDB/NRQL):** Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
 
@@ -75,7 +75,7 @@ Loads your page in a real Chrome or Firefox instance, so the check runs your Jav
     Common checks:
 
     * **Page availability:** Open the page from global locations and confirm it loads and renders the expected content.
-    * **Content and element checks:** Confirm that a specific element or text is present, such as the "Add to cart" button on a product page.
+    * **Content and element checks:** Use `assert` to ensure that a specific element or text is present, such as the "Add to cart" button on a product page.
     * **Core Web Vitals:** Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
 
   </Collapser>
@@ -125,7 +125,7 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 A scripted monitor can query your own New Relic data and alert on the result:
 
 * **Query your data:** Call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), to run a NRQL query.
-* **Alert on deviations:** Fail the check when the result crosses a threshold or deviates from a prior period.
+* **Alert on deviations:** Use an `assertion` or similar logic to fail the check when the result crosses a threshold or deviates from a prior period.
 
 This closes the loop between synthetic checks and your observability data — one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -21,7 +21,7 @@ New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings t
 
 ### Ping [#ping]
 
-Ping monitors are the lightest-weight check: they make a scheduled HTTP request to confirm an endpoint is online and answers within your latency budget, without executing JavaScript or rendering a page. That makes them cheap enough to run frequently across hundreds of endpoints, which is what makes them the right foundation for broad availability coverage and uptime reporting. Because they never load your front end, treat them as your outage-detection layer rather than proof that the application actually works for a customer.
+The cheapest check you can run: a scheduled HTTP request confirming an endpoint is online and fast enough — no JavaScript, no page render. Cheap enough to run frequently across hundreds of endpoints, which makes it your foundation for broad availability and uptime reporting. It detects outages, not broken functionality, so treat it as your first signal rather than proof the app works.
 
 <CollapserGroup>
   <Collapser
@@ -41,7 +41,7 @@ Ping monitors are the lightest-weight check: they make a scheduled HTTP request 
 
 ### Scripted API [#scripted-api]
 
-Scripted API monitors run Node.js with the `$http` API, so one check can chain requests, carry authentication and state across steps, parse any response, and assert on status, payload, and timing. This is where you encode a business transaction at the service layer — a sign-in followed by a data fetch, a third-party dependency you depend on but don't control, or a JSON contract that must not drift between releases. On private locations you can also `require()` your own npm modules, which is what lets a single check reach non-HTTP protocols or call model, vector-store, and cloud APIs with the same SDKs your applications already use.
+Node.js with the `$http` API: chain requests, carry auth and state across steps, and assert on status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, `require()` your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
 
 <CollapserGroup>
   <Collapser
@@ -62,7 +62,7 @@ Scripted API monitors run Node.js with the `$http` API, so one check can chain r
 
 ### Simple browser [#simple-browser]
 
-Simple browser monitors are pre-built scripted browsers: they request your page in a real Chrome or Firefox instance, so the check runs your JavaScript, fetches your assets, and exercises your CDN and caching the way a customer's browser would. That surfaces an entire class of failures a status code can't reveal — render-blocking script errors, missing bundles, and third-party tags that fail silently. They require no code, which makes them the fastest way to get real-render coverage across many pages at once.
+Loads your page in a real Chrome or Firefox instance, so the check runs your JavaScript, assets, CDN, and cache — not just the status code. Catches render-blocking script errors, missing bundles, and silently failing third-party tags that a ping never sees. No code required, so it's the fastest way to get real-render coverage across many pages.
 
 <CollapserGroup>
   <Collapser
@@ -81,7 +81,7 @@ Simple browser monitors are pre-built scripted browsers: they request your page 
 
 ### Scripted browser [#scripted-browser]
 
-Scripted browser monitors drive a real browser through the `$browser` API (Selenium WebDriver), so you can navigate multi-step journeys, branch on what the page returns, authenticate, and assert that specific elements and resources are present. Use them for the flows where revenue and trust actually live — sign-in, search, checkout, or a critical internal admin path — because a single check validates the whole stack from the browser down to your data layer. They're also the slowest and most resource-intensive monitor to run, so choose critical paths deliberately instead of scripting everything.
+Drives a real browser with the `$browser` API (Selenium WebDriver) through multi-step, conditional, authenticated journeys. One check validates the whole path from browser to data layer — sign-in, search, checkout, or a critical internal flow. It's the slowest and most resource-intensive monitor, so reserve it for the journeys that carry revenue and trust.
 
 <CollapserGroup>
   <Collapser

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -9,7 +9,13 @@ metaDescription: 'What you can monitor with New Relic synthetic monitoring, orga
 freshnessValidatedDate: never
 ---
 
-# Sample use cases [#sample-use-cases]
+## Establish a baseline across your stack [#overview]
+
+Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you find failures, slowdowns, and broken flows proactively rather than waiting for a customer to report them or for enough production traffic to expose the problem.
+
+Because those checks are consistent and always running, they give you a performance and availability baseline for every application you care about — both API endpoints and browser journeys. That baseline is what makes the rest of your observability data actionable: APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical paths work right now — overnight, in regions with little traffic, or before a release reaches users. Use the same checks to drive [alerts](/docs/synthetics/synthetic-monitoring/using-monitors/alerts-synthetic-monitoring/), report on uptime and [SLAs](/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics/), [compare synthetic timings against real-user data](/docs/synthetics/synthetic-monitoring/administration/compare-page-load-performance-browser-synthetic-monitoring/), and catch third-party, DNS, and certificate problems that live outside your own code.
+
+## Sample use cases [#sample-use-cases]
 
 What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
 
@@ -56,7 +62,7 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 
 New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
 
-# An extensible monitoring platform [#programmable-monitoring]
+## An extensible monitoring platform [#programmable-monitoring]
 
 New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check on the same schedule and alerting path as your uptime monitors. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
 
@@ -73,7 +79,7 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 
-# Related pages [#related]
+## Related pages [#related]
 
 * [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
 * [Custom node modules](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -9,7 +9,7 @@ metaDescription: 'What you can monitor with New Relic synthetic monitoring, orga
 freshnessValidatedDate: never
 ---
 
-## Establish a baseline across your monitoring stack [#overview]
+## Establishing a baseline for your Observability [#overview]
 
 Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you find failures, slowdowns, and broken flows proactively rather than waiting for a customer to report them or for enough production traffic to expose the problem.
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -104,7 +104,7 @@ Drives a real browser with the `$browser` API (Selenium WebDriver) through multi
 </Callout>
 
 
-## What's different? - The extensibility of the platform [#programmable-monitoring]
+## What's different about New Relic Synthetic Monitoring? - The extensibility of the platform [#programmable-monitoring]
 
 New Relic scripted monitors aren't fixed-function checkers — they're programs. If you can express it in code, you can monitor it.
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -41,7 +41,7 @@ To get started, see [Add and edit monitors](/docs/synthetics/synthetic-monitorin
 
 ### Scripted API [#scripted-api]
 
-Uses Node.js with the `$http` API to chain requests, carry auth and state across steps, and assert on status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, `require()` your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
+Uses Node.js with the `$http` API to chain requests, carry auth and state across steps, and check status, payload, and timing. Use it to encode a real business transaction at the service layer, or to watch a third-party dependency you rely on but don't control. On private locations, use `require()` for your own modules to reach non-HTTP protocols or call model, vector-store, and cloud APIs with your existing SDKs.
 
 <CollapserGroup>
   <Collapser
@@ -51,10 +51,10 @@ Uses Node.js with the `$http` API to chain requests, carry auth and state across
 
     Common checks:
 
-    * **Network and protocol:** Open a non-HTTP connection and assert it succeeds. Confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
-    * **Certificates and security:** Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
-    * **Cloud and SaaS integration:** Authenticate to AWS, Azure, or GCP and assert a resource is present, for example, confirm an S3 export object exists or read an Azure Key Vault secret.
-    * **Performance and SEO:** Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
+    * **Network and protocol:** Open a non-HTTP connection and check that it succeeds. Confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
+    * **Certificates and security:** Call an API with a client certificate (mutual TLS) and confirm it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
+    * **Cloud and SaaS integration:** Authenticate to AWS, Azure, or GCP and confirm a resource is present, for example, confirm an S3 export object exists or read an Azure Key Vault secret.
+    * **Performance and SEO:** Run a <DNT>Lighthouse</DNT> audit through the <DNT>PageSpeed</DNT> API and record the scores, or pull <DNT>Search Console</DNT> metrics on a schedule.
     * **New Relic data (NRDB/NRQL):** Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
 
   </Collapser>
@@ -75,7 +75,7 @@ Loads your page in a real Chrome or Firefox instance, so the check runs your Jav
     Common checks:
 
     * **Page availability:** Open the page from global locations and confirm it loads and renders the expected content.
-    * **Content and element checks:** Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
+    * **Content and element checks:** Confirm that a specific element or text is present, such as the "Add to cart" button on a product page.
     * **Core Web Vitals:** Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
 
   </Collapser>
@@ -103,11 +103,7 @@ Drives a real browser with the `$browser` API (Selenium WebDriver) through multi
 
 To get started, see [Introduction to scripted browser monitors](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/) for the basics, and the [scripted browser reference](/docs/synthetics/synthetic-monitoring/scripting-monitors/synthetic-scripted-browser-reference-monitor-versions-chrome-100/) for the full `$browser` API.
 
-<Callout variant="tip" title="Where custom code fits">
-
-  **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules. You power the protocol, cloud-SDK, and document checks above the same way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
-
-</Callout>
+Scripted API and scripted browser monitors run your JavaScript, so you can use `require()` on your own npm modules. You power the protocol, cloud-SDK, and document checks above the same way. On private locations, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
 
 
 ## Custom code and extensibility [#programmable-monitoring]
@@ -118,7 +114,7 @@ That means you can chain custom logic, query your own New Relic data, and extend
 
 ### Bring your own code [#bring-your-own-code]
 
-Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json`, and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor** — enough to speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, or decode proprietary formats. Your monitors' reach is the entire package ecosystem plus your own code, not a fixed feature list — so a new need means adding a dependency, not filing a feature request.
+Scripted monitors let you use `require()` on your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json`, and the job manager runs `npm install` at startup, so any npm package or internal library becomes part of your monitor — enough to speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, or decode proprietary formats. Your monitors' reach is the entire package ecosystem plus your own code, not a fixed feature list — so a new need means adding a dependency, not filing a feature request.
 
 ### Run it privately, inside your network [#run-privately]
 
@@ -126,6 +122,11 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 
 ### Get alerted on telemetry anomalies [#monitor-telemetry]
 
-A scripted monitor can query your own New Relic data and assert or alert on the result. Call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), and run a NRQL query. Fail the check when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data. One monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
+A scripted monitor can query your own New Relic data and alert on the result:
+
+* **Query your data:** Call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), to run a NRQL query.
+* **Alert on deviations:** Fail the check when the result crosses a threshold or deviates from a prior period.
+
+This closes the loop between synthetic checks and your observability data — one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 ---

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -17,7 +17,7 @@ Because those checks are consistent and always running, they give you a performa
 
 ## Sample use cases [#sample-use-cases]
 
-What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
+New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors running from private locations you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.  Here you can find what you can monitor, organized by monitor type - each use case names what the monitor does and what it checks.
 
 ### Ping [#ping]
 
@@ -103,8 +103,6 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 
 </Callout>
 
-
-New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors running from private locations you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network. 
 
 ## An extensible monitoring platform [#programmable-monitoring]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -1,0 +1,118 @@
+---
+title: Synthetic monitoring use cases
+tags:
+  - Synthetics
+  - Synthetic monitoring
+  - Scripting monitors
+  - Private locations
+metaDescription: 'What you can monitor with New Relic synthetic monitoring, organized by monitor type — from lightweight ping uptime checks to fully scripted API and browser journeys.'
+freshnessValidatedDate: never
+---
+
+<Callout variant="important" title="Draft for review — not yet published">
+
+  This page is a **working draft** circulated for review. Remove this callout and the [Contribution](#contributing) section before it ships.
+
+</Callout>
+
+New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.
+
+## An extensible monitoring platform [#programmable-monitoring]
+
+New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the `$http` API, and a scripted browser monitor drives a real browser with the `$browser` API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. Three capabilities turn that into a platform advantage rather than a longer checklist of built-in checks.
+
+### Bring your own code — the full npm ecosystem [#bring-your-own-code]
+
+Scripted monitors let you `require()` your own modules. On [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/), you mount a directory containing a `package.json` and the job manager runs `npm install` at startup, so **any npm package or internal library becomes part of your monitor**. That is what lets a single platform speak non-HTTP protocols (TCP, WebSocket, MQTT, LDAP, SFTP, SMTP), call cloud-provider SDKs, and decode proprietary formats. Your monitors' reach isn't a fixed feature list — it's the entire package ecosystem plus your own code. When a new need appears, you add a dependency instead of filing a feature request or leaving the platform. Tools that restrict scripts to a fixed set of built-in libraries hit a wall the moment a check needs a protocol, SDK, or format they didn't anticipate.
+
+### Monitor your own telemetry, not just endpoints [#monitor-telemetry]
+
+A scripted monitor can run a **NRQL query** against your New Relic data and assert or alert on the result — for example, run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period. This closes the loop between synthetic checks and your observability data: one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
+
+### Run it privately, inside your network [#run-privately]
+
+Because scripted monitors run on the synthetics job manager, you can execute them from [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network — exercising internal systems with your own modules, installed from your own registry, without exposing anything to the public internet.
+
+<Callout variant="tip">
+
+  Full programmability, unrestricted modules, and native access to your own telemetry make scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
+
+</Callout>
+
+## Sample use cases [#sample-use-cases]
+
+What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
+
+### Simple ping [#simple-ping]
+
+Send scheduled HTTP requests to confirm an endpoint is up, responds within budget, and returns the expected content — the cheapest way to cover availability broadly.
+
+* **Endpoint reachable** — Send a request on a schedule and confirm it returns a healthy status code (a 200, or any 2xx or 3xx), with no auth or scripting.
+* **Response-time threshold** — Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
+* **Body string-match** — Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
+
+### Advanced ping [#advanced-ping]
+
+Go beyond a basic ping to validate TLS certificates and trace the network path, so you can localize where availability or latency breaks down.
+
+* **SSL certificate validity** — Verify the TLS certificate is valid and warn before it expires, for example within 30 days.
+* **Traceroute** — Trace the network path to the endpoint and record per-hop latency to localize where delays or drops occur.
+
+### No-code API [#nocode-api]
+
+Point and click to build API checks that assert on status, latency, headers, and JSON — no code required.
+
+* **Reliability and availability** — Call the API on a schedule and assert it returns a healthy status within your latency budget, and read rate-limit headers to catch quota exhaustion.
+* **Security and compliance** — Send an authenticated request and assert it doesn't return 401 (catching key rotation or expiry), then verify TLS certificate validity and CORS headers.
+* **Performance and SLAs** — Fail the check when round-trip latency exceeds your SLA budget, and record usage metrics to NRDB for trend tracking.
+* **Contract and schema** — Assert the response matches its expected schema — required fields, types, and values — so a breaking change fails the monitor.
+
+### Scripted API [#scripted-api]
+
+Write JavaScript with the `$http` API to chain requests, parse responses, and assert on anything — and `require()` your own npm modules to reach protocols and services beyond HTTP.
+
+* **Network and protocol** — Open a non-HTTP connection and assert it succeeds: confirm a TCP or TLS port is open, resolve a DNS record, exchange WebSocket or MQTT messages, or reach LDAP, FTP/SFTP, and SMTP.
+* **Certificates and security** — Call an API with a client certificate (mutual TLS) and assert it authenticates, validate the certificate embedded in SAML metadata, or check your mail IPs against blocklists.
+* **Cloud and SaaS integration** — Authenticate to AWS, Azure, or GCP and assert a resource is present — for example, confirm an S3 export object exists or read an Azure Key Vault secret.
+* **Performance and SEO** — Run a Lighthouse audit through the PageSpeed API and record the scores, or pull Search Console metrics on a schedule.
+* **New Relic data (NRDB/NRQL)** — Run a NRQL query from the monitor and alert when the result crosses a threshold or deviates from a prior period.
+
+### No-code browser [#nocode-browser]
+
+Record a real user journey with no code; New Relic replays it from global locations to catch broken paths, slow pages, and missing elements.
+
+* **Page availability** — Open the page from global locations and confirm it loads and renders the expected content.
+* **Content and element checks** — Assert that a specific element or text is present, such as the "Add to cart" button on a product page.
+* **Core Web Vitals** — Measure page-load time and fail the check when it exceeds your budget, for example 3 seconds.
+
+### Scripted browser [#scripted-browser]
+
+Write JavaScript with the `$browser` API to drive complex, conditional, or authenticated journeys the recorder can't capture, extendable with your own npm modules.
+
+* **Browser UX and content** — Drive the page to crawl its links and fail on any broken one, time a file download, or verify the text inside a downloaded PDF.
+* **Cloud and SaaS integration** — Capture screenshots during the journey and upload them to cloud storage such as S3.
+
+<Callout variant="tip" title="Where custom code fits">
+
+  **Scripted API** and **scripted browser** monitors run your JavaScript, so you can `require()` your own npm modules — the protocol, cloud-SDK, and document checks above are all powered that way. On **private locations**, those modules install from your own registry and run inside your network. Store any keys or tokens as [secure credentials](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/).
+
+</Callout>
+
+
+## Related pages [#related]
+
+* [Private location capabilities](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/)
+* [Custom node modules](/docs/synthetics/synthetic-monitoring/private-locations/job-manager-configuration/#custom-modules)
+* [Import Node.js modules](/docs/synthetics/synthetic-monitoring/scripting-monitors/import-nodejs-modules/)
+* [Introduction to scripted browsers](/docs/synthetics/synthetic-monitoring/scripting-monitors/introduction-scripted-browser-monitors/)
+* [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/)
+
+---
+
+## Contribution [#contributing]
+
+<Callout variant="important" title="Remove before publishing">
+
+  Draft circulated for review. Delete this section and the draft banner before publishing.
+
+</Callout>

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -11,7 +11,7 @@ freshnessValidatedDate: never
 
 Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you catch failures, slowdowns, and broken flows as early as possible.
 
-Because those checks are always running, they give you a performance and availability baseline for every application you care about (both API endpoints and browser journeys). That baseline is what makes the rest of your observability data actionable. APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical paths work right now — overnight, in regions with little traffic, or before a release reaches users.
+Because those checks are always running, they provide availability, functionality, and a performance baseline for your applications (both API endpoints and browser journeys). APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical functionality works as expected at all times, including in regions with little traffic or before a release reaches users.
 
 ## Sample use cases [#sample-use-cases]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -120,11 +120,10 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 
 ### Get alerted on telemetry anomalies [#monitor-telemetry]
 
-A scripted API monitor can query your own New Relic data and alert on the result based on the logic you define in the custom scripts:
+A scripted API monitor can query your own New Relic data and alert on the result based on the logic you define in the custom scripts, providing coverage for scenarios that don't fit within alert conditions like querying data over a longer period of time or comparing results with a previous time period:
 
-* **Query your data:** Call the NerdGraph API with `$http`, using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), to run a NRQL query.
-* **Alert on deviations:** Fail the check when the result crosses a threshold or deviates from a prior period.
+* **Query your data:** [Call the NerdGraph API with `$http`](https://docs.newrelic.com/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/#get-nerdgraph-example), using an API key stored as a [secure credential](/docs/synthetics/synthetic-monitoring/using-monitors/store-secure-credentials-scripted-browsers-api-tests/), to run a NRQL query.
+* **Alert on deviations:** Use assert or similar logic to fail the check when the result crosses a threshold or deviates from a prior period.
 
-This closes the loop between synthetic checks and your observability data — one monitor can watch a business metric, an error rate, or a data-freshness signal on the same schedule and alerting path as your uptime checks.
 
 ---

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -13,7 +13,7 @@ freshnessValidatedDate: never
 
 Synthetic monitoring runs automated, scheduled checks against your applications and endpoints from locations you choose — public locations New Relic operates around the world, or [private locations](/docs/synthetics/synthetic-monitoring/guides/private-location-capabilities/) inside your own network. Each monitor performs a real request or user journey at a fixed interval and reports the result, so you find failures, slowdowns, and broken flows proactively rather than waiting for a customer to report them or for enough production traffic to expose the problem.
 
-Because those checks are consistent and always running, they give you a performance and availability baseline for every application you care about — both API endpoints and browser journeys. That baseline is what makes the rest of your observability data actionable: APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical paths work right now — overnight, in regions with little traffic, or before a release reaches users. Use the same checks to drive [alerts](/docs/synthetics/synthetic-monitoring/using-monitors/alerts-synthetic-monitoring/), report on uptime and [SLAs](/docs/synthetics/synthetic-monitoring/pages/synthetic-monitoring-aggregate-monitor-metrics/), [compare synthetic timings against real-user data](/docs/synthetics/synthetic-monitoring/administration/compare-page-load-performance-browser-synthetic-monitoring/), and catch third-party, DNS, and certificate problems that live outside your own code.
+Because those checks are consistent and always running, they give you a performance and availability baseline for every application you care about — both API endpoints and browser journeys. That baseline is what makes the rest of your observability data actionable: APM and browser monitoring tell you how real traffic behaved, while synthetic monitors tell you whether your critical paths work right now — overnight, in regions with little traffic, or before a release reaches users.
 
 ## Sample use cases [#sample-use-cases]
 
@@ -104,9 +104,11 @@ Drives a real browser with the `$browser` API (Selenium WebDriver) through multi
 </Callout>
 
 
-## Key New Relic Differentiator - The extensible synthetic monitoring platform [#programmable-monitoring]
+## What's different? - The extensibility of the platform [#programmable-monitoring]
 
-New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check on the same schedule and alerting path as your uptime monitors. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. If you can express it in code, you can monitor it.
+New Relic scripted monitors aren't fixed-function checkers — they're programs. If you can express it in code, you can monitor it.
+
+A scripted API monitor runs Node.js with the $http API, and a scripted browser monitor drives a real browser with the $browser API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. You can also query your own New Relic data through NerdGraph from inside a check, turning a business metric or error rate into a synthetic check. On private locations you can go further still: install your own npm modules and internal libraries, so a monitor can speak any protocol or handle any format your code can. That combination makes scripted monitoring an extensible platform rather than a catalog of pre-built checks. 
 
 ### Bring your own code — the full npm ecosystem [#bring-your-own-code]
 

--- a/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
+++ b/src/content/docs/synthetics/synthetic-monitoring/guides/synthetic-monitoring-use-cases.mdx
@@ -17,7 +17,7 @@ freshnessValidatedDate: never
 
 New Relic synthetic monitoring spans a spectrum: from lightweight uptime pings that cover availability broadly, to fully scripted API and browser journeys that exercise your most complex flows. On scripted monitors you can go further still, extending the runtime with your own npm modules to check almost anything reachable from your network.
 
-## An extensible monitoring platform [#programmable-monitoring]
+# An extensible monitoring platform [#programmable-monitoring]
 
 New Relic scripted monitors aren't fixed-function checkers — they're programs. A scripted API monitor runs Node.js with the `$http` API, and a scripted browser monitor drives a real browser with the `$browser` API, so you can chain steps, branch on logic, parse any response, and write arbitrary assertions. Three capabilities turn that into a platform advantage rather than a longer checklist of built-in checks.
 
@@ -39,7 +39,7 @@ Because scripted monitors run on the synthetics job manager, you can execute the
 
 </Callout>
 
-## Sample use cases [#sample-use-cases]
+# Sample use cases [#sample-use-cases]
 
 What you can monitor, organized by monitor type. Each use case names what the monitor does and what it checks.
 
@@ -51,21 +51,6 @@ Send scheduled HTTP requests to confirm an endpoint is up, responds within budge
 * **Response-time threshold** — Fail the check when the endpoint responds slower than your threshold, so latency regressions alert you early.
 * **Body string-match** — Pass only when the response body contains an expected string, such as `ok` or `"status":"healthy"`.
 
-### Advanced ping [#advanced-ping]
-
-Go beyond a basic ping to validate TLS certificates and trace the network path, so you can localize where availability or latency breaks down.
-
-* **SSL certificate validity** — Verify the TLS certificate is valid and warn before it expires, for example within 30 days.
-* **Traceroute** — Trace the network path to the endpoint and record per-hop latency to localize where delays or drops occur.
-
-### No-code API [#nocode-api]
-
-Point and click to build API checks that assert on status, latency, headers, and JSON — no code required.
-
-* **Reliability and availability** — Call the API on a schedule and assert it returns a healthy status within your latency budget, and read rate-limit headers to catch quota exhaustion.
-* **Security and compliance** — Send an authenticated request and assert it doesn't return 401 (catching key rotation or expiry), then verify TLS certificate validity and CORS headers.
-* **Performance and SLAs** — Fail the check when round-trip latency exceeds your SLA budget, and record usage metrics to NRDB for trend tracking.
-* **Contract and schema** — Assert the response matches its expected schema — required fields, types, and values — so a breaking change fails the monitor.
 
 ### Scripted API [#scripted-api]
 
@@ -108,11 +93,3 @@ Write JavaScript with the `$browser` API to drive complex, conditional, or authe
 * [Write synthetic API tests](/docs/synthetics/synthetic-monitoring/scripting-monitors/write-synthetic-api-tests/)
 
 ---
-
-## Contribution [#contributing]
-
-<Callout variant="important" title="Remove before publishing">
-
-  Draft circulated for review. Delete this section and the draft banner before publishing.
-
-</Callout>


### PR DESCRIPTION
Duplicate of #25051 with **forward-looking items removed**, so this version contains only capabilities available today.

**Removed:** the callout stating that AI and LLM endpoint monitoring "is covered in a dedicated guide" (that guide isn't published yet).

**Unchanged:** the extensible-platform section (bring your own code, monitor your own telemetry, run it privately) and the full use-case catalog by monitor type.

#25051 is intentionally left open for comparison — **only one of the two should merge**, since both touch the same file path. Nav entry for this page is in #25052, which merges first. Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)