### PR TITLE
docs(notebooks): remove public preview callouts for GA

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/blob-storage-api-for-notebooks.mdx
@@ -9,10 +9,6 @@ metaDescription: 'Use the New Relic Blob Storage API and NerdGraph to create, re
 freshnessValidatedDate: never
 ---
 
-<Callout title="Public preview">
-  The <DNT>Blob Storage API</DNT> for notebooks is currently in public preview. This feature is provided pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
-</Callout>
-
 The New Relic <DNT>Notebooks</DNT> API lets you create, read, update, and delete notebooks programmatically, including their full block content (<DNT>NRQL</DNT> queries, text). Notebooks are stored as versioned blobs, which means every save produces a new immutable revision you can retrieve later.
 
 Use this API to:

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -8,10 +8,6 @@ metaDescription: 'Use New Relic notebooks to create structured, data-driven docu
 freshnessValidatedDate: never
 ---
 
-<Callout title="Public preview">
-  The <DNT>Blob Storage API</DNT> for notebooks is currently in public preview. This feature is provided pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
-</Callout>
-
 When investigating complex issues or sharing insights with your team, you often find yourself jumping between different tools, copying queries, taking screenshots, and struggling to maintain context as you piece together a complete story from your data. Traditional dashboards are great for monitoring, but they fall short when you need to document investigations, create detailed post-mortems, or build step-by-step analytical workflows.
 
 Notebooks solve this problem by providing a dynamic and organized way to tell a complete story with your data. They are structured, data-driven documents that let you combine queries, visualizations, and descriptive text into a single, shareable asset, eliminating the need to switch between multiple tools or lose important context during your analysis.

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/share-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/share-notebooks.mdx
@@ -145,7 +145,7 @@ To maintain version control:
 If team members can't see your notebook:
 
 1. **Check organization access**: Ensure they belong to the same New Relic organization
-2. **Verify feature access**: Confirm they have access to the notebooks preview feature
+2. **Verify feature access**: Confirm they have access to notebooks
 3. **Try direct URL**: Share the specific notebook URL rather than expecting them to find it in the index
 
 ### Performance with shared notebooks


### PR DESCRIPTION
## Summary

Notebooks is now generally available. Removes all public preview callouts and updates preview-specific language across the Notebooks documentation.

## Files changed

| File | Change |
|---|---|
| `introduction-notebooks.mdx` | Removed Public preview callout |
| `blob-storage-api-for-notebooks.mdx` | Removed Public preview callout |
| `share-notebooks.mdx` | Updated "notebooks preview feature" → "notebooks" |

