### PR TITLE
docs(net-agent): document transactionTracer sqlMetadataCommentsEnabled

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -3171,7 +3171,7 @@ The `transactionTracer` element supports the following attributes:
       </tbody>
     </table>
 
-    When set to `true`, the agent adds a SQL comment that holds the service entity GUID to the start of each instrumented SQL statement before the database runs the statement. The comment has this format:
+    When set to `true`, the agent adds a SQL comment that holds the service entity GUID to the start of each instrumented SQL statement before the database runs the statement. The comment has the following format:
 
     ```sql
     /*nr_service_guid="YOUR_ENTITY_GUID"*/

--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -277,6 +277,7 @@ NEW_RELIC_CODE_LEVEL_METRICS_ENABLED=true
 NEW_RELIC_AI_MONITORING_ENABLED=true
 NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=true
 NEW_RELIC_CLOUD_AWS_ACCOUNT_ID=123456789012
+NEW_RELIC_TRANSACTION_TRACER_SQL_METADATA_COMMENTS_ENABLED=true
 ```
 
 <CollapserGroup>
@@ -2864,7 +2865,8 @@ The `transactionTracer` element is a child of the `configuration` element. `tran
     explainEnabled="true"
     explainThreshold="500"
     maxSegments="3000"
-    maxExplainPlans="20">
+    maxExplainPlans="20"
+    sqlMetadataCommentsEnabled="false">
   <attributes enabled="true">
     <exclude>myApiKey.*</exclude>
     <include>myApiKey.foo</include>
@@ -3139,6 +3141,53 @@ The `transactionTracer` element supports the following attributes:
     </table>
 
     By default `maxStackTrace` is set to `0`, which disables stack traces as part of a transaction trace. If this value is set greater than `0`, then stack traces will be captured for transaction traces.
+  </Collapser>
+
+  <Collapser
+    id="tracer-sqlMetadataCommentsEnabled"
+    title="sqlMetadataCommentsEnabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When set to `true`, the agent adds a SQL comment that holds the service entity GUID to the start of each instrumented SQL statement before the database runs the statement. The comment has this format:
+
+    ```sql
+    /*nr_service_guid="YOUR_ENTITY_GUID"*/
+    ```
+
+    Use this option to correlate APM data with [query performance monitoring](/docs/infrastructure/infrastructure-data/query-performance-monitoring). The agent changes the statement text that it sends to the database, so the database receives the full comment.
+
+    The agent also records the commented text. The comment appears in slow query traces, in transaction trace segments, and in the `db.statement` attribute of span events. With the default [`recordSql`](#tracer-recordSql) value of `obfuscated`, the agent replaces the quoted entity GUID with `?`, so these records show `/*nr_service_guid=?*/`. Set `recordSql` to `raw` to keep the entity GUID in this agent data.
+
+    This option is available starting in .NET agent version 10.52.0. You can also set it with the `NEW_RELIC_TRANSACTION_TRACER_SQL_METADATA_COMMENTS_ENABLED` environment variable.
+
+    <Callout variant="important">
+      This option changes the text of every instrumented SQL statement. A database that caches query plans or prepared statements by statement text sees each commented statement as a new statement. This can lower the cache hit rate and increase query planning work on the database. The effect is larger when more than one service queries the same database, because each service adds a different entity GUID to the same statement.
+
+      Enable this option in a test environment first, and measure the effect on your database before you enable it in production.
+    </Callout>
   </Collapser>
 
   <Collapser


### PR DESCRIPTION
Documents the `transactionTracer.sqlMetadataCommentsEnabled` option added by
[newrelic-dotnet-agent#3582](https://github.com/newrelic/newrelic-dotnet-agent/pull/3582)
and shipped in .NET agent 10.52.0. The option was missed when the feature merged.

Adds to `net-agent-configuration.mdx`:

- A `sqlMetadataCommentsEnabled` collapser under **Transaction traces** (Boolean, default `false`), with the `/*nr_service_guid="YOUR_ENTITY_GUID"*/` comment format.
- The attribute in the `transactionTracer` XML example.
- `NEW_RELIC_TRANSACTION_TRACER_SQL_METADATA_COMMENTS_ENABLED` in the optional environment variable list.
- An important callout that the comment changes the text of every instrumented statement, so a database that caches plans or prepared statements by statement text can see a lower cache hit rate.
- A note that the default `recordSql="obfuscated"` setting renders the comment as `/*nr_service_guid=?*/` in agent data, because the obfuscator replaces the quoted GUID.
