### PR TITLE
Add quota increase steps to GCP integrations troubleshooting doc

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/troubleshooting/troubleshooting-gcp-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/troubleshooting/troubleshooting-gcp-integrations.mdx
@@ -136,6 +136,14 @@ These errors are specific to [Workload Identity Federation](/docs/infrastructure
 * For WIF integrations, verify the service account's token hasn't been revoked.
 * Check the account status dashboard in <DNT>**Infrastructure > GCP**</DNT> for any reported errors.
 
+### Requesting a quota increase [#quota-increase]
+
+If metrics are consistently stale rather than just occasionally delayed, you may be hitting the <DNT>**Cloud Monitoring API**</DNT> quota for your project. To request a higher quota:
+
+1. In the Google Cloud console, go to <DNT>**IAM & Admin > Quotas & System Limits**</DNT>.
+2. Filter by <DNT>**Service: Cloud Monitoring API**</DNT>.
+3. Find the quota named <DNT>**Time series queries per minute**</DNT>, select it, and click <DNT>**Edit Quotas**</DNT> to request an increase.
+
 ## GCP projects not visible during setup [#no-projects]
 
 * The authenticated account needs the `resourcemanager.projects.get` permission to list projects.

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/troubleshooting/troubleshooting-gcp-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/troubleshooting/troubleshooting-gcp-integrations.mdx
@@ -132,17 +132,13 @@ These errors are specific to [Workload Identity Federation](/docs/infrastructure
 
 ## Stale or delayed metrics [#stale-metrics]
 
-* Check the GCP Cloud Monitoring API quotas in your GCP project. If you're hitting rate limits, data collection can slow down.
+* Check the GCP Cloud Monitoring API quotas in your GCP project. If you're hitting rate limits, data collection can slow down. To request a higher quota:
+
+  1. In the Google Cloud console, go to <DNT>**IAM & Admin > Quotas & System Limits**</DNT>.
+  2. Filter by <DNT>**Service: Cloud Monitoring API**</DNT>.
+  3. Find the quota named <DNT>**Time series queries per minute**</DNT>, select it, and click <DNT>**Edit Quotas**</DNT> to request an increase.
 * For WIF integrations, verify the service account's token hasn't been revoked.
 * Check the account status dashboard in <DNT>**Infrastructure > GCP**</DNT> for any reported errors.
-
-### Requesting a quota increase [#quota-increase]
-
-If metrics are consistently stale rather than just occasionally delayed, you may be hitting the <DNT>**Cloud Monitoring API**</DNT> quota for your project. To request a higher quota:
-
-1. In the Google Cloud console, go to <DNT>**IAM & Admin > Quotas & System Limits**</DNT>.
-2. Filter by <DNT>**Service: Cloud Monitoring API**</DNT>.
-3. Find the quota named <DNT>**Time series queries per minute**</DNT>, select it, and click <DNT>**Edit Quotas**</DNT> to request an increase.
 
 ## GCP projects not visible during setup [#no-projects]
 


### PR DESCRIPTION
## Summary
- Adds a "Requesting a quota increase" subsection under **Stale or delayed metrics** in the GCP integrations troubleshooting doc

Preview:
<img width="869" height="262" alt="Screenshot 2026-08-19 at 6 24 52 PM" src="https://github.com/user-attachments/assets/7aea3a06-c9ec-4aa3-8420-83f9c91c51a9" />


## Test plan
- [ ] Preview renders correctly (DNT tags, heading anchor)