### PR TITLE
fix: search on attribute dictionary page reloads to docs.newrelic.com

### DIFF
--- a/src/components/DataDictionaryFilter.js
+++ b/src/components/DataDictionaryFilter.js
@@ -49,18 +49,6 @@ const DataDictionaryFilter = ({ location, events }) => {
     });
   }, [queryParams]);
 
-  useEffect(() => {
-    const handler = (e) => {
-      if (e.keyCode === 13) {
-        navigateToParams(formState);
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => {
-      document.removeEventListener('keydown', handler);
-    };
-  });
-
   const navigateToParams = (params) => {
     Object.entries(params).forEach(([key, value]) => {
       value ? queryParams.set(key, value) : queryParams.delete(key);
@@ -70,103 +58,112 @@ const DataDictionaryFilter = ({ location, events }) => {
   };
 
   return (
-    <PageTools.Section>
-      <PageTools.Title>Search and filter</PageTools.Title>
-      <FormControl>
-        <Label htmlFor="attributeSearch">Attribute name</Label>
-        <SearchInput
-          value={formState.attributeSearch || ''}
-          onClear={() =>
-            setFormState((state) => ({ ...state, attributeSearch: null }))
-          }
-          onChange={(e) => {
-            const { value } = e.target;
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          navigateToParams(formState);
+        }
+      }}
+    >
+      <PageTools.Section>
+        <PageTools.Title>Search and filter</PageTools.Title>
+        <FormControl>
+          <Label htmlFor="attributeSearch">Attribute name</Label>
+          <SearchInput
+            value={formState.attributeSearch || ''}
+            onClear={() =>
+              setFormState((state) => ({ ...state, attributeSearch: null }))
+            }
+            onChange={(e) => {
+              const { value } = e.target;
 
-            setFormState((state) => ({
-              ...state,
-              attribute: null,
-              attributeSearch: value,
-            }));
-          }}
-          placeholder="Name contains..."
-        />
-      </FormControl>
-      <FormControl>
-        <Label htmlFor="dataSourceFilter">Data source</Label>
-        <Select
-          id="dataSourceFilter"
-          value={formState.dataSource || ''}
-          onChange={(e) => {
-            const { value } = e.target;
+              setFormState((state) => ({
+                ...state,
+                attribute: null,
+                attributeSearch: value,
+              }));
+            }}
+            placeholder="Name contains..."
+          />
+        </FormControl>
+        <FormControl>
+          <Label htmlFor="dataSourceFilter">Data source</Label>
+          <Select
+            id="dataSourceFilter"
+            value={formState.dataSource || ''}
+            onChange={(e) => {
+              const { value } = e.target;
 
-            setFormState((state) => ({
-              ...state,
-              event: null,
-              attribute: null,
-              dataSource: value,
-            }));
-          }}
-        >
-          <option value="">All</option>
-          {dataSources.map((dataSource) => (
-            <option key={dataSource} value={dataSource}>
-              {dataSource}
-            </option>
-          ))}
-        </Select>
-      </FormControl>
-      <FormControl>
-        <Label htmlFor="eventFilter">Data type</Label>
-        <Select
-          id="eventFilter"
-          value={formState.event || ''}
-          onChange={(e) => {
-            const { value } = e.target;
+              setFormState((state) => ({
+                ...state,
+                event: null,
+                attribute: null,
+                dataSource: value,
+              }));
+            }}
+          >
+            <option value="">All</option>
+            {dataSources.map((dataSource) => (
+              <option key={dataSource} value={dataSource}>
+                {dataSource}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl>
+          <Label htmlFor="eventFilter">Data type</Label>
+          <Select
+            id="eventFilter"
+            value={formState.event || ''}
+            onChange={(e) => {
+              const { value } = e.target;
 
-            setFormState((state) => ({
-              ...state,
-              event: value,
-              attribute: null,
-            }));
-          }}
-        >
-          <option value="">All</option>
-          {filteredEvents.map((event) => (
-            <option key={event.name} value={event.name}>
-              {event.name}
-            </option>
-          ))}
-        </Select>
-      </FormControl>
+              setFormState((state) => ({
+                ...state,
+                event: value,
+                attribute: null,
+              }));
+            }}
+          >
+            <option value="">All</option>
+            {filteredEvents.map((event) => (
+              <option key={event.name} value={event.name}>
+                {event.name}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
 
-      <FormControl>
-        <Button
-          variant={Button.VARIANT.PRIMARY}
-          onClick={() => {
-            navigateToParams(formState);
-          }}
-        >
-          Search
-        </Button>
-        <Button
-          as={Link}
-          to={location.pathname}
-          variant={Button.VARIANT.LINK}
-          onClick={() => {
-            const formState = {
-              event: null,
-              dataSource: null,
-              attribute: null,
-              attributeSearch: null,
-            };
+        <FormControl>
+          <Button
+            variant={Button.VARIANT.PRIMARY}
+            onClick={() => {
+              navigateToParams(formState);
+            }}
+          >
+            Search
+          </Button>
+          <Button
+            as={Link}
+            to={location.pathname}
+            variant={Button.VARIANT.LINK}
+            onClick={() => {
+              const formState = {
+                event: null,
+                dataSource: null,
+                attribute: null,
+                attributeSearch: null,
+              };
 
-            setFormState(formState);
-          }}
-        >
-          Reset
-        </Button>
-      </FormControl>
-    </PageTools.Section>
+              setFormState(formState);
+            }}
+          >
+            Reset
+          </Button>
+        </FormControl>
+      </PageTools.Section>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- Search from the global header search box on `/attribute-dictionary/` was forcing a full browser reload instead of a normal client-side navigation to search results.
- Root cause: `DataDictionaryFilter.js`'s "Search and filter" widget attached its Enter-key handler to `document` instead of scoping it to its own markup, so pressing Enter anywhere on the page (including in the unrelated global header search box) also fired this widget's own `navigate()` call. Two `navigate()` calls firing in the same tick corrupted Gatsby's client-side router, whose fallback is a hard page reload.
- Fix: move the Enter-key handling onto a wrapper `div` around the filter widget's own markup, so it only reacts to Enter presses that bubble from inside that widget. Also updated the legacy `e.keyCode === 13` check to `e.key === 'Enter'`.

Fixes NR-608923.

## Test plan
- [x] Verified in a local `gatsby develop` session that the widget's own Enter-to-search still works (via the Search button and Enter within the widget).
- [x] Verified via Chrome DevTools MCP that pressing Enter in the widget no longer fires a second, competing `navigate()` call.
- [x] `eslint` and `prettier` pass on the changed file.
- Note: local `gatsby develop` on this repo has a separate, pre-existing, site-wide dev-mode 404 quirk when navigating to any not-yet-visited page via client-side `navigate()` (tracked separately in NR-608934, unrelated to this fix — root cause lives in `@newrelic/gatsby-theme-newrelic`'s `GlobalSearch.js`). A production build does not lazily compile pages, so it isn't expected to reproduce there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)