### PR TITLE
[ENTERPRISE-32545] Rewrite personal data requests doc page

### DIFF
--- a/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
+++ b/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
@@ -15,7 +15,7 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-There may be times that you want to process personal data in New Relic products or services about your own customers. We have taken steps so that you can do this in accordance with applicable data protection laws, such as the General Data Protection Regulation (GDPR) in the EU.
+There may be times that you, or someone about whom New Relic holds personal data, want to make a request related to that personal data. We have taken steps so that these requests can be handled in accordance with applicable data protection laws, such as the General Data Protection Regulation (GDPR) in the EU.
 
 ## Responsibilities
 
@@ -23,29 +23,35 @@ When you receive a request from one of your own customers about their personal d
 
 New Relic is your data processor, so we only communicate with you as our customer. We don't communicate with your own customers. New Relic is unable to provide assistance to our customers with personal data requests via any third party platforms, including, for example, any data privacy or data privacy compliance platforms. The only method by which we can provide assistance is as set out below.
 
-## Requests for data access [#process]
+## Types of personal data requests [#request-types]
 
-For data access requests from any of your customers, you can:
+New Relic handles three distinct types of requests related to personal data:
 
-1. Query all data New Relic collected on your behalf.
-2. Extract the relevant information.
-3. Provide it to your customer (the data subject).
+* **Personal data access**: An individual asking to receive a copy of all the personal data New Relic holds about them, across all of New Relic's systems.
+* **Personal data deletion**: An individual asking New Relic to delete all the personal data it holds about them, across all of New Relic's systems.
+* **Event deletion**: A customer who has ingested personal data (such as PII) into their own New Relic account through telemetry, and wants that data removed from NRDB.
 
-As you work with your customers' data, you may find these resources helpful:
+Personal data access and deletion requests can only be made by the data subject themselves; New Relic requires the individual's own written consent and cannot act on a request submitted on someone else's behalf. Event deletion, by contrast, is a request the customer submits about data in their own account.
 
-* For a complete overview of what data we record, what it's used for, and how long this data is stored, see the [New Relic Services Data Privacy Notice](https://newrelic.com/termsandconditions/services-notices).
-* For information about your compliance with privacy laws when you use our <InlinePopover type="browser"/> service, see our documentation about [New Relic cookies used for browser monitoring](/docs/browser/new-relic-browser/page-load-timing-resources/new-relic-cookies-used-browser#gdpr).
-* For more information about our data privacy and security measures, see our [data privacy documentation](/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).
+## How to submit a request [#submit-requests]
 
-## Requests for personal data deletion [#submit-requests]
+### Personal data access
 
-Please note that New Relic is unable to provide assistance to our customers with personal data requests via any third party data privacy or data privacy compliance platforms. The only methods by which we can provide assistance are as set out in this section. To improve the security of the data you entrust us with, we restrict the ability to request data deletion to only admin and owner roles. If you have not been assigned this role, please contact one of your account's Admins or Owners. To find your account's users, follow the [instructions for viewing users](/docs/accounts/accounts/roles-permissions/add-update-users#viewing).
+Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/data-privacy-rights/).
 
-When you want to delete personal data for your customers, the admin or owner for your New Relic account follows this process:
+### Personal data deletion
 
-1. Identify the personal data that your own customer wants to have deleted or made anonymous.
+Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/data-privacy-rights/).
+
+### Event deletion
+
+You cannot delete data, such as PII, from NRDB yourself once it has been ingested. To have it removed, contact [New Relic Support](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/). To improve the security of the data you entrust us with, only admin and owner roles can request this deletion. If you have not been assigned this role, please contact one of your account's Admins or Owners. To find your account's users, follow the [instructions for viewing users](/docs/accounts/accounts/roles-permissions/add-update-users#viewing).
+
+When you want to delete ingested personal data from your account, the admin or owner for your New Relic account follows this process:
+
+1. Identify the personal data that needs to be deleted or made anonymous.
 2. Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com) to ask us for help. Include sufficient details so we can complete the change in the way you want, as explained in the following table.
-3. After we fulfill your request to remove the personal data, follow up with your customer who initiated the request.
+3. After we fulfill the request, follow up with whoever initiated it, if applicable.
 
 By law, we have 30 days to fulfill personal data deletion requests once we receive them.
 
@@ -71,7 +77,7 @@ Here are some examples of what to do, depending on your New Relic account type.
       </td>
 
       <td>
-        Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/data-privacy-rights/), or send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com).
+        Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com).
 
         * Include details of all enabled custom parameters that contain the personal data.
         * Indicate whether you want these parameters to be deleted or made anonymous.
@@ -84,7 +90,7 @@ Here are some examples of what to do, depending on your New Relic account type.
       </td>
 
       <td>
