### PR TITLE
iOS Release Notes v6.9.33

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111.mdx
@@ -12,6 +12,6 @@ redirects:
 - Dashboard: pull-to-refresh on detail, compact list + shimmer, thinner lines
 - Dashboard: log table timestamp format (MMM DD, HH:mm:ss.SSS)
 - Notification health UI — banner copy, Fix button style, permission card layout
-- MobileBreadcrumb recorded on Query Editor edits
+- `MobileBreadcrumb` recorded on Query Editor edits
 - Fixed: Notification config screen — removed stale coordinator dependency
 - Fixed: Push notification interactions now recorded synchronously, dismiss aligned with Android

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111.mdx
@@ -13,5 +13,5 @@ redirects:
 - Dashboard: log table timestamp format (MMM DD, HH:mm:ss.SSS)
 - Notification health UI — banner copy, Fix button style, permission card layout
 - MobileBreadcrumb recorded on Query Editor edits
-- Fix: Notification config screen — removed stale coordinator dependency
-- Fix: Push notification interactions now recorded synchronously, dismiss aligned with Android
+- Fixed: Notification config screen — removed stale coordinator dependency
+- Fixed: Push notification interactions now recorded synchronously, dismiss aligned with Android

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111.mdx
@@ -1,0 +1,17 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2026-08-19'
+version: '6.9.33'
+downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
+redirects:
+  - /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6111
+---
+
+### Features, Improvements & Fixes
+- New Relic AI V2 — inline charts, thread history, entitlement gating
+- Dashboard: pull-to-refresh on detail, compact list + shimmer, thinner lines
+- Dashboard: log table timestamp format (MMM DD, HH:mm:ss.SSS)
+- Notification health UI — banner copy, Fix button style, permission card layout
+- MobileBreadcrumb recorded on Query Editor edits
+- Fix: Notification config screen — removed stale coordinator dependency
+- Fix: Push notification interactions now recorded synchronously, dismiss aligned with Android


### PR DESCRIPTION
Release notes for iOS app v6.9.33 (build id 6111), released to production.

**Features**
- New Relic AI V2 — inline charts, thread history, entitlement gating
- Dashboard: pull-to-refresh on detail, compact list + shimmer, thinner lines
- Dashboard: log table timestamp format (MMM DD, HH:mm:ss.SSS)
- Notification health UI — banner copy, Fix button style, permission card layout
- MobileBreadcrumb recorded on Query Editor edits

**Bug Fixes**
- Notification config screen: removed stale coordinator dependency
- Push: notification interactions now recorded synchronously, dismiss aligned with Android

Release doc: https://newrelic.atlassian.net/wiki/spaces/UXMI/pages/5989859431/iOS+Release+6.9.33+Doc+-+13th+August+2026+Release+Owner+Punit+Naik