### PR TITLE
docs(NR-600520): Security RX Agent public preview overview page

### DIFF
--- a/src/content/docs/vulnerability-management/agent/overview.mdx
+++ b/src/content/docs/vulnerability-management/agent/overview.mdx
@@ -165,7 +165,7 @@ When you choose the comment trigger, you provide the trigger phrase your agent l
 
 ## How remediation works [#how-it-works]
 
-Once the Security RX Agent is configured, the remediation flow works as follows:
+Once the Security RX Agent is configured, the remediation flow works as follows. Each step passes the agent's analysis and remediation plan to the next, so your coding agent starts with context about where the vulnerability runs, not a bare CVE number:
 
 1. **Select a vulnerability** — In Security RX, open the Security Agent and select a vulnerability to address.
 2. **Review the analysis** — The agent analyzes the vulnerability, presenting its impact, importance, and relevant metrics for you to review.

--- a/src/content/docs/vulnerability-management/agent/overview.mdx
+++ b/src/content/docs/vulnerability-management/agent/overview.mdx
@@ -14,8 +14,6 @@ tags:
 
 The Security RX Agent assesses a vulnerability in the context of your tech stack and turns it into a suggested remediation plan. When Security RX identifies a vulnerability, the agent triages the CVE, provides an analysis, drafts step-by-step remediation recommendations, and can open a Jira ticket or GitHub issue in the affected repository — triggering a coding agent you already use (such as GitHub Copilot, Claude, or a custom agent) to initiate a fix via pull request for your team to review.
 
-<DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Security RX**</DNT>
-
 With the Security RX Agent, you can:
 
 * **Triage and understand a vulnerability in context**, including uncovering live signals of potential exploitation.
@@ -24,15 +22,15 @@ With the Security RX Agent, you can:
 * **Keep a human in the loop** — triage the creation of issues and pull requests to let your team review and merge.
 
 <Callout variant="important">
-  The Security RX Agent uses generative AI to provide a suggested remediation path. Remediation paths are suggestions and should be carefully reviewed by a human prior to implementation.
+  The Security RX Agent uses generative AI to provide a suggested remediation path. Remediation paths are suggestions. A human should carefully review them before implementation.
 </Callout>
 
 ## Prerequisites [#prerequisites]
 
 Before you onboard the Security RX Agent, make sure you have:
 
-* **Security RX Apps enabled** for your account and opted in to the Security Agent public preview.
-* **Permission to create connections** in New Relic (an Organization Manager role).
+* **Security RX Apps enabled** for your account, with your account opted in to the Security Agent public preview.
+* **An Organization Manager role** in New Relic to create connections.
 * **A GitHub personal access token (PAT)** for the account or organization that owns the repositories you want to remediate. The token needs **Issues: Read and write** permission on those repositories.
 * **A GitHub coding agent installed and enabled** on the repositories you want to remediate (for example, the GitHub Copilot coding agent, the Claude GitHub app, or your own agent). This setup is done in GitHub by a repository or organization administrator.
 
@@ -80,7 +78,7 @@ Connect the Jira destination where the agent files remediation tickets.
   <tbody>
     <tr>
       <td><DNT>**Select or add Jira connection**</DNT></td>
-      <td>Choose an existing Jira connection, or add a new one (Jira site URL and auth method).</td>
+      <td>An existing Jira connection, or a new one created with your Jira site URL and auth method.</td>
     </tr>
     <tr>
       <td><DNT>**Space/project**</DNT></td>
@@ -154,23 +152,23 @@ Coding agents are triggered in different ways. Choose the trigger that matches t
 When you choose the assignment trigger, New Relic shows the coding agents that can be assigned in your selected repositories and you pick one. When the agent creates an issue, it assigns that issue to your chosen agent, which begins work and opens a pull request.
 
 * Requires the coding agent (for example, `copilot-swe-agent` for Copilot) to be **enabled and assignable** on the repository.
