### PR TITLE
Add custom-role permissions for missing GCP services (NR-602142)

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -361,8 +361,6 @@ To set up a custom role:
           <td>
             * `datastore.databases.get`
             * `datastore.databases.list`
-            * `datastore.indexes.get`
-            * `datastore.indexes.list`
           </td>
         </tr>
 
@@ -421,8 +419,6 @@ To set up a custom role:
           <td>
             * `datastore.databases.get`
             * `datastore.databases.list`
-            * `datastore.indexes.get`
-            * `datastore.indexes.list`
           </td>
         </tr>
 

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -92,12 +92,7 @@ To control permissions more precisely than the `Viewer` role allows, create a cu
 </Callout>
 
 <Callout variant="tip">
-  If you connect with <DNT>**Workload Identity Federation**</DNT> (GCP V2) and use a custom role, the [list of permissions](#list-permissions) alone is not enough. New Relic discovers your resources through the Cloud Asset API, and folder-level integrations read folder metadata. In addition to your custom role, grant `roles/cloudasset.viewer` (and `roles/resourcemanager.folderViewer` for folder-level integrations), or include the equivalent permissions in your custom role:
-
-  * `cloudasset.assets.listResource`
-  * `cloudasset.assets.searchAllResources`
-  * `cloudasset.assets.listIamPolicy`
-  * `resourcemanager.folders.get` (folder-level integrations only)
+  If you connect with <DNT>**Workload Identity Federation**</DNT> (GCP V2) and use a custom role, the [list of permissions](#list-permissions) alone is not enough. New Relic discovers your resources through the Cloud Asset API. Alongside your custom role, also grant `roles/cloudasset.viewer` (and `roles/resourcemanager.folderViewer` for folder-level integrations), as described in [Required roles](#roles-wif).
 </Callout>
 
 To set up a custom role:

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -141,7 +141,7 @@ To set up a custom role:
       <tbody>
         <tr>
           <td>
-            [Google AlloyDB](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration)
+            [Google AlloyDB](/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration)
           </td>
 
           <td>
@@ -366,7 +366,7 @@ To set up a custom role:
 
         <tr>
           <td>
-            [Google Firebase Authentication](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-auth-monitoring-integration)
+            [Google Firebase Authentication](/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-auth-monitoring-integration)
           </td>
 
           <td>
@@ -434,7 +434,7 @@ To set up a custom role:
 
         <tr>
           <td>
-            [Google Managed Kafka](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-managed-kafka-monitoring-integration)
+            [Google Managed Kafka](/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-managed-kafka-monitoring-integration)
           </td>
 
           <td>
@@ -471,7 +471,7 @@ To set up a custom role:
 
         <tr>
           <td>
-            [Google Memorystore for Valkey](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-valkey)
+            [Google Memorystore for Valkey](/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-valkey)
           </td>
 
           <td>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -125,16 +125,6 @@ To set up a custom role:
     <TabsPageItem id="permissions-services">
       For some GCP integrations, New Relic also needs the following permissions, mainly to collect tags and other attributes.
 
-      {/*
-        REVIEWER NOTE (remove before merge) — NR-602142.
-        Rows NEW in this change and NOT yet empirically validated (permissions derived from
-        Google predefined viewer roles; validate per NR-484530 before publishing):
-        AlloyDB, Bigtable, Cloud API Gateway, Cloud Composer, Cloud Dataproc, Cloud Router,
-        Datastore, Firestore, Firebase (Auth/Realtime Database/Hosting/Storage), Managed Kafka,
-        Memorystore (Memcached/Redis/Valkey), Serverless VPC Access, Vertex AI.
-        Highest-risk to confirm: the four Firebase rows, Valkey (memorystore.* namespace), Vertex AI.
-      */}
-
       <table>
       <thead>
         <tr>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -91,10 +91,6 @@ To control permissions more precisely than the `Viewer` role allows, create a cu
   New Relic has no way of identifying problems related to custom permissions. If you choose to create a custom role, it is your responsibility to maintain it and ensure it collects the data properly.
 </Callout>
 
-<Callout variant="tip">
-  If you connect with <DNT>**Workload Identity Federation**</DNT> (GCP V2) and use a custom role, the [list of permissions](#list-permissions) alone is not enough. New Relic discovers your resources through the Cloud Asset API. Alongside your custom role, also grant `roles/cloudasset.viewer` (and `roles/resourcemanager.folderViewer` for folder-level integrations), as described in [Required roles](#roles-wif).
-</Callout>
-
 To set up a custom role:
 
 1. Create a Google Cloud IAM custom role in each GCP project you want to monitor.

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles.mdx
@@ -91,6 +91,15 @@ To control permissions more precisely than the `Viewer` role allows, create a cu
   New Relic has no way of identifying problems related to custom permissions. If you choose to create a custom role, it is your responsibility to maintain it and ensure it collects the data properly.
 </Callout>
 
+<Callout variant="tip">
+  If you connect with <DNT>**Workload Identity Federation**</DNT> (GCP V2) and use a custom role, the [list of permissions](#list-permissions) alone is not enough. New Relic discovers your resources through the Cloud Asset API, and folder-level integrations read folder metadata. In addition to your custom role, grant `roles/cloudasset.viewer` (and `roles/resourcemanager.folderViewer` for folder-level integrations), or include the equivalent permissions in your custom role:
+
+  * `cloudasset.assets.listResource`
+  * `cloudasset.assets.searchAllResources`
+  * `cloudasset.assets.listIamPolicy`
+  * `resourcemanager.folders.get` (folder-level integrations only)
+</Callout>
+
 To set up a custom role:
 
 1. Create a Google Cloud IAM custom role in each GCP project you want to monitor.
@@ -125,6 +134,16 @@ To set up a custom role:
     <TabsPageItem id="permissions-services">
       For some GCP integrations, New Relic also needs the following permissions, mainly to collect tags and other attributes.
 
+      {/*
+        REVIEWER NOTE (remove before merge) — NR-602142.
+        Rows NEW in this change and NOT yet empirically validated (permissions derived from
+        Google predefined viewer roles; validate per NR-484530 before publishing):
+        AlloyDB, Bigtable, Cloud API Gateway, Cloud Composer, Cloud Dataproc, Cloud Router,
+        Datastore, Firestore, Firebase (Auth/Realtime Database/Hosting/Storage), Managed Kafka,
+        Memorystore (Memcached/Redis/Valkey), Serverless VPC Access, Vertex AI.
+        Highest-risk to confirm: the four Firebase rows, Valkey (memorystore.* namespace), Vertex AI.
+      */}
+
       <table>
       <thead>
         <tr>
@@ -139,6 +158,19 @@ To set up a custom role:
       </thead>
 
       <tbody>
+        <tr>
+          <td>
+            [Google AlloyDB](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-alloydb-monitoring-integration)
+          </td>
+
+          <td>
+            * `alloydb.clusters.get`
+            * `alloydb.clusters.list`
+            * `alloydb.instances.get`
+            * `alloydb.instances.list`
+          </td>
+        </tr>
+
         <tr>
           <td>
             [Google AppEngine](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-app-engine-monitoring-integration)
@@ -164,6 +196,50 @@ To set up a custom role:
 
         <tr>
           <td>
+            [Google Bigtable](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-bigtable-monitoring-integration)
+          </td>
+
+          <td>
+            * `bigtable.instances.get`
+            * `bigtable.instances.list`
+            * `bigtable.clusters.get`
+            * `bigtable.clusters.list`
+            * `bigtable.tables.get`
+            * `bigtable.tables.list`
+            * `bigtable.appProfiles.get`
+            * `bigtable.appProfiles.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Cloud API Gateway](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-api-gateway-monitoring-integration)
+          </td>
+
+          <td>
+            * `apigateway.gateways.get`
+            * `apigateway.gateways.list`
+            * `apigateway.apis.get`
+            * `apigateway.apis.list`
+            * `apigateway.apiconfigs.get`
+            * `apigateway.apiconfigs.list`
+            * `apigateway.locations.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Cloud Composer](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-composer-monitoring-integration)
+          </td>
+
+          <td>
+            * `composer.environments.get`
+            * `composer.environments.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             [Google Cloud Dataflow](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataflow-monitoring-integration)
           </td>
 
@@ -172,6 +248,19 @@ To set up a custom role:
             * `dataflow.jobs.list`
             * `dataflow.messages.list`
             * `dataflow.metrics.get`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Cloud Dataproc](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-dataproc-monitoring-integration)
+          </td>
+
+          <td>
+            * `dataproc.clusters.get`
+            * `dataproc.clusters.list`
+            * `dataproc.jobs.get`
+            * `dataproc.jobs.list`
           </td>
         </tr>
 
@@ -205,6 +294,17 @@ To set up a custom role:
             * `pubsub.subscriptions.list`
             * `pubsub.topics.get`
             * `pubsub.topics.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Cloud Router](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-router-monitoring-integration)
+          </td>
+
+          <td>
+            * `compute.routers.get`
+            * `compute.routers.list`
           </td>
         </tr>
 
@@ -274,11 +374,157 @@ To set up a custom role:
 
         <tr>
           <td>
+            [Google Datastore](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-datastore-monitoring-integration)
+          </td>
+
+          <td>
+            * `datastore.databases.get`
+            * `datastore.databases.list`
+            * `datastore.indexes.get`
+            * `datastore.indexes.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Firebase Authentication](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-auth-monitoring-integration)
+          </td>
+
+          <td>
+            * `firebase.projects.get`
+            * `firebaseauth.configs.get`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Firebase Realtime Database](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-database-monitoring-integration)
+          </td>
+
+          <td>
+            * `firebase.projects.get`
+            * `firebasedatabase.instances.get`
+            * `firebasedatabase.instances.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Firebase Hosting](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-hosting-monitoring-integration)
+          </td>
+
+          <td>
+            * `firebase.projects.get`
+            * `firebasehosting.sites.get`
+            * `firebasehosting.sites.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Firebase Storage](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firebase-storage-monitoring-integration)
+          </td>
+
+          <td>
+            * `firebase.projects.get`
+            * `firebasestorage.buckets.get`
+            * `firebasestorage.buckets.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Firestore](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-firestore-monitoring-integration)
+          </td>
+
+          <td>
+            * `datastore.databases.get`
+            * `datastore.databases.list`
+            * `datastore.indexes.get`
+            * `datastore.indexes.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
             [Google Kubernetes Engine](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-kubernetes-engine-monitoring-integration)
           </td>
 
           <td>
             `container.clusters.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Managed Kafka](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-managed-kafka-monitoring-integration)
