### PR TITLE
docs(workflow-automation): add public documentation for Jira issue actions

### DIFF
--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/actions-catalog.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/actions-catalog.mdx
@@ -261,6 +261,38 @@ Execute Azure API operations to manage and automate Azure infrastructure and ser
   </tbody>
 </table>
 
+## Jira Actions [#jira-actions]
+
+Create, update, and manage Jira issues. See [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue) for authentication setup.
+
+<table>
+  <thead>
+    <tr>
+      <th>Action name</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>[**Get a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-get)</td>
+    </tr>
+    <tr>
+      <td>[**Search Jira issues**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-search)</td>
+    </tr>
+    <tr>
+      <td>[**Get Jira issue transitions**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions)</td>
+    </tr>
+    <tr>
+      <td>[**Update a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update)</td>
+    </tr>
+    <tr>
+      <td>[**Create a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-create)</td>
+    </tr>
+    <tr>
+      <td>[**Transition a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition)</td>
+    </tr>
+  </tbody>
+</table>
+
 ## HTTP Actions [#http-actions]
 
 Make HTTP requests to any REST API, webhook, or web service.

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-create.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-create.mdx
@@ -1,0 +1,282 @@
+---
+title: "Create a Jira issue"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "Reference for the jira.issue.create action in the workflow automation actions catalog"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-create
+freshnessValidatedDate: 2026-07-27
+---
+
+Creates a new Jira issue.
+
+For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="jira-issue-create-inputs">
+      Inputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-create-outputs">
+      Outputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-create-example">
+      Example
+    </TabsBarItem>
+  </TabsBar>
+  <TabsPages>
+    <TabsPageItem id="jira-issue-create-inputs">
+  <table>
+      <thead>
+          <tr>
+            <th>Input Field</th>
+            <th>Optionality</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Example</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**authToken**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Base64-encoded string of `email:API_Token` for Basic Authentication. Must be provided as a secret. See [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).</td>
+              <td>`"${{ :secrets:jiraAuthToken }}"`</td>
+          </tr>
+          <tr>
+              <td>**domain**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Your Jira Cloud instance domain (company name). Used to construct the base URL `your-domain.atlassian.net`.</td>
+              <td>`"mycompany"`</td>
+          </tr>
+          <tr>
+              <td>**projectKey**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The key of the Jira project in which to create the issue.</td>
+              <td>`"PROJ"`</td>
+          </tr>
+          <tr>
+              <td>**summary**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>A brief summary or title for the new issue.</td>
+              <td>`"Fix bug in login page"`</td>
+          </tr>
+          <tr>
+              <td>**description**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>A detailed description for the issue.</td>
+              <td>`"Users are unable to log in."`</td>
+          </tr>
+          <tr>
+              <td>**issueTypeName**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The type of issue to create.</td>
+              <td>`"Bug"` or `"Story"`</td>
+          </tr>
+          <tr>
+              <td>**parentKey**</td>
+              <td>Optional</td>
+              <td>String</td>
+              <td>The key of the parent issue. Used to create subtasks or child issues.</td>
+              <td>`"PROJ-123"`</td>
+          </tr>
+          <tr>
+              <td>**labels**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of labels to apply to the issue.</td>
+              <td>`["alerting", "p1"]`</td>
+          </tr>
+          <tr>
+              <td>**fields**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>A map for all other issue fields not listed above, including priority, assignee, components, and custom fields. To get all fields with allowed values for an issue type, use `GET /rest/api/3/issue/{issueKey}/editmeta`. See the fields reference table below.</td>
+              <td>`{"priority": {"name": "Highest"}, "assignee": {"accountId": "5e6b8c..."}}`</td>
+          </tr>
+          <tr>
+              <td>**selectors**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of named expressions to extract specific values from the response.</td>
+              <td>`[{"name": "summary", "expression": ".responseBody.result.summary"}]`</td>
+          </tr>
+      </tbody>
+  </table>
+
+<Callout variant="important" title="Fields reference">
+  <table>
+      <thead>
+          <tr>
+            <th>Field</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**priority**</td>
+              <td>Object</td>
+              <td>Issue priority. Example: `{"name": "High"}`</td>
+          </tr>
+          <tr>
+              <td>**assignee**</td>
+              <td>Object</td>
+              <td>User to assign the issue to. Example: `{"accountId": "5e6b8c..."}`</td>
+          </tr>
+          <tr>
+              <td>**reporter**</td>
+              <td>Object</td>
+              <td>User reporting the issue.</td>
+          </tr>
+          <tr>
+              <td>**components**</td>
+              <td>Array</td>
+              <td>Project components to associate with the issue. Example: `[{"name": "Backend"}]`</td>
+          </tr>
+          <tr>
+              <td>**duedate**</td>
+              <td>Date</td>
+              <td>Due date for the issue. Example: `"2025-12-31"`</td>
+          </tr>
+          <tr>
+              <td>**fixVersions**</td>
+              <td>Array</td>
+              <td>Fix version(s) for the issue.</td>
+          </tr>
+          <tr>
+              <td>**environment**</td>
+              <td>String</td>
+              <td>Description of the environment in which the issue occurred.</td>
+          </tr>
+          <tr>
+              <td>**customfield_10016**</td>
+              <td>Integer</td>
+              <td>Story point estimate.</td>
+          </tr>
+          <tr>
+              <td>**customfield_10001**</td>
+              <td>Team ID</td>
+              <td>Team associated with the issue.</td>
+          </tr>
+          <tr>
+              <td>**customfield_10020**</td>
+              <td>Array</td>
+              <td>Sprint association.</td>
+          </tr>
+          <tr>
+              <td>**customfield_10022**</td>
+              <td>Date</td>
+              <td>Target start date.</td>
+          </tr>
+          <tr>
+              <td>**customfield_10023**</td>
+              <td>Date</td>
+              <td>Target end date.</td>
+          </tr>
+      </tbody>
+  </table>
+</Callout>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-create-outputs">
+  <table>
+    <thead>
+        <tr>
+            <th>Output Field</th>
+            <th>Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**response**</td>
+            <td>Object</td>
+            <td>
+```yaml
+{
+  "id": "10001",
+  "key": "PROJ-124",
+  "self": "..."
+}
+```
+            </td>
+        </tr>
+        <tr>
+            <td>**success**</td>
+            <td>Boolean</td>
+            <td>`success: true | false`</td>
+        </tr>
+        <tr>
+            <td>**errorMessage**</td>
+            <td>String</td>
+            <td>
+```yaml
+{
+  "errorMessages": [],
+  "errors": {
+    "project": "Project is required.",
+    "issuetype": "Issue type is required."
+  }
+}
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-create-example">
+  <table>
+    <thead>
+        <tr>
+            <th>Workflow example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+```yaml
+name: create_jira_issue_example
+description: 'Creates a new bug ticket with priority and labels.'
+steps:
+  - name: create_jira_issue
+    type: action
+    action: jira.issue.create
+    version: 1
+    inputs:
+      domain: new-relic
+      authToken: ${{ :secrets:jiraBasicAuth }}
+      projectKey: PROJ
+      summary: Main order flow broken
+      issueTypeName: Story
+      description: Order entry fails when selecting supplier.
+      labels:
+        - staging
+        - blitz_test
+      fields:
+        priority:
+          name: Highest
+        components:
+         - name: "Backend"
+        duedate: "2025-12-31"
+    next: end
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition.mdx
@@ -1,0 +1,169 @@
+---
+title: "Transition a Jira issue"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "Reference for the jira.issue.doTransition action in the workflow automation actions catalog"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition
+freshnessValidatedDate: 2026-07-27
+---
+
+Transitions a Jira issue to a different status. Use the [Get Jira issue transitions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions) action to retrieve available transition IDs before calling this action.
+
+For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="jira-issue-dotransition-inputs">
+      Inputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-dotransition-outputs">
+      Outputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-dotransition-example">
+      Example
+    </TabsBarItem>
+  </TabsBar>
+  <TabsPages>
+    <TabsPageItem id="jira-issue-dotransition-inputs">
+  <table>
+      <thead>
+          <tr>
+            <th>Input Field</th>
+            <th>Optionality</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Example</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**authToken**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Base64-encoded string of `email:API_Token` for Basic Authentication. Must be provided as a secret. See [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).</td>
+              <td>`"${{ :secrets:jiraAuthToken }}"`</td>
+          </tr>
+          <tr>
+              <td>**domain**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Your Jira Cloud instance domain (company name). Used to construct the base URL `your-domain.atlassian.net`.</td>
+              <td>`"mycompany"`</td>
+          </tr>
+          <tr>
+              <td>**issueKey**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The key of the Jira issue to transition.</td>
+              <td>`"PROJ-123"`</td>
+          </tr>
+          <tr>
+              <td>**transitionId**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The ID of the target transition. Use the [Get Jira issue transitions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions) action to retrieve available transition IDs for an issue.</td>
+              <td>`"181"`</td>
+          </tr>
+          <tr>
+              <td>**fields**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>A map of issue screen fields to update during the transition. Fields included here cannot also be included in `update`. To get all fields with allowed values, use `GET /rest/api/3/issue/{issueKey}/editmeta`.</td>
+              <td>`{"priority": {"name": "High"}, "labels": ["bug", "production"]}`</td>
+          </tr>
+          <tr>
+              <td>**update**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>A map of field names and a list of operations to perform during the transition. Fields included here cannot also be included in `fields`.</td>
+              <td>`{"labels": [{"add": "critical"}, {"remove": "minor"}], "components": [{"set": [{"name": "Backend"}]}]}`</td>
+          </tr>
+          <tr>
+              <td>**selectors**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of named expressions to extract specific values from the response.</td>
+              <td>`[{"name": "statusCode", "expression": ".result.statusCode"}]`</td>
+          </tr>
+      </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-dotransition-outputs">
+  <table>
+    <thead>
+        <tr>
+            <th>Output Field</th>
+            <th>Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**response**</td>
+            <td>Object</td>
+            <td>A successful transition returns an empty body with status 204.</td>
+        </tr>
+        <tr>
+            <td>**success**</td>
+            <td>Boolean</td>
+            <td>`success: true | false`</td>
+        </tr>
+        <tr>
+            <td>**errorMessage**</td>
+            <td>String</td>
+            <td>
+```yaml
+{
+  "errorMessages": ["Can not update issue with invalid data"],
+  "errors": {
+    "summary": "Summary is required"
+  }
+}
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-dotransition-example">
+  <table>
+    <thead>
+        <tr>
+            <th>Workflow example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+```yaml
+name: transition-jira-issue
+description: 'Transition a Jira issue status and update fields during the transition.'
+steps:
+  - name: transitionJiraIssue
+    type: action
+    action: jira.issue.doTransition
+    version: 1
+    inputs:
+      authToken: ${{ :secrets:jiraAuthToken }}
+      domain: mycompany
+      issueKey: "PROJ-123"
+      transitionId: "181"
+      fields:
+        customfield_14691:
+          id: "17907"
+    next: end
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-get.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-get.mdx
@@ -1,0 +1,214 @@
+---
+title: "Get a Jira issue"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "Reference for the jira.issue.get action in the workflow automation actions catalog"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-get
+freshnessValidatedDate: 2026-07-27
+---
+
+Retrieves the details of a specific Jira issue using its key.
+
+For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="jira-issue-get-inputs">
+      Inputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-get-outputs">
+      Outputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-get-example">
+      Example
+    </TabsBarItem>
+  </TabsBar>
+  <TabsPages>
+    <TabsPageItem id="jira-issue-get-inputs">
+  <table>
+      <thead>
+          <tr>
+            <th>Input Field</th>
+            <th>Optionality</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Example</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**authToken**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Base64-encoded string of `email:API_Token` for Basic Authentication. Must be provided as a secret. See [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).</td>
+              <td>`"${{ :secrets:jiraAuthToken }}"`</td>
+          </tr>
+          <tr>
+              <td>**domain**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Your Jira Cloud instance domain (company name). Used to construct the base URL `your-domain.atlassian.net`.</td>
+              <td>`"mycompany"`</td>
+          </tr>
+          <tr>
+              <td>**issueKey**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The key of the Jira issue to retrieve.</td>
+              <td>`"PROJ-1234"`</td>
+          </tr>
+          <tr>
+              <td>**parameters**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>Optional URL query parameters for the Jira API request. See the parameters reference table below.</td>
+              <td>`{"fields": "summary,status", "expand": "transitions"}`</td>
+          </tr>
+          <tr>
+              <td>**selectors**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of named expressions to extract specific values from the response.</td>
+              <td>`[{"name": "summary", "expression": ".responseBody.result.summary"}]`</td>
+          </tr>
+      </tbody>
+  </table>
+
+<Callout variant="important" title="Parameters reference">
+  <table>
+      <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Default</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**fields**</td>
+              <td>array&lt;string&gt;</td>
+              <td>A comma-separated list of fields to return for the issue. Use `*all` for all fields, `*navigable` for navigable fields, or prefix a field name with `-` to exclude it. Examples: `summary,comment`, `-description`, `*navigable,-comment`.</td>
+              <td>All fields</td>
+          </tr>
+          <tr>
+              <td>**fieldsByKeys**</td>
+              <td>Boolean</td>
+              <td>Whether fields in `fields` are referenced by keys rather than IDs. Useful for connect app fields.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**expand**</td>
+              <td>String</td>
+              <td>Comma-separated list of additional information to include. Options: `renderedFields`, `names`, `schema`, `transitions`, `editmeta`, `changelog`, `versionedRepresentations`.</td>
+              <td></td>
+          </tr>
+          <tr>
+              <td>**properties**</td>
+              <td>array&lt;string&gt;</td>
+              <td>A comma-separated list of issue properties to return. Use `*all` for all properties, or prefix a property key with `-` to exclude it.</td>
+              <td></td>
+          </tr>
+          <tr>
+              <td>**updateHistory**</td>
+              <td>Boolean</td>
+              <td>Whether to add the issue's project to the user's recently viewed project list in Jira. Also populates the `lastViewed` field in JQL search.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**failFast**</td>
+              <td>Boolean</td>
+              <td>When `true`, the request fails immediately if any field cannot be loaded. When `false`, the response is returned with empty values for failed fields.</td>
+              <td>`false`</td>
+          </tr>
+      </tbody>
+  </table>
+</Callout>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-get-outputs">
+  <table>
+    <thead>
+        <tr>
+            <th>Output Field</th>
+            <th>Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**response**</td>
+            <td>Object</td>
+            <td>
+```yaml
+{
+  "id": "10001",
+  "key": "PROJ-1234",
+  "fields": {
+    "summary": "Test Ticket 1",
+    ...
+  }
+}
+```
+            </td>
+        </tr>
+        <tr>
+            <td>**success**</td>
+            <td>Boolean</td>
+            <td>`success: true | false`</td>
+        </tr>
+        <tr>
+            <td>**errorMessage**</td>
+            <td>String</td>
+            <td>
+```yaml
+{
+  "errorMessages": ["Issue does not exist or you do not have permission to see it."],
+  "errors": {}
+}
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-get-example">
+  <table>
+    <thead>
+        <tr>
+            <th>Workflow example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+```yaml
+name: get-jira-issue-details
+description: 'Retrieves the summary and status of a specific Jira issue.'
+steps:
+  - name: get_issue
+    type: action
+    action: jira.issue.get
+    version: 1
+    inputs:
+      authToken: ${{ :secrets:jiraAuthToken }}
+      domain: mycompany
+      issueKey: PROJ-567
+      parameters:
+        fields: "summary,status,issuetype"
+    next: end
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions.mdx
@@ -1,0 +1,205 @@
+---
+title: "Get Jira issue transitions"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "Reference for the jira.issue.getTransitions action in the workflow automation actions catalog"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions
+freshnessValidatedDate: 2026-07-27
+---
+
+Gets the available transitions for a Jira issue. Use this action to retrieve transition IDs before calling the [Transition a Jira issue](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition) action.
+
+For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="jira-issue-gettransitions-inputs">
+      Inputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-gettransitions-outputs">
+      Outputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-gettransitions-example">
+      Example
+    </TabsBarItem>
+  </TabsBar>
+  <TabsPages>
+    <TabsPageItem id="jira-issue-gettransitions-inputs">
+  <table>
+      <thead>
+          <tr>
+            <th>Input Field</th>
+            <th>Optionality</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Example</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**authToken**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Base64-encoded string of `email:API_Token` for Basic Authentication. Must be provided as a secret. See [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).</td>
+              <td>`"${{ :secrets:jiraAuthToken }}"`</td>
+          </tr>
+          <tr>
+              <td>**domain**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Your Jira Cloud instance domain (company name). Used to construct the base URL `your-domain.atlassian.net`.</td>
+              <td>`"mycompany"`</td>
+          </tr>
+          <tr>
+              <td>**issueKey**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The key of the Jira issue to get transitions for.</td>
+              <td>`"PROJ-1234"`</td>
+          </tr>
+          <tr>
+              <td>**parameters**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>Optional URL query parameters for the Jira API request. See the parameters reference table below.</td>
+              <td>`{"fields": "summary,status", "expand": "transitions"}`</td>
+          </tr>
+          <tr>
+              <td>**selectors**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of named expressions to extract specific values from the response.</td>
+              <td>`[{"name": "summary", "expression": ".responseBody.result.summary"}]`</td>
+          </tr>
+      </tbody>
+  </table>
+
+<Callout variant="important" title="Parameters reference">
+  <table>
+      <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Default</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**expand**</td>
+              <td>String</td>
+              <td>Use `transitions.fields` to return information about the fields in the transition screen for each transition. Fields hidden from the screen are not returned. Use this to populate the `fields` and `update` inputs in the [Transition a Jira issue](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition) action.</td>
+              <td></td>
+          </tr>
+          <tr>
+              <td>**transitionId**</td>
+              <td>String</td>
+              <td>Filter results to a specific transition by its ID.</td>
+              <td></td>
+          </tr>
+          <tr>
+              <td>**skipRemoteOnlyCondition**</td>
+              <td>Boolean</td>
+              <td>Whether to include transitions with the condition _Hide From User Condition_ in the response. Available to Connect and Forge app users with _Administer Jira_ global permission.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**includeUnavailableTransitions**</td>
+              <td>Boolean</td>
+              <td>Whether to include details of transitions that fail a condition in the response.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**sortByOpsBarAndStatus**</td>
+              <td>Boolean</td>
+              <td>When `true`, transitions are sorted by ops-bar sequence value first, then by category order (Todo, In Progress, Done). When `false`, sorted only by ops-bar sequence value.</td>
+              <td>`false`</td>
+          </tr>
+      </tbody>
+  </table>
+</Callout>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-gettransitions-outputs">
+  <table>
+    <thead>
+        <tr>
+            <th>Output Field</th>
+            <th>Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**response**</td>
+            <td>Object</td>
+            <td>
+```yaml
+{
+  "id": "151",
+  "name": "Selected for Development",
+  ...
+}
+```
+            </td>
+        </tr>
+        <tr>
+            <td>**success**</td>
+            <td>Boolean</td>
+            <td>`success: true | false`</td>
+        </tr>
+        <tr>
+            <td>**errorMessage**</td>
+            <td>String</td>
+            <td>
+```yaml
+{
+  "errorMessages": ["Issue does not exist or you do not have permission to see it."],
+  "errors": {}
+}
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-gettransitions-example">
+  <table>
+    <thead>
+        <tr>
+            <th>Workflow example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+```yaml
+name: get-jira-issue-transitions
+description: 'Get available transitions for a Jira issue.'
+steps:
+  - name: get_transitions
+    type: action
+    action: jira.issue.getTransitions
+    version: 1
+    inputs:
+      authToken: ${{ :secrets:jiraAuthToken }}
+      domain: mycompany
+      issueKey: PROJ-567
+      parameters:
+        sortByOpsBarAndStatus: true
+    next: end
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions.mdx
@@ -12,7 +12,7 @@ redirects:
 freshnessValidatedDate: 2026-07-27
 ---
 
