### PR TITLE
docs(infra): make parameters mandatory for silent Windows MSI installs

### DIFF
--- a/src/content/docs/infrastructure/infrastructure-agent/windows-installation/windows-msi-installer.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/windows-installation/windows-msi-installer.mdx
@@ -76,7 +76,7 @@ If you'd like to do a manual installation, follow the next steps:
      Don't double-click the installer. This won't install the local agent fully and can result in permissions issues.
    </Callout>
 
-3. Open PowerShell as an administrator, and run the install script using an absolute path.
+3. Open <DNT>PowerShell</DNT> as an administrator, and run the install script using an absolute path.
 
    **Note on v1.73.0 and above:** For silent installations using the `/qn` switch, you **must** supply `GENERATE_CONFIG=true` and `LICENSE_KEY` directly in the command. Running a parameter-less silent install will fail and roll back the installation with Error 1603.
 
@@ -85,11 +85,11 @@ If you'd like to do a manual installation, follow the next steps:
      msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY
      ```
 
-   For a scripted installation, you can append additional configuration parameters directly to the command:
+     * For a scripted installation, you can append additional configuration parameters directly to the command:
 
-   ```shell
-   msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY DISPLAY_NAME=YOUR_DISPLAY_NAME PROXY=http://YOUR_PROXY_SERVER:PROXY_PORT CUSTOM_ATTRIBUTES="{'ATTRIBUTE_1':'VALUE_1','ATTRIBUTE_2':'VALUE_2'}" METRICS_SYSTEM_SAMPLE_RATE=30 METRICS_STORAGE_SAMPLE_RATE=30 METRICS_NETWORK_SAMPLE_RATE=30 METRICS_PROCESS_SAMPLE_RATE=30 PAYLOAD_COMPRESSION_LEVEL=6
-   ```
+     ```shell
+     msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY DISPLAY_NAME=YOUR_DISPLAY_NAME PROXY=http://YOUR_PROXY_SERVER:PROXY_PORT CUSTOM_ATTRIBUTES="{'ATTRIBUTE_1':'VALUE_1','ATTRIBUTE_2':'VALUE_2'}" METRICS_SYSTEM_SAMPLE_RATE=30 METRICS_STORAGE_SAMPLE_RATE=30 METRICS_NETWORK_SAMPLE_RATE=30 METRICS_PROCESS_SAMPLE_RATE=30 PAYLOAD_COMPRESSION_LEVEL=6
+     ```
 
    Advanced customization is available via `NRIA_` environment variables and the agent configuration file. Learn how to [configure the agent](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/).
 

--- a/src/content/docs/infrastructure/infrastructure-agent/windows-installation/windows-msi-installer.mdx
+++ b/src/content/docs/infrastructure/infrastructure-agent/windows-installation/windows-msi-installer.mdx
@@ -76,29 +76,25 @@ If you'd like to do a manual installation, follow the next steps:
      Don't double-click the installer. This won't install the local agent fully and can result in permissions issues.
    </Callout>
 
-3. Open PowerShell as an administrator, and run the install script using an absolute path:
+3. Open PowerShell as an administrator, and run the install script using an absolute path.
 
-   * For 64-bit Windows:
+   **Note on v1.73.0 and above:** For silent installations using the `/qn` switch, you **must** supply `GENERATE_CONFIG=true` and `LICENSE_KEY` directly in the command. Running a parameter-less silent install will fail and roll back the installation with Error 1603.
+
+      * For 64-bit Windows:
      ```shell
-     msiexec.exe /qn /i PATH\TO\newrelic-infra.msi
+     msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY
      ```
 
-   For a scripted installation, you can pass a limited set of agent settings as configuration parameters. You must first add
-   `GENERATE_CONFIG=true` and `LICENSE_KEY=YOUR_LICENSE_KEY`, and then, you can add the following optional parameters::
+   For a scripted installation, you can append additional configuration parameters directly to the command:
 
    ```shell
