### PR TITLE
fix(agent-control): style review and table format fixes

### DIFF
--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -7,7 +7,7 @@ freshnessValidatedDate: never
   Agent Control and New Relic Control are **generally available** for Kubernetes. Support for Linux and Windows hosts is in **public preview** program, pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
-An agent type definition is a YAML file that describes how Agent Control should identify, download, configure, and run a specific agent. Its declared variables also form the configuration schema that Fleet Control exposes to operators when deploying or updating a sub-agent from the fleet. Every definition consists of three main sections, **metadata**, **variables**, and **deployment**, plus a top-level `protocol_version` field that versions the schema language the file is written against.
+An agent type definition is a YAML file that describes how Agent Control should identify, download, configure, and run a specific agent. Its declared variables also form the configuration schema that Fleet Control exposes to operators when deploying or updating a sub-agent from the fleet. Every definition consists of three main sections, <DNT>**metadata**</DNT>, <DNT>**variables**</DNT>, and <DNT>**deployment**</DNT>, plus a top-level `protocol_version` field that versions the schema language the file is written against.
 
 ## Metadata
 

--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -41,7 +41,7 @@ the writer's behalf.
 The shared filesystem root is:
 
 | OS | Path |
-|---|---|
+| :--- | :--- |
 | Linux | `/var/lib/newrelic-agent-control/shared-filesystem` |
 | Windows | `C:\ProgramData\New Relic\newrelic-agent-control\shared-filesystem` |
 
@@ -67,7 +67,7 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
    these shared directories:
 
    | Variable | Shared filesystem path | Purpose |
-   |---|---|---|
+   | :--- | :--- | :--- |
    | `NRIA_PLUGIN_DIR` | `…/infra-agent-ohi-configs` | Integration config discovery |
    | `NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR` | `…/infra-agent-ohi-binaries` | Integration binary discovery |
    | `NRIA_SAFE_BIN_DIR` | `…/infra-agent-ohi-binaries` | Allowed binary execution path |

--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -40,10 +40,24 @@ the writer's behalf.
 
 The shared filesystem root is:
 
-| OS | Path |
-| :--- | :--- |
-| Linux | `/var/lib/newrelic-agent-control/shared-filesystem` |
-| Windows | `C:\ProgramData\New Relic\newrelic-agent-control\shared-filesystem` |
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "120px" }}>OS</th>
+      <th>Path</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Linux</td>
+      <td>`/var/lib/newrelic-agent-control/shared-filesystem`</td>
+    </tr>
+    <tr>
+      <td>Windows</td>
+      <td>`C:\ProgramData\New Relic\newrelic-agent-control\shared-filesystem`</td>
+    </tr>
+  </tbody>
+</table>
 
 All agents managed by the same Agent Control instance share this root. Subdirectory names are
 chosen by convention between the linked agent types.
@@ -66,11 +80,32 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
 2. The Infrastructure Agent sub-agent is configured with environment variables that point it at
    these shared directories:
 
-   | Variable | Shared filesystem path | Purpose |
-   | :--- | :--- | :--- |
-   | `NRIA_PLUGIN_DIR` | `…/infra-agent-ohi-configs` | Integration config discovery |
-   | `NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR` | `…/infra-agent-ohi-binaries` | Integration binary discovery |
-   | `NRIA_SAFE_BIN_DIR` | `…/infra-agent-ohi-binaries` | Allowed binary execution path |
+   <table>
+     <thead>
+       <tr>
+         <th style={{ width: "280px" }}>Variable</th>
+         <th style={{ width: "240px" }}>Shared filesystem path</th>
+         <th>Purpose</th>
+       </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <td>`NRIA_PLUGIN_DIR`</td>
+         <td>`…/infra-agent-ohi-configs`</td>
+         <td>Integration config discovery</td>
+       </tr>
+       <tr>
+         <td>`NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR`</td>
+         <td>`…/infra-agent-ohi-binaries`</td>
+         <td>Integration binary discovery</td>
+       </tr>
+       <tr>
+         <td>`NRIA_SAFE_BIN_DIR`</td>
+         <td>`…/infra-agent-ohi-binaries`</td>
+         <td>Allowed binary execution path</td>
+       </tr>
+     </tbody>
+   </table>
 
 3. The Infrastructure Agent picks up the config and binary on its next scan cycle and begins
    running the integration.
@@ -97,21 +132,96 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
 
 The following table shows which agent types Agent Control supports and their availability across environments.
 
