### PR TITLE
docs: add Android 7.8.2 release notes for source map host fix

### DIFF
--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-782.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-782.mdx
@@ -1,0 +1,13 @@
+---
+subject: Android agent
+releaseDate: '2026-08-24'
+version: 7.8.2
+---
+
+
+## Bug fixes
+- fixed correct regional/default source map API host for React Native Source Map Upload
+
+## Support statement
+
+We recommend updating the agent at least every three months. Find specific policies and dates for Android agent support in the [Mobile Monitoring Agents EOL Policy](/docs/mobile-monitoring/new-relic-mobile/get-started/mobile-agents-eol-policy/#android-eol).

--- a/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-782.mdx
+++ b/src/content/docs/release-notes/mobile-release-notes/android-release-notes/android-782.mdx
@@ -6,7 +6,7 @@ version: 7.8.2
 
 
 ## Bug fixes
-- fixed correct regional/default source map API host for React Native Source Map Upload
+- Fixed correct regional/default source map API host for React Native Source Map Upload
 
 ## Support statement
 


### PR DESCRIPTION
## What & Why

`android-782.mdx` was accidentally created as a byte-for-byte duplicate of the 7.8.0 release notes (`android-780.mdx`). This corrects it to reflect the actual 7.8.2 patch release: a fix for the regional/default source map API host used for React Native source map uploads.

## Test plan

- [ ] Confirm `android-782.mdx` renders correctly on the release notes page
- [ ] Confirm it no longer duplicates the 7.8.0 feature/bug-fix list