-   DISPLAY_NAME=YOUR_DISPLAY_NAME PROXY=http://YOUR_PROXY_SERVER:PROXY_PORT CUSTOM_ATTRIBUTES="{'ATTRIBUTE_1':'VALUE_1','ATTRIBUTE_2':'VALUE_2'}" METRICS_SYSTEM_SAMPLE_RATE=30 METRICS_STORAGE_SAMPLE_RATE=30 METRICS_NETWORK_SAMPLE_RATE=30 METRICS_PROCESS_SAMPLE_RATE=30 PAYLOAD_COMPRESSION_LEVEL=6
+   msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY DISPLAY_NAME=YOUR_DISPLAY_NAME PROXY=http://YOUR_PROXY_SERVER:PROXY_PORT CUSTOM_ATTRIBUTES="{'ATTRIBUTE_1':'VALUE_1','ATTRIBUTE_2':'VALUE_2'}" METRICS_SYSTEM_SAMPLE_RATE=30 METRICS_STORAGE_SAMPLE_RATE=30 METRICS_NETWORK_SAMPLE_RATE=30 METRICS_PROCESS_SAMPLE_RATE=30 PAYLOAD_COMPRESSION_LEVEL=6
    ```
 
-   Advanced customization is available via `NRIA_` environment variables and agent configuration file, learn how to [configure the agent](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/).
+   Advanced customization is available via `NRIA_` environment variables and the agent configuration file. Learn how to [configure the agent](/docs/infrastructure/install-infrastructure-agent/configuration/configure-infrastructure-agent/).
 
-   The following example sets the <InlinePopover type="licenseKey"/> and configures a proxy server for outbound communication, as well as adding one custom [attribute](/docs/using-new-relic/welcome-new-relic/get-started/glossary#attribute):
+4. (Optional) If you did not pass the parameters during the MSI installation step, you must manually create and add your <InlinePopover type="licenseKey"/> to the `license_key` attribute in your `newrelic-infra.yml` file, located in `C:\Program Files\New Relic\newrelic-infra\`. When you're finished, your `newrelic-infra.yml` file should look like the following:
 
-   ```shell
-   msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY PROXY=http://YOUR_PROXY_SERVER:PROXY_PORT CUSTOM_ATTRIBUTES="{'ATTRIBUTE_1':'VALUE_1'}"
-   ```
-
-4. Add your <InlinePopover type="licenseKey"/> to the `license_key` attribute in your `newrelic-infra.yml` file, located in `C:\Program Files\New Relic\newrelic-infra\`. When you're finished, your `newrelic-infra.yml` file should look like the following:
    ```yml
    license_key: YOUR_LICENSE_KEY
    ```


### PR DESCRIPTION
## Overview

This PR updates the manual installation guide for the Windows Infrastructure Agent (`windows-msi-installer`). 

It aligns the primary command-line instructions with the strict requirements introduced in **agent v1.73.0 and above**, resolving the common issue where silent installations silently fail and roll back with **Error 1603** due to missing mandatory configuration parameters.

**Note: This PR is a direct companion to PR #25365 (which updated the 1603 troubleshooting guide) to ensure absolute consistency across our documentation.**

---

## The Problem (Root Cause)

Since **v1.73.0**, the Windows MSI installer executes a deferred PowerShell custom action during the installation phase to automatically validate and generate the agent's configuration file (`newrelic-infra.yml`). 

- **The Issue:** If a silent installation is initiated using the previously documented basic command (`msiexec.exe /qn /i PATH\TO\newrelic-infra.msi`), the custom action script fails due to null configuration values. Under the `/qn` (silent, strict) switch, the Windows Installer system immediately rolls back the transaction, resulting in a generic **Error 1603**.
- **The Reality:** Running a parameter-less silent install is guaranteed to fail in all recent versions of the agent.

---

## Changes Introduced

- **Corrected Basic Command (Step 3):** Replaced the failing parameter-less command with the correct parameter-inclusive syntax as the default standard: ```powershell msiexec.exe /qn /i PATH\TO\newrelic-infra.msi GENERATE_CONFIG=true LICENSE_KEY=YOUR_LICENSE_KEY ```

- *Clarified Mandatory Constraints:* Added a clear warning that `GENERATE_CONFIG=true` and `LICENSE_KEY` are *mandatory* prerequisites for the `/qn` switch, even if the user intends to manage or overwrite the `newrelic-infra.yml` file post-install via external configuration tools.
- *Improved Step 4 (Optional):* Marked the manual creation/modification of `newrelic-infra.yml` as `(Optional)`, as the corrected installation command in Step 3 now handles config file generation automatically.
- *MDX Formatting Fixes:* Corrected rendering structures (e.g., proper inline popover wrappers and YAML block code enclosures) to prevent Gatsby/MDX static site pipeline compilation errors.

---

*Why this is safe*

- This simply aligns the documentation with the actual, established product logic of the v1.73.0+ installer.
- It pairs perfectly with the troubleshooting path defined in *#25365*.
- It prevents users from experiencing immediate installation failures on their first attempt, significantly improving the Windows onboarding experience.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.