-* If a repository doesn't have the agent enabled, the issue is still created, and the agent adds a comment noting it couldn't be assigned there.
+* Creates the issue even if a repository doesn't have the agent enabled, and adds a comment noting it couldn't be assigned there.
 
 ### Comment (trigger phrase) trigger [#comment-trigger]
 
 When you choose the comment trigger, you provide the trigger phrase your agent listens for (for example, `@claude fix`). After creating the issue, the agent posts a comment with that phrase, which starts your agent.
 
 * Requires your agent to be **installed and configured to watch for that phrase** (for example, the Claude GitHub app, or your own agent).
-* The trigger phrase is specific to your agent — use the phrase your agent documents.
+* Uses a phrase specific to your agent — use the phrase your agent documents.
 
 ## How remediation works [#how-it-works]
 
 Once the Security RX Agent is configured, the remediation flow works as follows. Each step passes the agent's analysis and remediation plan to the next, so your coding agent starts with context about where the vulnerability runs, not a bare CVE number:
 
 1. **Select a vulnerability** — In Security RX, open the Security Agent and select a vulnerability to address.
-2. **Review the analysis** — The agent analyzes the vulnerability, presenting its impact, importance, and relevant metrics for you to review.
-3. **Generate a remediation plan** — Select the affected entities you want to fix and choose a remediation mode. The agent generates a detailed plan that outlines the fix and identifies the associated GitHub repository.
+2. **Review the analysis** — Review the agent's analysis of the vulnerability, including its impact, importance, and relevant metrics.
+3. **Generate a remediation plan** — Select the affected entities you want to fix and choose a remediation mode. Review the generated plan that outlines the fix and identifies the associated GitHub repository.
 4. **Create an issue** — Select <DNT>**Create GitHub Issue**</DNT>. This automatically generates an issue in your repository containing the full remediation plan.
-5. **Trigger the workflow** — Depending on your configured trigger mode, the Security RX Agent assigns the issue to a coding agent or posts a trigger phrase in the comments to initiate your workflow.
-6. **Open a pull request** — Your coding agent begins the fix by opening a pull request.
+5. **Trigger the workflow** — Depending on your configured trigger mode, confirm that the issue has been assigned to your coding agent or that the trigger phrase has been posted.
+6. **Open a pull request** — Wait for your coding agent to open a pull request with the fix.
 7. **Review and merge** — Your team reviews the pull request and merges the fix as appropriate.

