### PR TITLE
chore: Update Ruby Third Party Instrumentation

### DIFF
--- a/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
@@ -9,20 +9,22 @@ redirects:
   - /docs/agents/ruby-agent/api-guides/third-party-instrumentation
   - /docs/agents/ruby-agent/frameworks/third-party-instrumentation
   - /docs/agents/ruby-agent/customization/third-party-instrumentation
-freshnessValidatedDate: never
+freshnessValidatedDate: 2026-08-11
 ---
 
 This document details how to instrument third-party gems with the Ruby agent, as well as some best practices for interacting with the agent. This is useful if you are using a gem that the <DNT>Ruby</DNT> agent does not instrument by default, or if you are a gem author who wants to add instrumentation for your library.
 
+Keep in mind that New Relic welcomes contributions to the Ruby agent from the community! If you have a gem you'd like to see instrumented, or a feature you'd like to propose, please share your ideas by [opening an issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose) or submitting a pull request to the [`newrelic/newrelic-ruby-agent` repository on GitHub](https://github.com/newrelic/newrelic-ruby-agent).
+
 ## Finding third-party extensions
 
-Anyone can write a gem that builds on top of the <DNT>Ruby</DNT> agent. New Relic maintains a repository called [extends_newrelic_rpm](https://github.com/newrelic/extends_newrelic_rpm) to track these extensions and to provide links to other gems that build the <DNT>Ruby</DNT> agent.
+Anyone can write a gem that builds on top of the <DNT>Ruby</DNT> agent. Old examples of this are available in an archived repository called [extends_newrelic_rpm](https://github.com/newrelic/extends_newrelic_rpm) to track these extensions and to provide links to other gems that build the <DNT>Ruby</DNT> agent.
 
-These extensions are **not** supported by New Relic. New Relic gathers these links as a service to our customers. Issues with those gems should be reported to the respective projects on GitHub.
+These extensions are **not** supported by New Relic. New Relic gathered these links as a service to our customers. Issues with those gems should be reported to the respective projects on GitHub.
 
 ## Extensions as gems
 
-New Relic encourages third-party extensions to be maintained as gems, with one gem per instrumented library. For example, `newrelic-redis` provides instrumentation for the `redis` gem.
+If you choose to create a third-party extension, we recommend one gem per instrumented library. For example, `newrelic-redis` provides instrumentation for the `redis` gem (which also exists automatically within our agent).
 
 ## Starting transactions
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
@@ -14,7 +14,7 @@ freshnessValidatedDate: 2026-08-11
 
 This document details how to instrument third-party gems with the Ruby agent, as well as some best practices for interacting with the agent. This is useful if you are using a gem that the <DNT>Ruby</DNT> agent does not instrument by default, or if you are a gem author who wants to add instrumentation for your library.
 
-Keep in mind that New Relic welcomes contributions to the Ruby agent from the community! If you have a gem you'd like to see instrumented, or a feature you'd like to propose, please share your ideas by [opening an issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose) or submitting a pull request to the [`newrelic/newrelic-ruby-agent` repository on GitHub](https://github.com/newrelic/newrelic-ruby-agent).
+While third party instrumentation is always an option, New Relic also welcomes contributions to the Ruby agent from the community! If you have a gem you'd like to see instrumented, or a feature you'd like to propose, please share your ideas by [opening an issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose) or submitting a pull request to the [`newrelic/newrelic-ruby-agent` repository on GitHub](https://github.com/newrelic/newrelic-ruby-agent).
 
 ## Finding third-party extensions
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
@@ -15,7 +15,7 @@ freshnessValidatedDate: 2026-08-11
 This document details how to instrument third-party gems with the Ruby agent, as well as some best practices for interacting with the agent. This is useful if you are using a gem that the <DNT>Ruby</DNT> agent does not instrument by default, or if you are a gem author who wants to add instrumentation for your library.
 
 <Callout variant="tip">
-New Relic accepts community contributions for the <DNT>Ruby</DNT> agent. If you have a gem you want instrumented or a feature to propose, in the `newrelic/newrelic-ruby-agent` repository on GitHub, share your ideas by opening an [issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose or submitting a [pull request](https://github.com/newrelic/newrelic-ruby-agent).
+New Relic accepts community contributions for the <DNT>Ruby</DNT> agent. If you have a gem you want instrumented or a feature to propose, in the `newrelic/newrelic-ruby-agent` repository on GitHub, share your ideas by opening an [issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose) or submitting a [pull request](https://github.com/newrelic/newrelic-ruby-agent).
 </Callout>
 
 

--- a/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
+++ b/src/content/docs/apm/agents/ruby-agent/api-guides/third-party-instrumentation.mdx
@@ -14,7 +14,10 @@ freshnessValidatedDate: 2026-08-11
 
 This document details how to instrument third-party gems with the Ruby agent, as well as some best practices for interacting with the agent. This is useful if you are using a gem that the <DNT>Ruby</DNT> agent does not instrument by default, or if you are a gem author who wants to add instrumentation for your library.
 
-While third party instrumentation is always an option, New Relic also welcomes contributions to the Ruby agent from the community! If you have a gem you'd like to see instrumented, or a feature you'd like to propose, please share your ideas by [opening an issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose) or submitting a pull request to the [`newrelic/newrelic-ruby-agent` repository on GitHub](https://github.com/newrelic/newrelic-ruby-agent).
+<Callout variant="tip">
+New Relic accepts community contributions for the <DNT>Ruby</DNT> agent. If you have a gem you want instrumented or a feature to propose, in the `newrelic/newrelic-ruby-agent` repository on GitHub, share your ideas by opening an [issue](https://github.com/newrelic/newrelic-ruby-agent/issues/new/choose or submitting a [pull request](https://github.com/newrelic/newrelic-ruby-agent).
+</Callout>
+
 
 ## Finding third-party extensions
 


### PR DESCRIPTION
This is a general update to an old document in the Ruby agent docs. We have an open source repo and welcome community contributions and want to make that clear. In addition, we no longer update the extends_newrelic_rpm repo.
