### PR TITLE
MCP setup guide fixes for Sep 3 Hydra deployment

### DIFF
--- a/src/content/docs/agentic-ai/mcp/setup.mdx
+++ b/src/content/docs/agentic-ai/mcp/setup.mdx
@@ -93,7 +93,7 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
             "type": "http",
             "url": "https://mcp.newrelic.com/mcp/",
             "headers": {
-              "Api-Key": "NRAK-YOUR-KEY-HERE"
+              "api-Key": "NRAK-YOUR-KEY-HERE"
             }
           }
         }

--- a/src/content/docs/agentic-ai/mcp/setup.mdx
+++ b/src/content/docs/agentic-ai/mcp/setup.mdx
@@ -131,54 +131,26 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
     claude
     ```
 
-## Gemini CLI setup [#gemini-cli]
+## Antigravity CLI setup [#antigravity-cli]
 
-### OAuth method [#oauth]
-
-1. Edit the settings file: `~/.gemini/settings.json` (Linux/macOS) or `%APPDATA%\Gemini\settings.json` (Windows).
-
-    ```json
-    {
-      "theme": "Default",
-      "selectedAuthType": "oauth-personal",
-      "mcpServers": {
-        "newrelic": {
-          "httpUrl": "https://mcp.newrelic.com/mcp/",
-          "oauth": {
-            "enabled": true,
-            "clientId": "pUWGgnjsQ0bydqCbavTPpw==",
-            "authorizationUrl": "https://login.newrelic.com/login",
-            "tokenUrl": "https://mcp.newrelic.com/oauth2/token",
-            "scopes": ["openid"]
-          }
-        }
-      }
-    }
-    ```
-
-2. Start Gemini CLI:
-
-    ```shell
-    gemini
-    ```
-
-3. Authenticate:
-
-    ```shell
-    /mcp auth newrelic
-    ```
+<Callout variant="important">
+  Only the API key method is currently supported for Antigravity CLI. OAuth support is not yet available.
+</Callout>
 
 ### API key method [#api-key]
 
-1. Add the MCP server by editing `~/.gemini/settings.json` (Linux/macOS) or `%APPDATA%\Gemini\settings.json` (Windows) as shown here:
+1. Ensure you have Antigravity CLI installed on your machine.
+2. Configure the MCP server by opening (or creating) the configuration file:
+   - macOS/Linux: `~/.gemini/config/mcp_config.json`
+   - Windows: `%USERPROFILE%\.gemini\config\mcp_config.json`
+
+    Add the following configuration:
 
     ```json
     {
-      "theme": "Default",
-      "selectedAuthType": "oauth-personal",
       "mcpServers": {
         "newrelic": {
-          "url": "https://mcp.newrelic.com/mcp/",
+          "serverUrl": "https://mcp.newrelic.com/mcp/",
           "headers": {
             "api-key": "NRAK-YOUR-KEY-HERE"
           }
@@ -187,16 +159,10 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
     }
     ```
 
-2. Start Gemini CLI:
+3. Start Antigravity CLI:
 
     ```shell
-    gemini
-    ```
-
-3. Authenticate:
-
-    ```shell
-    /mcp auth newrelic
+    agy
     ```
 
 ## Kiro CLI setup [#kiro-cli]
@@ -230,40 +196,26 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
    - Complete the standard New Relic login process.
    - After you're authenticated, the browser will confirm success.
 
-## Codex CLI setup [#codex-cli]
+### API key method [#api-key]
 
-### API Key method [#api-key]
+1. Ensure you have the [Kiro CLI tool installed](https://kiro.dev/cli/) on your machine.
+2. Configure the MCP server by opening (or creating) `~/.kiro/settings/mcp.json` and add the following configuration:
 
-1. Ensure you have the [Codex CLI tool installed](https://developers.openai.com/codex/cli/) on your machine.
-2. Configure the MCP server by editing the configuration file located at `~/.codex/config.toml` and add the following configuration:
-
-    ```toml
-    [mcp_servers.new-relic]
-    url = "https://mcp.newrelic.com/mcp/"
-    env_http_headers = { "api-key" = "NEW_RELIC_API_KEY" }
+    ```json
+    {
+      "mcpServers": {
+        "newrelic-mcp-server": {
+          "url": "https://mcp.newrelic.com/mcp/",
+          "headers": {
+            "api-key": "NRAK-YOUR-KEY-HERE"
+          },
+          "disabled": false
+        }
+      }
+    }
     ```
 
-3. Authenticate and connect:
-    - Open your terminal and run `codex`.
-    - Type the command `/mcp` and hit enter.
-    - You will see the New Relic server listed with a URL.
-
-### OAuth method (recommended) [#oauth]
-
-1. Ensure you have the [Codex CLI tool installed](https://developers.openai.com/codex/cli/) on your machine.
-2. Run the below command in your terminal:
-
-    ```shell
-    codex mcp add new-relic-mcp-server --url "https://mcp.newrelic.com/mcp/" 
-    ```
-
-3. Authenticate and connect:
-    - The Oauth flow will take you to the authentication page where you need to provide your credentials to authenticate.
-    - After you're authenticated, the browser will confirm success.
-    - Open your terminal and run `codex`.
-    - Type the command `/mcp` and hit enter.
-    - You will see the New Relic server listed with a URL. Open that URL in your browser.
-
+3. Open your terminal and run `kiro-cli`. The New Relic MCP server will connect automatically.
 
 ## Claude Desktop setup [#claude-desktop]
 
@@ -285,6 +237,7 @@ Claude Desktop requires the `mcp-remote` proxy for `OAuth` authentication. Ensur
         "new-relic-mcp": {
           "command": "npx",
           "args": [
+            "-y",
             "mcp-remote",
             "https://mcp.newrelic.com/mcp/"
           ]
@@ -384,7 +337,7 @@ Claude Desktop requires the `mcp-remote` proxy for `OAuth` authentication. Ensur
 2. Restart Windsurf.
 
 ## VS Code setup [#vs-code]
-VS Code remains fully supported with both authentication methods. You need VS Code (version 1.60 or later).
+VS Code remains fully supported with both authentication methods. You need VS Code (version 1.91 or later).
 
 ### OAuth method [#oauth]
 
@@ -410,6 +363,7 @@ Add the MCP server by editing `.vscode/mcp.json` as shown here:
   "servers": {
     "new-relic-mcp": {
       "url": "https://mcp.newrelic.com/mcp/",
+      "type": "http",
       "headers": {
         "api-key": "NRAK-YOUR-API-KEY-HERE"
       }

--- a/src/content/docs/agentic-ai/mcp/setup.mdx
+++ b/src/content/docs/agentic-ai/mcp/setup.mdx
@@ -49,7 +49,7 @@ For the complete list of available tags and the tools associated with each, refe
 
 ## Claude Code setup [#claude-code]
 
-Claude Code supports both OAuth (recommended) and API key authentication methods.
+Claude Code supports both OAuth (recommended) and API key authentication methods. OAuth requires Claude Code version 2.1.186 or later. If you are on older versions, you should authenticate via `/mcp` inside Claude instead of `claude mcp login`.
 
 ### OAuth method (recommended) [#oauth]
 
@@ -57,7 +57,8 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
 2. Add the MCP server using the command line:
 
     ```shell
-    claude mcp add newrelic --transport http https://mcp.newrelic.com/mcp/
+    claude mcp add --transport http newrelic https://mcp.newrelic.com/mcp/
+    claude mcp login newrelic
     ```
 
     Or, edit `~/.claude.json` as shown here:
@@ -66,41 +67,21 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
     {
       "mcpServers": {
         "newrelic": {
-          "httpUrl": "https://mcp.newrelic.com/mcp/",
-          "oauth": {
-            "enabled": true,
-            "clientId": "pUWGgnjsQ0bydqCbavTPpw==",
-            "authorizationUrl": "https://login.newrelic.com/login",
-            "tokenUrl": "https://mcp.newrelic.com/oauth2/token",
-            "scopes": ["openid"]
-          }
+          "type": "http",
+          "url": "https://mcp.newrelic.com/mcp/"
         }
       }
     }
     ```
 
-3. Start Claude:
-
-  ```shell
-    claude
-  ```
-
-4. Authenticate:
-
-  ```shell
-    /mcp
-  ```
-
-5. Select the `newrelic` mcp server and press **ENTER**.
-
-6. Follow the browser `OAuth` flow.
+3. Follow the browser OAuth flow to complete authentication.
 
 ### API key method [#api-key]
 
 1. Add the MCP server using the command line:
 
     ```shell
-    claude mcp add newrelic https://mcp.newrelic.com/mcp/ --transport http --header "Api-Key: NRAK-YOUR-KEY-HERE"
+    claude mcp add --transport http newrelic https://mcp.newrelic.com/mcp/ --header "api-key: NRAK-YOUR-KEY-HERE"
     ```
 
     Or, edit `~/.claude.json` as shown here:
@@ -130,6 +111,8 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
     ```shell
     claude
     ```
+
+If you encounter connection errors after setup, refer to [Unexpected connection error in Claude Code](/docs/agentic-ai/mcp/troubleshoot#connection-error) and [Stale OAuth credentials in Claude Desktop](/docs/agentic-ai/mcp/troubleshoot#stale-creds).
 
 ## Antigravity CLI setup [#antigravity-cli]
 
@@ -164,6 +147,7 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
     ```shell
     agy
     ```
+4. Run `/mcp` to verify the New Relic server is connected.
 
 ## Kiro CLI setup [#kiro-cli]
 
@@ -178,9 +162,9 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
       "newrelic-mcp-server": {
         "url": "https://mcp.newrelic.com/mcp/",
         "oauth": {
-          "authorizationUrl": "https://login.newrelic.com/oauth2/authorize",
-          "tokenUrl": "https://login.newrelic.com/oauth2/token",
-          "scopes": ["openid", "profile", "mcp:access"],
+          "authorizationUrl": "https://oauth2.service.newrelic.com/oauth2/auth",
+          "tokenUrl": "https://oauth2.service.newrelic.com/oauth2/token",
+          "scopes": ["observability:read", "offline", "offline_access"],
           "usePKCE": true
         },
         "disabled": false
@@ -294,20 +278,15 @@ Claude Desktop requires the `mcp-remote` proxy for `OAuth` authentication. Ensur
 
 ## Windsurf setup [#windsurf]
 
-### OAuth method (via mcp-remote proxy) [#oauth]
+### OAuth method [#oauth]
 
 1. Edit the config file, `~/.codeium/windsurf/mcp_config.json`, as shown here:
 
     ```json
     {
       "mcpServers": {
-        "newrelic-oauth": {
-          "command": "npx",
-          "args": [
-            "-y",
-            "mcp-remote",
-            "https://mcp.newrelic.com/mcp/"
-          ]
+        "new-relic": {
+          "serverUrl": "https://mcp.newrelic.com/mcp/"
         }
       }
     }
@@ -360,12 +339,20 @@ Add the MCP server by editing `.vscode/mcp.json` as shown here:
 
 ```json
 {
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "nr-api-key",
+      "description": "New Relic User API Key",
+      "password": true
+    }
+  ],
   "servers": {
     "new-relic-mcp": {
-      "url": "https://mcp.newrelic.com/mcp/",
       "type": "http",
+      "url": "https://mcp.newrelic.com/mcp/",
       "headers": {
-        "api-key": "NRAK-YOUR-API-KEY-HERE"
+        "api-key": "${input:nr-api-key}"
       }
     }
   }

--- a/src/content/docs/agentic-ai/mcp/troubleshoot.mdx
+++ b/src/content/docs/agentic-ai/mcp/troubleshoot.mdx
@@ -24,6 +24,7 @@ freshnessValidatedDate: never
 - Restart the application completely.
 - Check `JSON` syntax validity.
 - Verify file paths and permissions.
+
 ## mcp-remote proxy issues
 - Ensure `Node.js` is installed.
 - Check internet connectivity.
@@ -47,6 +48,39 @@ Your org admin who has the `Authentication Domain Manager` role must implement o
     - The administrator must add you to an existing user group that already has an organization-scoped role with permission to read the MCP server.
 
 For detailed information on user management concepts, roles, and organization grants, refer to the [New Relic user management documentation](/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts). If your organization uses System for Cross-domain Identity Management (SCIM) for user management, these group and role adjustments must be performed within your external Identity Provider (IdP).
+
+{/* + ADDED START — P2: New troubleshooting entries from Vamsi's handoff */}
+## Unexpected connection error in Claude Code [#connection-error]
+
+### Problem
+You receive an unexpected error when connecting the New Relic MCP server via Claude Code.
+
+### Resolution
+Run the following in a fresh terminal, then reconnect:
+
+```shell
+claude mcp logout "plugin:nr:nr-mcp-server" 2>&1
+```
+
+## Stale OAuth credentials in Claude Desktop [#stale-creds]
+
+### Problem
+The connection error persists after logging out. Stale OAuth credentials cached across multiple stores may be causing Claude Desktop to reuse dead credentials instead of re-registering.
+
+### Resolution
+Ask Claude to help locate and clear the stale credentials:
+
+```
+Stale OAuth client ID or stale refresh and access tokens for MCP server `newrelic-mcp-server` is making
+Claude Desktop's Connect reuse dead credentials instead of re-registering. On macOS, find
+every store holding it — the "Claude Code-credentials" keychain item (`.mcpOAuth` keys, watch
+for a `plugin:` prefix), `~/Library/Application Support/Claude-3p/config.json`
+(`custom3pMcpOAuth."newrelic-mcp-server"`), and every registration across `claude mcp list`,
+`~/.claude.json`, and project `.mcp.json` files. Show me which stores match before changing
+anything; then clear it (quitting Claude Desktop and backing up config.json first), reconnect,
+and confirm a new client ID/new access token is issued.
+```
+{/* + ADDED END */}
 
 ## Error messages
 - **Connection refused**: Check URL and network connectivity of your tools.


### PR DESCRIPTION
Updates setup guide ahead of Sep 3 deployment: replaces Gemini CLI with Antigravity CLI, adds Kiro CLI API key method, removes Codex CLI, and fixes VS Code, Windsurf, and Claude Desktop configs. Also adds two troubleshooting entries for Claude Code connection errors.