+          </td>
+
+          <td>
+            * `managedkafka.clusters.get`
+            * `managedkafka.clusters.list`
+            * `managedkafka.topics.get`
+            * `managedkafka.topics.list`
+            * `managedkafka.consumerGroups.get`
+            * `managedkafka.consumerGroups.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Memorystore for Memcached](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-memcached)
+          </td>
+
+          <td>
+            * `memcache.instances.get`
+            * `memcache.instances.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Memorystore for Redis](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-redis)
+          </td>
+
+          <td>
+            * `redis.instances.get`
+            * `redis.instances.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Memorystore for Valkey](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-memorystore-valkey)
+          </td>
+
+          <td>
+            * `memorystore.instances.get`
+            * `memorystore.instances.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Serverless VPC Access](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-serverless-vpc-access-monitoring-integration)
+          </td>
+
+          <td>
+            * `vpcaccess.connectors.get`
+            * `vpcaccess.connectors.list`
+            * `vpcaccess.locations.list`
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            [Google Vertex AI](/docs/integrations/google-cloud-platform-integrations/gcp-integrations-list/google-vertexai-monitoring-integration)
+          </td>
+
+          <td>
+            * `aiplatform.endpoints.get`
+            * `aiplatform.endpoints.list`
+            * `aiplatform.models.get`
+            * `aiplatform.models.list`
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
## Summary

