### PR TITLE
docs(cli): add Japan (jp) region support to CLI tutorial

### DIFF
--- a/src/content/docs/new-relic-solutions/tutorials/new-relic-cli.mdx
+++ b/src/content/docs/new-relic-solutions/tutorials/new-relic-cli.mdx
@@ -71,7 +71,7 @@ For this guide you just need:
     ```
 
     <Callout variant="important">
-      You must set the [region](/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers) of your New Relic account. Use `-r` to set either `us` or `eu`.
+      You must set the [region](/docs/accounts/accounts-billing/account-setup/choose-your-data-center) of your New Relic account. Use `-r` to set `us`, `eu`, or `jp`.
     </Callout>
   </Step>
 


### PR DESCRIPTION
## Summary
- Updated the `profiles add` step to include `jp` as a valid value for the `-r` flag (alongside existing `us` and `eu`)
- Updated the linked region docs page to the current [data center page](https://docs.newrelic.com/docs/accounts/accounts-billing/account-setup/choose-your-data-center/) which covers all three regions

## Test plan
- [ ] Verify the data center link resolves correctly
- [ ] Confirm `newrelic profiles add -r jp` works for Japan region accounts