### PR TITLE
[chore] Fold in follow-up feedback on switching between user records

### DIFF
--- a/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
+++ b/src/content/docs/accounts/accounts-billing/account-setup/multiple-user-records.mdx
@@ -36,7 +36,7 @@ When you update your email address in New Relic, this won't cause double billing
 
 ## Switch between user records [#switch]
 
-Each [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) you have access to has its own user record for your email address. To switch between these user records, go to the user menu and select <DNT>**Other users**</DNT>. Then choose a user record for another organization. New Relic prompts you to log in for that organization, either directly or via your identity provider.
+Each [New Relic organization](/docs/accounts/accounts-billing/account-structure/new-relic-account-structure) you have access to has its own user record for your email address. To switch between these user records, in the user menu, select <DNT>**Other users**</DNT>. Each entry shows the organization name and [authentication domain](/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more) for that user record. If an organization has more than one authentication domain, you'll have a separate user record for each one. Choosing another entry prompts you to log in for that organization, either directly or via your identity provider.
 
 If you have access only to one organization, the <DNT>**Other users**</DNT> option won't appear in the user menu.
 


### PR DESCRIPTION
## Summary
- Follow-up to #25302. Hunter Beezley flagged that after the screenshot was replaced with descriptive text, a few details it conveyed visually were missing from the "Switch between user records" section on `multiple-user-records.mdx`.
- Adds that each entry in the **Other users** list is labeled with the organization name and authentication domain.
- Clarifies that a user can have multiple user records for the same organization if it has more than one authentication domain (one record per domain).
- Reorders the procedural sentence to purpose → place → action for clarity.

## Context
See Slack thread with Hunter: https://newrelic.slack.com/archives/C0DSGL3FZ/p1786727648860959