### PR TITLE
feat(search): same-origin Netlify Function proxy for SearchGPT (v2)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@ package = "@netlify/plugin-gatsby"
 [functions]
   included_files = ["!.cache/data/datastore/data.mdb","!.cache/query-engine"]
 
+# SearchGPT search proxy: netlify/functions/searchgpt-proxy.mjs serves /v2/* (its
+# route is declared via `config.path` in the function). It injects the api-key
+# from the SEARCHGPT_API_KEY env var server-side so the key never ships to the
+# browser. The client points at it via GATSBY_SEARCHGPT_BASE_URL="/".
+
 [[headers]]
 for = "/*"
 

--- a/netlify/functions/searchgpt-proxy.mjs
+++ b/netlify/functions/searchgpt-proxy.mjs
@@ -1,0 +1,77 @@
+// Same-origin proxy for the SearchGPT REST API (v2).
+//
+// The docs search client (gatsby-theme-newrelic/src/utils/searchGPT.js) is
+// configured with GATSBY_SEARCHGPT_BASE_URL="/", so the browser calls
+// <origin>/v2/* with NO credentials. This function runs server-side, injects the
+// api-key from the SEARCHGPT_API_KEY env var (set in the Netlify UI — never in
+// the repo), and forwards the request to the SearchGPT service. Because the key
+// only exists in this server-side env, it never reaches the public client
+// bundle. This is the production counterpart of the dev proxy in the theme's
+// demo/gatsby-node.js (onCreateDevServer).
+//
+// Routing is via the exported `config.path` below, which binds the function to
+// /v2/* while preserving the original request path (no rewrite needed).
+
+const SERVICE_BASE_URL =
+  process.env.SEARCHGPT_BASE_URL ||
+  'https://support-search.service.newrelic.com';
+
+const json = (status, body) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+export default async (req) => {
+  // The API surface we proxy is read-only; reject anything but GET so this can
+  // never be turned into a write path against the service.
+  if (req.method !== 'GET') {
+    return json(405, { error: { message: 'Method not allowed' } });
+  }
+
+  const apiKey = process.env.SEARCHGPT_API_KEY;
+  if (!apiKey) {
+    // Misconfiguration (key not set in Netlify env) — fail closed and loud
+    // rather than forwarding an unauthenticated request.
+    return json(500, { error: { message: 'Search is not configured' } });
+  }
+
+  const incoming = new URL(req.url);
+
+  // Defense in depth: only forward the /v2/ search API, nothing else.
+  if (!incoming.pathname.startsWith('/v2/')) {
+    return json(404, { error: { message: 'Not found' } });
+  }
+
+  // pathname is absolute ("/v2/search"), so this resolves to
+  // <service>/v2/search?<same query>. Any api-key the client may have sent is
+  // dropped here — we only pass through the query string and set our own header.
+  const target = new URL(incoming.pathname + incoming.search, SERVICE_BASE_URL);
+
+  try {
+    const upstream = await fetch(target, {
+      method: 'GET',
+      headers: { 'api-key': apiKey },
+    });
+
+    const body = await upstream.text();
+    const contentType =
+      upstream.headers.get('content-type') || 'application/json';
+
+    // Typeahead (suggest, on every keystroke) and repeated result-page queries
+    // dominate traffic. A short shared CDN cache collapses identical GETs into
+    // far fewer upstream calls, which also keeps us under the per-principal rate
+    // limit on /v2/search (all site traffic shares this one service key).
+    return new Response(body, {
+      status: upstream.status,
+      headers: {
+        'content-type': contentType,
+        'cache-control': 'public, max-age=60, stale-while-revalidate=300',
+      },
+    });
+  } catch (err) {
+    return json(502, { error: { message: `Search proxy error: ${String(err)}` } });
+  }
+};
+
+export const config = { path: '/v2/*' };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.17.1",
+    "@newrelic/gatsby-theme-newrelic": "9.18.0",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/src/content/docs/cci/cci-pricing.mdx
+++ b/src/content/docs/cci/cci-pricing.mdx
@@ -14,9 +14,9 @@ freshnessValidatedDate: never
 
 Billing file ingest rates depend on your cloud provider:
 
-- AWS: Ingest is charged at **23 aCCUs per GB** of billing data processed.
-- Azure: Ingest is charged at **690 aCCUs per GB** of billing data processed.
-- GCP: Ingest is charged at **46 aCCUs per GB** of billing data processed.
+- AWS: Ingest is charged at 23 aCCUs per GB of billing data processed.
+- Azure: Ingest is charged at 690 aCCUs per GB of billing data processed.
+- GCP: Ingest is charged at 46 aCCUs per GB of billing data processed.
 
 ## What is billing file ingest?
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,10 +3383,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.17.1":
-  version "9.17.1"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.17.1.tgz#44541fea9c5848305e41644310c899db76071946"
-  integrity sha512-pWinx9u6XsfBJEGgkZ6Tm5BSIb+4kiO1AiXJmmWSnn8gI6pbHaAbTyZAli5BzYPDYxwrFmM66HpGoOSjkw3YQw==
+"@newrelic/gatsby-theme-newrelic@9.18.0":
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.18.0.tgz#1994a9519cbe3e34bea260312651516aacf7c5c7"
+  integrity sha512-+03eTnawojHQ0ISFxPEqCuQB/Q0IjlPwsnjS8bSgexu9Y7jZMoCIUOoQhIIj5p+93UEbDxB0DR9sOHAp6BRy6w==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Summary
- Adds `netlify/functions/searchgpt-proxy.mjs`, bound to `/v2/*` via `config.path`. It injects the `api-key` from the server-side `SEARCHGPT_API_KEY` env var and forwards to `support-search.service.newrelic.com`, so the key never ships to the browser. The client points at it via `GATSBY_SEARCHGPT_BASE_URL="/"`.
- Hardening: GET-only (405 otherwise), fail-closed 500 if the key is unset, only `/v2/*` is forwarded (404 otherwise), any client-sent `api-key` header is dropped. Responses carry a 60s shared CDN cache (`stale-while-revalidate=300`) to collapse repeated typeahead/result GETs and stay under the per-principal rate limit on the shared key.
- Bumps `@newrelic/gatsby-theme-newrelic` to `9.18.0` to pick up the matching proxy-aware client (`GATSBY_SEARCHGPT_BASE_URL` resolution + omitting `api-key` when unset) and the debounced `suggest()`.

Verified live against the `searchgpt-search-results` deploy preview: browser calls same-origin `/v2/search` and `/v2/search/suggest` with no `api-key` header, and the function proxies to the real service and returns real results (see PR #25138).

## Test plan
- [ ] Confirm `SEARCHGPT_API_KEY` is set in Netlify's Production env (server-side only, never `GATSBY_`-prefixed)
- [ ] After deploy, search on the live site and confirm requests go to same-origin `/v2/*` with no `api-key` header in the browser
- [ ] Confirm the public JS bundle contains no API key (`grep -r NRAK public/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)