### PR TITLE
fix: make "gMSA" searchable on infra-agent docs

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/infrastructure-security.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/infrastructure-security.mdx
@@ -92,7 +92,7 @@ In Windows systems, the agent has the following installation and account require
 
 * The installation requires an Administrator account.
 * By default the agent runs as a service with the Local System logon context, meaning it has no access to other services on the network that require authentication.
-* As an alternative to Local System, the service could optionally be changed to a local user, an Active Directory/Microsoft Entra ID user, or Group Managed Service Account/gMSA. The included script `set-service-account.ps1` helps with the transition and sets the required privileges.
+* As an alternative to Local System, the service could optionally be changed to a local user, an Active Directory/Microsoft Entra ID user, or Group Managed Service Account / gMSA. The included script `set-service-account.ps1` helps with the transition and sets the required privileges.
 
 
 

--- a/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent.mdx
@@ -198,7 +198,7 @@ The infrastructure agent uses the hostname to uniquely identify each server. To 
 The infrastructure agent requires these permissions:
 
 * <DNT>**Linux**</DNT>: By default, [the agent runs and installs as root](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-linux#agent-mode-intro). You can also select [privileged](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-linux#install-privileged) or [unprivileged](/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-agent-linux#install-unprivileged) run modes.
-* <DNT>**Windows**</DNT>: The agent must be installed from an Administrator account, and by default it will run as a service with the `Local System` logon context. It can also run as a non-admin/user account (local, Active Directory, Microsoft Entra ID or Group Managed Service Account/gMSA). The included script `set-service-account.ps1` helps with the transition and sets the required privileges.
+* <DNT>**Windows**</DNT>: The agent must be installed from an Administrator account, and by default it will run as a service with the `Local System` logon context. It can also run as a non-admin/user account (local, Active Directory, Microsoft Entra ID or Group Managed Service Account / gMSA). The included script `set-service-account.ps1` helps with the transition and sets the required privileges.
 * <DNT>**macOS**</DNT>: The agent can be installed from any user account.
 
 ## Libraries


### PR DESCRIPTION
## Summary
- Both pages write the abbreviation as `Group Managed Service Account/gMSA` with no space around the slash.
- Postgres full-text search (used by support-search-service) tokenizes `Word/Word` with no surrounding whitespace as a single compound lexeme (`account/gmsa`), so `gmsa` never exists as its own searchable word. Searching "gMSA" in support search returns zero hits for these two pages as a result.
- Adding a space on each side of the slash is enough for the tokenizer to split it into two normal words.

## Pages fixed
- `/docs/infrastructure/infrastructure-agent/infrastructure-security/#windows`
- `/docs/infrastructure/infrastructure-agent/requirements-infrastructure-agent/#permissions`

## Test plan
- [ ] Confirm rendered pages read correctly with the added space
- [ ] After next ingestion cycle, confirm "gMSA" search in support search surfaces these two pages