### PR TITLE
docs(spanner): document restored GCPSPANNERDATABASE entity

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration.mdx
@@ -47,7 +47,7 @@ All Spanner metrics available in GCP Cloud Monitoring are collected as dimension
     id="entities-table"
     title="Spanner entities"
   >
-    A `GCPSPANNERINSTANCE` entity is synthesized for each Spanner instance, and a `GCPSPANNERDATABASE` entity for each database within it. Both entity types share the same underlying `spanner_instance` GCP monitored resource type—Spanner has no separate per-database monitored resource type—and are disambiguated by metric family: node, CPU, storage, session, backup, and leader-region metrics attach to `GCPSPANNERINSTANCE`; the `api`, `query_stat`, `read_stat`, `transaction_stat`, `lock_stat`, `query_count`, and `row_deletion_policy` metric families, which carry an additional `database` metric label, attach to `GCPSPANNERDATABASE`.
+    A `GCPSPANNERINSTANCE` entity is synthesized for each Spanner instance, and a `GCPSPANNERDATABASE` entity for each database within it. Both entity types share the same underlying `spanner_instance` GCP monitored resource type—Spanner has no separate per-database monitored resource type—and are disambiguated by metric family: node, CPU, storage, session, backup, and leader-region metrics attach to `GCPSPANNERINSTANCE`; the `api`, `query_stat`, `graph_query_stat`, `read_stat`, `transaction_stat`, `lock_stat`, `query_count`, and `row_deletion_policy` metric families, which carry an additional `database` metric label, attach to `GCPSPANNERDATABASE`.
 
     <table>
       <thead>

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-cloud-spanner-monitoring-integration.mdx
@@ -47,7 +47,7 @@ All Spanner metrics available in GCP Cloud Monitoring are collected as dimension
     id="entities-table"
     title="Spanner entities"
   >
-    A single `GCPSPANNERINSTANCE` entity is synthesized for each Spanner instance. Metrics emitted against both the `spanner_instance` and `spanner.googleapis.com/Instance` GCP monitored resource types are attached to this entity, faceted by `database` where applicable.
+    A `GCPSPANNERINSTANCE` entity is synthesized for each Spanner instance, and a `GCPSPANNERDATABASE` entity for each database within it. Both entity types share the same underlying `spanner_instance` GCP monitored resource type—Spanner has no separate per-database monitored resource type—and are disambiguated by metric family: node, CPU, storage, session, backup, and leader-region metrics attach to `GCPSPANNERINSTANCE`; the `api`, `query_stat`, `read_stat`, `transaction_stat`, `lock_stat`, `query_count`, and `row_deletion_policy` metric families, which carry an additional `database` metric label, attach to `GCPSPANNERDATABASE`.
 
     <table>
       <thead>
@@ -80,6 +80,20 @@ All Spanner metrics available in GCP Cloud Monitoring are collected as dimension
             `spanner_instance`, `spanner.googleapis.com/Instance`
           </td>
         </tr>
+
+        <tr>
+          <td>
+            Database
+          </td>
+
+          <td>
+            `GCPSPANNERDATABASE`
+          </td>
+
+          <td>
+            `spanner_instance`
+          </td>
+        </tr>
       </tbody>
     </table>
   </Collapser>
@@ -87,7 +101,9 @@ All Spanner metrics available in GCP Cloud Monitoring are collected as dimension
 
 ### Metric data [#metrics-wif]
 
-#### Key metrics
+#### Key metrics: Instance
+
+These metrics attach to the `GCPSPANNERINSTANCE` entity.
 
 <table>
   <thead>
@@ -288,6 +304,31 @@ All Spanner metrics available in GCP Cloud Monitoring are collected as dimension
         Share of Spanner leaders for the instance, faceted by region.
       </td>
     </tr>
+  </tbody>
+</table>
+
+#### Key metrics: Database
+
+Spanner has no separate per-database GCP monitored resource type; these metrics report against the same `spanner_instance` resource type as the Instance metrics above, with an additional `database` metric label, and attach to the `GCPSPANNERDATABASE` entity.
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>
+        Metric name
+      </th>
+
+      <th style={{ width: "100px" }}>
+        Unit
+      </th>
+
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
     <tr>
       <td>
         `gcp.spanner.api.request_count`


### PR DESCRIPTION
## Summary

Companion doc update to NR-608919 (restoring `GCPSPANNERDATABASE` entity discovery in gcp-polling-v2, see [beyond/gcp-polling-v2#268](https://source.datanerd.us/beyond/gcp-polling-v2/pull/268)). The Spanner integration doc previously described the (broken) single-entity behavior in prose, with no Database row in the entities table.

## Changes

- Added a `Database` / `GCPSPANNERDATABASE` / `spanner_instance` row to the Spanner entities table (same monitored resource type as Instance, disambiguated by metric family).
- Rewrote the "Entities" collapser's lead sentence to describe the real split instead of a single instance-only entity, and to mention the full set of metric families (including `graph_query_stat`) attributed to `GCPSPANNERDATABASE`.
- Split the single "Key metrics" table into "Key metrics: Instance" and "Key metrics: Database" for clarity, matching the entities-table split. The table's rows were already grouped contiguously by entity (instance metrics then database metrics, no interleaving), so this is a table-tag restructure with zero row-content changes.

The v1 `GcpSpannerInstanceSample`/`GcpSpannerDatabaseSample` section (separate pipeline) is unaffected and left unchanged. i18n mirror files under `src/i18n/content/*` were not touched (translation-managed, regenerated from the English source).

## Test plan

- [ ] Confirm the page renders correctly (table split, entities collapser) in a docs preview build
- [ ] Once the gcp-polling-v2 fix is deployed, confirm the documented entity/metric split matches what customers actually see