### PR TITLE
fix(ingest ips): Update dualstack section with more IPv4 CIDRs; fix duplicate anchor

### DIFF
--- a/src/content/docs/new-relic-solutions/get-started/networks.mdx
+++ b/src/content/docs/new-relic-solutions/get-started/networks.mdx
@@ -115,7 +115,7 @@ For more detail on specific agents and integrations, and about ports, keep readi
       <td>
         `collector.jp.nr-data.net`
       </td>
-    </tr>    
+    </tr>
   </tbody>
 
   <thead>
@@ -956,13 +956,13 @@ JP data center endpoints natively accept both IPv4 and IPv6, so no alternate end
     </tbody>
 </table>
 
-### Data ingest IP blocks [#ingest-blocks]
+### Dualstack data ingest IP blocks [#dualstack-ingest-blocks]
 
 We use these blocks for data ingestion:
 
 IPv4
-* US data center endpoints (default): `162.247.240.0/22`
-* EU data center endpoints: `185.221.84.0/22`
+* US data center endpoints (default): `162.247.240.0/22` and `152.38.128.0/21`
+* EU data center endpoints: `185.221.84.0/22` and `212.32.0.0/21`
 * JP data center endpoints: `64.251.192.0/20`
 
 IPv6
@@ -1141,12 +1141,12 @@ If your organization uses a firewall that restricts outbound traffic, follow the
         New Relic Partner API
       </td>
     </tr>
-    
+
     <tr>
       <td>
         `newrelic.github.io`
       </td>
-    
+
       <td>
         Public New Relic Github Pages
       </td>
@@ -1158,8 +1158,8 @@ If your organization uses a firewall that restricts outbound traffic, follow the
 
 [TLS](#tls) is required for all domains. Service for `download.newrelic.com` is provided through CDN and is subject to change without warning.
 
-<Callout variant="important"> 
-New Relic is updating its IP configuration for agent downloads. Starting April 22, 2025, `download.newrelic.com` will use IP addresses from the block `162.247.240.0/22`. Please update your network settings to accommodate this change. 
+<Callout variant="important">
+New Relic is updating its IP configuration for agent downloads. Starting April 22, 2025, `download.newrelic.com` will use IP addresses from the block `162.247.240.0/22`. Please update your network settings to accommodate this change.
 </Callout>
 
 ## Infrastructure details [#infrastructure]


### PR DESCRIPTION
## Summary
- We're rolling out a new ingest solution that adds IPv4 addresses to the dualstack endpoints from our broader IPv4 ingest range ([ingest blocks](https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/#ingest-blocks)), so this updates the dualstack ranges to reflect that: adds `152.38.128.0/21` (US) and `212.32.0.0/21` (EU).
- Fixes the anchor on the dualstack ranges since both the IPv4 and dualstack ranges were anchored with `#ingest-blocks` — renamed to `#dualstack-ingest-blocks`.
- Minor trailing-whitespace cleanup in the same file.

Migrated from [newrelic/docs-website-private#227](https://github.com/newrelic/docs-website-private/pull/227).
