### PR TITLE
Add Autopilot 2.1 release notes

### DIFF
--- a/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
+++ b/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
@@ -7,16 +7,16 @@ title: 'Autopilot 2.1'
 
 ## What's new
 
-### Autopilot: More reliable analysis
+### Autopilot: More Reliable Analysis
 
-* **More accurate anomaly detection:** Transaction dependency analysis now uses a more rigorous threshold. The previous setting was overly sensitive and flagged noise as anomalies. Downstream dependency analysis also more clearly differentiates between correlation and causation, reducing speculative root-cause attribution.
+* **More accurate anomaly detection:** Transaction dependency analysis now uses a more rigorous threshold. The previous setting was overly-sensitive and flagged noise as anomalies. Downstream dependency analysis also more clearly differentiates between correlation and causation, reducing speculative root-cause attribution.
 * **Trend comparisons grounded in real data:** When Autopilot compares current error rates or counts to a prior period, those baselines now come from verified NRQL queries.
 * **Longer investigations complete reliably:** Resolved a bug where some investigation flows did not properly perform context window compaction when they needed to occur. If compaction encounters an error, your investigation progress is preserved rather than lost. Investigations also properly stop when you navigate away, freeing browser resources.
-* **Correct active issue counts:** Added fixes to return a more accurate number of issues when asking for the number of active issues in your account.
+* **Correct active issue counts:** Added fixes to return more accurate number of issues when asking for number of active issues in your account.
 * **Slack responses render cleanly:** Markdown tables and structured formatting (headers, dividers, and lists) now display correctly in Slack notifications and workflow responses.
 * **EU entity resolution fixed:** Resolved a bug that made it difficult for Autopilot running in the EU to find the Kubernetes agent.
 * **Your timezone and context preserved:** Your timezone and the entity context you're investigating are now correctly maintained throughout the entire session. Previously, context could be lost when multiple context sources were present.
-* **Cleaner query result rendering:** NRQL queries containing comparison operators or other special characters are no longer mangled in the response visualization.
+* **General fixes to UI rendering when using comparison operators and special characters:** NRQL queries containing comparison operators or other special characters are no longer mangled in the response visualization.
 * **Improved prompt-injection identification, with fewer false positives:** Autopilot no longer incorrectly declines benign in-chat notes (such as providing context or clarifying details) with a misleading "prompt injection" warning. The guardrail is now properly scoped so valid requests proceed normally.
 * **Memory recall improvements:** Fixed bugs that prevented Autopilot from finding facts from multi-memory lookups and improper flags on valid memories.
 * **Preferences honored correctly:** Autopilot no longer incorrectly tells you it can't remember your stated preferences (like how you'd like to be addressed). Your conversational preferences are now recognized and respected.
@@ -28,17 +28,19 @@ title: 'Autopilot 2.1'
 * **Incident investigation follows related issues:** When investigating major incidents with related issues across different accounts, Autopilot now resolves each related issue using its own account ID rather than defaulting to the parent incident's account.
 * **UI polish:** Feedback ratings now only persist when you explicitly submit them. Action icons are always visible (no longer hidden behind hover). Copy conversation is properly disabled until there's content to copy. Slash command connector names display correctly.
 
-### GitHub MCP integration capability (Public Preview)
+### GitHub MCP Integration Capability (Public Preview)
 
-When an alert points to a deployment-related regression, the first question is almost always "what shipped?" Connect Autopilot to GitHub so it can pull the pull request behind a Change Tracking deployment and return the "what shipped" story inline.
+<Callout title="preview">
+  We're still working on this feature, but we'd love for you to try it out. This feature is currently provided as part of a preview program pursuant to our pre-release policies.
+</Callout>
 
