### PR TITLE
Clarify where to find the Include variable toggle

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables.mdx
@@ -43,45 +43,6 @@ With template variables, you can set up a wide variety of variables and filters 
 
 Furthermore, you can now decide if you want to include the variable or not without having to modify your queries. See the [Include variable](/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables/#include-variable) section for details. 
 
-## Include and exclude variables [#include-variable]
-
-When you enable the <DNT>**Include variable**</DNT> toggle and select a value, the dashboard data is filtered by that value. You can click <DNT>**Refresh to default value**</DNT> to restore the configured defaults. For more information, see [template variables](#create-variables).
-
-For example, you may be investigating an issue that is not specific to any particular value within a variable. In such cases, the variable's existing values might be limiting query results, even when selecting all possible options. To address this, you can exclude the variable from the query. This effectively removes the variable's condition and replaces it with a neutral boolean value (true or false), ensuring query validity and returning comprehensive results.  
-
-### Example
-
-Consider a query that filters results based on a `countryCode` variable. If you want to view data for all countries without filtering, you can exclude the variable:
-
-Original query:
-
-  ```sql
-  FROM PageAction 
-  SELECT count(*) AS 'views' 
-  WHERE countryCode IN ({{countryCode}}) AND appName = 'Test App' FACET countryCode
-  ```
-
-Query with an excluded variable:
-
-  ```sql
-  FROM PageAction 
-  SELECT count(*) AS 'views' 
-  WHERE true AND appName = 'Test App' FACET countryCode
-  ```
-
-This feature is particularly useful when: 
-
-* The variable has more values than the maximum allowed (for instance, 5000 max results for uniques by default) or a very high number of values. Choosing to disable the variable by default will deliver considerable performance improvements.
-
-* The data source for the variable differs from the database you're querying. 
-In these cases, selecting all values from the database using "Select all" isn't sufficient. By excluding the variable, you can retrieve all values from the database.
-
-Limitations on include variable:
-
-* When used in FACET cases, the condition is replaced with true and converts it to an always-true condition.
-
-* When used in other contexts like functions or with the `SELECT` statement, you'll get the following error: `"Unknown function Disable_variable()"`. This is because the disable variable function isn't implemented for these specific cases yet.
-
 ## Show and hide variables [#variable-visibility]
 
 You can hide template variables from the variables bar in View mode while they continue to function normally. In Edit mode, hidden variables display with a <Icon name="fe-eye-off"/> icon, so dashboard editors can identify and manage them.
@@ -264,7 +225,7 @@ Define a template variable that you'll use in a NRQL query to create a widget.
 
             To use multiple values on a `WHERE` clause you need to use [`IN`](/docs/query-your-data/nrql-new-relic-query-language/get-started/nrql-syntax-clauses-functions/#sel-where) instead of `=`.
             
-            The **Include variable** toggle will determine the default configuration, include or exclude, for that variable in the dashboard. This configuration can be modified by the user viewing the dashboard by using the **Include variable** toggle in the variable dropdown menu. The user selected configuration will be valid for the duration of the session. 
+            The **Include variable** toggle will determine the default configuration, include or exclude, for that variable in the dashboard. The user viewing the dashboard can modify this configuration using the **Include variable** toggle in the variable dropdown menu. The user-selected configuration will be valid for the duration of the session. For details on where to find this toggle and how it affects queries, see [Include and exclude variables](#include-variable).
             <Callout variant="important">
             Note that you can only configure default values when the toggle is set to include variable. Once you select the default values you can switch the toggle so the variable is not included by default. The default values will be preselected when any user turns the toggle to include the variable from the variable dropdown menu.
             </Callout>
@@ -351,6 +312,48 @@ When you're done defining a template variable and adding a widget that reference
 Here's an example of the resulting widget, on the right, with the `country` dropdown to the left.
 
 <img title="Country template variable example" alt="Country template variable example" src="/images/dashboards_screenshot-crop_country-variable-example.webp"/>
+
+## Include and exclude variables [#include-variable]
+
+The <DNT>**Include variable**</DNT> toggle, on by default, controls whether the dashboard filters by the variable's selected value. Because this setting is specific to that one variable rather than all the variables in the dashboard, it lives inside the variable's own value dropdown rather than on the shared variables bar. You can:
+
+* Exclude the variable from the query by turning off the toggle. This replaces the variable's condition with a neutral boolean value (`true`).
+* Restore both the toggle and the value to the variable's configured defaults using <DNT>**Reset to default value**</DNT>.
+
+This selection is valid only for the current session. To set the toggle's default state when you define a variable, see [Default value](#step1).
+
+### Example
+
+Consider a query that filters results based on a `countryCode` variable. If you want to view data for all countries without filtering, you can exclude the variable:
+
+Original query:
+
+  ```sql
+  FROM PageAction 
+  SELECT count(*) AS 'views' 
+  WHERE countryCode IN ({{countryCode}}) AND appName = 'Test App' FACET countryCode
+  ```
+
+Query with an excluded variable:
+
+  ```sql
+  FROM PageAction 
+  SELECT count(*) AS 'views' 
+  WHERE true AND appName = 'Test App' FACET countryCode
+  ```
+
+This feature is useful when: 
+
+* The variable has more values than the maximum allowed (for instance, 5000 max results for uniques by default) or a very high number of values. Disabling the variable by default reduces query load.
+
+* The data source for the variable differs from the database you're querying. 
+In these cases, selecting all values from the database using "Select all" isn't sufficient. By excluding the variable, you can retrieve all values from the database.
+
+Limitations on include variable:
+
+* When used in FACET cases, the condition is replaced with true and converts it to an always-true condition.
+
+* When used in other contexts like functions or with the `SELECT` statement, you'll get the following error: `"Unknown function Disable_variable()"`. This is because the disable variable function isn't implemented for these specific cases yet.
 
 ## Rules for writing a query-type template variable [#query-variable-rules]
 


### PR DESCRIPTION
## Summary
- Reorganizes the "Include and exclude variables" section on the [template variables](https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/dashboard-template-variables/) page to appear after the variable/widget creation procedure, so users see how to create variables and widgets before reading about the Include variable toggle.