### PR TITLE
chore: bump @newrelic/gatsby-theme-newrelic to 9.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@emotion/styled": "^11.3.0",
     "@mdx-js/mdx": "2.0.0-next.8",
     "@mdx-js/react": "2.0.0-next.8",
-    "@newrelic/gatsby-theme-newrelic": "9.18.0",
+    "@newrelic/gatsby-theme-newrelic": "9.18.1",
     "@splitsoftware/splitio-react": "^1.2.4",
     "ansi-colors": "^4.1.3",
     "cockatiel": "^3.0.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,10 +3383,10 @@
     eslint-plugin-promise "^4.2.1"
     eslint-plugin-react "^7.14.3"
 
-"@newrelic/gatsby-theme-newrelic@9.18.0":
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.18.0.tgz#1994a9519cbe3e34bea260312651516aacf7c5c7"
-  integrity sha512-+03eTnawojHQ0ISFxPEqCuQB/Q0IjlPwsnjS8bSgexu9Y7jZMoCIUOoQhIIj5p+93UEbDxB0DR9sOHAp6BRy6w==
+"@newrelic/gatsby-theme-newrelic@9.18.1":
+  version "9.18.1"
+  resolved "https://registry.yarnpkg.com/@newrelic/gatsby-theme-newrelic/-/gatsby-theme-newrelic-9.18.1.tgz#fcead62a683cfd49c88d7974ac832195f55dd91d"
+  integrity sha512-XnQA6Mi1u6wR/ovK3tjq06XH3/EWr2DNqh+x1Ami/xiL0ep7P7tULkHyNukD52q9SvlrPBf6tDbpi3IvZ//YRg==
   dependencies:
     "@wry/equality" "^0.4.0"
     "@xstate/react" "^1.3.1"


### PR DESCRIPTION
## Summary
- Bumps `@newrelic/gatsby-theme-newrelic` 9.18.0 → 9.18.1 to pick up the footer link fix ([newrelic/gatsby-theme-newrelic#1180](https://github.com/newrelic/gatsby-theme-newrelic/pull/1180)).
- Fixes the site-wide 404 on `newrelic.com/termsandconditions/uk-slavery-act` (now `modern-slavery-act`) and updates the footer label across all locales.

## Test plan
- [x] `yarn.lock` resolves `@newrelic/gatsby-theme-newrelic@9.18.1`
- [ ] Verify footer link/label render correctly after deploy preview

Jira: NR-605530

🤖 Generated with [Claude Code](https://claude.com/claude-code)