-* **Link a deployment to a pull request:** When Autopilot identifies a Change Tracking event with a commit SHA during an investigation, it fetches the associated pull request and returns the number, title, description, author, and URL as part of the investigation response.
-* **Summarize what changed:** Autopilot reports the files touched and the added and deleted line counts for the pull request that shipped the incident-adjacent deployment.
-* **Ask follow-up questions in the same thread:** Once a pull request is on the record, you can ask Autopilot to compare it to the previous deployment or correlate the change with the failing signal. The GitHub context stays live in that investigation.
-* **Works from any entry point:** GitHub context flows into investigations triggered by an alert with an SRE destination, a Slack message, or the AI Chat panel.
-* **Read-only access via a personal access token:** Autopilot uses a GitHub PAT scoped to `Pull requests: Read`, `Contents: Read`, and `Metadata: Read`. It never creates pull requests, posts comments, merges branches, or stores source code. This preview supports public `github.com` only. GitHub Enterprise Server (self-hosted) and GitHub Enterprise Cloud are not supported yet.
-* **Org-level setup:** A New Relic organization manager connects GitHub once from **Configure > Autopilot > External MCP connections**. The token is encrypted at rest in the New Relic Secrets Service, isolated to your organization, and retrieved into request-scoped memory only for the duration of a single investigation.
+When an alert points at a deployment-related regression, the first question is almost always "what shipped?" You end up switching between the New Relic incident, your Change Tracking event, and the GitHub PR to piece the story together. Connect Autopilot to GitHub so it can pull the Pull Request behind a Change Tracking deployment and return the "what shipped" story inline.
 
-Requires an active Autopilot setup, Change Tracking configured with commit SHAs, GitHub organization admin access to create a fine-grained PAT, New Relic organization manager access, and the `sre_agent_github_integration` feature flag enabled on your account. Contact your New Relic account team to confirm the flag.
+* **Link a deployment to a PR:** When Autopilot identifies a Change Tracking event with a commit SHA during an investigation, it fetches the associated Pull Request and returns the number, title, description, author, and URL as part of the investigation response. No tab switching needed.
+* **Summarize what changed:** Autopilot reports the files touched and the added and deleted line counts for the PR that shipped the incident-adjacent deployment.
+* **Follow-up questions in the same thread:** Once a PR is on the record, you can ask Autopilot to compare it to the previous deployment or correlate the change with the failing signal. The GitHub context stays live in that investigation.
+* **Works from any entry point:** GitHub context flows into investigations triggered by an SRE alert destination, a Slack message, or the AI Chat panel. Autopilot brings in the PR automatically whenever a Change Tracking event with a commit SHA is present.
+* **Read-only access via Personal Access Token:** Autopilot uses your configured GitHub PAT scoped to `Pull requests: Read`, `Contents: Read`, and `Metadata: Read`. It never creates PRs, posts comments, merges branches, or stores source code. This preview supports public **github.com only**. **GitHub Enterprise Server (self-hosted) and GitHub Enterprise Cloud** are not supported yet.
+* **Org-level setup:** A New Relic organization manager connects GitHub once from **Configure → Autopilot → External MCP connections**. The PAT is encrypted at rest in the New Relic Secrets Service, isolated to your organization, and retrieved into request-scoped memory only for the duration of a single investigation.
 
-For more information, refer to [Connect Autopilot to GitHub](/docs/agentic-ai/autopilot/connect-to-github/) and [Use Autopilot with GitHub](/docs/agentic-ai/autopilot/use-autopilot-with-github/).
+**Prerequisites:** Active Autopilot setup, Change Tracking configured with commit SHAs flowing into New Relic, GitHub organization admin access to create a fine-grained PAT, New Relic org manager access, and the `sre_agent_github_integration` feature flag enabled on your account. Contact your New Relic account team to confirm the flag.