-        Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com) and request us to remove all personal data in your account, or fill out a request on our [Data Privacy Portal](http://support.newrelic.com/s/data-privacy-rights).
+        Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com) and request us to remove all personal data in your account.
       </td>
     </tr>
 
@@ -101,19 +107,12 @@ Here are some examples of what to do, depending on your New Relic account type.
         3. Select **Account settings > Account > Subscription**.
       </td>
     </tr>
-
-    <tr>
-      <td>
-        I do not have a New Relic account.
-      </td>
-
-      <td>
-        If you are not a customer of New Relic, please refer to our [General Data Privacy Notice](https://newrelic.com/termsandconditions/privacy).
-      </td>
-    </tr>
   </tbody>
 </table>
 
-## Request sensitive data deletion from NRDB [#delete-event-data]
+## Additional resources
 
-You cannot delete sensitive data, such as Personally Identifiable Information (PII), yourself after it has been stored in NRDB. If you find that sensitive data has been ingested, you must contact [New Relic Support](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/) for assistance with its removal.
+* If you are not a customer of New Relic, please refer to our [General Data Privacy Notice](https://newrelic.com/termsandconditions/privacy).
+* For a complete overview of what data we record, what it's used for, and how long this data is stored, see the [New Relic Services Data Privacy Notice](https://newrelic.com/termsandconditions/services-notices).
+* For information about your compliance with privacy laws when you use our <InlinePopover type="browser"/> service, see our documentation about [New Relic cookies used for browser monitoring](/docs/browser/new-relic-browser/page-load-timing-resources/new-relic-cookies-used-browser#gdpr).
+* For more information about our data privacy and security measures, see our [data privacy documentation](/docs/security/new-relic-security/data-privacy/data-privacy-new-relic), or visit the [New Relic security website](https://newrelic.com/security).

--- a/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
+++ b/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
@@ -43,72 +43,15 @@ Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/d
 
 Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/data-privacy-rights/).
 
+By law, we have 30 days to fulfill personal data access and deletion requests once we receive them.
+
 ### Event deletion
 
-You cannot delete data, such as PII, from NRDB yourself once it has been ingested. To have it removed, contact [New Relic Support](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/). To improve the security of the data you entrust us with, only admin and owner roles can request this deletion. If you have not been assigned this role, please contact one of your account's Admins or Owners. To find your account's users, follow the [instructions for viewing users](/docs/accounts/accounts/roles-permissions/add-update-users#viewing).
+You can't delete data, such as personally identifiable information (PII), from NRDB yourself once it's been ingested. To request removal, contact [New Relic Support](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/) with your account ID and a NRQL query identifying the exact data you want removed.
 
-When you want to delete ingested personal data from your account, the admin or owner for your New Relic account follows this process:
+The request must come from, or be explicitly approved by, a Full Platform User with the All Product Admin role on the account, the organization's Authentication Domain Manager, or Organization Manager. Once submitted, the deletion is permanent and can't be recovered—there's no backup to restore from.
 
-1. Identify the personal data that needs to be deleted or made anonymous.
-2. Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com) to ask us for help. Include sufficient details so we can complete the change in the way you want, as explained in the following table.
-3. After we fulfill the request, follow up with whoever initiated it, if applicable.
-
-By law, we have 30 days to fulfill personal data deletion requests once we receive them.
-
-Here are some examples of what to do, depending on your New Relic account type.
-
-<table>
-  <thead>
-    <tr>
-      <th style={{ width: "250px" }}>
-        New Relic account type
-      </th>
-
-      <th>
-        What to do
-      </th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <tr>
-      <td>
-        I have a paid New Relic account.
-      </td>
-
-      <td>
-        Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com).
-
-        * Include details of all enabled custom parameters that contain the personal data.
-        * Indicate whether you want these parameters to be deleted or made anonymous.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        I have a free New Relic account.
-      </td>
-
-      <td>
-        Send an email to [personaldatarequests@newrelic.com](mailto:personaldatarequests@newrelic.com) and request us to remove all personal data in your account.
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        I'm not sure what type of New Relic account I have.
-      </td>
-
-      <td>
-        To check your New Relic subscription:
-
-        1. Go to **[one.newrelic.com](https://one.newrelic.com/all-capabilities)**.
-        2. Click the [user menu](/docs/accounts/accounts-billing/general-account-settings/intro-account-settings).
-        3. Select **Account settings > Account > Subscription**.
-      </td>
-    </tr>
-  </tbody>
-</table>
+New Relic has 30 days to fulfill event deletion requests once we receive them. For full submission details, see [How to Request Deletion of Sensitive or PII Data from New Relic NRDB](https://knowledge.newrelic.com/s/article/How-to-Request-Deletion-of-Sensitive-or-PII-Data-from-New-Relic-NRDB).
 
 ## Additional resources
 

--- a/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
+++ b/src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx
@@ -19,39 +19,39 @@ There may be times that you, or someone about whom New Relic holds personal data
 
 ## Responsibilities
 
-When you receive a request from one of your own customers about their personal data, you are the data controller, and you are responsible for all interactions with the data subject. (Your own customer is the data subject as defined by the GDPR.)
+You, the data subject, are responsible for submitting personal data access and deletion requests yourself. New Relic is your data processor, so we only communicate with data subjects who have submitted valid requests.
 
-New Relic is your data processor, so we only communicate with you as our customer. We don't communicate with your own customers. New Relic is unable to provide assistance to our customers with personal data requests via any third party platforms, including, for example, any data privacy or data privacy compliance platforms. The only method by which we can provide assistance is as set out below.
+New Relic is unable to provide assistance with personal data requests via any third party platforms, including, for example, any data privacy or data privacy compliance platforms. The only method by which we can provide assistance is as set out below.
 
 ## Types of personal data requests [#request-types]
 
 New Relic handles three distinct types of requests related to personal data:
 
-* **Personal data access**: An individual asking to receive a copy of all the personal data New Relic holds about them, across all of New Relic's systems.
-* **Personal data deletion**: An individual asking New Relic to delete all the personal data it holds about them, across all of New Relic's systems.
+* **Personal data access**: A data subject asking to receive a copy of all the personal data New Relic holds about them, across all of New Relic's systems.
+* **Personal data deletion**: A data subject asking New Relic to delete all the personal data it holds about them, across all of New Relic's systems.
 * **Event deletion**: A customer who has ingested personal data (such as PII) into their own New Relic account through telemetry, and wants that data removed from NRDB.
 
-Personal data access and deletion requests can only be made by the data subject themselves; New Relic requires the individual's own written consent and cannot act on a request submitted on someone else's behalf. Event deletion, by contrast, is a request the customer submits about data in their own account.
+Personal data access and deletion requests are made by the data subject directly; event deletion requests are made by the customer about data in their own account.
 
 ## How to submit a request [#submit-requests]
 
 ### Personal data access
 
-Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/data-privacy-rights/).
+Fill out a request on our [Data Privacy Portal](https://privacyrequests.newrelic.com/).
 
 ### Personal data deletion
 
-Fill out a request on our [Data Privacy Portal](https://support.newrelic.com/s/data-privacy-rights/).
+Fill out a request on our [Data Privacy Portal](https://privacyrequests.newrelic.com/).
 
 By law, we have 30 days to fulfill personal data access and deletion requests once we receive them.
 
 ### Event deletion
 
-You can't delete data, such as personally identifiable information (PII), from NRDB yourself once it's been ingested. To request removal, contact [New Relic Support](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/) with your account ID and a NRQL query identifying the exact data you want removed.
+You can't delete data, such as personally identifiable information (PII), from NRDB yourself once it's been ingested. To request removal, contact [New Relic Support](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings/) with your account ID and a NRQL query identifying the exact data you want removed. You must also provide the information described in [How to Request Deletion of Sensitive or PII Data from New Relic NRDB](https://knowledge.newrelic.com/s/article/How-to-Request-Deletion-of-Sensitive-or-PII-Data-from-New-Relic-NRDB) for the request to proceed.
 
 The request must come from, or be explicitly approved by, a Full Platform User with the All Product Admin role on the account, the organization's Authentication Domain Manager, or Organization Manager. Once submitted, the deletion is permanent and can't be recovered—there's no backup to restore from.
 
-New Relic has 30 days to fulfill event deletion requests once we receive them. For full submission details, see [How to Request Deletion of Sensitive or PII Data from New Relic NRDB](https://knowledge.newrelic.com/s/article/How-to-Request-Deletion-of-Sensitive-or-PII-Data-from-New-Relic-NRDB).
+New Relic has 30 days to fulfill event deletion requests once we receive them.
 
 ## Additional resources
 


### PR DESCRIPTION
## Summary
- Restructures the [Personal Data Requests](https://docs.newrelic.com/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests/) page around three clearly-defined request types: personal data access, personal data deletion, and event/NRDB deletion — instead of conflating them under one "personal data deletion" section as before.
- Each type now has its own submission instructions (Data Privacy Portal for access/deletion, contacting Support for event deletion).
- Removes language implying requests can be made on someone else's behalf; access/deletion requests must come from the data subject themselves.
- Retains all existing external links/notices, relocated under "Additional resources."

## Changes Made
- `src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx`

## Files Affected
- src/content/docs/security/security-privacy/data-privacy/new-relic-personal-data-requests.mdx

---

**⚠️ DO NOT MERGE — pending Security/Legal (SLC) review.**
This is a draft opened solely to generate a Netlify preview for SLC review. Do not request docs-team review or merge until SLC has explicitly signed off.

ENTERPRISE-32545