### PR TITLE
docs(gcp): document GCPSERVICEATTACHMENT and GCPPRIVATESERVICECONNECTENDPOINT entities

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/gcp-integrations-list/google-compute-engine-monitoring-integration.mdx
@@ -65,6 +65,16 @@ All Compute Engine metrics available in GCP Cloud Monitoring are collected as di
           <td>`GCPINTERCONNECTATTACHMENT`</td>
           <td>`interconnect_attachment`</td>
         </tr>
+        <tr>
+          <td>Service Attachment</td>
+          <td>`GCPSERVICEATTACHMENT`</td>
+          <td>`gce_service_attachment`</td>
+        </tr>
+        <tr>
+          <td>Private Service Connect Endpoint</td>
+          <td>`GCPPRIVATESERVICECONNECTENDPOINT`</td>
+          <td>`compute.googleapis.com/PrivateServiceConnectEndpoint`</td>
+        </tr>
       </tbody>
     </table>
   </Collapser>
@@ -254,6 +264,141 @@ All Compute Engine metrics available in GCP Cloud Monitoring are collected as di
 </table>
 
 For the complete list of Compute Engine and Interconnect metrics, see [Google's Compute Engine metrics documentation](https://cloud.google.com/monitoring/api/metrics_gcp#gcp-compute).
+
+#### Key metrics — Service Attachment
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>Metric name</th>
+      <th style={{ width: "100px" }}>Unit</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.closed_connections_count`</td>
+      <td>Count</td>
+      <td>Count of TCP/UDP connections closed over a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.connected_consumer_forwarding_rules`</td>
+      <td>Count</td>
+      <td>Number of Consumer Forwarding Rules connected to a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.dropped_received_packets_count`</td>
+      <td>Count</td>
+      <td>Count of received packets dropped by a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.dropped_sent_packets_count`</td>
+      <td>Count</td>
+      <td>Count of sent packets dropped by a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.nat_ip_address_capacity`</td>
+      <td>Count</td>
+      <td>Number of total IP addresses of a PSC Service Attachment resource ID. (Value -1 means the number is larger than the max value of INT64.).</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.new_connections_count`</td>
+      <td>Count</td>
+      <td>Count of new TCP/UDP connections created over a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.open_connections`</td>
+      <td>Count</td>
+      <td>Number of TCP/UDP connections currently open on a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.received_bytes_count`</td>
+      <td>Bytes</td>
+      <td>Count of bytes received (PSC -&gt; Service) over a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.received_packets_count`</td>
+      <td>Count</td>
+      <td>Count of packets received (PSC -&gt; Service) over a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.sent_bytes_count`</td>
+      <td>Bytes</td>
+      <td>Count of bytes sent (Service -&gt; PSC) over a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.sent_packets_count`</td>
+      <td>Count</td>
+      <td>Count of packets sent (Service -&gt; PSC) over a PSC Service Attachment resource ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.producer.used_nat_ip_addresses`</td>
+      <td>Count</td>
+      <td>IP usage of the monitored service attachment.</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Key metrics — Private Service Connect Endpoint
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: "440px" }}>Metric name</th>
+      <th style={{ width: "100px" }}>Unit</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.closed_connections_count`</td>
+      <td>Count</td>
+      <td>Count of TCP/UDP connections closed over a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.dropped_received_packets_count`</td>
+      <td>Count</td>
+      <td>Count of received packets dropped by a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.dropped_sent_packets_count`</td>
+      <td>Count</td>
+      <td>Count of sent packets dropped by a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.new_connections_count`</td>
+      <td>Count</td>
+      <td>Count of new TCP/UDP connections created over a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.open_connections`</td>
+      <td>Count</td>
+      <td>Number of TCP/UDP connections currently open on a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.received_bytes_count`</td>
+      <td>Bytes</td>
+      <td>Count of bytes received (PSC -&gt; Clients) over a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.received_packets_count`</td>
+      <td>Count</td>
+      <td>Count of packets received (PSC -&gt; Clients) over a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.sent_bytes_count`</td>
+      <td>Bytes</td>
+      <td>Count of bytes sent (Clients -&gt; PSC) over a PSC connection ID.</td>
+    </tr>
+    <tr>
+      <td>`gcp.compute.private_service_connect.consumer.sent_packets_count`</td>
+      <td>Count</td>
+      <td>Count of packets sent (Clients -&gt; PSC) over a PSC connection ID.</td>
+    </tr>
+  </tbody>
+</table>
+
+For the complete list of Private Service Connect metrics, see [Google's monitoring documentation for Private Service Connect connections](https://cloud.google.com/vpc/docs/monitor-private-service-connect-connections).
 
 ### Metrics-only resource types [#metrics-only]
 
@@ -2780,199 +2925,6 @@ New Relic also collects metrics for the following Compute Engine resource types.
   </Collapser>
 
   <Collapser
-    id="metrics-only-service-attachment"
-    title="Service Attachment — 12 metrics"
-  >
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "40%" }}>
-            Metric name
-          </th>
-
-          <th style={{ width: "10%" }}>
-            Unit
-          </th>
-
-          <th>
-            Description
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.closed_connections_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of TCP/UDP connections closed over a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.connected_consumer_forwarding_rules`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Number of Consumer Forwarding Rules connected to a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.dropped_received_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of received packets dropped by a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.dropped_sent_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of sent packets dropped by a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.nat_ip_address_capacity`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Number of total IP addresses of a PSC Service Attachment resource ID. (Value -1 means the number is larger than the max value of INT64.).
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.new_connections_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of new TCP/UDP connections created over a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.open_connections`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Number of TCP/UDP connections currently open on a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.received_bytes_count`
-          </td>
-
-          <td>
-            Bytes
-          </td>
-
-          <td>
-            Count of bytes received (PSC -&gt; Service) over a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.received_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of packets received (PSC -&gt; Service) over a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.sent_bytes_count`
-          </td>
-
-          <td>
-            Bytes
-          </td>
-
-          <td>
-            Count of bytes sent (Service -&gt; PSC) over a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.sent_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of packets sent (Service -&gt; PSC) over a PSC Service Attachment resource ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.producer.used_nat_ip_addresses`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            IP usage of the monitored service attachment.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
-
-  <Collapser
     id="metrics-only-node-group"
     title="Node Group — 11 metrics"
   >