-Gets the available transitions for a Jira issue. Use this action to retrieve transition IDs before calling the [Transition a Jira issue](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition) action.
+Gets the available statuses to which a Jira issue can transition. Use this action to retrieve transition IDs before calling the [Transition a Jira issue](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition) action.
 
 For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
 

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-search.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-search.mdx
@@ -1,0 +1,214 @@
+---
+title: "Search Jira issues"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "Reference for the jira.issue.search action in the workflow automation actions catalog"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-search
+freshnessValidatedDate: 2026-07-27
+---
+
+Searches for Jira issues using a Jira Query Language (JQL) string.
+
+For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="jira-issue-search-inputs">
+      Inputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-search-outputs">
+      Outputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-search-example">
+      Example
+    </TabsBarItem>
+  </TabsBar>
+  <TabsPages>
+    <TabsPageItem id="jira-issue-search-inputs">
+  <table>
+      <thead>
+          <tr>
+            <th>Input Field</th>
+            <th>Optionality</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Example</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**authToken**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Base64-encoded string of `email:API_Token` for Basic Authentication. Must be provided as a secret. See [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).</td>
+              <td>`"${{ :secrets:jiraAuthToken }}"`</td>
+          </tr>
+          <tr>
+              <td>**domain**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Your Jira Cloud instance domain (company name). Used to construct the base URL `your-domain.atlassian.net`.</td>
+              <td>`"mycompany"`</td>
+          </tr>
+          <tr>
+              <td>**jql**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>A [JQL](https://confluence.atlassian.com/x/egORLQ) expression. Requires a bounded query (a query with a search restriction). Example of an unbounded query: `order by key desc`. Example of a bounded query: `assignee = currentUser() order by key`. The `orderBy` clause can contain a maximum of 7 fields.</td>
+              <td>`"project = PROJ AND status != Done"`</td>
+          </tr>
+          <tr>
+              <td>**maxResults**</td>
+              <td>Optional</td>
+              <td>Integer</td>
+              <td>The maximum number of items to return per page. Returns a maximum of 5000 issues.</td>
+              <td>`50`</td>
+          </tr>
+          <tr>
+              <td>**parameters**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>Optional additional query parameters for the Jira API request. See the parameters reference table below.</td>
+              <td>`{"startAt": 0, "fields": "key,summary,status"}`</td>
+          </tr>
+          <tr>
+              <td>**selectors**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of named expressions to extract specific values from the response.</td>
+              <td>`[{"name": "summary", "expression": ".responseBody.result.summary"}]`</td>
+          </tr>
+      </tbody>
+  </table>
+
+<Callout variant="important" title="Parameters reference">
+  <table>
+      <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**expand**</td>
+              <td>String</td>
+              <td>Comma-separated list of additional information to include in the response. Options: `renderedFields`, `names`, `schema`, `transitions`, `operations`, `editmeta`, `changelog`, `versionedRepresentations`. Example: `"names,changelog"`.</td>
+          </tr>
+          <tr>
+              <td>**fields**</td>
+              <td>array&lt;string&gt;</td>
+              <td>A comma-separated list of fields to return for each issue. Use `*all` for all fields, `*navigable` for navigable fields, or `id` for issue IDs only. Prefix a field name with `-` to exclude it. Examples: `summary,comment`, `-description`, `*all,-comment`. Default is `id`.</td>
+          </tr>
+          <tr>
+              <td>**fieldsByKeys**</td>
+              <td>Boolean</td>
+              <td>Whether to reference fields by their key rather than ID. Default: `false`.</td>
+          </tr>
+          <tr>
+              <td>**nextPageToken**</td>
+              <td>String</td>
+              <td>Token for fetching the next page of results. The first page has a `nextPageToken` of `null`. Not included in the last page response.</td>
+          </tr>
+          <tr>
+              <td>**properties**</td>
+              <td>array&lt;string&gt;</td>
+              <td>A comma-separated list of up to 5 issue properties to include in the results.</td>
+          </tr>
+          <tr>
+              <td>**failFast**</td>
+              <td>Boolean</td>
+              <td>Whether to fail the request quickly if field data cannot be retrieved. Default: `false`.</td>
+          </tr>
+      </tbody>
+  </table>
+</Callout>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-search-outputs">
+  <table>
+    <thead>
+        <tr>
+            <th>Output Field</th>
+            <th>Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**response**</td>
+            <td>Object</td>
+            <td>
+```yaml
+{
+  "startAt": 0,
+  "maxResults": 50,
+  "total": 1,
+  "issues": [...]
+}
+```
+            </td>
+        </tr>
+        <tr>
+            <td>**success**</td>
+            <td>Boolean</td>
+            <td>`success: true | false`</td>
+        </tr>
+        <tr>
+            <td>**errorMessage**</td>
+            <td>String</td>
+            <td>
+```yaml
+{
+  "errorMessages": ["The value 'In Progresss' does not exist for the field 'status'."],
+  "errors": {}
+}
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-search-example">
+  <table>
+    <thead>
+        <tr>
+            <th>Workflow example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+```yaml
+name: search_jira_tickets
+description: 'Finds the 10 most recent open tickets for PROJ, returning summary and status.'
+steps:
+  - name: search_jira_tickets_1
+    type: action
+    action: jira.issue.search
+    version: 1
+    inputs:
+      authToken: ${{ :secrets:jiraAuthToken }}
+      domain: newrelic
+      jql: "project = PROJ AND status != Done"
+      maxResults: 10
+      parameters:
+        fields: "key,summary,status"
+        startAt: 0
+    next: end
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update.mdx
@@ -1,0 +1,227 @@
+---
+title: "Update a Jira issue"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "Reference for the jira.issue.update action in the workflow automation actions catalog"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update
+freshnessValidatedDate: 2026-07-27
+---
+
+Updates an existing Jira issue.
+
+For authentication setup, see [Jira issue actions](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue).
+
+<Tabs>
+  <TabsBar>
+    <TabsBarItem id="jira-issue-update-inputs">
+      Inputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-update-outputs">
+      Outputs
+    </TabsBarItem>
+    <TabsBarItem id="jira-issue-update-example">
+      Example
+    </TabsBarItem>
+  </TabsBar>
+  <TabsPages>
+    <TabsPageItem id="jira-issue-update-inputs">
+  <table>
+      <thead>
+          <tr>
+            <th>Input Field</th>
+            <th>Optionality</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Example</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**authToken**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Base64-encoded string of `email:API_Token` for Basic Authentication. Must be provided as a secret. See [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens).</td>
+              <td>`"${{ :secrets:jiraAuthToken }}"`</td>
+          </tr>
+          <tr>
+              <td>**domain**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>Your Jira Cloud instance domain (company name). Used to construct the base URL `your-domain.atlassian.net`.</td>
+              <td>`"mycompany"`</td>
+          </tr>
+          <tr>
+              <td>**issueKey**</td>
+              <td>Required</td>
+              <td>String</td>
+              <td>The key of the Jira issue to update.</td>
+              <td>`"PROJ-123"`</td>
+          </tr>
+          <tr>
+              <td>**parameters**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>Optional URL query parameters for the Jira API request. See the parameters reference table below.</td>
+              <td>`{"notifyUsers": "false", "returnIssue": "true", "expand": "changelog,renderedFields"}`</td>
+          </tr>
+          <tr>
+              <td>**fields**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>A map of issue screen fields to update, specifying the sub-field and its value. Use this for straightforward single sub-field updates. Fields included here cannot also be included in `update`. To get all fields with allowed values, use `GET /rest/api/3/issue/{issueKey}/editmeta`.</td>
+              <td>`{"priority": {"name": "High"}, "labels": ["bug", "production"]}`</td>
+          </tr>
+          <tr>
+              <td>**update**</td>
+              <td>Optional</td>
+              <td>Map</td>
+              <td>A map of field names and a list of operations to perform on the issue screen field. Use this when multiple sub-fields or other operations are required. Fields included here cannot also be included in `fields`.</td>
+              <td>`{"labels": [{"add": "critical"}, {"remove": "minor"}], "components": [{"set": [{"name": "Backend"}]}]}`</td>
+          </tr>
+          <tr>
+              <td>**selectors**</td>
+              <td>Optional</td>
+              <td>List</td>
+              <td>A list of named expressions to extract specific values from the response.</td>
+              <td>`[{"name": "summary", "expression": ".responseBody.result.summary"}]`</td>
+          </tr>
+      </tbody>
+  </table>
+
+<Callout variant="important" title="Parameters reference">
+  <table>
+      <thead>
+          <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Default</th>
+          </tr>
+      </thead>
+      <tbody>
+          <tr>
+              <td>**notifyUsers**</td>
+              <td>Boolean</td>
+              <td>Whether a notification email about the issue update is sent to all watchers. To disable notifications, _Administer Jira_ or _Administer project_ permissions are required. If the user doesn't have the necessary permission, this is ignored.</td>
+              <td>`true`</td>
+          </tr>
+          <tr>
+              <td>**overrideScreenSecurity**</td>
+              <td>Boolean</td>
+              <td>Whether screen security is overridden to enable hidden fields to be edited. Available to Connect and Forge app users with _Administer Jira_ global permission.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**overrideEditableFlag**</td>
+              <td>Boolean</td>
+              <td>Whether screen security is overridden to enable uneditable fields to be edited. Available to Connect and Forge app users with _Administer Jira_ global permission.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**returnIssue**</td>
+              <td>Boolean</td>
+              <td>Whether the response should contain the issue with the fields edited in this request, formatted as in the Get issue API.</td>
+              <td>`false`</td>
+          </tr>
+          <tr>
+              <td>**expand**</td>
+              <td>String</td>
+              <td>The Get issue API expand parameter to use in the response if `returnIssue` is `true`.</td>
+              <td></td>
+          </tr>
+      </tbody>
+  </table>
+</Callout>
+
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-update-outputs">
+  <table>
+    <thead>
+        <tr>
+            <th>Output Field</th>
+            <th>Type</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**response**</td>
+            <td>Object</td>
+            <td>A successful update returns an empty body with status 204.</td>
+        </tr>
+        <tr>
+            <td>**success**</td>
+            <td>Boolean</td>
+            <td>`success: true | false`</td>
+        </tr>
+        <tr>
+            <td>**errorMessage**</td>
+            <td>String</td>
+            <td>
+```yaml
+{
+  "errorMessages": ["Can not update issue with invalid data"],
+  "errors": {
+    "summary": "Summary is required"
+  }
+}
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+
+    <TabsPageItem id="jira-issue-update-example">
+  <table>
+    <thead>
+        <tr>
+            <th>Workflow example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>
+```yaml
+name: update-jira-issues
+description: 'Updates a ticket summary and adds a new label.'
+steps:
+  - name: set_summary
+    type: action
+    action: jira.issue.update
+    version: 1
+    inputs:
+      authToken: ${{ :secrets:jiraAuthToken }}
+      domain: mycompany
+      issueKey: "PROJ-123"
+      fields:
+        summary: "Updated: Critical production error resolved"
+        description:
+          type: "doc"
+          version: 1
+          content:
+            - type: "paragraph"
+              content:
+                - type: "text"
+                  text: "Root cause identified and fix deployed to production"
+      update:
+        labels:
+          - add: "resolved"
+          - add: "production"
+      parameters:
+        returnIssue: "true"
+    next: end
+```
+            </td>
+        </tr>
+    </tbody>
+  </table>
+    </TabsPageItem>
+  </TabsPages>
+</Tabs>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue.mdx
@@ -1,0 +1,87 @@
+---
+title: "Jira issue actions"
+tags:
+  - workflow automation
+  - workflow
+  - workflow automation actions
+  - Jira actions
+  - Jira issue actions
+metaDescription: "A list of available Jira issue actions in the actions catalog for workflow definitions"
+redirects:
+  - /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue
+freshnessValidatedDate: 2026-07-27
+---
+
+This page provides a reference for Jira issue actions available in the workflow automation actions catalog. These actions enable you to create and manage issues in Jira Cloud.
+
+## Prerequisites
+
+Before using Jira actions in workflow automation, ensure you have:
+
+  * A Jira Cloud instance with appropriate permissions.
+  * A Jira API token for authentication.
+  * The necessary permissions to create and manage issues in your Jira project.
+
+In the action input, `authToken` must be provided. It is a Base64-encoded string of your `email:API_Token` and is used to authenticate requests to the Jira API using Basic Authentication.
+
+## Set up API token authentication
+
+For more information, see [Create and manage API tokens](https://id.atlassian.com/manage-profile/security/api-tokens) in the Atlassian documentation.
+
+To generate and configure a Jira API token:
+
+<Steps>
+  <Step>
+    ### Create a Jira API token
+
+      1. Go to [Atlassian account security settings](https://id.atlassian.com/manage-profile/security/api-tokens).
+      2. Click <DNT>**Create API token**</DNT>.
+      3. Enter a label for the token and click <DNT>**Create**</DNT>.
+      4. Copy the generated token value — it is shown only once.
+  </Step>
+
+  <Step>
+    ### Create the Base64-encoded auth string
+
+      1. Combine your Atlassian account email and the API token in the format `email:API_token`.
+      2. Base64-encode the combined string.
+      3. Store this value as a secret in your workflow automation configuration and reference it as `${{ :secrets:jiraAuthToken }}`.
+  </Step>
+</Steps>
+
+## Available Jira issue actions
+
+<table>
+  <thead>
+    <tr>
+      <th>Action name</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>[**Get a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-get)</td>
+      <td>Retrieves the details of a specific Jira issue using its key.</td>
+    </tr>
+    <tr>
+      <td>[**Search Jira issues**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-search)</td>
+      <td>Searches for Jira issues using a JQL query string.</td>
+    </tr>
+    <tr>
+      <td>[**Get Jira issue transitions**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions)</td>
+      <td>Gets the available transitions for a Jira issue.</td>
+    </tr>
+    <tr>
+      <td>[**Update a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update)</td>
+      <td>Updates an existing Jira issue.</td>
+    </tr>
+    <tr>
+      <td>[**Create a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-create)</td>
+      <td>Creates a new Jira issue.</td>
+    </tr>
+    <tr>
+      <td>[**Transition a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition)</td>
+      <td>Transitions a Jira issue to a different status.</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue.mdx
@@ -69,7 +69,7 @@ To generate and configure a Jira API token:
     </tr>
     <tr>
       <td>[**Get Jira issue transitions**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions)</td>
-      <td>Gets the available transitions for a Jira issue.</td>
+      <td>Lists the available statuses to which the Jira issue can transition.</td>
     </tr>
     <tr>
       <td>[**Update a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update)</td>

--- a/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue.mdx
+++ b/src/content/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue.mdx
@@ -81,7 +81,7 @@ To generate and configure a Jira API token:
     </tr>
     <tr>
       <td>[**Transition a Jira issue**](/docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition)</td>
-      <td>Transitions a Jira issue to a different status.</td>
+      <td>Changes the status of the Jira issue.</td>
     </tr>
   </tbody>
 </table>

--- a/src/nav/workflow-automation.yml
+++ b/src/nav/workflow-automation.yml
@@ -63,6 +63,23 @@ pages:
                 path: /docs/workflow-automation/setup-and-configure/actions-catalog/azure/azure-vm-restart
               - title: Azure VM stop action
                 path: /docs/workflow-automation/setup-and-configure/actions-catalog/azure/azure-vm-stop
+          - title: Jira actions
+            path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira
+            pages:
+              - title: Jira issue actions
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue
+              - title: Get a Jira issue
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-get
+              - title: Search Jira issues
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-search
+              - title: Get Jira issue transitions
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-gettransitions
+              - title: Update a Jira issue
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-update
+              - title: Create a Jira issue
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-create
+              - title: Transition a Jira issue
+                path: /docs/workflow-automation/setup-and-configure/actions-catalog/jira/jira-issue-dotransition
           - title: HTTP actions
             path: /docs/workflow-automation/setup-and-configure/actions-catalog/http
             pages:


### PR DESCRIPTION
## Summary

- Adds 7 new MDX files documenting all 6 approved Jira issue actions (`jira.issue.get`, `jira.issue.search`, `jira.issue.getTransitions`, `jira.issue.update`, `jira.issue.create`, `jira.issue.doTransition`)
- Adds a `jira-issue.mdx` index page with prerequisites and API token authentication setup steps
- Updates `actions-catalog.mdx` to include a Jira Actions section with links to all 6 actions

Follows the same structure as the ServiceNow incident actions docs.

