### PR TITLE
NR:612276 - Document nrExporterEndpoints config block in gateway YAML

### DIFF
--- a/src/content/docs/new-relic-control/pipeline-control/gateway/yaml-overview.mdx
+++ b/src/content/docs/new-relic-control/pipeline-control/gateway/yaml-overview.mdx
@@ -21,6 +21,9 @@ configuration:
     troubleshooting:
       proxy: false
       requestTraceLogs: false
+    nrExporterEndpoints:
+      nrHost: collector.example.com
+      metricsEndpoint: https://metric-api.example.com
     steps:
       receivelogs:
         description: Receive logs from OTLP and New Relic proprietary sources
@@ -150,6 +153,7 @@ configuration:
 - `autoscaling`: Gateway replica scaling configuration
 - `configuration.simplified/v2`: Simplified abstraction layer for defining telemetry pipelines
 - `troubleshooting`: Debug settings
+- `nrExporterEndpoints`: Override the default New Relic ingest endpoints per pipeline
 
 ## Configuration hierarchy
 The gateway configuration follows a directed acyclic graph (DAG) structure where each step defines its behavior and points to the next step in the pipeline using the output field. This creates an explicit data flow: data enters through receivers, flows through processors (transform, filter, sample), and exits through exporters.
@@ -208,6 +212,14 @@ Config fields:
 | configuration.simplified/v2                | object  | Yes      | -       |
 | troubleshooting.proxy                      | boolean | No       | false   |
 | troubleshooting.requestTraceLogs           | boolean | No       | false   |
+| nrExporterEndpoints.nrHost                  | string  | No       | -       |
+| nrExporterEndpoints.metricsEndpoint         | string  | No       | -       |
+| nrExporterEndpoints.tracesEndpoint          | string  | No       | -       |
+| nrExporterEndpoints.logApiEndpoint          | string  | No       | -       |
+| nrExporterEndpoints.eventApiEndpoint        | string  | No       | -       |
+| nrExporterEndpoints.infraEventApiEndpoint   | string  | No       | -       |
+
+Each `nrExporterEndpoints` field is independent: set only the ones you need to override (for example, just `nrHost`), and any field you omit falls back to the account's default New Relic ingest endpoint.
 
 <Callout variant="tip">
 **Installation mode note:** The `version` and `autoscaling` fields behavior depends on your fleet's installation mode:


### PR DESCRIPTION
…reference

Customers can now override the default New Relic ingest endpoints (nrHost + 5 API endpoints) per pipeline for private-link routing. Adds the block to the structure example, top-level field list, and field reference table, matching the existing troubleshooting/autoscaling documentation pattern.

<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.