### PR TITLE
chore(.net agent): Update compatibility docs for latest supported library versions

### DIFF
--- a/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
+++ b/src/content/docs/apm/agents/net-agent/getting-started/net-agent-compatibility-requirements.mdx
@@ -415,7 +415,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   The .NET agent `v9.2.0` or higher automatically instruments the [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                   * Minimum supported version: 3.17.0
-                  * Latest verified compatible version: 3.61.0
+                  * Latest verified compatible version: 3.62.1
                   * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                 </td>
                 </tr>
@@ -499,7 +499,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     Use [Oracle.ManagedDataAccess.Core](https://www.nuget.org/packages/Oracle.ManagedDataAccess.Core/)
 
                     * Minimum supported version: 23.4.0
-                    * Latest verified compatible version: 23.26.200
+                    * Latest verified compatible version: 23.26.300
 
                     Older versions of `Oracle.ManagedDataAccess.Core` may be instrumented, but have not been tested and are not supported.
                 </td>
@@ -521,7 +521,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
         Use [Npgsql](https://www.nuget.org/packages/Npgsql/)
 
         * Minimum supported version: 4.0.0
-        * Latest verified compatible version: 7.0.7
+        * Latest verified compatible version: 10.0.3
 
         Prior versions of Npgsql may also be instrumented, but duplicate and/or missing metrics are possible.
                 </td>
@@ -542,7 +542,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                   Minimum supported version: 2.3.0
 
-                  Latest verified compatible version: 3.9.0
+                  Latest verified compatible version: 3.11.0
 
                   Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -574,12 +574,12 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   <DNT>**MySql.Data**</DNT>
                       * Minimum supported version: 6.10.7
-                      * Latest verified compatible version: 9.7.0
+                      * Latest verified compatible version: 26.7.0
                       * Versions 9.7.0 and higher are supported beginning with .NET agent v10.52.0
 
                   <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
-                      * Latest verified compatible version: 2.6.1
+                      * Latest verified compatible version: 2.6.2
                 </td>
                 </tr>
 
@@ -597,7 +597,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
             Minimum supported version: 1.0.488
 
-            Latest verified compatible version: 3.0.11
+            Latest verified compatible version: 3.1.13
                 </td>
                 </tr>
 
@@ -618,7 +618,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
               <DNT>**Elastic.Clients.Elasticsearch**</DNT>
                   * Minimum supported version: 8.0.0
-                  * Maximum supported version: 8.15.10
+                  * Maximum supported version: 9.0.7
                   * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
                   * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 
@@ -668,7 +668,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.100
+                  * Latest verified compatible version: 4.0.103.1
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -689,7 +689,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                 <td>
                 Use [System.Data.Odbc](https://www.nuget.org/packages/System.Data.Odbc/).
                     * Minimum supported version: 8.0.0
-                    * Latest verified compatible version: 10.0.9
+                    * Latest verified compatible version: 10.0.11
                     * Minimum agent version required: 10.35.0
                     
 
@@ -796,7 +796,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                 </td>
                 <td>
-                    4.0.100
+                    4.0.101.1
                 </td>
                 </tr>
                 <tr>
@@ -824,7 +824,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.37.0 (`CompleteChat`, `CompleteChatAsync` - only `Text` completions are supported)
                 </td>
                 <td>
-                    2.8.0-beta1
+                    2.8.0-beta.1
                 </td>
                 </tr>
             </tbody>
@@ -887,7 +887,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    4.3.1
+                    4.4.0
                 </td>
                 </tr>
 
@@ -902,7 +902,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     9.7.0
                 </td>
                 <td>
-                    6.1.3
+                    6.1.4
                 </td>
                 </tr>
 
@@ -917,7 +917,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.0.0
                 </td>
                 <td>
-                    10.0.9
+                    10.0.11
                 </td>
                 </tr>
             </tbody>
@@ -974,7 +974,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 5.0
 
-                    * Latest verified compatible version: 10.2.7
+                    * Latest verified compatible version: 10.2.8
                 </td>
                 </tr>
 
@@ -1028,7 +1028,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.100
+                  * Latest verified compatible version: 4.0.100.8
                 </td>
                 </tr>
 
@@ -1042,7 +1042,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.100
+                  * Latest verified compatible version: 4.0.100.8
                 </td>
                 </tr>
 
@@ -1056,7 +1056,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                   * Minimum supported version: 3.7.0
 
-                  * Latest verified compatible version: 4.0.100
+                  * Latest verified compatible version: 4.0.100.8
                 </td>
                 </tr>
 
@@ -1136,7 +1136,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     10.51.0
                 </td>
                 <td>
-                    1.8.23
+                    1.8.24
                 </td>
                 </tr>
             </tbody>
@@ -1534,7 +1534,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         The .NET agent `v9.2.0` or higher automatically instruments [Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) library.
 
                         * Minimum supported version: 3.17.0
-                        * Latest verified compatible version: 3.61.0
+                        * Latest verified compatible version: 3.62.1
                         * Versions 3.35.0 and higher are supported beginning with .NET agent v10.32.0
                       </td>
                     </tr>
@@ -1668,7 +1668,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     <td>
                       Minimum supported version: 2.3.0
 
-                      Latest verified compatible version: 3.9.0
+                      Latest verified compatible version: 3.11.0
 
                       Versions 3.0.0 and higher are supported beginning with .NET agent v10.40.0.
 
@@ -1700,12 +1700,12 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**MySql.Data**</DNT>
                       * Minimum supported version: 6.10.7
-                      * Latest verified compatible version: 9.7.0
+                      * Latest verified compatible version: 26.7.0
                       * Versions 9.7.0 and higher are supported beginning with .NET agent v10.52.0
 
                       <DNT>**MySqlConnector**</DNT>
                       * Minimum supported version: 1.0.1
-                      * Latest verified compatible version: 2.6.1
+                      * Latest verified compatible version: 2.6.2
                     </td>
                     </tr>
 
@@ -1725,7 +1725,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         Use [Oracle.ManagedDataAccess](https://www.nuget.org/packages/Oracle.ManagedDataAccess/)
 
                         * Minimum supported version: 12.1.2400
-                        * Latest verified compatible version: 23.26.200
+                        * Latest verified compatible version: 23.26.300
                     </td>
                     </tr>
                     
@@ -1745,7 +1745,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
             Use [Npgsql](https://www.nuget.org/packages/Npgsql/)
 
             * Minimum supported version: 4.0.0
-            * Latest verified compatible version: 7.0.7
+            * Latest verified compatible version: 8.0.9
 
             Prior versions of Npgsql may also be instrumented, but duplicate and/or missing metrics are possible.
                     </td>
@@ -1781,7 +1781,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                     </td>
                     <td>
                         * Minimum supported version: 1.0.488
-                        * Latest verified compatible version: 3.0.11
+                        * Latest verified compatible version: 3.1.13
                     </td>
                     </tr>
 
@@ -1802,7 +1802,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                       <DNT>**Elastic.Clients.Elasticsearch**</DNT>
                       * Minimum supported version: 8.0.0
-                      * Maximum supported version: 8.15.10
+                      * Maximum supported version: 8.18.3
                       * Versions 8.10.0 and higher are supported beginning with .NET agent v10.20.1
                       * Versions 8.12.1 and higher are supported beginning with .NET agent v10.23.0
 
@@ -1853,7 +1853,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                   Use [AWSSDK.DynamoDBv2](https://www.nuget.org/packages/AWSSDK.DynamoDBv2).
 
                   * Minimum supported version: 3.5.0
-                  * Latest verified compatible version: 4.0.100
+                  * Latest verified compatible version: 4.0.103.1
 
                   * Minimum agent version required: 10.33.0
                 </td>
@@ -1937,7 +1937,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                             Minimum supported version: 105.2.3
 
-                            Latest verified compatible version: 113.1.0
+                            Latest verified compatible version: 114.0.0
 
                             Known incompatible versions: 106.8.0, 106.9.0, 106.10.0, 106.10.1
                     </td>
@@ -2021,7 +2021,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`InvokeModelAsync`, `ConverseAsync`)
                     </td>
                     <td>
-                        4.0.100
+                        4.0.101.1
                     </td>
                     </tr>
                     <tr>
@@ -2049,7 +2049,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.37.0 (`CompleteChat`, `CompleteChatAsync` - only `Text` completions are supported)
                     </td>
                     <td>
-                        2.8.0-beta1
+                        2.8.0-beta.1
                     </td>
                     </tr>
                 </tbody>
@@ -2112,7 +2112,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        4.3.1
+                        4.4.0
                     </td>
                     </tr>
 
@@ -2127,7 +2127,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        6.1.2
+                        6.1.4
                     </td>
                     </tr>
 
@@ -2142,7 +2142,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         9.7.0
                     </td>
                     <td>
-                        10.0.9
+                        10.0.11
                     </td>
                     </tr>
                 </tbody>
@@ -2262,7 +2262,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                         * Minimum supported version: 3.7.0
 
-                        * Latest verified compatible version: 4.0.100
+                        * Latest verified compatible version: 4.0.100.8
                     </td>
                     </tr>
 
@@ -2276,7 +2276,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.100
+                    * Latest verified compatible version: 4.0.100.8
                     </td>
                     </tr>
 
@@ -2290,7 +2290,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
 
                     * Minimum supported version: 3.7.0
 
-                    * Latest verified compatible version: 4.0.100
+                    * Latest verified compatible version: 4.0.100.8
                     </td>
                     </tr>
 
@@ -2369,7 +2369,7 @@ Want to try out our .NET agent? [Create a New Relic account](https://newrelic.co
                         10.51.0
                     </td>
                     <td>
-                        1.8.23
+                        1.8.24
                     </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Updates the .NET agent compatibility and requirements page with the latest verified compatible library versions.

- Latest verified versions updated for the AWS SDK packages, Cosmos DB, MongoDB, MySqlConnector, MySQL, NServiceBus, StackExchange.Redis, System.Data.Odbc, Serilog, NLog, Hangfire, RestSharp, Oracle, Npgsql, and Elasticsearch. Some entries had drifted behind earlier updates and are now reconciled against the agent repo's generated compatibility doc.