### PR TITLE
Add eBPF AI monitoring docs

### DIFF
--- a/src/content/docs/ebpf/ai-monitoring.mdx
+++ b/src/content/docs/ebpf/ai-monitoring.mdx
@@ -23,7 +23,7 @@ This telemetry appears on the same auto-discovered eBPF entity that already repo
 
 * **Zero-code GenAI detection**: Automatically discovers outbound calls to LLM providers (such as OpenAI, Azure OpenAI, and Amazon Bedrock) at the kernel level, with no SDKs, wrapper libraries, or code changes required.
 
-* **On by default alongside eBPF APM**: Comes with the eBPF agent, so you don't need to deploy or manage a separate agent to start collecting GenAI telemetry. You have option to turn off monitoring AI workloads.
+* **On by default alongside eBPF APM**: Comes with the eBPF agent, so you don't need to deploy or manage a separate agent to start collecting GenAI telemetry. You have the option to turn off AI workload monitoring.
 
 * **Automatic detection and backoff**: Suppresses its own AI telemetry when a language APM agent is already instrumented and reporting AI monitoring data for the same service, avoiding duplicate data. This is the same pattern the eBPF agent already uses for APM, network, and log data.
 
@@ -60,12 +60,12 @@ eBPF AI monitoring is on by default whenever you install or upgrade the eBPF age
 
 Both the Linux host and Kubernetes guided install flows include two switches for AI monitoring:
 
-* **Enable eBPF AI Monitoring**: Turns on GenAI workload monitoring. Disabled by default.
-* **Enable recording model inputs and outputs**: Captures full message content (prompts and completions) for GenAI interactions. Disabled by default, and only available once **Enable eBPF AI Monitoring** is turned on. Use with caution: this sends the actual prompt and response text to New Relic.
+* <DNT>**Enable eBPF AI Monitoring:**</DNT> Turns on GenAI workload monitoring. Disabled by default.
+* <DNT>**Enable recording model inputs and outputs:**</DNT> Captures full message content (prompts and completions) for GenAI interactions. Disabled by default, and only available once <DNT>**Enable eBPF AI Monitoring**</DNT> is turned on. Use with caution, as this sends the actual prompt and response text to New Relic.
 
 <Callout variant="important" title="Important">
 
-eBPF AI Monitoring will be automatically disabled if language APM is detected, to avoid duplicating telemetry that the APM agent's own AI monitoring instrumentation already reports.
+New Relic automatically disables eBPF AI monitoring if it detects a language APM agent, to avoid duplicating telemetry that the APM agent's own AI monitoring instrumentation already reports.
 
 </Callout>
 
@@ -82,9 +82,9 @@ On Linux hosts using the install script, set the equivalent `ai_monitoring.enabl
 
 You can view eBPF AI monitoring data in the New Relic APM UI:
 
-1. Go to **[one.newrelic.com](https://one.newrelic.com) > APM & Services**.
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > APM & Services**</DNT>.
 2. Select the eBPF entity for the service that's calling an LLM provider.
-3. In the left nav, click **AI monitoring**, then select **AI traces**.
+3. Click <DNT>**AI monitoring**</DNT> in the left navigation, then select <DNT>**AI traces**</DNT>.
 
 <Callout variant="tip">
 
@@ -104,11 +104,11 @@ To view the list of attributes collected by the eBPF agent, refer to the [eBPF a
 
 eBPF AI monitoring doesn't obfuscate, mask, or drop sensitive data on its own. By design, it reports exactly what it observes on the wire.
 
-If you leave **Enable recording model inputs and outputs** off (the default), the agent never captures prompt or completion content, only metadata like model, vendor, token counts, and latency. This is the simplest way to avoid sending sensitive prompt or response text to New Relic in the first place.
+If you leave <DNT>**Enable recording model inputs and outputs**</DNT> off (the default), the agent never captures prompt or completion content, only metadata like model, vendor, token counts, and latency. This avoids sending sensitive prompt or response text to New Relic in the first place.
 
 If you turn recording on because you need that content for debugging or quality review, data obfuscation and dropping for sensitive information is only available through the [Pipeline Control Gateway (PCG)](/docs/new-relic-control/pipeline-control/gateway/transform-processor) using OpenTelemetry Transformation Language (OTTL). The direct eBPF-to-New Relic data flow doesn't include built-in obfuscation for AI monitoring data. Contact your account representative to add PCG to your order.
 
-For example, this configuration redacts the completion content captured from a GenAI interaction (adjust the attribute name to match what your eBPF agent reports; refer to the [eBPF agent attributes reference](/docs/ebpf/attributes-reference) for the exact attribute names):
+For example, this configuration redacts the completion content captured from a GenAI interaction (adjust the attribute name to match what your eBPF agent reports. Refer to the [eBPF agent attributes reference](/docs/ebpf/attributes-reference) for the exact attribute names):
 
 ```yaml
 transform/Traces:

