### PR TITLE
fix: correct subject casing on node-api-runtime 1.2.267 release note

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.267.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.267.mdx
@@ -1,5 +1,5 @@
 ---
-subject: Node API Runtime
+subject: Node API runtime
 releaseDate: '2026-09-03'
 version: 1.2.267
 ---


### PR DESCRIPTION
## Summary
- `node-api-runtime-1.2.267.mdx` had `subject: Node API Runtime` instead of the established `subject: Node API runtime` used by `index.mdx` and every other release note in this directory.
- Since the docs sidebar groups release notes by the `subject` frontmatter value, this casing mismatch caused the nav to render a second, duplicate "Node API Runtime" group containing only the overview link and v1.2.267 — separate from the main "Node API runtime" group with the rest of the version history.

## Fix
Corrected `subject` to `Node API runtime` so v1.2.267 merges back into the existing nav group.

## Test plan
- [ ] Confirm sidebar shows a single "Node API runtime" group containing all versions including v1.2.267