--- a/src/content/docs/vulnerability-management/agent/overview.mdx
+++ b/src/content/docs/vulnerability-management/agent/overview.mdx
@@ -1,0 +1,176 @@
+---
+title: Triage vulnerability remediation with the Security RX Agent
+metaDescription: Use the Security RX Agent to analyze CVEs, generate remediation plans, and trigger your existing coding agent to open a pull request.
+freshnessValidatedDate: never
+tags:
+  - Security RX
+  - Vulnerability management
+  - AI
+---
+
+<Callout variant="caution" title="Public preview">
+  This feature is currently available as a public preview and is subject to change. For more information, see our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+The Security RX Agent assesses a vulnerability in the context of your tech stack and turns it into a suggested remediation plan. When Security RX identifies a vulnerability, the agent triages the CVE, provides an analysis, drafts step-by-step remediation recommendations, and can open a Jira ticket or GitHub issue in the affected repository — triggering a coding agent you already use (such as GitHub Copilot, Claude, or a custom agent) to initiate a fix via pull request for your team to review.
+
+<DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Security RX**</DNT>
+
+With the Security RX Agent, you can:
+
+* **Triage and understand a vulnerability in context**, including uncovering live signals of potential exploitation.
+* **Move from finding a vulnerability to a remediation plan** without leaving New Relic.
+* **Use your existing GitHub coding agent** (such as Copilot, Claude, or your own agent) to initiate a fix.
+* **Keep a human in the loop** — triage the creation of issues and pull requests to let your team review and merge.
+
+<Callout variant="important">
+  The Security RX Agent uses generative AI to provide a suggested remediation path. Remediation paths are suggestions and should be carefully reviewed by a human prior to implementation.
+</Callout>
+
+## Prerequisites [#prerequisites]
+
+Before you onboard the Security RX Agent, make sure you have:
+
+* **Security RX Apps enabled** for your account and opted in to the Security Agent public preview.
+* **Permission to create connections** in New Relic (an Organization Manager role).
+* **A GitHub personal access token (PAT)** for the account or organization that owns the repositories you want to remediate. The token needs **Issues: Read and write** permission on those repositories.
+* **A GitHub coding agent installed and enabled** on the repositories you want to remediate (for example, the GitHub Copilot coding agent, the Claude GitHub app, or your own agent). This setup is done in GitHub by a repository or organization administrator.
+
+<Callout variant="tip">
+  The coding agent must be enabled **per repository**. GitHub Issues must also be enabled on each repository you select. If either isn't enabled on a repository you select, the Security RX Agent still creates the labeled issue, but your agent won't act on it until you enable both there.
+</Callout>
+
+## Set up the Security RX Agent [#setup]
+
+Onboarding is a guided wizard you complete once to connect the Security RX Agent to the destinations where it files work — **GitHub** (issues for your coding agent to fix) and **Jira** (tickets for your team). The wizard has four steps:
+
+<DNT>**GitHub configuration → Jira configuration → Review → Finish**</DNT>
+
+To start, go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > Security RX > Security Agent**</DNT>, then select <DNT>**Onboard Security Agent**</DNT>.
+
+<Steps>
+
+<Step>
+
+### GitHub configuration [#step-github]
+
+Connect the GitHub destination and choose how the Security RX Agent triggers your coding agent.
+
+* **Select or add a GitHub connection.** Choose an existing connection, or add a new one by entering your GitHub GraphQL URL (for GitHub.com: `https://api.github.com/graphql`) and a personal access token (PAT) with **Issues: Read and write**.
+* **Select repositories.** New Relic lists the repositories your token can access. Choose the ones where you want the Security RX Agent to raise remediation issues (an allow-list).
+* **Choose a remediation trigger.** Pick how each issue is handed to your coding agent — **Assignment**, **Comment (trigger phrase)**, or **Workflow (label)**. See [Choose a remediation trigger](#remediation-trigger) for details.
+
+Select <DNT>**Continue**</DNT>.
+
+</Step>
+
+<Step>
+
+### Jira configuration [#step-jira]
+
+Connect the Jira destination where the agent files remediation tickets.
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>What to enter</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><DNT>**Select or add Jira connection**</DNT></td>
+      <td>Choose an existing Jira connection, or add a new one (Jira site URL and auth method).</td>
+    </tr>
+    <tr>
+      <td><DNT>**Space/project**</DNT></td>
+      <td>The Jira project where remediation tickets are created.</td>
+    </tr>
+    <tr>
+      <td><DNT>**Jira issue type**</DNT></td>
+      <td>The issue type used for created tickets (for example, Task or Bug).</td>
+    </tr>
+    <tr>
+      <td><DNT>**Jira org ID**</DNT></td>
+      <td>Your Jira organization ID.</td>
+    </tr>
+    <tr>
+      <td><DNT>**Jira priority ID**</DNT></td>
+      <td>The priority assigned to created tickets (for example, High or Critical).</td>
+    </tr>
+  </tbody>
+</table>
+
+Select <DNT>**Continue**</DNT>.
+
+</Step>
+
+<Step>
+
+### Review [#step-review]
+
+Review your selections across both destinations — GitHub connection, selected repositories, and remediation trigger; Jira connection, space/project, issue type, and org ID. Return to any step to change a value before continuing.
+
+</Step>
+
+<Step>
+
+### Finish [#step-finish]
+
+Confirm to activate the Security RX Agent. From then on, when you begin a workflow to remediate a vulnerability, the agent files the work in the destination you chose — creating a GitHub issue (and triggering your coding agent) or a Jira ticket — with the suggested remediation plan attached.
+
+</Step>
+
+</Steps>
+
+## Choose a remediation trigger [#remediation-trigger]
+
+Coding agents are triggered in different ways. Choose the trigger that matches the coding agent you use. The Security RX Agent always creates the issue and applies the `srx-remediate` label; the trigger determines how your agent is invoked.
+
+<table>
+  <thead>
+    <tr>
+      <th>Trigger</th>
+      <th>How it works</th>
+      <th>Use this for</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><DNT>**Assignment**</DNT></td>
+      <td>The Security RX Agent assigns the issue to your coding agent, which starts working when assigned.</td>
+      <td>GitHub Copilot coding agent, Claude, and custom agents.</td>
+    </tr>
+    <tr>
+      <td><DNT>**Comment (trigger phrase)**</DNT></td>
+      <td>The Security RX Agent posts a comment containing a trigger phrase you configure (for example, <code>@claude fix</code>). Your agent watches for that phrase and starts working.</td>
+      <td>Claude, and custom agents that respond to a comment phrase.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Assignment trigger [#assignment-trigger]
+
+When you choose the assignment trigger, New Relic shows the coding agents that can be assigned in your selected repositories and you pick one. When the agent creates an issue, it assigns that issue to your chosen agent, which begins work and opens a pull request.
+
+* Requires the coding agent (for example, `copilot-swe-agent` for Copilot) to be **enabled and assignable** on the repository.
+* If a repository doesn't have the agent enabled, the issue is still created, and the agent adds a comment noting it couldn't be assigned there.
+
+### Comment (trigger phrase) trigger [#comment-trigger]
+
+When you choose the comment trigger, you provide the trigger phrase your agent listens for (for example, `@claude fix`). After creating the issue, the agent posts a comment with that phrase, which starts your agent.
+
+* Requires your agent to be **installed and configured to watch for that phrase** (for example, the Claude GitHub app, or your own agent).
+* The trigger phrase is specific to your agent — use the phrase your agent documents.
+
+## How remediation works [#how-it-works]
+
+Once the Security RX Agent is configured, the remediation flow works as follows:
+
+1. **Select a vulnerability** — In Security RX, open the Security Agent and select a vulnerability to address.
+2. **Review the analysis** — The agent analyzes the vulnerability, presenting its impact, importance, and relevant metrics for you to review.
+3. **Generate a remediation plan** — Select the affected entities you want to fix and choose a remediation mode. The agent generates a detailed plan that outlines the fix and identifies the associated GitHub repository.
+4. **Create an issue** — Select <DNT>**Create GitHub Issue**</DNT>. This automatically generates an issue in your repository containing the full remediation plan.
+5. **Trigger the workflow** — Depending on your configured trigger mode, the Security RX Agent assigns the issue to a coding agent or posts a trigger phrase in the comments to initiate your workflow.
+6. **Open a pull request** — Your coding agent begins the fix by opening a pull request.
+7. **Review and merge** — Your team reviews the pull request and merges the fix as appropriate.

--- a/src/nav/vuln-management.yml
+++ b/src/nav/vuln-management.yml
@@ -63,6 +63,10 @@ pages:
         path: /docs/vulnerability-management/cloud/manage-misconfiguration-status
       - title: Remediate misconfigurations
         path: /docs/vulnerability-management/cloud/remediation
+  - title: Security RX Agent
+    pages:
+      - title: Triage vulnerability remediation with the Security RX Agent
+        path: /docs/vulnerability-management/agent/overview
   - title: Manage your security data
     pages:
       - title: Set up vulnerability alerts


### PR DESCRIPTION
## Summary


Adds the Security RX Agent overview page for public preview, based on draft content from Krystle Portocarrero (NR-600520).

- New page: `src/content/docs/vulnerability-management/agent/overview.mdx`
- New nav section: **Security RX Agent** in `vuln-management.yml`

## What's included

- Public preview callout
- Intro + what you can do (4 capabilities)
- AI disclaimer callout
- Prerequisites (Organization Manager role; GitHub PAT; coding agent per-repo requirement)
- 4-step onboarding wizard: GitHub config → Jira config → Review → Finish
- Remediation trigger reference (Assignment + Comment; Workflow/label excluded — Post PP)
- 7-step end-to-end remediation flow

## Style fixes applied (P1)

- Fixed outcome-promise language in intro: "ready-to-action fix" → "suggested remediation plan"
- Fixed capability bullet: "actionable fix" → "remediation plan"
- Added missing comma in lead-in: "With the Security RX Agent, you can:"

## P2 issues for author review

- Two passive-voice instances (lines 27, 37)
- Two semicolons in body prose (lines 112, 128)
- List-item parallelism: Assignment trigger bullets (lines 156–157) and Comment trigger bullets (lines 163–164)
- Table column parallelism: Jira config table "What to enter" column (row 1 is imperative; rows 2–5 are noun phrases)

