### PR TITLE
docs(scorecards): Clarify accounts and joinAccounts intent

### DIFF
--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-scorecards-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-scorecards-tutorial.mdx
@@ -287,13 +287,13 @@ You can create a new rule for a Scorecard using the `entityManagementCreateScore
       <td>`accounts`</td>
       <td>Int</td>
       <td>Yes</td>
-      <td>List of account IDs where the rule should execute the query.</td>
+      <td>The account IDs targeted for rule evaluation. The NRQL query executes against each account specified in this list to assess compliance.</td>
     </tr>
     <tr>
       <td>`joinAccounts`</td>
       <td>Int</td>
       <td>No</td>
-      <td>List of account IDs that need to be joined with each account where the query is executed.</td>
+      <td>Optional auxiliary account IDs to include during query execution. Enables cross-account NRQL queries by joining data from these secondary accounts with each primary target account.</td>
     </tr>
     <tr>
       <td>`organizationId`</td>
@@ -533,13 +533,13 @@ You can update a rule for the Scorecard using the `entityManagementUpdateScoreca
       <td>`queryAccounts`</td>
       <td>Int</td>
       <td>Yes</td>
-      <td>List of account IDs where the rule should execute the query.</td>
+      <td>The account IDs targeted for rule evaluation. The NRQL query executes against each account specified in this list to assess compliance.</td>
     </tr>
     <tr>
       <td>`joinAccounts`</td>
       <td>Int</td>
       <td>No</td>
-      <td>List of account IDs that need to be joined with each account where the query is executed.</td>
+      <td>Optional auxiliary account IDs to include during query execution. Enables cross-account NRQL queries by joining data from these secondary accounts with each primary target account.</td>
     </tr>
     <tr>
       <td>`enabled`</td>

--- a/src/content/docs/apis/nerdgraph/examples/nerdgraph-scorecards-tutorial.mdx
+++ b/src/content/docs/apis/nerdgraph/examples/nerdgraph-scorecards-tutorial.mdx
@@ -293,7 +293,7 @@ You can create a new rule for a Scorecard using the `entityManagementCreateScore
       <td>`joinAccounts`</td>
       <td>Int</td>
       <td>No</td>
-      <td>Optional auxiliary account IDs to include during query execution. Enables cross-account NRQL queries by joining data from these secondary accounts with each primary target account.</td>
+      <td>Auxiliary account IDs to include during query execution. Enables cross-account NRQL queries by joining data from these secondary accounts with each primary target account.</td>
     </tr>
     <tr>
       <td>`organizationId`</td>
@@ -539,7 +539,7 @@ You can update a rule for the Scorecard using the `entityManagementUpdateScoreca
       <td>`joinAccounts`</td>
       <td>Int</td>
       <td>No</td>
-      <td>Optional auxiliary account IDs to include during query execution. Enables cross-account NRQL queries by joining data from these secondary accounts with each primary target account.</td>
+      <td>Auxiliary account IDs to include during query execution. Enables cross-account NRQL queries by joining data from these secondary accounts with each primary target account.</td>
     </tr>
     <tr>
       <td>`enabled`</td>


### PR DESCRIPTION
Clarifies the accounts and joinAccounts attributes intent so that scorecards users are able to deal with different scenarios and get the expected results when the rule is executed.