### PR TITLE
docs: .NET agent, add section on IIS env var settings to env var understanding document

### DIFF
--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -224,11 +224,11 @@ CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/linux-arm64/libNewRelicP
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
 
-## Setting environment variables for IIS-hosted applications [#iis]
+## Set environment variables for IIS-hosted applications [#iis]
 
 If your application is hosted in IIS, you can set environment variables on a per-application-pool basis by editing IIS's `ApplicationHost.config` file directly, instead of (or in addition to) setting them as system-wide environment variables. This is useful when you want to enable or configure the .NET agent for only specific application pools, rather than for every process on the machine.
 
-By default, `ApplicationHost.config` is located at `C:\Windows\System32\inetsrv\config\ApplicationHost.config`. Within the `<applicationPools>` section, each `<add>` element representing an application pool can contain an `<environmentVariables>` child element, which in turn contains `<add name="..." value="..." />` entries for each environment variable you want to set for that application pool.
+By default, you'll find `ApplicationHost.config` at `C:\Windows\System32\inetsrv\config\ApplicationHost.config`. Within the `<applicationPools>` section, each `<add>` element representing an application pool can contain an `<environmentVariables>` child element, which in turn contains `<add name="..." value="..." />` entries for each environment variable you want to set for that application pool.
 
 For example, to enable the .NET agent and set a few common configuration options for an application pool named `TestApplication`:
 
@@ -250,8 +250,10 @@ For example, to enable the .NET agent and set a few common configuration options
 </applicationPools>
 ```
 
-You can also use `applicationPoolDefaults` to set environment variables that apply to all application pools by default, in the same way system-wide environment variables would, unless overridden by a specific pool's own `environmentVariables` settings.
+You can also use `applicationPoolDefaults` to set environment variables that apply to all application pools by default, in the same way system-wide environment variables would, unless a specific pool's own `environmentVariables` settings override them.
 
-Note: Editing `ApplicationHost.config` directly requires administrator privileges, and an application pool must be recycled (or IIS restarted) for changes to take effect. Always back up the file before editing it, since a malformed configuration can prevent IIS from starting sites or application pools.
+<Callout title ="Note">
+Editing `ApplicationHost.config` directly requires administrator privileges, and you must recycle an application pool (or restart IIS) for changes to take effect. Always back up the file before editing it, since a malformed configuration can prevent IIS from starting sites or application pools.
+</Callout>
 
 For more details on this configuration element, see Microsoft's documentation on [applicationPoolDefaults environmentVariables](https://learn.microsoft.com/en-us/iis/configuration/system.applicationhost/applicationpools/applicationpooldefaults/environmentvariables/).

--- a/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
+++ b/src/content/docs/apm/agents/net-agent/other-installation/understanding-net-agent-environment-variables.mdx
@@ -223,3 +223,35 @@ CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A}
 CORECLR_PROFILER_PATH="<YOUR_APPLICATION_PATH>/newrelic/linux-arm64/libNewRelicProfiler.so"
 CORECLR_NEWRELIC_HOME="<YOUR_APPLICATION_PATH>/newrelic"
 ```
+
+## Setting environment variables for IIS-hosted applications [#iis]
+
+If your application is hosted in IIS, you can set environment variables on a per-application-pool basis by editing IIS's `ApplicationHost.config` file directly, instead of (or in addition to) setting them as system-wide environment variables. This is useful when you want to enable or configure the .NET agent for only specific application pools, rather than for every process on the machine.
+
+By default, `ApplicationHost.config` is located at `C:\Windows\System32\inetsrv\config\ApplicationHost.config`. Within the `<applicationPools>` section, each `<add>` element representing an application pool can contain an `<environmentVariables>` child element, which in turn contains `<add name="..." value="..." />` entries for each environment variable you want to set for that application pool.
+
+For example, to enable the .NET agent and set a few common configuration options for an application pool named `TestApplication`:
+
+```xml
+<applicationPools>
+    <add name="DefaultAppPool" />
+    <add name="TestApplication" autoStart="true" managedRuntimeVersion="v4.0">
+        <environmentVariables>
+            <add name="COR_ENABLE_PROFILING" value="1" />
+            <add name="NEW_RELIC_LICENSE_KEY" value="xxxxxxxx" />
+            <add name="NEW_RELIC_APP_NAME" value="MyIisApplication" />
+            <add name="NEWRELIC_LOG_LEVEL" value="debug" />
+            <add name="NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED" value="true" />
+        </environmentVariables>
+    </add>
+    <applicationPoolDefaults managedRuntimeVersion="v4.0">
+        <processModel identityType="ApplicationPoolIdentity" loadUserProfile="true" setProfileEnvironment="false" />
+    </applicationPoolDefaults>
+</applicationPools>
+```
+
+You can also use `applicationPoolDefaults` to set environment variables that apply to all application pools by default, in the same way system-wide environment variables would, unless overridden by a specific pool's own `environmentVariables` settings.
+
+Note: Editing `ApplicationHost.config` directly requires administrator privileges, and an application pool must be recycled (or IIS restarted) for changes to take effect. Always back up the file before editing it, since a malformed configuration can prevent IIS from starting sites or application pools.
+
+For more details on this configuration element, see Microsoft's documentation on [applicationPoolDefaults environmentVariables](https://learn.microsoft.com/en-us/iis/configuration/system.applicationhost/applicationpools/applicationpooldefaults/environmentvariables/).


### PR DESCRIPTION
This updates the .NET agent's "understanding .NET agent environment variables" doc with info on how to configure env vars for IIS-hosted applications in ApplicationHost.config.
