### PR TITLE
Update Node agent config with updated GCR options

### DIFF
--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -5926,7 +5926,7 @@ Configure how the agent detects host and cloud environment information to accura
           </th>
 
           <td>
-            `false`
+            `true`
           </td>
         </tr>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -5858,7 +5858,9 @@ Configure how the agent detects host and cloud environment information to accura
       </tbody>
     </table>
 
-    When enabled, the agent uses the GCP metadata instance ID to set the hostname of the running application.
+    **Deprecated and will be removed in version 15 of the agent.** Please use `gcp_cloud_run.use_instance_as_host` instead.
+
+     When enabled, it will use the GCP metadata id to set the hostname of the running application (Services, Worker Pools, and Jobs).
   </Collapser>
 
   <Collapser
@@ -5899,7 +5901,48 @@ Configure how the agent detects host and cloud environment information to accura
       </tbody>
     </table>
 
-    When enabled, and `gcp_use_instance_as_host` is also enabled, the GCP Cloud Run revision (`K_REVISION`) is prepended to the instance ID when setting the hostname of the running application, resulting in a hostname of `${K_REVISION}-${instance_id}`.
+    If `true`, the agent prepends the Cloud Run revision name to the GCP instance id to form the hostname (`{revision}-{instance id}`) on Google Cloud Run. The revision name comes from `K_REVISION` on a Cloud Run Service, `CLOUD_RUN_REVISION` on a Cloud Run Worker Pool, and `CLOUD_RUN_EXECUTION` on a Cloud Run Job. Has no effect unless `utilization.gcp_cloud_run.use_instance_as_host` is also `true`.
+  </Collapser>
+
+  <Collapser
+    id="utilization-gcp-cloud-run-use-instance-as-host"
+    title="gcp_cloud_run.use_instance_as_host"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            [Environ variable](#environment)
+          </th>
+
+          <td>
+            `NEW_RELIC_UTILIZATION_GCP_CLOUD_RUN_USE_INSTANCE_AS_HOST`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    When enabled, it will use the GCP metadata id to set the hostname of the running application (Services, Worker Pools, and Jobs).
   </Collapser>
 </CollapserGroup>
 

--- a/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration.mdx
@@ -5857,8 +5857,9 @@ Configure how the agent detects host and cloud environment information to accura
         </tr>
       </tbody>
     </table>
-
-    **Deprecated and will be removed in version 15 of the agent.** Please use `gcp_cloud_run.use_instance_as_host` instead.
+      <Callout variant="important">
+        Deprecated and will be removed in version 15 of the agent. Please use `gcp_cloud_run.use_instance_as_host` instead.
+      </Callout>
 
      When enabled, it will use the GCP metadata id to set the hostname of the running application (Services, Worker Pools, and Jobs).
   </Collapser>


### PR DESCRIPTION
The Node agent has deprecated the `utilization.gcp_use_instance_as_host` config option in favor of `utilization.gcp_cloud_run.use_instance_as_host` to match other language agents. It and `utilization.gcp_cloud_run.include_revision_in_host` have had their logic expanded to include support for Google Cloud Run worker pools and jobs, in addition to existing GCR service support, so the description of these config options have been updated.