### PR TITLE
docs: add BigQuery Table entity to GCP BigQuery WIF docs

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
@@ -169,7 +169,7 @@ All BigQuery metrics available in GCP Cloud Monitoring are collected as dimensio
     <tr>
       <td>`gcp.bigquery.storage.stored_bytes`</td>
       <td>Bytes</td>
-      <td>Number of logical bytes stored in the table.</td>
+      <td>Number of logical bytes stored in the table. GCP labels the top 100 tables per dataset (by size) with a `table` label on this metric; the rest are grouped together with no table label.</td>
     </tr>
     <tr>
       <td>`gcp.bigquery.storage.uploaded_bytes`</td>
@@ -188,10 +188,6 @@ All BigQuery metrics available in GCP Cloud Monitoring are collected as dimensio
     </tr>
   </tbody>
 </table>
-
-<Callout variant="tip">
-  GCP labels the top 100 tables per dataset (by size) with a `table` label on `stored_bytes`; the rest are grouped together with no table label, so `stored_bytes` data may not be available for every table in large datasets.
-</Callout>
 
 For the complete list of BigQuery metrics, see [Google's BigQuery metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-bigquery).
 

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
@@ -69,6 +69,11 @@ All BigQuery metrics available in GCP Cloud Monitoring are collected as dimensio
           <td>`GCPBIGQUERYDATASET`</td>
           <td>`bigquery_dataset`</td>
         </tr>
+        <tr>
+          <td>Table</td>
+          <td>`GCPBIGQUERYTABLE`</td>
+          <td>`bigquery_table`</td>
+        </tr>
       </tbody>
     </table>
   </Collapser>
@@ -146,6 +151,35 @@ All BigQuery metrics available in GCP Cloud Monitoring are collected as dimensio
       <td>`gcp.bigquery.storage.stored_physical_bytes`</td>
       <td>Bytes</td>
       <td>Physical bytes stored in the dataset (compressed on-disk size).</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Key metrics — Table
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>Metric name</th>
+      <th style={{ width: "100px" }}>Unit</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`gcp.bigquery.storage.uploaded_bytes`</td>
+      <td>Bytes</td>
+      <td>Bytes uploaded to the table.</td>
+    </tr>
+    <tr>
+      <td>`gcp.bigquery.storage.uploaded_bytes_billed`</td>
+      <td>Bytes</td>
+      <td>Bytes billed for data uploaded to the table. Currently only the streaming API is billed.</td>
+    </tr>
+    <tr>
+      <td>`gcp.bigquery.storage.uploaded_row_count`</td>
+      <td>Count</td>
+      <td>Number of rows uploaded to the table.</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-bigquery-monitoring-integration.mdx
@@ -167,6 +167,11 @@ All BigQuery metrics available in GCP Cloud Monitoring are collected as dimensio
   </thead>
   <tbody>
     <tr>
+      <td>`gcp.bigquery.storage.stored_bytes`</td>
+      <td>Bytes</td>
+      <td>Number of logical bytes stored in the table.</td>
+    </tr>
+    <tr>
       <td>`gcp.bigquery.storage.uploaded_bytes`</td>
       <td>Bytes</td>
       <td>Bytes uploaded to the table.</td>
@@ -183,6 +188,10 @@ All BigQuery metrics available in GCP Cloud Monitoring are collected as dimensio
     </tr>
   </tbody>
 </table>
+
+<Callout variant="tip">
+  GCP labels the top 100 tables per dataset (by size) with a `table` label on `stored_bytes`; the rest are grouped together with no table label, so `stored_bytes` data may not be available for every table in large datasets.
+</Callout>
 
 For the complete list of BigQuery metrics, see [Google's BigQuery metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-bigquery).
 


### PR DESCRIPTION
## Summary
- Adds the new `GCPBIGQUERYTABLE` entity to the Workload Identity Federation (WIF) section of the Google BigQuery monitoring integration doc:
  - New row in the **Entities** table: Table / `GCPBIGQUERYTABLE` / `bigquery_table`.
  - New **Key metrics — Table** section listing `gcp.bigquery.storage.uploaded_bytes`, `gcp.bigquery.storage.uploaded_bytes_billed`, and `gcp.bigquery.storage.uploaded_row_count`.
- Matches the BigQuery Table entity/dashboards added in companion PRs:
  - https://source.datanerd.us/Pegasus/infra-summary/pull/1351
  - https://source.datanerd.us/Pegasus/infrastructure/pull/959

## Test plan
- [ ] Preview the page and confirm the new table row and metrics table render correctly.