### PR TITLE
GitHub integration updates — Autopilot 2.2 + legal fixes

### DIFF
--- a/src/content/docs/agentic-ai/autopilot/connect-to-github.mdx
+++ b/src/content/docs/agentic-ai/autopilot/connect-to-github.mdx
@@ -24,6 +24,15 @@ Connect <DNT>Autopilot</DNT> to GitHub so it can pull the Pull Request behind a 
   <DNT>Autopilot</DNT> uses read-only access to your GitHub organization. It never writes to GitHub. No PR is created, commented on, merged, or approved. It never stores full file contents or source code — only commit metadata and PR metadata.
 </Callout>
 
+## What you can do [#capabilities]
+
+When <DNT>Autopilot</DNT> has GitHub access and a Change Tracking event with a commit SHA, it can:
+
+* **Link a deployment to a PR.** Given a commit SHA on a Change Tracking event, return the associated Pull Request (number, title, description, URL).
+* **Summarize what changed.** Report the files touched and the added/deleted line counts for the PR that shipped the incident-adjacent deployment.
+* **Answer follow-ups in the same investigation.** Once the PR is on the record, you can ask <DNT>Autopilot</DNT> to compare it to the previous deployment or to correlate the change with the failing signal.
+* **Run alert-triggered or manual investigations.** The GitHub lookup runs the same way whether <DNT>Autopilot</DNT> is triggered by an alert with an SRE destination or invoked manually from Slack or the AI Chat panel.
+
 ## Prerequisites [#prerequisites]
 
 Before you begin, make sure you have:
@@ -33,9 +42,14 @@ Before you begin, make sure you have:
 * **GitHub admin access:** Admin permission on the GitHub organization (or on the specific repositories) whose PRs you want <DNT>Autopilot</DNT> to read. Only an admin can create a fine-grained Personal Access Token scoped to organization resources.
 * **New Relic org manager access:** Only an organization manager for your New Relic account can configure the GitHub connection.
 * **Preview opt-ins:** Active <DNT>Autopilot</DNT> preview trial and the `sre_agent_github_integration` feature flag enabled for your New Relic account. Your New Relic contact can confirm this.
+* **GitHub Enterprise Cloud (GHE.com users):** Your organization's GHE.com subdomain in the format `YOURSUBDOMAIN.ghe.com`. You can find this in your GitHub Enterprise Cloud organization settings.
 
 <Callout variant="important">
   This preview uses a single organization-level Personal Access Token. Per-user authorization is not available yet. Any user in your New Relic organization who can use <DNT>Autopilot</DNT> will see the same GitHub PR and commit data the token can see. Create the token with least privilege (see Step 1). If your GitHub organization requires per-user read boundaries on PRs or commits, wait for per-user support before enabling this integration.
+</Callout>
+
+<Callout variant="important">
+  This preview also retrieves code diffs from PRs and may save and store lines from your repos. You may only connect to GitHub organizations and repositories that do not have any hardcoded credentials, keys, secrets, or highly sensitive information in them.
 </Callout>
 
 ## Set up the GitHub connection [#setup]
@@ -53,6 +67,10 @@ A GitHub admin creates the token that <DNT>Autopilot</DNT> will use. The token g
    - **Resource owner:** your GitHub organization (not a personal account). Owning the token at the org level lets a GitHub admin revoke it centrally.
    - **Expiration:** 90 days or less. Short expirations force healthy rotation.
    - **Repository access:** select <DNT>**Only select repositories**</DNT> and pick the specific repos whose deployments are tracked in New Relic Change Tracking. Do not select <DNT>**All repositories**</DNT>.
+
+   <Callout variant="tip">
+     Scope the PAT only to repositories you actively track in New Relic Change Tracking. Exclude any repository that contains hardcoded credentials, API keys, secrets, or sensitive configuration. You control <DNT>Autopilot</DNT>'s read access entirely through which repositories you configure in the PAT.
+   </Callout>
 
 4. Under <DNT>**Repository permissions**</DNT>, set exactly these three:
    - **Pull requests: Read** — required for PR lookup by commit SHA, PR search, and listing recent PRs.