--- a/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
+++ b/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
@@ -1,0 +1,42 @@
+---
+subject: Autopilot
+releaseDate: '2026-08-13'
+version: '2.1'
+title: 'Autopilot 2.1'
+---
+
+## What's new
+
+### Autopilot 2.1: GitHub context for investigations, and more reliable analysis
+
+* **Connect Autopilot to GitHub for deployment context (Public Preview)**
+
+  * When an alert points to a deployment-related regression, the first question is almost always "what shipped?" Connect Autopilot to GitHub so it can pull the pull request behind a Change Tracking deployment and return the "what shipped" story inline, instead of switching between the incident, the Change Tracking event, and the pull request.
+  * **Link a deployment to a pull request:** When Autopilot identifies a Change Tracking event with a commit SHA during an investigation, it fetches the associated pull request and returns the number, title, description, author, and URL as part of the investigation response.
+  * **Summarize what changed:** Autopilot reports the files touched and the added and deleted line counts for the pull request that shipped the incident-adjacent deployment.
+  * **Ask follow-up questions in the same thread:** Once a pull request is on the record, you can ask Autopilot to compare it to the previous deployment or correlate the change with the failing signal. The GitHub context stays live in that investigation.
+  * **Works from any entry point:** GitHub context flows into investigations triggered by an alert with an SRE destination, a Slack message, or the AI Chat panel.
+  * **Read-only access via a personal access token:** Autopilot uses a GitHub PAT scoped to `Pull requests: Read`, `Contents: Read`, and `Metadata: Read`. It never creates pull requests, posts comments, merges branches, or stores source code. This preview supports public `github.com` only. GitHub Enterprise Server (self-hosted) and GitHub Enterprise Cloud are not supported yet.
+  * **Org-level setup:** A New Relic organization manager connects GitHub once from **Configure > Autopilot > External MCP connections**. The token is encrypted at rest in the New Relic Secrets Service, isolated to your organization, and retrieved into request-scoped memory only for the duration of a single investigation.
+  * Requires an active Autopilot setup, Change Tracking configured with commit SHAs, GitHub organization admin access to create a fine-grained PAT, New Relic organization manager access, and the `sre_agent_github_integration` feature flag enabled on your account. Contact your New Relic account team to confirm the flag.
+  * For more information, refer to [Connect Autopilot to GitHub](/docs/agentic-ai/autopilot/connect-to-github/) and [Use Autopilot with GitHub](/docs/agentic-ai/autopilot/use-autopilot-with-github/).
+* **Improvements and fixes**
+
+  * **More accurate anomaly detection:** Transaction dependency analysis now uses a more rigorous threshold. The previous setting was overly sensitive and flagged noise as anomalies. Downstream dependency analysis also more clearly differentiates between correlation and causation, reducing speculative root-cause attribution.
+  * **Trend comparisons grounded in real data:** When Autopilot compares current error rates or counts to a prior period, those baselines now come from verified NRQL queries.
+  * **Longer investigations complete reliably:** Resolved a bug where some investigation flows did not properly perform context window compaction when they needed to occur. If compaction encounters an error, your investigation progress is preserved rather than lost. Investigations also properly stop when you navigate away, freeing browser resources.
+  * **Correct active issue counts:** Added fixes to return a more accurate number of issues when asking for the number of active issues in your account.
+  * **Slack responses render cleanly:** Markdown tables and structured formatting (headers, dividers, and lists) now display correctly in Slack notifications and workflow responses.
+  * **EU entity resolution fixed:** Resolved a bug that made it difficult for Autopilot running in the EU to find the Kubernetes agent.
+  * **Your timezone and context preserved:** Your timezone and the entity context you're investigating are now correctly maintained throughout the entire session. Previously, context could be lost when multiple context sources were present.
+  * **Cleaner query result rendering:** NRQL queries containing comparison operators or other special characters are no longer mangled in the response visualization.
+  * **Improved prompt-injection identification, with fewer false positives:** Autopilot no longer incorrectly declines benign in-chat notes (such as providing context or clarifying details) with a misleading "prompt injection" warning. The guardrail is now properly scoped so valid requests proceed normally.
+  * **Memory recall improvements:** Fixed bugs that prevented Autopilot from finding facts from multi-memory lookups and improper flags on valid memories.
+  * **Preferences honored correctly:** Autopilot no longer incorrectly tells you it can't remember your stated preferences (like how you'd like to be addressed). Your conversational preferences are now recognized and respected.
+  * **Documentation citations reference the right account:** When Autopilot cites documentation or entity information from RAG lookups, it now references entity GUIDs belonging to your account.
+  * **Accurate timeseries results reporting:** TIMESERIES NRQL queries that return valid data are no longer incorrectly reported as having no results.
+  * **No more repeated reasoning text:** Fixed a bug where the same reasoning text could appear multiple times in Autopilot's thinking display during an investigation.
+  * **Improved stability of the chat panel in the browser:** Fixed a memory leak that could cause browser tab crashes when loading chat history on accounts with many conversations. Also fixed crashes when multiple browser tabs had the AI chat panel open simultaneously, and prevented concurrent agent streams from conflicting when starting a new conversation mid-stream.
+  * **Better visualization summaries:** Investigation responses now capture both NRQL queries and their resulting visualizations more completely, giving you richer context in summary cards.
+  * **Incident investigation follows related issues:** When investigating major incidents with related issues across different accounts, Autopilot now resolves each related issue using its own account ID rather than defaulting to the parent incident's account.
+  * **UI polish:** Feedback ratings now only persist when you explicitly submit them. Action icons are always visible (no longer hidden behind hover). Copy conversation is properly disabled until there's content to copy. Slash command connector names display correctly.

