### PR TITLE
[To be merged on 24th August] docs: add infra-agent 1.80.0 release notes

### DIFF
--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1800.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1800.mdx
@@ -1,6 +1,6 @@
 ---
 subject: Infrastructure agent
-releaseDate: '2026-08-21'
+releaseDate: '2026-08-24'
 version: 1.80.0
 features:
   - 'Added Azure Key Vault as another databind secret source'

--- a/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1800.mdx
+++ b/src/content/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1800.mdx
@@ -1,0 +1,21 @@
+---
+subject: Infrastructure agent
+releaseDate: '2026-08-21'
+version: 1.80.0
+features:
+  - 'Added Azure Key Vault as another databind secret source'
+bugs: []
+security:
+  - 'Fixed a local privilege escalation vulnerability caused by predictable Fluent Bit config directory reuse'
+chore:
+  - 'Bumped Go to 1.26.6 and updated embedded OHI versions (nri-docker, nri-flex, nri-winservices, nri-prometheus) to fix CVEs'
+---
+
+A new version of the agent has been released. Follow standard procedures to [update the Infrastructure agent](/docs/infrastructure/install-configure-manage-infrastructure/update-or-uninstall/update-infrastructure-agent).
+New Relic recommends that you upgrade the agent regularly and at a minimum every 3 months. As of this release, the oldest supported version is [Infrastructure agent 1.65.3](/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/new-relic-infrastructure-agent-1653/).
+
+## Changed
+* Added Azure Key Vault as another databind secret source. [#2304](https://github.com/newrelic/infrastructure-agent/pull/2304)
+* Fixed a local privilege escalation vulnerability caused by predictable Fluent Bit config directory reuse. [#2306](https://github.com/newrelic/infrastructure-agent/pull/2306)
+* Bumped Go to 1.26.6 to fix multiple Go stdlib CVEs. [#2308](https://github.com/newrelic/infrastructure-agent/pull/2308)
+* Updated embedded OHI versions (`nri-docker`, `nri-flex`, `nri-winservices`, `nri-prometheus`) to fix CVEs. [#2316](https://github.com/newrelic/infrastructure-agent/pull/2316)


### PR DESCRIPTION
## Summary
Adds release notes for New Relic Infrastructure Agent 1.80.0, following the same format as previous releases.

Changes covered:
- feat: Added Azure Key Vault as another databind secret source (#2304)
- security: Fixed a local privilege escalation vulnerability caused by predictable Fluent Bit config directory reuse (#2306)
- chore: Bumped Go to 1.26.6 (#2308)
- chore: Updated embedded OHI versions (nri-docker, nri-flex, nri-winservices, nri-prometheus) to fix CVEs (#2316)