### PR TITLE
docs(notebooks): restore FGA permissions model with roles and CRUD capabilities

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -159,10 +159,6 @@ These are granted via custom roles in the New Relic admin UI.
 | **Full access** | `notebooks.create.notebook`<br />`notebooks.read.notebook`<br />`notebooks.update.notebook`<br />`notebooks.delete.notebook` | Create, read, edit, and delete any notebook in the org |
 | **Creator** | `notebooks.create.notebook` | Create new notebooks (own notebooks only) |
 
-<Callout variant="tip">
-  For Fine Grain Access control to work, users should be given the Creator role at the org level. Read, update, and delete access is then granted per individual notebook.
-</Callout>
-
 #### Notebook-level roles
 
 These are assigned on a specific notebook, typically by the notebook's creator.

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -154,20 +154,58 @@ New Relic Notebooks uses custom roles with CRUD capabilities to control access. 
 
 These are granted via custom roles in the New Relic admin UI.
 
-| Role | Capabilities | What it allows |
-|------|-------------|----------------|
-| **Full access** | `notebooks.create.notebook`<br />`notebooks.read.notebook`<br />`notebooks.update.notebook`<br />`notebooks.delete.notebook` | Create, read, edit, and delete any notebook in the org |
-| **Creator** | `notebooks.create.notebook` | Create new notebooks (own notebooks only) |
+<table>
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>Capabilities</th>
+      <th>What it allows</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>**Full access**</td>
+      <td>`notebooks.create.notebook`<br />`notebooks.read.notebook`<br />`notebooks.update.notebook`<br />`notebooks.delete.notebook`</td>
+      <td>Create, read, edit, and delete any notebook in the org</td>
+    </tr>
+    <tr>
+      <td>**Creator**</td>
+      <td>`notebooks.create.notebook`</td>
+      <td>Create new notebooks (own notebooks only)</td>
+    </tr>
+  </tbody>
+</table>
 
 #### Notebook-level roles
 
 These are assigned on a specific notebook, typically by the notebook's creator.
 
-| Role | Permission | What it allows |
-|------|-----------|----------------|
-| **Owner** | `notebook_owner` | Read, edit, delete, and manage permissions — automatically assigned to the creator |
-| **Editor** | `notebook_editor` | Edit the notebook |
-| **Reader** | `notebook_reader` | View the notebook (read-only) |
+<table>
+  <thead>
+    <tr>
+      <th>Role</th>
+      <th>Permission</th>
+      <th>What it allows</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>**Owner**</td>
+      <td>`notebook_owner`</td>
+      <td>Read, edit, delete, and manage permissions — automatically assigned to the creator</td>
+    </tr>
+    <tr>
+      <td>**Editor**</td>
+      <td>`notebook_editor`</td>
+      <td>Edit the notebook</td>
+    </tr>
+    <tr>
+      <td>**Reader**</td>
+      <td>`notebook_reader`</td>
+      <td>View the notebook (read-only)</td>
+    </tr>
+  </tbody>
+</table>
 
 #### How it works together
 

--- a/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks.mdx
@@ -148,14 +148,37 @@ Every notebook is a resource that belongs to the organization in which it was cr
 
 ### Current permissions model
 
+New Relic Notebooks uses custom roles with CRUD capabilities to control access. There are two levels of access: organization-level (set by an admin) and notebook-level (set per notebook by its creator).
+
+#### Organization-level permissions
+
+These are granted via custom roles in the New Relic admin UI.
+
+| Role | Capabilities | What it allows |
+|------|-------------|----------------|
+| **Full access** | `notebooks.create.notebook`<br />`notebooks.read.notebook`<br />`notebooks.update.notebook`<br />`notebooks.delete.notebook` | Create, read, edit, and delete any notebook in the org |
+| **Creator** | `notebooks.create.notebook` | Create new notebooks (own notebooks only) |
+
 <Callout variant="tip">
-  Notebooks currently do not have granular permission settings. Anyone in the organization who has access to the feature can create new notebooks, edit and delete existing ones.
+  For Fine Grain Access control to work, users should be given the Creator role at the org level. Read, update, and delete access is then granted per individual notebook.
 </Callout>
 
-**Current capabilities:**
-* All organization members with notebooks access can view all notebooks
-* All organization members with notebooks access can create, edit, and delete any notebook
-* Notebooks are automatically shared across your entire organization
+#### Notebook-level roles
+
+These are assigned on a specific notebook, typically by the notebook's creator.
+
+| Role | Permission | What it allows |
+|------|-----------|----------------|
+| **Owner** | `notebook_owner` | Read, edit, delete, and manage permissions — automatically assigned to the creator |
+| **Editor** | `notebook_editor` | Edit the notebook |
+| **Reader** | `notebook_reader` | View the notebook (read-only) |
+
+#### How it works together
+
+1. An admin gives a user the **Creator** org-level role — this lets them create notebooks.
+2. When a user creates a notebook, they automatically become its **Owner**.
+3. The owner can then share the notebook with others by granting them **Editor** or **Reader** roles on that specific notebook.
+4. Users who need access to all notebooks org-wide (for example, admins) get the **Full access** role instead.
 
 
 ## What's next?


### PR DESCRIPTION
## Summary

Restores the correct Notebooks permissions section that was accidentally dropped during a merge conflict fix.

**Problem:** The live doc at `/docs/query-your-data/explore-query-data/notebooks/introduction-notebooks/` incorrectly states:
> "Notebooks currently do not have granular permission settings. Anyone in the organization who has access to the feature can create new notebooks, edit and delete existing ones."

Notebooks **does** support Fine-Grained Access (FGA). This content was written, approved by Legal, and present in a Netlify preview — but lost during a merge conflict resolution.

**Fix:**
- Replaces the incorrect callout with the FGA-based permissions model
- Adds organization-level permissions table (Full access, Creator roles with CRUD capabilities)
- Adds notebook-level roles table (Owner, Editor, Reader)
- Adds "How it works together" step-by-step explanation