@@ -3324,157 +3276,6 @@ New Relic also collects metrics for the following Compute Engine resource types.
 
           <td>
             This is a writable metric that allows users to report the total elapsed time of the workload since it started (CUMULATIVE) or over a rolling window (INTERVAL).
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </Collapser>
-
-  <Collapser
-    id="metrics-only-private-service-connect-endpoint"
-    title="Private Service Connect Endpoint — 9 metrics"
-  >
-    <table>
-      <thead>
-        <tr>
-          <th style={{ width: "40%" }}>
-            Metric name
-          </th>
-
-          <th style={{ width: "10%" }}>
-            Unit
-          </th>
-
-          <th>
-            Description
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.closed_connections_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of TCP/UDP connections closed over a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.dropped_received_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of received packets dropped by a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.dropped_sent_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of sent packets dropped by a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.new_connections_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of new TCP/UDP connections created over a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.open_connections`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Number of TCP/UDP connections currently open on a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.received_bytes_count`
-          </td>
-
-          <td>
-            Bytes
-          </td>
-
-          <td>
-            Count of bytes received (PSC -&gt; Clients) over a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.received_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of packets received (PSC -&gt; Clients) over a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.sent_bytes_count`
-          </td>
-
-          <td>
-            Bytes
-          </td>
-
-          <td>
-            Count of bytes sent (Clients -&gt; PSC) over a PSC connection ID.
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            `gcp.compute.private_service_connect.consumer.sent_packets_count`
-          </td>
-
-          <td>
-            Count
-          </td>
-
-          <td>
-            Count of packets sent (Clients -&gt; PSC) over a PSC connection ID.
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
## Relevant information

Graduates GCP Private Service Connect **Service Attachment** and **Private Service Connect Endpoint** from metrics-only to full entities in New Relic, following the precedent set by #25416 (Spanner Database restoring `GCPSPANNERDATABASE`).

Companion PR (NR-605048): entity synthesis in `beyond/gcp-polling-v2#280` (internal) and platform registration in `newrelic/entity-definitions#3218`.

## What changed

`google-compute-engine-monitoring-integration.mdx` (the "VMs" / Compute Engine integration page):

- Added **Service Attachment** (`GCPSERVICEATTACHMENT`, resource type `gce_service_attachment`) and **Private Service Connect Endpoint** (`GCPPRIVATESERVICECONNECTENDPOINT`, resource type `compute.googleapis.com/PrivateServiceConnectEndpoint`) rows to the Compute Engine entities table.
- Removed their two `Metrics-only resource types` collapsers (`metrics-only-service-attachment`, `metrics-only-private-service-connect-endpoint`).
- Relocated their metric tables — content unchanged, 12 producer metrics + 9 consumer metrics — into new `#### Key metrics — Service Attachment` / `#### Key metrics — Private Service Connect Endpoint` sections, matching the existing per-entity `Key metrics` layout used for VM Instance / VM Disk / Interconnect / Interconnect Attachment on the same page.

`src/i18n/content/**` left untouched (translation-managed).

## Test plan

- [x] Verified no content was lost in the collapser → table relocation (metric names/units/descriptions copied verbatim).
- [x] Manual tag-balance check across the whole file (`<table>`/`<tr>`/`<td>`/`<tbody>`/`<thead>` all balanced, pre- and post-edit).
- [x] Cross-checked resource types, metric name NR-prefix derivation, and unit presence against `gcp-polling-v2`'s entity definitions.
- [ ] `verify-mdx` / `vale-lint` CI (not run locally — Node/Yarn toolchain setup wasn't available in this environment; relying on CI).