### PR TITLE
Clarify navigation for switching between organizations with the same email

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
@@ -38,7 +38,7 @@ When you update your email address in New Relic, this won't cause double billing
 
 Each [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) you have access to has its own user record for your email address. To switch between these user records, go to the user menu and select <DNT>**Other users**</DNT>, then choose a user record for another organization. You'll be prompted to log in for that organization, either directly or via your identity provider.
 
-If you only have access to one organization, the <DNT>**Other users**</DNT> option won't appear in the user menu.
+If you have access only to one organization, the <DNT>**Other users**</DNT> option won't appear in the user menu.
 
 <Callout variant="tip">
   To access user records that have a different email address, you must log out and log back in.

--- a/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
@@ -36,9 +36,13 @@ When you update your email address in New Relic, this won't cause double billing
 
 ## Switch between user records [#switch]
 
-When you log in to New Relic, you can go to the [user menu](/docs/accounts/accounts-billing/general-account-settings/intro-account-settings) to switch to other user records that have the same email address. When you choose a user record from the menu, you'll be prompted to log in for that user record (either directly to New Relic or via your identity provider).
+Each [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) you have access to has its own user record for your email address. To switch between these user records, go to the user menu and select <DNT>**Other users**</DNT>, then choose a user record for another organization. You'll be prompted to log in for that organization, either directly or via your identity provider.
 
-To access user records that have a different email address, you must log out and log back in.
+If you only have access to one organization, the <DNT>**Other users**</DNT> option won't appear in the user menu.
+
+<Callout variant="tip">
+  To access user records that have a different email address, you must log out and log back in.
+</Callout>
 
 ## "Multiple logins found" message [#login-message]
 

--- a/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
@@ -36,7 +36,7 @@ When you update your email address in New Relic, this won't cause double billing
 
 ## Switch between user records [#switch]
 
-Each [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) you have access to has its own user record for your email address. To switch between these user records, go to the user menu and select <DNT>**Other users**</DNT>, then choose a user record for another organization. You'll be prompted to log in for that organization, either directly or via your identity provider.
+Each [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) you have access to has its own user record for your email address. To switch between these user records, go to the user menu and select <DNT>**Other users**</DNT>. Then choose a user record for another organization. New Relic prompts you to log in for that organization, either directly or via your identity provider.
 
 If you have access only to one organization, the <DNT>**Other users**</DNT> option won't appear in the user menu.
 


### PR DESCRIPTION
## Summary
- Rewrites the "Switch between user records" section on `multiple-user-records.mdx` to describe the actual UI path (user menu > **Other users**) instead of the previous generic wording.
- Links first mention of organization to the New Relic account structure doc, notes the option is hidden when a user has access to only one organization, and moves the cross-email log-out/log-in note into a tip callout.