### PR TITLE
iOS Release Notes v6.9.35

### DIFF
--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
@@ -4,7 +4,7 @@ releaseDate: '2026-09-08'
 version: '6.9.35'
 downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
 features: []
-enhancements:[]
+enhancements: []
 bugs: ['Bug fixes and Minor UI changes']
 security: []
 redirects:

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
@@ -5,7 +5,7 @@ version: '6.9.35'
 downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
 features: []
 enhancements:[]
-bugs: [`Bug fixes and Minor UI changes`]
+bugs: ['Bug fixes and Minor UI changes']
 security: []
 redirects:
   - /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
@@ -3,6 +3,10 @@ subject: Mobile app for iOS
 releaseDate: '2026-09-08'
 version: '6.9.35'
 downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
+features: []
+enhancements:[]
+bugs: [`Bug fixes and Minor UI changes`]
+security: []
 redirects:
   - /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112
 ---

--- a/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
+++ b/src/content/docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112.mdx
@@ -1,0 +1,11 @@
+---
+subject: Mobile app for iOS
+releaseDate: '2026-09-08'
+version: '6.9.35'
+downloadLink: 'https://itunes.apple.com/us/app/new-relic/id594038638?mt=8'
+redirects:
+  - /docs/release-notes/mobile-apps-release-notes/new-relic-ios-release-notes/new-relic-ios-6112
+---
+
+### Features, Improvements & Fixes
+- Bug fixes and Minor UI changes


### PR DESCRIPTION
Release notes for New Relic iOS app v6.9.35, build 6112.

Bug fixes and minor UI changes.