### PR TITLE
docs(whats-new): New Relic Notebooks is now generally available

### DIFF
--- a/src/content/whats-new/2026/08/whats-new-08-11-notebooks.md
+++ b/src/content/whats-new/2026/08/whats-new-08-11-notebooks.md
@@ -1,0 +1,32 @@
+---
+title: 'New Relic Notebooks is now generally available'
+summary: 'Notebooks are now part of the core New Relic platform. Create and share structured documents that combine live queries, visualizations, and text to streamline troubleshooting and accelerate data discovery.'
+releaseDate: '2026-08-11'
+learnMoreLink: 'https://docs.newrelic.com/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks/'
+---
+
+New Relic Notebooks is now generally available and integrated into the core New Relic platform. Notebooks let you build structured, collaborative documents that combine live telemetry queries, visualizations, and markdown text in a single workspace — ending "tab fatigue" and preserving the investigative context that disappears when an incident is over.
+
+## What you can do with Notebooks
+
+**Unified multi-cell canvas**
+Build step-by-step logical narratives by combining live telemetry and explanatory text in one collaborative workspace. Each cell can be an independent NRQL query, a visualization, or a block of markdown — so your analysis tells a complete story.
+
+**Save, share, and collaborate**
+Save notebooks as persistent documents and share them directly with teammates. Your investigative work no longer lives only in your browser history.
+
+**Natural language to query translator**
+Accelerate exploration by describing what you want to see in plain English. Notebooks translates your intent into precise NRQL syntax, lowering the barrier for teams less familiar with our query language.
+
+**Reusable variables**
+Define dynamic variables once and reference them across every query in the notebook. Change a value in one place and every dependent query updates automatically.
+
+**Inline query comparison**
+Compare datasets side-by-side without juggling browser tabs. Spot anomalies and correlate signals from different parts of your stack in a single view.
+
+**Dynamic runbooks**
+Turn incident analyses into reusable, interactive assets. Shared runbooks built in Notebooks give your team a repeatable starting point for future investigations and help lower mean time to resolution (MTTR).
+
+## Get started
+
+Open Notebooks from the New Relic navigation and create your first notebook in minutes. To learn more, read the [Notebooks documentation](https://docs.newrelic.com/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks/).

--- a/src/content/whats-new/2026/08/whats-new-08-11-notebooks.md
+++ b/src/content/whats-new/2026/08/whats-new-08-11-notebooks.md
@@ -5,12 +5,12 @@ releaseDate: '2026-08-11'
 learnMoreLink: 'https://docs.newrelic.com/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks/'
 ---
 
-New Relic Notebooks is now generally available and integrated into the core New Relic platform. Notebooks let you build structured, collaborative documents that combine live telemetry queries, visualizations, and markdown text in a single workspace — ending "tab fatigue" and preserving the investigative context that disappears when an incident is over.
+New Relic Notebooks is now generally available and integrated into the core New Relic platform. Notebooks let you build structured, collaborative documents that combine live telemetry queries, visualizations, and markdown text in a single workspace—ending "tab fatigue" and preserving the investigative context that disappears when an incident is over.
 
 ## What you can do with Notebooks
 
 **Unified multi-cell canvas**
-Build step-by-step logical narratives by combining live telemetry and explanatory text in one collaborative workspace. Each cell can be an independent NRQL query, a visualization, or a block of markdown — so your analysis tells a complete story.
+Build step-by-step logical narratives by combining live telemetry and explanatory text in one collaborative workspace. Each cell can be an independent NRQL query, a visualization, or a block of markdown—so your analysis tells a complete story.
 
 **Save, share, and collaborate**
 Save notebooks as persistent documents and share them directly with teammates. Your investigative work no longer lives only in your browser history.


### PR DESCRIPTION
## Summary

What's New post announcing the general availability of New Relic Notebooks.

## Details

- **Release date**: August 11, 2026
- **Learn more link**: https://docs.newrelic.com/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks/
- **File**: `src/content/whats-new/2026/08/whats-new-08-11-notebooks.md`

## Capabilities covered

- Unified multi-cell canvas
- Save, share, and collaborate
- Natural language to NRQL translator
- Reusable variables
- Inline query comparison
- Dynamic runbooks

## Test plan

- [ ] Verify post renders correctly on the What's New page
- [ ] Confirm `learnMoreLink` resolves to the Notebooks intro doc
- [ ] Check formatting matches existing what's new posts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)