### PR TITLE
Remove translationType: machine from Mobile User Journeys doc

### DIFF
--- a/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys.mdx
+++ b/src/content/docs/mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys.mdx
@@ -6,7 +6,6 @@ tags:
   - Mobile app pages
 metaDescription: Mobile User Journeys visualizes how end users navigate your mobile app in aggregate, helping you understand user behavior, identify friction points, and improve the overall app experience.
 freshnessValidatedDate: never
-translationType: machine
 ---
 
 Mobile User Journeys visualizes how end users navigate your mobile app in aggregate. It reveals patterns in user behavior — where users go after opening the app, where they get stuck, and which paths lead to the outcomes you care about.


### PR DESCRIPTION
Removes the `translationType: machine` frontmatter field from `mobile-monitoring/mobile-monitoring-ui/mobile-app-pages/user-journeys.mdx`