### PR TITLE
fix: Update trace-api and OTLP oldest timestamp

### DIFF
--- a/src/content/docs/apm/distributed-tracing/trace-api/troubleshooting-missing-trace-api-data.mdx
+++ b/src/content/docs/apm/distributed-tracing/trace-api/troubleshooting-missing-trace-api-data.mdx
@@ -27,7 +27,7 @@ Here are some ideas for troubleshooting Trace API-reported data:
 * If a call generates a HTTP response code, look up the [response code meaning](/docs/understand-dependencies/distributed-tracing/trace-api/trace-api-general-requirements-limits#status-codes).
 * If rate-limiting issues occur, we generate an [`NrIntegrationError`](/docs/telemetry-data-platform/manage-data/nrintegrationerror). You can [run a NRQL query of that event](https://one.newrelic.com/launcher/nr1-core.home?pane=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5ob21lLXNjcmVlbiJ9&overlay=eyJuZXJkbGV0SWQiOiJ3YW5kYS1kYXRhLWV4cGxvcmF0aW9uLmRhdGEtZXhwbG9yZXIiLCJpbml0aWFsQWN0aXZlSW50ZXJmYWNlIjoibnJxbEVkaXRvciIsImluaXRpYWxBY2NvdW50SWQiOjI0NTkxMTUsImluaXRpYWxOcnFsVmFsdWUiOiIiLCJpbml0aWFsUXVlcmllcyI6W3siYWNjb3VudElkIjoyNDU5MTE1LCJucnFsIjoiRlJPTSBOckludGVncmF0aW9uRXJyb3Igc2VsZWN0ICogIn1dLCJpbml0aWFsQ2hhcnRTZXR0aW5ncyI6eyJjaGFydFR5cGUiOiJDSEFSVF9UQUJMRSJ9fQ==) to see if your trace data encountered an issue. If you want to correlate `NrIntegrationError` events, you can use the `requestId` provided by each Trace API request.
 * If your spans have timestamps, be sure they meet the following guidelines:
-  * Span timestamps must have occurred within last 60 minutes.
+  * Span timestamps must have occurred within the last 24 hours.
   * `newrelic`-format timestamps must be in <DNT>**milliseconds**</DNT>. You can get the current time in milliseconds at [currentmillis.com](https://currentmillis.com).
   * `zipkin`-format timestamps must be in <DNT>**microseconds**</DNT>.
   * Timestamps should be in UTC.

--- a/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
+++ b/src/content/docs/distributed-tracing/troubleshooting/missing-trace-data.mdx
@@ -196,13 +196,13 @@ Here are some causes and solutions for missing trace data:
     id="late-spans"
     title="Missing spans due to spans being sent late"
   >
-    Spans must be sent within the last sixty minutes to be captured in a trace index. If you send any spans older than sixty minutes but newer than a day, the span data will still be written. However, it won't be rolled into the trace index, which controls the trace list in the distributed tracing UI. If a span has a timestamp older than a day, it will be dropped. This often occurs when there is clock skew (timing differences) between systems or long running background jobs.
+    Spans must be sent within the last twenty-four hours to be saved. If a span has a timestamp older than a day, it will be dropped. This often occurs when there is clock skew (timing differences) between systems or long running background jobs.
 
     <Callout variant="important">
-      Any spans sent via the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) (OTLP for short) that are longer than sixty minutes will not be written to [NRDB](/docs/data-apis/get-started/nrdb-horsepower-under-hood/), producing the following NrIntegrationError:
+      Any spans sent via the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md) (OTLP for short) that are longer than twenty-four hours will not be written to [NRDB](/docs/data-apis/get-started/nrdb-horsepower-under-hood/), producing the following NrIntegrationError:
 
       ```
-      The span timestamp cannot be older than 60 minutes.
+      The span timestamp cannot be older than 24 hours.
       ```
     </Callout>
   </Collapser>


### PR DESCRIPTION
Since 2024, the Trace API and OTLP endpoints have accepted spans up to twenty-four hours old.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.