@@ -85,7 +103,9 @@ A New Relic organization manager connects GitHub from the <DNT>Autopilot</DNT> c
 4. Scroll to the <DNT>**External MCP connections**</DNT> section, find the GitHub row (shown as <DNT>**Not connected**</DNT>), and click <DNT>**Create GitHub MCP connection**</DNT> to expand it.
 5. Fill in the two fields:
    - **GitHub personal access token:** paste the fine-grained PAT you created in Step 1. The field is masked; use the eye icon to reveal only if you need to verify what you pasted.
-   - **GitHub URL:** leave as `github.com`. This preview supports public GitHub only. GitHub Enterprise Server (self-hosted) and GHE.com (data-residency tier) are not supported.
+   - **GitHub URL:** enter the URL for your GitHub environment:
+     - Public GitHub: `github.com`
+     - GitHub Enterprise Cloud: `YOURSUBDOMAIN.ghe.com` (replace with your organization's subdomain)
 6. Click <DNT>**Save**</DNT>. The GitHub row updates to <DNT>**Connected**</DNT>.
 7. Click <DNT>**Update agent**</DNT> at the bottom of the modal to save the overall <DNT>Autopilot</DNT> configuration.
 
@@ -100,6 +120,20 @@ There is no separate test button. The connection is exercised by the next <DNT>A
 * If you need to test, trigger an incident that has a Change Tracking event with a GitHub commit SHA. Alternatively, wait for one to come in naturally.
 * Ask <DNT>Autopilot</DNT> to investigate. If the token is valid and has the correct scope, <DNT>Autopilot</DNT>'s response will include the PR that shipped the deployment along with the files it touched.
 * If the token is invalid, missing scope, or not SSO-authorized, the GitHub step of the investigation will fail silently and <DNT>Autopilot</DNT> will continue without PR context. Any org manager can open the <DNT>Autopilot</DNT> configuration panel and paste a corrected token to fix it.
+
+## Connect GitHub Enterprise Cloud (GHE.com) [#connect-ghe]
+
+GitHub Enterprise Cloud is the data-residency tier with organization-specific subdomains (`YOURSUBDOMAIN.ghe.com`). The setup is identical to the public GitHub flow — follow [Steps 1–3](#setup) with one change:
+
+In **Step 2**, enter `YOURSUBDOMAIN.ghe.com` in the **GitHub URL** field instead of `github.com`.
+
+**PAT requirements:** Same as public GitHub — fine-grained PAT with Pull requests: Read, Contents: Read, and Metadata: Read.
+
+**Finding your subdomain:** Sign in to your GitHub Enterprise Cloud organization. Your URL is `https://YOURSUBDOMAIN.ghe.com` — use that subdomain here.
+
+**SAML SSO:** If your GHE.com organization enforces SAML SSO, authorize the PAT for SSO after generating it, before entering it in New Relic (same step as public GitHub).
+
+Once connected, <DNT>Autopilot</DNT> surfaces PR and commit context from your GHE.com instance whenever a Change Tracking event carries a commit SHA from that environment.
 
 ## Rotate the GitHub token [#rotate-token]
 

--- a/src/content/docs/agentic-ai/autopilot/troubleshoot-github-connection.mdx
+++ b/src/content/docs/agentic-ai/autopilot/troubleshoot-github-connection.mdx
@@ -80,7 +80,7 @@ Use this page to diagnose connection issues, understand current limitations, and
 
 ## Current limitations [#limitations]
 
-* **Public github.com only.** GitHub Enterprise Server (self-hosted) and GHE.com (data-residency tier) are not supported in this preview.
+* **GitHub environments supported:** Public `github.com` and GitHub Enterprise Cloud (`YOURSUBDOMAIN.ghe.com`) are available in this preview. GitHub Enterprise Server (GHES) support is coming in a future release.
 * **Read-only, no writes.** <DNT>Autopilot</DNT> fetches PR metadata and commit change data (title, description, files changed, line counts). It does not store full file contents, source code, or PR review comments.
 * **Organization-level token only.** All users of <DNT>Autopilot</DNT> in your New Relic org share one token's read access. Per-user tokens with individual authorization are planned for a later release.
 * **No in-product disconnect button yet.** In this preview, removing the integration requires revoking the token in GitHub. See [Disable the GitHub integration](/docs/agentic-ai/autopilot/connect-to-github/#disable).

--- a/src/content/docs/agentic-ai/autopilot/use-autopilot-with-github.mdx
+++ b/src/content/docs/agentic-ai/autopilot/use-autopilot-with-github.mdx
@@ -16,7 +16,7 @@ freshnessValidatedDate: never
   This feature is currently provided as part of a preview program pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy).
 </Callout>
 
-Once you [connect Autopilot to GitHub](/docs/agentic-ai/autopilot/connect-to-github), GitHub context flows into investigations automatically. You do not have to mention GitHub. When <DNT>Autopilot</DNT> finds a Change Tracking event with a commit SHA during an investigation, it fetches the associated Pull Request and surfaces it as part of the response.
+Once you [connect Autopilot to GitHub](/docs/agentic-ai/autopilot/connect-to-github), GitHub context flows into investigations automatically. The examples on this page apply to all supported GitHub environments: public GitHub (`github.com`) and GitHub Enterprise Cloud (`YOURSUBDOMAIN.ghe.com`). You do not have to mention GitHub. When <DNT>Autopilot</DNT> finds a Change Tracking event with a commit SHA during an investigation, it fetches the associated Pull Request and surfaces it as part of the response.
 
 ## What you can do [#capabilities]
 
@@ -99,7 +99,11 @@ When <DNT>Autopilot</DNT> identifies a Change Tracking event containing a commit
 * Returns a synthesized summary of the PR and commit to the requesting user through the same response channel as the rest of the investigation.
 
 <Callout variant="caution">
-  <DNT>Autopilot</DNT> reads whatever PR metadata GitHub returns for the linked commit, including the free-text PR description body. Don't put passwords, API keys, tokens, or other credentials in PR descriptions of the repositories you connect. If a credential is ever pasted into a PR description in a connected repo, revoke it and rewrite the PR description before enabling the integration on that repo.
+  <DNT>Autopilot</DNT> reads whatever GitHub returns for the linked commit — including the free-text PR description body and file change metadata (files changed, additions/deletions) from the Contents: Read scope. If a connected repository contains hardcoded credentials, API keys, secrets, or highly sensitive information in code files or PR descriptions, that content may flow into <DNT>Autopilot</DNT>'s investigation context and may be saved.
+
+  To reduce this risk:
+  - Do not connect repositories where credentials, keys, secrets, or highly sensitive information are committed directly to code or configuration files. Use the PAT's repository scope to exclude those repos (see [Step 1](/docs/agentic-ai/autopilot/connect-to-github/#create-token)).
+  - Do not put credentials, secrets, API keys, highly sensitive information, or tokens in PR descriptions of connected repositories. If those are included in a PR description, revoke it and rewrite the PR description before enabling the integration on that repo.
 </Callout>
 
 <Callout variant="important">


### PR DESCRIPTION
## Summary

Updates the Autopilot GitHub integration docs for Autopilot 2.2 and applies legally-approved language from the approved document.

Companion to [docs-website-private PR #249](https://github.com/newrelic/docs-website-private/pull/249).

## Changes

### connect-to-github.mdx
- Add **What you can do** section (4 capabilities) per approved doc
- Add GHE.com prerequisite bullet
- Add **legal Important callout**: preview retrieves code diffs and may save/store lines from repos; restrict to repos without credentials/keys/secrets/highly sensitive info
- Strengthen PAT scope tip: add "secrets" to exclusion list; match approved wording
- Update GitHub URL field to support `github.com` and `YOURSUBDOMAIN.ghe.com`
- Add new **Connect GitHub Enterprise Cloud (GHE.com)** section

### use-autopilot-with-github.mdx
- Add multi-environment note (public GitHub + GHE.com)
- Caution callout: add **"and may be saved"** (legally required data storage disclosure)
- Strengthen Caution to match legal-approved language: "credentials, keys, secrets, or highly sensitive information"

### troubleshoot-github-connection.mdx
- Update current limitations: GHE.com now supported in preview, GHES coming in a future release