--- a/src/content/docs/ebpf/ai-monitoring.mdx
+++ b/src/content/docs/ebpf/ai-monitoring.mdx
@@ -104,6 +104,8 @@ To view the list of attributes collected by the eBPF agent, refer to the [eBPF a
 
 eBPF AI monitoring doesn't obfuscate, mask, or drop sensitive data on its own. By design, it reports exactly what it observes on the wire.
 
+</Callout>
+
 If you leave <DNT>**Enable recording model inputs and outputs**</DNT> off (the default), the agent never captures prompt or completion content, only metadata like model, vendor, token counts, and latency. This avoids sending sensitive prompt or response text to New Relic in the first place.
 
 If you turn recording on because you need that content for debugging or quality review, data obfuscation and dropping for sensitive information is only available through the [Pipeline Control Gateway (PCG)](/docs/new-relic-control/pipeline-control/gateway/transform-processor) using OpenTelemetry Transformation Language (OTTL). The direct eBPF-to-New Relic data flow doesn't include built-in obfuscation for AI monitoring data. Contact your account representative to add PCG to your order.
@@ -120,8 +122,6 @@ transform/Traces:
 ```
 
 This example redacts only the completion attribute shown. For additional or customizable obfuscation and drop rules, including rules for the prompt content, specific model vendors, or other attributes, configure the [OTTL Transform processor](/docs/new-relic-control/pipeline-control/gateway/transform-processor) supported by PCG directly. Refer to [Redact PII](/docs/new-relic-control/pipeline-control/gateway/transform-processor#example-5-redact-pii) for more examples.
-
-</Callout>
 
 <DocTiles>
     <DocTile title="eBPF APM" path="/docs/ebpf/ebpf-apm/">Learn how to use New Relic's eBPF APM for zero-code, language-agnostic application monitoring.</DocTile>

--- a/src/content/docs/ebpf/ai-monitoring.mdx
+++ b/src/content/docs/ebpf/ai-monitoring.mdx
@@ -123,6 +123,8 @@ transform/Traces:
 
 This example redacts only the completion attribute shown. For additional or customizable obfuscation and drop rules, including rules for the prompt content, specific model vendors, or other attributes, configure the [OTTL Transform processor](/docs/new-relic-control/pipeline-control/gateway/transform-processor) supported by PCG directly. Refer to [Redact PII](/docs/new-relic-control/pipeline-control/gateway/transform-processor#example-5-redact-pii) for more examples.
 
+## Related articles
+
 <DocTiles>
     <DocTile title="eBPF APM" path="/docs/ebpf/ebpf-apm/">Learn how to use New Relic's eBPF APM for zero-code, language-agnostic application monitoring.</DocTile>
     <DocTile title="Introduction to AI monitoring" path="/docs/ai-monitoring/intro-to-ai-monitoring/">Learn how AI monitoring gives you visibility into the performance, cost, and quality of your AI-powered app.</DocTile>

--- a/src/content/docs/ebpf/ai-monitoring.mdx
+++ b/src/content/docs/ebpf/ai-monitoring.mdx
@@ -60,7 +60,7 @@ eBPF AI monitoring is on by default whenever you install or upgrade the eBPF age
 
 Both the Linux host and Kubernetes guided install flows include two switches for AI monitoring:
 
-* **Enable eBPF AI Monitoring**: Turns on GenAI workload monitoring. Enabled by default.
+* **Enable eBPF AI Monitoring**: Turns on GenAI workload monitoring. Disabled by default.
 * **Enable recording model inputs and outputs**: Captures full message content (prompts and completions) for GenAI interactions. Disabled by default, and only available once **Enable eBPF AI Monitoring** is turned on. Use with caution: this sends the actual prompt and response text to New Relic.
 
 <Callout variant="important" title="Important">
@@ -76,7 +76,7 @@ If you're not using the guided install, set these parameters in your agent confi
 * `ai_monitoring.enabled`: Controls GenAI telemetry reporting. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when no language APM or OTel agent is already reporting AI monitoring data for the entity).
 * `ai_monitoring.genAICaptureMessageContent`: When `true`, captures full prompt and completion content for GenAI interactions. Only takes effect when `ai_monitoring.enabled` is `true` or `auto`. Use with caution.
 
-On Linux hosts using the install script, set the equivalent `REPORT_AI_METRICS` and `GENAI_CAPTURE_MESSAGE_CONTENT` environment variables instead. This mirrors the pattern already used by `reportApmData`, `reportNetworkMetrics`, and `reportLogs`. For the full list of parameters, refer to the Configuration parameters section of the [Linux installation](/docs/ebpf/linux-installation/#config-params) or [Kubernetes installation](/docs/ebpf/k8s-installation/#config-params) guide.
+On Linux hosts using the install script, set the equivalent `ai_monitoring.enabled` and `ai_monitoring.genAICaptureMessageContent` environment variables instead. This mirrors the pattern already used by `reportApmData`, `reportNetworkMetrics`, and `reportLogs`. For the full list of parameters, refer to the Configuration parameters section of the [Linux installation](/docs/ebpf/linux-installation/#config-params) or [Kubernetes installation](/docs/ebpf/k8s-installation/#config-params) guide.
 
 ## View your eBPF AI monitoring data [#view-data]
 
@@ -84,7 +84,7 @@ You can view eBPF AI monitoring data in the New Relic APM UI:
 
 1. Go to **[one.newrelic.com](https://one.newrelic.com) > APM & Services**.
 2. Select the eBPF entity for the service that's calling an LLM provider.
-3. In the left nav, click **AI monitoring**, then select **AI responses**.
+3. In the left nav, click **AI monitoring**, then select **AI traces**.
 
 <Callout variant="tip">
 

--- a/src/content/docs/ebpf/ai-monitoring.mdx
+++ b/src/content/docs/ebpf/ai-monitoring.mdx
@@ -23,11 +23,11 @@ This telemetry appears on the same auto-discovered eBPF entity that already repo
 
 * **Zero-code GenAI detection**: Automatically discovers outbound calls to LLM providers (such as OpenAI, Azure OpenAI, and Amazon Bedrock) at the kernel level, with no SDKs, wrapper libraries, or code changes required.
 
-* **On by default alongside eBPF APM**: Comes with the eBPF agent, so you don't need to deploy or manage a separate agent to start collecting GenAI telemetry. You have the option to turn off AI workload monitoring.
+* **Works seamlessly alongside eBPF APM**: Comes with the eBPF agent, so you don't need to deploy or manage a separate agent to start collecting GenAI telemetry. You have the option to enable/disable eBPF AI workload monitoring (off by default).
 
 * **Automatic detection and backoff**: Suppresses its own AI telemetry when a language APM agent is already instrumented and reporting AI monitoring data for the same service, avoiding duplicate data. This is the same pattern the eBPF agent already uses for APM, network, and log data.
 
-* **Optional prompt and response capture**: By default the agent captures GenAI metadata only, such as model, vendor, token usage, latency, and errors. A separate setting lets you additionally capture the full prompt and completion content when you need it for debugging or quality review.
+* **Optional prompt and response capture**: When enabled, the agent captures GenAI metadata only, such as model, vendor, token usage, latency, and errors. A separate setting lets you additionally capture the full prompt and completion content when you need it for debugging or quality review.
 
 * **Unified entity view**: GenAI telemetry appears on the same entity as your eBPF APM, network metrics, and logs data, so you don't need to correlate across multiple entities to understand a service's behavior.
 
@@ -54,7 +54,7 @@ Detection happens at the kernel level, based on the HTTP calls your services mak
 
 ## Enable eBPF AI monitoring [#enable]
 
-eBPF AI monitoring is on by default whenever you install or upgrade the eBPF agent. You can control it, and whether to capture full prompt and response content, from the guided install flow or by editing your agent configuration directly.
+While the capability is off be default, you can enable it easily - with a separate control to capture full prompt and response content, from the guided install flow or by editing your agent configuration directly.
 
 ### Guided install
 

--- a/src/content/docs/ebpf/ai-monitoring.mdx
+++ b/src/content/docs/ebpf/ai-monitoring.mdx
@@ -1,0 +1,131 @@
+---
+title: "eBPF AI monitoring"
+metaDescription: "Learn how New Relic's eBPF agent automatically detects and monitors GenAI/LLM workloads, giving you AI performance and cost visibility without code changes."
+tags:
+    - Integrations
+    - eBPF integration
+    - eBPF AI monitoring
+    - eBPF AIM
+    - AI monitoring
+    - GenAI
+    - LLM observability
+    - eBPF
+    - Linux host
+    - Kubernetes cluster
+freshnessValidatedDate: never
+---
+
+New Relic's eBPF agent extends the same zero-code, language-agnostic approach it uses for [eBPF APM](/docs/ebpf/ebpf-apm) to the AI layer of your stack. Once the agent is installed, it automatically detects outbound calls your services make to LLM providers directly from the Linux kernel, and reports GenAI performance, cost, and reliability telemetry without any SDK, code change, or dedicated AI monitoring agent.
+
+This telemetry appears on the same auto-discovered eBPF entity that already reports your APM, network, and log data, giving you a single, unified view of a service's health alongside its AI usage. This is especially useful for spotting GenAI workloads you didn't know existed: third-party services, legacy applications, or code you don't own that are quietly calling out to an LLM vendor.
+
+## Key features [#key-features]
+
+* **Zero-code GenAI detection**: Automatically discovers outbound calls to LLM providers (such as OpenAI, Azure OpenAI, and Amazon Bedrock) at the kernel level, with no SDKs, wrapper libraries, or code changes required.
+
+* **On by default alongside eBPF APM**: Comes with the eBPF agent, so you don't need to deploy or manage a separate agent to start collecting GenAI telemetry. You have option to turn off monitoring AI workloads.
+
+* **Automatic detection and backoff**: Suppresses its own AI telemetry when a language APM agent is already instrumented and reporting AI monitoring data for the same service, avoiding duplicate data. This is the same pattern the eBPF agent already uses for APM, network, and log data.
+
+* **Optional prompt and response capture**: By default the agent captures GenAI metadata only, such as model, vendor, token usage, latency, and errors. A separate setting lets you additionally capture the full prompt and completion content when you need it for debugging or quality review.
+
+* **Unified entity view**: GenAI telemetry appears on the same entity as your eBPF APM, network metrics, and logs data, so you don't need to correlate across multiple entities to understand a service's behavior.
+
+## Supported LLM providers [#supported-providers]
+
+eBPF AI monitoring currently detects and reports on outbound calls to these LLM providers:
+
+* Google Gemini
+* OpenAI
+* Anthropic Claude
+* Amazon Bedrock
+
+Detection happens at the kernel level, based on the HTTP calls your services make to these providers' APIs, so no vendor SDK or client library is required. Calls to other providers aren't reported as GenAI telemetry.
+
+## Use cases [#use-cases]
+
+* **For platform engineers**: Get an inventory of every service in your environment that's calling an LLM provider, including ones you don't own or didn't know were AI-enabled.
+
+* **For teams with opaque or third-party workloads**: Monitor GenAI usage, cost, and latency for legacy applications or vendor binaries that you can't instrument directly.
+
+* **For AI cost and performance oversight**: Identify token-heavy or slow-responding GenAI calls across your estate before deciding where to invest in deeper, code-level AI monitoring instrumentation.
+
+* **For security and compliance visibility**: Understand which of your services send data to external AI providers, so you can decide where to apply obfuscation or drop rules. Refer to [Sensitive data and eBPF AI monitoring](#sensitive-data) below.
+
+## Enable eBPF AI monitoring [#enable]
+
+eBPF AI monitoring is on by default whenever you install or upgrade the eBPF agent. You can control it, and whether to capture full prompt and response content, from the guided install flow or by editing your agent configuration directly.
+
+### Guided install
+
+Both the Linux host and Kubernetes guided install flows include two switches for AI monitoring:
+
+* **Enable eBPF AI Monitoring**: Turns on GenAI workload monitoring. Enabled by default.
+* **Enable recording model inputs and outputs**: Captures full message content (prompts and completions) for GenAI interactions. Disabled by default, and only available once **Enable eBPF AI Monitoring** is turned on. Use with caution: this sends the actual prompt and response text to New Relic.
+
+<Callout variant="important" title="Important">
+
+eBPF AI Monitoring will be automatically disabled if language APM is detected, to avoid duplicating telemetry that the APM agent's own AI monitoring instrumentation already reports.
+
+</Callout>
+
+### Configure it manually [#manual-config]
+
+If you're not using the guided install, set these parameters in your agent configuration:
+
+* `ai_monitoring.enabled`: Controls GenAI telemetry reporting. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when no language APM or OTel agent is already reporting AI monitoring data for the entity).
+* `ai_monitoring.genAICaptureMessageContent`: When `true`, captures full prompt and completion content for GenAI interactions. Only takes effect when `ai_monitoring.enabled` is `true` or `auto`. Use with caution.
+
+On Linux hosts using the install script, set the equivalent `REPORT_AI_METRICS` and `GENAI_CAPTURE_MESSAGE_CONTENT` environment variables instead. This mirrors the pattern already used by `reportApmData`, `reportNetworkMetrics`, and `reportLogs`. For the full list of parameters, refer to the Configuration parameters section of the [Linux installation](/docs/ebpf/linux-installation/#config-params) or [Kubernetes installation](/docs/ebpf/k8s-installation/#config-params) guide.
+
+## View your eBPF AI monitoring data [#view-data]
+
+You can view eBPF AI monitoring data in the New Relic APM UI:
+
+1. Go to **[one.newrelic.com](https://one.newrelic.com) > APM & Services**.
+2. Select the eBPF entity for the service that's calling an LLM provider.
+3. In the left nav, click **AI monitoring**, then select **AI responses**.
+
+<Callout variant="tip">
+
+The eBPF agent automatically generates entity names based on your environment:
+
+* **In hosts or Docker**: Names combine process name, directory path or container ID, and listening port. Examples: `ruby:/home/ubuntu/app:[5678]` or `java:f4aead533895:[8080]`
+* **In Kubernetes**: Names are derived from service names, like `mysql-database-service`
+
+
+To view the list of attributes collected by the eBPF agent, refer to the [eBPF agent attributes reference](/docs/ebpf/attributes-reference).
+
+</Callout>
+
+## Sensitive data and eBPF AI monitoring [#sensitive-data]
+
+<Callout variant="important" title="Important">
+
+eBPF AI monitoring doesn't obfuscate, mask, or drop sensitive data on its own. By design, it reports exactly what it observes on the wire.
+
+If you leave **Enable recording model inputs and outputs** off (the default), the agent never captures prompt or completion content, only metadata like model, vendor, token counts, and latency. This is the simplest way to avoid sending sensitive prompt or response text to New Relic in the first place.
+
+If you turn recording on because you need that content for debugging or quality review, data obfuscation and dropping for sensitive information is only available through the [Pipeline Control Gateway (PCG)](/docs/new-relic-control/pipeline-control/gateway/transform-processor) using OpenTelemetry Transformation Language (OTTL). The direct eBPF-to-New Relic data flow doesn't include built-in obfuscation for AI monitoring data. Contact your account representative to add PCG to your order.
+
+For example, this configuration redacts the completion content captured from a GenAI interaction (adjust the attribute name to match what your eBPF agent reports; refer to the [eBPF agent attributes reference](/docs/ebpf/attributes-reference) for the exact attribute names):
+
+```yaml
+transform/Traces:
+  trace_statements:
+  - statements:
+    - replace_pattern(attributes["gen_ai.completion"], ".+", "***REDACTED***")
+    conditions:
+    - attributes["gen_ai.completion"] != nil
+```
+
+This example redacts only the completion attribute shown. For additional or customizable obfuscation and drop rules, including rules for the prompt content, specific model vendors, or other attributes, configure the [OTTL Transform processor](/docs/new-relic-control/pipeline-control/gateway/transform-processor) supported by PCG directly. Refer to [Redact PII](/docs/new-relic-control/pipeline-control/gateway/transform-processor#example-5-redact-pii) for more examples.
+
+</Callout>
+
+<DocTiles>
+    <DocTile title="eBPF APM" path="/docs/ebpf/ebpf-apm/">Learn how to use New Relic's eBPF APM for zero-code, language-agnostic application monitoring.</DocTile>
+    <DocTile title="Introduction to AI monitoring" path="/docs/ai-monitoring/intro-to-ai-monitoring/">Learn how AI monitoring gives you visibility into the performance, cost, and quality of your AI-powered app.</DocTile>
+    <DocTile title="Pipeline Control Gateway transform processor" path="/docs/new-relic-control/pipeline-control/gateway/transform-processor/">Learn how to obfuscate, redact, or drop sensitive data using OTTL before it reaches New Relic.</DocTile>
+    <DocTile title="eBPF agent attributes reference" path="/docs/ebpf/attributes-reference/">See the full list of attributes the eBPF agent adds to your data.</DocTile>
+</DocTiles>

--- a/src/nav/ebpf.yml
+++ b/src/nav/ebpf.yml
@@ -19,6 +19,8 @@ pages:
     pages:
       - title: eBPF APM
         path: /docs/ebpf/ebpf-apm
+      - title: AI monitoring
+        path: /docs/ebpf/ai-monitoring
       - title: Network metrics
         path: /docs/ebpf/network-metrics
       - title: Logs


### PR DESCRIPTION
## Summary
- Adds a new eBPF capabilities doc (`src/content/docs/ebpf/ai-monitoring.mdx`) covering eBPF AI monitoring: key features, supported LLM providers (Google Gemini, OpenAI, Anthropic Claude, Amazon Bedrock), use cases, the guided-install toggles (enable AI monitoring / enable recording model inputs and outputs), how to view the telemetry under APM > AI monitoring, and PCG-based obfuscation for sensitive prompt/response content.
- Adds the page to `src/nav/ebpf.yml` under Capabilities, right after eBPF APM.

## Test plan
- [ ] Preview build renders the new page and nav entry correctly
- [ ] Links resolve (eBPF APM, AI monitoring intro, PCG transform processor, eBPF attributes reference, Linux/Kubernetes install config-params anchors)