### PR TITLE
Update React Native JS Error reporting 403 status

### DIFF
--- a/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/react-native-agent-js-error-reporting.mdx
+++ b/src/content/docs/mobile-monitoring/new-relic-monitoring-react-native/react-native-agent-js-error-reporting.mdx
@@ -253,9 +253,7 @@ Responses use `Content-Type: application/json`.
 
     <tr>
       <td>`403 Forbidden`</td>
-      <td>The `Api-Key` doesn't have the required capability. Make sure your User API key belongs to a user with permission to upload symbols. Example: `{"message": "User not authorized"}`</td>
-    </tr>
-
+      <td>The `Api-Key` doesn't have the required capability. Make sure your User API key belongs to a user with mobile entity view permissions. Example: `{"message": "User not authorized"}`</td>    </tr>
     <tr>
       <td>`404 Not Found`</td>
       <td>The application token provided in the header doesn't exist. Example: `{"message": "applicationToken is invalid"}`</td>


### PR DESCRIPTION
We made a change to the capabilities checks that will impact the meaning behind the 403/Forbidden status code. Updating the docs so that a user knows what permissions they need and what will cause a 403

## Give us some context

* What problems does this PR solve? 
   * We want users to have clarity on why they might get a 403 response from the API
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
   * No testing needed
* If your issue relates to an existing GitHub issue, please link to it.