### PR TITLE
Update wildfly with logmanager scenario

### DIFF
--- a/src/content/docs/apm/agents/java-agent/troubleshooting/classloading-issues-from-jboss-and-wildfly.mdx
+++ b/src/content/docs/apm/agents/java-agent/troubleshooting/classloading-issues-from-jboss-and-wildfly.mdx
@@ -102,7 +102,7 @@ Below are three potential fixes for this error.
 
 Make sure that your Java agent is version `8.6` or higher.
 
-#### Fix 2: Mark packages to be loaded by the system classloader" [#telemetry-fix-2]
+#### Fix 2: Mark packages to be loaded by the system classloader [#telemetry-fix-2]
 
 Since the class `java.util.logging.Level` causes the error, we have to set a system property called `jboss.modules.system.pkgs`. This lets JBoss recognize all classes in the `java.util.logging` package as a system package. As such classes under the package namespace will be loaded by a system class-loader rather than JBoss's classloader.
 
@@ -149,9 +149,13 @@ Repeat these steps for all affected modules.
 
 ## Application fails to start or has other classloading issues [#problem-application-runtime]
 
-### Problem 1: Startup failure due to using the Jakarta/J2EE Management API [#startup-failure-j2ee-management]
+This issue can occur due to any of the following problems:
 
-If your Java agent is version `8.6` or higher and you're using the Jakarta/J2EE Management API (JSR-777), but your application fails to start up. In this instance, you'll see cases of `ClassNotFoundException` where the package name included in the class is `javax.management.j2ee`
+### Startup failure due to using the Jakarta/J2EE Management API [#startup-failure-j2ee-management]
+
+#### Problem [#startup-failure-j2ee-management-problem]
+
+If your Java agent is version `8.6` or higher and you're using the Jakarta/J2EE Management API (JSR-777), your application fails to start up. In this instance, you'll see cases of `ClassNotFoundException` where the package name included in the class is `javax.management.j2ee`.
 
 #### Solution [#startup-failure-j2ee-management-solution-runtime]
 
@@ -190,9 +194,11 @@ Here is an example XML snippet for JBoss EAP 7.4:
 </module>
 ```
 
-### Problem 2: Startup failure due to Jboss's logmanager [#start-up-failure-logmanager]
+### Startup failure due to JBoss's logmanager [#start-up-failure-logmanager]
 
-If your application fails to startup and in your application log and you see this exception, `java.lang.ClassNotFoundException: org.jboss.logmanager.LogManager`.
+#### Problem [#start-up-failure-logmanager-problem]
+
+If your application fails to start up, you'll see this exception in your application log: `java.lang.ClassNotFoundException: org.jboss.logmanager.LogManager`.
 
 #### Solution [#start-up-failure-logmanager-solution-runtime]
 

--- a/src/content/docs/apm/agents/java-agent/troubleshooting/classloading-issues-from-jboss-and-wildfly.mdx
+++ b/src/content/docs/apm/agents/java-agent/troubleshooting/classloading-issues-from-jboss-and-wildfly.mdx
@@ -149,13 +149,13 @@ Repeat these steps for all affected modules.
 
 ## Application fails to start or has other classloading issues [#problem-application-runtime]
 
-### Problem [#start-up-fails]
+### Problem 1: Startup failure due to using the Jakarta/J2EE Management API [#startup-failure-j2ee-management]
 
-This is the solution if your Java agent is version `8.6` or higher and you're using the Jakarta/J2EE Management API (JSR-777), but your application fails to start up. In this instance, you'll see cases of `ClassNotFoundException` where the package name included in the class is `javax.management.j2ee`
+If your Java agent is version `8.6` or higher and you're using the Jakarta/J2EE Management API (JSR-777), but your application fails to start up. In this instance, you'll see cases of `ClassNotFoundException` where the package name included in the class is `javax.management.j2ee`
 
-### Solution [#solution-runtime]
+#### Solution [#startup-failure-j2ee-management-solution-runtime]
 
-If you upgraded the Java Agent to `8.6` or higher, your application may fail to start up if you are using the Jakarta/J2EE Management API. The solution to this is to upgrade your agent to `8.7` or higher and then add the system property:
+Upgrade your agent to `8.7` or higher and then add the system property:
 
 ```
 -Dcom.newrelic.jboss.jsr77.fix=true
@@ -188,4 +188,17 @@ Here is an example XML snippet for JBoss EAP 7.4:
        <module name="java.management"/>
    </dependencies>
 </module>
+```
+
+### Problem 2: Startup failure due to Jboss's logmanager [#start-up-failure-logmanager]
+
+If your application fails to startup and in your application log and you see this exception, `java.lang.ClassNotFoundException: org.jboss.logmanager.LogManager`.
+
+#### Solution [#start-up-failure-logmanager-solution-runtime]
+
+Update `WILDFLY_HOME/bin/standalone.conf` to add the following:
+
+```
+MODULE_OPTS="$MODULE_OPTS -javaagent:/Users/jkeller/nr/agents/newrelic_snapshot_build/newrelic.jar"
+JAVA_OPTS="$JAVA_OPTS -Dorg.wildfly.logging.skipLogManagerCheck=true"
 ```


### PR DESCRIPTION
## Summary

- Recreates the contribution from #25252 by @obenkenobi (a new troubleshooting scenario for a JBoss logmanager classloading failure), since we can't push maintainer edits directly to that fork's protected `develop` branch.
- Restructures the "Application fails to start or has other classloading issues" section so each problem's title is its own heading, with dedicated Problem/Solution subheadings underneath — matching the pattern already used in the doc's first section — instead of numbered "Problem 1"/"Problem 2" labels.
- Adds a lead-in sentence noting the app-runtime failure can stem from either problem.
- Fixes a stray quote in the "Fix 2" heading.

Supersedes #25252, which will be closed in favor of this PR.