### PR TITLE
newrelic-ebpf-agent release v1.6.0

### DIFF
--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -252,6 +252,12 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`"false"`</td>
         </tr>
         <tr>
+            <td>`agentMetadataReporting`</td>
+            <td>Enables agent/entity metadata reporting. When enabled (default), the agent exports agent and entity metadata to New Relic over HTTP. Set to `false` to disable the metadata reporting HTTP export path entirely.</td>
+            <td>`Boolean`</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
             <td>`customOtlpEndpoint`</td>
             <td>Custom OTLP endpoint URL. When set, this takes precedence over the region-based static endpoints.</td>
             <td>`String`</td>
@@ -316,6 +322,30 @@ These parameters control the core identity and data destination for the eBPF age
             <td>Name of an existing Kubernetes secret containing proxy credentials. The secret must contain the keys `proxy-user` and `proxy-password`.</td>
             <td>`String`</td>
             <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.enabled`</td>
+            <td>Controls GenAI telemetry reporting. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when no language APM or OTel agent is already reporting AI monitoring data for the entity).</td>
+            <td>`String`</td>
+            <td>`"false"`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.samplingLatency`</td>
+            <td>Defines the latency-based sampling threshold for exporting GenAI spans. Supports any percentile from `p0` to `p99`.</td>
+            <td>`String`</td>
+            <td>`"p50"`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.samplingErrorRate`</td>
+            <td>Defines the error-rate threshold for a GenAI route where surpassing it means the corresponding spans of the route are exported. Options: `1`-`100`.</td>
+            <td>`String`</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.genAICaptureMessageContent`</td>
+            <td>When `true`, captures full prompt and completion content for GenAI interactions. Only takes effect when `ai_monitoring.enabled` is `true` or `auto`. Use with caution.</td>
+            <td>`Boolean`</td>
+            <td>`false`</td>
         </tr>
         <tr>
             <td>`httpPathNormalizationPatterns`</td>
@@ -574,6 +604,8 @@ This section allows you to enable monitoring for specific network protocols and 
 * HTTP
 * Thrift
 * MySQL
+* MariaDB
+* Aurora MySQL
 * PostgreSQL
 * MongoDB
 * Apache Cassandra
@@ -584,6 +616,7 @@ This section allows you to enable monitoring for specific network protocols and 
 * AMQP
 * DNS
 
+MySQL protocol tracing (`protocols.mysql`) also covers MariaDB and Aurora MySQL, since both speak the same wire protocol as MySQL. There's no separate `mariadb` or `aurora_mysql` section to configure—enabling or disabling `protocols.mysql` is enough. The specific flavor is auto-detected per connection from the server handshake and reported per record; it can't be configured.
 
 <table>
     <thead>

--- a/src/content/docs/ebpf/k8s-installation.mdx
+++ b/src/content/docs/ebpf/k8s-installation.mdx
@@ -253,7 +253,7 @@ These parameters control the core identity and data destination for the eBPF age
         </tr>
         <tr>
             <td>`agentMetadataReporting`</td>
-            <td>Enables agent/entity metadata reporting. When enabled (default), the agent exports agent and entity metadata to New Relic over HTTP. Set to `false` to disable the metadata reporting HTTP export path entirely.</td>
+            <td>Enables agent and entity metadata reporting. By default, the agent exports agent and entity metadata to New Relic over HTTP. Set this to `false` to disable the metadata reporting HTTP export path entirely.</td>
             <td>`Boolean`</td>
             <td>`true`</td>
         </tr>
@@ -616,7 +616,7 @@ This section allows you to enable monitoring for specific network protocols and 
 * AMQP
 * DNS
 
-MySQL protocol tracing (`protocols.mysql`) also covers MariaDB and Aurora MySQL, since both speak the same wire protocol as MySQL. There's no separate `mariadb` or `aurora_mysql` section to configure—enabling or disabling `protocols.mysql` is enough. The specific flavor is auto-detected per connection from the server handshake and reported per record; it can't be configured.
+MySQL protocol tracing (`protocols.mysql`) also covers MariaDB and Aurora MySQL, as both engines use the same wire protocol as MySQL. Configuration doesn't require a separate `mariadb` or `aurora_mysql` section; enabling or disabling `protocols.mysql` controls tracing for all supported engines. The agent automatically detects the specific database flavor per connection during the server handshake and reports it on each record. You can't configure this detection manually.
 
 <table>
     <thead>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -244,6 +244,36 @@ These parameters control the core identity and data destination for the eBPF age
             <td>`"false"`</td>
         </tr>
         <tr>
