### PR TITLE
Document sandbox isolation fix on node-api-runtime 1.2.267 release notes

### DIFF
--- a/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.267.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.267.mdx
@@ -1,12 +1,17 @@
 ---
 subject: Node API runtime
 releaseDate: '2026-09-03'
+features: [] 
+enhancements: []
+bugs:  
+  - For the Scripted API monitors, updated script execution to run in an isolated context, preventing scripts from traversing the JavaScript prototype chain to access sandbox-restricted objects and functions.
+security: []
 version: 1.2.267
 ---
 
 ### Fixes
 
-* Scripted API monitor scripts now run in their own isolated execution context, closing off a way a script could walk the JavaScript prototype chain to reach objects and functions outside its sandbox.
+* **Scripted API monitors**: Updated script execution to run in an isolated context, preventing scripts from traversing the JavaScript prototype chain to access sandbox-restricted objects and functions.
 
 ### Security patches
 

--- a/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.267.mdx
+++ b/src/content/docs/release-notes/synthetics-release-notes/node-api-runtime-release-notes/node-api-runtime-1.2.267.mdx
@@ -4,6 +4,10 @@ releaseDate: '2026-09-03'
 version: 1.2.267
 ---
 
+### Fixes
+
+* Scripted API monitor scripts now run in their own isolated execution context, closing off a way a script could walk the JavaScript prototype chain to reach objects and functions outside its sandbox.
+
 ### Security patches
 
 Fixed the following vulnerabilities:


### PR DESCRIPTION
## What
Adds a `### Fixes` entry to the node-api-runtime 1.2.267 release notes documenting the vm-context sandbox isolation change (synthetics-node-api-runtime PR #460, NR-610225).

## Why
This change shipped internally as part of the 1.2.263-1.2.267 range but only ever got a routine CVE-patch note published — the actual sandbox behavior change was never documented publicly. It's come up in multiple support cases (Scripted API monitors using `assert.deepStrictEqual`), so customers should be able to find it in the release notes for the version they're actually running.

## Reference
synthetics-node-api-runtime PR #460: https://source.datanerd.us/synthetics/synthetics-node-api-runtime/pull/460/files