### PR TITLE
Add config approvals documentation for Fleet Control

### DIFF
--- a/src/content/docs/new-relic-control/fleet-control/manage-fleets.mdx
+++ b/src/content/docs/new-relic-control/fleet-control/manage-fleets.mdx
@@ -545,7 +545,7 @@ Your organization has no approval policy until someone creates one. Setting one 
 4. Set the minimum number of approvals. This defaults to `1` and can be raised as high as `5`. The count refers to approvals from people *other than* the author, so a minimum of `1` means two people have seen the configuration: the author and one approver.
 5. Click <DNT>**Save**</DNT>.
 
-To discard your changes and return every agent type and the approval count to their defaults, click <DNT>**Reset**</DNT>.
+To discard unsaved changes, click <DNT>**Reset**</DNT>. This returns the form to your organization's saved policy, so it undoes your edits rather than clearing your policy. If you have not saved a policy yet, it returns the form to its starting state with every agent type selected.
 
 If you don't have permission to create a policy, the page tells you so and directs you to contact an administrator. Ask whoever holds the <DNT>**Organization Manager**</DNT> role in your organization to complete the setup.
 

--- a/src/content/docs/new-relic-control/fleet-control/manage-fleets.mdx
+++ b/src/content/docs/new-relic-control/fleet-control/manage-fleets.mdx
@@ -6,6 +6,8 @@ tags:
   - deployment
   - configuration
   - agent-management
+  - config approvals
+  - governance
 metaDescription: "Learn how to perform day-to-day operations on your fleets, including managing deployments, updating configurations, and organizing your managed entities."
 freshnessValidatedDate: never
 ---
@@ -468,7 +470,7 @@ To create a new global configuration from scratch:
    * **Left Pane (Active Configuration):** This is where you author your configuration. You can type directly into this pane or paste content from another source.
    * **Right Pane (Template):** This pane contains the latest default template for the agent type you selected. These templates provide the minimal required settings to run the agent, but they also include many additional commented-out options. You can use these examples for reference or uncomment them to build a more custom configuration.
 4. A common workflow is to click <DNT>**Copy**</DNT> in the template pane and paste the contents into the active configuration pane on the left to use as a starting point.