--- a/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
+++ b/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
@@ -7,36 +7,38 @@ title: 'Autopilot 2.1'
 
 ## What's new
 
-### Autopilot 2.1: GitHub context for investigations, and more reliable analysis
+### Autopilot: More reliable analysis
 
-* **Connect Autopilot to GitHub for deployment context (Public Preview)**
+* **More accurate anomaly detection:** Transaction dependency analysis now uses a more rigorous threshold. The previous setting was overly sensitive and flagged noise as anomalies. Downstream dependency analysis also more clearly differentiates between correlation and causation, reducing speculative root-cause attribution.
+* **Trend comparisons grounded in real data:** When Autopilot compares current error rates or counts to a prior period, those baselines now come from verified NRQL queries.
+* **Longer investigations complete reliably:** Resolved a bug where some investigation flows did not properly perform context window compaction when they needed to occur. If compaction encounters an error, your investigation progress is preserved rather than lost. Investigations also properly stop when you navigate away, freeing browser resources.
+* **Correct active issue counts:** Added fixes to return a more accurate number of issues when asking for the number of active issues in your account.
+* **Slack responses render cleanly:** Markdown tables and structured formatting (headers, dividers, and lists) now display correctly in Slack notifications and workflow responses.
+* **EU entity resolution fixed:** Resolved a bug that made it difficult for Autopilot running in the EU to find the Kubernetes agent.
+* **Your timezone and context preserved:** Your timezone and the entity context you're investigating are now correctly maintained throughout the entire session. Previously, context could be lost when multiple context sources were present.
+* **Cleaner query result rendering:** NRQL queries containing comparison operators or other special characters are no longer mangled in the response visualization.
+* **Improved prompt-injection identification, with fewer false positives:** Autopilot no longer incorrectly declines benign in-chat notes (such as providing context or clarifying details) with a misleading "prompt injection" warning. The guardrail is now properly scoped so valid requests proceed normally.
+* **Memory recall improvements:** Fixed bugs that prevented Autopilot from finding facts from multi-memory lookups and improper flags on valid memories.
+* **Preferences honored correctly:** Autopilot no longer incorrectly tells you it can't remember your stated preferences (like how you'd like to be addressed). Your conversational preferences are now recognized and respected.
+* **Documentation citations reference the right account:** When Autopilot cites documentation or entity information from RAG lookups, it now references entity GUIDs belonging to your account.
+* **Accurate timeseries results reporting:** TIMESERIES NRQL queries that return valid data are no longer incorrectly reported as having no results.
+* **No more repeated reasoning text:** Fixed a bug where the same reasoning text could appear multiple times in Autopilot's thinking display during an investigation.
+* **Improved stability of the chat panel in the browser:** Fixed a memory leak that could cause browser tab crashes when loading chat history on accounts with many conversations. Also fixed crashes when multiple browser tabs had the AI chat panel open simultaneously, and prevented concurrent agent streams from conflicting when starting a new conversation mid-stream.
+* **Better visualization summaries:** Investigation responses now capture both NRQL queries and their resulting visualizations more completely, giving you richer context in summary cards.
+* **Incident investigation follows related issues:** When investigating major incidents with related issues across different accounts, Autopilot now resolves each related issue using its own account ID rather than defaulting to the parent incident's account.
+* **UI polish:** Feedback ratings now only persist when you explicitly submit them. Action icons are always visible (no longer hidden behind hover). Copy conversation is properly disabled until there's content to copy. Slash command connector names display correctly.
 