-| Agent type | Kubernetes support | Linux host support | Windows host support |
-| :--- | :---: | :---: | :---: |
-| [**New Relic infrastructure agent**](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview/) | ✅ Yes | Public Preview | Public Preview |
-| [**Apache**](https://docs.newrelic.com/install/apache/) | ✅ Yes | Public Preview | Public Preview |
-| [**Flex**](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration/) | ✅ Yes | Public Preview | Public Preview |
-| [**Memcached**](https://docs.newrelic.com/install/memcached/) | ✅ Yes | Public Preview | Public Preview |
-| [**MySQL**](https://docs.newrelic.com/install/mysql/) | ✅ Yes | Public Preview | Public Preview |
-| [**NGINX**](https://docs.newrelic.com/install/nginx/) | ✅ Yes | Public Preview | Public Preview |
-| [**PostgreSQL**](https://docs.newrelic.com/install/postgresql/) | ✅ Yes | Public Preview | Public Preview |
-| [**Redis**](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/redis/redis-integration/) | ✅ Yes | Public Preview | Public Preview |
-| [**New Relic OpenTelemetry Collector (NRDOT)**](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-intro/) | ✅ Yes | ✅ Yes | ⚠️ Experimental |
-| [**Fluent Bit**](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/) | ✅ Yes | 🚫 No | 🚫 No |
-| [**New Relic Prometheus agent**](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) | ✅ Yes | 🚫 No | 🚫 No |
-| [**New Relic eBPF agent**](https://docs.newrelic.com/docs/ebpf/overview/) | ✅ Yes | ⚠️ Experimental | 🚫 No |
-| [**APM agents (.NET, Java, Node, Python, Ruby)**](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/introduction-apm/) | 🚫 No | 🚫 No | 🚫 No |
+<table>
+  <thead>
+    <tr>
+      <th>Agent type</th>
+      <th style={{ width: "150px" }}>Kubernetes support</th>
+      <th style={{ width: "150px" }}>Linux host support</th>
+      <th style={{ width: "160px" }}>Windows host support</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>[**New Relic infrastructure agent**](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**Apache**](https://docs.newrelic.com/install/apache/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**Flex**](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**Memcached**](https://docs.newrelic.com/install/memcached/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**MySQL**](https://docs.newrelic.com/install/mysql/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**NGINX**](https://docs.newrelic.com/install/nginx/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**PostgreSQL**](https://docs.newrelic.com/install/postgresql/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**Redis**](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/redis/redis-integration/)</td>
+      <td>✅ Yes</td>
+      <td>Public Preview</td>
+      <td>Public Preview</td>
+    </tr>
+    <tr>
+      <td>[**New Relic OpenTelemetry Collector (NRDOT)**](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-intro/)</td>
+      <td>✅ Yes</td>
+      <td>✅ Yes</td>
+      <td>⚠️ Experimental</td>
+    </tr>
+    <tr>
+      <td>[**Fluent Bit**](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/)</td>
+      <td>✅ Yes</td>
+      <td>🚫 No</td>
+      <td>🚫 No</td>
+    </tr>
+    <tr>
+      <td>[**New Relic Prometheus agent**](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/)</td>
+      <td>✅ Yes</td>
+      <td>🚫 No</td>
+      <td>🚫 No</td>
+    </tr>
+    <tr>
+      <td>[**New Relic eBPF agent**](https://docs.newrelic.com/docs/ebpf/overview/)</td>
+      <td>✅ Yes</td>
+      <td>⚠️ Experimental</td>
+      <td>🚫 No</td>
+    </tr>
+    <tr>
+      <td>[**APM agents (.NET, Java, Node, Python, Ruby)**](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/introduction-apm/)</td>
+      <td>🚫 No</td>
+      <td>🚫 No</td>
+      <td>🚫 No</td>
+    </tr>
+  </tbody>
+</table>
 
 <Callout variant="important">
   Agent-specific permissions: Agent Control is designed to provide you with flexible permissions management. While Agent Control itself requires a certain level of access to function, the permissions it grants to individual agents are tailored to their specific needs. Below, you can find a breakdown of the permissions required for each agent type.
@@ -121,21 +231,82 @@ The following table shows which agent types Agent Control supports and their ava
 
 The following table lists the key permissions each agent type requires and the environments where it applies.
 
-| Agent type | Key permissions required | Environment |
-| :--- | :--- | :--- |
-| **New Relic infrastructure agent** | Host-level access for system metrics and Kubernetes API access for cluster data. | Kubernetes / host-based |
-| **Apache** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **Flex** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **Memcached** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **MySQL** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **NGINX** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **PostgreSQL** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **Redis** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
-| **New Relic OpenTelemetry Collector (NRDOT)** | Permissions depend on specific receivers and exporters. Often requires Kubernetes API access for service discovery. | Kubernetes / host-based |
-| **Fluent Bit** | Read access to pod and container logs. | Kubernetes |
-| **New Relic Prometheus agent** | Permissions to discover and access service endpoints within the cluster for scraping metrics. | Kubernetes |
-| **New Relic eBPF agent** | Elevated privileges (for example, `CAP_SYS_ADMIN`) to load eBPF programs on the host kernel. | Kubernetes, Linux hosts (experimental) |
-| **APM agents (.NET, Java, Node, Python, Ruby)** | *Not currently supported by Agent Control.* | N/A |
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "220px" }}>Agent type</th>
+      <th>Key permissions required</th>
+      <th style={{ width: "180px" }}>Environment</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>**New Relic infrastructure agent**</td>
+      <td>Host-level access for system metrics and Kubernetes API access for cluster data.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**Apache**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**Flex**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**Memcached**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**MySQL**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**NGINX**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**PostgreSQL**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**Redis**</td>
+      <td>Executed by infra-agent with the same permissions.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**New Relic OpenTelemetry Collector (NRDOT)**</td>
+      <td>Permissions depend on specific receivers and exporters. Often requires Kubernetes API access for service discovery.</td>
+      <td>Kubernetes / host-based</td>
+    </tr>
+    <tr>
+      <td>**Fluent Bit**</td>
+      <td>Read access to pod and container logs.</td>
+      <td>Kubernetes</td>
+    </tr>
+    <tr>
+      <td>**New Relic Prometheus agent**</td>
+      <td>Permissions to discover and access service endpoints within the cluster for scraping metrics.</td>
+      <td>Kubernetes</td>
+    </tr>
+    <tr>
+      <td>**New Relic eBPF agent**</td>
+      <td>Elevated privileges (for example, `CAP_SYS_ADMIN`) to load eBPF programs on the host kernel.</td>
+      <td>Kubernetes, Linux hosts (experimental)</td>
+    </tr>
+    <tr>
+      <td>**APM agents (.NET, Java, Node, Python, Ruby)**</td>
+      <td>*Not currently supported by Agent Control.*</td>
+      <td>N/A</td>
+    </tr>
+  </tbody>
+</table>
 
 <Callout variant="caution" title="NRDOT on Windows hosts is experimental">
   The New Relic OpenTelemetry Collector (NRDOT) on Windows is available but not officially tested or documented by the NRDOT team. The default bundled configuration is designed for Linux and may produce warnings or errors on Windows (for example, from `filelogreceiver` paths). No default configuration is bundled for Windows — you must supply your own collector configuration. Use NRDOT on Windows only in non-critical or testing environments.

--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -95,6 +95,8 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
 
 ### Current support
 
+The following table shows which agent types Agent Control supports and their availability across environments.
+
 | Agent type | Kubernetes support | Linux host support | Windows host support |
 | :--- | :---: | :---: | :---: |
 | [**New Relic infrastructure agent**](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview/) | ✅ Yes | Public Preview | Public Preview |
@@ -116,6 +118,8 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
 </Callout>
 
 ## Required permissions per agent type
+
+The following table lists the key permissions each agent type requires and the environments where it applies.
 
 | Agent Type | Key Permissions Required                                                                                            | Environment |
 | :--- |:--------------------------------------------------------------------------------------------------------------------| :--- |

--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -121,8 +121,8 @@ The following table shows which agent types Agent Control supports and their ava
 
 The following table lists the key permissions each agent type requires and the environments where it applies.
 
-| Agent Type | Key Permissions Required                                                                                            | Environment |
-| :--- |:--------------------------------------------------------------------------------------------------------------------| :--- |
+| Agent type | Key permissions required | Environment |
+| :--- | :--- | :--- |
 | **New Relic infrastructure agent** | Host-level access for system metrics and Kubernetes API access for cluster data. | Kubernetes / host-based |
 | **Apache** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
 | **Flex** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |

--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -1,23 +1,110 @@
 ---
-title: "Supported agent types"
-metaDescription: "Types of agents that can be managed by Agent Control"
+title: "Agent types"
+metaDescription: "What agent types are in Agent Control, how they work, and which agents are currently supported"
 freshnessValidatedDate: never
 ---
 <Callout variant="important">
   Agent Control and New Relic Control are **generally available** for Kubernetes. Support for Linux and Windows hosts is in **public preview** program, pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
-## Overview
+An agent type definition is a YAML file that describes how Agent Control should identify, download, configure, and run a specific agent. Its declared variables also form the configuration schema that Fleet Control exposes to operators when deploying or updating a sub-agent from the fleet. Every definition consists of three main sections, **metadata**, **variables**, and **deployment**, plus a top-level `protocol_version` field that versions the schema language the file is written against.
 
-Agent Control provides a single, unified platform for managing a wide variety of New Relic and OpenTelemetry agents across your fleets. By centralizing management, you can deploy, configure, and update your instrumentation with ease.
+### Metadata
 
-While Agent Control is designed to support both Kubernetes and host-based environments, support for specific agent types varies. The following table provides a comprehensive overview of which agents can be managed by Agent Control and their support status across environments.
+The metadata section identifies the agent type: its `name`, `namespace`, `version`, target `platform` (`host` or `kubernetes`), and `operating_system` (required for host-based types). Agent Control uses these fields to uniquely address the definition and dispatch it to the correct deployment engine.
+
+### Variables
+
+The variables section declares the configurable inputs that operators can set when adding a sub-agent to their configuration. Each variable has a `type` (such as `string`, `bool`, or `yaml`), an optional `default`, and an optional `variants` list of accepted values. Variables are referenced throughout the deployment section using `${nr-var:variable_name}`.
+
+### Deployment
+
+The deployment section describes how Agent Control installs and runs the agent on the target platform. It is composed of several sub-sections:
+
+- **`packages`**: OCI artifacts to download before the agent starts — typically the agent binary or integration package.
+- **`executables`**: the list of processes Agent Control will start, monitor, and restart. An agent type without this section is treated as a managed integration (OHI): Agent Control handles its artifacts but delegates execution to another agent.
+- **`health`**: how Agent Control determines whether the agent is healthy — via process presence, an HTTP endpoint check, or both.
+- **`filesystem`**: individual files or directories that Agent Control writes to the host before starting the agent, such as configuration files or certificates.
+- **`shared_filesystem`**: entries written into a shared drop zone accessible to other agents managed by the same Agent Control instance. Used by OHI agent types to hand their configuration and binaries to the Infrastructure Agent.
+
+For the full schema reference and all available fields, see [Agent type schema reference](https://github.com/newrelic/newrelic-agent-control/blob/main/docs/agent_type.md).
+
+## Linked agent types
+
+Two agent types are **linked** when one writes artifacts (configuration, binaries, or other files)
+into the shared filesystem and the other is configured to read from those same paths. The writer
+may have no `executables` section, Agent Control manages its artifacts but never starts a process
+for it. Instead, the reader agent has the built-in logic to discover and execute binaries and
+configurations from a well-known path in the shared filesystem, effectively running the add-on on
+the writer's behalf.
+
+The shared filesystem root is:
+
+| OS | Path |
+|---|---|
+| Linux | `/var/lib/newrelic-agent-control/shared-filesystem` |
+| Windows | `C:\ProgramData\New Relic\newrelic-agent-control\shared-filesystem` |
+
+All agents managed by the same Agent Control instance share this root. Subdirectory names are
+chosen by convention between the linked agent types.
+
+### On Host Integrations (OHI)
+
+On-Host Integrations (OHIs) are the primary example of linked agents in Agent Control; where other agents have a process
+started by Agent Control, OHI agents have no process of their own and are never started by Agent Control.
+They let Agent Control manage the full lifecycle of New Relic infrastructure integrations,
+downloading, configuring, upgrading, and uninstalling them while delegating their execution to
+the Infrastructure Agent, which discovers and runs the integration binaries from the shared filesystem.
+
+### The Infrastructure Agent and OHI agent relationship
+
+1. When an OHI agent type is installed, Agent Control downloads the integration binary via OCI and
+   writes two entries into the shared filesystem:
+   - A config file under `infra-agent-ohi-configs/` (e.g. `nri-redis.yaml`)
+   - The integration binary under `infra-agent-ohi-binaries/` (e.g. `nri-redis`)
+
+2. The Infrastructure Agent sub-agent is configured with environment variables that point it at
+   these shared directories:
+
+   | Variable | Shared filesystem path | Purpose |
+   |---|---|---|
+   | `NRIA_PLUGIN_DIR` | `…/infra-agent-ohi-configs` | Integration config discovery |
+   | `NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR` | `…/infra-agent-ohi-binaries` | Integration binary discovery |
+   | `NRIA_SAFE_BIN_DIR` | `…/infra-agent-ohi-binaries` | Allowed binary execution path |
+
+3. The Infrastructure Agent picks up the config and binary on its next scan cycle and begins
+   running the integration.
+
+   ```
+   shared-filesystem/
+   ├── infra-agent-ohi-configs/      # Integration YAML configs (read by NRIA_PLUGIN_DIR)
+   │   ├── nri-redis.yaml
+   │   └── nri-mysql.yaml
+   └── infra-agent-ohi-binaries/     # Integration binaries (read by NRIA_CUSTOM_PLUGIN_INSTALLATION_DIR)
+       ├── nri-redis
+       └── nri-mysql
+   ```
+
+<Callout variant="important">
+  OHI agent types have no process of their own and depend entirely on the Infrastructure Agent to
+  execute. You must have `com.newrelic.infrastructure` configured as a sub-agent in the same Agent
+  Control instance before deploying any OHI agent type.
+</Callout>
+
+## Supported agent types
 
 ### Current support
 
 | Agent type | Kubernetes support | Linux host support | Windows host support |
 | :--- | :---: | :---: | :---: |
 | [**New Relic infrastructure agent**](https://docs.newrelic.com/docs/infrastructure/infrastructure-agent/new-relic-guided-install-overview/) | ✅ Yes | Public Preview | Public Preview |
+| [**Apache**](https://docs.newrelic.com/install/apache/) | ✅ Yes | Public Preview | Public Preview |
+| [**Flex**](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/flex-integration-tool-build-your-own-integration/) | ✅ Yes | Public Preview | Public Preview |
+| [**Memcached**](https://docs.newrelic.com/install/memcached/) | ✅ Yes | Public Preview | Public Preview |
+| [**MySQL**](https://docs.newrelic.com/install/mysql/) | ✅ Yes | Public Preview | Public Preview |
+| [**NGINX**](https://docs.newrelic.com/install/nginx/) | ✅ Yes | Public Preview | Public Preview |
+| [**PostgreSQL**](https://docs.newrelic.com/install/postgresql/) | ✅ Yes | Public Preview | Public Preview |
+| [**Redis**](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/redis/redis-integration/) | ✅ Yes | Public Preview | Public Preview |
 | [**New Relic OpenTelemetry Collector (NRDOT)**](https://docs.newrelic.com/docs/opentelemetry/nrdot/nrdot-intro/) | ✅ Yes | ✅ Yes | ⚠️ Experimental |
 | [**Fluent Bit**](https://docs.newrelic.com/docs/logs/forward-logs/forward-your-logs-using-infrastructure-agent/) | ✅ Yes | 🚫 No | 🚫 No |
 | [**New Relic Prometheus agent**](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/get-started/send-prometheus-metric-data-new-relic/) | ✅ Yes | 🚫 No | 🚫 No |
@@ -25,14 +112,21 @@ While Agent Control is designed to support both Kubernetes and host-based enviro
 | [**APM agents (.NET, Java, Node, Python, Ruby)**](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/introduction-apm/) | 🚫 No | 🚫 No | 🚫 No |
 
 <Callout variant="important">
-Agent-specific permissions: Agent Control is designed to provide you with flexible permissions management. While Agent Control itself requires a certain level of access to function, the permissions it grants to individual agents are tailored to their specific needs. Below, you can find a breakdown of the permissions required for each agent type.
+  Agent-specific permissions: Agent Control is designed to provide you with flexible permissions management. While Agent Control itself requires a certain level of access to function, the permissions it grants to individual agents are tailored to their specific needs. Below, you can find a breakdown of the permissions required for each agent type.
 </Callout>
 
 ## Required Permissions per agent type
 
-| Agent Type | Key Permissions Required | Environment |
-| :--- | :--- | :--- |
+| Agent Type | Key Permissions Required                                                                                            | Environment |
+| :--- |:--------------------------------------------------------------------------------------------------------------------| :--- |
 | **New Relic infrastructure agent** | Host-level access for system metrics and Kubernetes API access for cluster data. | Kubernetes / host-based |
+| **Apache** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
+| **Flex** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
+| **Memcached** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
+| **MySQL** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
+| **NGINX** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
+| **PostgreSQL** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
+| **Redis** | Executed by infra-agent with the same permissions. | Kubernetes / host-based |
 | **New Relic OpenTelemetry Collector (NRDOT)** | Permissions depend on specific receivers and exporters. Often requires Kubernetes API access for service discovery. | Kubernetes / host-based |
 | **Fluent Bit** | Read access to pod and container logs. | Kubernetes |
 | **New Relic Prometheus agent** | Permissions to discover and access service endpoints within the cluster for scraping metrics. | Kubernetes |

--- a/src/content/docs/new-relic-control/agent-control/agent-types.mdx
+++ b/src/content/docs/new-relic-control/agent-control/agent-types.mdx
@@ -9,15 +9,15 @@ freshnessValidatedDate: never
 
 An agent type definition is a YAML file that describes how Agent Control should identify, download, configure, and run a specific agent. Its declared variables also form the configuration schema that Fleet Control exposes to operators when deploying or updating a sub-agent from the fleet. Every definition consists of three main sections, **metadata**, **variables**, and **deployment**, plus a top-level `protocol_version` field that versions the schema language the file is written against.
 
-### Metadata
+## Metadata
 
 The metadata section identifies the agent type: its `name`, `namespace`, `version`, target `platform` (`host` or `kubernetes`), and `operating_system` (required for host-based types). Agent Control uses these fields to uniquely address the definition and dispatch it to the correct deployment engine.
 
-### Variables
+## Variables
 
 The variables section declares the configurable inputs that operators can set when adding a sub-agent to their configuration. Each variable has a `type` (such as `string`, `bool`, or `yaml`), an optional `default`, and an optional `variants` list of accepted values. Variables are referenced throughout the deployment section using `${nr-var:variable_name}`.
 
-### Deployment
+## Deployment
 
 The deployment section describes how Agent Control installs and runs the agent on the target platform. It is composed of several sub-sections:
 
@@ -51,7 +51,7 @@ chosen by convention between the linked agent types.
 ### On Host Integrations (OHI)
 
 On-Host Integrations (OHIs) are the primary example of linked agents in Agent Control; where other agents have a process
-started by Agent Control, OHI agents have no process of their own and are never started by Agent Control.
+started by Agent Control, OHI agents have no process of their own and Agent Control never starts them.
 They let Agent Control manage the full lifecycle of New Relic infrastructure integrations,
 downloading, configuring, upgrading, and uninstalling them while delegating their execution to
 the Infrastructure Agent, which discovers and runs the integration binaries from the shared filesystem.
@@ -115,7 +115,7 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
   Agent-specific permissions: Agent Control is designed to provide you with flexible permissions management. While Agent Control itself requires a certain level of access to function, the permissions it grants to individual agents are tailored to their specific needs. Below, you can find a breakdown of the permissions required for each agent type.
 </Callout>
 
-## Required Permissions per agent type
+## Required permissions per agent type
 
 | Agent Type | Key Permissions Required                                                                                            | Environment |
 | :--- |:--------------------------------------------------------------------------------------------------------------------| :--- |
@@ -134,7 +134,7 @@ the Infrastructure Agent, which discovers and runs the integration binaries from
 | **APM agents (.NET, Java, Node, Python, Ruby)** | *Not currently supported by Agent Control.* | N/A |
 
 <Callout variant="caution" title="NRDOT on Windows hosts is experimental">
-  The New Relic OpenTelemetry Collector (NRDOT) on Windows is available but not officially tested or documented by the NRDOT team. The default bundled configuration is designed for Linux and may produce warnings or errors on Windows (for example, from `filelogreceiver` paths). No default configuration is bundled for Windows — you must supply your own collector configuration. Use NRDOT on Windows only in non-critical or testing environments until full Windows support is released.
+  The New Relic OpenTelemetry Collector (NRDOT) on Windows is available but not officially tested or documented by the NRDOT team. The default bundled configuration is designed for Linux and may produce warnings or errors on Windows (for example, from `filelogreceiver` paths). No default configuration is bundled for Windows — you must supply your own collector configuration. Use NRDOT on Windows only in non-critical or testing environments.
 </Callout>
 
 <Callout variant="caution" title="eBPF on Linux hosts is experimental">

--- a/src/content/docs/new-relic-control/agent-control/overview.mdx
+++ b/src/content/docs/new-relic-control/agent-control/overview.mdx
@@ -16,7 +16,7 @@ Managing instrumentation at scale is labor intensive and error prone. Multiple a
 Agent Control provides a single, extensible supervisor you install once per host or cluster. It keeps all your New Relic and open source agents healthy and up to date, applies remote configuration, and enforces consistent settings without individually touching each agent.
 
 <Callout variant="tip" title="Note about cost and data ingestion">
-Agent Control can be installed on any supported environment and doesn't require any paid entitlement. The supervisor itself doesn't push any new telemetry to New Relic. Ingest cost will depend on the instrumentation enabled in the managed agents (Infrastructure, APM, Logs).
+  Agent Control can be installed on any supported environment and doesn't require any paid entitlement. The supervisor itself doesn't push any new telemetry to New Relic. Ingest cost will depend on the instrumentation enabled in the managed agents (Infrastructure, APM, Logs).
 </Callout>
 
 ## Architecture
@@ -57,6 +57,14 @@ Agent Control is designed to be a supervisor for managing instrumentation which 
   - **No automatic agent migration:** Agent Control does not automatically migrate or replace existing agent installations. Uninstall any existing agents before installing Agent Control, then manage them through Fleet Control. See [Manage existing instrumentation](/docs/new-relic-control/agent-control/reinstrumentation).
 </Callout>
 
+## Agent type definitions
+
+Every agent managed by Agent Control is backed by an **agent type**, a versioned specification that describes how Agent Control should download, configure, and run that agent. Supporting a new agent always requires an agent type definition; without one, Agent Control has no knowledge of how to manage it.
+
+Agent types are identified by a qualified name and version (e.g. `newrelic/com.newrelic.infrastructure:0.1.0`). When you add a sub-agent to your configuration, you reference an agent type; Agent Control uses that definition to fetch the correct artifact, apply configuration defaults, and manage the agent's lifecycle.
+
+For the full list of available agent types, refer to [Agent types](/docs/new-relic-control/agent-control/agent-types#agent-types).
+
 ## Agent Control permissions
 Deploying and managing agents in a Kubernetes cluster requires a clear understanding of the necessary permissions. Here, we'll explain the roles of both Agent Control and Flux and how they interact to securely install, update, and remove agents while ensuring that each agent only has the permissions it needs.
 
@@ -80,7 +88,7 @@ Different agent types and their configurations require different permissions. Fo
 
 Agent Control is designed to manage these permissions flexibly. While Flux requires a high degree of access to function, our goal is to ensure that Agent Control only requests the **minimum required permissions** for the specific combination of agents you are managing.
 
-For detailed information on the specific permissions required by each agent, refer to [Supported agent types](/docs/new-relic-control/agent-control/agent-types).
+For detailed information on the specific permissions required by each agent, refer to [Required Permissions per agent type](/docs/new-relic-control/agent-control/agent-types#required-permissions-per-agent-type).
 
 ## Requirements and compatibility
 
@@ -115,38 +123,38 @@ Before installing Agent Control, make sure you have a New Relic account and that
 We support these operating systems up to their manufacturer's end-of-life.
 
 <table>
-    <tbody>
-        <tr>
-            <td>
-                **Processor architectures**
-            </td>
-            <td>
-                Agent Control supports these processor architectures:
+  <tbody>
+  <tr>
+    <td>
+      **Processor architectures**
+    </td>
+    <td>
+      Agent Control supports these processor architectures:
 
-                  * 64-bit for x86 processor architectures
-                  * arm64 architecture
-            </td>
-        </tr>
-        <tr>
-            <td>
-                **Operating systems**
-            </td>
-            <td>
-                Agent Control supports these operating systems up to their manufacturer's end-of-life.
-                  * Amazon Linux version 2 and 2023
-                  * CentOS 8 or higher
-                  * Debian 11 ("Bullseye") or higher
-                  * Red Hat Enterprise Linux (RHEL) 7 or higher
-                  * Oracle Linux 8 or higher
-                  * SUSE Linux Enterprise Server (SLES) version 12.5, 15.2, 15.3, 15.4, 15.5
-                  * Ubuntu 16.04 or higher (major long-term releases only)
+      * 64-bit for x86 processor architectures
+      * arm64 architecture
+    </td>
+  </tr>
+  <tr>
+    <td>
+      **Operating systems**
+    </td>
+    <td>
+      Agent Control supports these operating systems up to their manufacturer's end-of-life.
+      * Amazon Linux version 2 and 2023
+      * CentOS 8 or higher
+      * Debian 11 ("Bullseye") or higher
+      * Red Hat Enterprise Linux (RHEL) 7 or higher
+      * Oracle Linux 8 or higher
+      * SUSE Linux Enterprise Server (SLES) version 12.5, 15.2, 15.3, 15.4, 15.5
+      * Ubuntu 16.04 or higher (major long-term releases only)
 
-                  The following operating systems are not yet supported:
-                  * MacOS
-                  * Docker (containerized)
-            </td>
-        </tr>
-    </tbody>
+      The following operating systems are not yet supported:
+      * MacOS
+      * Docker (containerized)
+    </td>
+  </tr>
+  </tbody>
 </table>
 
 To check your operating system details, run this command:
@@ -160,52 +168,52 @@ cat /etc/os-release
 Before installing Agent Control on Windows, make sure you have a New Relic account and that your system meets the requirements below.
 
 <table>
-    <tbody>
-        <tr>
-            <td>
-                **Processor architectures**
-            </td>
-            <td>
-                Agent Control supports these processor architectures:
+  <tbody>
+  <tr>
+    <td>
+      **Processor architectures**
+    </td>
+    <td>
+      Agent Control supports these processor architectures:
 
-                  * 64-bit for x86 processor architectures (x86_64)
-            </td>
-        </tr>
-        <tr>
-            <td>
-                **Operating systems**
-            </td>
-            <td>
-                Agent Control supports these Windows operating systems:
-                  * Windows Server 2016 or higher
-                  * Windows 10 or higher
-            </td>
-        </tr>
-        <tr>
-            <td>
-                **Prerequisites**
-            </td>
-            <td>
-                  * Administrator privileges required for installation and runtime
-                  * PowerShell 5.0 or higher
-                  * Port 51200 available for Agent Control health endpoint
-                  * Outbound HTTPS connectivity (port 443) to New Relic services
-            </td>
-        </tr>
-        <tr>
-            <td>
-                **Network Requirements**
-            </td>
-            <td>
-                Agent Control requires outbound HTTPS connectivity to:
-                  * Fleet Control API endpoints
-                  * New Relic data ingest endpoints (varies by region)
-                  * Package download servers
+      * 64-bit for x86 processor architectures (x86_64)
+    </td>
+  </tr>
+  <tr>
+    <td>
+      **Operating systems**
+    </td>
+    <td>
+      Agent Control supports these Windows operating systems:
+      * Windows Server 2016 or higher
+      * Windows 10 or higher
+    </td>
+  </tr>
+  <tr>
+    <td>
+      **Prerequisites**
+    </td>
+    <td>
+      * Administrator privileges required for installation and runtime
+      * PowerShell 5.0 or higher
+      * Port 51200 available for Agent Control health endpoint
+      * Outbound HTTPS connectivity (port 443) to New Relic services
+    </td>
+  </tr>
+  <tr>
+    <td>
+      **Network Requirements**
+    </td>
+    <td>
+      Agent Control requires outbound HTTPS connectivity to:
+      * Fleet Control API endpoints
+      * New Relic data ingest endpoints (varies by region)
+      * Package download servers
 
-                If you're behind a corporate firewall, ensure these New Relic domains are accessible.
-            </td>
-        </tr>
-    </tbody>
+      If you're behind a corporate firewall, ensure these New Relic domains are accessible.
+    </td>
+  </tr>
+  </tbody>
 </table>
 
 To check your Windows version, run this command in PowerShell:

--- a/src/content/docs/new-relic-control/agent-control/overview.mdx
+++ b/src/content/docs/new-relic-control/agent-control/overview.mdx
@@ -105,7 +105,7 @@ Before you begin deploying Agent Control to your Kubernetes clusters, ensure tha
   If your Kubernetes cluster is already instrumented with New Relic, you must uninstall the existing instrumentation before installing Agent Control. After installing Agent Control, you can use New Relic Control to install and manage all infrastructure agents on the cluster. For guidance on this process, refer to [Manage existing instrumentation with Agent Control](/docs/new-relic-control/agent-control/reinstrumentation).
 </Callout>
 
-<Callout variant="caution" title="warning">
+<Callout variant="caution" title="Warning">
   Installing multiple instances of Agent Control on the same cluster is not supported.
 </Callout>
 
@@ -123,6 +123,12 @@ Before installing Agent Control, make sure you have a New Relic account and that
 We support these operating systems up to their manufacturer's end-of-life.
 
 <table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>Property</th>
+      <th>Details</th>
+    </tr>
+  </thead>
   <tbody>
   <tr>
     <td>
@@ -168,6 +174,12 @@ cat /etc/os-release
 Before installing Agent Control on Windows, make sure you have a New Relic account and that your system meets the requirements below.
 
 <table>
+  <thead>
+    <tr>
+      <th style={{ width: "200px" }}>Property</th>
+      <th>Details</th>
+    </tr>
+  </thead>
   <tbody>
   <tr>
     <td>
@@ -202,7 +214,7 @@ Before installing Agent Control on Windows, make sure you have a New Relic accou
   </tr>
   <tr>
     <td>
-      **Network Requirements**
+      **Network requirements**
     </td>
     <td>
       Agent Control requires outbound HTTPS connectivity to:

--- a/src/content/docs/new-relic-control/agent-control/overview.mdx
+++ b/src/content/docs/new-relic-control/agent-control/overview.mdx
@@ -130,36 +130,34 @@ We support these operating systems up to their manufacturer's end-of-life.
     </tr>
   </thead>
   <tbody>
-  <tr>
-    <td>
-      **Processor architectures**
-    </td>
-    <td>
-      Agent Control supports these processor architectures:
+    <tr>
+      <td>**Processor architectures**</td>
+      <td>
+        Agent Control supports these processor architectures:
 
-      * 64-bit for x86 processor architectures
-      * arm64 architecture
-    </td>
-  </tr>
-  <tr>
-    <td>
-      **Operating systems**
-    </td>
-    <td>
-      Agent Control supports these operating systems up to their manufacturer's end-of-life.
-      * Amazon Linux version 2 and 2023
-      * CentOS 8 or higher
-      * Debian 11 ("Bullseye") or higher
-      * Red Hat Enterprise Linux (RHEL) 7 or higher
-      * Oracle Linux 8 or higher
-      * SUSE Linux Enterprise Server (SLES) version 12.5, 15.2, 15.3, 15.4, 15.5
-      * Ubuntu 16.04 or higher (major long-term releases only)
+        * 64-bit for x86 processor architectures
+        * arm64 architecture
+      </td>
+    </tr>
+    <tr>
+      <td>**Operating systems**</td>
+      <td>
+        Agent Control supports these operating systems up to their manufacturer's end-of-life:
 
-      The following operating systems are not yet supported:
-      * MacOS
-      * Docker (containerized)
-    </td>
-  </tr>
+        * Amazon Linux version 2 and 2023
+        * CentOS 8 or higher
+        * Debian 11 ("Bullseye") or higher
+        * Red Hat Enterprise Linux (RHEL) 7 or higher
+        * Oracle Linux 8 or higher
+        * SUSE Linux Enterprise Server (SLES) version 12.5, 15.2, 15.3, 15.4, 15.5
+        * Ubuntu 16.04 or higher (major long-term releases only)
+
+        The following operating systems are not yet supported:
+
+        * MacOS
+        * Docker (containerized)
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -181,50 +179,44 @@ Before installing Agent Control on Windows, make sure you have a New Relic accou
     </tr>
   </thead>
   <tbody>
-  <tr>
-    <td>
-      **Processor architectures**
-    </td>
-    <td>
-      Agent Control supports these processor architectures:
+    <tr>
+      <td>**Processor architectures**</td>
+      <td>
+        Agent Control supports these processor architectures:
 
-      * 64-bit for x86 processor architectures (x86_64)
-    </td>
-  </tr>
-  <tr>
-    <td>
-      **Operating systems**
-    </td>
-    <td>
-      Agent Control supports these Windows operating systems:
-      * Windows Server 2016 or higher
-      * Windows 10 or higher
-    </td>
-  </tr>
-  <tr>
-    <td>
-      **Prerequisites**
-    </td>
-    <td>
-      * Administrator privileges required for installation and runtime
-      * PowerShell 5.0 or higher
-      * Port 51200 available for Agent Control health endpoint
-      * Outbound HTTPS connectivity (port 443) to New Relic services
-    </td>
-  </tr>
-  <tr>
-    <td>
-      **Network requirements**
-    </td>
-    <td>
-      Agent Control requires outbound HTTPS connectivity to:
-      * Fleet Control API endpoints
-      * New Relic data ingest endpoints (varies by region)
-      * Package download servers
+        * 64-bit for x86 processor architectures (x86_64)
+      </td>
+    </tr>
+    <tr>
+      <td>**Operating systems**</td>
+      <td>
+        Agent Control supports these Windows operating systems:
 
-      If you're behind a corporate firewall, ensure these New Relic domains are accessible.
-    </td>
-  </tr>
+        * Windows Server 2016 or higher
+        * Windows 10 or higher
+      </td>
+    </tr>
+    <tr>
+      <td>**Prerequisites**</td>
+      <td>
+        * Administrator privileges required for installation and runtime
+        * PowerShell 5.0 or higher
+        * Port 51200 available for Agent Control health endpoint
+        * Outbound HTTPS connectivity (port 443) to New Relic services
+      </td>
+    </tr>
+    <tr>
+      <td>**Network requirements**</td>
+      <td>
+        Agent Control requires outbound HTTPS connectivity to:
+
+        * Fleet Control API endpoints
+        * New Relic data ingest endpoints (varies by region)
+        * Package download servers
+
+        If you're behind a corporate firewall, ensure these New Relic domains are accessible.
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/nav/new-relic-control.yml
+++ b/src/nav/new-relic-control.yml
@@ -9,7 +9,7 @@ pages:
         path: /docs/new-relic-control/agent-control/overview
       - title: Set up & install
         path: /docs/new-relic-control/agent-control/setup
-      - title: Supported Agent types
+      - title: Agent types
         path: /docs/new-relic-control/agent-control/agent-types
       - title: Reinstrument your agents
         path: /docs/new-relic-control/agent-control/reinstrumentation


### PR DESCRIPTION
## Summary

Style review fixes and table format correction for [PR #25406](https://github.com/newrelic/docs-website/pull/25406). That PR is from a fork so changes are submitted here separately.

## Changes

### `agent-types.mdx`
- `### Metadata/Variables/Deployment` → `##` — H1→H3 skipped heading level (Rule 29)
- `## Required Permissions` → `## Required permissions` — sentence case (Rule 9)
- `"are never started by Agent Control"` → active voice (Rule 12)
- Removed `"until full Windows support is released"` — future-release promise (Rule 34)

### `overview.mdx`
- `title="warning"` → `title="Warning"` — callout title sentence case (Rule 9)
- **Table format fix:** Added `<thead>` with `Property / Details` headers to both the Linux hosts and Windows hosts tables — root cause of missing table formatting (Rule 31)
- `"Network Requirements"` → `"Network requirements"` in Windows table cell (Rule 9)