### PR TITLE
docs: release notes for infra agent v1.79.0

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1790.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1790.mdx
@@ -3,7 +3,7 @@ subject: Infrastructure agent
 releaseDate: '2026-08-10'
 version: 1.79.0
 features:
-  - 'Added OCI tag support to match AWS tags'
+  - 'Add additional OCI tags to align with AWS tags'
   - 'Added support to ignore default integration locations via `disable_plugin_default_dir_scan`'
   - 'Exposed environment variables used by Agent Control (AC) as public'
 bugs: []
@@ -17,7 +17,7 @@ A new version of the agent has been released. Follow standard procedures to [upd
 New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [Infrastructure agent 1.65.3](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1653/).
 
 ## Changed
-* Added OCI tag support to match AWS tags. [#2295](https://github.com/newrelic/infrastructure-agent/pull/2295)
+* Add additional OCI tags to align with AWS tags. [#2295](https://github.com/newrelic/infrastructure-agent/pull/2295)
 * Added support to ignore default integration locations via `disable_plugin_default_dir_scan`. [#2290](https://github.com/newrelic/infrastructure-agent/pull/2290)
 * Exposed environment variables used by Agent Control (AC) as public. [#2293](https://github.com/newrelic/infrastructure-agent/pull/2293)
 * Fixed a remote code execution (RCE) vulnerability caused by path traversal. [#2292](https://github.com/newrelic/infrastructure-agent/pull/2292)

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1790.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1790.mdx
@@ -1,0 +1,24 @@
+---
+subject: Infrastructure agent
+releaseDate: '2026-08-10'
+version: 1.79.0
+features:
+  - 'Added OCI tag support to match AWS tags'
+  - 'Added support to ignore default integration locations via `disable_plugin_default_dir_scan`'
+  - 'Exposed environment variables used by Agent Control (AC) as public'
+bugs: []
+security:
+  - 'Fixed a remote code execution (RCE) vulnerability caused by path traversal'
+chore:
+  - 'Bumped vulnerable dependencies flagged by a Trivy scan, and updated embedded OHI versions (nri-docker, nri-flex) to fix CVEs'
+---
+
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [Infrastructure agent 1.65.3](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1653/).
+
+## Changed
+* Added OCI tag support to match AWS tags. [#2295](https://github.com/newrelic/infrastructure-agent/pull/2295)
+* Added support to ignore default integration locations via `disable_plugin_default_dir_scan`. [#2290](https://github.com/newrelic/infrastructure-agent/pull/2290)
+* Exposed environment variables used by Agent Control (AC) as public. [#2293](https://github.com/newrelic/infrastructure-agent/pull/2293)
+* Fixed a remote code execution (RCE) vulnerability caused by path traversal. [#2292](https://github.com/newrelic/infrastructure-agent/pull/2292)
+* Bumped vulnerable dependencies flagged by a Trivy scan, and updated embedded OHI versions (`nri-docker`, `nri-flex`) to fix CVEs. [#2301](https://github.com/newrelic/infrastructure-agent/pull/2301) [#2302](https://github.com/newrelic/infrastructure-agent/pull/2302)


### PR DESCRIPTION
## Give us some context

Adds the release notes for New Relic Infrastructure agent v1.79.0.

**Features**
- Added OCI tag support to match AWS tags
- Added support to ignore default integration locations via `disable_plugin_default_dir_scan`
- Exposed environment variables used by Agent Control (AC) as public

**Security**
- Fixed a remote code execution (RCE) vulnerability caused by path traversal

**Chore**
- Bumped vulnerable dependencies flagged by a Trivy scan, and updated embedded OHI versions (nri-docker, nri-flex) to fix CVEs

Source: https://github.com/newrelic/infrastructure-agent/releases/tag/1.79.0