### PR TITLE
Update API Gateway v1 (REST) docs for CloudWatch Metric Streams support

### DIFF
--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v1-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v1-monitoring-integration.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration
   - /docs/aws-apigateway-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-api-gateway-monitoring-integration
-freshnessValidatedDate: never
+freshnessValidatedDate: 2026-08-06
 ---
 
 <Callout variant="important">
@@ -19,7 +19,7 @@ freshnessValidatedDate: never
 [New Relic infrastructure integrations](/docs/infrastructure/introduction-infra-monitoring) include an integration for reporting your Amazon API Gateway data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
 <Callout variant="tip">
-  API Gateway v1 metrics are available exclusively through the API polling integration for Amazon API Gateway. [API Gateway v2 metrics](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v2-monitoring-integration) are streamed through CloudWatch Metric Streams.
+  API Gateway v1 (REST) metrics are available through both the [CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) and the API polling integration for Amazon API Gateway. [API Gateway v2 metrics](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v2-monitoring-integration) are also streamed through CloudWatch Metric Streams.
 </Callout>
 
 ## Features [#features]
@@ -43,7 +43,10 @@ To enable CloudWatch metrics, use either of these options:
 
 ## Activate integration [#activate]
 
-To enable this integration follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
+To enable this integration, use one of the following methods:
+
+* <DNT>**CloudWatch Metric Streams**</DNT> (recommended): follow the procedure to [set up CloudWatch Metric Streams](/docs/infrastructure/amazon-integrations/connect/aws-metric-stream-setup/).
+* <DNT>**API polling**</DNT>: follow standard procedures to [Connect AWS services to New Relic](/docs/infrastructure/infrastructure-integrations/getting-started/connect-aws-integrations-infrastructure).
 
 ## Configuration and polling [#polling]
 
@@ -58,7 +61,10 @@ Default [polling](/docs/infrastructure/amazon-integrations/aws-integrations-list
 
 To find your integration data in the infrastructure UI, go to <DNT>**[one.newrelic.com > All capabilities](https://one.newrelic.com/all-capabilities) > Infrastructure > AWS**</DNT> and select one of the API Gateway integration links.
 
-You can [query and explore your data](/docs/using-new-relic/data/understand-data/query-new-relic-data) using the `ApiGatewaySample` [event type](/docs/data-apis/understand-data/new-relic-data-types/#event-data).
+How you query your data depends on the ingest method:
+
+* <DNT>**CloudWatch Metric Streams**</DNT>: data is reported as dimensional metrics. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com/all-capabilities) > Metrics & Events**</DNT> and filter by `aws.apigateway`.
+* <DNT>**API polling**</DNT>: data is reported to the `ApiGatewaySample` [event type](/docs/data-apis/understand-data/new-relic-data-types/#event-data), which you can [query and explore](/docs/using-new-relic/data/understand-data/query-new-relic-data).
 
 For more on how to use your data, see [Understand and use integration data](/docs/infrastructure/integrations/find-use-infrastructure-integration-data).
 

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v1-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v1-monitoring-integration.mdx
@@ -9,7 +9,7 @@ redirects:
   - /docs/integrations/amazon-integrations/aws-integrations-list/aws-api-gateway-monitoring-integration
   - /docs/aws-apigateway-integration
   - /docs/infrastructure/amazon-integrations/amazon-integrations/aws-api-gateway-monitoring-integration
-freshnessValidatedDate: 2026-08-06
+freshnessValidatedDate: never
 ---
 
 <Callout variant="important">

--- a/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v1-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v1-monitoring-integration.mdx
@@ -19,7 +19,7 @@ freshnessValidatedDate: 2026-08-06
 [New Relic infrastructure integrations](/docs/infrastructure/introduction-infra-monitoring) include an integration for reporting your Amazon API Gateway data to New Relic. This document explains how to activate this integration and describes the data that can be reported.
 
 <Callout variant="tip">
-  API Gateway v1 (REST) metrics are available through both the [CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) and the API polling integration for Amazon API Gateway. [API Gateway v2 metrics](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-api-gateway-v2-monitoring-integration) are also streamed through CloudWatch Metric Streams.
+  API Gateway v1 (REST) metrics are available through both the [CloudWatch Metric Streams integration](/docs/infrastructure/amazon-integrations/aws-integrations-list/aws-metric-stream/) and the API polling integration for Amazon API Gateway.
 </Callout>
 
 ## Features [#features]


### PR DESCRIPTION
API Gateway v1 (REST) is now supported via both API polling and CloudWatch Metric Streams (previously polling only). Update the page to document both ingest paths:

- Correct the tip callout that said v1 was available exclusively via polling.
- Add the Metric Streams setup path to "Activate integration".
- Clarify how data surfaces per ingest method under "Find and use data" (dimensional metrics under aws.apigateway via Metric Streams; ApiGatewaySample events via polling).
- Set freshnessValidatedDate.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->



## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.