Updates the GCP **Integrations and custom roles** doc for [NR-602142](https://new-relic.atlassian.net/browse/NR-602142).

### Fill the service gap in the custom-role permission list (12 → 30)
The **List of permissions → Service-specific permissions** table only covered 12 integrations; the GCP integration documents 30. This adds the 18 missing services (table re-ordered alphabetically):

AlloyDB · Bigtable · Cloud API Gateway · Cloud Composer · Dataproc · Cloud Router · Datastore · Firestore · Firebase (Auth / Realtime Database / Hosting / Storage) · Managed Kafka · Memorystore (Memcached / Redis / Valkey) · Serverless VPC Access · Vertex AI

## Validation status

**Permission names + predefined-role membership — verified** via `gcloud iam roles describe` against Google's live predefined roles. Every permission in the 18 new rows exists and is a member of the service's predefined **viewer** role (`roles/alloydb.viewer`, `roles/redis.viewer`, `roles/memorystore.viewer` for Valkey, the four `roles/firebase*` roles, `roles/aiplatform.viewer`, etc.).

- One correction applied during validation: Datastore & Firestore originally listed `datastore.indexes.get/list`, which are **not** in `roles/datastore.viewer`; corrected to `datastore.databases.get/list`.

**Still pending — NR polling necessity/sufficiency.** This validation confirms the permissions are real and viewer-role-scoped; it does **not** confirm that this exact set is what New Relic V2 polling requires (nothing more, nothing less). Per the doc's own disclaimer and the V1 process in [NR-484530](https://new-relic.atlassian.net/browse/NR-484530), each row should ideally be confirmed against live polling (create custom role → select service → verify dashboard populates) before/soon after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[NR-602142]: https://new-relic.atlassian.net/browse/NR-602142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-484530]: https://new-relic.atlassian.net/browse/NR-484530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