### PR TITLE
Add CVE fix release notes for SJM, Ping, Node-API, Node-Browser

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-618.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/job-manager-release-notes/job-manager-release-618.mdx
@@ -1,0 +1,18 @@
+---
+subject: Job Manager
+releaseDate: '2026-08-27'
+version: '618'
+---
+
+### Security patches
+
+Fixed the following vulnerabilities:
+
+**OS vulnerabilities:**
+  * CVE-2026-11856
+  * CVE-2026-8932
+
+**Library vulnerabilities:**
+  * CVE-2026-54399
+  * CVE-2026-54428
+  * CVE-2026-64607

--- a/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.262.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.262.mdx
@@ -1,0 +1,21 @@
+---
+subject: Node API runtime
+releaseDate: '2026-08-27'
+version: 1.2.262
+---
+
+### Security patches
+
+Fixed the following vulnerabilities:
+
+**OS vulnerabilities:**
+  * CVE-2026-53224
+  * CVE-2026-64531
+  * CVE-2026-11856
+  * CVE-2026-53246
+  * CVE-2026-62289
+  * CVE-2026-53247
+  * CVE-2026-8932
+
+**Library vulnerabilities:**
+  * CVE-2026-55553

--- a/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-3.0.211.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-browser-runtime-release-notes/node-browser-runtime-3.0.211.mdx
@@ -1,0 +1,39 @@
+---
+subject: Node browser runtime
+releaseDate: '2026-08-27'
+version: 3.0.211
+---
+
+### Security patches
+
+Upgraded Chrome from version 151.0.7922.137-1 to 151.0.7922.173-1.
+
+Fixed the following vulnerabilities:
+
+**OS vulnerabilities:**
+  * CVE-2026-53224
+  * CVE-2026-64531
+  * CVE-2026-11856
+  * CVE-2026-53246
+  * CVE-2026-62289
+  * CVE-2026-53247
+  * CVE-2026-8932
+
+**Library vulnerabilities:**
+  * CVE-2026-55553
+
+**Chrome vulnerabilities:**
+  * CVE-2026-76033
+  * CVE-2026-76034
+  * CVE-2026-76035
+  * CVE-2026-76036
+  * CVE-2026-76038
+  * CVE-2026-76039
+  * CVE-2026-76040
+  * CVE-2026-76041
+  * CVE-2026-76042
+  * CVE-2026-76043
+  * CVE-2026-76044
+  * CVE-2026-76045
+  * CVE-2026-76046
+  * CVE-2026-76047

--- a/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.80.0.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/ping-runtime-release-notes/ping-runtime-1.80.0.mdx
@@ -1,0 +1,13 @@
+---
+subject: Ping Runtime
+releaseDate: '2026-08-27'
+version: 1.80.0
+---
+
+### Security patches
+
+Fixed the following vulnerabilities:
+
+**OS vulnerabilities:**
+  * CVE-2026-11856
+  * CVE-2026-8932


### PR DESCRIPTION
## Summary
- Adds security-patch release notes for the latest CVE-fix builds:
  - job-manager-release-618 (OS + library CVEs)
  - ping-runtime-1.80.0 (OS CVEs)
  - node-api-runtime-1.2.262 (OS + library CVEs)
  - node-browser-runtime-3.0.211 (OS + library + Chrome CVEs, Chrome bumped 151.0.7922.137-1 → 151.0.7922.173-1)
- Vulnerabilities are broken out under labeled OS / Library / Chrome sections for clarity.

## Test plan
- [ ] Verify MDX renders correctly in docs preview
- [ ] Confirm version numbers match the corresponding DockerHub tags