### PR TITLE
fix(i18n): restore JSX string-literal syntax in pt/haproxy/metrics-reference

### DIFF
--- a/src/i18n/content/pt/docs/opentelemetry/integrations/haproxy/metrics-reference.mdx
+++ b/src/i18n/content/pt/docs/opentelemetry/integrations/haproxy/metrics-reference.mdx
@@ -104,7 +104,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{errors}&apos;}
+        {'{errors}'}
       </td>
     </tr>
 
@@ -122,7 +122,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{connections}/s&apos;}
+        {'{connections}/s'}
       </td>
     </tr>
 
@@ -140,7 +140,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{retries}&apos;}
+        {'{retries}'}
       </td>
     </tr>
 
@@ -158,7 +158,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{requests}&apos;}
+        {'{requests}'}
       </td>
     </tr>
 
@@ -176,7 +176,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{errors}&apos;}
+        {'{errors}'}
       </td>
     </tr>
 
@@ -194,7 +194,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{requests}&apos;}
+        {'{requests}'}
       </td>
     </tr>
 
@@ -212,7 +212,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{requests}/s&apos;}
+        {'{requests}/s'}
       </td>
     </tr>
 
@@ -230,7 +230,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{requests}&apos;}
+        {'{requests}'}
       </td>
     </tr>
 
@@ -248,7 +248,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{requests}&apos;}
+        {'{requests}'}
       </td>
     </tr>
 
@@ -266,7 +266,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{responses}&apos;}
+        {'{responses}'}
       </td>
     </tr>
 
@@ -284,7 +284,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{errors}&apos;}
+        {'{errors}'}
       </td>
     </tr>
 
@@ -302,7 +302,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{selections}&apos;}
+        {'{selections}'}
       </td>
     </tr>
 
@@ -338,7 +338,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{sessions}&apos;}
+        {'{sessions}'}
       </td>
     </tr>
 
@@ -356,7 +356,7 @@ Estas 17 métricas são coletadas com a configuração padrão (nenhuma seção 
       </td>
 
       <td>
-        \{&apos;{sessions}/s&apos;}
+        {'{sessions}/s'}
       </td>
     </tr>
   </tbody>
@@ -474,7 +474,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{servers}&apos;}
+        {'{servers}'}
       </td>
     </tr>
 
@@ -496,7 +496,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{servers}&apos;}
+        {'{servers}'}
       </td>
     </tr>
 
@@ -540,7 +540,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{checks}&apos;}
+        {'{checks}'}
       </td>
     </tr>
 
@@ -562,7 +562,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{weight}&apos;}
+        {'{weight}'}
       </td>
     </tr>
 
@@ -584,7 +584,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{sessions}&apos;}
+        {'{sessions}'}
       </td>
     </tr>
 
@@ -606,7 +606,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{connections}&apos;}
+        {'{connections}'}
       </td>
     </tr>
 
@@ -678,7 +678,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{responses}&apos;}
+        {'{responses}'}
       </td>
     </tr>
 
@@ -696,7 +696,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{cancellations}&apos;}
+        {'{cancellations}'}
       </td>
     </tr>
 
@@ -714,7 +714,7 @@ A configuração abrangente do NRDOT habilita os primeiros 10 destes (marcados c
       </td>
 
       <td>
-        \{&apos;{sessions}&apos;}
+        {'{sessions}'}
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Problem

`pt/docs/opentelemetry/integrations/haproxy/metrics-reference.mdx` was introduced onto develop via MT PR #25216 with 23 corrupted JSX-APOS patterns:

```
\{&apos;{errors}&apos;}  →  should be  {'{errors}'}
```

This pattern is not caught by `verify-mdx` but causes Gatsby HTML render failures (exit code 2) on locale Netlify builds — same issue as incidents on Jul 21, Jul 24, Jul 27, Aug 1, Aug 4.

## Fix

Replaced all 23 instances of `\{&apos;{...}&apos;}` → `{'{...}'}` in pt/haproxy/metrics-reference.mdx.

## Verification

- `verify_mdx` passes ✅
- 0 remaining `\{&apos;` hits ✅