+            <td>`agentMetadataReporting`</td>
+            <td>Enables agent/entity metadata reporting. When enabled (default), the agent exports agent and entity metadata to New Relic over HTTP. Set to `false` to disable the metadata reporting HTTP export path entirely.</td>
+            <td>Boolean</td>
+            <td>`true`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.enabled`</td>
+            <td>Controls GenAI telemetry reporting. Accepted values: `"true"` (always send), `"false"` (never send), `"auto"` (send only when no language APM or OTel agent is already reporting AI monitoring data for the entity).</td>
+            <td>String</td>
+            <td>`"false"`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.samplingLatency`</td>
+            <td>Defines the latency-based sampling threshold for exporting GenAI spans. Supports values from `p0` to `p99`.</td>
+            <td>String</td>
+            <td>`"p50"`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.samplingErrorRate`</td>
+            <td>Defines the error-rate threshold for a GenAI route where surpassing it means the corresponding spans of the route are exported. Options: `1`-`100`.</td>
+            <td>String</td>
+            <td>`""`</td>
+        </tr>
+        <tr>
+            <td>`ai_monitoring.genAICaptureMessageContent`</td>
+            <td>When `true`, captures full prompt and completion content for GenAI interactions. Only takes effect when `ai_monitoring.enabled` is `true` or `auto`. Use with caution.</td>
+            <td>Boolean</td>
+            <td>`false`</td>
+        </tr>
+        <tr>
             <td>`httpPathNormalizationPatterns`</td>
             <td>Defines HTTP path normalization patterns. Each pattern must contain at least one `*` wildcard. Use a `!` prefix for exclusion patterns to preserve paths as is (skip auto-clustering). The agent applies these patterns before auto-clustering, and they take precedence over it.</td>
             <td>List</td>
@@ -477,6 +507,8 @@ This section allows you to enable monitoring for specific network protocols and 
 * HTTP
 * Thrift
 * MySQL
+* MariaDB
+* Aurora MySQL
 * PostgreSQL
 * MongoDB
 * Apache Cassandra
@@ -486,6 +518,8 @@ This section allows you to enable monitoring for specific network protocols and 
 * Kafka
 * AMQP
 * DNS
+
+MySQL protocol tracing (`protocols.mysql`) also covers MariaDB and Aurora MySQL, since both speak the same wire protocol as MySQL. There's no separate `mariadb` or `aurora_mysql` section to configure—enabling or disabling `protocols.mysql` is enough. The specific flavor is auto-detected per connection from the server handshake and reported per record; it can't be configured.
 
 <table>
     <thead>

--- a/src/content/docs/ebpf/linux-installation.mdx
+++ b/src/content/docs/ebpf/linux-installation.mdx
@@ -245,7 +245,7 @@ These parameters control the core identity and data destination for the eBPF age
         </tr>
         <tr>
             <td>`agentMetadataReporting`</td>
-            <td>Enables agent/entity metadata reporting. When enabled (default), the agent exports agent and entity metadata to New Relic over HTTP. Set to `false` to disable the metadata reporting HTTP export path entirely.</td>
+            <td>Enables agent and entity metadata reporting. By default, the agent exports agent and entity metadata to New Relic over HTTP. Set this to `false` to disable the metadata reporting HTTP export path entirely.</td>
             <td>Boolean</td>
             <td>`true`</td>
         </tr>
@@ -519,7 +519,7 @@ This section allows you to enable monitoring for specific network protocols and 
 * AMQP
 * DNS
 
-MySQL protocol tracing (`protocols.mysql`) also covers MariaDB and Aurora MySQL, since both speak the same wire protocol as MySQL. There's no separate `mariadb` or `aurora_mysql` section to configure—enabling or disabling `protocols.mysql` is enough. The specific flavor is auto-detected per connection from the server handshake and reported per record; it can't be configured.
+MySQL protocol tracing (`protocols.mysql`) also covers MariaDB and Aurora MySQL, as both engines use the same wire protocol as MySQL. Configuration doesn't require a separate `mariadb` or `aurora_mysql` section; enabling or disabling `protocols.mysql` controls tracing for all supported engines. The agent automatically detects the specific database flavor per connection during the server handshake and reports it on each record. You can't configure this detection manually.
 
 <table>
     <thead>


### PR DESCRIPTION
## Summary

Updates the eBPF Linux host and Kubernetes installation docs to cover config parameters introduced in the latest release 1.6.0.

- Adds `agentMetadataReporting` to the config-params table in both guides — controls whether the agent exports agent/entity metadata to New Relic over HTTP (default `true`).
- Adds the full `ai_monitoring.*` block to both config-params tables: `ai_monitoring.enabled`, `ai_monitoring.samplingLatency`, `ai_monitoring.samplingErrorRate`, and `ai_monitoring.genAICaptureMessageContent`. These were previously only referenced in prose on the AI monitoring page, not documented as parameters in either installation guide.
- Lists **MariaDB** and **Aurora MySQL** as separate entries in the supported protocols list (alongside MySQL), with a note clarifying both are traced via `protocols.mysql` — there's no separate `mariadb`/`aurora_mysql` config key, and the flavor is auto-detected per connection from the server handshake.