### PR TITLE
feat(whats-new): OTel AI Monitoring — send GenAI traces without a New Relic agent

### DIFF
--- a/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
+++ b/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
@@ -1,7 +1,7 @@
 ---
 title: 'OpenTelemetry support for AI monitoring is now GA'
 summary: 'No New Relic agent required. If your app already emits OpenTelemetry traces, you can now send GenAI spans directly to AI monitoring and see every LLM call, tool call, and agent step.'
-releaseDate: '2026-08-26'
+releaseDate: '2026-08-31'
 learnMoreLink: 'https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/'
 ---
 

--- a/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
+++ b/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
@@ -1,0 +1,28 @@
+---
+title: 'Send GenAI traces to New Relic AI Monitoring with OpenTelemetry'
+summary: 'No New Relic agent required. If your app already emits OpenTelemetry traces, you can now send GenAI spans directly to AI Monitoring and see every LLM call, tool call, and agent step.'
+releaseDate: '2026-08-26'
+learnMoreLink: 'https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/'
+---
+
+New Relic AI Monitoring now supports OpenTelemetry (OTel) as a first-class instrumentation path. If your application already emits OTel traces, you can send GenAI spans directly to AI Monitoring without installing a New Relic agent — just point your OTLP exporter at New Relic and add the right OTel GenAI instrumentation package.
+
+Once your app is sending traces, the AI Monitoring view shows every LLM call your service makes, tool calls and agent steps as part of the full request trace, and errors and slow calls surfaced alongside the rest of your APM data.
+
+## What you get
+
+**Full LLM visibility without a New Relic agent**
+If your app already uses OpenTelemetry, there's no new agent to install. Set two environment variables, add an instrumentation package, and your GenAI spans start flowing into AI Monitoring.
+
+**Support for popular frameworks**
+Works with the OpenTelemetry GenAI instrumentation packages for OpenAI, Anthropic, LangChain, and AWS Bedrock. Any other language or framework with OTel GenAI instrumentation works the same way.
+
+**Privacy-first content capture**
+Prompt and completion content capture is disabled by default. You control whether message bodies appear in AI Monitoring — opt in explicitly when you're ready, and use drop filters or attribute-level obfuscation to protect sensitive data before it reaches New Relic.
+
+**Full trace context**
+LLM calls appear as spans within your existing distributed traces, so you can correlate model latency and errors with the rest of your service's behavior in a single view.
+
+## Get started
+
+Set your OTLP exporter environment variables, add the GenAI instrumentation package for your framework, and trigger a small amount of traffic. Within a few minutes you should see your service appear in AI Monitoring. To learn more, see the [OTel AI Monitoring documentation](https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/).

--- a/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
+++ b/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
@@ -1,28 +1,23 @@
 ---
-title: 'Send GenAI traces to New Relic AI Monitoring with OpenTelemetry'
-summary: 'No New Relic agent required. If your app already emits OpenTelemetry traces, you can now send GenAI spans directly to AI Monitoring and see every LLM call, tool call, and agent step.'
+title: 'OpenTelemetry support for AI monitoring is now GA'
+summary: 'No New Relic agent required. If your app already emits OpenTelemetry traces, you can now send GenAI spans directly to AI monitoring and see every LLM call, tool call, and agent step.'
 releaseDate: '2026-08-26'
 learnMoreLink: 'https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/'
 ---
 
-New Relic AI Monitoring now supports OpenTelemetry (OTel) as a first-class instrumentation path. If your application already emits OTel traces, you can send GenAI spans directly to AI Monitoring without installing a New Relic agent — just point your OTLP exporter at New Relic and add the right OTel GenAI instrumentation package.
+No New Relic agent required. If your app already emits OpenTelemetry traces, you can now send GenAI spans directly to AI monitoring and see every LLM call, tool call, and agent step — as part of your existing distributed traces.
 
-Once your app is sending traces, the AI Monitoring view shows every LLM call your service makes, tool calls and agent steps as part of the full request trace, and errors and slow calls surfaced alongside the rest of your APM data.
+[Learn more](https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/)
 
 ## What you get
 
-**Full LLM visibility without a New Relic agent**
-If your app already uses OpenTelemetry, there's no new agent to install. Set two environment variables, add an instrumentation package, and your GenAI spans start flowing into AI Monitoring.
-
-**Support for popular frameworks**
-Works with the OpenTelemetry GenAI instrumentation packages for OpenAI, Anthropic, LangChain, and AWS Bedrock. Any other language or framework with OTel GenAI instrumentation works the same way.
-
-**Privacy-first content capture**
-Prompt and completion content capture is disabled by default. You control whether message bodies appear in AI Monitoring — opt in explicitly when you're ready, and use drop filters or attribute-level obfuscation to protect sensitive data before it reaches New Relic.
-
-**Full trace context**
-LLM calls appear as spans within your existing distributed traces, so you can correlate model latency and errors with the rest of your service's behavior in a single view.
+- **Full LLM visibility without an agent** — Set two environment variables, add the GenAI instrumentation package for your framework, and your spans start flowing into AI monitoring. No new agent to install.
+- **Support for popular frameworks** — Works with the OpenTelemetry GenAI instrumentation packages for OpenAI, Anthropic, LangChain, and AWS Bedrock. Any other language or framework with OTel GenAI instrumentation works the same way.
+- **Privacy-first content capture** — Prompt and completion content capture is off by default. Opt in explicitly when you're ready, and use drop filters or attribute-level obfuscation to protect sensitive data before it reaches New Relic.
+- **Full trace context** — LLM calls appear as spans within your existing distributed traces, so you can correlate model latency and errors with the rest of your service in a single view.
 
 ## Get started
 
-Set your OTLP exporter environment variables, add the GenAI instrumentation package for your framework, and trigger a small amount of traffic. Within a few minutes you should see your service appear in AI Monitoring. To learn more, see the [OTel AI Monitoring documentation](https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/).
+Set your two OTLP exporter environment variables, add the GenAI instrumentation package for your framework, and send a small amount of traffic. Within a few minutes your service appears in AI monitoring.
+
+See the [OpenTelemetry AI monitoring documentation](https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/) for the full setup.

--- a/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
+++ b/src/content/whats-new/2026/08/whats-new-08-26-otel-ai-monitoring.md
@@ -7,7 +7,7 @@ learnMoreLink: 'https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-mo
 
 No New Relic agent required. If your app already emits OpenTelemetry traces, you can now send GenAI spans directly to AI monitoring and see every LLM call, tool call, and agent step — as part of your existing distributed traces.
 
-[Learn more](https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/)
+
 
 ## What you get
 


### PR DESCRIPTION
## Summary

What's new post for the OTel AI Monitoring page published on 2026-08-26.

**Doc:** https://docs.newrelic.com/docs/ai-monitoring/opentelemetry-ai-monitoring/

## Post highlights

- OTel as a first-class AI Monitoring instrumentation path (no NR agent required)
- Support for OpenAI, Anthropic, LangChain, AWS Bedrock via OTel GenAI packages
- Privacy-first: content capture off by default
- Full distributed trace context for LLM calls

Follows the established What's new post format (direct opening, **bold** feature subheadings, ## Get started CTA).