### PR TITLE
[ENTERPRISE-32202] Add agent restart callout to alias v2 API doc

### DIFF
--- a/src/content/docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2.mdx
+++ b/src/content/docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2.mdx
@@ -29,6 +29,10 @@ To change the alias for the app name from the New Relic REST API (v2), use this 
 * You will need to supply the `${APP_ID}`, `${API_KEY}`, and the alias `name` you want the application to be displayed as in the New Relic UI.
 * You must also provide `APP_APDEX_THRESHOLD`, `BROWSER_APDEX_THRESHOLD`, and the monitoring enabled `BOOLEAN` (`true` or `false`) even if they are not being modified.
 
+<Callout variant="important">
+Changing the app alias causes all agents that report under this app identifier to restart. See [renaming your application](/docs/apm/agents/manage-apm-agents/app-naming/name-your-application/#app-alias) for details.
+</Callout>
+
 ```bash
 curl -X PUT "https://api.newrelic.com/v2/applications/${APP_ID}.json" \
      -H "X-Api-Key:${API_KEY}" -i \


### PR DESCRIPTION
## Summary
- Adds an "important" callout to the alias-change v2 API doc noting that changing an app's alias restarts all agents reporting under that app identifier
- This behavior is already documented on the UI-based renaming page, but was missing from this API-based equivalent, which led to a support agent giving a customer incorrect information

## Changes Made
- Added a `Callout` (variant `important`) right before the `curl` example, linking to the canonical explanation on the renaming doc's `#app-alias` section

## Files Affected
- `src/content/docs/apis/rest-api-v2/application-examples-v2/change-alias-your-application-v2.mdx`