-  * When an alert points to a deployment-related regression, the first question is almost always "what shipped?" Connect Autopilot to GitHub so it can pull the pull request behind a Change Tracking deployment and return the "what shipped" story inline, instead of switching between the incident, the Change Tracking event, and the pull request.
-  * **Link a deployment to a pull request:** When Autopilot identifies a Change Tracking event with a commit SHA during an investigation, it fetches the associated pull request and returns the number, title, description, author, and URL as part of the investigation response.
-  * **Summarize what changed:** Autopilot reports the files touched and the added and deleted line counts for the pull request that shipped the incident-adjacent deployment.
-  * **Ask follow-up questions in the same thread:** Once a pull request is on the record, you can ask Autopilot to compare it to the previous deployment or correlate the change with the failing signal. The GitHub context stays live in that investigation.
-  * **Works from any entry point:** GitHub context flows into investigations triggered by an alert with an SRE destination, a Slack message, or the AI Chat panel.
-  * **Read-only access via a personal access token:** Autopilot uses a GitHub PAT scoped to `Pull requests: Read`, `Contents: Read`, and `Metadata: Read`. It never creates pull requests, posts comments, merges branches, or stores source code. This preview supports public `github.com` only. GitHub Enterprise Server (self-hosted) and GitHub Enterprise Cloud are not supported yet.
-  * **Org-level setup:** A New Relic organization manager connects GitHub once from **Configure > Autopilot > External MCP connections**. The token is encrypted at rest in the New Relic Secrets Service, isolated to your organization, and retrieved into request-scoped memory only for the duration of a single investigation.
-  * Requires an active Autopilot setup, Change Tracking configured with commit SHAs, GitHub organization admin access to create a fine-grained PAT, New Relic organization manager access, and the `sre_agent_github_integration` feature flag enabled on your account. Contact your New Relic account team to confirm the flag.
-  * For more information, refer to [Connect Autopilot to GitHub](/docs/agentic-ai/autopilot/connect-to-github/) and [Use Autopilot with GitHub](/docs/agentic-ai/autopilot/use-autopilot-with-github/).
-* **Improvements and fixes**
+### GitHub MCP integration capability (Public Preview)
 
