### PR TITLE
Update otel-tab.mdx

### DIFF
--- a/src/content/docs/errors-inbox/otel-tab.mdx
+++ b/src/content/docs/errors-inbox/otel-tab.mdx
@@ -15,8 +15,8 @@ With **Group errors** tab, you can dynamically filter and group errors for deepe
 
 The following spans will display as error events in the errors inbox UI:
 
-* `otel.status` = `ERROR` and `span.kind` = `server` or `consumer`
-* `otel.status` = `ERROR` and `kind` = `server` or `consumer`
+* `otel.status_code` = `ERROR` and `span.kind` = `server` or `consumer`
+* `otel.status_code` = `ERROR` and `kind` = `server` or `consumer`
 
 These spans are treated as an individual error instance.
 

--- a/src/content/docs/errors-inbox/otel-tab.mdx
+++ b/src/content/docs/errors-inbox/otel-tab.mdx
@@ -15,8 +15,8 @@ With **Group errors** tab, you can dynamically filter and group errors for deepe
 
 The following spans will display as error events in the errors inbox UI:
 
-* `otel.status_code` = `ERROR` and `span.kind` = `server` or `consumer`
-* `otel.status_code` = `ERROR` and `kind` = `server` or `consumer`
+* `otel.status_code` = `ERROR` and `span.kind` = `server`, `consumer`, `producer`, `client`, or `internal`
+* `otel.status_code` = `ERROR` and `kind` = `server`, `consumer`, `producer`, `client`, or `internal`
 
 These spans are treated as an individual error instance.
 


### PR DESCRIPTION
otel.status_code, not otel.status quote from Eng:

> This is the query [removed] being used to fetch this data. Key difference being `otel.status_code = 'ERROR'` instead of `otel.status = 'ERROR'` (docs needs to be updated probably)

```sql
SELECT count(*), latest(otel.status_code) as otelStatusCode, earliest(timestamp) as firstOccurrence, latest(timestamp) as latestOccurrence 
FROM Span 
WHERE (entityGuid = 'GUID') AND (otel.status_code = 'ERROR' 
AND nr.categories like '%:ei:%' 
AND (span.kind IN ('server','consumer','producer','client','internal') 
OR kind IN ('server','consumer','producer','client','internal'))) 
FACET `error.group.name`, `error.group.message` 
LIMIT 100 SINCE X UNTIL Y
```