### PR TITLE
docs(mysql): document custom query support for nri-mysql

### DIFF
--- a/src/install/mysql/linux/configure-mysql.mdx
+++ b/src/install/mysql/linux/configure-mysql.mdx
@@ -416,6 +416,89 @@ If you are using our legacy configuration and definition files, refer to [this d
           environment: production
     ```
   </Collapser>
+
+  <Collapser
+    id="custom-query"
+    title="Custom Query"
+  >
+    You can use a custom SQL query to collect additional metrics. Custom metrics are added to the `MysqlCustomSample` event by default:
+
+    <Callout variant="tip">
+      If you need to run multiple custom queries, use the [`CUSTOM_METRICS_CONFIG`](#multi-custom-query) example instead.
+    </Callout>
+
+    ```yml
+    integrations:
+      - name: nri-mysql
+        env:
+          HOSTNAME: localhost
+          PORT: 3306
+          USERNAME: mysql_user
+          PASSWORD: mysql_password
+          REMOTE_MONITORING: true
+          CUSTOM_METRICS_QUERY: >-
+            SELECT
+              COUNT(*) as active_connections,
+              SUM(CASE WHEN command != 'Sleep' THEN 1 ELSE 0 END) as busy_connections
+            FROM information_schema.processlist
+        interval: 30s
+        labels:
+          environment: production
+    ```
+
+    Numeric columns returned by the query (integer or float) are collected as `GAUGE` metrics, and any other column type is collected as an attribute. If the query returns multiple rows, one `MysqlCustomSample` event is created for each row.
+  </Collapser>
+
+  <Collapser
+    id="multi-custom-query"
+    title="Multiple Custom Queries"
+  >
+    If you need to run multiple custom SQL queries, add them to a YAML file such as `mysql-custom-query.yml`, and reference that file from your configuration. For more examples, see the [sample file on GitHub](https://github.com/newrelic/nri-mysql/blob/master/mysql-custom-query.yml.sample).
+
+    ```yml
+    integrations:
+      - name: nri-mysql
+        env:
+          HOSTNAME: localhost
+          PORT: 3306
+          USERNAME: mysql_user
+          PASSWORD: mysql_password
+          REMOTE_MONITORING: true
+          CUSTOM_METRICS_CONFIG: /etc/newrelic-infra/mysql-custom-query.yml
+        interval: 30s
+        labels:
+          environment: production
+    ```
+
+    * Here's an example `mysql-custom-query.yml`:
+
+    ```yml
+    ---
+    # Metric names are set to the column names in the query results.
+    queries:
+      - query: >-
+          SELECT
+            COUNT(*) as total_connections,
+            SUM(CASE WHEN command != 'Sleep' THEN 1 ELSE 0 END) as active_connections
+          FROM information_schema.processlist
+
+        # If unset, sample_name defaults to MysqlCustomSample
+        sample_name: MysqlConnectionsSample
+
+      # `database` runs this query on a dedicated connection to that database instead
+      # of the integration's default connection, leaving the default database used by
+      # other queries unaffected. Repeat the query with a different `database` value to
+      # collect the same metric from multiple databases.
+      - query: >-
+          SELECT COUNT(*) as active_orders FROM orders WHERE status != 'completed'
+        database: myapp_db
+        sample_name: MysqlActiveOrdersSample
+    ```
+
+    <Callout variant="tip">
+      `CUSTOM_METRICS_QUERY` and `CUSTOM_METRICS_CONFIG` can both be set at the same time; the integration runs both. If an individual query fails, the integration logs a warning and continues collecting standard metrics and any other custom queries.
+    </Callout>
+  </Collapser>
 </CollapserGroup>
 
 ### Configuration options for the integration [#config-options]

--- a/src/install/mysql/windows/configure-mysql.mdx
+++ b/src/install/mysql/windows/configure-mysql.mdx
@@ -415,6 +415,89 @@ If you are using our legacy configuration and definition files, refer [this docu
           environment: production
     ```
   </Collapser>
+
+  <Collapser
+    id="custom-query"
+    title="Custom Query"
+  >
+    You can use a custom SQL query to collect additional metrics. Custom metrics are added to the `MysqlCustomSample` event by default:
+
+    <Callout variant="tip">
+      If you need to run multiple custom queries, use the [`CUSTOM_METRICS_CONFIG`](#multi-custom-query) example instead.
+    </Callout>
+
+    ```yml
+    integrations:
+      - name: nri-mysql
+        env:
+          HOSTNAME: localhost
+          PORT: 3306
+          USERNAME: mysql_user
+          PASSWORD: mysql_password
+          REMOTE_MONITORING: true
+          CUSTOM_METRICS_QUERY: >-
+            SELECT
+              COUNT(*) as active_connections,
+              SUM(CASE WHEN command != 'Sleep' THEN 1 ELSE 0 END) as busy_connections
+            FROM information_schema.processlist
+        interval: 30s
+        labels:
+          environment: production
+    ```
+
+    Numeric columns returned by the query (integer or float) are collected as `GAUGE` metrics, and any other column type is collected as an attribute. If the query returns multiple rows, one `MysqlCustomSample` event is created for each row.
+  </Collapser>
+
+  <Collapser
+    id="multi-custom-query"
+    title="Multiple Custom Queries"
+  >
+    If you need to run multiple custom SQL queries, add them to a YAML file such as `mysql-custom-query.yml`, and reference that file from your configuration. For more examples, see the [sample file on GitHub](https://github.com/newrelic/nri-mysql/blob/master/mysql-custom-query.yml.sample).
+
+    ```yml
+    integrations:
+      - name: nri-mysql
+        env:
+          HOSTNAME: localhost
+          PORT: 3306
+          USERNAME: mysql_user
+          PASSWORD: mysql_password
+          REMOTE_MONITORING: true
+          CUSTOM_METRICS_CONFIG: /etc/newrelic-infra/mysql-custom-query.yml
+        interval: 30s
+        labels:
+          environment: production
+    ```
+
+    * Here's an example `mysql-custom-query.yml`:
+
+    ```yml
+    ---
+    # Metric names are set to the column names in the query results.
+    queries:
+      - query: >-
+          SELECT
+            COUNT(*) as total_connections,
+            SUM(CASE WHEN command != 'Sleep' THEN 1 ELSE 0 END) as active_connections
+          FROM information_schema.processlist
+
+        # If unset, sample_name defaults to MysqlCustomSample
+        sample_name: MysqlConnectionsSample
+
+      # `database` runs this query on a dedicated connection to that database instead
+      # of the integration's default connection, leaving the default database used by
+      # other queries unaffected. Repeat the query with a different `database` value to
+      # collect the same metric from multiple databases.
+      - query: >-
+          SELECT COUNT(*) as active_orders FROM orders WHERE status != 'completed'
+        database: myapp_db
+        sample_name: MysqlActiveOrdersSample
+    ```
+
+    <Callout variant="tip">
+      `CUSTOM_METRICS_QUERY` and `CUSTOM_METRICS_CONFIG` can both be set at the same time; the integration runs both. If an individual query fails, the integration logs a warning and continues collecting standard metrics and any other custom queries.
+    </Callout>
+  </Collapser>
 </CollapserGroup>
 
 ### Configuration options for the integration [#config-options]


### PR DESCRIPTION
## Summary
- Documents the custom SQL query support added to nri-mysql in [newrelic/nri-mysql#228](https://github.com/newrelic/nri-mysql/pull/228)
- Adds `Custom Query` and `Multiple Custom Queries` examples to the `mysql-config.yml` sample files section, mirroring the existing pattern for nri-postgresql and nri-mssql
- Covers `CUSTOM_METRICS_QUERY` (single inline query) and `CUSTOM_METRICS_CONFIG` (YAML file with a `queries:` list), including the `sample_name` and `database` (dedicated-connection) options and automatic GAUGE/ATTRIBUTE metric-type inference