### PR TITLE
fix(eol): add missing eolEffectiveDate to Chrome 134/Node.js 16 synthetics placeholder

### DIFF
--- a/src/content/eol/2025/11/eol-chrome-140-node-22-synthetics.md
+++ b/src/content/eol/2025/11/eol-chrome-140-node-22-synthetics.md
@@ -2,6 +2,7 @@
 title: "End of Life announcement for Node.js 16 and Chrome 134 runtimes used in synthetic monitors: Update Forthcoming"
 subject: "Updated communication regarding Chrome 134 and Node.js 16 synthetics runtime support will be published shortly. Please stand by for official details."
 publishDate: '2025-11-05'
+eolEffectiveDate: '2026-11-18'
 ---
 
 Regarding the End-of-Life announcement about ending our support for Chrome 134 and Node.js 16 synthetics runtimes, we have published an updated comprehensive communication. Please refer to the updated [Node.js 16 and Chrome 134 EOL documentation](/eol/2026/05/eol-05-18-26-node-16-chrome-134-runtimes/) for key milestones and required migration actions.


### PR DESCRIPTION
## Summary

- Adds `eolEffectiveDate: '2026-11-18'` to `/eol/2025/11/eol-chrome-140-node-22-synthetics.md`
- This field was removed on Nov 21, 2025 when the planned date was being revised, leaving it null
- The null date causes Sedona to crash with a `NullPointerException` on `.toEpochMilli()` during NerdGraph serialization, returning a blank **End of Life announcements** tab in the Product Updates nerdlet
- Date matches the updated comprehensive EOL post at `/eol/2026/05/eol-05-18-26-node-16-chrome-134-runtimes/` which this placeholder links to

## Test plan

- [ ] Verify `page-data/eol/page-data.json` includes `eolEffectiveDate` for this entry after deploy
- [ ] Verify End of Life announcements tab in Product Updates nerdlet renders correctly after Sedona re-indexes (~60 min after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)