-5. Once you are satisfied with your configuration in the left pane, click <DNT>**Save**</DNT>. The editing view will close, returning you to the main configurations page where you can find your new configuration.
+5. Once you are satisfied with your configuration in the left pane, click <DNT>**Save**</DNT>. The editing view will close, returning you to the main configurations page where you can find your new configuration. If your organization requires approval for this agent type, saving submits the version for review instead of making it available right away — see [Config approvals](#config-approvals).
 
 ### View and version a specific configuration
 
@@ -478,17 +480,20 @@ This view shows you:
 
 * The configuration's name, agent type, and a list of its available versions.
 * The **deployment status**, which indicates if the configuration has been deployed to any fleets and, if so, which ones.
+* The **approval state** of each version, if your organization requires approval for this agent type. See [Config approvals](#config-approvals).
 
 From this pane, you can also perform several actions like **Download**, **Copy**, and **Clone**. The primary action here is creating a new version of the configuration.
 
 To create a new version:
 
-1. Click <DNT>**Create config version**</DNT>.
+1. Click <DNT>**Add new version**</DNT>.
 2. This opens the editing pane where you can modify the configuration.
 3. When you are finished with your edits, click <DNT>**Save**</DNT>.
 4. You will be returned to the main configurations page, and you will see the <DNT>**revisions**</DNT> count for that configuration has incremented by one.
 
 If you click back into the configuration, you can now select the new version from the list to view it.
+
+Existing versions can't be edited. Creating a new version is how you change a configuration, which keeps a record of what changed over time and means an approved version stays exactly as it was when it was reviewed.
 
 ## Delete a configuration and its versions
 To delete a configuration, you must first delete all of its individual versions. The parent configuration is automatically deleted once its last version is removed.
@@ -513,6 +518,146 @@ Cloning is a fast way to create a new configuration based on an existing one.
 2. From the dropdown, select the existing configuration you want to use as a starting point for your clone.
 3. This opens the same two-pane editing view, pre-populated with the content of the configuration you selected.
 4. You can now author your new configuration and save it.
+
+## Config approvals
+
+<Callout title="Feature launch info" variant="important">
+  Config approvals are available now. Enforcement begins **September 22, 2026**.
+
+  Before that date, you can set up an approval policy and use approvals, but deployments are not blocked if your organization hasn't set one up. From September 22, an <DNT>**Organization Manager**</DNT> must set up an approval policy before anyone in your organization can create new deployments.
+
+  Deployments that are already running are never affected, before or after this date.
+</Callout>
+
+Config approvals require at least one person other than the author to approve a configuration version before that version can be used in a deployment. If you've used pull request reviews with a Git provider, the workflow will feel familiar: a reviewer reads the configuration and then approves it, requests changes, or denies it.
+
+The reason this matters is that <DNT>Fleet Control</DNT> manages configurations remotely. A user can author a configuration and push it to production infrastructure across your fleets from a central control plane, rather than editing files on individual hosts. Config approvals put a second set of eyes on that path, so no single person can author a configuration and deploy it on their own.
+
+Approvals apply to configurations for every agent type you choose to include, across both infrastructure and APM.
+
+### Set up an approval policy
+
+Your organization has no approval policy until someone creates one. Setting one up requires the <DNT>**Organization Manager**</DNT> role, or a custom role carrying the policy capability.
+
+1. In the left navigation, go to <DNT>**New Relic Control → Fleet Control Settings → Approvals**</DNT>.
+2. If your organization has never set up a policy, you'll see a prompt to create approval policies for config changes. Click through to start.
+3. Under <DNT>**Governance for agent types**</DNT>, select the agent types that should require approval. Every agent type that supports approvals is selected for you by default, so you can deselect the ones you don't need rather than building the list from scratch.
+4. Set the minimum number of approvals. This defaults to `1` and can be raised as high as `5`. The count refers to approvals from people *other than* the author, so a minimum of `1` means two people have seen the configuration: the author and one approver.
+5. Click <DNT>**Save**</DNT>.
+
+To discard your changes and return every agent type and the approval count to their defaults, click <DNT>**Reset**</DNT>.
+
+If you don't have permission to create a policy, the page tells you so and directs you to contact an administrator. Ask whoever holds the <DNT>**Organization Manager**</DNT> role in your organization to complete the setup.
+
+<Callout title="We recommend requiring approval for every agent type" variant="tip">
+  Because <DNT>Fleet Control</DNT> configurations are managed remotely rather than locally on each host, any agent type you leave out is one a single user can author and deploy without review. We recommend requiring approval for all of them, then relaxing it only where you're confident you don't need it.
+</Callout>
+
+If you leave any on-host integration ungoverned, saving prompts you to acknowledge the risk before the change takes effect. On-host integrations can execute scripts on your hosts, which makes them the highest-impact configurations to leave unreviewed. NRI Flex is the most widely used example. The acknowledgment is a confirmation step, not a restriction: you can save the change once you've accepted it.
+
+### Agent types excluded from approvals
+
+Two kinds of configuration are permanently excluded, for different reasons:
+
+* <DNT>**Agent Control:**</DNT> It's the supervisor rather than an agent. <DNT>Fleet Control</DNT> works through Agent Control to carry out every lifecycle operation, so requiring approval on it would gate the mechanism that performs all of your other approved changes.
+* <DNT>**Pipeline Control Gateway (including Config Mode):**</DNT> <DNT>Pipeline Control</DNT> owns these configurations. <DNT>Fleet Control</DNT> delivers them, but they are authored and managed in <DNT>Pipeline Control</DNT>.
+
+Every other agent type available to your organization can be set to require approval.
+
+### Understanding approval states
+
+Configuration versions are immutable. Editing a configuration always produces a new version rather than changing an existing one, which means an approved version stays exactly as it was when it was reviewed. Each version is approved on its own.
+
+A version that requires approval moves through these states:
+
+| State | What it means |
+|:------|:--------------|
+| <DNT>**Awaiting approval**</DNT> | The version has been submitted and is waiting for review. It cannot be used in a deployment yet. The banner shows progress toward the required count, for example `0 of 1 approvals`. |
+| <DNT>**Changes requested**</DNT> | A reviewer has asked for changes. Because versions are immutable, you respond by adding a new version rather than editing this one. |
+| <DNT>**Approved**</DNT> | The required number of approvals has been reached. The version can be used in any deployment. |
+| <DNT>**Denied**</DNT> | A reviewer has blocked this version permanently, and the version shows the reviewer's reason. Denial is the only state a version cannot move out of. To proceed, add a new version from it. |
+
+An approved version can still be denied later. If a reviewer approves a configuration and afterward notices a problem, such as sensitive data that should not be there, denying it immediately stops anyone from deploying that version. This is deliberate: it lets you take a problematic configuration out of circulation at any point, not only during the initial review.
+
+### Author a configuration that requires approval
+
+When you create or edit a configuration for an agent type that requires approval, the editor tells you so before you save, and saving submits the version for review rather than making it immediately available.
+
+1. Author your configuration as usual.
+2. Click <DNT>**Save**</DNT>. The version is saved and submitted for review in one step. There is no separate submit action.
+3. On the main configurations page, the configuration appears with a lock icon, indicating it requires approval. Its current state is shown alongside it.
+
+You cannot deploy the version until it reaches the approved state.
+
+To respond to a reviewer's feedback, add a new version:
+
+1. Click the configuration's name to open it. This view lists the configuration's versions along with their approval states, so you can see which version was denied or had changes requested.
+2. Click <DNT>**Add new version**</DNT>. The editor opens with a copy of the configuration's latest version, so a request for a small change does not mean starting over.
+3. Click <DNT>**View configuration history**</DNT> to read what your reviewers said. This shows request-for-changes comments, denial comments, and the approval activity recorded against the configuration over time, across all of its versions.
+4. Make your changes and save the new version. It starts its own review.
+
+Each configuration has a parent record with its versions as children. <DNT>**View configuration history**</DNT> spans them, so it doubles as an audit trail for who reviewed what and when. To retrieve identifiers for troubleshooting, use <DNT>**View metadata**</DNT>, which shows the configuration ID for the parent and the configuration version ID for the specific version you're viewing.
+
+### Review a configuration
+
+Reviewing requires the <DNT>**Organization Manager**</DNT> role, or a custom role carrying the approval capability.
+
+Open the configuration version and choose one of three actions:
+
+* <DNT>**Approve:**</DNT> Records your approval. A comment is optional. Once the version reaches the required number of approvals, it can be used in deployments immediately.
+* <DNT>**Request changes:**</DNT> Asks the author to revise. Use this when the configuration is close but needs specific edits. Say which lines and why, since the author sees your comment in the configuration history.
+* <DNT>**Deny:**</DNT> Blocks the version permanently. Use this when the configuration should not proceed at all rather than needing edits. The author must add a new version.
+
+You'll be asked to confirm approvals and denials before they're recorded.
+
+<Callout title="You cannot approve your own configuration" variant="important">
+  The author of a version cannot approve it, even if they hold the approval capability. This is the core control the feature provides, and it's enforced by the API as well as the interface, so it cannot be bypassed by calling the API directly.
+
+  Your own submissions don't appear in your pending review queue.
+</Callout>
+
+Make sure enough people hold the approval capability to cover the time zones your team works across. If your minimum approval count is higher than the number of available approvers, configurations will sit unreviewed.
+
+### Find configurations awaiting your review
+
+If configurations are waiting on you, a card at the top of the configurations page shows how many need review. Click <DNT>**Show pending configurations**</DNT> to open a drawer listing everything awaiting approval, so you can see the queue at a glance and jump straight into any item to start reviewing.
+
+### Delegate approval authority
+
+Both capabilities, approving configuration versions and setting up the approval policy, belong to the <DNT>**Organization Manager**</DNT> role by default. There is no predefined approver role, so if you want anyone else to approve configurations, an Organization Manager creates a custom role and grants it to a group.
+
+Both capabilities are organization-scoped, which means the custom role has to be an [organization-scoped role](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#role-scopes). An account-scoped or entity-scoped role cannot carry them, and creating the role is only half the job: permissions don't take effect until you link the role to a group with an [access grant](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#access-grants).
+
+<Callout title="Important: What to know before creating an organization-scoped custom role" variant="important">
+  Creating custom roles is available to organizations with Pro or Enterprise editions. If your organization cannot create custom roles, approving configurations remains limited to holders of the <DNT>**Organization Manager**</DNT> role.
+
+  Custom organization-scoped roles also do not pick up new permissions automatically. Standard roles receive the permissions for new organization-scoped features as they ship, but a custom role only ever contains what an administrator added to it. If <DNT>Fleet Control</DNT> adds governance capabilities later, someone has to add them to each custom role that should have them.
+</Callout>
+
+To create the role:
+
+1. From the bottom of the left navigation menu, click your user name, then select <DNT>**Administration**</DNT>.
+2. On the <DNT>Administration</DNT> page, select <DNT>**Access Management**</DNT>, then go to the <DNT>roles</DNT> tab.
+3. Click <DNT>**Add a role**</DNT>.
+4. For the role's scope, choose <DNT>**Organization**</DNT>, then click <DNT>**Next**</DNT>.
+5. Give the role a name that will make sense to whoever maintains it later, for example `Config Approver`.
+6. Find the <DNT>**Fleet Control**</DNT> section and expand it.
+7. On the <DNT>**Fleets (all)**</DNT> row, under <DNT>**Other**</DNT>, select the capabilities this role should carry:
+   * <DNT>**Approve configurations:**</DNT> Lets holders act on configuration versions awaiting review.
+   * <DNT>**Configure organization governance:**</DNT> Lets holders set up and change the approval policy, including which agent types require approval and the minimum approval count.
+8. Save the role.
+
+Grant these independently based on what each group needs. Someone who should review configurations but should not be able to change which agent types require approval needs only <DNT>**Approve configurations**</DNT>.
+
+To assign the role:
+
+1. In <DNT>**Access Management**</DNT>, go to the <DNT>access grants</DNT> tab.
+2. Click <DNT>**Create new grant**</DNT>.
+3. Pair the group whose members should approve configurations with the role you created, targeting your organization.
+
+Roles are assigned to groups rather than to individual users, so add people to the group to give them approval authority and remove them to take it away.
+
+Because approval authority is organization-scoped, an approver can approve any configuration version in the organization. Configurations in <DNT>Fleet Control</DNT> are organization-level objects rather than belonging to a specific fleet, so an approved version can be used in any fleet's deployments. Scoping approvers to particular fleets, or setting a different approval policy per fleet, is not supported.
 
 ## The main managed entities page
 


### PR DESCRIPTION
## What

Documents Fleet Control's config approvals feature, which requires someone other than the author to approve an agent configuration version before that version can be used in a deployment. There is currently no public documentation for this feature.

Adds a `Config approvals` section to `manage-fleets.mdx` covering:

- Setting up an organization-level approval policy
- Which agent types can require approval, and which are permanently excluded
- The approval states a configuration version moves through
- Authoring a configuration that requires approval
- Reviewing: approve, request changes, deny
- Finding configurations awaiting your review
- Delegating approval authority through a custom organization-scoped role

## Why now

Config approvals are available today, with enforcement beginning September 22, 2026. From that date, an organization without a configured approval policy cannot create new deployments, so the setup steps need to be published ahead of it. The section carries a time-boxed "Feature launch info" callout for the enforcement date that can be removed once it passes.

## Also in this PR

- Conditional cross-references in the existing `Create a configuration` and `View and version a specific configuration` sections, so authors learn that saving submits a version for review when their agent type requires approval.
- Corrects a stale button label: `Create config version` -> `Add new version`. The former string doesn't exist in the Fleet Control UI; the control on the configuration detail pane is `Add new version`.

## Notes for reviewers

- No screenshots, consistent with #24612, which intentionally removed inline screenshots from this page to reduce visual clutter and maintenance overhead.
- UI labels and approval state names are taken verbatim from the shipped Fleet Control UI rather than from design docs.
- Built and reviewed locally with `yarn start`.

Could I get a preview link for this PR?