-  * **More accurate anomaly detection:** Transaction dependency analysis now uses a more rigorous threshold. The previous setting was overly sensitive and flagged noise as anomalies. Downstream dependency analysis also more clearly differentiates between correlation and causation, reducing speculative root-cause attribution.
-  * **Trend comparisons grounded in real data:** When Autopilot compares current error rates or counts to a prior period, those baselines now come from verified NRQL queries.
-  * **Longer investigations complete reliably:** Resolved a bug where some investigation flows did not properly perform context window compaction when they needed to occur. If compaction encounters an error, your investigation progress is preserved rather than lost. Investigations also properly stop when you navigate away, freeing browser resources.
-  * **Correct active issue counts:** Added fixes to return a more accurate number of issues when asking for the number of active issues in your account.
-  * **Slack responses render cleanly:** Markdown tables and structured formatting (headers, dividers, and lists) now display correctly in Slack notifications and workflow responses.
-  * **EU entity resolution fixed:** Resolved a bug that made it difficult for Autopilot running in the EU to find the Kubernetes agent.
-  * **Your timezone and context preserved:** Your timezone and the entity context you're investigating are now correctly maintained throughout the entire session. Previously, context could be lost when multiple context sources were present.
-  * **Cleaner query result rendering:** NRQL queries containing comparison operators or other special characters are no longer mangled in the response visualization.
-  * **Improved prompt-injection identification, with fewer false positives:** Autopilot no longer incorrectly declines benign in-chat notes (such as providing context or clarifying details) with a misleading "prompt injection" warning. The guardrail is now properly scoped so valid requests proceed normally.
-  * **Memory recall improvements:** Fixed bugs that prevented Autopilot from finding facts from multi-memory lookups and improper flags on valid memories.
-  * **Preferences honored correctly:** Autopilot no longer incorrectly tells you it can't remember your stated preferences (like how you'd like to be addressed). Your conversational preferences are now recognized and respected.
-  * **Documentation citations reference the right account:** When Autopilot cites documentation or entity information from RAG lookups, it now references entity GUIDs belonging to your account.
-  * **Accurate timeseries results reporting:** TIMESERIES NRQL queries that return valid data are no longer incorrectly reported as having no results.
-  * **No more repeated reasoning text:** Fixed a bug where the same reasoning text could appear multiple times in Autopilot's thinking display during an investigation.
-  * **Improved stability of the chat panel in the browser:** Fixed a memory leak that could cause browser tab crashes when loading chat history on accounts with many conversations. Also fixed crashes when multiple browser tabs had the AI chat panel open simultaneously, and prevented concurrent agent streams from conflicting when starting a new conversation mid-stream.
-  * **Better visualization summaries:** Investigation responses now capture both NRQL queries and their resulting visualizations more completely, giving you richer context in summary cards.
-  * **Incident investigation follows related issues:** When investigating major incidents with related issues across different accounts, Autopilot now resolves each related issue using its own account ID rather than defaulting to the parent incident's account.
-  * **UI polish:** Feedback ratings now only persist when you explicitly submit them. Action icons are always visible (no longer hidden behind hover). Copy conversation is properly disabled until there's content to copy. Slash command connector names display correctly.
+When an alert points to a deployment-related regression, the first question is almost always "what shipped?" Connect Autopilot to GitHub so it can pull the pull request behind a Change Tracking deployment and return the "what shipped" story inline.
+
+* **Link a deployment to a pull request:** When Autopilot identifies a Change Tracking event with a commit SHA during an investigation, it fetches the associated pull request and returns the number, title, description, author, and URL as part of the investigation response.
+* **Summarize what changed:** Autopilot reports the files touched and the added and deleted line counts for the pull request that shipped the incident-adjacent deployment.
+* **Ask follow-up questions in the same thread:** Once a pull request is on the record, you can ask Autopilot to compare it to the previous deployment or correlate the change with the failing signal. The GitHub context stays live in that investigation.
+* **Works from any entry point:** GitHub context flows into investigations triggered by an alert with an SRE destination, a Slack message, or the AI Chat panel.
+* **Read-only access via a personal access token:** Autopilot uses a GitHub PAT scoped to `Pull requests: Read`, `Contents: Read`, and `Metadata: Read`. It never creates pull requests, posts comments, merges branches, or stores source code. This preview supports public `github.com` only. GitHub Enterprise Server (self-hosted) and GitHub Enterprise Cloud are not supported yet.
+* **Org-level setup:** A New Relic organization manager connects GitHub once from **Configure > Autopilot > External MCP connections**. The token is encrypted at rest in the New Relic Secrets Service, isolated to your organization, and retrieved into request-scoped memory only for the duration of a single investigation.
+
+Requires an active Autopilot setup, Change Tracking configured with commit SHAs, GitHub organization admin access to create a fine-grained PAT, New Relic organization manager access, and the `sre_agent_github_integration` feature flag enabled on your account. Contact your New Relic account team to confirm the flag.
+
+For more information, refer to [Connect Autopilot to GitHub](/docs/agentic-ai/autopilot/connect-to-github/) and [Use Autopilot with GitHub](/docs/agentic-ai/autopilot/use-autopilot-with-github/).

--- a/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
+++ b/src/content/docs/release-notes/autopilot-release-notes/autopilot-26-08-13.mdx
@@ -31,7 +31,9 @@ title: 'Autopilot 2.1'
 ### GitHub MCP Integration Capability (Public Preview)
 
 <Callout title="preview">
-  We're still working on this feature, but we'd love for you to try it out. This feature is currently provided as part of a preview program pursuant to our pre-release policies.
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
 When an alert points at a deployment-related regression, the first question is almost always "what shipped?" You end up switching between the New Relic incident, your Change Tracking event, and the GitHub PR to piece the story together. Connect Autopilot to GitHub so it can pull the Pull Request behind a Change Tracking deployment and return the "what shipped" story inline.


### PR DESCRIPTION
Adds the Autopilot 2.1 release notes, based on the SRE Agent 2.1 Release Confluence page.